### PR TITLE
[Woo POS][Barcodes] Map variations from POSProducts during scanning

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1153,6 +1153,8 @@ extension Networking.POSProduct {
             regularPrice: .fake(),
             salePrice: .fake(),
             onSale: .fake(),
+            downloadable: .fake(),
+            parentID: .fake(),
             images: .fake(),
             attributes: .fake(),
             manageStock: .fake(),

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1671,6 +1671,7 @@
 				Extended/Mapper/ShippingLabelRefundMapper.swift,
 				Extended/Mapper/ShippingLabelStatusMapper.swift,
 				Extended/Mapper/ShippingMethodMapper.swift,
+				Extended/Mapper/SingleItemMapper.swift,
 				Extended/Mapper/SiteAPIMapper.swift,
 				Extended/Mapper/SiteListMapper.swift,
 				Extended/Mapper/SitePlanMapper.swift,

--- a/Networking/NetworkingTests/Remote/POSProductsNetworkingTests.swift
+++ b/Networking/NetworkingTests/Remote/POSProductsNetworkingTests.swift
@@ -187,6 +187,8 @@ struct POSProductsNetworkingTests {
         #expect(fieldNames.contains("regular_price"))
         #expect(fieldNames.contains("sale_price"))
         #expect(fieldNames.contains("on_sale"))
+        #expect(fieldNames.contains("downloadable"))
+        #expect(fieldNames.contains("parent_id"))
         #expect(fieldNames.contains("images"))
         #expect(fieldNames.contains("attributes"))
         #expect(fieldNames.contains("manage_stock"))

--- a/Networking/NetworkingTests/Remote/POSProductsNetworkingTests.swift
+++ b/Networking/NetworkingTests/Remote/POSProductsNetworkingTests.swift
@@ -263,14 +263,14 @@ struct POSProductsNetworkingTests {
         #expect(pagedProducts.totalItems == nil)
     }
 
-    @Test func fetchPOSProductByGlobalUniqueIdentifier_returns_single_product() async throws {
+    @Test func loadPOSProductByGlobalUniqueIdentifier_returns_single_product() async throws {
         // Given
         let remote = ProductsRemote(network: network)
         let globalUniqueID = "123456789"
 
         // When
         network.simulateResponse(requestUrlSuffix: "products", filename: "pos-products")
-        let product = try await remote.fetchPOSProductByGlobalUniqueIdentifier(for: sampleSiteID, globalUniqueID: globalUniqueID)
+        let product = try await remote.loadPOSProductByGlobalUniqueIdentifier(for: sampleSiteID, globalUniqueID: globalUniqueID)
 
         // Then
         let request = try #require(network.requestsForResponseData.first as? JetpackRequest)

--- a/Networking/NetworkingTests/Responses/pos-products.json
+++ b/Networking/NetworkingTests/Responses/pos-products.json
@@ -14,7 +14,9 @@
             "attributes": [],
             "manage_stock": true,
             "stock_quantity": 10,
-            "stock_status": "instock"
+            "stock_status": "instock",
+            "downloadable": true,
+            "parent_id": 0
         }
     ]
 }

--- a/Networking/Sources/Extended/Mapper/SingleItemMapper.swift
+++ b/Networking/Sources/Extended/Mapper/SingleItemMapper.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// SingleItemMapper: Maps generic REST API requests for a single item
+///
+struct SingleItemMapper<Output: Decodable>: Mapper {
+    /// Site Identifier associated to the items that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned by our endpoints.
+    ///
+    let siteID: Int64
+
+    /// (Attempts) to convert a dictionary into Output.
+    ///
+    func map(response: Data) throws -> Output {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(SingleItemEnvelope<Output>.self, from: response).item
+        } else {
+            return try decoder.decode(Output.self, from: response)
+        }
+    }
+}
+
+/// SingleItemEnvelope Disposable Entity:
+/// Our list endpoints return the item in the `data` key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct SingleItemEnvelope<Output: Decodable>: Decodable {
+    let item: Output
+
+    private enum CodingKeys: String, CodingKey {
+        case item = "data"
+    }
+}

