### PR TITLE
[Woo POS][Product labels] Set `inventoryProductLabelsInPOS` flag to false

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -106,7 +106,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .searchCouponsInPOS:
             return true
         case .inventoryProductLabelsInPOS:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return false
         case .pointOfSaleReceipts:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .productImageOptimizedHandling:


### PR DESCRIPTION
## Description

Since this feature has been kicked forward and won't be implemented immediately, we disable the feature flag for stock levels in dev builds temporarily, so stock doesn't show in item list for the time being.

## Testing
- Load POS and observe that stock levels are not shown in the product cards in the item list

![simulator_screenshot_BBC5D06C-1F3D-43C4-8FE8-62CD8F8EB099](https://github.com/user-attachments/assets/910c7197-414c-4d1a-acf8-35b30273e290)
