### PR TITLE
Shipping Labels: Confirm UPS T&C acceptance

### DIFF
--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -802,6 +802,44 @@ final class WooShippingRemoteTests: XCTestCase {
         // Then
         XCTAssertNotNil(result.failure)
     }
+
+    // MARK: Accept UPS TOS
+
+    func test_acceptUPSTermsOfService_parses_success_response() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "carrier-strategy/upsdap", filename: "generic_success")
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            remote.acceptUPSTermsOfService(siteID: self.sampleSiteID,
+                                           originAddress: WooShippingAddress.fake()) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let success = try XCTUnwrap(result.get())
+        XCTAssertTrue(success)
+    }
+
+    func test_acceptUPSTermsOfService_returns_error_on_failure() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        let expectedError = NetworkError.timeout(response: nil)
+        network.simulateError(requestUrlSuffix: "carrier-strategy/upsdap", error: expectedError)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            remote.acceptUPSTermsOfService(siteID: self.sampleSiteID,
+                                           originAddress: WooShippingAddress.fake()) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertNotNil(result.failure)
+    }
 }
 
 private extension WooShippingRemoteTests {

--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -808,7 +808,7 @@ final class WooShippingRemoteTests: XCTestCase {
     func test_acceptUPSTermsOfService_parses_success_response() throws {
         // Given
         let remote = WooShippingRemote(network: network)
-        network.simulateResponse(requestUrlSuffix: "carrier-strategy/upsdap", filename: "generic_success")
+        network.simulateResponse(requestUrlSuffix: "carrier-strategy/upsdap", filename: "generic_success_data")
 
         // When
         let result: Result<Bool, Error> = waitFor { promise in

--- a/Networking/Sources/Extended/Model/ShippingLabel/WooShippingAddress.swift
+++ b/Networking/Sources/Extended/Model/ShippingLabel/WooShippingAddress.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents an address for the WooCommerce Shipping extension.
 ///
-public struct WooShippingAddress: Equatable, GeneratedFakeable, GeneratedCopiable {
+public struct WooShippingAddress: Equatable, Hashable, GeneratedFakeable, GeneratedCopiable {
     /// The name of the company at the address.
     public let company: String
 

--- a/Networking/Sources/Extended/Remote/WooShippingRemote.swift
+++ b/Networking/Sources/Extended/Remote/WooShippingRemote.swift
@@ -552,7 +552,7 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
                                          path: path,
                                          parameters: parameters,
                                          availableAsRESTRequest: true)
-            let mapper = SuccessResultMapper()
+            let mapper = SuccessDataResultMapper()
             enqueue(request, mapper: mapper, completion: completion)
         } catch {
             completion(.failure(error))

--- a/Networking/Sources/Extended/Remote/WooShippingRemote.swift
+++ b/Networking/Sources/Extended/Remote/WooShippingRemote.swift
@@ -72,6 +72,10 @@ public protocol WooShippingRemoteProtocol {
                              orderID: Int64,
                              shippingLabelID: Int64,
                              completion: @escaping (Result<ShippingLabelRefund, Error>) -> Void)
+
+    func acceptUPSTermsOfService(siteID: Int64,
+                                 originAddress: WooShippingAddress,
+                                 completion: @escaping(Result<Bool, Error>) -> Void)
 }
 
 /// Shipping Labels Remote Endpoints for the WooShipping Plugin.
@@ -526,6 +530,34 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
         let mapper = ShippingLabelRefundMapper()
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Updates the Terms of Service agreement status for a specific origin address in the UPS DAP carrier strategies.
+    /// - Parameters:
+    ///   - siteID: Remote ID of the site that owns the shipping label.
+    ///   - originAddress: The origin address to accept the TOS.
+    ///   - completion: Closure to be executed upon completion.
+    ///
+    public func acceptUPSTermsOfService(siteID: Int64,
+                                        originAddress: WooShippingAddress,
+                                        completion: @escaping(Result<Bool, Error>) -> Void) {
+        do {
+            let path = Path.upsdapCarrierStrategy
+            let parameters: [String: Any] = [
+                ParameterKey.originAddress: try originAddress.toDictionary(),
+                ParameterKey.confirmed: true
+            ]
+            let request = JetpackRequest(wooApiVersion: .wooShipping,
+                                         method: .post,
+                                         siteID: siteID,
+                                         path: path,
+                                         parameters: parameters,
+                                         availableAsRESTRequest: true)
+            let mapper = SuccessResultMapper()
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
+            completion(.failure(error))
+        }
+    }
 }
 
 // MARK: Constants
@@ -555,6 +587,7 @@ private extension WooShippingRemote {
         static func refundLabel(orderID: Int64, labelID: Int64) -> String {
             "label/refund/\(orderID)/\(labelID)"
         }
+        static let upsdapCarrierStrategy = "carrier-strategy/upsdap"
     }
 
     enum ParameterKey {
@@ -578,6 +611,7 @@ private extension WooShippingRemote {
         static let emailReceipts = "email_receipts"
         static let enabled = "enabled"
         static let featuresSupported = "features_supported_by_client"
+        static let confirmed = "confirmed"
     }
 
     enum Values {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTOS/UPSTermsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTOS/UPSTermsView.swift
@@ -70,6 +70,8 @@ struct UPSTermsView: View {
                 }
             }
             Button(Localization.cancel, role: .cancel) {}
+        } message: {
+            Text(Localization.errorMessage)
         }
 
     }
@@ -187,6 +189,11 @@ private extension UPSTermsView {
         static let errorTitle = NSLocalizedString(
             "upsTermsView.errorTitle",
             value: "Error confirming acceptance",
+            comment: "Title of the alert when confirming all agreements on the UPS Terms and Conditions view fails"
+        )
+        static let errorMessage = NSLocalizedString(
+            "upsTermsView.errorMessage",
+            value: "An unexpected error occurred when confirming your acceptance. Please try again.",
             comment: "Title of the alert when confirming all agreements on the UPS Terms and Conditions view fails"
         )
         static let retry = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTOS/UPSTermsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTOS/UPSTermsView.swift
@@ -7,6 +7,8 @@ struct UPSTermsView: View {
 
     let onConfirmation: () -> Void
 
+    @State private var didFailToConfirmAcceptance = false
+
     var body: some View {
         ScrollableVStack(alignment: .leading,
                          padding: Layout.contentPadding,
@@ -52,11 +54,24 @@ struct UPSTermsView: View {
 
             Spacer()
 
-            Button(Localization.confirmButton, action: onConfirmation)
-                .buttonStyle(PrimaryButtonStyle())
-                .disabled(!viewModel.shouldEnableConfirmButton)
+            Button(Localization.confirmButton, action: {
+                Task { @MainActor in
+                    await confirmAcceptance()
+                }
+            })
+            .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isConfirming))
+            .disabled(!viewModel.shouldEnableConfirmButton)
         }
         .padding(.top, Layout.contentPadding)
+        .alert(Localization.errorTitle, isPresented: $didFailToConfirmAcceptance) {
+            Button(Localization.retry) {
+                Task { @MainActor in
+                    await confirmAcceptance()
+                }
+            }
+            Button(Localization.cancel, role: .cancel) {}
+        }
+
     }
 }
 
@@ -78,6 +93,21 @@ private extension UPSTermsView {
             attributedText[range].mergeAttributes(linkContainer)
         }
         return attributedText
+    }
+
+    @MainActor
+    func confirmAcceptance() async {
+        do {
+            let result = try await viewModel.confirmAcceptance()
+            if result {
+                onConfirmation()
+            } else {
+                didFailToConfirmAcceptance = true
+            }
+        } catch {
+            DDLogError("⛔️ Error accepting UPS terms of service \(error)")
+            didFailToConfirmAcceptance = true
+        }
     }
 }
 