--- a/Networking/Sources/Extended/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Sources/Extended/Model/Copiable/Models+Copiable.generated.swift
@@ -1890,6 +1890,8 @@ extension Networking.POSProduct {
         regularPrice: NullableCopiableProp<String> = .copy,
         salePrice: NullableCopiableProp<String> = .copy,
         onSale: CopiableProp<Bool> = .copy,
+        downloadable: CopiableProp<Bool> = .copy,
+        parentID: CopiableProp<Int64> = .copy,
         images: CopiableProp<[ProductImage]> = .copy,
         attributes: CopiableProp<[ProductAttribute]> = .copy,
         manageStock: CopiableProp<Bool> = .copy,
@@ -1906,6 +1908,8 @@ extension Networking.POSProduct {
         let regularPrice = regularPrice ?? self.regularPrice
         let salePrice = salePrice ?? self.salePrice
         let onSale = onSale ?? self.onSale
+        let downloadable = downloadable ?? self.downloadable
+        let parentID = parentID ?? self.parentID
         let images = images ?? self.images
         let attributes = attributes ?? self.attributes
         let manageStock = manageStock ?? self.manageStock
@@ -1923,6 +1927,8 @@ extension Networking.POSProduct {
             regularPrice: regularPrice,
             salePrice: salePrice,
             onSale: onSale,
+            downloadable: downloadable,
+            parentID: parentID,
             images: images,
             attributes: attributes,
             manageStock: manageStock,

--- a/Networking/Sources/Extended/Model/POSProduct.swift
+++ b/Networking/Sources/Extended/Model/POSProduct.swift
@@ -20,6 +20,10 @@ public struct POSProduct: Codable, Equatable, GeneratedCopiable, GeneratedFakeab
     public let salePrice: String?
     public let onSale: Bool
 
+    public let downloadable: Bool
+
+    public let parentID: Int64
+
     public let images: [ProductImage]
 
     public let attributes: [ProductAttribute]
@@ -49,6 +53,8 @@ public struct POSProduct: Codable, Equatable, GeneratedCopiable, GeneratedFakeab
                 regularPrice: String?,
                 salePrice: String?,
                 onSale: Bool,
+                downloadable: Bool,
+                parentID: Int64,
                 images: [ProductImage],
                 attributes: [ProductAttribute],
                 manageStock: Bool,
@@ -65,6 +71,10 @@ public struct POSProduct: Codable, Equatable, GeneratedCopiable, GeneratedFakeab
         self.regularPrice = regularPrice
         self.salePrice = salePrice
         self.onSale = onSale
+
+        self.downloadable = downloadable
+
+        self.parentID = parentID
 
         self.images = images
 
@@ -120,6 +130,10 @@ public struct POSProduct: Codable, Equatable, GeneratedCopiable, GeneratedFakeab
                 .string(transform: { (onSale && $0.isEmpty) ? "0" : $0 }),
                 decimalString])
 
+        let downloadable = try container.decode(Bool.self, forKey: .downloadable)
+
+        let parentID = try container.decode(Int64.self, forKey: .parentID)
+
         let images = try container.decode([ProductImage].self, forKey: .images)
 
         let attributes = try container.decode([ProductAttribute].self, forKey: .attributes)
@@ -138,6 +152,8 @@ public struct POSProduct: Codable, Equatable, GeneratedCopiable, GeneratedFakeab
                   regularPrice: regularPrice,
                   salePrice: salePrice,
                   onSale: onSale,
+                  downloadable: downloadable,
+                  parentID: parentID,
                   images: images,
                   attributes: attributes,
                   manageStock: manageStock,
@@ -169,6 +185,8 @@ private extension POSProduct {
         case regularPrice = "regular_price"
         case salePrice = "sale_price"
         case onSale = "on_sale"
+        case downloadable
+        case parentID = "parent_id"
         case images
         case attributes
         case manageStock = "manage_stock"

--- a/Networking/Sources/Extended/Model/Product/ProductAttribute.swift
+++ b/Networking/Sources/Extended/Model/Product/ProductAttribute.swift
@@ -93,6 +93,23 @@ public extension ProductAttribute {
     var isGlobal: Bool {
         !isLocal
     }
+
+    /// This is intended for use for converting variations-as-products to variations.
+    /// This inverts the assumption made when we decoded `option` as `options = [option]`
+    ///
+    func toProductVariationAttribute() throws -> ProductVariationAttribute {
+        guard options.count == 1,
+              let option = options.first else {
+            throw ProductAttributeError.notFromAVariationAsAProduct
+        }
+        return ProductVariationAttribute(id: attributeID,
+                                         name: name,
+                                         option: option)
+    }
+
+    enum ProductAttributeError: Error {
+        case notFromAVariationAsAProduct
+    }
 }
 
 /// Defines all the ProductAttribute CodingKeys.

--- a/Networking/Sources/Extended/Remote/ProductsRemote.swift
+++ b/Networking/Sources/Extended/Remote/ProductsRemote.swift
@@ -98,6 +98,8 @@ public protocol ProductsRemoteProtocol {
 
     func fetchPOSProductByGlobalUniqueIdentifier(for siteID: Int64,
                                                    globalUniqueID: String) async throws -> POSProduct
+
+    func fetchPOSProduct(for siteID: Int64, productID: Int64) async throws -> POSProduct
 }
 
 extension ProductsRemoteProtocol {
@@ -356,6 +358,29 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             throw NetworkError.notFound()
         }
         return product
+    }
+
+    /// Fetches a single product or variation by its ID for Point of Sale.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll fetch the product.
+    ///     - productID: The ID of the product to fetch.
+    /// - Returns: A POSProduct if found
+    /// - Throws: Error if the product is not found or if there's a network error
+    ///
+    public func fetchPOSProduct(for siteID: Int64, productID: Int64) async throws -> POSProduct {
+        let parameters = [
+            ParameterKey.fields: POSProduct.requestFields.joined(separator: ",")
+        ]
+        let path = "\(Path.products)/\(productID)"
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
+        let mapper = SingleItemMapper<POSProduct>(siteID: siteID)
+
+        do {
+            return try await enqueue(request, mapper: mapper)
+        } catch {
+            throw NetworkError.notFound()
+        }
     }
 
     /// Retrieves a specific list of `Product`s by `productID`.

--- a/Networking/Sources/Extended/Remote/ProductsRemote.swift
+++ b/Networking/Sources/Extended/Remote/ProductsRemote.swift
@@ -96,10 +96,10 @@ public protocol ProductsRemoteProtocol {
                                            pageNumber: Int,
                                            perPage: Int) async throws -> PagedItems<POSProduct>
 
-    func fetchPOSProductByGlobalUniqueIdentifier(for siteID: Int64,
+    func loadPOSProductByGlobalUniqueIdentifier(for siteID: Int64,
                                                    globalUniqueID: String) async throws -> POSProduct
 
-    func fetchPOSProduct(for siteID: Int64, productID: Int64) async throws -> POSProduct
+    func loadPOSProduct(for siteID: Int64, productID: Int64) async throws -> POSProduct
 }
 
 extension ProductsRemoteProtocol {
@@ -341,7 +341,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     /// - Returns: A POSProduct if found
     /// - Throws: Error if the product is not found or if there's a network error
     ///
-    public func fetchPOSProductByGlobalUniqueIdentifier(for siteID: Int64,
+    public func loadPOSProductByGlobalUniqueIdentifier(for siteID: Int64,
                                                        globalUniqueID: String) async throws -> POSProduct {
         let parameters = [
             ParameterKey.globalUniqueID: globalUniqueID,
@@ -368,7 +368,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     /// - Returns: A POSProduct if found
     /// - Throws: Error if the product is not found or if there's a network error
     ///
-    public func fetchPOSProduct(for siteID: Int64, productID: Int64) async throws -> POSProduct {
+    public func loadPOSProduct(for siteID: Int64, productID: Int64) async throws -> POSProduct {
         let parameters = [
             ParameterKey.fields: POSProduct.requestFields.joined(separator: ",")
         ]

--- a/Networking/Sources/Extended/Remote/ProductsRemote.swift
+++ b/Networking/Sources/Extended/Remote/ProductsRemote.swift
@@ -376,11 +376,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
         let mapper = SingleItemMapper<POSProduct>(siteID: siteID)
 
-        do {
-            return try await enqueue(request, mapper: mapper)
-        } catch {
-            throw NetworkError.notFound()
-        }
+        return try await enqueue(request, mapper: mapper)
     }
 
     /// Retrieves a specific list of `Product`s by `productID`.

--- a/Networking/Sources/Extended/Remote/ProductsRemote.swift
+++ b/Networking/Sources/Extended/Remote/ProductsRemote.swift
@@ -360,7 +360,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         return product
     }
 
-    /// Fetches a single product or variation by its ID for Point of Sale.
+    /// Fetches a single product by its ID for Point of Sale.
     ///
     /// - Parameters:
     ///     - siteID: Site for which we'll fetch the product.

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		206643572DAEABF7002D5191 /* POSSearchHistoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206643562DAEABF7002D5191 /* POSSearchHistoryService.swift */; };
 		206643592DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206643582DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift */; };
 		2066435B2DAEAC76002D5191 /* POSItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2066435A2DAEAC76002D5191 /* POSItemType.swift */; };
+		206BFD562DF20EB5000BD68E /* POSProductOrVariationResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206BFD552DF20EB5000BD68E /* POSProductOrVariationResolver.swift */; };
 		20716F322D9DA24C008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20716F312D9DA24C008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift */; };
 		207D2D1B2CFA06BD00F79204 /* POSCartItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207D2D192CFA06BD00F79204 /* POSCartItemTests.swift */; };
 		207D2D1D2CFA0CEF00F79204 /* MockPOSOrderableItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207D2D1C2CFA0CEF00F79204 /* MockPOSOrderableItem.swift */; };
