### PR TITLE
[Woo POS][Barcodes] Add POSProductVariation entity

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1161,6 +1161,29 @@ extension Networking.POSProduct {
         )
     }
 }
+extension Networking.POSProductVariation {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.POSProductVariation {
+        .init(
+            siteID: .fake(),
+            productID: .fake(),
+            productVariationID: .fake(),
+            attributes: .fake(),
+            image: .fake(),
+            sku: .fake(),
+            globalUniqueID: .fake(),
+            price: .fake(),
+            regularPrice: .fake(),
+            salePrice: .fake(),
+            onSale: .fake(),
+            downloadable: .fake(),
+            manageStock: .fake(),
+            stockQuantity: .fake(),
+            stockStatusKey: .fake()
+        )
+    }
+}
 extension Networking.PaymentGateway {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1746,6 +1746,7 @@
 				Extended/Model/PaymentGateway.swift,
 				Extended/Model/PaymentGatewayAccount.swift,
 				Extended/Model/POSProduct.swift,
+				Extended/Model/POSProductVariation.swift,
 				Extended/Model/Post.swift,
 				Extended/Model/Product/AIProduct.swift,
 				Extended/Model/Product/CreateProductVariation.swift,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		077F39E626A5D15800ABEADC /* SystemPluginMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39DB26A58F4800ABEADC /* SystemPluginMapperTests.swift */; };
 		09885C8027C3FFD200910A62 /* product-variations-bulk-update.json in Resources */ = {isa = PBXBuildFile; fileRef = 09885C7F27C3FFD200910A62 /* product-variations-bulk-update.json */; };
 		204CBD2B2D43BDBB006FF89A /* wcpay-charge-error-site-credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = 204CBD2A2D43BDBB006FF89A /* wcpay-charge-error-site-credentials.json */; };
+		206BF42E2DF1FADA000BD68E /* product-variations-load-all-with-parent-id.json in Resources */ = {isa = PBXBuildFile; fileRef = 206BF42D2DF1FADA000BD68E /* product-variations-load-all-with-parent-id.json */; };
 		207D816C2D4A30A30097012E /* products-load-simple-products-empty-price.json in Resources */ = {isa = PBXBuildFile; fileRef = 207D816B2D4A30A30097012E /* products-load-simple-products-empty-price.json */; };
 		20887FAB2D9AA55700F7AE03 /* POSProductsNetworkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20887FAA2D9AA55700F7AE03 /* POSProductsNetworkingTests.swift */; };
 		20A8E9302DEF4EC9000C3DE7 /* pos-products.json in Resources */ = {isa = PBXBuildFile; fileRef = 20A8E92F2DEF4EC9000C3DE7 /* pos-products.json */; };
@@ -855,6 +856,7 @@
 		077F39DB26A58F4800ABEADC /* SystemPluginMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPluginMapperTests.swift; sourceTree = "<group>"; };
 		09885C7F27C3FFD200910A62 /* product-variations-bulk-update.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variations-bulk-update.json"; sourceTree = "<group>"; };
 		204CBD2A2D43BDBB006FF89A /* wcpay-charge-error-site-credentials.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-error-site-credentials.json"; sourceTree = "<group>"; };
+		206BF42D2DF1FADA000BD68E /* product-variations-load-all-with-parent-id.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-variations-load-all-with-parent-id.json"; sourceTree = "<group>"; };
 		207D816B2D4A30A30097012E /* products-load-simple-products-empty-price.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "products-load-simple-products-empty-price.json"; sourceTree = "<group>"; };
 		20887FAA2D9AA55700F7AE03 /* POSProductsNetworkingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSProductsNetworkingTests.swift; sourceTree = "<group>"; };
 		20A8E92F2DEF4EC9000C3DE7 /* pos-products.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "pos-products.json"; sourceTree = "<group>"; };
@@ -2588,6 +2590,7 @@
 				26BD9FCC2965EC3C004E0D15 /* product-variations-bulk-create.json */,
 				EE57C133297F985A00BC31E7 /* product-variations-bulk-create-without-data.json */,
 				EE57C132297F985A00BC31E7 /* product-variations-bulk-update-without-data.json */,
+				206BF42D2DF1FADA000BD68E /* product-variations-load-all-with-parent-id.json */,
 				451274A525276C82009911FF /* product-variation.json */,
 				CE13681029FA809600EBF43C /* product-variation-min-max-quantities.json */,
 				CCEC5E9029E9BF1400912D6B /* product-variation-subscription.json */,
@@ -3185,6 +3188,7 @@
 				45D685FA23D0C3CF005F87D0 /* product-search-sku.json in Resources */,
 				DEEF8E6529C832B500D47411 /* wordpress-site-info-with-auth-url.json in Resources */,
 				D865CE5F278CA183002C8520 /* stripe-payment-intent-requires-action.json in Resources */,
