### PR TITLE
Settings: Remove entry point to domain purchase

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -38,8 +38,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             // It is not possible to get the TTPoI entitlement for an enterprise certificate,
             // so we should not enable this for alpha builds.
             return buildConfig == .localDeveloper || buildConfig == .appStore
-        case .domainSettings:
-            return true
         case .jetpackSetupWithApplicationPassword:
             return true
         case .manualErrorHandlingForSiteCredentialLogin:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -84,10 +84,6 @@ public enum FeatureFlag: Int {
     /// - Note: The app will ignore this if `performanceMonitoring` is `false`.
     case performanceMonitoringViewController
 
-    /// Whether to enable domain updates from the settings for a WPCOM site.
-    ///
-    case domainSettings
-
     /// Whether to enable the new support request form.
     ///
     case supportRequests

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [internal] Optimized product image handling to reduce memory pressure by leveraging KingFisher's built-in capabilities [https://github.com/woocommerce/woocommerce-ios/pull/15629]
 - [*] Payments: Added a two-minute timeout when waiting for card payments, to reduce the risk of battery drain or mistaken payments. [https://github.com/woocommerce/woocommerce-ios/pull/15665]
 - [internal] POS: Handle payment intent creation error. [https://github.com/woocommerce/woocommerce-ios/pull/15661]
+- [*] Removed domain purchase from app settings [https://github.com/woocommerce/woocommerce-ios/pull/15680]
 
 22.4
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -320,7 +320,6 @@ enum WooAnalyticsStat: String {
     case settingsTapped = "main_menu_settings_tapped"
     case settingsSelectedStoreTapped = "settings_selected_site_tapped"
     case settingsContactSupportTapped = "main_menu_contact_support_tapped"
-    case settingsDomainsTapped = "settings_domains_tapped"
     case settingsTroubleshootConnectionTapped = "settings_troubleshoot_connection_tapped"
 
     case settingsBetaFeaturesButtonTapped = "settings_beta_features_button_tapped"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -142,8 +142,6 @@ private extension SettingsViewController {
             configurePlugins(cell: cell)
         case let cell as HostingTableViewCell<PluginDetailsRowContent> where row == .woocommerceDetails:
             configureWooCommmerceDetails(cell: cell)
-        case let cell as BasicTableViewCell where row == .domain:
-            configureDomain(cell: cell)
         case let cell as BasicTableViewCell where row == .connectivity:
             configureConnectivity(cell: cell)
         case let cell as BasicTableViewCell where row == .installJetpack:
@@ -205,12 +203,6 @@ private extension SettingsViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = Localization.helpAndSupport
-    }
-
-    func configureDomain(cell: BasicTableViewCell) {
-        cell.accessoryType = .disclosureIndicator
-        cell.selectionStyle = .default
-        cell.textLabel?.text = Localization.domain
     }
 
     func configureConnectivity(cell: BasicTableViewCell) {
@@ -388,18 +380,6 @@ private extension SettingsViewController {
             fatalError("Cannot instantiate `HelpAndSupportViewController` from Dashboard storyboard")
         }
         show(viewController, sender: self)
-    }
-
-    func domainWasPressed() {
-        guard let site = ServiceLocator.stores.sessionManager.defaultSite, let navigationController else {
-            return
-        }
-
-        ServiceLocator.analytics.track(.settingsDomainsTapped)
-
-        let coordinator = DomainSettingsCoordinator(source: .settings, site: site, navigationController: navigationController)
-        domainSettingsCoordinator = coordinator
-        coordinator.start()
     }
 
     func installJetpackWasPressed() {
@@ -642,8 +622,6 @@ extension SettingsViewController: UITableViewDelegate {
             openWoocommerceDetails()
         case .support:
             supportWasPressed()
-        case .domain:
-            domainWasPressed()
         case .installJetpack:
             installJetpackWasPressed()
         case .storeName:
@@ -725,7 +703,6 @@ extension SettingsViewController {
         case woocommerceDetails
 
         // Store settings
-        case domain
         case installJetpack
         case storeName
         case themes
@@ -774,7 +751,7 @@ extension SettingsViewController {
                 return HostingTableViewCell<PluginDetailsRowContent>.self
             case .support:
                 return BasicTableViewCell.self
-            case .domain, .connectivity:
+            case .connectivity:
                 return BasicTableViewCell.self
             case .installJetpack:
                 return BasicTableViewCell.self
@@ -841,11 +818,6 @@ private extension SettingsViewController {
         static let inPersonPayments = NSLocalizedString(
             "In-Person Payments",
             comment: "Navigates to In-Person Payments screen"
-        )
-
-        static let domain = NSLocalizedString(
-            "Domains",
-            comment: "Navigates to domain settings screen."
         )
 
         static let connectivity = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -208,12 +208,6 @@ private extension SettingsViewModel {
         let configureSection: Section? = {
             var rows: [Row] = []
 
-            if featureFlagService.isFeatureFlagEnabled(.domainSettings)
-                && stores.sessionManager.defaultSite?.isWordPressComStore == true
-                && stores.sessionManager.defaultRoles.contains(.administrator) {
-                rows.append(.domain)
-            }
-
             if stores.isAuthenticated,
                stores.isAuthenticatedWithoutWPCom == false,
                stores.sessionManager.defaultSite?.isWordPressComStore == false {

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -6,7 +6,6 @@ final class MockFeatureFlagService: FeatureFlagService {
     var isShowInboxCTAEnabled: Bool
     var isUpdateOrderOptimisticallyOn: Bool
     var shippingLabelsOnboardingM1: Bool
-    var isDomainSettingsEnabled: Bool
     var isSupportRequestEnabled: Bool
     var jetpackSetupWithApplicationPassword: Bool
     var betterCustomerSelectionInOrder: Bool
@@ -33,7 +32,6 @@ final class MockFeatureFlagService: FeatureFlagService {
          isShowInboxCTAEnabled: Bool = false,
          isUpdateOrderOptimisticallyOn: Bool = false,
          shippingLabelsOnboardingM1: Bool = false,
-         isDomainSettingsEnabled: Bool = false,
          isSupportRequestEnabled: Bool = false,
          jetpackSetupWithApplicationPassword: Bool = false,
          betterCustomerSelectionInOrder: Bool = false,
@@ -97,8 +95,6 @@ final class MockFeatureFlagService: FeatureFlagService {
             return isUpdateOrderOptimisticallyOn
         case .shippingLabelsOnboardingM1:
             return shippingLabelsOnboardingM1
-        case .domainSettings:
-            return isDomainSettingsEnabled
         case .supportRequests:
             return isSupportRequestEnabled
         case .jetpackSetupWithApplicationPassword:

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -56,7 +56,6 @@ final class MockFeatureFlagService: FeatureFlagService {
         self.isShowInboxCTAEnabled = isShowInboxCTAEnabled
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
-        self.isDomainSettingsEnabled = isDomainSettingsEnabled
         self.isSupportRequestEnabled = isSupportRequestEnabled
         self.jetpackSetupWithApplicationPassword = jetpackSetupWithApplicationPassword
         self.betterCustomerSelectionInOrder = betterCustomerSelectionInOrder

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -190,69 +190,6 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.accountSettings) })
     }
 
-    func test_domain_is_hidden_when_domainSettings_feature_is_disabled() {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isDomainSettingsEnabled: false)
-        stores.updateDefaultStore(.fake().copy(isWordPressComStore: true))
-        let viewModel = SettingsViewModel(stores: stores,
-                                          storageManager: storageManager,
-                                          featureFlagService: featureFlagService)
-
-        // When
-        viewModel.onViewDidLoad()
-
-        // Then
-        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.domain) })
-    }
-
-    func test_domain_is_hidden_when_domainSettings_feature_is_enabled_and_site_is_not_wpcom() {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isDomainSettingsEnabled: true)
-        sessionManager.defaultSite = .fake().copy(isWordPressComStore: false)
-        sessionManager.defaultRoles = [.administrator]
-        let viewModel = SettingsViewModel(stores: stores,
-                                          storageManager: storageManager,
-                                          featureFlagService: featureFlagService)
-
-        // When
-        viewModel.onViewDidLoad()
-
-        // Then
-        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.domain) })
-    }
-
-    func test_domain_is_not_shown_when_domainSettings_feature_is_enabled_and_site_is_wpcom_for_shop_manager_role() {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isDomainSettingsEnabled: true)
-        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true)
-        sessionManager.defaultRoles = [.shopManager]
-        let viewModel = SettingsViewModel(stores: stores,
-                                          storageManager: storageManager,
-                                          featureFlagService: featureFlagService)
-
-        // When
-        viewModel.onViewDidLoad()
-
-        // Then
-        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.domain) })
-    }
-
-    func test_domain_is_shown_when_domainSettings_feature_is_enabled_and_site_is_wpcom_for_admin_role() {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isDomainSettingsEnabled: true)
-        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true)
-        sessionManager.defaultRoles = [.administrator]
-        let viewModel = SettingsViewModel(stores: stores,
-                                          storageManager: storageManager,
-                                          featureFlagService: featureFlagService)
-
-        // When
-        viewModel.onViewDidLoad()
-
-        // Then
-        XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.domain) })
-    }
-
     func test_sections_contains_whats_new_row_when_announcement_for_this_version_is_available() {
         // Given
         let viewModel = SettingsViewModel(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of WOOMOB-521

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR removes the entry point to domain purchase from the app Settings screen.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a WPCom test store without a custom domain.
- Navigate to the Menu tab > Settings.
- Confirm that the Domains row is no longer available.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested on simulator iPhone 16 iOS 18.4.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/user-attachments/assets/099c75e4-35fc-4448-8d0e-ca1da96467df" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