@@ -733,6 +734,7 @@
 		206643562DAEABF7002D5191 /* POSSearchHistoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSearchHistoryService.swift; sourceTree = "<group>"; };
 		206643582DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSearchHistoryServiceTests.swift; sourceTree = "<group>"; };
 		2066435A2DAEAC76002D5191 /* POSItemType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSItemType.swift; sourceTree = "<group>"; };
+		206BFD552DF20EB5000BD68E /* POSProductOrVariationResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSProductOrVariationResolver.swift; sourceTree = "<group>"; };
 		20716F312D9DA24C008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPointOfSalePurchasableItemFetchStrategy.swift; sourceTree = "<group>"; };
 		207D2D192CFA06BD00F79204 /* POSCartItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSCartItemTests.swift; sourceTree = "<group>"; };
 		207D2D1C2CFA0CEF00F79204 /* MockPOSOrderableItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPOSOrderableItem.swift; sourceTree = "<group>"; };
@@ -1164,6 +1166,7 @@
 				68EA25332C08734800C49AE2 /* POSSimpleProduct.swift */,
 				027ADB6B2D1BF3AD009608DB /* POSVariableParentProduct.swift */,
 				029149752D2663AB00F7B3B3 /* POSVariation.swift */,
+				206BFD552DF20EB5000BD68E /* POSProductOrVariationResolver.swift */,
 			);
 			path = Items;
 			sourceTree = "<group>";
@@ -2457,6 +2460,7 @@
 				B5631ECD2114DF8C008D3535 /* EntityListener.swift in Sources */,
 				02CC7C2E2D2CE5F600907B83 /* VariationAttributeViewModel.swift in Sources */,
 				D80F758A223F72AA002F4A3B /* ShipmentTrackingProviderGroup+ReadOnlyConvertible.swift in Sources */,
+				206BFD562DF20EB5000BD68E /* POSProductOrVariationResolver.swift in Sources */,
 				B9AECD442851D95600E78584 /* TotalRefundedCalculationUseCase.swift in Sources */,
 				86DAA7982CD9E31E002AE55E /* MockPaymentActionHandler.swift in Sources */,
 				031C1EAE27B1877000298699 /* WCPayCardPresentPaymentDetails+ReadOnlyConvertible.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		206643592DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206643582DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift */; };
 		2066435B2DAEAC76002D5191 /* POSItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2066435A2DAEAC76002D5191 /* POSItemType.swift */; };
 		206BFD562DF20EB5000BD68E /* POSProductOrVariationResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206BFD552DF20EB5000BD68E /* POSProductOrVariationResolver.swift */; };
