### PR TITLE
Update Codegen to work with sync folder and packages

### DIFF
--- a/Fakes/Fakes.xcodeproj/project.pbxproj
+++ b/Fakes/Fakes.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		26EEDC9026FE1C7B00D5BA0E /* Networking.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EEDC8E26FE1C7B00D5BA0E /* Networking.generated.swift */; };
 		26EEDC9126FE1C7B00D5BA0E /* Yosemite.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EEDC8F26FE1C7B00D5BA0E /* Yosemite.generated.swift */; };
 		3F2B4AC22DDC30B200E5E49C /* XcodeTarget_Fakes in Frameworks */ = {isa = PBXBuildFile; productRef = 3F2B4AC12DDC30B200E5E49C /* XcodeTarget_Fakes */; };
+		3F37E1232DEEAC7200D8BF2B /* WooFoundationCore.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F37E1222DEEAC7200D8BF2B /* WooFoundationCore.generated.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -45,6 +46,7 @@
 		26EEDC8C26FE1C1C00D5BA0E /* Yosemite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Yosemite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		26EEDC8E26FE1C7B00D5BA0E /* Networking.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Networking.generated.swift; sourceTree = "<group>"; };
 		26EEDC8F26FE1C7B00D5BA0E /* Yosemite.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Yosemite.generated.swift; sourceTree = "<group>"; };
+		3F37E1222DEEAC7200D8BF2B /* WooFoundationCore.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooFoundationCore.generated.swift; sourceTree = "<group>"; };
 		3FA7DA002D547F2600CE5611 /* Fakes.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Fakes.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -95,6 +97,7 @@
 				26EEDC8E26FE1C7B00D5BA0E /* Networking.generated.swift */,
 				26EEDC8F26FE1C7B00D5BA0E /* Yosemite.generated.swift */,
 				20AD34D02B0CD9AF00F38F44 /* WooFoundation.generated.swift */,
+				3F37E1222DEEAC7200D8BF2B /* WooFoundationCore.generated.swift */,
 				26106B3B25FA4F5F0000DF30 /* Products */,
 				26CA6D2425F6C87800B01F48 /* Fakes.h */,
 				26CA6D2525F6C87800B01F48 /* Info.plist */,
@@ -200,6 +203,7 @@
 				26CA6D2F25F6C8FC00B01F48 /* Fake.swift in Sources */,
 				02B5147E2825532A00750B71 /* Hardware.generated.swift in Sources */,
 				26EEDC9026FE1C7B00D5BA0E /* Networking.generated.swift in Sources */,
+				3F37E1232DEEAC7200D8BF2B /* WooFoundationCore.generated.swift in Sources */,
 				20AD34D12B0CD9AF00F38F44 /* WooFoundation.generated.swift in Sources */,
 				26106B3D25FA4F6C0000DF30 /* ProductFactory.swift in Sources */,
 				26EEDC9126FE1C7B00D5BA0E /* Yosemite.generated.swift in Sources */,

--- a/Fakes/Fakes/WooFoundation.generated.swift
+++ b/Fakes/Fakes/WooFoundation.generated.swift
@@ -6,10 +6,3 @@ import Networking
 import Hardware
 import WooFoundation
 
-extension WooFoundation.CurrencyCode {
-    /// Returns a "ready to use" type filled with fake values.
-    ///
-    public static func fake() -> WooFoundation.CurrencyCode {
-        .AED
-    }
-}

--- a/Fakes/Fakes/WooFoundation.generated.swift
+++ b/Fakes/Fakes/WooFoundation.generated.swift
@@ -1,8 +1,4 @@
 // Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
-import Yosemite
-import Networking
-import Hardware
-import WooFoundation
-
+// Currently empty because none of the given sources conforms to GeneratedFakeable