@@ -153,6 +183,21 @@ private extension UPSTermsView {
             "upsTermsView.confirmButton",
             value: "Confirm and continue",
             comment: "Button to confirm all agreements on the UPS Terms and Conditions view"
+        )
+        static let errorTitle = NSLocalizedString(
+            "upsTermsView.errorTitle",
+            value: "Error confirming acceptance",
+            comment: "Title of the alert when confirming all agreements on the UPS Terms and Conditions view fails"
+        )
+        static let retry = NSLocalizedString(
+            "upsTermsView.retry",
+            value: "Retry",
+            comment: "Button to retry confirming all agreements on the UPS Terms and Conditions view fails"
+        )
+        static let cancel = NSLocalizedString(
+            "upsTermsView.cancel",
+            value: "Cancel",
+            comment: "Button to cancel confirming all agreements on the UPS Terms and Conditions view fails"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTOS/UPSTermsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTOS/UPSTermsViewModel.swift
@@ -7,6 +7,8 @@ final class UPSTermsViewModel: ObservableObject {
     @Published var isProhibitedItemsAccepted = false
     @Published var isTechnologyAgreementAccepted = false
 
+    @Published private(set) var isConfirming = false
+
     var displayedOriginAddress: String {
         originAddress.formattedPostalAddress ?? ""
     }
@@ -25,5 +27,18 @@ final class UPSTermsViewModel: ObservableObject {
         self.siteID = siteID
         self.originAddress = originAddress
         self.stores = stores
+    }
+
+    @MainActor
+    func confirmAcceptance() async throws -> Bool {
+        isConfirming = true
+        defer {
+            isConfirming = false
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(WooShippingAction.acceptUPSTermsOfService(siteID: siteID, originAddress: originAddress) { result in
+                continuation.resume(with: result)
+            })
+        }
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2897,6 +2897,7 @@
 		DEFE13C32DF1553E005B3D39 /* UPSTermsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE13C22DF1553E005B3D39 /* UPSTermsView.swift */; };
 		DEFE13C52DF15F55005B3D39 /* ToggleStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE13C42DF15F36005B3D39 /* ToggleStyles.swift */; };
 		DEFE13C82DF2A359005B3D39 /* UPSTermsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE13C72DF2A354005B3D39 /* UPSTermsViewModel.swift */; };
