### PR TITLE
[Woo POS][Barcodes] Barcode scan loading state

### DIFF
--- a/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -244,9 +244,13 @@ extension WooAnalyticsEvent.PointOfSale {
         case variation
 
         init?(cartItem: Cart.PurchasableItem) {
-            if cartItem.item is POSSimpleProduct {
+            guard case let .loaded(item) = cartItem.state else {
+                return nil
+            }
+
+            if item is POSSimpleProduct {
                 self = .simple
-            } else if cartItem.item is POSVariation {
+            } else if item is POSVariation {
                 self = .variation
             } else {
                 return nil

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -330,7 +330,10 @@ private extension PointOfSaleOrderController {
 
 private extension POSCart {
     init(cart: Cart) {
-        let items = cart.purchasableItems.map { POSCartItem(item: $0.item, quantity: Decimal($0.quantity)) }
+        let items = cart.purchasableItems.compactMap { (purchasableItem: Cart.PurchasableItem) -> POSCartItem? in
+            guard case let .loaded(item) = purchasableItem.state else { return nil }
+            return POSCartItem(item: item, quantity: Decimal(purchasableItem.quantity))
+        }
         let coupons = cart.coupons.map { POSCoupon(id: $0.id, code: $0.code, summary: $0.summary) }
         self.init(items: items, coupons: coupons)
     }

--- a/WooCommerce/Classes/POS/Models/Cart.swift
+++ b/WooCommerce/Classes/POS/Models/Cart.swift
@@ -29,6 +29,15 @@ extension Cart {
         enum ItemState {
             case loaded(POSOrderableItem)
             case loading
+
+            var isLoading: Bool {
+                switch self {
+                case .loading:
+                    return true
+                default:
+                    return false
+                }
+            }
         }
 
         init(id: UUID, title: String, subtitle: String?, quantity: Int, state: ItemState) {

--- a/WooCommerce/Classes/POS/Models/Cart.swift
+++ b/WooCommerce/Classes/POS/Models/Cart.swift
@@ -98,6 +98,23 @@ extension Cart {
         }
     }
 
+    mutating func addLoadingItem() -> UUID {
+        let id = UUID()
+        let loadingItem = PurchasableItem.loading(id: id)
+        purchasableItems.insert(loadingItem, at: purchasableItems.startIndex)
+        return id
+    }
+
+    mutating func updateLoadingItem(id: UUID, with posItem: POSItem) {
+        guard let index = purchasableItems.firstIndex(where: { $0.id == id }) else { return }
+
+        if let productItem = createPurchasableItem(id: id, from: posItem) {
+            purchasableItems[index] = productItem
+        } else {
+            purchasableItems.remove(at: index)
+        }
+    }
+
     var isEmpty: Bool {
         purchasableItems.isEmpty && coupons.isEmpty
     }

--- a/WooCommerce/Classes/POS/Models/Cart.swift
+++ b/WooCommerce/Classes/POS/Models/Cart.swift
@@ -79,18 +79,22 @@ extension Cart {
 
 extension Cart {
     mutating func add(_ posItem: POSItem) {
-        switch posItem {
-        case .simpleProduct(let simpleProduct):
-            let productItem = Cart.PurchasableItem(id: UUID(), item: simpleProduct, title: simpleProduct.name, subtitle: nil, quantity: 1)
-            purchasableItems.insert(productItem, at: purchasableItems.startIndex)
-        case .variation(let variation):
-            let productItem = Cart.PurchasableItem(id: UUID(), item: variation, title: variation.parentProductName, subtitle: variation.name, quantity: 1)
-            purchasableItems.insert(productItem, at: purchasableItems.startIndex)
-        case .variableParentProduct:
-            return
-        case .coupon(let coupon):
+        if let purchasableItem = createPurchasableItem(id: UUID(), from: posItem) {
+            purchasableItems.insert(purchasableItem, at: purchasableItems.startIndex)
+        } else if case .coupon(let coupon) = posItem {
             let couponItem = Cart.CouponItem(id: coupon.id, code: coupon.code, summary: coupon.summary)
             coupons.insert(couponItem, at: coupons.startIndex)
+        }
+    }
+
+    private func createPurchasableItem(id: UUID, from posItem: POSItem) -> Cart.PurchasableItem? {
+        switch posItem {
+        case .simpleProduct(let simpleProduct):
+            return PurchasableItem(id: UUID(), item: simpleProduct, title: simpleProduct.name, subtitle: nil, quantity: 1)
+        case .variation(let variation):
+            return PurchasableItem(id: UUID(), item: variation, title: variation.parentProductName, subtitle: variation.name, quantity: 1)
+        case .variableParentProduct, .coupon:
+            return nil
         }
     }
 

--- a/WooCommerce/Classes/POS/Models/Cart.swift
+++ b/WooCommerce/Classes/POS/Models/Cart.swift
@@ -115,6 +115,10 @@ extension Cart {
         }
     }
 
+    mutating func removeItem(id: UUID) {
+        purchasableItems.removeAll(where: { $0.id == id })
+    }
+
     var isEmpty: Bool {
         purchasableItems.isEmpty && coupons.isEmpty
     }

--- a/WooCommerce/Classes/POS/Models/Cart.swift
+++ b/WooCommerce/Classes/POS/Models/Cart.swift
@@ -20,11 +20,42 @@ enum CartItemType: CaseIterable {
 extension Cart {
     struct PurchasableItem: CartItem {
         let id: UUID
-        let item: POSOrderableItem
         let title: String
         let subtitle: String?
         let quantity: Int
         let type: CartItemType = .purchasableItem
+        let state: ItemState
+
+        enum ItemState {
+            case loaded(POSOrderableItem)
+            case loading
+        }
+
+        init(id: UUID, title: String, subtitle: String?, quantity: Int, state: ItemState) {
+            self.id = id
+            self.title = title
+            self.subtitle = subtitle
+            self.quantity = quantity
+            self.state = state
+        }
+
+        init(id: UUID, item: POSOrderableItem, title: String, subtitle: String?, quantity: Int) {
+            self.id = id
+            self.title = title
+            self.subtitle = subtitle
+            self.quantity = quantity
+            self.state = .loaded(item)
+        }
+
+        static func loading(id: UUID) -> PurchasableItem {
+            PurchasableItem(
+                id: id,
+                title: "Loading...",
+                subtitle: nil,
+                quantity: 1,
+                state: .loading
+            )
+        }
     }
 
     struct CouponItem: CartItem {

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -179,8 +179,12 @@ extension PointOfSaleAggregateModel {
     func barcodeScanned(_ barcode: String) {
         Task {
             let placeholderItemID = cart.addLoadingItem()
-            let item = try await barcodeScanService.getItem(barcode: barcode)
-            cart.updateLoadingItem(id: placeholderItemID, with: item)
+            do {
+                let item = try await barcodeScanService.getItem(barcode: barcode)
+                cart.updateLoadingItem(id: placeholderItemID, with: item)
+            } catch {
+                cart.removeItem(id: placeholderItemID)
+            }
         }
     }
 }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -178,8 +178,9 @@ extension PointOfSaleAggregateModel {
 extension PointOfSaleAggregateModel {
     func barcodeScanned(_ barcode: String) {
         Task {
+            let placeholderItemID = cart.addLoadingItem()
             let item = try await barcodeScanService.getItem(barcode: barcode)
-            addToCart(item)
+            cart.updateLoadingItem(id: placeholderItemID, with: item)
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -30,9 +30,15 @@ struct ItemRowView: View {
                         .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
                         .font(Constants.itemSubtitleFont)
                 }
-                Text(cartItem.item.formattedPrice)
-                    .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
-                    .font(Constants.itemPriceFont)
+
+                switch cartItem.state {
+                case .loaded(let item):
+                    Text(item.formattedPrice)
+                        .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
+                        .font(Constants.itemPriceFont)
+                default:
+                    EmptyView()
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, showProductImage ? 0 : Constants.cardContentHorizontalPadding)
@@ -56,10 +62,15 @@ struct ItemRowView: View {
         if !showProductImage {
             EmptyView()
         } else {
-            POSItemImageView(imageSource: cartItem.item.productImageSource,
-                             imageSize: dimension,
-                             scale: 1)
-            .frame(width: dimension, height: dimension)
+            switch cartItem.state {
+            case .loaded(let item):
+                POSItemImageView(imageSource: item.productImageSource,
+                                 imageSize: dimension,
+                                 scale: 1)
+                .frame(width: dimension, height: dimension)
+            default:
+                EmptyView()
+            }
         }
     }
 }
@@ -96,6 +107,12 @@ private extension ItemRowView {
                                                title: "Item Title",
                                                subtitle: nil,
                                                quantity: 2),
+                onItemRemoveTapped: { })
+}
+
+@available(iOS 17.0, *)
+#Preview(traits: .sizeThatFitsLayout) {
+    ItemRowView(cartItem: Cart.PurchasableItem.loading(id: UUID()),
                 onItemRemoveTapped: { })
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -25,10 +25,12 @@ struct ItemRowView: View {
                 Text(cartItem.title)
                     .foregroundColor(PointOfSaleItemListCardConstants.titleColor)
                     .font(Constants.itemTitleFont)
+                    .redacted(reason: cartItem.state.isLoading ? .placeholder : [])
                 if let subtitle = cartItem.subtitle {
                     Text(subtitle)
                         .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
                         .font(Constants.itemSubtitleFont)
+                        .redacted(reason: cartItem.state.isLoading ? .placeholder : [])
                 }
 
                 switch cartItem.state {
@@ -36,13 +38,17 @@ struct ItemRowView: View {
                     Text(item.formattedPrice)
                         .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
                         .font(Constants.itemPriceFont)
-                default:
-                    EmptyView()
+                case .loading:
+                    Text("$0.00")
+                        .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
+                        .font(Constants.itemPriceFont)
+                        .redacted(reason: .placeholder)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, showProductImage ? 0 : Constants.cardContentHorizontalPadding)
             .accessibilityElement(children: .combine)
+            .shimmering(active: cartItem.state.isLoading)
 
             if let onItemRemoveTapped {
                 CartRowRemoveButton {
@@ -68,8 +74,13 @@ struct ItemRowView: View {
                                  imageSize: dimension,
                                  scale: 1)
                 .frame(width: dimension, height: dimension)
-            default:
-                EmptyView()
+            case .loading:
+                POSItemImageView(imageSource: nil,
+                                 imageSize: dimension,
+                                 scale: 1)
+                .frame(width: dimension, height: dimension)
+                .redacted(reason: .placeholder)
+                .shimmering()
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -115,6 +115,43 @@ struct PointOfSaleAggregateModelTests {
         }
 
         @available(iOS 17.0, *)
+        @Test func addLoadingItem_adds_loading_item_to_cart() async throws {
+            // Given
+            var cart = Cart()
+            try #require(cart.purchasableItems.isEmpty)
+
+            // When
+            let id = cart.addLoadingItem()
+
+            // Then
+            #expect(cart.purchasableItems.count == 1)
+            let item = try #require(cart.purchasableItems.first)
+            #expect(item.id == id)
+            guard case .loading = item.state else {
+                throw CartTestError.unexpectedItemStateInCart
+            }
+        }
+
+        @available(iOS 17.0, *)
+        @Test func updateLoadingItem_updates_loading_item_with_simple_product() async throws {
+            // Given
+            var cart = Cart()
+            let id = cart.addLoadingItem()
+            let purchasableItem = makePurchasableItem(name: "Test Product")
+
+            // When
+            cart.updateLoadingItem(id: id, with: purchasableItem)
+
+            // Then
+            #expect(cart.purchasableItems.count == 1)
+            let item = try #require(cart.purchasableItems.first)
+            guard case .loaded(let loadedItem) = item.state else {
+                throw CartTestError.unexpectedItemStateInCart
+            }
+            #expect(loadedItem.name == "Test Product")
+        }
+
+        @available(iOS 17.0, *)
         @Test func addItem_results_in_a_non_empty_cart() async throws {
             // Given
             let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -158,7 +158,13 @@ struct PointOfSaleAggregateModelTests {
             items.forEach(sut.addToCart(_:))
 
             // Then
-            #expect(sut.cart.purchasableItems.map(\.item.id) == items.reversed().map(\.id))
+            let cartItemIDs = try sut.cart.purchasableItems.map { purchasableItem in
+                guard case let .loaded(item) = purchasableItem.state else {
+                    throw CartTestError.unexpectedItemStateInCart
+                }
+                return item.id
+            }
+            #expect(cartItemIDs == items.reversed().map(\.id))
         }
 
         @available(iOS 17.0, *)
@@ -248,6 +254,10 @@ struct PointOfSaleAggregateModelTests {
             // Then
             #expect(sut.cart.purchasableItems.count == 2)
             #expect(sut.cart.coupons.count == 0)
+        }
+
+        enum CartTestError: Error {
+            case unexpectedItemStateInCart
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of WOOPRD-561

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the loading state for scanned items. The rows in the cart now have a `state` property, instead of and `item` property, which encapsulates the possible options.

When a barcode is "scanned", a loading cell is added to the cart. When we get the item back from the network request, we update that loading row to show the item.

Error handling is under a different ticket – for now, the loading row is just removed when we get an error.

Remaining work for this ticket:
 - Disable the `Check out` button while there are any loading cells in the cart.
 - Update the visual style to match loading state for the item list.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Enable the `pointOfSaleBarcodeScanningi1` feature flag, and ensure you have a value set for the `GTIN, UPC, EAN, or ISBN` field on at least one product and variation.

1. Launch the app and open POS
2. Tap the barcode item to open the simulated scanner
3. Type the barcode for your item and tap scan. Observe that a loading cell is added to the cart, and updates to your item when the network request is done.
4. Type an invalid barcode and tap scan. Observe that the loading cell is removed when the request is done.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

I've tested this on an iPad Air running iOS 17.7.2

I tested adding and removing items quickly, and saw that the correct items were updated and had sequence consistency in the cart.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/5772a055-fd33-48de-9794-3ae77b2a4c04


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
