### PR TITLE
[Woo POS] Remove unnecessary TTP events from POS whitelist

### DIFF
--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -158,8 +158,6 @@ private extension TracksProvider {
             WooAnalyticsStat.cardReaderConnectionFailed,
             WooAnalyticsStat.cardReaderConnectionSuccess,
             WooAnalyticsStat.cardReaderDisconnectTapped,
-            WooAnalyticsStat.manageCardReadersTapToPayReaderAutoDisconnect,
-            WooAnalyticsStat.cardReaderAutomaticDisconnect,
             WooAnalyticsStat.cardReaderLocationPermissionPreAlertShown,
             WooAnalyticsStat.cardReaderLocationPermissionRequiredShown,
 


### PR DESCRIPTION
## Description

When we added a decorator for POS events and whitelisted specific card-payment events that we share between app and POS, some TTP-related events were whitelisted unnecessarily, as the switch between reader and TTP does not happen in POS mode. This PR removes them as part of WOOMOB-526 

## Changes
From `TracksProvider.decorateEventNameForPOSIfNeeded()` removed: 
- `woocommerceios_pos_manage_card_readers_automatic_disconnect_built_in_reader`
- `woocommerceios_pos_card_reader_automatic_disconnect`

## Testing information
CI should pass