+		DEFE1B242DF2C6C8005B3D39 /* UPSTermsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE1B232DF2C6C8005B3D39 /* UPSTermsViewModelTests.swift */; };
 		E10459C627BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */; };
 		E1068058285C787100668B46 /* BetaFeaturesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1068057285C787100668B46 /* BetaFeaturesTests.swift */; };
 		E107FCE126C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift in Sources */ = {isa = PBXBuildFile; fileRef = E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */; };
@@ -6130,6 +6131,7 @@
 		DEFE13C22DF1553E005B3D39 /* UPSTermsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UPSTermsView.swift; sourceTree = "<group>"; };
 		DEFE13C42DF15F36005B3D39 /* ToggleStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleStyles.swift; sourceTree = "<group>"; };
 		DEFE13C72DF2A354005B3D39 /* UPSTermsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UPSTermsViewModel.swift; sourceTree = "<group>"; };
+		DEFE1B232DF2C6C8005B3D39 /* UPSTermsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UPSTermsViewModelTests.swift; sourceTree = "<group>"; };
 		E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentConfigurationLoader.swift; sourceTree = "<group>"; };
 		E1068057285C787100668B46 /* BetaFeaturesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaFeaturesTests.swift; sourceTree = "<group>"; };
 		E107FCE026C12B2700BAF51B /* InPersonPaymentsCountryNotSupported.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCountryNotSupported.swift; sourceTree = "<group>"; };
@@ -12604,6 +12606,7 @@
 				CE56C01D2D2431C000EBDE24 /* WooShippingOriginAddressListViewModelTests.swift */,
 				CE5A9BBC2D315E0500FBADDF /* WooShippingEditAddressViewModelTests.swift */,
 				CE755F742D4A6BF3002539F6 /* WooShippingNormalizeAddressViewModelTests.swift */,
+				DEFE1B232DF2C6C8005B3D39 /* UPSTermsViewModelTests.swift */,
 			);
 			path = "WooShipping Create Shipping Labels";
 			sourceTree = "<group>";
