### PR TITLE
Shipping Labels: Fix UI issues with shipping service view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
@@ -99,7 +99,7 @@ struct WooCarrierPackagesSelectionView: View {
             if viewModel.carrierTabs.isNotEmpty {
                 TopTabView(tabs: viewModel.carrierTabs,
                            showContent: false,
-                           selectedTabIndex: $viewModel.selectedCarriersTabIndex,
+                           selectedTabIndex: viewModel.selectedCarriersTabIndex,
                            tabsContainerHorizontalPadding: nil,
                            selectedStateColor: Color.accentColor,
                            unselectedStateColor: .secondary,
@@ -107,7 +107,8 @@ struct WooCarrierPackagesSelectionView: View {
                            tabPadding: Constants.tabPadding,
                            tabsNameFont: Font.subheadline.bold(),
                            tabItemContentHorizontalPadding: Constants.tabItemContentHorizontalPadding,
-                           tabItemContentVerticalPadding: Constants.tabItemContentVerticalPadding)
+                           tabItemContentVerticalPadding: Constants.tabItemContentVerticalPadding,
+                           onTabChange: { viewModel.selectedCarriersTabIndex = $0 })
             } else if viewModel.isLoadingPackages {
                 // Loading state
                 loadingStateView

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -5,11 +5,11 @@ import SwiftUI
 struct WooShippingServiceView: View {
     @ObservedObject var viewModel: WooShippingServiceViewModel
 
-    private var carriers: [TopTabItem<WooShippingServiceCardListView>] {
+    private var carriers: [TopTabItem<EmptyView>] {
         viewModel.serviceTabs.map { tab in
             TopTabItem(name: tab.id.name,
                        icon: tab.id.logo) {
-                WooShippingServiceCardListView(cards: tab.cards)
+                EmptyView()
             }
         }
     }
@@ -78,12 +78,17 @@ struct WooShippingServiceView: View {
     }
 
     var contentView: some View {
-        TopTabView(tabs: carriers,
-                   tabsContainerHorizontalPadding: 16,
-                   unselectedStateColor: .secondary,
-                   tabsNameFont: .subheadline.bold(),
-                   tabItemContentHorizontalPadding: 6,
-                   tabItemContentVerticalPadding: 12)
+        VStack(spacing: 0) {
+            TopTabView(tabs: carriers,
+                       showContent: false,
+                       tabsContainerHorizontalPadding: 16,
+                       unselectedStateColor: .secondary,
+                       tabsNameFont: .subheadline.bold(),
+                       tabItemContentHorizontalPadding: 6,
+                       tabItemContentVerticalPadding: 12,
+                       onTabChange: { viewModel.selectedTabIndex = $0 })
+            WooShippingServiceCardListView(cards: viewModel.displayedServiceCards)
+        }
         .padding(.horizontal, Layout.padding * -1) // Offset the additional padding in TopTabView
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -17,6 +17,10 @@ final class WooShippingServiceViewModel: ObservableObject {
     /// Contains the data about available shipping rates, grouped by carrier.
     @Published private(set) var serviceTabs: [WooShippingServiceTab] = []
 
+    @Published var selectedTabIndex: Int = 0
+
+    @Published private(set) var displayedServiceCards: [WooShippingServiceCardViewModel] = []
+
     /// Selected shipping service rate.
     @Published private(set) var selectedRate: WooShippingSelectedRate?
 
@@ -57,6 +61,7 @@ final class WooShippingServiceViewModel: ObservableObject {
         self.stores = stores
         self.analytics = analytics
         self.onSelectRate = onSelectRate
+        observeSelectedTab()
     }
 
     /// Sorts the shipping services by the provided sort order.
@@ -218,6 +223,14 @@ private extension WooShippingServiceViewModel {
             serviceTabs = []
         }
         loadingState = state
+    }
+
+    func observeSelectedTab() {
+        $serviceTabs.combineLatest($selectedTabIndex)
+            .map { tabs, index in
+                tabs[safe: index]?.cards ?? []
+            }
+            .assign(to: &$displayedServiceCards)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
@@ -108,7 +108,7 @@ private extension WooShippingSplitShipmentsView {
             TopTabView(tabs: viewModel.topTabItems,
                        showContent: false,
                        showDividerBelowTabs: false,
-                       selectedTabIndex: $viewModel.selectedShipmentIndex,
+                       selectedTabIndex: viewModel.selectedShipmentIndex,
                        tabsContainerHorizontalPadding: nil,
                        selectedStateColor: .accentColor,
                        unselectedStateColor: .secondary,
@@ -119,7 +119,8 @@ private extension WooShippingSplitShipmentsView {
                        tabsIconAlignment: .trailing,
                        tabsIconForegroundColor: Layout.green,
                        tabItemContentHorizontalPadding: Layout.tabItemContentHorizontalPadding,
-                       tabItemContentVerticalPadding: Layout.tabItemContentVerticalPadding)
+                       tabItemContentVerticalPadding: Layout.tabItemContentVerticalPadding,
+                       onTabChange: { viewModel.selectedShipmentIndex = $0 })
             .overlay(alignment: .trailing) {
                 LinearGradient(gradient: Gradient(colors: [.clear, Color(.basicBackground)]), startPoint: .leading, endPoint: .center)
                     .frame(width: Layout.gradientViewWidth)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -144,7 +144,7 @@ private extension WooShippingCreateLabelsView {
             TopTabView(tabs: tabs,
                        showContent: false,
                        showDividerBelowTabs: false,
-                       selectedTabIndex: $viewModel.selectedShipmentIndex,
+                       selectedTabIndex: viewModel.selectedShipmentIndex,
                        tabsContainerHorizontalPadding: nil,
                        selectedStateColor: .accentColor,
                        unselectedStateColor: .secondary,
@@ -155,7 +155,8 @@ private extension WooShippingCreateLabelsView {
                        tabsIconAlignment: .trailing,
                        tabsIconForegroundColor: Layout.green,
                        tabItemContentHorizontalPadding: Layout.tabItemContentHorizontalPadding,
-                       tabItemContentVerticalPadding: Layout.tabItemContentVerticalPadding)
+                       tabItemContentVerticalPadding: Layout.tabItemContentVerticalPadding,
+                       onTabChange: { viewModel.selectedShipmentIndex = $0 })
             .overlay(alignment: .trailing) {
                 LinearGradient(gradient: Gradient(colors: [.clear, Color(.basicBackground)]), startPoint: .leading, endPoint: .center)
                     .frame(width: Layout.gradientViewWidth)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -23,7 +23,7 @@ struct TopTabView<Content: View>: View {
         case trailing
     }
 
-    @Binding private var selectedTab: Int
+    @State private var selectedTab: Int = 0
     @State private var underlineOffset: CGFloat = 0
     @State private var tabWidths: [CGFloat]
     @GestureState private var dragState: DragState = .inactive
@@ -61,11 +61,13 @@ struct TopTabView<Content: View>: View {
     let tabItemContentHorizontalPadding: CGFloat?
     let tabItemContentVerticalPadding: CGFloat?
 
+    let onTabChange: (Int) -> Void
+
     init(tabs: [TopTabItem<Content>],
          showTabs: Binding<Bool> = .constant(true),
          showContent: Bool = true,
          showDividerBelowTabs: Bool = true,
-         selectedTabIndex: Binding<Int> = .constant(0),
+         selectedTabIndex: Int = 0,
          tabsContainerHorizontalPadding: CGFloat? = 0.0,
          selectedStateColor: Color = Colors.selected,
          unselectedStateColor: Color = .primary,
@@ -76,12 +78,13 @@ struct TopTabView<Content: View>: View {
          tabsIconAlignment: TabsIconAlignment = .leading,
          tabsIconForegroundColor: Color? = nil,
          tabItemContentHorizontalPadding: CGFloat? = nil,
-         tabItemContentVerticalPadding: CGFloat? = nil) {
+         tabItemContentVerticalPadding: CGFloat? = nil,
+         onTabChange: @escaping (Int) -> Void = { _ in }) {
         self.tabs = tabs
         self._showTabs = showTabs
         self.showContent = showContent
         self.showDividerBelowTabs = showDividerBelowTabs
-        self._selectedTab = selectedTabIndex
+        self.selectedTab = selectedTabIndex
         _tabWidths = State(initialValue: [CGFloat](repeating: 0, count: tabs.count))
         self.tabsContainerHorizontalPadding = tabsContainerHorizontalPadding
         self.selectedStateColor = selectedStateColor
@@ -94,6 +97,7 @@ struct TopTabView<Content: View>: View {
         self.tabsIconForegroundColor = tabsIconForegroundColor
         self.tabItemContentHorizontalPadding = tabItemContentHorizontalPadding
         self.tabItemContentVerticalPadding = tabItemContentVerticalPadding
+        self.onTabChange = onTabChange
     }
 
     private func tabItemContentView(_ index: Int, selected: Bool) -> some View {
@@ -189,6 +193,7 @@ struct TopTabView<Content: View>: View {
                                 withAnimation {
                                     selectTab(in: scrollViewProxy, at: newSelectedTab)
                                 }
+                                onTabChange(newSelectedTab)
                             })
                             .coordinateSpace(name: Constants.tabsHorizontalStackNameSpace)
                         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -295,6 +295,28 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.loadingState, .error(.noRatesAvailable(isHAZMAT: true)))
     }
+
+    func test_switching_tab_updates_the_card_list() {
+        // Given
+        let viewModel = WooShippingServiceViewModel(order: Order.fake(),
+                                                    originAddress: WooShippingAddress.fake(),
+                                                    destinationAddress: sampleDestinationAddress(),
+                                                    stores: stores)
+
+        // When
+        viewModel.loadLabelRates(for: samplePackage)
+
+        // Then
+        XCTAssertEqual(viewModel.displayedServiceCards.count, 2)
+        XCTAssertEqual(viewModel.displayedServiceCards.first?.title, "USPS - Media Mail")
+
+        // When
+        viewModel.selectedTabIndex = 1
+
+        // Then
+        XCTAssertEqual(viewModel.displayedServiceCards.count, 1)
+        XCTAssertEqual(viewModel.displayedServiceCards.first?.title, "DHL - Next Day")
+    }
 }
 
 private extension WooShippingServiceViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-565

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes the UI issues [reported](https://github.com/woocommerce/woocommerce-ios/pull/15711#pullrequestreview-2904549008) in #15711. 

One of the issues was that the service tabs could not be switched. This was due to the tab view here doesn't provide a binding for `selectedTabIndex`, which then defaults to `.constant(0)`, meaning the tab will always be 0 and cannot be switched.

=> The fix is to replace the use of the binding parameter with an Int for the intial selected tab index, and an optional callback closure for when the selected tab changes.

Another issue is the view being horizontally scrollable when there are more than 1 provider for the shipping services. The UX is not great, so I moved the shipping rate list out of the tab view to disable the scrolling.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with the Woo Shipping plugin set up in the staging environment.
2. Navigate to the Orders tab and select a paid order with physical products and unfulfilled shipments.
3. Select Create shipping label then move items to different shipments. Confirm that the tab view still works correctly on the spit shipment screen and the creation form.
4. Select Add a package and confirm that the tab view still works correctly.
5. Select a custom package and proceed to load shipping rates.
6. If the shipping rates include rates from more than 1 carrier, confirm that the rate list cannot be swiped horizontally.
7. Switch between different carriers and confirm that the selection works.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested and confirmed the fix with simulator iPhone 16 iOS 18.4.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/d9eb1e14-8d3d-4896-bbc9-ced574f59136



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