+		206BFD582DF31432000BD68E /* POSProductOrVariationResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206BFD572DF31432000BD68E /* POSProductOrVariationResolverTests.swift */; };
 		20716F322D9DA24C008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20716F312D9DA24C008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift */; };
 		207D2D1B2CFA06BD00F79204 /* POSCartItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207D2D192CFA06BD00F79204 /* POSCartItemTests.swift */; };
 		207D2D1D2CFA0CEF00F79204 /* MockPOSOrderableItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207D2D1C2CFA0CEF00F79204 /* MockPOSOrderableItem.swift */; };
@@ -735,6 +736,7 @@
 		206643582DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSearchHistoryServiceTests.swift; sourceTree = "<group>"; };
 		2066435A2DAEAC76002D5191 /* POSItemType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSItemType.swift; sourceTree = "<group>"; };
 		206BFD552DF20EB5000BD68E /* POSProductOrVariationResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSProductOrVariationResolver.swift; sourceTree = "<group>"; };
+		206BFD572DF31432000BD68E /* POSProductOrVariationResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSProductOrVariationResolverTests.swift; sourceTree = "<group>"; };
 		20716F312D9DA24C008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPointOfSalePurchasableItemFetchStrategy.swift; sourceTree = "<group>"; };
 		207D2D192CFA06BD00F79204 /* POSCartItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSCartItemTests.swift; sourceTree = "<group>"; };
 		207D2D1C2CFA0CEF00F79204 /* MockPOSOrderableItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPOSOrderableItem.swift; sourceTree = "<group>"; };
@@ -1640,6 +1642,7 @@
 				206643582DAEAC06002D5191 /* POSSearchHistoryServiceTests.swift */,
 				3F7E6AC72DDAD3C1008309F0 /* PointOfSalePopularPurchasableItemFetchStrategyTests.swift */,
 				2005590C2DCCF7CF00E12021 /* PointOfSaleSearchPurchasableItemFetchStrategyTests.swift */,
+				206BFD572DF31432000BD68E /* POSProductOrVariationResolverTests.swift */,
 			);
 			path = PointOfSale;
 			sourceTree = "<group>";
@@ -2783,6 +2786,7 @@
 				02A26F1E2744FE97008E4EDB /* MockAccountRemote.swift in Sources */,
 				02124DAC24318D6B00980D74 /* Media+MediaTypeTests.swift in Sources */,
 				E1F54D0427AD4DAF00012983 /* CardPresentConfigurationTests.swift in Sources */,
