### PR TITLE
Update duplicated string identifier and re-enable failing test

### DIFF
--- a/WooCommerce/Classes/POS/Utils/POSStockFormatter.swift
+++ b/WooCommerce/Classes/POS/Utils/POSStockFormatter.swift
@@ -25,7 +25,7 @@ struct POSStockFormatter {
             comment: "Label to be displayed in the product's card when out of stock")
 
         static let inStockWithQuantity = NSLocalizedString(
-            "pos.stockStatusLabel.outofstock",
+            "pos.stockStatusLabel.inStockWithQuantity",
             value: "%1$@ in stock",
             comment: "Label to be displayed in the product's card when there's stock of a given product")
     }

--- a/WooCommerce/WooCommerceTests/POS/Presentation/POSStockFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/POSStockFormatterTests.swift
@@ -98,9 +98,7 @@ struct POSStockFormatterTests {
         #expect(stockLabel == "Out of stock")
     }
 
-    // Disabled temporarily due to failure to code freeze 22.5
-    // Context: p1748609128918879?thread_ts=1748592083.887729&cid=CC7L49W13-slack-CC7L49W13
-    @Test(.disabled()) func test_when_managestock_enabled_and_stockQuantity_is_positive_then_returns_number_in_stock_stockLabel() async throws {
+    @Test func test_when_managestock_enabled_and_stockQuantity_is_positive_then_returns_number_in_stock_stockLabel() async throws {
         // Given
         let manageStockEnabled: Bool = true
         let stockQuantity: Decimal = 5


### PR DESCRIPTION
## Description
This test updates the duplicated string `pos.stockStatusLabel.outofstock` identifier and re-enables the test we disabled on p1748592083887729-slack-CC7L49W13 in order to unblock 22.5 code freeze.

The string usage is behind a feature flag and not currently visible.

## Testing information

CI should pass.