--- a/Fakes/Fakes/WooFoundationCore.generated.swift
+++ b/Fakes/Fakes/WooFoundationCore.generated.swift
@@ -1,0 +1,15 @@
+// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import Yosemite
+import Networking
+import Hardware
+import WooFoundation
+
+extension WooFoundationCore.CurrencyCode {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> WooFoundationCore.CurrencyCode {
+        .AED
+    }
+}

--- a/Modules/Sources/Codegen/Sourcery/Copiable/Models+Copiable.swifttemplate
+++ b/Modules/Sources/Codegen/Sourcery/Copiable/Models+Copiable.swifttemplate
@@ -182,8 +182,14 @@ let specsToGenerate: [CopiableSpec] = matchingTypes.map { type in
         )
     }
 
+    // When passing an Xcode project with synchronized folders or a source from a Swift package, globalName will not include the module name.
+    var name = type.globalName
+    if let moduleName = argument["moduleName"] as? String {
+        name = "\(moduleName).\(name)"
+    }
+
     return CopiableSpec(
-        name: type.globalName,
+        name: name,
         accessLevelWithSpacePostfix: type.accessLevel == "internal" ? "" : "\(type.accessLevel) ",
         properties: propSpecs
     )

--- a/Modules/Sources/Codegen/Sourcery/Copiable/Networking-Copiable.sourcery.yaml
+++ b/Modules/Sources/Codegen/Sourcery/Copiable/Networking-Copiable.sourcery.yaml
@@ -1,7 +1,8 @@
-project: 
-    file: ../../../../../Networking/Networking.xcodeproj
-    target: 
-        name: Networking
+sources:
+    include:
+        - ../../../../../Networking/Sources
 templates:
     - Models+Copiable.swifttemplate
-output: ../../../../../Networking/Networking/Model/Copiable/
+output: ../../../../../Networking/Sources/Extended/Model/Copiable/
+args:
+    moduleName: Networking

--- a/Modules/Sources/Codegen/Sourcery/Copiable/WooFoundation-Copiable.sourcery.yaml
+++ b/Modules/Sources/Codegen/Sourcery/Copiable/WooFoundation-Copiable.sourcery.yaml
@@ -1,7 +1,17 @@
-project:
-    file: ../../../../../WooFoundation/WooFoundation.xcodeproj
-    target:
-        name: WooFoundation
-templates:
-    - Models+Copiable.swifttemplate
-output: ../../../../../WooFoundation/WooFoundation/Model/Copiable/
+configurations:
+    - sources:
+        include:
+            - ../../../../../Modules/Sources/WooFoundation
+      templates:
+          - Models+Copiable.swifttemplate
+      output: ../../../../../Modules/Sources/WooFoundation/Model/Copiable/
+      args:
+          moduleName: WooFoundation
+    - sources:
+        include:
+            - ../../../../../Modules/Sources/WooFoundationCore
+      templates:
+          - Models+Copiable.swifttemplate
+      output: ../../../../../Modules/Sources/WooFoundationCore/Model/Copiable/
+      args:
+          moduleName: WooFoundationCore

--- a/Modules/Sources/Codegen/Sourcery/Fakes/Fakes.swifttemplate
+++ b/Modules/Sources/Codegen/Sourcery/Fakes/Fakes.swifttemplate
@@ -89,6 +89,9 @@ let specsToGenerate: [FakeableSpec] = matchingTypes.map { type in
 // Template
 // --------------------------------------------------------------------------------
 -%>
+<% if specsToGenerate.isEmpty { -%>
+// Currently empty because none of the given sources conforms to GeneratedFakeable
+<% } else { -%>
 import Yosemite
 import Networking
 import Hardware
@@ -110,4 +113,5 @@ extension <%= spec.name -%> {
 <% } -%>
     }
 }
+<% } -%>
 <% } -%>

