### PR TITLE
Accessibility: Fix issues on Product details screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [internal] Optimized product image handling to reduce memory pressure by leveraging KingFisher's built-in capabilities [https://github.com/woocommerce/woocommerce-ios/pull/15629]
 - [*] Payments: Added a two-minute timeout when waiting for card payments, to reduce the risk of battery drain or mistaken payments. [https://github.com/woocommerce/woocommerce-ios/pull/15665]
 - [internal] POS: Handle payment intent creation error. [https://github.com/woocommerce/woocommerce-ios/pull/15661]
+- [*] Fixed accessibility issues on the Product details screen [https://github.com/woocommerce/woocommerce-ios/pull/15686]
 - [*] Removed domain purchase from app settings [https://github.com/woocommerce/woocommerce-ios/pull/15680]
 
 22.4

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -29,6 +29,7 @@ struct BlazeCampaignItemView: View {
                         .aspectRatio(contentMode: .fill)
                         .frame(width: Layout.imageSize * scale, height: Layout.imageSize * scale)
                         .cornerRadius(Layout.cornerRadius)
+                        .accessibilityHidden(true)
                     Spacer()
                 }
 

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorSectionHeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorSectionHeaderView.swift
@@ -16,7 +16,9 @@ final class BottomSheetListSelectorSectionHeaderView: UITableViewHeaderFooterVie
 
     func configure(title: String?, subtitle: String?) {
         self.title.text = title
+        self.title.numberOfLines = 0
         self.subtitle.text = subtitle
+        self.subtitle.numberOfLines = 0
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/DiscountTypeBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/DiscountTypeBottomSheetListSelectorCommand.swift
@@ -27,6 +27,7 @@ final class DiscountTypeBottomSheetListSelectorCommand: BottomSheetListSelectorC
                                                                     text: model.actionSheetDescription,
                                                                     image: model.actionSheetIcon,
                                                                     imageTintColor: .gray(.shade20),
+                                                                    numberOfLinesForTitle: 0,
                                                                     numberOfLinesForText: 0,
                                                                     isSelected: isSelected(model: model)
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -153,6 +153,7 @@ private extension BlazeCampaignDashboardView {
                 Image(uiImage: .blaze)
                     .resizable()
                     .frame(width: Layout.logoSize * scale, height: Layout.logoSize * scale)
+                    .accessibilityHidden(true)
                 Text(DashboardCard.CardType.blaze.name)
                     .headlineStyle()
                 Spacer()
@@ -307,6 +308,7 @@ private struct ProductInfoView: View {
                 .aspectRatio(contentMode: .fill)
                 .frame(width: Layout.imageSize * scale, height: Layout.imageSize * scale)
                 .cornerRadius(Layout.cornerRadius)
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading) {
                 Text(Localization.suggestedProductLabel)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormBottomSheetListSelectorCommand.swift
@@ -21,7 +21,10 @@ final class ProductFormBottomSheetListSelectorCommand: BottomSheetListSelectorCo
     func configureCell(cell: ImageAndTitleAndTextTableViewCell, model: ProductFormBottomSheetAction) {
         cell.selectionStyle = .none
         cell.accessoryType = .disclosureIndicator
-        let viewModel = ImageAndTitleAndTextTableViewCell.ViewModel(title: model.title, text: model.subtitle, numberOfLinesForText: 0)
+        let viewModel = ImageAndTitleAndTextTableViewCell.ViewModel(title: model.title,
+                                                                    text: model.subtitle,
+                                                                    numberOfLinesForTitle: 0,
+                                                                    numberOfLinesForText: 0)
         cell.updateUI(viewModel: viewModel)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
@@ -54,6 +54,7 @@ final class ProductTypeBottomSheetListSelectorCommand: BottomSheetListSelectorCo
                                                                     text: model.actionSheetDescription,
                                                                     image: model.actionSheetImage,
                                                                     imageTintColor: .gray(.shade20),
+                                                                    numberOfLinesForTitle: 0,
                                                                     numberOfLinesForText: 0)
         cell.updateUI(viewModel: viewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -324,6 +324,8 @@ private extension ImageAndTitleAndTextTableViewCell {
     func configureImageView() {
         contentImageView.contentMode = .center
         contentImageView.setContentHuggingPriority(.required, for: .horizontal)
+        // set this to false and update the view model to support custom accessibility label if needed
+        contentImageView.accessibilityElementsHidden = true
     }
 
     func configureContentStackView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ProductReviewsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ProductReviewsTableViewCell.swift
@@ -51,14 +51,17 @@ private extension ProductReviewsTableViewCell {
 
     func configureImageView() {
         contentImageView.contentMode = .center
+        contentImageView.accessibilityElementsHidden = true
     }
 
     func configureLabels() {
         titleLabel.applyBodyStyle()
         titleLabel.textColor = .text
+        titleLabel.numberOfLines = 0
 
         reviewsLabel.applySubheadlineStyle()
         reviewsLabel.textColor = .textSubtle
+        reviewsLabel.numberOfLines = 0
     }
 
     func configureStarView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileBottomSheetListSelectorCommand.swift
@@ -27,6 +27,7 @@ final class DownloadableFileBottomSheetListSelectorCommand: BottomSheetListSelec
                                                                     textTintColor: .text,
                                                                     image: model.image,
                                                                     imageTintColor: .gray(.shade20),
+                                                                    numberOfLinesForTitle: 0,
                                                                     numberOfLinesForText: 0,
                                                                     showsDisclosureIndicator: true)
         cell.updateUI(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -348,7 +348,6 @@ private extension ProductFormTableViewDataSource {
         cell.backgroundColor = .listBackground
         cell.hideSeparator()
         cell.configure(height: Constants.settingsHeaderHeight)
-        cell.accessibilityElementsHidden = true
     }
 
     func configureLinkedProductsPromo(cell: UITableViewCell, viewModel: FeatureAnnouncementCardViewModel) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -9,6 +9,7 @@ private extension ProductFormSection.SettingsRow.ViewModel {
                                                            textTintColor: tintColor,
                                                            image: icon,
                                                            imageTintColor: tintColor ?? .textSubtle,
+                                                           numberOfLinesForTitle: 0,
                                                            numberOfLinesForText: numberOfLinesForDetails,
                                                            isActionable: isActionable,
                                                            showsDisclosureIndicator: isActionable,
@@ -238,6 +239,7 @@ private extension ProductFormTableViewDataSource {
                                           comment: "Title in the Product description row on Product form screen when the description is non-empty.")
             let viewModel = ImageAndTitleAndTextTableViewCell.ViewModel(title: title, text: description, isActionable: isEditable)
             cell.updateUI(viewModel: viewModel)
+            cell.accessibilityHint = Localization.Accessibility.descriptionHint
         } else {
             guard let cell = cell as? BasicTableViewCell else {
                 fatalError()
@@ -346,6 +348,7 @@ private extension ProductFormTableViewDataSource {
         cell.backgroundColor = .listBackground
         cell.hideSeparator()
         cell.configure(height: Constants.settingsHeaderHeight)
+        cell.accessibilityElementsHidden = true
     }
 
     func configureLinkedProductsPromo(cell: UITableViewCell, viewModel: FeatureAnnouncementCardViewModel) {
@@ -482,5 +485,12 @@ private extension ProductFormTableViewDataSource {
             value: "Tap to learn more.",
             comment: "Text message prompting the user to tap to learn more about changing the privacy setting."
         )
+        enum Accessibility {
+            static let descriptionHint = NSLocalizedString(
+                "productFormTableViewDataSource.accessibility.descriptionHint",
+                value: "Tap to view more or edit product description",
+                comment: "Accessibility hint for product description on Product form screen"
+            )
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationsSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationsSelectorCommand.swift
@@ -41,6 +41,7 @@ final class GenerateVariationsSelectorCommand: BottomSheetListSelectorCommand {
     func configureCell(cell: ImageAndTitleAndTextTableViewCell, model: Options) {
         let viewModel = ImageAndTitleAndTextTableViewCell.ViewModel(title: model.title,
                                                                     text: model.description,
+                                                                    numberOfLinesForTitle: 0,
                                                                     numberOfLinesForText: 0,
                                                                     isSelected: isSelected(model: model)
         )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of WOOMOB-505

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes accessibility issues in the layout of the Product details screen. Additionally, some unnecessary accessibility items on the Blaze dashboard card are also hidden to avoid confusion.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Dashboard card

1. Log in to a test store eligibile for Blaze.
2. On the My Store tab, enable the Blaze card on the dashboard.
3. Confirm that the Blaze icon and product image are no longer identified as accessibility items.

### Product details

1. Log in to a test store with at least one product.
2. Navigate to the Products tab and select a product. Increase the font size to an accesibility size.
3. Confirm that no text is clipped except for the product description row. This is intentional as the description can be long. However, there's now an accessibility hint on the description row suggesting to tap the row to read more and edit the description.
4. Select Add more details and confirm that no text is clipped.
5. Select Product type and confirm that no text is clipped on the product type sheet.
6. Confirm that icons are no longer identified as accessibility items.
7. Confirm that the spacer rows are no longer identified as tappable.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested on simulator iPhone 16 iOS 18.4 with large font sizes.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/0a74727f-0aab-43ca-99cf-fb53b27c453e



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
