### PR TITLE
Shipping Label: Resubmit purchase after accepting UPS TOS

### DIFF
--- a/Networking/Sources/Extended/Remote/WooShippingRemote.swift
+++ b/Networking/Sources/Extended/Remote/WooShippingRemote.swift
@@ -272,6 +272,7 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
                 ParameterKey.selectedRate: try package.encodedShipmentRate(),
                 // TODO: `selected_rate_options` will be updated while adding UPS support PaJDVv-2Gf-p2
                 ParameterKey.selectedRateOptions: [:],
+                ParameterKey.featuresSupported: [Values.upsdap],
                 ParameterKey.hazmat: package.encodedHazmat(),
                 ParameterKey.customs: try package.encodedCustomsForm(),
             ]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -180,6 +180,27 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
         analytics.track(event: .WooShipping.packageSelectionStep(state: .selected))
     }
 
+    @MainActor
+    func refreshPackagesAndShippingRates() async throws {
+        guard let selectedPackage, let updatedPackage = try await refreshSelectedPackage(from: selectedPackage) else {
+            throw WooShippingPurchaseError.failedToRefreshSelectedPackage
+        }
+        self.selectedPackage = updatedPackage
+
+        guard let finalPackage = currentPackage, let shippingService, let selectedRate else {
+            throw WooShippingPurchaseError.failedToRefreshSelectedRate
+        }
+        try await withCheckedThrowingContinuation { continuation in
+            shippingService.loadLabelRates(for: finalPackage) { result in
+                continuation.resume(with: result)
+            }
+        }
+        guard let updatedRate = shippingService.refreshSelectedRate(from: selectedRate) else {
+            throw WooShippingPurchaseError.failedToRefreshSelectedRate
+        }
+        self.selectedRate = updatedRate
+    }
+
     /// Purchases a shipping label with the provided label details and settings.
     @MainActor
     func purchaseLabel() async throws {
@@ -363,6 +384,35 @@ private extension WooShippingShipmentDetailsViewModel {
             return rate - baseRate
         }()
         return (name, currencyFormatter.formatAmount(Decimal(amount)) ?? amount.description)
+    }
+
+    @MainActor
+    func refreshSelectedPackage(from oldPackage: WooShippingPackageDataRepresentable) async throws -> WooShippingPackageDataRepresentable? {
+        let packages = try await withCheckedThrowingContinuation { continuation in
+            let loadPackagesAction = WooShippingAction.loadPackages(siteID: order.siteID) { result in
+                continuation.resume(with: result)
+            }
+            stores.dispatch(loadPackagesAction)
+        }
+        let customSavedPackages = packages.customPackages.map { $0.toPackageData() }
+        let predefinedSavedPackages = packages.savedPredefinedPackages.map { $0.toPackageData() }
+        let carrierPackages = packages.allPredefinedOptions.compactMap { $0.toCarrierPackages() }
+
+        if let foundPackage = (customSavedPackages + predefinedSavedPackages).first(where: { $0.id == oldPackage.id }) {
+            return foundPackage
+        }
+
+        var foundCarrierPackage: WooShippingPackageDataRepresentable?
+        outerLoop: for carrierPackage in carrierPackages {
+            let packageGroups = carrierPackage.packageGroups
+            for group in packageGroups {
+                if let foundPackage = group.packages.first(where: { $0.id == oldPackage.id }) {
+                    foundCarrierPackage = foundPackage
+                    break outerLoop
+                }
+            }
+        }
+        return foundCarrierPackage
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -180,15 +180,27 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
         analytics.track(event: .WooShipping.packageSelectionStep(state: .selected))
     }
 