@@ -17632,6 +17635,7 @@
 				01A3093C2DAE768600B672F6 /* MockPointOfSaleCouponService.swift in Sources */,
 				03CF78D127C3DBC000523706 /* WCPayCardBrand+IconsTests.swift in Sources */,
 				CEEF742C2B9A052300B03948 /* OrdersReportCardViewModelTests.swift in Sources */,
+				DEFE1B242DF2C6C8005B3D39 /* UPSTermsViewModelTests.swift in Sources */,
 				AEFF77AA29786DAA00667F7A /* PriceInputViewModelTests.swift in Sources */,
 				EEC2D27F292CF60E0072132E /* JetpackSetupHostingControllerTests.swift in Sources */,
 				4535EE82281BE726004212B4 /* CouponCodeInputFormatterTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/UPSTermsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/UPSTermsViewModelTests.swift
@@ -1,0 +1,114 @@
+import Testing
+import Yosemite
+@testable import WooCommerce
+
+struct UPSTermsViewModelTests {
+
+    @Test func displayedOriginAddress_returns_correct_value() async throws {
+        // Given
+        let originAddress = WooShippingAddress(company: "A8C",
+                                               name: "Teddy Bear",
+                                               phone: "0985728394",
+                                               country: "US",
+                                               state: "New York",
+                                               address1: "1 E 35th St",
+                                               address2: "",
+                                               city: "New York",
+                                               postcode: "10028")
+
+        // When
+        let viewModel = UPSTermsViewModel(siteID: 123, originAddress: originAddress)
+
+        // Then
+        #expect(viewModel.displayedOriginAddress == "1 E 35th St, New York New York 10028, US")
+    }
+
+    @Test(arguments: [
+        (false, false, false),
+        (true, false, false),
+        (true, true, false),
+        (false, true, false),
+        (false, true, true),
+        (false, false, true)
+    ])
+    func confirm_button_is_not_enabled_when_any_of_the_agreements_are_not_accepted(isTOSAccepted: Bool,
+                                                                                   isProhibitedItemsAccepted: Bool,
+                                                                                   isTechAgreementAccepted: Bool) {
+        // Given
+        let originAddress = WooShippingAddress(company: "A8C",
+                                               name: "Teddy Bear",
+                                               phone: "0985728394",
+                                               country: "US",
+                                               state: "New York",
+                                               address1: "1 E 35th St",
+                                               address2: "",
+                                               city: "New York",
+                                               postcode: "10028")
+        let viewModel = UPSTermsViewModel(siteID: 123, originAddress: originAddress)
+
+        // When
+        viewModel.isTOSAccepted = isTOSAccepted
+        viewModel.isProhibitedItemsAccepted = isProhibitedItemsAccepted
+        viewModel.isTechnologyAgreementAccepted = isTechAgreementAccepted
+
+        // Then
+        #expect(viewModel.shouldEnableConfirmButton == false)
+    }
+
+    @Test func confirm_button_is_enabled_when_all_agreements_are_accepted() {
+        // Given
+        let originAddress = WooShippingAddress(company: "A8C",
+                                               name: "Teddy Bear",
+                                               phone: "0985728394",
+                                               country: "US",
+                                               state: "New York",
+                                               address1: "1 E 35th St",
+                                               address2: "",
+                                               city: "New York",
+                                               postcode: "10028")
+        let viewModel = UPSTermsViewModel(siteID: 123, originAddress: originAddress)
+
+        // When
+        viewModel.isTOSAccepted = true
+        viewModel.isProhibitedItemsAccepted = true
+        viewModel.isTechnologyAgreementAccepted = true
+
+        // Then
+        #expect(viewModel.shouldEnableConfirmButton == true)
+    }
+
+    @MainActor
+    @Test func isConfirming_returns_correct_values() async throws {
+        // Given
+        let originAddress = WooShippingAddress(company: "A8C",
+                                               name: "Teddy Bear",
+                                               phone: "0985728394",
+                                               country: "US",
+                                               state: "New York",
+                                               address1: "1 E 35th St",
+                                               address2: "",
+                                               city: "New York",
+                                               postcode: "10028")
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = UPSTermsViewModel(siteID: 123, originAddress: originAddress, stores: stores)
+        #expect(viewModel.isConfirming == false)
+
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .acceptUPSTermsOfService(_, _, completion):
+                #expect(viewModel.isConfirming == true)
+                completion(.success(true))
+            default:
+                break
+            }
+        }
+
+        // When
+        let result = try await viewModel.confirmAcceptance()
+
+        // Then
+        #expect(viewModel.isConfirming == false)
+        #expect(result == true)
+    }
+}

--- a/Yosemite/Yosemite/Actions/WooShippingAction.swift
+++ b/Yosemite/Yosemite/Actions/WooShippingAction.swift
@@ -110,4 +110,9 @@ public enum WooShippingAction: Action {
     case refundShippingLabel(shippingLabel: ShippingLabel,
                              completion: (Result<ShippingLabel, Error>) -> Void)
 
+    /// Accept UPS TOS for an origin address
+    case acceptUPSTermsOfService(siteID: Int64,
+                                 originAddress: WooShippingAddress,
+                                 completion: (Result<Bool, Error>) -> Void)
+
 }

--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -89,6 +89,8 @@ public final class WooShippingStore: Store {
                            completion: completion)
         case let .refundShippingLabel(shippingLabel, completion):
             refundShippingLabel(shippingLabel: shippingLabel, completion: completion)
+        case let .acceptUPSTermsOfService(siteID, originAddress, completion):
+            acceptUPSTermsOfService(siteID: siteID, originAddress: originAddress, completion: completion)
         }
     }
 }
@@ -238,6 +240,12 @@ private extension WooShippingStore {
                 completion(.failure(error))
             }
         }
+    }
+
+    func acceptUPSTermsOfService(siteID: Int64,
+                                 originAddress: WooShippingAddress,
+                                 completion: @escaping (Result<Bool, Error>) -> Void) {
+        remote.acceptUPSTermsOfService(siteID: siteID, originAddress: originAddress, completion: completion)
     }
 }
 

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
@@ -18,6 +18,11 @@ final class MockWooShippingRemote {
         let shippingLabelID: Int64
     }
 
+    private struct AcceptUPSTOSKey: Hashable {
+        let siteID: Int64
+        let originAddress: WooShippingAddress
+    }
+
     /// The results to return based on the given arguments in `createPackage`
     private var createPackageResults = [ResultKey: Result<WooShippingCreatePackageResponse, Error>]()
 
@@ -70,7 +75,7 @@ final class MockWooShippingRemote {
     private var refundShippingLabel = [RefundResultKey: Result<ShippingLabelRefund, Error>]()
 
     /// The results to return for `acceptUPSTermsOfService`
-    private var acceptUPSTermsOfService = [ResultKey: Result<Bool, Error>]()
+    private var acceptUPSTermsOfService = [AcceptUPSTOSKey: Result<Bool, Error>]()
 
     /// Set the value passed to the `completion` block if `createPackage` is called.
     func whenCreatePackage(siteID: Int64,
@@ -196,7 +201,7 @@ final class MockWooShippingRemote {
     func whenAcceptingUPSTOS(siteID: Int64,
                              originAddress: WooShippingAddress,
                              thenReturn result: Result<Bool, Error>) {
-        let key = ResultKey(siteID: siteID)
+        let key = AcceptUPSTOSKey(siteID: siteID, originAddress: originAddress)
         acceptUPSTermsOfService[key] = result
     }
 }
@@ -475,7 +480,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
                                  completion: @escaping (Result<Bool, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            let key = ResultKey(siteID: siteID)
+            let key = AcceptUPSTOSKey(siteID: siteID, originAddress: originAddress)
             if let result = self.acceptUPSTermsOfService[key] {
                 completion(result)
             } else {

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
@@ -69,6 +69,9 @@ final class MockWooShippingRemote {
     /// The results to return based on the given arguments in `refundShippingLabel`
     private var refundShippingLabel = [RefundResultKey: Result<ShippingLabelRefund, Error>]()
 
+    /// The results to return for `acceptUPSTermsOfService`
+    private var acceptUPSTermsOfService = [ResultKey: Result<Bool, Error>]()
+
     /// Set the value passed to the `completion` block if `createPackage` is called.
     func whenCreatePackage(siteID: Int64,
                            thenReturn result: Result<WooShippingCreatePackageResponse, Error>) {
@@ -187,6 +190,14 @@ final class MockWooShippingRemote {
                                     thenReturn result: Result<ShippingLabelRefund, Error>) {
         let key = RefundResultKey(siteID: siteID, orderID: orderID, shippingLabelID: shippingLabelID)
         refundShippingLabel[key] = result
+    }
+
+    /// Set the value passed to the `completion` block if `acceptUPSTermsOfService` is called
+    func whenAcceptingUPSTOS(siteID: Int64,
+                             originAddress: WooShippingAddress,
+                             thenReturn result: Result<Bool, Error>) {
+        let key = ResultKey(siteID: siteID)
+        acceptUPSTermsOfService[key] = result
     }
 }
 
@@ -452,6 +463,20 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
             guard let self else { return }
             let key = RefundResultKey(siteID: siteID, orderID: orderID, shippingLabelID: shippingLabelID)
             if let result = self.refundShippingLabel[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+
+    func acceptUPSTermsOfService(siteID: Int64,
+                                 originAddress: WooShippingAddress,
+                                 completion: @escaping (Result<Bool, Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            let key = ResultKey(siteID: siteID)
+            if let result = self.acceptUPSTermsOfService[key] {
                 completion(result)
             } else {
                 XCTFail("\(String(describing: self)) Could not find Result for \(key)")

--- a/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/WooShippingStoreTests.swift
@@ -1059,6 +1059,50 @@ final class WooShippingStoreTests: XCTestCase {
         let error = try XCTUnwrap(result.failure)
         XCTAssertEqual(error as? NetworkError, expectedError)
     }
+
+    // MARK: - `acceptUPSTermsOfService`
+
+    func test_acceptUPSTermsOfService_returns_true_on_success() throws {
+        // Given
+        let remote = MockWooShippingRemote()
+        let originAddress = WooShippingAddress.fake()
+
+        remote.whenAcceptingUPSTOS(siteID: sampleSiteID, originAddress: originAddress, thenReturn: .success(true))
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = WooShippingAction.acceptUPSTermsOfService(siteID: self.sampleSiteID, originAddress: originAddress) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(result.get()))
+    }
+
+    func test_acceptUPSTermsOfService_returns_error_on_failure() throws {
+        // Given
+        let remote = MockWooShippingRemote()
+        let originAddress = WooShippingAddress.fake()
+        let expectedError = NetworkError.notFound()
+
+        remote.whenAcceptingUPSTOS(siteID: sampleSiteID, originAddress: originAddress, thenReturn: .failure(expectedError))
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let result: Result<Bool, Error> = waitFor { promise in
+            let action = WooShippingAction.acceptUPSTermsOfService(siteID: self.sampleSiteID, originAddress: originAddress) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error as? NetworkError, expectedError)
+    }
 }
 
 private extension WooShippingStoreTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-518

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR integrates the endpoint to accept UPS terms of service for the selected origin address during the shipping label purchase flow.

Changes include:
- Integration of the new endpoint in the Networking layer.
- Updated WooShippingAction and store for the new endpoint.
- Integration of the new endpoint on the UI when tapping the Confirm button on the UPS T&C screen.
- Error handling for the request.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with the Woo Shipping plugin set up in the staging environment.
2. Navigate to the Orders tab and select a paid order with physical products and unfulfilled shipments.
3. Select a UPS package and rate for a shipment, and update the origin address if you have already accepted the UPS TOS for that address before.
4. Proceed to purchase a label. When the alert about UPS TOS appears, tick all the checkboxes and tap the Confirm button.
5. Use Proxyman to confirm that the request completes successfully.
6. Repeat the above steps but use Proxyman to mock the response of the `POST carrier-strategy/upsdap` request to fail. Confirm that an error alert is displayed with the option to retry the request.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested the changes using simulator iPhone 16 Pro iOS 18.4.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Error alert:

<img src="https://github.com/user-attachments/assets/422430b7-f923-454d-9fc1-c9768154e9e8" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
