### PR TITLE
[WCAG 2.1 AA] Blaze budget VoiceOver update

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -69,6 +69,9 @@ private extension BlazeBudgetSettingView {
                        in: viewModel.dailyAmountSliderRange,
                        step: BlazeBudgetSettingViewModel.Constants.dailyAmountSliderStep)
             }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(Localization.dailySpend)
+            .accessibilityValue(String(format: Localization.dailySpendValue, Int(viewModel.dailyAmount)))
 
             // Schedule
             VStack(alignment: .leading) {
@@ -213,6 +216,11 @@ private extension BlazeBudgetSettingView {
             "blazeBudgetSettingView.dailySpend",
             value: "Daily spend",
             comment: "Title label for the daily spend amount on the Blaze ads campaign budget settings screen."
+        )
+        static let dailySpendValue = NSLocalizedString(
+            "blazeBudgetSettingView.dailySpendValue",
+            value: "$%d",
+            comment: "Value format for the daily spend amount on the Blaze ads campaign budget settings screen."
         )
         static let estimatedImpressions = NSLocalizedString(
             "blazeBudgetSettingView.estimatedTotalImpressions",

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -53,6 +53,7 @@ private extension BlazeBudgetSettingView {
                     .multilineTextAlignment(.center)
                     .subheadlineStyle()
             }
+            .accessibilityElement(children: .combine)
 
             // Daily budget amount details
             VStack(spacing: Layout.dailyBudgetSectionSpacing) {

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -94,7 +94,7 @@ private extension BlazeBudgetSettingView {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            // Estimated impressions
+            // Estimated impressions - grouped for accessibility
             VStack(alignment: .leading) {
                 Button {
                     showingImpressionInfo = true
@@ -106,12 +106,15 @@ private extension BlazeBudgetSettingView {
                     .font(.subheadline)
                 }
                 .buttonStyle(.plain)
-                .accessibilityHint(Localization.estimatedImpressionsAccessibilityHint)
                 .renderedIf(viewModel.forecastedImpressionState != .failure)
 
                 forecastedImpressionsView
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityElement(children: .ignore)
+            .accessibilityAddTraits(.isButton)
+            .accessibilityHint(Localization.estimatedImpressionsAccessibilityHint)
+            .accessibilityLabel(viewModel.impressionsSectionAccessibilityLabel)
         }
     }
 
@@ -120,7 +123,7 @@ private extension BlazeBudgetSettingView {
         switch viewModel.forecastedImpressionState {
         case .loading:
             ActivityIndicator(isAnimating: .constant(true), style: .medium)
-        case .result(let formattedResult):
+        case .result(let formattedResult, _, _):
             Text(formattedResult)
                 .fontWeight(.semibold)
                 .tertiaryTitleStyle()

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -161,7 +161,7 @@ private extension BlazeBudgetSettingView {
                     .bodyStyle()
                     .padding(Layout.contentPadding)
             }
-            .navigationTitle(Localization.title)
+            .navigationTitle(Localization.impressions)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
@@ -242,6 +242,11 @@ private extension BlazeBudgetSettingView {
             "blazeBudgetSettingView.update",
             value: "Update",
             comment: "Button to update the budget on the Blaze budget setting screen"
+        )
+        static let impressions = NSLocalizedString(
+            "blazeBudgetSettingView.impressions",
+            value: "Impressions",
+            comment: "Title of the modal to explain Blaze campaign impressions"
         )
         static let impressionInfo = NSLocalizedString(
             "blazeBudgetSettingView.impressionInfo",

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -111,7 +111,7 @@ private extension BlazeBudgetSettingView {
                 forecastedImpressionsView
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .accessibilityElement(children: .ignore)
+            .accessibilityElement(children: .combine)
             .accessibilityAddTraits(.isButton)
             .accessibilityHint(Localization.estimatedImpressionsAccessibilityHint)
             .accessibilityLabel(viewModel.impressionsSectionAccessibilityLabel)

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -242,11 +242,6 @@ private extension BlazeBudgetSettingView {
             value: "Update",
             comment: "Button to update the budget on the Blaze budget setting screen"
         )
-        static let impressions = NSLocalizedString(
-            "blazeBudgetSettingView.impressions",
-            value: "Impressions",
-            comment: "Title of the modal to explain Blaze campaign impressions"
-        )
         static let impressionInfo = NSLocalizedString(
             "blazeBudgetSettingView.impressionInfo",
             value: "Impressions reflect the frequency with which your ad appears to potential customers.\n\n" +

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -93,6 +93,9 @@ private extension BlazeBudgetSettingView {
                 .tertiaryTitleStyle()
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityElement(children: .combine)
+            .accessibilityAddTraits(.isButton)
+            .accessibilityHint(Localization.scheduleAccessibilityHint)
 
             // Estimated impressions - grouped for accessibility
             VStack(alignment: .leading) {
@@ -273,6 +276,11 @@ private extension BlazeBudgetSettingView {
             "blazeBudgetSettingView.estimatedImpressionsAccessibilityHint",
             value: "Tap for more information about estimated impressions",
             comment: "Accessibility hint for the estimated impression button on the Blaze campaign budget setting screen"
+        )
+        static let scheduleAccessibilityHint = NSLocalizedString(
+            "blazeBudgetSettingView.scheduleAccessibilityHint",
+            value: "Opens campaign schedule settings",
+            comment: "Accessibility hint for the schedule section on the Blaze budget setting screen"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -148,10 +148,26 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
                                               locale: locale,
                                               result.totalImpressionsMin,
                                               result.totalImpressionsMax)
-            forecastedImpressionState = .result(formattedResult: formattedImpressions)
+            forecastedImpressionState = .result(
+                formattedResult: formattedImpressions,
+                minValue: result.totalImpressionsMin,
+                maxValue: result.totalImpressionsMax
+            )
         } catch {
             DDLogError("⛔️ Error fetching forecasted impression: \(error)")
             forecastedImpressionState = .failure
+        }
+    }
+
+    /// Provides a combined accessibility label for the entire impressions section
+    var impressionsSectionAccessibilityLabel: String {
+        switch forecastedImpressionState {
+        case .result(_, let minValue, let maxValue):
+            return String.localizedStringWithFormat(Localization.impressionsSectionAccessibility, minValue, maxValue)
+        case .loading:
+            return Localization.impressionsLoading
+        case .failure:
+            return Localization.impressionsFailure
         }
     }
 }
@@ -227,7 +243,7 @@ extension BlazeBudgetSettingViewModel {
 
     enum ForecastedImpressionState: Equatable {
         case loading
-        case result(formattedResult: String)
+        case result(formattedResult: String, minValue: Int64, maxValue: Int64)
         case failure
     }
 
@@ -285,6 +301,22 @@ extension BlazeBudgetSettingViewModel {
             value: "%1$@ weekly spend",
             comment: "The total amount for weekly spend on the Blaze budget setting screen. " +
             "Reads like: $35 USD weekly spend"
+        )
+        static let impressionsSectionAccessibility = NSLocalizedString(
+            "blazeBudgetSettingViewModel.impressionsSectionAccessibility",
+            value: "Estimated total impressions range is from %1$lld to %2$lld",
+            comment: "The formatted estimated impression range for a Blaze campaign. " +
+            "Reads like: Estimated total impressions range is from 26100 to 35300"
+        )
+        static let impressionsLoading = NSLocalizedString(
+            "blazeBudgetSettingViewModel.impressionsLoading",
+            value: "Loading...",
+            comment: "The label for loading impressions"
+        )
+        static let impressionsFailure = NSLocalizedString(
+            "blazeBudgetSettingViewModel.impressionsFailure",
+            value: "Failed to load impressions",
+            comment: "The label for failed to load impressions"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeScheduleSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeScheduleSettingView.swift
@@ -91,6 +91,9 @@ struct BlazeScheduleSettingView: View {
                            in: dayCountSliderRange,
                            step: Double(BlazeBudgetSettingViewModel.Constants.dayCountSliderStep))
                 }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(Localization.duration)
+                .accessibilityValue(durationTextFormatter(duration).string)
                 .renderedIf(hasEndDate)
 
                 Spacer()

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeScheduleSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeScheduleSettingView.swift
@@ -43,6 +43,7 @@ struct BlazeScheduleSettingView: View {
                 AdaptiveStack(horizontalAlignment: .leading) {
                     Text(Localization.startDate)
                         .bodyStyle()
+                        .accessibilityHidden(true)
 
                     Spacer().renderedIf(sizeCategory.isAccessibilityCategory == false)
 
@@ -58,8 +59,6 @@ struct BlazeScheduleSettingView: View {
                         view.datePickerStyle(.compact)
                     }
                 }
-                .accessibilityElement(children: .combine)
-                .accessibilityAddTraits(.isButton)
                 .accessibilityHint(Localization.startDateAccessibilityHint)
                 .accessibilityLabel(
                     String(
@@ -71,6 +70,18 @@ struct BlazeScheduleSettingView: View {
                         )
                     )
                 )
+                // Apply accessibility grouping only for non-accessibility size categories.
+                // For accessibility size categories, we use .graphical date picker style which is embedded
+                // directly in the view and maintains its native "date picker" traits. For standard size
+                // categories, we use .compact date picker style which acts as a popover, so we group the
+                // elements with .combine and add .isButton trait to make the entire section actionable.
+                // Applying .combine to the graphical date picker would override its native accessibility
+                // traits and degrade the user experience.
+                .if(!sizeCategory.isAccessibilityCategory) { view in
+                    view
+                    .accessibilityElement(children: .combine)
+                    .accessibilityAddTraits(.isButton)
+                }
 
                 // Toggle to switch between evergreen and not. Hidden under a feature flag.
                 Toggle(Localization.specifyDuration, isOn: $hasEndDate)

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeScheduleSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeScheduleSettingView.swift
@@ -53,6 +53,19 @@ struct BlazeScheduleSettingView: View {
                     }
                                .datePickerStyle(.compact)
                 }
+                .accessibilityElement(children: .combine)
+                .accessibilityAddTraits(.isButton)
+                .accessibilityHint(Localization.startDateAccessibilityHint)
+                .accessibilityLabel(
+                    String(
+                        format: Localization.startDateAccessibilityLabel,
+                        DateFormatter.localizedString(
+                            from: startDate,
+                            dateStyle: .medium,
+                            timeStyle: .none
+                        )
+                    )
+                )
 
                 // Toggle to switch between evergreen and not. Hidden under a feature flag.
                 Toggle(Localization.specifyDuration, isOn: $hasEndDate)
@@ -148,6 +161,16 @@ private extension BlazeScheduleSettingView {
             "blazeScheduleSettingView.cancel",
             value: "Cancel",
             comment: "Button to dismiss the Blaze schedule setting screen"
+        )
+        static let startDateAccessibilityLabel = NSLocalizedString(
+            "blazeScheduleSettingView.startDateAccessibilityLabel",
+            value: "Campaign start date is %@",
+            comment: "Accessibility label for the start date picker on the Blaze campaign duration setting screen. %@ is replaced with the selected date."
+        )
+        static let startDateAccessibilityHint = NSLocalizedString(
+            "blazeScheduleSettingView.startDateAccessibilityHint",
+            value: "Double tap to edit the campaign start date",
+            comment: "Accessibility hint for the start date picker on the Blaze campaign duration setting screen"
         )
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeBudgetSettingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeBudgetSettingViewModelTests.swift
@@ -150,7 +150,14 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
         await viewModel.updateImpressions(startDate: .now, dayCount: 3, dailyBudget: 15)
 
         // Then
-        XCTAssertEqual(viewModel.forecastedImpressionState, .result(formattedResult: "1,000 - 5,000"))
+        XCTAssertEqual(
+            viewModel.forecastedImpressionState,
+            .result(
+                formattedResult: "1,000 - 5,000",
+                minValue: 1000,
+                maxValue: 5000
+            )
+        )
     }
 
     @MainActor


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
Part of: WOOMOB-505

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds accessibility customization to address grouping issues below for better EAA compliance:
- Each label/element was announced independently.
- “Set your budget” wasn’t announced as a title.
- “Daily spend” and “$5” weren’t announced together as a group.
- Scroll bar selector wasn’t announced as a “daily spend” selector but just as some general selector.

### Accessibility Improvements Justification

To align with the **EU Accessibility Act** and ensure compliance with **WCAG 2.1 Level AA**, the following VoiceOver-specific enhancements have been implemented:

#### 1. Semantic Grouping of UI Elements
- **Related WCAG Criterion**: [1.3.1 – Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html)
- Grouped related UI elements to convey structural and semantic relationships. This allows VoiceOver users to understand contextual connections between controls (e.g., labels and inputs, grouped options), improving overall screen comprehension and navigation efficiency.

#### 2. Custom Accessibility Labels and Hints
- **Related WCAG Criterion**: [4.1.2 – Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)
- Added manual `accessibilityLabel` and `accessibilityHint` values to ensure all interactive elements have clear, descriptive identifiers and instructions. This enhances the usability of the app for screen reader users by providing meaningful and actionable descriptions.

#### 3. Improved Navigation Order and Context
- **Related WCAG Criteria**: 
  - [2.4.3 – Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html)
  - [2.4.6 – Headings and Labels](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html)
- Adjusted the screen reading order and ensured that all headings and labels provide sufficient context. This helps VoiceOver users maintain orientation within the interface and improves task flow predictability.


## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Navigate to a product details screen
- Open "Promote with blaze" for that product
- Go to "Details" -> "Budget"
- Enable VoiceOver and iterate through header wording to the budget selector group
- Make sure Header (title + subtitle) are grouped
- Make sure the budget selector title, value and slider are grouped as one accessibility element
- Make sure the voice over notation sounds logical for the budget control so it announces the control purpose, current value and directions about how to change the value.

## Demo
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/f10ad769-46ca-46b0-ac9a-c754766d82d9

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.