### PR TITLE
[Woo POS] Remove unnecessary pos events

### DIFF
--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -154,9 +154,6 @@ private extension TracksProvider {
             WooAnalyticsStat.orderCreationFailed,
 
             // Card Reader Connection
-            WooAnalyticsStat.cardReaderSelectTypeShown,
-            WooAnalyticsStat.cardReaderSelectTypeTapToPayTapped,
-            WooAnalyticsStat.cardReaderSelectTypeBluetoothTapped,
             WooAnalyticsStat.cardReaderDiscoveryFailed,
             WooAnalyticsStat.cardReaderConnectionFailed,
             WooAnalyticsStat.cardReaderConnectionSuccess,

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -192,12 +192,6 @@ private extension TracksProvider {
             WooAnalyticsStat.collectPaymentFailed,
             WooAnalyticsStat.collectPaymentSuccess,
 
-            // Payment Methods
-            WooAnalyticsStat.paymentsFlowCompleted,
-            WooAnalyticsStat.paymentsFlowCanceled,
-            WooAnalyticsStat.paymentsFlowFailed,
-            WooAnalyticsStat.paymentsFlowCollect,
-
             // Coupons
             WooAnalyticsStat.couponSettingEnabled,
             WooAnalyticsStat.couponCreationSuccess,

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -191,10 +191,6 @@ private extension TracksProvider {
             WooAnalyticsStat.collectPaymentCanceled,
             WooAnalyticsStat.collectPaymentFailed,
             WooAnalyticsStat.collectPaymentSuccess,
-            WooAnalyticsStat.collectInteracPaymentSuccess,
-            WooAnalyticsStat.interacRefundSuccess,
-            WooAnalyticsStat.interacRefundFailed,
-            WooAnalyticsStat.interacRefundCanceled,
 
             // Payment Methods
             WooAnalyticsStat.paymentsFlowCompleted,


### PR DESCRIPTION
## Description
When we added a decorator for POS events and whitelisted specific card-payment events that we share between app and POS to go through, some of them that are not really used in POS sneaked through. This PR removes them from the POS whitelist, so are not tracked as `woocommerceios_pos_*`, only remain as `woocommerceios_*` when they happen in-app.

## Changes
From `TracksProvider.decorateEventNameForPOSIfNeeded()` :
- Removed interac-related events
- Removed card reader selection shown events (tracked when the merchant has to choose between readers/TTP at the start of connection flow)
- Removed payments flow events (only triggered after collecting via order creation flow)

## Testing information
CI should pass