+				206BFD582DF31432000BD68E /* POSProductOrVariationResolverTests.swift in Sources */,
 				025CA2D0238F54E800B05C81 /* ProductShippingClassStoreTests.swift in Sources */,
 				74A7688E20D45ED400F9D437 /* OrderStoreTests.swift in Sources */,
 				02DAE7F8291A9F11009342B7 /* DomainStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
@@ -4,12 +4,13 @@ import class WooFoundation.CurrencySettings
 
 struct POSProductOrVariationResolver {
     private let productsRemote: ProductsRemoteProtocol
-    private let itemMapper: PointOfSaleItemMapper
+    private let itemMapper: PointOfSaleItemMapperProtocol
 
     init (productsRemote: ProductsRemoteProtocol,
-          currencySettings: CurrencySettings) {
+          currencySettings: CurrencySettings,
+          itemMapper: PointOfSaleItemMapperProtocol? = nil) {
         self.productsRemote = productsRemote
-        self.itemMapper = PointOfSaleItemMapper(currencySettings: currencySettings)
+        self.itemMapper = itemMapper ?? PointOfSaleItemMapper(currencySettings: currencySettings)
     }
 
     func itemForProductOrVariation(_ productOrVariation: POSProduct) async throws -> POSItem {

--- a/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
@@ -38,7 +38,7 @@ struct POSProductOrVariationResolver {
             throw PointOfSaleBarcodeScanError.noParentProductForVariation
         }
 
-        let parentProduct = try await productsRemote.fetchPOSProduct(for: variation.siteID,
+        let parentProduct = try await productsRemote.loadPOSProduct(for: variation.siteID,
                                                                      productID: variation.productID)
         let mappedProducts = itemMapper.mapProductsToPOSItems(products: [parentProduct])
 

--- a/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
@@ -1,0 +1,72 @@
+import Foundation
+import protocol Networking.ProductsRemoteProtocol
+import class WooFoundation.CurrencySettings
+
+struct POSProductOrVariationResolver {
+    private let productsRemote: ProductsRemoteProtocol
+    private let itemMapper: PointOfSaleItemMapper
+
+    init (productsRemote: ProductsRemoteProtocol,
+          currencySettings: CurrencySettings) {
+        self.productsRemote = productsRemote
+        self.itemMapper = PointOfSaleItemMapper(currencySettings: currencySettings)
+    }
+
+    func itemForProductOrVariation(_ productOrVariation: POSProduct) async throws -> POSItem {
+        let items: [POSItem]
+        switch productOrVariation.productType {
+        case .simple:
+            let product = productOrVariation
+            items = itemMapper.mapProductsToPOSItems(products: [product])
+        case .custom("variation"):
+            let variation = try productOrVariation.toProductVariation()
+            let variableProduct = try await parentProductForVariation(variation)
+            items = itemMapper.mapVariationsToPOSItems(variations: [variation], parentProduct: variableProduct)
+        default:
+            throw PointOfSaleBarcodeScanError.unknown
+        }
+
+        guard let item = items.first else {
+            throw PointOfSaleBarcodeScanError.unknown
+        }
+        return item
+    }
+
+    private func parentProductForVariation(_ variation: POSProductVariation) async throws -> POSVariableParentProduct {
+        guard variation.productID != 0 else {
+            throw PointOfSaleBarcodeScanError.noParentProductForVariation
+        }
+
+        let parentProduct = try await productsRemote.fetchPOSProduct(for: variation.siteID,
+                                                                     productID: variation.productID)
+        let mappedProducts = itemMapper.mapProductsToPOSItems(products: [parentProduct])
+
+        guard let mappedProduct = mappedProducts.first,
+              case .variableParentProduct(let variableProduct) = mappedProduct else {
+            throw PointOfSaleBarcodeScanError.variationCouldNotBeConverted
+        }
+        return variableProduct
+    }
+}
+
+
+private extension POSProduct {
+    func toProductVariation() throws -> POSProductVariation {
+        POSProductVariation(
+            siteID: siteID,
+            productID: parentID,
+            productVariationID: productID,
+            attributes: try attributes.compactMap { try $0.toProductVariationAttribute() },
+            image: images.first,
+            sku: sku,
+            globalUniqueID: globalUniqueID,
+            price: price,
+            regularPrice: regularPrice,
+            salePrice: salePrice,
+            onSale: onSale,
+            downloadable: downloadable,
+            manageStock: manageStock,
+            stockQuantity: stockQuantity,
+            stockStatusKey: stockStatusKey)
+    }
+}

--- a/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
@@ -1,7 +1,6 @@
 import Foundation
 import protocol Networking.ProductsRemoteProtocol
 import class Networking.ProductsRemote
-import class WooFoundation.CurrencyFormatter
 import class WooFoundation.CurrencySettings
 import class Networking.AlamofireNetwork
 
@@ -19,14 +18,15 @@ public enum PointOfSaleBarcodeScanError: Error, Equatable {
 public final class PointOfSaleBarcodeScanService: PointOfSaleBarcodeScanServiceProtocol {
     private let productsRemote: ProductsRemoteProtocol
     private let siteID: Int64
-    private let itemMapper: PointOfSaleItemMapper
+    private let itemResolver: POSProductOrVariationResolver
 
     init (siteID: Int64,
           productsRemote: ProductsRemoteProtocol,
           currencySettings: CurrencySettings) {
         self.siteID = siteID
         self.productsRemote = productsRemote
-        self.itemMapper = PointOfSaleItemMapper(currencySettings: currencySettings)
+        self.itemResolver = POSProductOrVariationResolver(productsRemote: productsRemote,
+                                                          currencySettings: currencySettings)
     }
 
     public convenience init(siteID: Int64,
@@ -45,66 +45,9 @@ public final class PointOfSaleBarcodeScanService: PointOfSaleBarcodeScanServiceP
         do {
             let productOrVariation = try await productsRemote.fetchPOSProductByGlobalUniqueIdentifier(for: siteID,
                                                                                                       globalUniqueID: barcode)
-            return try await itemForScannedBarcodeProduct(productOrVariation)
+            return try await itemResolver.itemForProductOrVariation(productOrVariation)
         } catch {
             throw PointOfSaleBarcodeScanError.unknown
         }
-    }
-
-    private func itemForScannedBarcodeProduct(_ productOrVariation: POSProduct) async throws -> POSItem {
-        let items: [POSItem]
-        switch productOrVariation.productType {
-        case .simple:
-            let product = productOrVariation
-            items = itemMapper.mapProductsToPOSItems(products: [product])
-        case .custom("variation"):
-            let variation = try productOrVariation.toProductVariation()
-            let variableProduct = try await parentProductForVariation(variation)
-            items = itemMapper.mapVariationsToPOSItems(variations: [variation], parentProduct: variableProduct)
-        default:
-            throw PointOfSaleBarcodeScanError.unknown
-        }
-
-        guard let item = items.first else {
-            throw PointOfSaleBarcodeScanError.unknown
-        }
-        return item
-    }
-
-    private func parentProductForVariation(_ variation: POSProductVariation) async throws -> POSVariableParentProduct {
-        guard variation.productID != 0 else {
-            throw PointOfSaleBarcodeScanError.noParentProductForVariation
-        }
-
-        let parentProduct = try await productsRemote.fetchPOSProduct(for: siteID, productID: variation.productID)
-        let mappedProducts = itemMapper.mapProductsToPOSItems(products: [parentProduct])
-
-        guard let mappedProduct = mappedProducts.first,
-              case .variableParentProduct(let variableProduct) = mappedProduct else {
-            throw PointOfSaleBarcodeScanError.variationCouldNotBeConverted
-        }
-        return variableProduct
-    }
-}
-
-
-private extension POSProduct {
-    func toProductVariation() throws -> POSProductVariation {
-        POSProductVariation(
-            siteID: siteID,
-            productID: parentID,
-            productVariationID: productID,
-            attributes: try attributes.compactMap { try $0.toProductVariationAttribute() },
-            image: images.first,
-            sku: sku,
-            globalUniqueID: globalUniqueID,
-            price: price,
-            regularPrice: regularPrice,
-            salePrice: salePrice,
-            onSale: onSale,
-            downloadable: downloadable,
-            manageStock: manageStock,
-            stockQuantity: stockQuantity,
-            stockStatusKey: stockStatusKey)
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
@@ -43,7 +43,7 @@ public final class PointOfSaleBarcodeScanService: PointOfSaleBarcodeScanServiceP
     /// - Returns: A POSItem if found, or throws an error
     public func getItem(barcode: String) async throws -> POSItem {
         do {
-            let productOrVariation = try await productsRemote.fetchPOSProductByGlobalUniqueIdentifier(for: siteID,
+            let productOrVariation = try await productsRemote.loadPOSProductByGlobalUniqueIdentifier(for: siteID,
                                                                                                       globalUniqueID: barcode)
             return try await itemResolver.itemForProductOrVariation(productOrVariation)
         } catch {

--- a/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
@@ -11,6 +11,8 @@ public protocol PointOfSaleBarcodeScanServiceProtocol {
 
 public enum PointOfSaleBarcodeScanError: Error, Equatable {
     case unknown
+    case noParentProductForVariation
+    case variationCouldNotBeConverted
 }
 
 /// Service for handling barcode scanning in Point of Sale
@@ -41,17 +43,68 @@ public final class PointOfSaleBarcodeScanService: PointOfSaleBarcodeScanServiceP
     /// - Returns: A POSItem if found, or throws an error
     public func getItem(barcode: String) async throws -> POSItem {
         do {
-            let product = try await productsRemote.fetchPOSProductByGlobalUniqueIdentifier(for: siteID, globalUniqueID: barcode)
-
-            let items = itemMapper.mapProductsToPOSItems(products: [product])
-
-            guard let item = items.first else {
-                throw PointOfSaleBarcodeScanError.unknown
-            }
-
-            return item
+            let productOrVariation = try await productsRemote.fetchPOSProductByGlobalUniqueIdentifier(for: siteID,
+                                                                                                      globalUniqueID: barcode)
+            return try await itemForScannedBarcodeProduct(productOrVariation)
         } catch {
             throw PointOfSaleBarcodeScanError.unknown
         }
+    }
+
+    private func itemForScannedBarcodeProduct(_ productOrVariation: POSProduct) async throws -> POSItem {
+        let items: [POSItem]
+        switch productOrVariation.productType {
+        case .simple:
+            let product = productOrVariation
+            items = itemMapper.mapProductsToPOSItems(products: [product])
+        case .custom("variation"):
+            let variation = try productOrVariation.toProductVariation()
+            let variableProduct = try await parentProductForVariation(variation)
+            items = itemMapper.mapVariationsToPOSItems(variations: [variation], parentProduct: variableProduct)
+        default:
+            throw PointOfSaleBarcodeScanError.unknown
+        }
+
+        guard let item = items.first else {
+            throw PointOfSaleBarcodeScanError.unknown
+        }
+        return item
+    }
+
+    private func parentProductForVariation(_ variation: POSProductVariation) async throws -> POSVariableParentProduct {
+        guard variation.productID != 0 else {
+            throw PointOfSaleBarcodeScanError.noParentProductForVariation
+        }
+
+        let parentProduct = try await productsRemote.fetchPOSProduct(for: siteID, productID: variation.productID)
+        let mappedProducts = itemMapper.mapProductsToPOSItems(products: [parentProduct])
+
+        guard let mappedProduct = mappedProducts.first,
+              case .variableParentProduct(let variableProduct) = mappedProduct else {
+            throw PointOfSaleBarcodeScanError.variationCouldNotBeConverted
+        }
+        return variableProduct
+    }
+}
+
+
+private extension POSProduct {
+    func toProductVariation() throws -> POSProductVariation {
+        POSProductVariation(
+            siteID: siteID,
+            productID: parentID,
+            productVariationID: productID,
+            attributes: try attributes.compactMap { try $0.toProductVariationAttribute() },
+            image: images.first,
+            sku: sku,
+            globalUniqueID: globalUniqueID,
+            price: price,
+            regularPrice: regularPrice,
+            salePrice: salePrice,
+            onSale: onSale,
+            downloadable: downloadable,
+            manageStock: manageStock,
+            stockQuantity: stockQuantity,
+            stockStatusKey: stockStatusKey)
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -78,10 +78,10 @@ final class MockProductsRemote {
 
     private var posProductLoadingResults = [ResultKey: Result<POSProduct, Error>]()
 
-    /// The number of times that `fetchPOSProduct()` was invoked.
-    private(set) var invocationCountOfFetchPOSProduct: Int = 0
+    /// The number of times that `loadPOSProduct()` was invoked.
+    private(set) var invocationCountOfLoadPOSProduct: Int = 0
 
-    /// List of product IDs requested for `fetchPOSProduct`
+    /// List of product IDs requested for `loadPOSProduct`
     private(set) var requestedProductIDsForFetchingPOSProduct: [Int64] = []
 
     /// Set the value passed to the `completion` block if `addProduct()` is called.
@@ -453,9 +453,9 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         }
     }
 
-    func fetchPOSProductByGlobalUniqueIdentifier(for siteID: Int64, globalUniqueID: String) async throws -> POSProduct {
-        return POSProduct.fake().copy(siteID: siteID,
-                                      globalUniqueID: globalUniqueID)
+    func loadPOSProductByGlobalUniqueIdentifier(for siteID: Int64, globalUniqueID: String) async throws -> POSProduct {
+            return POSProduct.fake().copy(siteID: siteID,
+                                          globalUniqueID: globalUniqueID)
     }
 
     func loadPopularProductsForPointOfSale(for siteID: Int64,
@@ -474,8 +474,8 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         }
     }
 
-    func fetchPOSProduct(for siteID: Int64, productID: Int64) async throws -> POSProduct {
-        invocationCountOfFetchPOSProduct += 1
+    func loadPOSProduct(for siteID: Int64, productID: Int64) async throws -> POSProduct {
+        invocationCountOfLoadPOSProduct += 1
         requestedProductIDsForFetchingPOSProduct.append(productID)
 
         let key = ResultKey(siteID: siteID, productIDs: [productID])

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -76,6 +76,14 @@ final class MockProductsRemote {
     /// The results to return based on the given site ID in `loadPopularProductsForPointOfSale`
     private var posPopularProductsResultsBySiteID = [Int64: Result<PagedItems<POSProduct>, Error>]()
 
+    private var posProductLoadingResults = [ResultKey: Result<POSProduct, Error>]()
+
+    /// The number of times that `fetchPOSProduct()` was invoked.
+    private(set) var invocationCountOfFetchPOSProduct: Int = 0
+
+    /// List of product IDs requested for `fetchPOSProduct`
+    private(set) var requestedProductIDsForFetchingPOSProduct: [Int64] = []
+
     /// Set the value passed to the `completion` block if `addProduct()` is called.
     ///
     func whenAddingProduct(siteID: Int64, thenReturn result: Result<Product, Error>) {
@@ -167,6 +175,11 @@ final class MockProductsRemote {
     ///
     func whenLoadingPopularProductsForPointOfSale(siteID: Int64, thenReturn result: Result<PagedItems<POSProduct>, Error>) {
         posPopularProductsResultsBySiteID[siteID] = result
+    }
+
+    func whenLoadingProductForPointOfSale(siteID: Int64, productID: Int64, thenReturn result: Result<POSProduct, Error>) {
+        let key = ResultKey(siteID: siteID, productIDs: [productID])
+        posProductLoadingResults[key] = result
     }
 }
 
@@ -456,6 +469,22 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         switch result {
         case let .success(pagedProducts):
             return pagedProducts
+        case let .failure(error):
+            throw error
+        }
+    }
+
+    func fetchPOSProduct(for siteID: Int64, productID: Int64) async throws -> POSProduct {
+        invocationCountOfFetchPOSProduct += 1
+        requestedProductIDsForFetchingPOSProduct.append(productID)
+
+        let key = ResultKey(siteID: siteID, productIDs: [productID])
+        guard let result = posProductLoadingResults[key] else {
+            throw NetworkError.notFound()
+        }
+        switch result {
+        case let .success(product):
+            return product
         case let .failure(error):
             throw error
         }

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
@@ -89,7 +89,7 @@ struct POSProductOrVariationResolverTests {
         let result = try await sut.itemForProductOrVariation(variation)
 
         // Then
-        #expect(mockProductsRemote.invocationCountOfFetchPOSProduct == 1)
+        #expect(mockProductsRemote.invocationCountOfLoadPOSProduct == 1)
         #expect(mockProductsRemote.requestedProductIDsForFetchingPOSProduct.contains(variation.parentID))
 
         #expect(mockItemMapper.mapVariationsToPOSItemsCalled)

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
@@ -1,0 +1,152 @@
+import Testing
+import WooFoundation
+@testable import Yosemite
+
+struct POSProductOrVariationResolverTests {
+    private var mockProductsRemote: MockProductsRemote!
+    private var mockItemMapper: MockPointOfSaleItemMapper!
+    private var sut: POSProductOrVariationResolver!
+    private var currencySettings: CurrencySettings!
+
+    init() {
+        mockProductsRemote = MockProductsRemote()
+        mockItemMapper = MockPointOfSaleItemMapper()
+        currencySettings = CurrencySettings()
+        sut = POSProductOrVariationResolver(productsRemote: mockProductsRemote,
+                                          currencySettings: currencySettings,
+                                          itemMapper: mockItemMapper)
+    }
+
+    @Test("Resolves simple product correctly")
+    func testResolvesSimpleProduct() async throws {
+        // Given
+        let simpleProduct = POSProduct.fake().copy(
+            productID: 123,
+            name: "Simple Product",
+            productTypeKey: "simple",
+            price: "10.00"
+        )
+        let expectedItem = POSItem.simpleProduct(POSSimpleProduct(
+            id: UUID(),
+            name: "Simple Product",
+            formattedPrice: "$10.00",
+            productID: 123,
+            price: "10.00",
+            manageStock: false,
+            stockQuantity: nil,
+            stockStatusKey: ""
+        ))
+        mockItemMapper.mockMappedProducts = [expectedItem]
+
+        // When
+        let result = try await sut.itemForProductOrVariation(simpleProduct)
+
+        // Then
+        #expect(mockItemMapper.mapProductsToPOSItemsCalled)
+        #expect(mockItemMapper.mockProducts.count == 1)
+        #expect(mockItemMapper.mockProducts.first?.productID == 123)
+        #expect(result == expectedItem)
+    }
+
+    @Test("Resolves variation correctly")
+    func testResolvesVariation() async throws {
+        // Given
+        let variation = POSProduct.fake().copy(
+            productID: 456,
+            name: "Variation",
+            productTypeKey: "variation",
+            price: "15.00",
+            parentID: 123
+        )
+        let parentProduct = POSProduct.fake().copy(
+            productID: 123,
+            name: "Parent Product",
+            productTypeKey: "variable"
+        )
+        let expectedParentItem = POSItem.variableParentProduct(POSVariableParentProduct(
+            id: UUID(),
+            name: "Parent Product",
+            productImageSource: nil,
+            productID: 123,
+            allAttributes: []
+        ))
+        let expectedVariationItem = POSItem.variation(POSVariation(
+            id: UUID(),
+            name: "Variation",
+            formattedPrice: "$15.00",
+            price: "15.00",
+            productImageSource: nil,
+            productID: 123,
+            variationID: 456,
+            parentProductName: "Parent Product"
+        ))
+
+        mockProductsRemote.whenLoadingProductForPointOfSale(siteID: variation.siteID, productID: variation.parentID, thenReturn: .success(parentProduct))
+        mockItemMapper.mockMappedProducts = [expectedParentItem]
+        mockItemMapper.mockMappedVariations = [expectedVariationItem]
+
+        // When
+        let result = try await sut.itemForProductOrVariation(variation)
+
+        // Then
+        #expect(mockProductsRemote.invocationCountOfFetchPOSProduct == 1)
+        #expect(mockProductsRemote.requestedProductIDsForFetchingPOSProduct.contains(variation.parentID))
+
+        #expect(mockItemMapper.mapVariationsToPOSItemsCalled)
+        #expect(mockItemMapper.mockVariations.count == 1)
+        #expect(mockItemMapper.mockVariations.first?.productVariationID == 456)
+        #expect(result == expectedVariationItem)
+    }
+
+    @Test("Throws error for unknown product type")
+    func testThrowsErrorForUnknownProductType() async {
+        // Given
+        let unknownProduct = POSProduct.fake().copy(
+            productID: 789,
+            productTypeKey: "grouped"
+        )
+
+        // When/Then
+        await #expect(throws: PointOfSaleBarcodeScanError.unknown) {
+            _ = try await sut.itemForProductOrVariation(unknownProduct)
+        }
+    }
+
+    @Test("Throws error when no parent product found for variation")
+    func testThrowsErrorWhenNoParentProductFound() async {
+        // Given
+        let variation = POSProduct.fake().copy(
+            productID: 456,
+            productTypeKey: "variation",
+            parentID: 0 // Invalid parent ID for a variation
+        )
+
+        // When/Then
+        await #expect(throws: PointOfSaleBarcodeScanError.noParentProductForVariation) {
+            _ = try await sut.itemForProductOrVariation(variation)
+        }
+    }
+
+    @Test("Throws error when variation cannot be converted")
+    func testThrowsErrorWhenVariationCannotBeConverted() async {
+        // Given
+        let variation = POSProduct.fake().copy(
+            productID: 456,
+            productTypeKey: "variation",
+            parentID: 123
+        )
+        let parentProduct = POSProduct.fake().copy(
+            productID: 123,
+            name: "Parent Product",
+            productTypeKey: "simple" // Wrong type for parent
+        )
+
+        mockProductsRemote.whenLoadingProductForPointOfSale(siteID: variation.siteID, productID: variation.parentID, thenReturn: .success(parentProduct))
+        mockItemMapper.mockMappedProducts = []
+
+        // When/Then
+        await #expect(throws: PointOfSaleBarcodeScanError.variationCouldNotBeConverted) {
+            _ = try await sut.itemForProductOrVariation(variation)
+        }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Merge after: #15712 
Closes: WOOPRD-564
Part of: WOOPRD-560

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR enables scanned barcodes for variations to result in the variation being added to the cart.

When we scan a barcode, we request it using the `/products?global_unique_id={scanned_value}` endpoint. This differs from most product endpoints, because it can also return variations.

Variations have their own `post_type` in the database, they're a different entity... but they are similar to products. For most of the information, we can just copy across from the variation-as-product to a `POSProductVariation` entity, and use that... but unfortunately, we rely on having the parent product to build the name. 

That means, to resolve a scan of a variation, we need to do an extra network request to get its parent product.

In this PR, we:

1. Fetch `parentID` for all `POSProduct` fetches – to support resolving the parent of a variation-as-product.
2. Allow fetches of a single `POSProduct`, so we can get the parent product
3. Resolve variations by fetching the parent and using the two `POSProduct`s to make a fully populated `POSProductVariation` to return for adding to the cart.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Enable the `pointOfSaleBarcodeScanningi1` feature flag.

Prepare a variation, variable parent product, and a simple product on your test store, each should have a unique value for `GTIN, UPC, EAN, or ISBN`, which is the user-facing name for the `global_unique_id` field.

1. Launch the app and go to POS
2. Tap the barcode scan simulator button
3. Type the barcode value for your variation and tap scan
4. Observe that after a few seconds, the variation is added to your cart. Check that it's name matches what it says when you add it from the list UI.

You can also test the simple and parent product – the simple product should be added in the same way, but the variable parent product should be ignored (in future, an error will be shown.) 

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

I've tested this using the "simulated scanner" text field, on an iPad Air running iOS 17.7.2

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/8cf8cec5-2ae9-42a1-b76c-90f14f2a602a


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
