### PR TITLE
Add imports that required once frameworks become modules

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import WooFoundation
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Experiments
+import UIKit
 import Yosemite
 import protocol Storage.StorageManagerType
 import protocol WooFoundation.Analytics

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import enum Alamofire.AFError
 import enum Networking.NetworkError

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NonAtomicSiteViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NonAtomicSiteViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 
 /// Configuration and actions for an ULErrorViewController, modelling

--- a/WooCommerce/Classes/Authentication/PostSiteCredentialLoginChecker.swift
+++ b/WooCommerce/Classes/Authentication/PostSiteCredentialLoginChecker.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Yosemite
 import protocol Networking.ApplicationPasswordUseCase
 import protocol WooFoundation.Analytics

--- a/WooCommerce/Classes/Blaze/BlazeLocalNotificationScheduler.swift
+++ b/WooCommerce/Classes/Blaze/BlazeLocalNotificationScheduler.swift
@@ -1,3 +1,5 @@
+import Foundation
+import UserNotifications
 import Yosemite
 import protocol Storage.StorageManagerType
 import Combine

--- a/WooCommerce/Classes/Extensions/Product+SwiftUIPreviewHelpers.swift
+++ b/WooCommerce/Classes/Extensions/Product+SwiftUIPreviewHelpers.swift
@@ -1,5 +1,6 @@
 #if canImport(SwiftUI) && DEBUG
 