--- a/Modules/Sources/Codegen/Sourcery/Fakes/Fakes.swifttemplate
+++ b/Modules/Sources/Codegen/Sourcery/Fakes/Fakes.swifttemplate
@@ -53,7 +53,13 @@ let specsToGenerate: [FakeableSpec] = matchingTypes.map { type in
 
     /// If we are generating for an `Enum`, return with `.value` for content 
     if let enumType = type as? Enum, let firstEnumCase = enumType.cases.first {
-        return FakeableSpec(name: enumType.globalName, accessLevelWithSpacePostfix: accessLevel, content: .value(firstEnumCase.name))
+        var name = enumType.globalName
+        // When passing an Xcode project with synchronized folders or a source from a Swift package, globalName will not include the module name.
+        if let moduleName = argument["moduleName"] as? String {
+            name = "\(moduleName).\(name)"
+        }
+
+        return FakeableSpec(name: name, accessLevelWithSpacePostfix: accessLevel, content: .value(firstEnumCase.name))
     }
 
     /// Make sure we have at least one non throwable-initializer to work with.
@@ -69,7 +75,13 @@ let specsToGenerate: [FakeableSpec] = matchingTypes.map { type in
         )
     }
 
-    return FakeableSpec(name: type.globalName, accessLevelWithSpacePostfix: accessLevel, content: .initializer(propSpecs))
+    // When passing an Xcode project with synchronized folders or a source from a Swift package, globalName will not include the module name.
+    var name = type.globalName
+    if let moduleName = argument["moduleName"] as? String {
+        name = "\(moduleName).\(name)"
+    }
+
+    return FakeableSpec(name: name, accessLevelWithSpacePostfix: accessLevel, content: .initializer(propSpecs))
 }
 -%>
 <%#

--- a/Modules/Sources/Codegen/Sourcery/Fakes/Networking-Fakes.yaml
+++ b/Modules/Sources/Codegen/Sourcery/Fakes/Networking-Fakes.yaml
@@ -1,8 +1,8 @@
-project:
-    file: ../../../../../Networking/Networking.xcodeproj
-    target:
-        name: Networking
+sources:
+    include:
+        - ../../../../../Networking/Sources
 templates:
     - Fakes.swifttemplate
 output: ../../../../../Fakes/Fakes/Networking.generated.swift
-
+args:
+    moduleName: Networking

--- a/Modules/Sources/Codegen/Sourcery/Fakes/WooFoundation-Fakes.yaml
+++ b/Modules/Sources/Codegen/Sourcery/Fakes/WooFoundation-Fakes.yaml
@@ -1,7 +1,17 @@
-project:
-    file: ../../../../../WooFoundation/WooFoundation.xcodeproj
-    target:
-        name: WooFoundation
-templates:
-    - Fakes.swifttemplate
-output: ../../../../../Fakes/Fakes/WooFoundation.generated.swift
+configurations:
+    - sources:
+        include:
+            - ../../../../../Modules/Sources/WooFoundation
+      templates:
+          - Fakes.swifttemplate
+      output: ../../../../../Fakes/Fakes/WooFoundation.generated.swift
+      args:
+          moduleName: WooFoundation
+    - sources:
+        include:
+            - ../../../../../Modules/Sources/WooFoundationCore
+      templates:
+          - Fakes.swifttemplate
+      output: ../../../../../Fakes/Fakes/WooFoundationCore.generated.swift
+      args:
+          moduleName: WooFoundationCore