+				206BF42E2DF1FADA000BD68E /* product-variations-load-all-with-parent-id.json in Resources */,
 				DE2004662BF7499600660A72 /* product-stock-decimal-sku.json in Resources */,
 				EE1042B42D65DF9B005AB07F /* wooshipping-verify-destination-success.json in Resources */,
 				EE1042B52D65DF9B005AB07F /* wooshipping-verify-destination-error.json in Resources */,

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -157,20 +157,20 @@ final class ProductVariationsRemoteTests: XCTestCase {
     func test_loadVariationsForPointOfSale_returns_parsed_variation() async throws {
         // Given
         let remote = ProductVariationsRemote(network: network)
-        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all-with-parent-id")
 
         // When
         let variations = try await remote.loadVariationsForPointOfSale(for: sampleSiteID, parentProductID: sampleProductID).items
 
         // Then
-        XCTAssertEqual(variations.count, 8)
+        XCTAssertEqual(variations.count, 2)
 
         guard let firstVariation = variations.first else {
             XCTFail("The first product variation should exist.")
             return
         }
         XCTAssertEqual(firstVariation.productVariationID, 1275)
-        XCTAssertEqual(firstVariation.productID, sampleProductID)
+        XCTAssertEqual(firstVariation.productID, 10275)
         XCTAssertEqual(firstVariation.sku, "99%-nuts-marble")
         XCTAssertEqual(firstVariation.globalUniqueID, "12345")
 
@@ -194,40 +194,12 @@ final class ProductVariationsRemoteTests: XCTestCase {
         XCTAssertEqual(firstVariation.stockStatusKey, "instock")
     }
 
-    func test_loadVariationsForPointOfSale_handles_manage_stock_parent_value() async throws {
-        // Given
-        let remote = ProductVariationsRemote(network: network)
-        let json = """
-        {
-            "id": 1275,
-            "parent_id": 173,
-            "attributes": [],
-            "manage_stock": "parent",
-            "stock_quantity": 16.5,
-            "stock_status": "instock",
-            "downloadable": true
-        }
-        """
-        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: json)
-
-        // When
-        let variations = try await remote.loadVariationsForPointOfSale(for: sampleSiteID, parentProductID: sampleProductID).items
-
-        // Then
-        XCTAssertEqual(variations.count, 1)
-        guard let variation = variations.first else {
-            XCTFail("The product variation should exist.")
-            return
-        }
-        XCTAssertFalse(variation.manageStock)
-    }
-
     func test_loadVariationsForPointOfSale_returns_total_items_from_header() async throws {
         // Given
         let remote = ProductVariationsRemote(network: network)
-        let expectedTotalItems = 15
+        let expectedTotalItems = 2
         network.responseHeaders = ["X-WP-Total": "\(expectedTotalItems)"]
-        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all-with-parent-id")
 
         // When
         let pagedVariations = try await remote.loadVariationsForPointOfSale(for: sampleSiteID, parentProductID: sampleProductID)
@@ -240,7 +212,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
         // Given
         let remote = ProductVariationsRemote(network: network)
         network.responseHeaders = nil
-        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all-with-parent-id")
 
         // When
         let pagedVariations = try await remote.loadVariationsForPointOfSale(for: sampleSiteID, parentProductID: sampleProductID)
@@ -252,7 +224,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
     func test_loadVariationsForPointOfSale_returns_page_details() async throws {
         // Given
         let remote = ProductVariationsRemote(network: network)
-        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all-with-parent-id")
 
         // When
         let hasMorePages = try await remote.loadVariationsForPointOfSale(for: sampleSiteID, parentProductID: sampleProductID).hasMorePages
@@ -265,7 +237,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
         // Given
         let remote = ProductVariationsRemote(network: network)
         network.responseHeaders = ["X-WP-TotalPages": "5"]
-        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all-with-parent-id")
 
         // When loading page 1 to 4
         for pageNumber in 1...4 {
@@ -290,7 +262,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
         // Given
         let remote = ProductVariationsRemote(network: network)
         network.responseHeaders = nil
-        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all-with-parent-id")
 
         // When loading the first 5 pages
         for pageNumber in 1...5 {

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -170,23 +170,15 @@ final class ProductVariationsRemoteTests: XCTestCase {
             return
         }
         XCTAssertEqual(firstVariation.productVariationID, 1275)
-        XCTAssertEqual(firstVariation.description, "<p>Nutty chocolate marble, 99% and organic.</p>\n")
+        XCTAssertEqual(firstVariation.productID, sampleProductID)
         XCTAssertEqual(firstVariation.sku, "99%-nuts-marble")
         XCTAssertEqual(firstVariation.globalUniqueID, "12345")
-        XCTAssertEqual(firstVariation.permalink, "https://chocolate.com/marble")
-
-        XCTAssertEqual(firstVariation.dateCreated, DateFormatter.dateFromString(with: "2019-11-14T12:40:55"))
-        XCTAssertEqual(firstVariation.dateModified, DateFormatter.dateFromString(with: "2019-11-14T13:06:42"))
-        XCTAssertEqual(firstVariation.dateOnSaleStart, DateFormatter.dateFromString(with: "2019-10-15T21:30:00"))
-        XCTAssertEqual(firstVariation.dateOnSaleEnd, DateFormatter.dateFromString(with: "2019-10-27T21:29:59"))
 
         let expectedPrice = 12
         XCTAssertEqual(firstVariation.price, "\(expectedPrice)")
         XCTAssertEqual(firstVariation.regularPrice, "\(expectedPrice)")
         XCTAssertEqual(firstVariation.salePrice, "8")
-
-        XCTAssertEqual(firstVariation.status, .published)
-        XCTAssertEqual(firstVariation.stockStatus, .inStock)
+        XCTAssertFalse(firstVariation.onSale)
 
         let expectedAttributes: [ProductVariationAttribute] = [
             ProductVariationAttribute(id: 0, name: "Darkness", option: "99%"),
@@ -196,32 +188,38 @@ final class ProductVariationsRemoteTests: XCTestCase {
         XCTAssertEqual(firstVariation.attributes, expectedAttributes)
 
         XCTAssertEqual(firstVariation.image?.imageID, 1063)
-
-        XCTAssertFalse(firstVariation.onSale)
-        XCTAssertTrue(firstVariation.purchasable)
-        XCTAssertFalse(firstVariation.virtual)
         XCTAssertTrue(firstVariation.downloadable)
-
         XCTAssertTrue(firstVariation.manageStock)
         XCTAssertEqual(firstVariation.stockQuantity, 16.5)
-        XCTAssertEqual(firstVariation.backordersKey, "notify")
-        XCTAssertTrue(firstVariation.backordersAllowed)
-        XCTAssertFalse(firstVariation.backordered)
+        XCTAssertEqual(firstVariation.stockStatusKey, "instock")
+    }
 
-        XCTAssertEqual(firstVariation.downloads.count, 0)
-        XCTAssertEqual(firstVariation.downloadLimit, -1)
-        XCTAssertEqual(firstVariation.downloadExpiry, 0)
+    func test_loadVariationsForPointOfSale_handles_manage_stock_parent_value() async throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+        let json = """
+        {
+            "id": 1275,
+            "parent_id": 173,
+            "attributes": [],
+            "manage_stock": "parent",
+            "stock_quantity": 16.5,
+            "stock_status": "instock",
+            "downloadable": true
+        }
+        """
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: json)
 
-        XCTAssertEqual(firstVariation.taxStatusKey, "taxable")
-        XCTAssertEqual(firstVariation.taxClass, "")
+        // When
+        let variations = try await remote.loadVariationsForPointOfSale(for: sampleSiteID, parentProductID: sampleProductID).items
 
-        XCTAssertEqual(firstVariation.weight, "2.5")
-        XCTAssertEqual(firstVariation.dimensions, ProductDimensions(length: "10", width: "2.5", height: ""))
-
-        XCTAssertEqual(firstVariation.shippingClass, "")
-        XCTAssertEqual(firstVariation.shippingClassID, 0)
-
-        XCTAssertEqual(firstVariation.menuOrder, 8)
+        // Then
+        XCTAssertEqual(variations.count, 1)
+        guard let variation = variations.first else {
+            XCTFail("The product variation should exist.")
+            return
+        }
+        XCTAssertFalse(variation.manageStock)
     }
 
     func test_loadVariationsForPointOfSale_returns_total_items_from_header() async throws {

--- a/Networking/NetworkingTests/Responses/product-variations-load-all-with-parent-id.json
+++ b/Networking/NetworkingTests/Responses/product-variations-load-all-with-parent-id.json
@@ -1,0 +1,195 @@
+{
+    "data": [
+        {
+            "id": 1275,
+            "date_created": "2019-11-14T15:10:55",
+            "date_created_gmt": "2019-11-14T12:40:55",
+            "date_modified": "2019-11-14T15:36:42",
+            "date_modified_gmt": "2019-11-14T13:06:42",
+            "description": "<p>Nutty chocolate marble, 99% and organic.</p>\n",
+            "permalink": "https://chocolate.com/marble",
+            "sku": "99%-nuts-marble",
+            "global_unique_id": "12345",
+            "price": "12",
+            "regular_price": "12",
+            "sale_price": "8",
+            "date_on_sale_from": "2019-10-16T00:00:00",
+            "date_on_sale_from_gmt": "2019-10-15T21:30:00",
+            "date_on_sale_to": "2019-10-27T23:59:59",
+            "date_on_sale_to_gmt": "2019-10-27T21:29:59",
+            "on_sale": false,
+            "status": "publish",
+            "purchasable": true,
+            "virtual": false,
+            "downloadable": true,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": 0,
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": true,
+            "stock_quantity": 16.5,
+            "stock_status": "instock",
+            "backorders": "notify",
+            "backorders_allowed": true,
+            "backordered": false,
+            "weight": "2.5",
+            "dimensions": {
+                "length": "10",
+                "width": "2.5",
+                "height": ""
+            },
+            "shipping_class": "",
+            "shipping_class_id": 0,
+            "image": {
+                "id": 1063,
+                "date_created": "2019-11-01T08:42:05",
+                "date_created_gmt": "2019-11-01T04:12:05",
+                "date_modified": "2019-11-01T08:42:05",
+                "date_modified_gmt": "2019-11-01T04:12:05",
+                "src": "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1",
+                "name": "DSC_0010",
+                "alt": ""
+            },
+            "attributes": [
+                {
+                    "id": 0,
+                    "name": "Darkness",
+                    "option": "99%"
+                },
+                {
+                    "id": 0,
+                    "name": "Flavor",
+                    "option": "nuts"
+                },
+                {
+                    "id": 0,
+                    "name": "Shape",
+                    "option": "marble"
+                }
+            ],
+            "menu_order": 8,
+            "meta_data": [
+                {
+                    "id": 6767,
+                    "key": "_created_via",
+                    "value": "ajax-unknown"
+                }
+            ],
+            "parent_id": 10275,
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations/1275"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations"
+                    }
+                ],
+                "up": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846"
+                    }
+                ]
+            }
+        },
+        {
+            "id": 1274,
+            "date_created": "2019-11-14T15:10:55",
+            "date_created_gmt": "2019-11-14T12:40:55",
+            "date_modified": "2019-11-14T15:36:42",
+            "date_modified_gmt": "2019-11-14T13:06:42",
+            "description": "",
+            "permalink": "https://funtestingusa.wpcomstaging.com/product/chocolate-2/?attribute_darkness=99%25&attribute_flavor=nuts&attribute_shape=brick",
+            "sku": "",
+            "global_unique_id": "",
+            "price": "",
+            "regular_price": "",
+            "sale_price": "",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": null,
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": null,
+            "on_sale": false,
+            "status": "publish",
+            "purchasable": false,
+            "virtual": false,
+            "downloadable": false,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": -1,
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": false,
+            "stock_quantity": null,
+            "stock_status": "instock",
+            "backorders": "no",
+            "backorders_allowed": false,
+            "backordered": false,
+            "weight": "",
+            "dimensions": {
+                "length": "",
+                "width": "",
+                "height": ""
+            },
+            "shipping_class": "",
+            "shipping_class_id": 0,
+            "image": {
+                "id": 1063,
+                "date_created": "2019-11-01T08:42:05",
+                "date_created_gmt": "2019-11-01T04:12:05",
+                "date_modified": "2019-11-01T08:42:05",
+                "date_modified_gmt": "2019-11-01T04:12:05",
+                "src": "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1",
+                "name": "DSC_0010",
+                "alt": ""
+            },
+            "attributes": [
+                {
+                    "id": 0,
+                    "name": "Darkness",
+                    "option": "99%"
+                },
+                {
+                    "id": 0,
+                    "name": "Flavor",
+                    "option": "nuts"
+                },
+                {
+                    "id": 0,
+                    "name": "Shape",
+                    "option": "brick"
+                }
+            ],
+            "menu_order": 7,
+            "meta_data": [
+                {
+                    "id": 6747,
+                    "key": "_created_via",
+                    "value": "ajax-unknown"
+                }
+            ],
+            "parent_id": 10275,
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations/1274"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations"
+                    }
+                ],
+                "up": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846"
+                    }
+                ]
+            }
+        }
+    ]
+}
+

