### PR TITLE
[Woo POS][Barcodes] Fetch Simple Products by GTIN

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		204CBD2B2D43BDBB006FF89A /* wcpay-charge-error-site-credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = 204CBD2A2D43BDBB006FF89A /* wcpay-charge-error-site-credentials.json */; };
 		207D816C2D4A30A30097012E /* products-load-simple-products-empty-price.json in Resources */ = {isa = PBXBuildFile; fileRef = 207D816B2D4A30A30097012E /* products-load-simple-products-empty-price.json */; };
 		20887FAB2D9AA55700F7AE03 /* POSProductsNetworkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20887FAA2D9AA55700F7AE03 /* POSProductsNetworkingTests.swift */; };
+		20A8E9302DEF4EC9000C3DE7 /* pos-products.json in Resources */ = {isa = PBXBuildFile; fileRef = 20A8E92F2DEF4EC9000C3DE7 /* pos-products.json */; };
 		20B8B37D2D96B6920025734D /* ListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B8B37C2D96B6920025734D /* ListMapperTests.swift */; };
 		20D210C32B1780CE0099E517 /* deposits-overview-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 20D210C22B1780CE0099E517 /* deposits-overview-all.json */; };
 		20D210C52B1788E60099E517 /* deposits-overview-all-no-default-currency.json in Resources */ = {isa = PBXBuildFile; fileRef = 20D210C42B1788E60099E517 /* deposits-overview-all-no-default-currency.json */; };
@@ -856,6 +857,7 @@
 		204CBD2A2D43BDBB006FF89A /* wcpay-charge-error-site-credentials.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-error-site-credentials.json"; sourceTree = "<group>"; };
 		207D816B2D4A30A30097012E /* products-load-simple-products-empty-price.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "products-load-simple-products-empty-price.json"; sourceTree = "<group>"; };
 		20887FAA2D9AA55700F7AE03 /* POSProductsNetworkingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSProductsNetworkingTests.swift; sourceTree = "<group>"; };
+		20A8E92F2DEF4EC9000C3DE7 /* pos-products.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "pos-products.json"; sourceTree = "<group>"; };
 		20B8B37C2D96B6920025734D /* ListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListMapperTests.swift; sourceTree = "<group>"; };
 		20D210C22B1780CE0099E517 /* deposits-overview-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "deposits-overview-all.json"; sourceTree = "<group>"; };
 		20D210C42B1788E60099E517 /* deposits-overview-all-no-default-currency.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "deposits-overview-all-no-default-currency.json"; sourceTree = "<group>"; };
@@ -2565,6 +2567,7 @@
 				EE57C141297FCCA700BC31E7 /* product-shipping-classes-load-all-without-data.json */,
 				EE57C142297FCCA700BC31E7 /* product-shipping-classes-load-one-without-data.json */,
 				457FC68B2382B2FD00B41B02 /* product-update.json */,
+				20A8E92F2DEF4EC9000C3DE7 /* pos-products.json */,
 				AEA056E3296DBA6E00948D52 /* products-batch-update.json */,
 				45152818257A84A60076B03C /* product-attributes-all.json */,
 				EE57C124297EB4E300BC31E7 /* product-attributes-all-without-data.json */,
@@ -3515,6 +3518,7 @@
 				DE42F95D2966CB6A00D514C2 /* order-notes-without-data.json in Resources */,
 				31723C892787A299007F1405 /* stripe-connection-token.json in Resources */,
 				DEC2B08D297AA048003923FB /* reviews-all-without-data.json in Resources */,
+				20A8E9302DEF4EC9000C3DE7 /* pos-products.json in Resources */,
 				74A1D266211898F000931DFA /* site-visits-year.json in Resources */,
 				743BF8BE21191B63008A9D87 /* site-visits.json in Resources */,
 				CEB9BF352BB190960007978A /* product-bundle-stats-without-data.json in Resources */,

--- a/Networking/NetworkingTests/Remote/POSProductsNetworkingTests.swift
+++ b/Networking/NetworkingTests/Remote/POSProductsNetworkingTests.swift
@@ -260,4 +260,24 @@ struct POSProductsNetworkingTests {
         // Then
         #expect(pagedProducts.totalItems == nil)
     }
+
+    @Test func fetchPOSProductByGlobalUniqueIdentifier_returns_single_product() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        let globalUniqueID = "123456789"
+
+        // When
+        network.simulateResponse(requestUrlSuffix: "products", filename: "pos-products")
+        let product = try await remote.fetchPOSProductByGlobalUniqueIdentifier(for: sampleSiteID, globalUniqueID: globalUniqueID)
+
+        // Then
+        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
+        #expect(request.method == .get)
+        #expect(request.path == "products")
+        #expect(request.parameters["global_unique_id"] as? String == globalUniqueID)
+        #expect(request.parameters["page"] as? String == "1")
+        #expect(request.parameters["per_page"] as? String == "1")
+        #expect(request.parameters["context"] as? String == "edit")
+        #expect(request.parameters["_fields"] as? String == POSProduct.requestFields.joined(separator: ","))
+    }
 }

