### PR TITLE
[Order List] Stop truncating the last updated string in order list with large fonts.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 22.6
 -----
 - [internal] Updated Xcode version to 16.4 [https://github.com/woocommerce/woocommerce-ios/pull/15696]
+- [*] Order List: Prevent last updated time being truncated at larger font sizes [https://github.com/woocommerce/woocommerce-ios/pull/15717]
 
 22.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
@@ -8,6 +8,7 @@ final class FilteredOrdersHeaderBar: UIView {
     @IBOutlet private weak var mainLabel: UILabel!
     @IBOutlet private weak var lastUpdatedLabel: UILabel!
     @IBOutlet private weak var filterButton: UIButton!
+    @IBOutlet weak var headerBarLayoutStackView: UIStackView!
 
     private let bottomBorder = CALayer()
 
@@ -26,6 +27,7 @@ final class FilteredOrdersHeaderBar: UIView {
         configureLabels()
         configureButtons()
         configureBackground()
+        updateStackViewAxis(for: traitCollection)
     }
 
     override func layoutSubviews() {
@@ -48,6 +50,28 @@ final class FilteredOrdersHeaderBar: UIView {
         onAction?()
     }
 
+}
+// MARK: - Dynamic type support
+/// The `Last updated: time` tends to get truncated at larger text sizes by the filter button.
+/// Laying out the overall stack view vertically avoids this with accessibility sizes.
+extension FilteredOrdersHeaderBar {
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        guard let previousTraitCollection,
+              traitCollection.preferredContentSizeCategory != previousTraitCollection.preferredContentSizeCategory else {
+            return
+        }
+        updateStackViewAxis(for: traitCollection)
+    }
+
+    private func updateStackViewAxis(for traitCollection: UITraitCollection) {
+        if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
+            headerBarLayoutStackView.axis = .vertical
+        } else {
+            headerBarLayoutStackView.axis = .horizontal
+        }
+    }
 }
 
 // MARK: - Setup

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -15,31 +15,27 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="hrV-V9-BdB">
-                    <rect key="frame" x="16" y="8" width="343" height="51"/>
+                    <rect key="frame" x="16" y="14" width="343" height="45"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Uce-kq-wOt">
-                            <rect key="frame" x="0.0" y="0.0" width="41.5" height="51"/>
+                            <rect key="frame" x="0.0" y="0.0" width="269" height="45"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r3U-zo-uYF">
-                                    <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="269" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rLu-fm-bTC" userLabel="Last Updated Label">
-                                    <rect key="frame" x="0.0" y="24.5" width="41.5" height="26.5"/>
+                                    <rect key="frame" x="0.0" y="24.5" width="269" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                             </subviews>
                         </stackView>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dRc-UB-LAM">
-                            <rect key="frame" x="61.5" y="0.0" width="175.5" height="51"/>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        </view>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3R4-Zy-CEM">
-                            <rect key="frame" x="257" y="0.0" width="86" height="51"/>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3R4-Zy-CEM">
+                            <rect key="frame" x="289" y="0.0" width="54" height="45"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" id="HKe-ba-c7Z"/>
                             </constraints>
@@ -60,9 +56,12 @@
                 <constraint firstItem="hrV-V9-BdB" firstAttribute="leading" secondItem="iLp-Xv-4wn" secondAttribute="leading" constant="16" id="F6e-Nm-Kc4"/>
                 <constraint firstItem="hrV-V9-BdB" firstAttribute="trailing" secondItem="iLp-Xv-4wn" secondAttribute="trailing" constant="-16" id="c5H-jX-XYc"/>
             </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="filterButton" destination="3R4-Zy-CEM" id="Cah-6b-bfB"/>
+                <outlet property="headerBarLayoutStackView" destination="hrV-V9-BdB" id="Bas-Ts-JJz"/>
                 <outlet property="lastUpdatedLabel" destination="rLu-fm-bTC" id="XQY-3n-lw2"/>
                 <outlet property="mainLabel" destination="r3U-zo-uYF" id="2bV-ER-1xX"/>
             </connections>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.xib
@@ -15,19 +15,19 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="hrV-V9-BdB">
-                    <rect key="frame" x="16" y="14" width="343" height="45"/>
+                    <rect key="frame" x="20" y="8" width="335" height="51"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Uce-kq-wOt">
-                            <rect key="frame" x="0.0" y="0.0" width="269" height="45"/>
+                            <rect key="frame" x="0.0" y="0.0" width="261" height="51"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r3U-zo-uYF">
-                                    <rect key="frame" x="0.0" y="0.0" width="269" height="20.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="261" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rLu-fm-bTC" userLabel="Last Updated Label">
-                                    <rect key="frame" x="0.0" y="24.5" width="269" height="20.5"/>
+                                    <rect key="frame" x="0.0" y="24.5" width="261" height="26.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
@@ -35,7 +35,7 @@
                             </subviews>
                         </stackView>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3R4-Zy-CEM">
-                            <rect key="frame" x="289" y="0.0" width="54" height="45"/>
+                            <rect key="frame" x="281" y="0.0" width="54" height="51"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" id="HKe-ba-c7Z"/>
                             </constraints>
@@ -51,10 +51,10 @@
             </subviews>
             <viewLayoutGuide key="safeArea" id="iLp-Xv-4wn"/>
             <constraints>
-                <constraint firstAttribute="bottomMargin" secondItem="hrV-V9-BdB" secondAttribute="bottom" id="17F-Tz-u3i"/>
-                <constraint firstAttribute="topMargin" secondItem="hrV-V9-BdB" secondAttribute="top" id="72O-3b-e5w"/>
-                <constraint firstItem="hrV-V9-BdB" firstAttribute="leading" secondItem="iLp-Xv-4wn" secondAttribute="leading" constant="16" id="F6e-Nm-Kc4"/>
-                <constraint firstItem="hrV-V9-BdB" firstAttribute="trailing" secondItem="iLp-Xv-4wn" secondAttribute="trailing" constant="-16" id="c5H-jX-XYc"/>
+                <constraint firstAttribute="bottom" secondItem="hrV-V9-BdB" secondAttribute="bottom" constant="8" id="17F-Tz-u3i"/>
+                <constraint firstItem="hrV-V9-BdB" firstAttribute="leading" secondItem="iLp-Xv-4wn" secondAttribute="leading" constant="20" id="F6e-Nm-Kc4"/>
+                <constraint firstItem="hrV-V9-BdB" firstAttribute="trailing" secondItem="iLp-Xv-4wn" secondAttribute="trailing" constant="-20" id="c5H-jX-XYc"/>
+                <constraint firstItem="hrV-V9-BdB" firstAttribute="top" secondItem="eDg-Zp-eCF" secondAttribute="top" constant="8" id="eUg-Ei-6y2"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR prevents the `last updated` text from being truncated at larger font sizes, by converting the order list header to a vertical arrangement for accessibility sizes.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and go to orders
2. Increase font size to 160% or above
3. Observe that the `Filter` button is shown below the last updated text

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

I've tested this on an iPhone 15 Pro Max running iOS 18.5, and an iPad Air running iOS 17.7.2

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/4f2a1f67-097e-4086-8af5-3221218152ce


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