--- a/Networking/Sources/Extended/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Sources/Extended/Model/Copiable/Models+Copiable.generated.swift
@@ -1932,6 +1932,60 @@ extension Networking.POSProduct {
     }
 }
 
+extension Networking.POSProductVariation {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        productID: CopiableProp<Int64> = .copy,
+        productVariationID: CopiableProp<Int64> = .copy,
+        attributes: CopiableProp<[ProductVariationAttribute]> = .copy,
+        image: NullableCopiableProp<ProductImage> = .copy,
+        sku: NullableCopiableProp<String> = .copy,
+        globalUniqueID: NullableCopiableProp<String> = .copy,
+        price: CopiableProp<String> = .copy,
+        regularPrice: NullableCopiableProp<String> = .copy,
+        salePrice: NullableCopiableProp<String> = .copy,
+        onSale: CopiableProp<Bool> = .copy,
+        downloadable: CopiableProp<Bool> = .copy,
+        manageStock: CopiableProp<Bool> = .copy,
+        stockQuantity: NullableCopiableProp<Decimal> = .copy,
+        stockStatusKey: CopiableProp<String> = .copy
+    ) -> Networking.POSProductVariation {
+        let siteID = siteID ?? self.siteID
+        let productID = productID ?? self.productID
+        let productVariationID = productVariationID ?? self.productVariationID
+        let attributes = attributes ?? self.attributes
+        let image = image ?? self.image
+        let sku = sku ?? self.sku
+        let globalUniqueID = globalUniqueID ?? self.globalUniqueID
+        let price = price ?? self.price
+        let regularPrice = regularPrice ?? self.regularPrice
+        let salePrice = salePrice ?? self.salePrice
+        let onSale = onSale ?? self.onSale
+        let downloadable = downloadable ?? self.downloadable
+        let manageStock = manageStock ?? self.manageStock
+        let stockQuantity = stockQuantity ?? self.stockQuantity
+        let stockStatusKey = stockStatusKey ?? self.stockStatusKey
+
+        return Networking.POSProductVariation(
+            siteID: siteID,
+            productID: productID,
+            productVariationID: productVariationID,
+            attributes: attributes,
+            image: image,
+            sku: sku,
+            globalUniqueID: globalUniqueID,
+            price: price,
+            regularPrice: regularPrice,
+            salePrice: salePrice,
+            onSale: onSale,
+            downloadable: downloadable,
+            manageStock: manageStock,
+            stockQuantity: stockQuantity,
+            stockStatusKey: stockStatusKey
+        )
+    }
+}
+
 extension Networking.PaymentGateway {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,
@@ -3113,7 +3167,7 @@ extension Networking.ShippingLabelAccountSettings {
         isEmailReceiptsEnabled: CopiableProp<Bool> = .copy,
         paperSize: CopiableProp<ShippingLabelPaperSize> = .copy,
         lastSelectedPackageID: CopiableProp<String> = .copy,
-        addPaymentMethodURL: CopiableProp<URL> = .copy
+        addPaymentMethodURL: NullableCopiableProp<URL> = .copy
     ) -> Networking.ShippingLabelAccountSettings {
         let siteID = siteID ?? self.siteID
         let canManagePayments = canManagePayments ?? self.canManagePayments

--- a/Networking/Sources/Extended/Model/POSProductVariation.swift
+++ b/Networking/Sources/Extended/Model/POSProductVariation.swift
@@ -1,0 +1,176 @@
+import Foundation
+import Codegen
+
+/// Represents a Product Variation Entity for use in Point of Sale.
+/// This deliberately only includes a subset of the fields available for ProductVariation.
+/// It's likely that most or all of a store's variations will be fetched and stored for POS,
+/// so we wanted a smaller representation and to reduce the risk of decoding issues
+/// caused by plugin incompatibilities.
+///
+public struct POSProductVariation: Codable, Equatable, GeneratedCopiable, GeneratedFakeable {
+    public let siteID: Int64
+    public let productID: Int64
+
+    public let productVariationID: Int64
+
+    public let attributes: [ProductVariationAttribute]
+    public let image: ProductImage?
+
+    public let sku: String?
+    public let globalUniqueID: String?
+
+    public let price: String
+    public let regularPrice: String?
+    public let salePrice: String?
+    public let onSale: Bool
+
+    public let downloadable: Bool
+
+    public let manageStock: Bool
+    public let stockQuantity: Decimal?
+    public let stockStatusKey: String
+
+    public var stockStatus: ProductStockStatus {
+        return ProductStockStatus(rawValue: stockStatusKey)
+    }
+
+    public init(siteID: Int64,
+                productID: Int64,
+                productVariationID: Int64,
+                attributes: [ProductVariationAttribute],
+                image: ProductImage?,
+                sku: String?,
+                globalUniqueID: String?,
+                price: String,
+                regularPrice: String?,
+                salePrice: String?,
+                onSale: Bool,
+                downloadable: Bool,
+                manageStock: Bool,
+                stockQuantity: Decimal?,
+                stockStatusKey: String) {
+        self.siteID = siteID
+        self.productID = productID
+        self.productVariationID = productVariationID
+        self.attributes = attributes
+        self.image = image
+        self.sku = sku
+        self.globalUniqueID = globalUniqueID
+        self.price = price
+        self.regularPrice = regularPrice
+        self.salePrice = salePrice
+        self.onSale = onSale
+        self.downloadable = downloadable
+        self.manageStock = manageStock
+        self.stockQuantity = stockQuantity
+        self.stockStatusKey = stockStatusKey
+    }
+
+    public init(from decoder: Decoder) throws {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
+            throw POSProductVariationDecodingError.missingSiteID
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let decimalString = AlternativeDecodingType.decimal { value in
+            NSDecimalNumber(decimal: value).stringValue
+        }
+
+        let productVariationID = try container.decode(Int64.self, forKey: .productVariationID)
+        let productID = try container.decode(Int64.self, forKey: .productID)
+        let attributes = try container.decode([ProductVariationAttribute].self, forKey: .attributes)
+        let image = try container.decodeIfPresent(ProductImage.self, forKey: .image)
+        let sku = container.failsafeDecodeIfPresent(
+            targetType: String.self,
+            forKey: .sku,
+            alternativeTypes: [decimalString])
+        let globalUniqueID = try container.decodeIfPresent(String.self, forKey: .globalUniqueID)
+        let price = container.failsafeDecodeIfPresent(
+            targetType: String.self,
+            forKey: .price,
+            alternativeTypes: [decimalString]) ?? ""
+        let regularPrice = container.failsafeDecodeIfPresent(
+            targetType: String.self,
+            forKey: .regularPrice,
+            alternativeTypes: [decimalString])
+        let salePrice = container.failsafeDecodeIfPresent(
+            targetType: String.self,
+            forKey: .salePrice,
+            alternativeTypes: [decimalString])
+        let onSale = container.failsafeDecodeIfPresent(
+            targetType: Bool.self,
+            forKey: .onSale,
+            alternativeTypes: [.string(transform: { NSString(string: $0).boolValue })]) ?? false
+        let downloadable = try container.decode(Bool.self, forKey: .downloadable)
+        let manageStock = container.failsafeDecodeIfPresent(
+            targetType: Bool.self,
+            forKey: .manageStock,
+            alternativeTypes: [
+                .string(transform: { value in
+                    guard value.lowercased() == Values.manageStockParent else {
+                        let message = "Unexpected manage stock value: \(value)"
+                        assertionFailure(message)
+                        DDLogError(message)
+                        return false
+                    }
+                    return false
+                })
+        ]) ?? false
+        let stockQuantity = container.failsafeDecodeIfPresent(decimalForKey: .stockQuantity)
+        let stockStatusKey = try container.decode(String.self, forKey: .stockStatusKey)
+
+        self.init(siteID: siteID,
+                  productID: productID,
+                  productVariationID: productVariationID,
+                  attributes: attributes,
+                  image: image,
+                  sku: sku,
+                  globalUniqueID: globalUniqueID,
+                  price: price,
+                  regularPrice: regularPrice,
+                  salePrice: salePrice,
+                  onSale: onSale,
+                  downloadable: downloadable,
+                  manageStock: manageStock,
+                  stockQuantity: stockQuantity,
+                  stockStatusKey: stockStatusKey)
+    }
+
+    static let requestFields: [String] = {
+        CodingKeys.allCases.map( \.rawValue )
+    }()
+}
+
+// MARK: - Decoding Errors
+//
+enum POSProductVariationDecodingError: Error {
+    case missingSiteID
+    case missingProductID
+}
+
+// MARK: - Coding Keys
+//
+private extension POSProductVariation {
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case productVariationID = "id"
+        case productID = "parent_id"
+        case attributes
+        case image
+        case price
+        case regularPrice = "regular_price"
+        case salePrice = "sale_price"
+        case onSale = "on_sale"
+        case sku
+        case globalUniqueID = "global_unique_id"
+        case downloadable
+        case manageStock = "manage_stock"
+        case stockQuantity = "stock_quantity"
+        case stockStatusKey = "stock_status"
+    }
+}
+
+private extension POSProductVariation {
+    enum Values {
+        static let manageStockParent = "parent"
+    }
+}

--- a/Networking/Sources/Extended/Remote/ProductVariationsRemote.swift
+++ b/Networking/Sources/Extended/Remote/ProductVariationsRemote.swift
@@ -90,6 +90,10 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
                                                context: nil,
                                                pageNumber: pageNumber,
                                                pageSize: POSConstants.variationsPerPage)