+    /// After accepting UPS TOS, the selected UPS package/rate need to be reloaded with user data.
+    /// We need to reload the package list and update the selected package with the one with the same ID.
+    /// Similarly, we need to reload the shipping rates and updated the selected rate with the one with the same service ID.
+    /// When the backend supports this reloading, we can remove this extra step.
+    /// Ref: pe5sF9-4kN-p2/#ups-tos-flow
+    ///
     @MainActor
     func refreshPackagesAndShippingRates() async throws {
         guard let selectedPackage, let updatedPackage = try await refreshSelectedPackage(from: selectedPackage) else {
-            throw WooShippingPurchaseError.failedToRefreshSelectedPackage
+            throw WooShippingLabelPurchaseError.failedToRefreshSelectedPackage
         }
         self.selectedPackage = updatedPackage
 
-        guard let finalPackage = currentPackage, let shippingService, let selectedRate else {
-            throw WooShippingPurchaseError.failedToRefreshSelectedRate
+        let finalPackage = buildSelectedPackage(updatedPackage,
+                                                weight: Double(shipmentWeight) ?? 0,
+                                                shipmentID: shipment.id,
+                                                hazmatCategory: hazmatCategory,
+                                                customsForm: customsForm)
+
+        guard let shippingService, let selectedRate else {
+            throw WooShippingLabelPurchaseError.failedToRefreshSelectedRate
         }
         try await withCheckedThrowingContinuation { continuation in
             shippingService.loadLabelRates(for: finalPackage) { result in
@@ -196,7 +208,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
             }
         }
         guard let updatedRate = shippingService.refreshSelectedRate(from: selectedRate) else {
-            throw WooShippingPurchaseError.failedToRefreshSelectedRate
+            throw WooShippingLabelPurchaseError.failedToRefreshSelectedRate
         }
         self.selectedRate = updatedRate
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -408,12 +408,12 @@ private extension WooShippingShipmentDetailsViewModel {
         }
         let customSavedPackages = packages.customPackages.map { $0.toPackageData() }
         let predefinedSavedPackages = packages.savedPredefinedPackages.map { $0.toPackageData() }
-        let carrierPackages = packages.allPredefinedOptions.compactMap { $0.toCarrierPackages() }
 
         if let foundPackage = (customSavedPackages + predefinedSavedPackages).first(where: { $0.id == oldPackage.id }) {
             return foundPackage
         }
 
+        let carrierPackages = packages.allPredefinedOptions.compactMap { $0.toCarrierPackages() }
         var foundCarrierPackage: WooShippingPackageDataRepresentable?
         outerLoop: for carrierPackage in carrierPackages {
             let packageGroups = carrierPackage.packageGroups

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -135,6 +135,7 @@ final class WooShippingServiceViewModel: ObservableObject {
                     let error = Error.noRatesAvailable(isHAZMAT: isHAZMAT)
                     updateLoadingState(to: .error(error))
                     analytics.track(event: .WooShipping.rateSelectionStep(state: .loadingFailed, error: error))
+                    onLoadingCompletion(.failure(error))
                     return
                 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -125,6 +125,7 @@ final class WooShippingServiceViewModel: ObservableObject {
             guard let self,
                   /// Avoids showing the obsolete rates if the user changes the package weight while loading.
                   [self.selectedPackage] == remotePackages else {
+                onLoadingCompletion(.success(()))
                 return
             }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -107,10 +107,12 @@ final class WooShippingServiceViewModel: ObservableObject {
         self.selectedPackage = selectedPackage
 
         guard let originAddress, let destinationAddress, hasDestinationAddress else {
+            onLoadingCompletion(.failure(Error.missingDestinationAddress))
             return updateLoadingState(to: .error(Error.missingDestinationAddress))
         }
 
         guard selectedPackage.weight > 0 else {
+            onLoadingCompletion(.failure(Error.missingShipmentWeight))
             return updateLoadingState(to: .error(Error.missingShipmentWeight))
         }
 
@@ -149,7 +151,7 @@ final class WooShippingServiceViewModel: ObservableObject {
                 DDLogError("⛔️ Error loading shipping label rates for Woo Shipping: \(error)")
                 updateLoadingState(to: .error(Error.failedLoadingLabelRates))
                 analytics.track(event: .WooShipping.rateSelectionStep(state: .loadingFailed, error: error))
-                onLoadingCompletion(.failure(error))
+                onLoadingCompletion(.failure(Error.failedLoadingLabelRates))
             }
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -79,8 +79,30 @@ final class WooShippingServiceViewModel: ObservableObject {
         analytics.track(event: .WooShipping.rateSelectionStep(state: .selected))
     }
 
+    func refreshSelectedRate(from oldRate: WooShippingSelectedRate) -> WooShippingSelectedRate? {
+        let updatedStandardRate = standardRates.first(where: {
+            $0.serviceID == oldRate.rate.serviceID
+        })
+        let updatedSignatureRate = signatureRates.first(where: {
+            $0.serviceID == oldRate.signatureRate?.serviceID
+        })
+        let updatedAdultSignatureRate = adultSignatureRates.first(where: {
+            $0.serviceID == oldRate.adultSignatureRate?.serviceID
+        })
+        guard let updatedStandardRate else {
+            return nil
+        }
+        let newSelectedRate = WooShippingSelectedRate(rate: updatedStandardRate,
+                                                      signatureRate: updatedSignatureRate,
+                                                      adultSignatureRate: updatedAdultSignatureRate)
+        self.selectedRate = newSelectedRate
+        generateServiceTabs()
+        return newSelectedRate
+    }
+
     /// Retrieves shipping label rates for this shipment from remote.
-    func loadLabelRates(for selectedPackage: ShippingLabelPackageSelected) {
+    func loadLabelRates(for selectedPackage: ShippingLabelPackageSelected,
+                        onLoadingCompletion: @escaping (Result<Void, Swift.Error>) -> Void = { _ in }) {
         // Store the selected package for retrying if error occurs
         self.selectedPackage = selectedPackage
 
@@ -121,10 +143,12 @@ final class WooShippingServiceViewModel: ObservableObject {
                 adultSignatureRates = rates.adultSignatureRequired
                 updateLoadingState(to: .loaded)
                 analytics.track(event: .WooShipping.rateSelectionStep(state: .loadingSuccess))
+                onLoadingCompletion(.success(()))
             case let .failure(error):
                 DDLogError("⛔️ Error loading shipping label rates for Woo Shipping: \(error)")
                 updateLoadingState(to: .error(Error.failedLoadingLabelRates))
                 analytics.track(event: .WooShipping.rateSelectionStep(state: .loadingFailed, error: error))
+                onLoadingCompletion(.failure(error))
             }
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -187,6 +187,7 @@ private extension WooShippingCreateLabelsView {
                     })
                 }
                 WooShippingShipmentDetailsView(viewModel: viewModel.currentShipmentDetailsViewModel)
+                    .disabled(viewModel.isPurchasingLabel)
             }
             .padding(Layout.contentSpacing)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -121,7 +121,7 @@ struct WooShippingCreateLabelsView: View {
                     UPSTermsView(viewModel: termsViewModel) {
                         viewModel.shouldShowUPSTermsAndConditions = false
                         Task { @MainActor in
-                            await viewModel.retryPurchaseAfterAcceptingUPSTerms()
+                            await viewModel.purchaseLabel(shouldRefreshPackageAndRate: true)
                         }
                     }
                     .presentationDetents([.fraction(0.8), .large])
@@ -538,7 +538,7 @@ private extension WooShippingCreateLabelsView {
     var purchaseButton: some View {
         Button {
             Task {
-                await viewModel.purchaseLabel()
+                await viewModel.purchaseLabel(shouldRefreshPackageAndRate: false)
             }
         } label: {
             Text(Localization.BottomSheet.purchaseLabel(with: viewModel.totalCost))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -119,7 +119,10 @@ struct WooShippingCreateLabelsView: View {
             .sheet(isPresented: $viewModel.shouldShowUPSTermsAndConditions) {
                 if let termsViewModel = viewModel.upsTermsViewModel {
                     UPSTermsView(viewModel: termsViewModel) {
-                        // TODO: reload rates
+                        viewModel.shouldShowUPSTermsAndConditions = false
+                        Task { @MainActor in
+                            await viewModel.retryPurchaseAfterAcceptingUPSTerms()
+                        }
                     }
                     .presentationDetents([.fraction(0.8), .large])
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -293,28 +293,16 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.paymentMethodsViewModel = ShippingLabelPaymentMethodsViewModel(accountSettings: accountSettings)
     }
 
-    @MainActor
-    func retryPurchaseAfterAcceptingUPSTerms() async {
-        isPurchasingLabel = true
-        defer {
-            isPurchasingLabel = false
-        }
-        do {
-            try await currentShipmentDetailsViewModel.refreshPackagesAndShippingRates()
-            await purchaseLabel()
-        } catch {
-            DDLogError("⛔️ Error refreshing data for purchasing label: \(error)")
-            // TODO: show notice for error refetching?
-        }
-    }
-
     /// Purchases a shipping label with the provided label details and settings.
     @MainActor
-    func purchaseLabel() async {
+    func purchaseLabel(shouldRefreshPackageAndRate: Bool) async {
         isPurchasingLabel = true
         labelPurchaseErrorNotice = nil
 
         do {
+            if shouldRefreshPackageAndRate {
+                try await currentShipmentDetailsViewModel.refreshPackagesAndShippingRates()
+            }
             try await currentShipmentDetailsViewModel.purchaseLabel()
         } catch let DotcomError.unknown(code, _) where code == Constants.missingUPSDAPTermsOfServiceAcceptance {
             shouldShowUPSTermsAndConditions = true
@@ -324,7 +312,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
                                               feedbackType: .error,
                                               actionTitle: Localization.LabelPurchaseError.retry) { [weak self] in
                 Task {
-                    await self?.purchaseLabel()
+                    await self?.purchaseLabel(shouldRefreshPackageAndRate: shouldRefreshPackageAndRate)
                 }
             }
             DDLogError("⛔️ Error purchasing shipping label: \(error)")
@@ -748,9 +736,4 @@ private extension Address {
                                   city: city,
                                   postcode: postcode)
     }
-}
-
-enum WooShippingPurchaseError: Error {
-    case failedToRefreshSelectedPackage
-    case failedToRefreshSelectedRate
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -293,11 +293,24 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.paymentMethodsViewModel = ShippingLabelPaymentMethodsViewModel(accountSettings: accountSettings)
     }
 
+    @MainActor
+    func retryPurchaseAfterAcceptingUPSTerms() async {
+        isPurchasingLabel = true
+        defer {
+            isPurchasingLabel = false
+        }
+        do {
+            try await currentShipmentDetailsViewModel.refreshPackagesAndShippingRates()
+            await purchaseLabel()
+        } catch {
+            DDLogError("⛔️ Error refreshing data for purchasing label: \(error)")
+            // TODO: show notice for error refetching?
+        }
+    }
+
     /// Purchases a shipping label with the provided label details and settings.
     @MainActor
     func purchaseLabel() async {
-        guard isPurchaseButtonEnabled, !isPurchasingLabel else { return }
-
         isPurchasingLabel = true
         labelPurchaseErrorNotice = nil
 
@@ -735,4 +748,9 @@ private extension Address {
                                   city: city,
                                   postcode: postcode)
     }
+}
+
+enum WooShippingPurchaseError: Error {
+    case failedToRefreshSelectedPackage
+    case failedToRefreshSelectedRate
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -42,9 +42,11 @@ final class WooShippingServiceViewModelTests: XCTestCase {
                                                     stores: stores)
 
         // When
-        viewModel.loadLabelRates(for: samplePackage)
+        var loadingResult: Result<Void, Error>?
+        viewModel.loadLabelRates(for: samplePackage, onLoadingCompletion: { loadingResult = $0 })
 
         // Then
+        XCTAssert(loadingResult?.isSuccess == true)
         XCTAssertEqual(viewModel.loadingState, .loaded)
 
         XCTAssertEqual(viewModel.serviceTabs.count, 2)
@@ -111,11 +113,15 @@ final class WooShippingServiceViewModelTests: XCTestCase {
                                                     stores: stores)
 
         // When
-        viewModel.loadLabelRates(for: samplePackage)
+        var loadingResult: Result<Void, Error>?
+        viewModel.loadLabelRates(for: samplePackage, onLoadingCompletion: { loadingResult = $0 })
 
         // Then
         XCTAssertEqual(viewModel.loadingState, .error(.failedLoadingLabelRates))
         XCTAssertTrue(viewModel.serviceTabs.isEmpty)
+        XCTAssert(loadingResult?.isFailure == true)
+        XCTAssertEqual(loadingResult?.failure as? WooShippingServiceViewModel.Error,
+                       WooShippingServiceViewModel.Error.failedLoadingLabelRates)
     }
 
     func test_selecting_standard_rate_updates_expected_values() {
@@ -316,6 +322,78 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.displayedServiceCards.count, 1)
         XCTAssertEqual(viewModel.displayedServiceCards.first?.title, "DHL - Next Day")
+    }
+
+    func test_refreshSelectedRate_returns_updated_rate() throws {
+        // Given
+        let oldStandardRate = ShippingLabelCarrierRate(title: "USPS - Media Mail",
+                                                       insurance: "100",
+                                                       retailRate: 8,
+                                                       rate: 7.53,
+                                                       rateID: "test_rateID",
+                                                       serviceID: "test_serviceID",
+                                                       carrierID: "usps",
+                                                       shipmentID: "",
+                                                       hasTracking: true,
+                                                       isSelected: false,
+                                                       isPickupFree: true,
+                                                       deliveryDays: 7,
+                                                       deliveryDateGuaranteed: false)
+
+        let newRate = ShippingLabelCarrierRate(title: "USPS - Media Mail",
+                                               insurance: "100",
+                                               retailRate: 8,
+                                               rate: 7.53,
+                                               rateID: "updated_rateID",
+                                               serviceID: "test_serviceID",
+                                               carrierID: "usps",
+                                               shipmentID: "",
+                                               hasTracking: true,
+                                               isSelected: false,
+                                               isPickupFree: true,
+                                               deliveryDays: 7,
+                                               deliveryDateGuaranteed: false)
+
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let updatedRates = [ShippingLabelCarriersAndRates(packageID: Self.samplePackageID,
+                                                          defaultRates: [newRate],
+                                                          signatureRequired: [],
+                                                          adultSignatureRequired: [])]
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .loadLabelRates(_, _, _, _, packages, completion):
+                completion(packages, .success(updatedRates))
+            default:
+                XCTFail("Received unexpected action: \(action)")
+            }
+        }
+
+        let viewModel = WooShippingServiceViewModel(order: Order.fake(),
+                                                    originAddress: WooShippingAddress.fake(),
+                                                    destinationAddress: sampleDestinationAddress(),
+                                                    stores: stores)
+
+        viewModel.loadLabelRates(for: samplePackage)
+        viewModel.selectRate(oldStandardRate, signatureRate: nil, adultSignatureRate: nil)
+        let oldSelectedRate = try XCTUnwrap(viewModel.selectedRate)
+
+        // When
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .loadLabelRates(_, _, _, _, packages, completion):
+                completion(packages, .success(updatedRates))
+            default:
+                XCTFail("Received unexpected action: \(action)")
+            }
+        }
+        viewModel.loadLabelRates(for: samplePackage)
+        let updatedRate = viewModel.refreshSelectedRate(from: oldSelectedRate)
+
+        // Then
+        XCTAssertNotNil(updatedRate)
+        XCTAssertNil(updatedRate?.signatureRate)
+        XCTAssertNil(updatedRate?.adultSignatureRate)
+        XCTAssertEqual(updatedRate?.rate.rateID, newRate.rateID)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -208,7 +208,7 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         XCTAssertEqual(uspsCards?.first?.title, "USPS - Media Mail")
     }
 
-    func test_shortShipping_by_deliveryDays_returns_sorted_list() {
+    func test_sortShipping_by_deliveryDays_returns_sorted_list() {
         // Given
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),
                                                     originAddress: WooShippingAddress.fake(),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
@@ -570,6 +570,51 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(viewModel.customsInformationIsCompleted)
     }
+
+    @MainActor
+    func test_refreshPackagesAndShippingRates_updates_selected_package() async {
+        // Given
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
+
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingShipmentDetailsViewModel(order: Order.fake(),
+                                                            shipment: sampleShipment,
+                                                            shippingLabel: nil,
+                                                            originAddress: originAddressSubject.eraseToAnyPublisher(),
+                                                            destinationAddress: destinationAddressSubject.eraseToAnyPublisher(),
+                                                            stores: stores)
+        let package = samplePackageData()
+        viewModel.selectPackage(package)
+        viewModel.shippingService?.onSelectRate?(sampleSelectedRate())
+
+        // Confidence check
+        XCTAssertEqual(viewModel.selectedPackage?.id, package.id)
+
+        // When: package is refreshed
+        let updatedPackage = WooShippingCustomPackage(id: "small_flat_box",
+                                                      name: "custom",
+                                                      rawType: "box",
+                                                      dimensions: "21.91 x 13.65 x 4.13",
+                                                      boxWeight: 0.25)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .loadPackages(_, let completion):
+                completion(.success(WooShippingPackagesResponse(siteID: 123,
+                                                                customPackages: [updatedPackage],
+                                                                savedPredefinedPackages: [],
+                                                                allPredefinedOptions: [])))
+            case let .loadLabelRates(_, _, _, _, packages, completion):
+                completion(packages, .success([]))
+            default:
+                break
+            }
+        }
+        try? await viewModel.refreshPackagesAndShippingRates() // ignoring failure in refreshing rate for simplicity
+
+        // Then
+        XCTAssertEqual(viewModel.selectedPackage?.name, updatedPackage.name)
+    }
 }
 
 private extension WooShippingShipmentDetailsViewModelTests {

--- a/Yosemite/Yosemite/Stores/WooShippingStore.swift
+++ b/Yosemite/Yosemite/Stores/WooShippingStore.swift
@@ -622,4 +622,6 @@ public enum WooShippingLabelPurchaseError: Error {
     case purchaseErrorStatus
     /// No labels are returned by initial purchase request
     case purchaseMissingLabels
+    case failedToRefreshSelectedPackage
+    case failedToRefreshSelectedRate
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Close WOOMOB-565

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR wraps up support for UPS rates by resubmitting purchase after UPS TOS is accepted for a new origin address.

Since backend has yet to support reloading selected packages and rates upon resubmitting purchase, here we need to handle the reloading manually. The logic will need to be removed when the backend supports reloading.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with Woo Shipping plugin set up in staging environment.
2. Navigate to the Orders tab and select a paid order with multiple physical products and unfulfilled shipments.
3. Select Create shipping label > select Add a package and select a custom package.
4. Select a UPS shipping service.
5. Switch to a new origin address if your current origin address already accepted the UPS TOS.
6. Proceed to purchase a label. A sheet should display asking you to confirm UPS TOS.
7. Tick all the checkboxes to confirm agreements. After tapping the Confirm the button, the purchase is resubmitted automatically and should the succeeds.


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested and confirmed in simulator iPhone 16 iOS 18.4.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/4afd8dcb-4d33-4e0a-a3d7-506601cafcde



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