--- a/Networking/Sources/Extended/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Sources/Extended/Model/Copiable/Models+Copiable.generated.swift
@@ -1939,7 +1939,7 @@ extension Networking.PaymentGateway {
         title: CopiableProp<String> = .copy,
         description: CopiableProp<String> = .copy,
         enabled: CopiableProp<Bool> = .copy,
-        features: CopiableProp<[PaymentGateway.Feature]> = .copy,
+        features: CopiableProp<[Feature]> = .copy,
         instructions: NullableCopiableProp<String> = .copy
     ) -> Networking.PaymentGateway {
         let siteID = siteID ?? self.siteID
@@ -3113,7 +3113,7 @@ extension Networking.ShippingLabelAccountSettings {
         isEmailReceiptsEnabled: CopiableProp<Bool> = .copy,
         paperSize: CopiableProp<ShippingLabelPaperSize> = .copy,
         lastSelectedPackageID: CopiableProp<String> = .copy,
-        addPaymentMethodURL: CopiableProp<URL> = .copy
+        addPaymentMethodURL: NullableCopiableProp<URL> = .copy
     ) -> Networking.ShippingLabelAccountSettings {
         let siteID = siteID ?? self.siteID
         let canManagePayments = canManagePayments ?? self.canManagePayments
@@ -4248,7 +4248,7 @@ extension Networking.WooShippingAddress {
 extension Networking.WooShippingConfig {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,
-        shipments: CopiableProp<WooShippingShipments> = .copy,
+        shipments: CopiableProp<[String: [WooShippingShipmentItem]]> = .copy,
         shippingLabelData: NullableCopiableProp<WooShippingLabelData> = .copy
     ) -> Networking.WooShippingConfig {
         let siteID = siteID ?? self.siteID
@@ -4509,7 +4509,7 @@ extension Networking.WooShippingShipmentItem {
 extension Networking.WooShippingUpdateShipment {
     public func copy(
         shipmentIdsToUpdate: CopiableProp<[String]> = .copy,
-        shipments: CopiableProp<WooShippingShipments> = .copy
+        shipments: CopiableProp<[String: [WooShippingShipmentItem]]> = .copy
     ) -> Networking.WooShippingUpdateShipment {
         let shipmentIdsToUpdate = shipmentIdsToUpdate ?? self.shipmentIdsToUpdate
         let shipments = shipments ?? self.shipments
@@ -4523,7 +4523,7 @@ extension Networking.WooShippingUpdateShipment {
 
 extension Networking.WooShippingUpdateShipmentResponse {
     public func copy(
-        shipments: CopiableProp<WooShippingShipments> = .copy
+        shipments: CopiableProp<[String: [WooShippingShipmentItem]]> = .copy
     ) -> Networking.WooShippingUpdateShipmentResponse {
         let shipments = shipments ?? self.shipments
 

--- a/Rakefile
+++ b/Rakefile
@@ -120,7 +120,7 @@ end
 desc 'Run all code generation tasks'
 task :generate do
   # See note in BuildTools/.sourcery.yml for why we call without arguments
-  run_package_plugin(cmd: 'sourcery-command')
+  run_package_plugin(cmd: 'sourcery-command --disableCache')
 end
 
 def fold(label)


### PR DESCRIPTION
<!-- blue -->
> [!NOTE]  
> Superseded by #15707

---

<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
Updates the Sourcery configuration to restore code generation after the recent changes to WooFoundation and Networking.

**WooFoundation**

When updating WooFoundation to be a Swift package, see https://github.com/woocommerce/woocommerce-ios/pull/15651, I neglected updating the Codegen/Sourcery configuration.

In the migration from framework to package, we lost the Xcode project file. Sourcery provides a `package` configuration option, but I was not able to make it work.

The only option I could find was to list `sources`.

**Networking**

It seems that after migrating the Networking project to synchronized folders, https://github.com/woocommerce/woocommerce-ios/pull/15653, Sourcery could no longer access the sources.

The only fix I could find was to move from passing a `project` to passing a straight `sources` array.

**`args.moduleName`**

Unfortunately using `sources` results in Sourcery being unable to add the module name to the `globalName` property which we use in the templates to identify each of the types handle. Including the module is necessary to avoid name clashes. To work around this limitation, I updated the template to check for an optional `moduleName` argument in the configuration and interpolate it in the type name if present.

Later, I'll follow up with bug reports on Sourcery. Either they'll help me fix the configuration, or this will be useful for them to address an edge case.

I also created https://linear.app/a8c/issue/AINFRA-679 to follow this up by adding a CI step to run codegen one every build and fail when there are untracked changes.

## Steps to reproduce & Testing information
Checkout this branch and run `bundle exec rake generate`. It should not result in any code change.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.