+        // N.B. POS is only available for WC 9.6 and later.
+        // `parent_id` was added in WC 8.3, so we don't need to pass the parent product ID to the decoder.
+        // https://github.com/woocommerce/woocommerce/pull/40606
+        // This isn't safe to do in the endpoints for the main app, as older sites won't have `parent_id`.
         let mapper = ListMapper<POSProductVariation>(siteID: siteID)
 
         let (variations, responseHeaders) = try await enqueueWithResponseHeaders(request, mapper: mapper)

--- a/Networking/Sources/Extended/Remote/ProductVariationsRemote.swift
+++ b/Networking/Sources/Extended/Remote/ProductVariationsRemote.swift
@@ -14,7 +14,7 @@ public protocol ProductVariationsRemoteProtocol {
                                   completion: @escaping ([ProductVariation]?, Error?) -> Void)
     func loadVariationsForPointOfSale(for siteID: Int64,
                                       parentProductID: Int64,
-                                      pageNumber: Int) async throws -> PagedItems<ProductVariation>
+                                      pageNumber: Int) async throws -> PagedItems<POSProductVariation>
     func loadProductVariation(for siteID: Int64, productID: Int64, variationID: Int64, completion: @escaping (Result<ProductVariation, Error>) -> Void)
     func createProductVariation(for siteID: Int64,
                                 productID: Int64,
@@ -78,7 +78,7 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
     /// - Returns: Variations for the provided parent product.
     public func loadVariationsForPointOfSale(for siteID: Int64,
                                              parentProductID: Int64,
-                                             pageNumber: Int = Default.pageNumber) async throws -> PagedItems<ProductVariation> {
+                                             pageNumber: Int = Default.pageNumber) async throws -> PagedItems<POSProductVariation> {
         let request = productVariationsRequest(for: siteID,
                                                productID: parentProductID,
                                                variationIDs: [],
@@ -86,10 +86,11 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
                                                status: .published,
                                                orderBy: .menuOrder,
                                                order: .ascending,
+                                               fields: POSProductVariation.requestFields,
                                                context: nil,
                                                pageNumber: pageNumber,
                                                pageSize: POSConstants.variationsPerPage)
-        let mapper = ProductVariationListMapper(siteID: siteID, productID: parentProductID)
+        let mapper = ListMapper<POSProductVariation>(siteID: siteID)
 
         let (variations, responseHeaders) = try await enqueueWithResponseHeaders(request, mapper: mapper)
 
@@ -113,16 +114,19 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
                                           status: ProductStatus? = nil,
                                           orderBy: OrderByField? = nil,
                                           order: OrderDirection? = nil,
+                                          fields: [String] = [],
                                           context: String?,
                                           pageNumber: Int,
                                           pageSize: Int) -> JetpackRequest {
         let stringOfVariationIDs = variationIDs.map { String($0) }
             .joined(separator: ",")
+        let stringOfRequiredFields = fields.joined(separator: ",")
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),
             ParameterKey.downloadable: downloadable.map { String($0) },
             ParameterKey.contextKey: context ?? Default.context,
+            ParameterKey.fields: fields.isEmpty ? nil : stringOfRequiredFields,
             ParameterKey.include: variationIDs.isEmpty ? nil: stringOfVariationIDs,
             ParameterKey.status: status?.rawValue,
             ParameterKey.orderBy: orderBy?.rawValue,
@@ -346,6 +350,7 @@ public extension ProductVariationsRemote {
         static let page: String       = "page"
         static let perPage: String    = "per_page"
         static let contextKey: String = "context"
+        static let fields: String     = "_fields"
         static let image: String = "image"
         static let include: String    = "include"
         static let downloadable: String = "downloadable"

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 22.6
 -----
 - [internal] Updated Xcode version to 16.4 [https://github.com/woocommerce/woocommerce-ios/pull/15696]
+- [internal] Reduced fields fetched for variations in Point of Sale [https://github.com/woocommerce/woocommerce-ios/pull/15712]
 
 22.5
 -----

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -15,7 +15,7 @@ import struct Yosemite.ProductBundleItem
 import struct Yosemite.OrderItem
 import protocol Yosemite.PointOfSalePurchasableItemFetchStrategy
 import struct Yosemite.POSProduct
-import struct Yosemite.ProductVariation
+import struct Yosemite.POSProductVariation
 import protocol Yosemite.POSSearchHistoryProviding
 import enum Yosemite.POSItemType
 import protocol Yosemite.PointOfSaleBarcodeScanServiceProtocol
@@ -75,7 +75,7 @@ struct PointOfSalePreviewPurchasableItemFetchStrategy: PointOfSalePurchasableIte
         return .init(items: [], hasMorePages: true, totalItems: nil)
     }
 
-    func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<ProductVariation> {
+    func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
         return .init(items: [], hasMorePages: true, totalItems: nil)
     }
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -90,6 +90,7 @@ public typealias PaymentGateway = Networking.PaymentGateway
 public typealias PaymentGatewayAccount = Networking.PaymentGatewayAccount
 public typealias Product = Networking.Product
 public typealias POSProduct = Networking.POSProduct
+public typealias POSProductVariation = Networking.POSProductVariation
 public typealias ProductAddOn = Networking.ProductAddOn
 public typealias ProductAddOnOption = Networking.ProductAddOnOption
 public typealias ProductBackordersSetting = Networking.ProductBackordersSetting

--- a/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleItemMapper.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleItemMapper.swift
@@ -4,7 +4,7 @@ import class WooFoundation.CurrencyFormatter
 
 public protocol PointOfSaleItemMapperProtocol {
     func mapProductsToPOSItems(products: [POSProduct]) -> [POSItem]
-    func mapVariationsToPOSItems(variations: [ProductVariation], parentProduct: POSVariableParentProduct) -> [POSItem]
+    func mapVariationsToPOSItems(variations: [POSProductVariation], parentProduct: POSVariableParentProduct) -> [POSItem]
 }
 
 /// Maps products and variations to POSItems, and populates the output with:
@@ -46,7 +46,7 @@ final class PointOfSaleItemMapper: PointOfSaleItemMapperProtocol {
         }
     }
 
-    func mapVariationsToPOSItems(variations: [ProductVariation], parentProduct: POSVariableParentProduct) -> [POSItem] {
+    func mapVariationsToPOSItems(variations: [POSProductVariation], parentProduct: POSVariableParentProduct) -> [POSItem] {
         return variations.compactMap { variation in
             let variationName = ProductVariationFormatter().generateNameWithAttributeNames(
                 for: variation,

--- a/Yosemite/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
@@ -4,7 +4,7 @@ import protocol Networking.ProductVariationsRemoteProtocol
 
 public protocol PointOfSalePurchasableItemFetchStrategy {
     func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct>
-    func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<ProductVariation>
+    func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation>
 }
 
 extension PointOfSalePurchasableItemFetchStrategy {
@@ -40,7 +40,7 @@ public struct PointOfSaleDefaultPurchasableItemFetchStrategy: PointOfSalePurchas
         return pagedProducts
     }
 
-    public func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<ProductVariation> {
+    public func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
         try await variationsRemote
             .loadVariationsForPointOfSale(for: siteID,
                                           parentProductID: parentProductID,
@@ -83,7 +83,7 @@ public struct PointOfSaleSearchPurchasableItemFetchStrategy: PointOfSalePurchasa
         return pagedProducts
     }
 
-    public func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<ProductVariation> {
+    public func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
         try await variationsRemote
             .loadVariationsForPointOfSale(for: siteID,
                                           parentProductID: parentProductID,
@@ -118,7 +118,7 @@ public struct PointOfSalePopularPurchasableItemFetchStrategy: PointOfSalePurchas
         return modifiedItems
     }
 
-    public func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<ProductVariation> {
+    public func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
         try await variationsRemote
             .loadVariationsForPointOfSale(for: siteID,
                                           parentProductID: parentProductID,

--- a/Yosemite/Yosemite/Tools/ProductVariations/ProductVariationFormatter.swift
+++ b/Yosemite/Yosemite/Tools/ProductVariations/ProductVariationFormatter.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+public protocol ProductVariationFormattable {
+    var attributes: [ProductVariationAttribute] { get }
+}
+
+// MARK: - Model Conformance
+extension ProductVariation: ProductVariationFormattable {}
+extension POSProductVariation: ProductVariationFormattable {}
+
 /// Helper to format product variation details, such as variation name or attributes.
 ///
 public struct ProductVariationFormatter {
@@ -11,7 +19,7 @@ public struct ProductVariationFormatter {
     ///   - allAttributes: A list of attributes from the parent `Product`
     ///   - separator: The string to use to separate attributes used to make up the name. Default `" - "`
     ///
-    public func generateName(for variation: ProductVariation,
+    public func generateName(for variation: ProductVariationFormattable,
                              from allAttributes: [ProductAttribute],
                              separator: String = " - ") -> String {
         let variationAttributes = generateAttributes(for: variation, from: allAttributes)
@@ -24,7 +32,7 @@ public struct ProductVariationFormatter {
     ///   - allAttributes: A list of attributes from the parent `Product`
     ///   - separator: The string to use to separate attributes used to make up the name. Default `" - "`
     ///
-    public func generateNameWithAttributeNames(for variation: ProductVariation,
+    public func generateNameWithAttributeNames(for variation: ProductVariationFormattable,
                                                from allAttributes: [ProductAttribute],
                                                separator: String = " - ") -> String {
         let variationAttributes = generateAttributes(for: variation, from: allAttributes)
@@ -36,7 +44,7 @@ public struct ProductVariationFormatter {
     ///   - variation: The product variation whose attributes are being generated
     ///   - allAttributes: A list of attributes from the parent `Product`
     ///
-    public func generateAttributes(for variation: ProductVariation, from allAttributes: [ProductAttribute]) -> [VariationAttributeViewModel] {
+    public func generateAttributes(for variation: ProductVariationFormattable, from allAttributes: [ProductAttribute]) -> [VariationAttributeViewModel] {
         return allAttributes
             .sorted(by: { (lhs, rhs) -> Bool in
                 lhs.position < rhs.position

--- a/Yosemite/YosemiteTests/Mocks/MockPointOfSaleItemMapper.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockPointOfSaleItemMapper.swift
@@ -5,7 +5,7 @@ final class MockPointOfSaleItemMapper: PointOfSaleItemMapperProtocol {
     var mapProductsToPOSItemsCalled = false
     var mapVariationsToPOSItemsCalled = false
     var mockProducts: [POSProduct] = []
-    var mockVariations: [ProductVariation] = []
+    var mockVariations: [POSProductVariation] = []
     var mockParentProduct: POSVariableParentProduct?
     var mockMappedProducts: [POSItem] = []
     var mockMappedVariations: [POSItem] = []
@@ -16,7 +16,7 @@ final class MockPointOfSaleItemMapper: PointOfSaleItemMapperProtocol {
         return mockMappedProducts
     }
 
-    func mapVariationsToPOSItems(variations: [ProductVariation], parentProduct: POSVariableParentProduct) -> [POSItem] {
+    func mapVariationsToPOSItems(variations: [POSProductVariation], parentProduct: POSVariableParentProduct) -> [POSItem] {
         mapVariationsToPOSItemsCalled = true
         mockVariations = variations
         mockParentProduct = parentProduct

--- a/Yosemite/YosemiteTests/Mocks/MockPointOfSalePurchasableItemFetchStrategy.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockPointOfSalePurchasableItemFetchStrategy.swift
@@ -6,7 +6,7 @@ final class MockPointOfSalePurchasableItemFetchStrategy: PointOfSalePurchasableI
     var fetchProductsCalled = false
     var spyFetchProductsPageNumber: Int?
     var mockPagedProductsResult: Result<PagedItems<POSProduct>, Error>?
-    var mockPagedVariationsResult: Result<PagedItems<ProductVariation>, Error>?
+    var mockPagedVariationsResult: Result<PagedItems<POSProductVariation>, Error>?
 
     func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct> {
         fetchProductsCalled = true
@@ -24,7 +24,7 @@ final class MockPointOfSalePurchasableItemFetchStrategy: PointOfSalePurchasableI
     var fetchVariationsCalled = false
     var spyFetchVariationsParentProductID: Int64?
     var spyFetchVariationsPageNumber: Int?
-    func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<ProductVariation> {
+    func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
         fetchVariationsCalled = true
         spyFetchVariationsParentProductID = parentProductID
         spyFetchVariationsPageNumber = pageNumber
@@ -34,7 +34,7 @@ final class MockPointOfSalePurchasableItemFetchStrategy: PointOfSalePurchasableI
         case .failure(let error):
             throw error
         case .none:
-            return PagedItems<ProductVariation>(items: [], hasMorePages: false, totalItems: nil)
+            return PagedItems<POSProductVariation>(items: [], hasMorePages: false, totalItems: nil)
         }
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
@@ -31,7 +31,7 @@ final class MockProductVariationsRemote {
     private var productVariationDeleteResults = [ResultKey: Result<ProductVariation, Error>]()
 
     /// The results to return based on the given arguments in `loadVariationsForPointOfSale`
-    private var variationsForPointOfSaleResults = [ResultKey: Result<[ProductVariation], Error>]()
+    private var variationsForPointOfSaleResults = [ResultKey: Result<[POSProductVariation], Error>]()
 
     /// Set the value passed to the `completion` block if `createProductVariation()` is called.
     ///
@@ -81,7 +81,7 @@ final class MockProductVariationsRemote {
 
     /// Set the value to return if `loadVariationsForPointOfSale()` is called.
     ///
-    func whenLoadingVariationsForPointOfSale(siteID: Int64, parentProductID: Int64, thenReturn result: Result<[ProductVariation], Error>) {
+    func whenLoadingVariationsForPointOfSale(siteID: Int64, parentProductID: Int64, thenReturn result: Result<[POSProductVariation], Error>) {
         let key = ResultKey(siteID: siteID, productID: parentProductID, productVariationIDs: [])
         variationsForPointOfSaleResults[key] = result
     }
@@ -100,7 +100,7 @@ extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
         // no-op
     }
 
-    func loadVariationsForPointOfSale(for siteID: Int64, parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<ProductVariation> {
+    func loadVariationsForPointOfSale(for siteID: Int64, parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
         let key = ResultKey(siteID: siteID, productID: parentProductID, productVariationIDs: [])
         guard let result = variationsForPointOfSaleResults[key] else {
             throw NetworkError.notFound()

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemMapperTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemMapperTests.swift
@@ -87,7 +87,7 @@ struct PointOfSaleItemMapperTests {
             ([], createParentProduct())
           ])
     func mapVariationsToPOSItemsWithCount(
-        variations: [ProductVariation],
+        variations: [POSProductVariation],
         parentProduct: POSVariableParentProduct
     ) {
         // When
@@ -193,8 +193,8 @@ struct PointOfSaleItemMapperTests {
         )
     }
 
-    private static func createVariation1() -> ProductVariation {
-        ProductVariation.fake().copy(
+    private static func createVariation1() -> POSProductVariation {
+        POSProductVariation.fake().copy(
             productID: 125,
             productVariationID: 456,
             attributes: [ProductVariationAttribute.fake().copy(name: "Color", option: "Red")],
@@ -203,8 +203,8 @@ struct PointOfSaleItemMapperTests {
         )
     }
 
-    private static func createVariation2() -> ProductVariation {
-        ProductVariation.fake().copy(
+    private static func createVariation2() -> POSProductVariation {
+        POSProductVariation.fake().copy(
             productID: 125,
             productVariationID: 457,
             attributes: [ProductVariationAttribute.fake().copy(name: "Color", option: "Blue")],

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
@@ -184,7 +184,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         )
 
         let mockFetchStrategy = MockPointOfSalePurchasableItemFetchStrategy()
-        let mockVariation = ProductVariation.fake().copy(
+        let mockVariation = POSProductVariation.fake().copy(
             productID: parentProductID,
             productVariationID: 1274,
             image: .fake().copy(src: "https://example.com/variation.jpg"),
@@ -297,7 +297,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         )
 
         let mockFetchStrategy = MockPointOfSalePurchasableItemFetchStrategy()
-        mockFetchStrategy.mockPagedVariationsResult = .success(PagedItems(items: [ProductVariation.fake()],
+        mockFetchStrategy.mockPagedVariationsResult = .success(PagedItems(items: [POSProductVariation.fake()],
                                                                           hasMorePages: false,
                                                                           totalItems: 1))
 
@@ -371,7 +371,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
     func test_providePointOfSaleVariationItems_returns_expected_items() async throws {
         // Given
         let mockFetchStrategy = MockPointOfSalePurchasableItemFetchStrategy()
-        mockFetchStrategy.mockPagedVariationsResult = .success(PagedItems(items: [ProductVariation.fake()],
+        mockFetchStrategy.mockPagedVariationsResult = .success(PagedItems(items: [POSProductVariation.fake()],
                                                                           hasMorePages: false,
                                                                           totalItems: 1))
 
@@ -447,13 +447,13 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         )
 
         let mockFetchStrategy = MockPointOfSalePurchasableItemFetchStrategy()
-        let mockVariation = ProductVariation.fake().copy(
+        let mockVariation = POSProductVariation.fake().copy(
             productID: parentProductID,
             productVariationID: 456,
             price: "20.00",
             manageStock: true,
             stockQuantity: 10,
-            stockStatus: .inStock
+            stockStatusKey: "instock"
         )
         mockFetchStrategy.mockPagedVariationsResult = .success(PagedItems(items: [mockVariation],
                                                                           hasMorePages: false,

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSalePopularPurchasableItemFetchStrategyTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSalePopularPurchasableItemFetchStrategyTests.swift
@@ -63,8 +63,8 @@ struct PointOfSalePopularPurchasableItemFetchStrategyTests {
         // Given
         let parentProductID: Int64 = 1
         let variations = [
-            ProductVariation.fake().copy(siteID: siteID, productID: parentProductID, productVariationID: 1),
-            ProductVariation.fake().copy(siteID: siteID, productID: parentProductID, productVariationID: 2)
+            POSProductVariation.fake().copy(siteID: siteID, productID: parentProductID, productVariationID: 1),
+            POSProductVariation.fake().copy(siteID: siteID, productID: parentProductID, productVariationID: 2)
         ]
         variationsRemote.whenLoadingVariationsForPointOfSale(siteID: siteID, parentProductID: parentProductID, thenReturn: .success(variations))
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of WOOPRD-560

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a `POSProductVariation` networking entity, for the same reasons that we have `POSProduct`. Fetching a subset of fields makes POS safer and faster to use, and makes it easier for us to write our model manipulation code.

This is a dependency of the barcode scanning, as we'll have to transform a `POSProduct` into a `POSProductVariation` when we get variations-as-products in response to barcode scan lookups.

We should have done this originally with variable product support, but forgot.

There's no behavioural change in this PR, except that the request for product variations from POS now specifies a limited subset of fields – you can observe this with a network proxy tool.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and open POS
2. Open a variable product, observe that they load as expected and you can purchase the variations.
3. Repeat using search, observe that it works as normal.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

I tested on an iPad Air running iOS 17.7.2 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/8958e89a-11c7-422d-8022-5a3b35468f58


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
