### PR TITLE
[WCAG 2.1 AA] Resolve remaining Blaze accessibility layout issues

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeScheduleSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeScheduleSettingView.swift
@@ -51,7 +51,12 @@ struct BlazeScheduleSettingView: View {
                                displayedComponents: [.date]) {
                         EmptyView()
                     }
-                               .datePickerStyle(.compact)
+                    .if(sizeCategory.isAccessibilityCategory) { view in
+                        view.datePickerStyle(.graphical)
+                    }
+                    .if(!sizeCategory.isAccessibilityCategory) { view in
+                        view.datePickerStyle(.compact)
+                    }
                 }
 
                 // Toggle to switch between evergreen and not. Hidden under a feature flag.

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -329,7 +329,7 @@ private extension BlazeCampaignCreationForm {
                 if viewModel.isLoadingAISuggestions ||
                     viewModel.ctaText.isNotEmpty {
                     Text(viewModel.isLoadingAISuggestions ? "CTA placeholder" : viewModel.ctaText)
-                        .font(.system(size: Constants.ctaButtonFontSize))
+                        .font(.caption)
                         .foregroundColor(Constants.backgroundViewColor)
                         .padding(Layout.ctaButtonPadding)
                         .background(Constants.ctaButtonColor)
@@ -477,8 +477,6 @@ private extension BlazeCampaignCreationForm {
         static let ctaButtonColor = Color(red: 0, green: 0.219, blue: 1)
 
         static let ctaButtonTextColor = Color.white
-
-        static let ctaButtonFontSize: CGFloat = 13
 
         static let supportTag = "origin:blaze-native-campaign-creation"
     }

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
@@ -12,14 +12,26 @@ struct BlazeConfirmPaymentView: View {
     @State private var showingAddPaymentWebView: Bool = false
     @State private var isShowingSupport = false
 
-    private let agreementText: NSAttributedString = {
+    /// Computed property to ensure the attributed string is recreated with current accessibility font settings
+    /// when dynamic type size changes, rather than being fixed at initialization time.
+    private var agreementText: NSAttributedString {
         let content = String.localizedStringWithFormat(Localization.agreement, Localization.termsOfService, Localization.adPolicy, Localization.learnMore)
         let paragraph = NSMutableParagraphStyle()
         paragraph.alignment = .center
 
+        // Cap the font size to prevent the footer from becoming too large
+        let baseFont = UIFont.preferredFont(forTextStyle: .caption1)
+        let cappedFont = baseFont.pointSize > Layout.maxAgreementTextFontSize ?
+            UIFont.preferredFont(
+                forTextStyle: .caption1,
+                compatibleWith: UITraitCollection(
+                    preferredContentSizeCategory: .accessibilityMedium
+                )
+            ) : baseFont
+
         let mutableAttributedText = NSMutableAttributedString(
             string: content,
-            attributes: [.font: UIFont.caption1,
+            attributes: [.font: cappedFont,
                          .foregroundColor: UIColor.secondaryLabel,
                          .paragraphStyle: paragraph]
         )
@@ -31,7 +43,7 @@ struct BlazeConfirmPaymentView: View {
         mutableAttributedText.setAsLink(textToFind: Localization.learnMore,
                                         linkURL: Constants.learnMoreLink)
         return mutableAttributedText
-    }()
+    }
 
     init(viewModel: BlazeConfirmPaymentViewModel) {
         self.viewModel = viewModel
@@ -250,6 +262,7 @@ private extension BlazeConfirmPaymentView {
     enum Layout {
         static let contentPadding: CGFloat = 16
         static let cardIconWidth: CGFloat = 35
+        static let maxAgreementTextFontSize: CGFloat = 20
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
@@ -7,6 +7,7 @@ struct BlazeConfirmPaymentView: View {
     @ScaledMetric private var scale: CGFloat = 1.0
     @ObservedObject private var viewModel: BlazeConfirmPaymentViewModel
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.sizeCategory) private var sizeCategory
 
     @State private var externalURL: URL?
     @State private var showingAddPaymentWebView: Bool = false
@@ -19,19 +20,9 @@ struct BlazeConfirmPaymentView: View {
         let paragraph = NSMutableParagraphStyle()
         paragraph.alignment = .center
 
-        // Cap the font size to prevent the footer from becoming too large
-        let baseFont = UIFont.preferredFont(forTextStyle: .caption1)
-        let cappedFont = baseFont.pointSize > Layout.maxAgreementTextFontSize ?
-            UIFont.preferredFont(
-                forTextStyle: .caption1,
-                compatibleWith: UITraitCollection(
-                    preferredContentSizeCategory: .accessibilityMedium
-                )
-            ) : baseFont
-
         let mutableAttributedText = NSMutableAttributedString(
             string: content,
-            attributes: [.font: cappedFont,
+            attributes: [.font: UIFont.caption1,
                          .foregroundColor: UIColor.secondaryLabel,
                          .paragraphStyle: paragraph]
         )
@@ -72,7 +63,11 @@ struct BlazeConfirmPaymentView: View {
                         .padding(.horizontal, Layout.contentPadding)
                 }
 
-                Divider()
+                if sizeCategory.isAccessibilityCategory {
+                    footerView
+                } else {
+                    Divider()
+                }
             }
             .padding(.vertical, Layout.contentPadding)
         }
@@ -86,7 +81,9 @@ struct BlazeConfirmPaymentView: View {
             }
         }
         .safeAreaInset(edge: .bottom) {
-            footerView
+            if !sizeCategory.isAccessibilityCategory {
+                footerView
+            }
         }
         .task {
             await viewModel.updatePaymentInfo()
@@ -262,7 +259,6 @@ private extension BlazeConfirmPaymentView {
     enum Layout {
         static let contentPadding: CGFloat = 16
         static let cardIconWidth: CGFloat = 35
-        static let maxAgreementTextFontSize: CGFloat = 20
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderTableViewCell.swift
@@ -4,6 +4,7 @@ import Yosemite
 final class ProductImagesHeaderTableViewCell: UITableViewCell {
 
     @IBOutlet weak var collectionView: UICollectionView!
+    @IBOutlet weak var collectionViewHeightConstraint: NSLayoutConstraint!
 
     /// View Model
     ///
@@ -34,6 +35,7 @@ final class ProductImagesHeaderTableViewCell: UITableViewCell {
 
         configureBackground()
         configureSeparator()
+        updateCollectionViewHeight()
     }
 
     /// Configure cell
@@ -54,14 +56,24 @@ final class ProductImagesHeaderTableViewCell: UITableViewCell {
         }
     }
 
-    /// Rotation management
+    /// Rotation management and accessibility changes
     ///
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection != previousTraitCollection {
+            // Update collection view height for accessibility changes
+            updateCollectionViewHeight()
+            // Invalidate layout when trait collection changes (including accessibility changes)
             collectionView.collectionViewLayout.invalidateLayout()
             collectionView.reloadData()
         }
+    }
+
+    /// Updates the collection view height based on current accessibility settings
+    private func updateCollectionViewHeight() {
+        let cellSize = ProductImagesHeaderViewModel.cellSize(for: traitCollection.preferredContentSizeCategory)
+        // Add padding to accommodate the cell size
+        collectionViewHeightConstraint.constant = cellSize.height + Layout.collectionViewPadding
     }
 }
 
@@ -98,7 +110,8 @@ extension ProductImagesHeaderTableViewCell: UICollectionViewDelegateFlowLayout {
         case .extendedAddImage:
             return frame.size
         default:
-            return ProductImagesHeaderViewModel.defaultCollectionViewCellSize
+            // Use dynamic sizing based on current accessibility settings
+            return ProductImagesHeaderViewModel.cellSize(for: traitCollection.preferredContentSizeCategory)
         }
     }
 }
@@ -141,11 +154,23 @@ private extension ProductImagesHeaderTableViewCell {
 
         self.config = config
 
+        // Update height for the new configuration
+        updateCollectionViewHeight()
+
         switch config {
         case .extendedAddImages:
             collectionView.collectionViewLayout = ProductImagesFlowLayout(itemSize: frame.size, config: config)
         default:
-            collectionView.collectionViewLayout = ProductImagesFlowLayout(itemSize: ProductImagesHeaderViewModel.defaultCollectionViewCellSize, config: config)
+            // Use dynamic sizing based on current accessibility settings
+            let dynamicSize = ProductImagesHeaderViewModel.cellSize(for: traitCollection.preferredContentSizeCategory)
+            collectionView.collectionViewLayout = ProductImagesFlowLayout(itemSize: dynamicSize, config: config)
         }
+    }
+}
+
+private extension ProductImagesHeaderTableViewCell {
+    enum Layout {
+        /// Padding around the collection view (16pt top and bottom)
+        static let collectionViewPadding: CGFloat = 32
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderTableViewCell.xib
@@ -42,6 +42,7 @@
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="collectionView" destination="WFL-te-HOK" id="6lI-qf-ou5"/>
+                <outlet property="collectionViewHeightConstraint" destination="o7N-sD-4mr" id="height-constraint-outlet"/>
             </connections>
             <point key="canvasLocation" x="131.15942028985509" y="122.54464285714285"/>
         </tableViewCell>

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderViewModel.swift
@@ -11,9 +11,6 @@ final class ProductImagesHeaderViewModel {
     /// Whether we should scroll to the beginning of the collection view.
     let shouldScrollToStart: Bool
 
-    // Fixed width/height of collection view cell
-    static let defaultCollectionViewCellSize = CGSize(width: 128.0, height: 128.0)
-
     // Base size for accessibility scaling
     private static let baseCellSize: CGFloat = 128.0
 

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderViewModel.swift
@@ -14,6 +14,25 @@ final class ProductImagesHeaderViewModel {
     // Fixed width/height of collection view cell
     static let defaultCollectionViewCellSize = CGSize(width: 128.0, height: 128.0)
 
+    // Base size for accessibility scaling
+    private static let baseCellSize: CGFloat = 128.0
+
+    /// Returns the appropriate cell size based on the content size category for accessibility
+    static func cellSize(for contentSizeCategory: UIContentSizeCategory) -> CGSize {
+        let scaledSize = scaledValue(baseCellSize, contentSizeCategory: contentSizeCategory, maximumContentSizeCategory: .accessibilityExtraExtraExtraLarge)
+        return CGSize(width: scaledSize, height: scaledSize)
+    }
+
+    /// Returns a scaled value using native iOS scaling, with a maximum cap for accessibility
+    private static func scaledValue(_ value: CGFloat, contentSizeCategory: UIContentSizeCategory, maximumContentSizeCategory: UIContentSizeCategory) -> CGFloat {
+        let metrics = UIFontMetrics.default
+        let scaledValue = metrics.scaledValue(for: value, compatibleWith: .init(preferredContentSizeCategory: contentSizeCategory))
+
+        let maximumScaledValue = metrics.scaledValue(for: value, compatibleWith: .init(preferredContentSizeCategory: maximumContentSizeCategory))
+
+        return min(scaledValue, maximumScaledValue)
+    }
+
     private(set) var items: [ProductImagesItem] = []
 
     init(productImageStatuses: [ProductImageStatus], config: ProductImagesCellConfig) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
Part of: WOOMOB-505

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Resolves layout / accessibility issues in Blaze flow to comply to EAA: p2y3YZ-9eX-p2
- Implements dynamic size scaling for product images in product details screen.
- Adds CTA font scaling in Blaze campaign preview
- In Blaze campaign Budget/Schedule screen embeds `.graphical` date picker **FOR LARGER FONTS ONLY**. Keeps `.compact` for non-accessibility environment. Replaced `.compact` `DatePicker` with `.graphical` style to improve accessibility for users with larger fonts. The `.compact` style does not scale well with Dynamic Type and can become unreadable at accessibility sizes. While `.wheel` supports scaling, it can be harder to navigate for some users. `.graphical` offers better Dynamic Type support, clearer layout, and easier interaction, aligning with WCAG 2.1 AA (1.4.4 – Resize Text, 1.3.1 – Info and Relationships).
- Fixes the Blaze campaign agreement footer text font. Caps the font size below `20` to avoid covering main content.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

**Consider testing on iOS simulator to have a convenient access to font scaling (Cmd • Option • "+/-")**

#### Product image scaling

- Open product details screen
- Toggle larger fonts and make sure the product image cells are scaled correspondingly

Before | After
--- | ---
![Simulator Screenshot - iPhone 16 - 2025-06-02 at 16 44 48](https://github.com/user-attachments/assets/36a19532-bc9a-4fb6-b528-08121bf3fa29) | ![Simulator Screenshot - iPhone 16 - 2025-06-02 at 16 22 17](https://github.com/user-attachments/assets/07d1dd9d-c554-4b16-9c24-bc3c6ab8cb46)

#### Preview CTA text scaling

- Navigate to Blaze campaign creation for a product by tapping "Promote with Blaze" on product details screen
- Scroll down to see the blue CTA button preview
- Toggle larger fonts and make sure the button text is scaled correspondingly

Before | After
--- | ---
<img width="299" alt="Снимок экрана 2025-06-02 в 16 47 12" src="https://github.com/user-attachments/assets/664474a3-3e44-41f7-aa8f-5ccc603f9773" /> | <img width="293" alt="Снимок экрана 2025-06-02 в 16 22 38" src="https://github.com/user-attachments/assets/7e0b3651-a70b-43c4-bc7a-f8b20081ac2e" />

#### Campaign schedule date picker

- In Blaze campaign preview screen select the "Budget" option
- Tap on "Edit" and open a date picker by editing a date
- Toggle accessibility font sizes and make sure that:
   - The compact popover style date picker is presented for smaller fonts
   - The embedded `.graphical` picker is embedded and presented for bigger fonts
- Consider testing same behaviour on iPad

Before | After
--- | ---
<img width="294" alt="Снимок экрана 2025-06-02 в 16 50 27" src="https://github.com/user-attachments/assets/357d5618-9bdf-4d47-9081-a5869bf2cc7d" /> | <img width="297" alt="Снимок экрана 2025-06-02 в 17 02 50" src="https://github.com/user-attachments/assets/fac0e00a-7352-4b46-b22f-7cf7b2e6b4e0" />

#### Blaze campaign agreement text

- On Blaze campaign preview screen make sure all fields are filled to unlock the "Confirm Details" button.
- Tap on "Confirm Details"
- Toggle accessibility font sizes and make sure that bottom confirmation text is scaling up until a certain size.

Before: 

https://github.com/user-attachments/assets/d572e5d0-6625-4307-99b6-9c1e62bb312b

After:

https://github.com/user-attachments/assets/b9f47cf7-f5e2-4fce-9e7f-0e1fe821aefd

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.