+import Foundation
 import Yosemite
 
 extension Product {

--- a/WooCommerce/Classes/Extensions/ShippingLabel+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/ShippingLabel+Helpers.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 extension ShippingLabel {

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import protocol WooFoundation.Analytics
 

--- a/WooCommerce/Classes/Model/APNSDevice+Woo.swift
+++ b/WooCommerce/Classes/Model/APNSDevice+Woo.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 
 

--- a/WooCommerce/Classes/Model/BetaFeature.swift
+++ b/WooCommerce/Classes/Model/BetaFeature.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 import Storage
 import protocol WooFoundation.WooAnalyticsEventPropertyType
 

--- a/WooCommerce/Classes/Notifications/LocalNotificationScheduler.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotificationScheduler.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UserNotifications
 import Yosemite
 
 /// Handles the scheduling of local notifications with support of remote feature flags.

--- a/WooCommerce/Classes/Notifications/PushNotificationBackgroundSynchronizer.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationBackgroundSynchronizer.swift
@@ -1,4 +1,6 @@
+import Foundation
 import protocol Storage.StorageType
+import UIKit
 import Yosemite
 
 protocol PushNotificationBackgroundSynchronizerProtocol {

--- a/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
@@ -1,3 +1,4 @@
+import Foundation
 import protocol WooFoundation.Analytics
 import Yosemite
 

--- a/WooCommerce/Classes/Tools/InfiniteScroll/AsyncPaginationTracker.swift
+++ b/WooCommerce/Classes/Tools/InfiniteScroll/AsyncPaginationTracker.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 /// Async/await version of `PaginationTracker`, consider renaming `PaginationTracker` as deprecated and this class to `PaginationTracker`.

--- a/WooCommerce/Classes/Tools/InfiniteScroll/PaginationTracker.swift
+++ b/WooCommerce/Classes/Tools/InfiniteScroll/PaginationTracker.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 /// Delegate of `PaginationTracker` that implements syncing per page number and size.

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderStatusListViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderStatusListViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import class AutomatticTracks.CrashLogging
 import protocol Storage.StorageManagerType

--- a/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 /// ViewModel supporting the backed-generated receipt preview.

--- a/WooCommerce/Classes/ViewModels/Order Details/Refunded Products/RefundedProductsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Refunded Products/RefundedProductsViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 
 

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/AggregatedShippingLabelOrderItems.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/AggregatedShippingLabelOrderItems.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 import WooFoundation
 

--- a/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPaperSize+UI.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Shipping Labels/ShippingLabelPaperSize+UI.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 extension ShippingLabelPaperSize {

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import UIKit
 import Yosemite
 import protocol WooFoundation.Analytics
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeAddPaymentMethodWebViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeAddPaymentMethodWebViewModel.swift
@@ -1,3 +1,5 @@
+import Combine
+import Foundation
 import Yosemite
 import protocol WooFoundation.Analytics
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import class Photos.PHAsset
 import enum Networking.NetworkError

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Yosemite
 
 /// View model for `BlazePaymentMethodsView`.

--- a/WooCommerce/Classes/ViewRelated/Blaze/TargetLocations/BlazeTargetLocationPickerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/TargetLocations/BlazeTargetLocationPickerViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import protocol WooFoundation.Analytics
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/WCPayCardBrand+icons.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/WCPayCardBrand+icons.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 
 extension WCPayCardBrand {

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Combine
 import Networking
+import UIKit
 import Yosemite
 
 final class ConnectivityToolViewModel {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import UIKit
 import Yosemite
 import WooFoundation
 import protocol Storage.StorageManagerType

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import Experiments
 import WooFoundation

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import class SwiftUI.UIHostingController
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 
 /// ViewModel for an individual custom field

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import WooFoundation
 import protocol Storage.StorageManagerType

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import protocol WooFoundation.Analytics
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCustomizationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCustomizationViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Yosemite
 
 final class DashboardCustomizationViewModel: ObservableObject {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 import Combine
 import enum Networking.DotcomError

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/WCAnalyticsStatsTotals+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/WCAnalyticsStatsTotals+UI.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 /// Protocol for `WCAnalyticsStatsTotals` that can be parsed with the `StatsIntervalDataParser`

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 /// ViewModel to format the text that goes into the Free Trial Banner.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 import Yosemite
 import protocol Storage.StorageManagerType
 import protocol WooFoundation.Analytics

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewModel.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 import Yosemite
 import Experiments
 import WooFoundation

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 
 struct Manual: Identifiable, Equatable {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import protocol Storage.StorageManagerType
 import protocol WooFoundation.Analytics

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/OrderStatsV4Interval+Chart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/OrderStatsV4Interval+Chart.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 extension OrderStatsV4Interval {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StatsTimeRangeBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StatsTimeRangeBarViewModel.swift
@@ -1,4 +1,5 @@
 import Experiments
+import Foundation
 import Yosemite
 
 private extension StatsTimeRangeV4 {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StatsTimeRangeV4+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StatsTimeRangeV4+UI.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 extension StatsTimeRangeV4 {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -1,4 +1,5 @@
 import Combine
+import UIKit
 import WidgetKit
 import WooFoundation
 import Yosemite

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 import WooFoundation
 import Yosemite
 import protocol Storage.StorageManagerType

--- a/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Yosemite
 
 protocol Editor {

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
@@ -6,6 +6,10 @@ import Yosemite
 import NetworkingWatchOS
 #endif
 
+#if !os(watchOS)
+import UIKit
+#endif
+
 import WooFoundationCore
 
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 import Yosemite
 import protocol Storage.StorageManagerType
 import protocol WooFoundation.Analytics

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import Experiments
 import protocol WooFoundation.Analytics

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -2,6 +2,7 @@ import Yosemite
 import Combine
 import protocol Storage.StorageManagerType
 import Experiments
+import UIKit
 import WooFoundation
 import enum Networking.DotcomError
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Taxes/TaxEducationalDialogViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Taxes/TaxEducationalDialogViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 import WooFoundation
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingLineViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingLineViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import WooFoundation
 import Yosemite
 import protocol Experiments.FeatureFlagService

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModel.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 import Yosemite
 import Experiments
 import class WordPressShared.EmailFormatValidator

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 import Yosemite
 import protocol Storage.StorageManagerType
 import protocol WooFoundation.Analytics

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundCoordinatingController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 
 /// Controls navigation for the issue refund feedback flow. Meant to be presented modally.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import WooFoundation
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderFulfillmentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderFulfillmentUseCase.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 import Yosemite
 import protocol WooFoundation.Analytics
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import protocol Storage.StorageManagerType
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelServicePackageListViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Yosemite
 
 /// View model for `ShippingLabelServicePackageList`.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Yosemite
 import WooFoundation
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftUI
 
 /// View to display the available shipping services (carriers and rates) with the Woo Shipping extension.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -1,3 +1,5 @@
+import Combine
+import Foundation
 import Yosemite
 import protocol WooFoundation.Analytics
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
@@ -1,3 +1,6 @@
+import Combine
+import Foundation
+import UIKit
 import Yosemite
 import WooFoundation
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
@@ -1,3 +1,5 @@
+import Combine
+import Foundation
 import Yosemite
 
 final class WooShippingNormalizeAddressViewModel: ObservableObject, Identifiable {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Date Range Filter/OrderDateRangeFilter+Utils.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Date Range Filter/OrderDateRangeFilter+Utils.swift
@@ -1,3 +1,5 @@
+import Foundation
+import UIKit
 import Yosemite
 
 /// Extension of OrderDateRangeFilter struct

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -1,4 +1,6 @@
 import Combine
+import Foundation
+import UIKit
 import Experiments
 import Yosemite
 import class AutomatticTracks.CrashLogging

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import UIKit
 import Yosemite
 import WooFoundation
 import protocol Storage.StorageManagerType

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import protocol WooFoundation.Analytics
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import protocol WooFoundation.Analytics
 import Experiments

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedViewModel.swift
@@ -1,3 +1,5 @@
+import Foundation
+import UIKit
 import Yosemite
 import protocol WooFoundation.Analytics
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 /// Creates a new product given a set of parameters.

--- a/WooCommerce/Classes/ViewRelated/Products/BottomSheetListSelector/ProductsSortOrderBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/BottomSheetListSelector/ProductsSortOrderBottomSheetListSelectorCommand.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 private extension ProductsSortOrder {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/BottomSheetProductType.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/BottomSheetProductType.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 
 /// Represents the product types available when creating or editing products.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/ProductBundleItemStockStatus+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/ProductBundleItemStockStatus+UI.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 extension ProductBundleItemStockStatus {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/CompositeComponentOptionType+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/CompositeComponentOptionType+UI.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 extension CompositeComponentOptionType {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileSource.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 
 /// Actions in the downloadable file form bottom sheet to add a new downloadable file.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 import WooFoundation
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 import WooFoundation
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 /// Represents an editable data model based on `Product`.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 /// Represents an editable data model based on `ProductVariation`.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/Product+InventorySettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/Product+InventorySettingsViewModels.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 extension Product {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventoryEditableData.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventoryEditableData.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 /// Contains editable properties of a product model in the inventory settings.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewModel.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 import Yosemite
 import Experiments
 import WooFoundation

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/ProductListSelector/ProductListMultiSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/ProductListSelector/ProductListMultiSelectorDataSource.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 import Yosemite
 
 /// Enables the user to select multiple products from a paginated list.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/ProductListSelector/ProductListMultiSelectorSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/ProductListSelector/ProductListMultiSelectorSearchUICommand.swift
@@ -1,3 +1,5 @@
+import Foundation
+import UIKit
 import Yosemite
 
 /// Implementation of `SearchUICommand` for selecting linked products to a grouped product from search UI.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 extension Product {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 /// Describes a data model that contains necessary properties for rendering a product form (`ProductFormViewController`).

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 /// Makes network requests for each product form remote action that includes adding/editing a product and password.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -1,4 +1,6 @@
 import Combine
+import Foundation
+import UIKit
 import Yosemite
 import Experiments
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 import Yosemite
 
 /// The type of product form: adding a new one or editing an existing one.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -1,4 +1,6 @@
 import Combine
+import Foundation
+import UIKit
 import Yosemite
 
 /// Provides data for product form UI on a `ProductVariation`, and handles product editing actions.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 extension Product {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 import protocol Storage.StorageManagerType
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/SubscriptionPeriod+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/SubscriptionPeriod+UI.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 import WooFoundation
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/CancellableMedia.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/CancellableMedia.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 import Combine
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
@@ -1,4 +1,5 @@
 import Photos
+import UIKit
 import Yosemite
 import Combine
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageStatus+Extension.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageStatus+Extension.swift
@@ -1,4 +1,5 @@
 import Photos
+import UIKit
 import Yosemite
 
 extension Collection where Element == ProductImageStatus {

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductUIImageLoader.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductUIImageLoader.swift
@@ -1,4 +1,5 @@
 import Photos
+import UIKit
 import Yosemite
 import Combine
 

--- a/WooCommerce/Classes/ViewRelated/Products/Product Loader/ProductVariationLoadUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Product Loader/ProductVariationLoadUseCase.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 
 /// Encapsulates the async logic for loading product variation and related data (its parent product) for UI display.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 import protocol Storage.StorageManagerType
 import Combine

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import Experiments
 

--- a/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 
 private extension ProductStatus {

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 
 final class ReviewViewModel {

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -1,3 +1,5 @@
+import Foundation
+import UIKit
 import Yosemite
 import Networking
 import protocol Storage.StorageManagerType

--- a/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
@@ -1,4 +1,6 @@
 import Combine
+import Foundation
+import UIKit
 import Yosemite
 import protocol WooFoundation.Analytics
 

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemeInstaller.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemeInstaller.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 import enum Networking.InstallThemeError
 import protocol WooFoundation.Analytics

--- a/WooCommerce/Classes/ViewRelated/Top Banner/ErrorTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/ErrorTopBannerFactory.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Yosemite
 import enum Networking.DotcomError
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import Combine
 import protocol Experiments.FeatureFlagService


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When moving from frameworks to Swift packages, see for example https://github.com/woocommerce/woocommerce-ios/pull/15622 and https://github.com/woocommerce/woocommerce-ios/pull/15651, we lose the framework headers which had statements like `#import <Foundation/Foundation.h>`. This means that basic frameworks such as
Foundation and UIKit are no longer imported as part of consumers frameworks such as Yosemite. To simplify the code review of the upcoming PRs migrating those frameworks to Swift packages in `Modules/`, this PR preemptively adds the required imports in the files that need them.

This was done by running `git reset trunk` on the workbench branch `temp-branch-for-swiftpm-migration` and only committing the `import` additions in this branch.

Closes https://linear.app/a8c/issue/AINFRA-673

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.