--- a/Networking/NetworkingTests/Responses/pos-products.json
+++ b/Networking/NetworkingTests/Responses/pos-products.json
@@ -1,0 +1,20 @@
+{
+    "data": [
+        {
+            "id": 123,
+            "name": "Test Product",
+            "type": "simple",
+            "sku": "TEST-SKU",
+            "global_unique_id": "123456789",
+            "price": "10.00",
+            "regular_price": "10.00",
+            "sale_price": null,
+            "on_sale": false,
+            "images": [],
+            "attributes": [],
+            "manage_stock": true,
+            "stock_quantity": 10,
+            "stock_status": "instock"
+        }
+    ]
+}

--- a/Networking/Sources/Extended/Mapper/ListMapper.swift
+++ b/Networking/Sources/Extended/Mapper/ListMapper.swift
@@ -9,7 +9,7 @@ struct ListMapper<Output: Decodable>: Mapper {
     ///
     let siteID: Int64
 
-    /// (Attempts) to convert a dictionary into [Product].
+    /// (Attempts) to convert a dictionary into [Output].
     ///
     func map(response: Data) throws -> [Output] {
         let decoder = JSONDecoder()

--- a/Networking/Sources/Extended/Remote/ProductsRemote.swift
+++ b/Networking/Sources/Extended/Remote/ProductsRemote.swift
@@ -95,6 +95,9 @@ public protocol ProductsRemoteProtocol {
                                            productTypes: [ProductType],
                                            pageNumber: Int,
                                            perPage: Int) async throws -> PagedItems<POSProduct>
+
+    func fetchPOSProductByGlobalUniqueIdentifier(for siteID: Int64,
+                                                   globalUniqueID: String) async throws -> POSProduct
 }
 
 extension ProductsRemoteProtocol {
@@ -325,6 +328,34 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             for: siteID,
             pageNumber: pageNumber,
             parameters: parameters)
+    }
+
+    /// Fetches a single product or variation by its global unique identifier for Point of Sale.
+    /// This method is optimized for barcode scanning, returning only the first matching product.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll fetch the product.
+    ///     - globalUniqueID: The global unique identifier (e.g. barcode) to search for.
+    /// - Returns: A POSProduct if found
+    /// - Throws: Error if the product is not found or if there's a network error
+    ///
+    public func fetchPOSProductByGlobalUniqueIdentifier(for siteID: Int64,
+                                                       globalUniqueID: String) async throws -> POSProduct {
+        let parameters = [
+            ParameterKey.globalUniqueID: globalUniqueID,
+            ParameterKey.page: "1",
+            ParameterKey.perPage: "1",
+            ParameterKey.contextKey: Default.context,
+            ParameterKey.fields: POSProduct.requestFields.joined(separator: ",")
+        ]
+        let path = Path.products
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
+        let mapper = ListMapper<POSProduct>(siteID: siteID)
+
+        guard let product = try await enqueue(request, mapper: mapper).first else {
+            throw NetworkError.notFound()
+        }
+        return product
     }
 
     /// Retrieves a specific list of `Product`s by `productID`.

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -169,6 +169,8 @@
 		2095A64B2D9D82D400CA1849 /* PointOfSalePurchasableItemFetchStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2095A64A2D9D82D400CA1849 /* PointOfSalePurchasableItemFetchStrategy.swift */; };
 		209AD3CC2AC1A68800825D76 /* WooPaymentsPayoutService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CB2AC1A68800825D76 /* WooPaymentsPayoutService.swift */; };
 		209AD3CE2AC1A9C200825D76 /* WooPaymentsPayoutsOverview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CD2AC1A9C200825D76 /* WooPaymentsPayoutsOverview.swift */; };
+		20A8E9322DEF5043000C3DE7 /* PointOfSaleBarcodeScanService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A8E9312DEF5043000C3DE7 /* PointOfSaleBarcodeScanService.swift */; };
+		20A8E9342DEF5452000C3DE7 /* PointOfSaleBarcodeScanServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A8E9332DEF5452000C3DE7 /* PointOfSaleBarcodeScanServiceTests.swift */; };
 		20AE687C2DE60DFF00C4AB2B /* PointOfSaleDefaultPurchasableItemFetchStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20AE687B2DE60DFF00C4AB2B /* PointOfSaleDefaultPurchasableItemFetchStrategyTests.swift */; };
 		20AE687E2DE60E2800C4AB2B /* MockPOSItemFetchAnalyticsTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20AE687D2DE60E2800C4AB2B /* MockPOSItemFetchAnalyticsTracking.swift */; };
 		20B9F7842DB0FDDB00512EF5 /* SiteSpecificAppSettingsStoreMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B9F7832DB0FDDB00512EF5 /* SiteSpecificAppSettingsStoreMethods.swift */; };
