### PR TITLE
Bump Fastlane `xcodebuild -showBuildSettings` interval to avoid timeouts

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -150,6 +150,14 @@ def get_required_env(key)
 end
 
 before_all do |lane|
+  # Various actions run 'xcodebuild -showBuildSettings ...' which can at times fail, possibly due to networking and SPM resolution.
+  # See for example this failure https://buildkite.com/automattic/woocommerce-ios/builds/30183#01972179-91dd-4cda-961e-88fa62a8c64f/861-940
+  #
+  # Bumping the interval Fastlane waits for xcodebuild to provide output before retrying seems to be an effective workaround.
+  #
+  # See also https://github.com/fastlane/fastlane/issues/20919
+  ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '120'
+
   # Skip these checks/steps for test lane (not needed for testing)
   next if lane == :test_without_building
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Similarly to https://github.com/wordpress-mobile/WordPress-iOS/pull/23403, this PR bumps up the timeout for the `xcodebuild -showBuildSettings` command to 120 seconds. This aims to reduce UI test flakiness.

- [Example of a UI test failing because the command timed out](https://buildkite.com/automattic/woocommerce-ios/builds/30183#01972179-91dd-4cda-961e-88fa62a8c64f/861-940)
- [Example of a UI test succeeding because the command didn't time out](https://buildkite.com/automattic/woocommerce-ios/builds/30170#0197205e-5020-45f2-afb7-fd61db2a4358/849-931)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Currently when UI tests run (limited to `trunk` and `release` branches) there are retry attempts for the `xcodebuild -showBuildSettings` command. (see examples above)
- After this change there should be no retry attempts in the CI build log.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

CI is green and there are no retries for the `xcodebuild -showBuildSettings` command in the CI build logs.

This can be observed by the UI tests that I forced with this PR:
- [Phone](https://buildkite.com/automattic/woocommerce-ios/builds/30220#01973290-ef9b-4c60-96bd-127dead81870/860-939)
- [iPad](https://buildkite.com/automattic/woocommerce-ios/builds/30220#01973290-ef9c-4840-8e4d-6735ee9b2369/868-947)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
