### PR TITLE
Skip tests in code rather than in test plan for Networking

### DIFF
--- a/Networking/NetworkingTests/Mapper/InAppPurchaseOrderResultMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/InAppPurchaseOrderResultMapperTests.swift
@@ -3,6 +3,8 @@ import XCTest
 
 final class InAppPurchasesOrderResultMapperTests: XCTestCase {
     func test_iap_order_creation_is_decoded_from_json_response() throws {
+        try XCTSkipIf(true)
+
         // Given
         let jsonData = try XCTUnwrap(Loader.contentsOf("iap-order-create"))
         let expectedOrderId = 12345

--- a/Networking/NetworkingTests/Mapper/InAppPurchasesProductsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/InAppPurchasesProductsMapperTests.swift
@@ -3,6 +3,8 @@ import XCTest
 
 final class InAppPurchasesProductsMapperTests: XCTestCase {
     func test_iap_products_list_is_decoded_from_json_response() throws {
+        try XCTSkipIf(true)
+
         // Given
         let jsonData = try XCTUnwrap(Loader.contentsOf("iap-products"))
         let expectedProductIdentifiers = [

--- a/Networking/NetworkingTests/Mapper/InAppPurchasesTransactionMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/InAppPurchasesTransactionMapperTests.swift
@@ -3,6 +3,8 @@ import XCTest
 
 final class InAppPurchasesTransactionMapperTests: XCTestCase {
     func test_iap_handled_transaction_is_decoded_from_json_response() throws {
+        try XCTSkipIf(true)
+
         // Given
         let jsonData = try XCTUnwrap(Loader.contentsOf("iap-transaction-handled"))
         let expectedSiteID = Int64(1234)
@@ -15,6 +17,8 @@ final class InAppPurchasesTransactionMapperTests: XCTestCase {
     }
 
     func test_iap_unhandled_transaction_is_decoded_from_json_response() throws {
+        try XCTSkipIf(true)
+
         // Given
         let jsonData = try XCTUnwrap(Loader.contentsOf("iap-transaction-not-handled"))
         let expectedErrorMessage = "Transaction not found."

--- a/Networking/NetworkingTests/Remote/InAppPurchasesRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/InAppPurchasesRemoteTests.swift
@@ -28,6 +28,8 @@ class InAppPurchasesRemoteTests: XCTestCase {
     /// Verifies that 'moderateComment' as spam properly parses the successful response
     ///
     func test_load_products_returns_list_of_products() throws {
+        try XCTSkipIf(true)
+
         // Given
         let remote = InAppPurchasesRemote(network: network)
 
@@ -48,6 +50,8 @@ class InAppPurchasesRemoteTests: XCTestCase {
     }
 
     func test_purchase_product_returns_created_order() throws {
+        try XCTSkipIf(true)
+
         // Given
         let remote = InAppPurchasesRemote(network: network)
 
@@ -75,6 +79,8 @@ class InAppPurchasesRemoteTests: XCTestCase {
     }
 
     func test_retrieveHandledTransactionSiteID_when_success_to_retrieve_response_and_transaction_is_handled_then_returns_siteID() throws {
+        try XCTSkipIf(true)
+
         // Given
         let remote = InAppPurchasesRemote(network: network)
         let transactionID: UInt64 = 1234
@@ -118,6 +124,8 @@ class InAppPurchasesRemoteTests: XCTestCase {
     }
 
     func test_retrieveHandledTransactionSiteID_when_fails_to_retrieve_response_then_returns_network_error() throws {
+        try XCTSkipIf(true)
+
         // Given
         let remote = InAppPurchasesRemote(network: network)
         let transactionID: UInt64 = 1234

--- a/Networking/NetworkingTests/Remote/WCPayRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WCPayRemoteTests.swift
@@ -111,6 +111,8 @@ final class WCPayRemoteTests: XCTestCase {
 
         XCTAssertTrue(result.isSuccess)
         let account = try result.get()
+
+        XCTExpectFailure("isCardPresentEligible has been hardcoded to true. See https://github.com/woocommerce/woocommerce-ios/pull/5030")
         XCTAssertEqual(account.isCardPresentEligible, false)
     }
 
@@ -130,6 +132,8 @@ final class WCPayRemoteTests: XCTestCase {
 
         XCTAssertTrue(result.isSuccess)
         let account = try result.get()
+
+        XCTExpectFailure("isCardPresentEligible has been hardcoded to true. See https://github.com/woocommerce/woocommerce-ios/pull/5030")
         XCTAssertEqual(account.isCardPresentEligible, false)
     }
 

--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -88,20 +88,6 @@
       }
     },
     {
-      "skippedTests" : [
-        "InAppPurchasesOrderResultMapperTests",
-        "InAppPurchasesOrderResultMapperTests\/test_iap_order_creation_is_decoded_from_json_response()",
-        "InAppPurchasesProductsMapperTests",
-        "InAppPurchasesRemoteTests",
-        "InAppPurchasesRemoteTests\/test_load_products_returns_list_of_products()",
-        "InAppPurchasesRemoteTests\/test_purchase_product_returns_created_order()",
-        "InAppPurchasesRemoteTests\/test_retrieveHandledTransactionSiteID_when_fails_to_retrieve_response_then_returns_network_error()",
-        "InAppPurchasesRemoteTests\/test_retrieveHandledTransactionSiteID_when_success_to_retrieve_response_and_transaction_is_handled_then_returns_siteID()",
-        "InAppPurchasesRemoteTests\/test_retrieveHandledTransactionSiteID_when_success_to_retrieve_response_and_transaction_is_not_handled_then_returns_errorResponse()",
-        "InAppPurchasesTransactionMapperTests",
-        "InAppPurchasesTransactionMapperTests\/test_iap_handled_transaction_is_decoded_from_json_response()",
-        "InAppPurchasesTransactionMapperTests\/test_iap_unhandled_transaction_is_decoded_from_json_response()"
-      ],
       "target" : {
         "containerPath" : "container:..\/Networking\/Networking.xcodeproj",
         "identifier" : "B557D9EB209753AA005962F4",

--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -100,9 +100,7 @@
         "InAppPurchasesRemoteTests\/test_retrieveHandledTransactionSiteID_when_success_to_retrieve_response_and_transaction_is_not_handled_then_returns_errorResponse()",
         "InAppPurchasesTransactionMapperTests",
         "InAppPurchasesTransactionMapperTests\/test_iap_handled_transaction_is_decoded_from_json_response()",
-        "InAppPurchasesTransactionMapperTests\/test_iap_unhandled_transaction_is_decoded_from_json_response()",
-        "WCPayRemoteTests\/test_loadAccount_properly_handles_implicitly_not_eligible_for_card_present_payments()",
-        "WCPayRemoteTests\/test_loadAccount_properly_handles_not_eligible_for_card_present_payments()"
+        "InAppPurchasesTransactionMapperTests\/test_iap_unhandled_transaction_is_decoded_from_json_response()"
       ],
       "target" : {
         "containerPath" : "container:..\/Networking\/Networking.xcodeproj",


### PR DESCRIPTION
## Description
I thought I was done with https://github.com/woocommerce/woocommerce-ios/pull/15678 when I saw test failures.

It took a moment to realize the failure was not due to my code changes but to the fact that the failing test was disabled on `trunk` via the `xctestplan`. The `xctestplan` configuration however changed in moving from framework to module and the test go re-enabled.

I understand the convenience of disabling the tests via the test plan, but the side effect is that we spread test configuration logic between to files and we can run in situations like this one where a test suddenly fails despite no code changes.

Moreover, test plans hide the fact that tests are skipped—out of sight, out of mind. Ideally, tests should remain skipped for as little time as possible.

So, here I propose to use `XCTSkip` and `XCTExpectFailure` to bring the test skipping configuration as close to the test code as possible.


## Steps to reproduce & Testing information
See how https://buildkite.com/automattic/woocommerce-ios/builds/30327/summary/annotations fails

![image](https://github.com/user-attachments/assets/c777e5a4-aa08-4ecd-bcd4-777eefd13df4)

and how https://buildkite.com/automattic/woocommerce-ios/builds/30334/summary/annotations, which cherry picks these commit, passes

<img width="1416" alt="image" src="https://github.com/user-attachments/assets/5e88304c-d1f7-4a4d-aa31-3da5693ae883" />

<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.