@@ -735,6 +737,8 @@
 		2095A64A2D9D82D400CA1849 /* PointOfSalePurchasableItemFetchStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSalePurchasableItemFetchStrategy.swift; sourceTree = "<group>"; };
 		209AD3CB2AC1A68800825D76 /* WooPaymentsPayoutService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutService.swift; sourceTree = "<group>"; };
 		209AD3CD2AC1A9C200825D76 /* WooPaymentsPayoutsOverview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsOverview.swift; sourceTree = "<group>"; };
+		20A8E9312DEF5043000C3DE7 /* PointOfSaleBarcodeScanService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleBarcodeScanService.swift; sourceTree = "<group>"; };
+		20A8E9332DEF5452000C3DE7 /* PointOfSaleBarcodeScanServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleBarcodeScanServiceTests.swift; sourceTree = "<group>"; };
 		20AE687B2DE60DFF00C4AB2B /* PointOfSaleDefaultPurchasableItemFetchStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleDefaultPurchasableItemFetchStrategyTests.swift; sourceTree = "<group>"; };
 		20AE687D2DE60E2800C4AB2B /* MockPOSItemFetchAnalyticsTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPOSItemFetchAnalyticsTracking.swift; sourceTree = "<group>"; };
 		20B9F7832DB0FDDB00512EF5 /* SiteSpecificAppSettingsStoreMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSpecificAppSettingsStoreMethods.swift; sourceTree = "<group>"; };
@@ -1145,6 +1149,7 @@
 		0149547A2DBBA50A00C8870D /* Items */ = {
 			isa = PBXGroup;
 			children = (
+				20A8E9312DEF5043000C3DE7 /* PointOfSaleBarcodeScanService.swift */,
 				2095A6482D9D81C900CA1849 /* PointOfSaleItemFetchStrategyFactory.swift */,
 				68EA25372C0876DF00C49AE2 /* PointOfSaleItemService.swift */,
 				6898F3732C0842150039F10A /* PointOfSaleItemServiceProtocol.swift */,
@@ -1614,6 +1619,7 @@
 		687F83702C0EBF3E00460AB3 /* PointOfSale */ = {
 			isa = PBXGroup;
 			children = (
+				20A8E9332DEF5452000C3DE7 /* PointOfSaleBarcodeScanServiceTests.swift */,
 				013337902DBFE970000B1D8D /* PointOfSaleSearchCouponFetchStrategyTests.swift */,
 				0133302A2DBFB478000B1D8D /* PointOfSaleDefaultCouponFetchStrategyTests.swift */,
 				68E75F1F2DB8BFAC00A2DA21 /* POSCouponTests.swift */,
@@ -2649,6 +2655,7 @@
 				DEB387842C2AB50B0025256E /* GoogleAdsAction.swift in Sources */,
 				26E5A07625A626CA000DF8F6 /* ProductAttributeTerm+ReadOnlyConvertible.swift in Sources */,
 				FEEB2F5D268A15730075A6E0 /* User+Roles.swift in Sources */,
+				20A8E9322DEF5043000C3DE7 /* PointOfSaleBarcodeScanService.swift in Sources */,
 				261CF1C9255B2C7B0090D8D3 /* PaymentGateway+ReadOnlyConvertible.swift in Sources */,
 				45E4620E2684C45500011BF2 /* Country+ReadOnlyConvertible.swift in Sources */,
 				7455D4672141B57600FA8C1F /* TopEarnerStats+ReadOnlyConvertible.swift in Sources */,
@@ -2885,6 +2892,7 @@
 				02FF056923DECD5B0058E6E7 /* MediaImageExporterTests.swift in Sources */,
 				0202B6972387AFBF00F3EBE0 /* MockInMemoryStorage.swift in Sources */,
 				CCE24F8829F025BB00B416BC /* SubscriptionStoreTests.swift in Sources */,
+				20A8E9342DEF5452000C3DE7 /* PointOfSaleBarcodeScanServiceTests.swift in Sources */,
 				028BCE2422DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift in Sources */,
 				5758EB3324DC9631009ED8A6 /* InAppFeedbackCardVisibilityUseCaseTests.swift in Sources */,
 				B5F2AE9520EBAD6000FEDC59 /* ResultsControllerTests.swift in Sources */,

--- a/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
@@ -1,0 +1,64 @@
+import Foundation
+import protocol Networking.ProductsRemoteProtocol
+import class Networking.ProductsRemote
+import class WooFoundation.CurrencyFormatter
+import class WooFoundation.CurrencySettings
+import class Networking.AlamofireNetwork
+
+public enum PointOfSaleBarcodeScanError: Error, Equatable {
+    case unknown
+}
+
+/// Service for handling barcode scanning in Point of Sale
+public final class PointOfSaleBarcodeScanService {
+    private let productsRemote: ProductsRemoteProtocol
+    private let currencyFormatter: CurrencyFormatter
+    private let siteID: Int64
+
+    init (siteID: Int64,
+          productsRemote: ProductsRemoteProtocol,
+          currencySettings: CurrencySettings) {
+        self.siteID = siteID
+        self.productsRemote = productsRemote
+        self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+    }
+
+    public convenience init(siteID: Int64,
+                            credentials: Credentials?,
+                            currencySettings: CurrencySettings) {
+        let network = AlamofireNetwork(credentials: credentials)
+        self.init(siteID: siteID,
+                  productsRemote: ProductsRemote(network: network),
+                  currencySettings: currencySettings)
+    }
+
+    /// Looks up a POSItem using a barcode scan string
+    /// - Parameter barcode: The barcode string from a scan (global unique identifier)
+    /// - Returns: A POSItem if found, or throws an error
+    public func getItem(barcode: String) async throws -> POSItem {
+        do {
+            let product = try await productsRemote.fetchPOSProductByGlobalUniqueIdentifier(for: siteID, globalUniqueID: barcode)
+
+            guard product.productType == .simple else {
+                throw PointOfSaleBarcodeScanError.unknown
+            }
+
+            // Convert POSProduct to POSSimpleProduct
+            let simpleProduct = POSSimpleProduct(
+                id: UUID(),
+                name: product.name,
+                formattedPrice: currencyFormatter.formatAmount(product.price) ?? "",
+                productImageSource: product.images.first?.src,
+                productID: product.productID,
+                price: product.price,
+                manageStock: product.manageStock,
+                stockQuantity: product.stockQuantity,
+                stockStatusKey: product.stockStatusKey
+            )
+
+            return .simpleProduct(simpleProduct)
+        } catch {
+            throw PointOfSaleBarcodeScanError.unknown
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -440,6 +440,11 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         }
     }
 
+    func fetchPOSProductByGlobalUniqueIdentifier(for siteID: Int64, globalUniqueID: String) async throws -> POSProduct {
+        return POSProduct.fake().copy(siteID: siteID,
+                                      globalUniqueID: globalUniqueID)
+    }
+
     func loadPopularProductsForPointOfSale(for siteID: Int64,
                                            productTypes: [ProductType],
                                            pageNumber: Int,

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleBarcodeScanServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleBarcodeScanServiceTests.swift
@@ -1,0 +1,54 @@
+import Testing
+import WooFoundation
+@testable import Networking
+@testable import Yosemite
+
+struct PointOfSaleBarcodeScanServiceTests {
+    private var currencySettings: CurrencySettings!
+    private var network: MockNetwork!
+    private let siteID: Int64 = 123
+    private var sut: PointOfSaleBarcodeScanService!
+
+    init() {
+        network = MockNetwork()
+        currencySettings = CurrencySettings()
+        sut = PointOfSaleBarcodeScanService(
+            siteID: siteID,
+            productsRemote: ProductsRemote(network: network),
+            currencySettings: currencySettings
+        )
+    }
+
+    @Test func getItem_returns_simple_product_when_found() async throws {
+        // Given
+        let barcode = "123456789"
+        network.simulateResponse(requestUrlSuffix: "products", filename: "pos-products")
+
+        // When
+        let item = try await sut.getItem(barcode: barcode)
+
+        // Then
+        guard case let .simpleProduct(product) = item else {
+            Issue.record("Expected simple product, but got \(item)")
+            return
+        }
+
+        #expect(product.name == "Test Product")
+        #expect(product.price == "10.00")
+        #expect(product.productID == 123)
+        #expect(product.manageStock == true)
+        #expect(product.stockQuantity == 10)
+        #expect(product.stockStatusKey == "instock")
+    }
+
+    @Test func getItem_throws_error_when_product_not_found() async throws {
+        // Given
+        let barcode = "nonexistent"
+        network.simulateError(requestUrlSuffix: "products", error: NetworkError.notFound())
+
+        // When/Then
+        await #expect(throws: PointOfSaleBarcodeScanError.unknown) {
+            _ = try await sut.getItem(barcode: barcode)
+        }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of: WOOPRD-560

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a very simple remote request and service as the basis of barcode scanning on iOS.

At the moment, it's not hooked up to anything in the app target, so no need for a feature flag yet.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Check unit tests pass.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

This isn't hooked up to the UI yet – but there's not much point doing extensive testing of it before other cases like variations and errors are handled anyway.

You can't test this code in the app, unless you insert a call to it directly somewhere in the code. I'll add some UI to allow testing when I build out the basic path from the main screen, including a simple barcode scan simulator (a text field!)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
