### PR TITLE
Shipping Labels: Display alert when missing TOS acceptance for UPS

### DIFF
--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -127,7 +127,7 @@ final class WooShippingRemoteTests: XCTestCase {
         XCTAssertEqual(result.failure as? DotcomError, expectedError)
     }
 
-    func test_loadLabelRates_parses_success_response() throws {
+    func test_loadLabelRates_sends_correct_params_and_parses_success_response() throws {
         // Given
         let remote = WooShippingRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "label/rate", filename: "wooshipping-get-label-rates-success")
@@ -145,6 +145,10 @@ final class WooShippingRemoteTests: XCTestCase {
         }
 
         // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        let featuresParam = try XCTUnwrap(request.parameters["features_supported_by_client"] as? [String])
+        XCTAssertEqual(featuresParam, ["upsdap"])
+
         let successResponse = try XCTUnwrap(result.get())
         XCTAssertEqual(successResponse.first?.defaultRates.first, expectedDefaultRate)
     }
@@ -169,7 +173,7 @@ final class WooShippingRemoteTests: XCTestCase {
         XCTAssertNotNil(result.failure)
     }
 
-    func test_loadPackages_parses_success_response() throws {
+    func test_loadPackages_sends_correct_params_and_parses_success_response() throws {
         // Given
         let remote = WooShippingRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "packages", filename: "wooshipping-get-packages-success")
@@ -183,6 +187,10 @@ final class WooShippingRemoteTests: XCTestCase {
         }
 
         // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        let featuresParam = try XCTUnwrap(request.parameters["features_supported_by_client"] as? [String])
+        XCTAssertEqual(featuresParam, ["upsdap"])
+
         let successResponse = try XCTUnwrap(result.get())
         XCTAssertEqual(successResponse.savedPredefinedPackages.count, 2)
         XCTAssertEqual(successResponse.savedPredefinedPackages.first?.package.groupId, "pri_flat_boxes")

--- a/Networking/Sources/Extended/Remote/WooShippingRemote.swift
+++ b/Networking/Sources/Extended/Remote/WooShippingRemote.swift
@@ -159,7 +159,7 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
                 ParameterKey.originAddress: try originAddress.toDictionary(),
                 ParameterKey.destinationAddress: try destinationAddress.toDictionary(),
                 ParameterKey.packages: try packages.map { try $0.toDictionary() },
-                "features_supported_by_client": ["upsdap"]
+                ParameterKey.featuresSupported: [Values.upsdap]
             ]
             let path = Path.rates
             let request = JetpackRequest(wooApiVersion: .wooShipping,
@@ -185,7 +185,7 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
                              completion: @escaping (Result<WooShippingPackagesResponse, Error>) -> Void) {
         do {
             let parameters: [String: Any] = [
-                "features_supported_by_client": ["upsdap"]
+                ParameterKey.featuresSupported: [Values.upsdap]
             ]
             let path = Path.packages
             let request = JetpackRequest(wooApiVersion: .wooShipping,
@@ -577,6 +577,11 @@ private extension WooShippingRemote {
         static let selectedPaymentMethodID = "selected_payment_method_id"
         static let emailReceipts = "email_receipts"
         static let enabled = "enabled"
+        static let featuresSupported = "features_supported_by_client"
+    }
+
+    enum Values {
+        static let upsdap = "upsdap"
     }
 }
 

--- a/Networking/Sources/Extended/Remote/WooShippingRemote.swift
+++ b/Networking/Sources/Extended/Remote/WooShippingRemote.swift
@@ -158,7 +158,8 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
                 ParameterKey.orderID: orderID,
                 ParameterKey.originAddress: try originAddress.toDictionary(),
                 ParameterKey.destinationAddress: try destinationAddress.toDictionary(),
-                ParameterKey.packages: try packages.map { try $0.toDictionary() }
+                ParameterKey.packages: try packages.map { try $0.toDictionary() },
+                "features_supported_by_client": ["upsdap"]
             ]
             let path = Path.rates
             let request = JetpackRequest(wooApiVersion: .wooShipping,
@@ -183,11 +184,15 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
     public func loadPackages(siteID: Int64,
                              completion: @escaping (Result<WooShippingPackagesResponse, Error>) -> Void) {
         do {
+            let parameters: [String: Any] = [
+                "features_supported_by_client": ["upsdap"]
+            ]
             let path = Path.packages
             let request = JetpackRequest(wooApiVersion: .wooShipping,
                                          method: .get,
                                          siteID: siteID,
                                          path: path,
+                                         parameters: parameters,
                                          availableAsRESTRequest: true)
 
             let mapper = WooShippingPackagesMapper(siteID: siteID)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTOS/UPSTermsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTOS/UPSTermsView.swift
@@ -3,12 +3,9 @@ import SwiftUI
 /// View for reviewing UPS Terms and Conditions.
 struct UPSTermsView: View {
 
-    let originAddress: String
-    let onConfirmation: () -> Void
+    @ObservedObject var viewModel: UPSTermsViewModel
 
-    @State private var isTOSAccepted = false
-    @State private var isProhibitedItemsAccepted = false
-    @State private var isTechnologyAgreementAccepted = false
+    let onConfirmation: () -> Void
 
     var body: some View {
         ScrollableVStack(alignment: .leading,
@@ -21,7 +18,7 @@ struct UPSTermsView: View {
             VStack(alignment: .leading, spacing: Layout.contentSpacing) {
                 Text(Localization.shippingFrom)
                     .headlineStyle()
-                Text(originAddress)
+                Text(viewModel.displayedOriginAddress)
                     .foregroundStyle(Color.primary)
                     .subheadlineStyle()
                 Divider()
@@ -31,21 +28,21 @@ struct UPSTermsView: View {
             Text(Localization.message)
 
             VStack(alignment: .leading, spacing: Layout.contentPadding) {
-                Toggle(isOn: $isTOSAccepted) {
+                Toggle(isOn: $viewModel.isTOSAccepted) {
                     Text(checkboxContent(mainContent: Localization.checkbox1,
                                          linkText: Localization.termsOfService,
                                          link: Links.termsOfService))
                 }
                 .toggleStyle(CheckboxToggleStyle())
 
-                Toggle(isOn: $isProhibitedItemsAccepted) {
+                Toggle(isOn: $viewModel.isProhibitedItemsAccepted) {
                     Text(checkboxContent(mainContent: Localization.checkbox2,
                                          linkText: Localization.prohibitedItems,
                                          link: Links.prohibitedItems))
                 }
                 .toggleStyle(CheckboxToggleStyle())
 
-                Toggle(isOn: $isTechnologyAgreementAccepted) {
+                Toggle(isOn: $viewModel.isTechnologyAgreementAccepted) {
                     Text(checkboxContent(mainContent: Localization.checkbox3,
                                          linkText: Localization.technologyAgreement,
                                          link: Links.techAgreement))
@@ -57,9 +54,7 @@ struct UPSTermsView: View {
 
             Button(Localization.confirmButton, action: onConfirmation)
                 .buttonStyle(PrimaryButtonStyle())
-                .disabled(!isTOSAccepted ||
-                          !isProhibitedItemsAccepted ||
-                          !isTechnologyAgreementAccepted)
+                .disabled(!viewModel.shouldEnableConfirmButton)
         }
         .padding(.top, Layout.contentPadding)
     }
@@ -163,6 +158,15 @@ private extension UPSTermsView {
 }
 
 #Preview {
-    UPSTermsView(originAddress: "3028 24TH ST, SAN FRANCISCO, CA 94110-4129, US",
+    UPSTermsView(viewModel: UPSTermsViewModel(siteID: 123,
+                                              originAddress: .init(company: "A8C",
+                                                                   name: "John Doe",
+                                                                   phone: "09381734543",
+                                                                   country: "US",
+                                                                   state: "New York",
+                                                                   address1: "1 E 35th St",
+                                                                   address2: "",
+                                                                   city: "New York",
+                                                                   postcode: "10028")),
                  onConfirmation: {})
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTOS/UPSTermsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTOS/UPSTermsViewModel.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Yosemite
+
+/// View model for `UPSTermsView`
+final class UPSTermsViewModel: ObservableObject {
+    @Published var isTOSAccepted = false
+    @Published var isProhibitedItemsAccepted = false
+    @Published var isTechnologyAgreementAccepted = false
+
+    var displayedOriginAddress: String {
+        originAddress.formattedPostalAddress ?? ""
+    }
+
+    var shouldEnableConfirmButton: Bool {
+        isTOSAccepted && isProhibitedItemsAccepted && isTechnologyAgreementAccepted
+    }
+
+    private let siteID: Int64
+    private let originAddress: WooShippingAddress
+    private let stores: StoresManager
+
+    init(siteID: Int64,
+         originAddress: WooShippingAddress,
+         stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.originAddress = originAddress
+        self.stores = stores
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTermsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTermsView.swift
@@ -61,6 +61,7 @@ struct UPSTermsView: View {
                           !isProhibitedItemsAccepted ||
                           !isTechnologyAgreementAccepted)
         }
+        .padding(.top, Layout.contentPadding)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTermsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTermsView.swift
@@ -22,30 +22,35 @@ struct UPSTermsView: View {
                 Text(Localization.shippingFrom)
                     .headlineStyle()
                 Text(originAddress)
+                    .foregroundStyle(Color.primary)
                     .subheadlineStyle()
                 Divider()
             }
+            .accessibilityElement(children: .combine)
 
             Text(Localization.message)
 
-            VStack(alignment: .leading, spacing: Layout.contentSpacing) {
+            VStack(alignment: .leading, spacing: Layout.contentPadding) {
                 Toggle(isOn: $isTOSAccepted) {
                     Text(checkboxContent(mainContent: Localization.checkbox1,
                                          linkText: Localization.termsOfService,
                                          link: Links.termsOfService))
                 }
+                .toggleStyle(CheckboxToggleStyle())
 
                 Toggle(isOn: $isProhibitedItemsAccepted) {
                     Text(checkboxContent(mainContent: Localization.checkbox2,
                                          linkText: Localization.prohibitedItems,
                                          link: Links.prohibitedItems))
                 }
+                .toggleStyle(CheckboxToggleStyle())
 
                 Toggle(isOn: $isTechnologyAgreementAccepted) {
                     Text(checkboxContent(mainContent: Localization.checkbox3,
                                          linkText: Localization.technologyAgreement,
                                          link: Links.techAgreement))
                 }
+                .toggleStyle(CheckboxToggleStyle())
             }
 
             Spacer()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTermsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTermsView.swift
@@ -2,33 +2,118 @@ import SwiftUI
 
 /// View for reviewing UPS Terms and Conditions.
 struct UPSTermsView: View {
+
+    let originAddress: String
+    let onConfirmation: () -> Void
+
+    @State private var isTOSAccepted = false
+    @State private var isProhibitedItemsAccepted = false
+    @State private var isTechnologyAgreementAccepted = false
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ScrollableVStack(alignment: .leading,
+                         padding: Layout.contentPadding,
+                         spacing: Layout.sectionSpacing) {
+            Text(Localization.title)
+                .font(.title3)
+                .bold()
+
+            VStack(alignment: .leading, spacing: Layout.contentSpacing) {
+                Text(Localization.shippingFrom)
+                    .headlineStyle()
+                Text(originAddress)
+                    .subheadlineStyle()
+                Divider()
+            }
+
+            Text(Localization.message)
+
+            VStack(alignment: .leading, spacing: Layout.contentSpacing) {
+                Toggle(isOn: $isTOSAccepted) {
+                    Text(checkboxContent(mainContent: Localization.checkbox1,
+                                         linkText: Localization.termsOfService,
+                                         link: Links.termsOfService))
+                }
+
+                Toggle(isOn: $isProhibitedItemsAccepted) {
+                    Text(checkboxContent(mainContent: Localization.checkbox2,
+                                         linkText: Localization.prohibitedItems,
+                                         link: Links.prohibitedItems))
+                }
+
+                Toggle(isOn: $isTechnologyAgreementAccepted) {
+                    Text(checkboxContent(mainContent: Localization.checkbox3,
+                                         linkText: Localization.technologyAgreement,
+                                         link: Links.techAgreement))
+                }
+            }
+
+            Spacer()
+
+            Button(Localization.confirmButton, action: onConfirmation)
+                .buttonStyle(PrimaryButtonStyle())
+                .disabled(!isTOSAccepted ||
+                          !isProhibitedItemsAccepted ||
+                          !isTechnologyAgreementAccepted)
+        }
     }
 }
 
 private extension UPSTermsView {
+    func checkboxContent(mainContent: String,
+                         linkText: String,
+                         link: String) -> AttributedString {
+        let content = String.localizedStringWithFormat(mainContent, linkText)
+        var attributedText = AttributedString(content)
+        attributedText.font = .body
+        attributedText.foregroundColor = Color(.text)
+
+        if let range = attributedText.range(of: linkText),
+           let url = URL(string: link) {
+            var linkContainer = AttributeContainer()
+                .link(url)
+                .foregroundColor(Color.accentColor)
+            linkContainer.underlineStyle = .single
+            attributedText[range].mergeAttributes(linkContainer)
+        }
+        return attributedText
+    }
+}
+
+private extension UPSTermsView {
+    enum Layout {
+        static let contentPadding: CGFloat = 16
+        static let sectionSpacing: CGFloat = 24
+        static let contentSpacing: CGFloat = 8
+    }
+
+    enum Links {
+        static let termsOfService = "https://www.ups.com/assets/resources/webcontent/en_US/ups_dap_supplemental_tc.pdf"
+        static let prohibitedItems = "https://www.ups.com/us/en/support/shipping-support/shipping-special-care-regulated-items/prohibited-items.page"
+        static let techAgreement = "https://www.ups.com/assets/resources/webcontent/en_US/UTA.pdf"
+    }
+
     enum Localization {
         static let title = NSLocalizedString(
             "upsTermsView.title",
             value: "UPS® Terms and Conditions",
-            comment: "Title of the UPS Terms and Conditions alert"
+            comment: "Title of the UPS Terms and Conditions view"
         )
         static let shippingFrom = NSLocalizedString(
             "upsTermsView.shippingFrom",
             value: "Shipping from",
-            comment: "Title label for the origin address on the UPS Terms and Conditions alert"
+            comment: "Title label for the origin address on the UPS Terms and Conditions view"
         )
         static let message = NSLocalizedString(
             "upsTermsView.message",
             value: "To start shipping from this address with UPS®, " +
             "we need you to agree to the following terms and conditions:",
-            comment: "Message on the UPS Terms and Conditions alert"
+            comment: "Message on the UPS Terms and Conditions view"
         )
         static let checkbox1 = NSLocalizedString(
             "upsTermsView.checkbox1",
             value: "I agree to the %1$@.",
-            comment: "The first checkbox on the UPS Terms and Conditions alert. " +
+            comment: "The first checkbox on the UPS Terms and Conditions view. " +
             "The placeholder is a link to the UPS Terms of Service. " +
             "Reads as: 'I agree to the UPS® Terms of Service.'"
         )
@@ -36,7 +121,7 @@ private extension UPSTermsView {
             "upsTermsView.checkbox2",
             value: "I will not ship any %1$@ that UPS® disallows, " +
             "nor any regulated items without the necessary permissions.",
-            comment: "The second checkbox on the UPS Terms and Conditions alert. " +
+            comment: "The second checkbox on the UPS Terms and Conditions view. " +
             "The placeholder is a link to the list of prohibited items. " +
             "Reads as: 'I will not ship any Prohibited Items that UPS® disallows, " +
             "nor any regulated items without the necessary permissions.'"
@@ -44,28 +129,34 @@ private extension UPSTermsView {
         static let checkbox3 = NSLocalizedString(
             "upsTermsView.checkbox3",
             value: "I also agree to the %1$@.",
-            comment: "The third checkbox on the UPS Terms and Conditions alert. " +
+            comment: "The third checkbox on the UPS Terms and Conditions view. " +
             "The placeholder is a link to the UPS Technology Agreement. " +
             "Reads as: 'I also agree to the UPS® Technology Agreement.'"
         )
         static let termsOfService = NSLocalizedString(
             "upsTermsView.termsOfService",
             value: "UPS® Terms of Service",
-            comment: "Link to the terms of service on the UPS Terms and Conditions alert"
+            comment: "Link to the terms of service on the UPS Terms and Conditions view"
         )
         static let prohibitedItems = NSLocalizedString(
             "upsTermsView.prohibitedItems",
             value: "Prohibited Items",
-            comment: "Link to the prohibited items on the UPS Terms and Conditions alert"
+            comment: "Link to the prohibited items on the UPS Terms and Conditions view"
         )
         static let technologyAgreement = NSLocalizedString(
             "upsTermsView.technologyAgreement",
             value: "UPS® Technology Agreement",
-            comment: "Link to the technology agreement on the UPS Terms and Conditions alert"
+            comment: "Link to the technology agreement on the UPS Terms and Conditions view"
+        )
+        static let confirmButton = NSLocalizedString(
+            "upsTermsView.confirmButton",
+            value: "Confirm and continue",
+            comment: "Button to confirm all agreements on the UPS Terms and Conditions view"
         )
     }
 }
 
 #Preview {
-    UPSTermsView()
+    UPSTermsView(originAddress: "3028 24TH ST, SAN FRANCISCO, CA 94110-4129, US",
+                 onConfirmation: {})
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTermsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTermsView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// View for reviewing UPS Terms and Conditions.
+struct UPSTermsView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+private extension UPSTermsView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "upsTermsView.title",
+            value: "UPS® Terms and Conditions",
+            comment: "Title of the UPS Terms and Conditions alert"
+        )
+        static let shippingFrom = NSLocalizedString(
+            "upsTermsView.shippingFrom",
+            value: "Shipping from",
+            comment: "Title label for the origin address on the UPS Terms and Conditions alert"
+        )
+        static let message = NSLocalizedString(
+            "upsTermsView.message",
+            value: "To start shipping from this address with UPS®, " +
+            "we need you to agree to the following terms and conditions:",
+            comment: "Message on the UPS Terms and Conditions alert"
+        )
+        static let checkbox1 = NSLocalizedString(
+            "upsTermsView.checkbox1",
+            value: "I agree to the %1$@.",
+            comment: "The first checkbox on the UPS Terms and Conditions alert. " +
+            "The placeholder is a link to the UPS Terms of Service. " +
+            "Reads as: 'I agree to the UPS® Terms of Service.'"
+        )
+        static let checkbox2 = NSLocalizedString(
+            "upsTermsView.checkbox2",
+            value: "I will not ship any %1$@ that UPS® disallows, " +
+            "nor any regulated items without the necessary permissions.",
+            comment: "The second checkbox on the UPS Terms and Conditions alert. " +
+            "The placeholder is a link to the list of prohibited items. " +
+            "Reads as: 'I will not ship any Prohibited Items that UPS® disallows, " +
+            "nor any regulated items without the necessary permissions.'"
+        )
+        static let checkbox3 = NSLocalizedString(
+            "upsTermsView.checkbox3",
+            value: "I also agree to the %1$@.",
+            comment: "The third checkbox on the UPS Terms and Conditions alert. " +
+            "The placeholder is a link to the UPS Technology Agreement. " +
+            "Reads as: 'I also agree to the UPS® Technology Agreement.'"
+        )
+        static let termsOfService = NSLocalizedString(
+            "upsTermsView.termsOfService",
+            value: "UPS® Terms of Service",
+            comment: "Link to the terms of service on the UPS Terms and Conditions alert"
+        )
+        static let prohibitedItems = NSLocalizedString(
+            "upsTermsView.prohibitedItems",
+            value: "Prohibited Items",
+            comment: "Link to the prohibited items on the UPS Terms and Conditions alert"
+        )
+        static let technologyAgreement = NSLocalizedString(
+            "upsTermsView.technologyAgreement",
+            value: "UPS® Technology Agreement",
+            comment: "Link to the technology agreement on the UPS Terms and Conditions alert"
+        )
+    }
+}
+
+#Preview {
+    UPSTermsView()
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingCarrier.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingCarrier.swift
@@ -2,7 +2,7 @@ import UIKit
 
 /// Represents a shipping carrier in the Woo Shipping extension.
 enum WooShippingCarrier: String, Comparable, CaseIterable {
-    case ups
+    case upsdap
     case usps
     case dhlExpress = "dhlexpress"
     case dhlEcommerce = "dhlecommerce"
@@ -10,7 +10,7 @@ enum WooShippingCarrier: String, Comparable, CaseIterable {
 
     var logo: UIImage? {
         switch self {
-        case .ups:
+        case .upsdap:
             return UIImage(named: "shipping-label-ups-logo")
         case .usps:
             return UIImage(named: "shipping-label-usps-logo")
@@ -21,7 +21,7 @@ enum WooShippingCarrier: String, Comparable, CaseIterable {
 
     var name: String {
         switch self {
-        case .ups:
+        case .upsdap:
             "UPS"
         case .usps:
             "USPS"
@@ -38,7 +38,7 @@ enum WooShippingCarrier: String, Comparable, CaseIterable {
         switch self {
         case .usps:
             return URL(string: "https://tools.usps.com/schedule-pickup-steps.htm")
-        case .ups:
+        case .upsdap:
             return URL(string: "https://wwwapps.ups.com/pickup/request")
         case .dhlExpress:
             return URL(string: "https://mydhl.express.dhl/us/en/schedule-pickup.html#/schedule-pickup#label-reference")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -117,10 +117,12 @@ struct WooShippingCreateLabelsView: View {
                 }
             }
             .sheet(isPresented: $viewModel.shouldShowUPSTermsAndConditions) {
-                UPSTermsView(originAddress: viewModel.originAddress) {
-                    // TODO: integrate TOS acceptance endpoint & reload rates
+                if let termsViewModel = viewModel.upsTermsViewModel {
+                    UPSTermsView(viewModel: termsViewModel) {
+                        // TODO: reload rates
+                    }
+                    .presentationDetents([.fraction(0.8), .large])
                 }
-                .presentationDetents([.fraction(0.8), .large])
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -116,6 +116,12 @@ struct WooShippingCreateLabelsView: View {
                     .presentationDetents([.fraction(0.7), .large])
                 }
             }
+            .sheet(isPresented: $viewModel.shouldShowUPSTermsAndConditions) {
+                UPSTermsView(originAddress: viewModel.originAddress) {
+                    // TODO: integrate TOS acceptance endpoint & reload rates
+                }
+                .presentationDetents([.fraction(0.8), .large])
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -189,6 +189,13 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     @Published var shouldShowUPSTermsAndConditions = false
 
+    var upsTermsViewModel: UPSTermsViewModel? {
+        guard let originAddress = selectedOriginAddress?.toWooShippingAddress() else {
+            return nil
+        }
+        return UPSTermsViewModel(siteID: order.siteID, originAddress: originAddress)
+    }
+
     /// Initialize the view model with or without an existing shipping label.
     init(order: Order,
          selectedShippingLabel: ShippingLabel? = nil,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -187,6 +187,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     private(set) var paymentMethodsViewModel: ShippingLabelPaymentMethodsViewModel?
 
+    @Published var shouldShowUPSTermsAndConditions = false
+
     /// Initialize the view model with or without an existing shipping label.
     init(order: Order,
          selectedShippingLabel: ShippingLabel? = nil,
@@ -295,7 +297,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         do {
             try await currentShipmentDetailsViewModel.purchaseLabel()
         } catch let DotcomError.unknown(code, _) where code == Constants.missingUPSDAPTermsOfServiceAcceptance {
-            // TODO: show error
+            shouldShowUPSTermsAndConditions = true
         } catch {
             labelPurchaseErrorNotice = Notice(title: Localization.LabelPurchaseError.title,
                                               message: Localization.LabelPurchaseError.message,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -3,6 +3,7 @@ import Yosemite
 import WooFoundation
 import Combine
 import struct Networking.WooShippingAccountSettings
+import enum Networking.DotcomError
 
 /// Provides view data for `WooShippingCreateLabelsView`.
 ///
@@ -293,6 +294,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
         do {
             try await currentShipmentDetailsViewModel.purchaseLabel()
+        } catch let DotcomError.unknown(code, _) where code == Constants.missingUPSDAPTermsOfServiceAcceptance {
+            // TODO: show error
         } catch {
             labelPurchaseErrorNotice = Notice(title: Localization.LabelPurchaseError.title,
                                               message: Localization.LabelPurchaseError.message,
@@ -627,6 +630,9 @@ private extension WooShippingCreateLabelsViewModel {
 }
 
 private extension WooShippingCreateLabelsViewModel {
+    enum Constants {
+        static let missingUPSDAPTermsOfServiceAcceptance = "missing_upsdap_terms_of_service_acceptance"
+    }
     enum Localization {
         enum OriginAddressStatus {
             static let unverified = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ToggleStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ToggleStyles.swift
@@ -6,7 +6,8 @@ struct CheckboxToggleStyle: ToggleStyle {
             configuration.isOn.toggle()
         }, label: {
             HStack(alignment: .firstTextBaseline) {
-                Image(systemName: configuration.isOn ? "checkmark.square" : "square")
+                Image(systemName: configuration.isOn ? "checkmark.square.fill" : "square")
+                    .foregroundStyle(configuration.isOn ? Color.accentColor : Color.primary)
                 configuration.label
             }
         })

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ToggleStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ToggleStyles.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct CheckboxToggleStyle: ToggleStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        Button(action: {
+            configuration.isOn.toggle()
+        }, label: {
+            HStack(alignment: .firstTextBaseline) {
+                Image(systemName: configuration.isOn ? "checkmark.square" : "square")
+                configuration.label
+            }
+        })
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    Toggle(isOn: .constant(true)) {
+        Text("I'm not a robot")
+    }
+    .toggleStyle(CheckboxToggleStyle())
+}
+
+#Preview {
+    Toggle(isOn: .constant(false)) {
+        Text("I'm a human")
+    }
+    .toggleStyle(CheckboxToggleStyle())
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2896,6 +2896,7 @@
 		DEFD6E61264990FB00E51E0D /* PluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* PluginListViewModelTests.swift */; };
 		DEFE13C32DF1553E005B3D39 /* UPSTermsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE13C22DF1553E005B3D39 /* UPSTermsView.swift */; };
 		DEFE13C52DF15F55005B3D39 /* ToggleStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE13C42DF15F36005B3D39 /* ToggleStyles.swift */; };
+		DEFE13C82DF2A359005B3D39 /* UPSTermsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE13C72DF2A354005B3D39 /* UPSTermsViewModel.swift */; };
 		E10459C627BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */; };
 		E1068058285C787100668B46 /* BetaFeaturesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1068057285C787100668B46 /* BetaFeaturesTests.swift */; };
 		E107FCE126C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift in Sources */ = {isa = PBXBuildFile; fileRef = E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */; };
@@ -6128,6 +6129,7 @@
 		DEFD6E60264990FB00E51E0D /* PluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModelTests.swift; sourceTree = "<group>"; };
 		DEFE13C22DF1553E005B3D39 /* UPSTermsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UPSTermsView.swift; sourceTree = "<group>"; };
 		DEFE13C42DF15F36005B3D39 /* ToggleStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleStyles.swift; sourceTree = "<group>"; };
+		DEFE13C72DF2A354005B3D39 /* UPSTermsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UPSTermsViewModel.swift; sourceTree = "<group>"; };
 		E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentConfigurationLoader.swift; sourceTree = "<group>"; };
 		E1068057285C787100668B46 /* BetaFeaturesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaFeaturesTests.swift; sourceTree = "<group>"; };
 		E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCountryNotSupported.swift; sourceTree = "<group>"; };
@@ -12566,7 +12568,7 @@
 				CE7FE6922D13249D000F9475 /* WooShippingAddresses */,
 				CEAEB7582CD0F96800C3E117 /* WooShipping Post-Purchase */,
 				CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */,
-				DEFE13C22DF1553E005B3D39 /* UPSTermsView.swift */,
+				DEFE13C62DF2A34A005B3D39 /* UPSTOS */,
 				CEC3CC6E2C93146700B93FBE /* WooShippingCreateLabelsViewModel.swift */,
 				CE49C4742CBEC84C00EA5C84 /* WooShipping_ShippingLineViewModel.swift */,
 			);
@@ -13796,6 +13798,15 @@
 				68A5221A2BA1804900A6A584 /* PluginDetailsViewModelTests.swift */,
 			);
 			path = Plugins;
+			sourceTree = "<group>";
+		};
+		DEFE13C62DF2A34A005B3D39 /* UPSTOS */ = {
+			isa = PBXGroup;
+			children = (
+				DEFE13C72DF2A354005B3D39 /* UPSTermsViewModel.swift */,
+				DEFE13C22DF1553E005B3D39 /* UPSTermsView.swift */,
+			);
+			path = UPSTOS;
 			sourceTree = "<group>";
 		};
 		E10459C427BBC20C00C1DCBA /* In-Person Payments */ = {
@@ -17088,6 +17099,7 @@
 				EEADF622281A40CB001B40F1 /* ShippingValueLocalizer.swift in Sources */,
 				26D86B692C50110600435411 /* TopPerformersCardDataSyncUseCase.swift in Sources */,
 				262C922126F1370000011F92 /* StorePickerError.swift in Sources */,
+				DEFE13C82DF2A359005B3D39 /* UPSTermsViewModel.swift in Sources */,
 				4515C89825D6C00E0099C8E3 /* ShippingLabelAddressFormViewModel.swift in Sources */,
 				20AE33C72B0510D200527B60 /* HubMenuDestination.swift in Sources */,
 				95B6C60C2D9DA5E900E1A661 /* WPComMagicLinkRequestView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2895,6 +2895,7 @@
 		DEFC9BE22B2FF62C00138B05 /* WooAnalyticsEvent+Themes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFC9BE12B2FF62C00138B05 /* WooAnalyticsEvent+Themes.swift */; };
 		DEFD6E61264990FB00E51E0D /* PluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* PluginListViewModelTests.swift */; };
 		DEFE13C32DF1553E005B3D39 /* UPSTermsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE13C22DF1553E005B3D39 /* UPSTermsView.swift */; };
+		DEFE13C52DF15F55005B3D39 /* ToggleStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE13C42DF15F36005B3D39 /* ToggleStyles.swift */; };
 		E10459C627BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */; };
 		E1068058285C787100668B46 /* BetaFeaturesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1068057285C787100668B46 /* BetaFeaturesTests.swift */; };
 		E107FCE126C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift in Sources */ = {isa = PBXBuildFile; fileRef = E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */; };
@@ -6126,6 +6127,7 @@
 		DEFC9BE12B2FF62C00138B05 /* WooAnalyticsEvent+Themes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+Themes.swift"; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* PluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModelTests.swift; sourceTree = "<group>"; };
 		DEFE13C22DF1553E005B3D39 /* UPSTermsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UPSTermsView.swift; sourceTree = "<group>"; };
+		DEFE13C42DF15F36005B3D39 /* ToggleStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleStyles.swift; sourceTree = "<group>"; };
 		E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentConfigurationLoader.swift; sourceTree = "<group>"; };
 		E1068057285C787100668B46 /* BetaFeaturesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaFeaturesTests.swift; sourceTree = "<group>"; };
 		E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCountryNotSupported.swift; sourceTree = "<group>"; };
@@ -9595,6 +9597,7 @@
 				E15FC74026BC1CED00CF83E6 /* AttributedText.swift */,
 				E15FC74226BC1D2700CF83E6 /* SafariSheet.swift */,
 				E1BAAE9F26BBECEF00F2C037 /* ButtonStyles.swift */,
+				DEFE13C42DF15F36005B3D39 /* ToggleStyles.swift */,
 				DE19BB0B26C2688B00AB70D9 /* SingleSelectionList.swift */,
 				DE7E5E7E2B4BC52C002E28D2 /* MultiSelectionList.swift */,
 				CE4FE7D72B7D306200F66DD5 /* MultiSelectionReorderableList.swift */,
@@ -15375,6 +15378,7 @@
 				B5DB01B52114AB2D00A4F797 /* WooCrashLoggingStack.swift in Sources */,
 				205B7EBF2C19FBCA00D14A36 /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel.swift in Sources */,
 				027ADB6E2D1BF5E3009608DB /* ParentProductCardView.swift in Sources */,
+				DEFE13C52DF15F55005B3D39 /* ToggleStyles.swift in Sources */,
 				26ED9660274328BC00FA00A1 /* SimplePaymentsSummaryViewModel.swift in Sources */,
 				024DF31E23743045006658FE /* TextList+AztecFormatting.swift in Sources */,
 				CEEF742E2B9A0BAA00B03948 /* SessionsReportCardViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2894,6 +2894,7 @@
 		DEFB3011289904E300A620B3 /* WooSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */; };
 		DEFC9BE22B2FF62C00138B05 /* WooAnalyticsEvent+Themes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFC9BE12B2FF62C00138B05 /* WooAnalyticsEvent+Themes.swift */; };
 		DEFD6E61264990FB00E51E0D /* PluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* PluginListViewModelTests.swift */; };
+		DEFE13C32DF1553E005B3D39 /* UPSTermsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE13C22DF1553E005B3D39 /* UPSTermsView.swift */; };
 		E10459C627BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */; };
 		E1068058285C787100668B46 /* BetaFeaturesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1068057285C787100668B46 /* BetaFeaturesTests.swift */; };
 		E107FCE126C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift in Sources */ = {isa = PBXBuildFile; fileRef = E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */; };
@@ -6124,6 +6125,7 @@
 		DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DEFC9BE12B2FF62C00138B05 /* WooAnalyticsEvent+Themes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+Themes.swift"; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* PluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModelTests.swift; sourceTree = "<group>"; };
+		DEFE13C22DF1553E005B3D39 /* UPSTermsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UPSTermsView.swift; sourceTree = "<group>"; };
 		E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentConfigurationLoader.swift; sourceTree = "<group>"; };
 		E1068057285C787100668B46 /* BetaFeaturesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaFeaturesTests.swift; sourceTree = "<group>"; };
 		E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCountryNotSupported.swift; sourceTree = "<group>"; };
@@ -12561,6 +12563,7 @@
 				CE7FE6922D13249D000F9475 /* WooShippingAddresses */,
 				CEAEB7582CD0F96800C3E117 /* WooShipping Post-Purchase */,
 				CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */,
+				DEFE13C22DF1553E005B3D39 /* UPSTermsView.swift */,
 				CEC3CC6E2C93146700B93FBE /* WooShippingCreateLabelsViewModel.swift */,
 				CE49C4742CBEC84C00EA5C84 /* WooShipping_ShippingLineViewModel.swift */,
 			);
@@ -15836,6 +15839,7 @@
 				03E471DC29424EC9001A58AD /* CardPresentModalTapToPaySuccessWithoutEmail.swift in Sources */,
 				45C91CFE25E55A1200FD8812 /* ShippingLabelAddressTopBannerFactory.swift in Sources */,
 				B5DBF3CB20E149CC00B53AED /* AuthenticatedState.swift in Sources */,
+				DEFE13C32DF1553E005B3D39 /* UPSTermsView.swift in Sources */,
 				B90DDF7C2A9E21DF009CFDA2 /* NewTaxRateSelectorView.swift in Sources */,
 				DE61979328A20C17005E4362 /* StorePickerViewModel.swift in Sources */,
 				DEB387A32C36474F0025256E /* GoogleAdsDashboardCard.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/ShippingLabelHelpersTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/ShippingLabelHelpersTests.swift
@@ -13,7 +13,7 @@ struct ShippingLabelHelpersTests {
     }
 
     @Test(arguments: [
-        WooShippingCarrier.ups,
+        WooShippingCarrier.upsdap,
         WooShippingCarrier.usps,
         WooShippingCarrier.dhlEcommerce,
         WooShippingCarrier.dhlEcommerceAsia


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-518
Also closes WOOMOB-529

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds support for purchasing labels with UPS. Changes include:
- Updated packages and rates requests to include UPS packages and rates.
- Catch error when TOS acceptance is missing for an origin address.
- Show alert for accepting UPS TOS.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with the Woo Shipping plugin set up in staging mode.
2. Navigate to the Orders tab and select a paid order with physical products and unfulfilled shipments.
3. Select Create shipping label > Select a package > Switch to Carrier tab.
4. Confirm that UPS packages are available. Select one of those packages.
5. Confirm that shipping rates are loaded successfully with UPS. 
6. Ensure that you haven't accepted UPS TOS for your origin address. Otherwise, edit the address to a new one.
7. Select one of the UPS rates and proceed to purchase a label.
8. Confirm that a bottom sheet is displayed with terms for UPS. The UI should match the alert on the web.
9. Verify that the Confirm button is only available after all checkboxes are checked.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested and confirmed the behavior and UI in light & dark modes, portrait and landscape modes and diffirent font sizes on simulator iPhone 16 iOS 18.4

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

UPS packages | UPS rates | Terms & Conditions
--- | --- | ---
<img src="https://github.com/user-attachments/assets/42373bbe-923b-4249-a878-fe96045da4c5" width=320 /> | <img src="https://github.com/user-attachments/assets/9053dc65-8461-48bb-8364-90499960406a" width=320 /> | <img src="https://github.com/user-attachments/assets/7a4f52a5-f7d6-4815-9359-013b10576729" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
