### PR TITLE
Re-enable skipped receipt generation test that crashes from WebCore under iOS 18.4+

### DIFF
--- a/Hardware/Hardware/Printer/AirPrintReceipt/AirPrintReceiptPrinterService.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/AirPrintReceiptPrinterService.swift
@@ -19,6 +19,7 @@ public final class AirPrintReceiptPrinterService: NSObject, PrinterService {
         printController.delegate = self
 
         let renderer = ReceiptRenderer(content: content)
+        renderer.configureFormatterForPrinting()
         printController.printPageRenderer = renderer
 
         printController.present(animated: true) { (controller, completed, error) in

--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -18,8 +18,14 @@ public final class ReceiptRenderer: UIPrintPageRenderer {
         self.content = content
 
         super.init()
+    }
 
-        configureFormatter()
+    public func configureFormatterForPrinting() {
+        let formatter = UIMarkupTextPrintFormatter(markupText: htmlContent())
+        formatter.perPageContentInsets = .init(top: 0, left: Constants.margin, bottom: 0, right: Constants.margin)
+        formatter.maximumContentWidth = content.preferredPageSizeForPrinting.width - 2 * Constants.margin
+
+        addPrintFormatter(formatter, startingAtPageAt: 0)
     }
 }
 
@@ -100,14 +106,6 @@ public extension ReceiptRenderer {
 
 
 private extension ReceiptRenderer {
-    private func configureFormatter() {
-        let formatter = UIMarkupTextPrintFormatter(markupText: htmlContent())
-        formatter.perPageContentInsets = .init(top: 0, left: Constants.margin, bottom: 0, right: Constants.margin)
-        formatter.maximumContentWidth = content.preferredPageSizeForPrinting.width - 2 * Constants.margin
-
-        addPrintFormatter(formatter, startingAtPageAt: 0)
-    }
-
     private func summaryTable() -> String {
         var summaryContent = "<table>"
         for line in content.lineItems {

--- a/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
@@ -415,10 +415,6 @@ final class ReceiptStoreTests: XCTestCase {
     }
 
     func test_generateContent_callsGenerate_passingUnmodified_customerNote() throws {
-        if #available(iOS 18.4, *) {
-            throw XCTSkip("Skipped on iOS 18.4 because of a WebKit crash when running on that OS.")
-        }
-
         // Given
         let mockIntent = PaymentIntent.fake().copy(charges: [Mocks.cardPresentCharge])
         let mockParameters = try XCTUnwrap(mockIntent.receiptParameters())


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Fixes WOOMOB-473

## Why

When the apps infra team upgraded CI to Xcode 16.3 / iOS 18.4, `ReceiptStoreTests.test_generateContent_callsGenerate_passingUnmodified_customerNote` caused a crash later on in the test class consistently in a WebThread:

```
#0	0x000000018f5cd040 in WebCore::DocumentLoader::removeSubresourceLoader ()
#1	0x000000018f67deb8 in WebCore::SubresourceLoader::notifyDone ()
#2	0x000000018f67e834 in WebCore::SubresourceLoader::didCancel ()
#3	0x000000018f666f04 in WebCore::ResourceLoader::cancel ()
#4	0x000000018f66416c in WebCore::ResourceLoader::cancel ()
#5	0x000000018f663814 in WebCore::ResourceLoader::init ()
#6	0x000000018f677740 in WebCore::SubresourceLoader::startLoading ()
```

I can repro this crash in Xcode 16.4 / iOS 18.5 that CI runs on. In the Xcode console, a warning (shown with red background color) `WebThread enabled` also appeared after starting this test case.

This stack trace shows that the crash is happening in WebKit's resource loading system (`SubresourceLoader`), specifically when trying to load and then cancel a resource. Looking at the `ReceiptRenderer` code, I found that [`cardIconCSS()`](https://github.com/woocommerce/woocommerce-ios/blob/ec01cbc53693d18e989453d8aa05e9833a5e5e94/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift#L192-L196) is the only place where external resources are being loaded into the HTML and returning an empty for this function fixes the crash.

However, looking at the `ReceiptRenderer.htmlContent` function that the test case triggers, it doesn't seem to invoke WebKit. Why is there a crash in WebKit? It's the `configureFormatter` function called in the initializer that starts WebKit from `UIMarkupTextPrintFormatter`. But in the test case `ReceiptAction.generateContent`, it just returns a HTML string without the need to configure the formatter for printing.

## How
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We can move the `configureFormatter` that triggers WebKit from the initializer to a separate public function for the printing use case.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: have a store with WC version < 8.7, WooPayments with dev tools (I used JN with Woo Beta Tester to switch to an earlier version). set up store for WooPayments as local receipt is only generated after a successful IPP

- Go to the orders tab
- Create an order with non-zero amount and pay with card --> in the success modal, it should include CTAs to print or save receipt
- Tap on print CTA --> the receipt content should look correct
- Go back to order details, refresh if needed --> `See receipt` CTA should appear
- Tap `See receipt` --> the receipt content should look correct
- Tap the print icon --> the receipt content should look correct

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested with WC version 8.5.0 and the latest WooPayments.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

backend receipt | local receipt
-- | --
![Simulator Screenshot - iPad mini (A17 Pro) - 2025-06-06 at 09 48 04](https://github.com/user-attachments/assets/f5e35750-737c-4934-808a-5ff421c02478) | ![Simulator Screenshot - iPad mini (A17 Pro) - 2025-06-06 at 10 00 52](https://github.com/user-attachments/assets/d87f7e6e-167d-44e0-9357-fa1cbe0ed280)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.