### PR TITLE
[Woo POS][Barcodes] Match barcode scan load state to item list

### DIFF
--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -144,6 +144,10 @@ extension PointOfSaleAggregateModel {
         }
     }
 
+    func cancelLoadingItem(id: UUID) {
+        cart.removeItem(id: id)
+    }
+
     func removeAllItemsFromCart(types: [CartItemType] =  CartItemType.allCases) {
         for type in types {
             switch type {

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -78,7 +78,10 @@ struct CartView: View {
                                             )
                                         )
                                         posModel.remove(cartItem: cartItem)
-                                    } : nil)
+                                    } : nil,
+                                                onCancelLoading: {
+                                        posModel.cancelLoadingItem(id: cartItem.id)
+                                    })
                                     .id(cartItem.id)
                                     .transition(.opacity)
                                 }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
@@ -26,6 +26,7 @@ struct GhostItemCardView: View {
             placeholders
                 .foregroundStyle(Color.posOnSurfaceVariantLowest)
                 .shimmering()
+                .accessibilityLabel(Localization.loadingItemAccessibilityLabel)
 
             Spacer()
 
@@ -63,6 +64,13 @@ fileprivate typealias Constants = PointOfSaleItemListCardConstants
 
 fileprivate enum Layout {
     static let cornerRadius: CGFloat = POSCornerRadiusStyle.medium.value
+}
+
+fileprivate enum Localization {
+    static let loadingItemAccessibilityLabel = NSLocalizedString(
+        "pointOfSale.itemListCard.loadingItemAccessibilityLabel",
+        value: "Loading",
+        comment: "Loading item accessibility label in POS")
 }
 
 struct GhostItemCardViewConfiguration {

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
@@ -7,7 +7,7 @@ struct GhostItemCardView: View {
     private let accessory: AnyView?
 
     private var dimension: CGFloat {
-        min(Constants.productCardSize * scale, Constants.maximumProductCardSize)
+        min(configuration.cardSize * scale, configuration.maximumCardSize)
     }
 
     init(configuration: GhostItemCardViewConfiguration = .itemList) {
@@ -32,7 +32,7 @@ struct GhostItemCardView: View {
 
             if let accessory {
                 accessory
-                    .padding(Constants.accessoryButtonPadding * (1 / scale))
+                    .padding(Constants.accessoryButtonPadding)
             }
         }
         .measureWidth { width in
@@ -46,13 +46,16 @@ struct GhostItemCardView: View {
     @ViewBuilder var placeholders: some View {
         HStack(alignment: .center, spacing: Constants.cardSpacing) {
             Rectangle()
-                .aspectRatio(1, contentMode: .fit)
+                .frame(maxWidth: dimension)
+                .aspectRatio(1, contentMode: .fill)
             VStack(alignment: .leading) {
                 Rectangle()
-                    .frame(width: viewWidth * 0.5, height: configuration.placeholderHeight * scale)
+                    .frame(maxWidth: viewWidth * configuration.placeholderWidthMultiplier,
+                           maxHeight: configuration.placeholderHeight * scale)
                     .cornerRadius(Layout.cornerRadius)
                 Rectangle()
-                    .frame(width: viewWidth * 0.1, height: configuration.placeholderHeight * scale)
+                    .frame(maxWidth: viewWidth * configuration.placeholderWidthMultiplier * 0.2,
+                           maxHeight: configuration.placeholderHeight * scale)
                     .cornerRadius(Layout.cornerRadius)
             }
             .foregroundColor(.posOnSurfaceVariantLowest)
@@ -76,22 +79,21 @@ fileprivate enum Localization {
 
 struct GhostItemCardViewConfiguration {
     let placeholderHeight: CGFloat
+    let cardSize: CGFloat
+    let maximumCardSize: CGFloat
+    let placeholderWidthMultiplier: CGFloat
 
     static let itemList = GhostItemCardViewConfiguration(
-        placeholderHeight: 32
-    )
-
-    static let cart = GhostItemCardViewConfiguration(
-        placeholderHeight: 24
+        placeholderHeight: 32,
+        cardSize: Constants.productCardSize,
+        maximumCardSize: Constants.maximumProductCardSize,
+        placeholderWidthMultiplier: 0.5
     )
 }
 
 #Preview {
     VStack(spacing: 20) {
         GhostItemCardView(configuration: .itemList) {
-            CartRowRemoveButton {}
-        }
-        GhostItemCardView(configuration: .cart) {
             CartRowRemoveButton {}
         }
         GhostItemCardView(configuration: .itemList)

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct GhostItemCardView: View {
     @ScaledMetric private var scale: CGFloat = 1.0
     @State private var viewWidth: CGFloat = 0.0
+    @Binding private var showProductImage: Bool
     private let configuration: GhostItemCardViewConfiguration
     private let accessory: AnyView?
 
@@ -10,14 +11,18 @@ struct GhostItemCardView: View {
         min(configuration.cardSize * scale, configuration.maximumCardSize)
     }
 
-    init(configuration: GhostItemCardViewConfiguration = .itemList) {
+    init(configuration: GhostItemCardViewConfiguration = .itemList,
+         showProductImage: Binding<Bool> = .constant(true)) {
         self.configuration = configuration
+        self._showProductImage = showProductImage
         self.accessory = nil
     }
 
     init<Accessory: View>(configuration: GhostItemCardViewConfiguration = .itemList,
+                          showProductImage: Binding<Bool> = .constant(true),
                          @ViewBuilder accessory: () -> Accessory) {
         self.configuration = configuration
+        self._showProductImage = showProductImage
         self.accessory = AnyView(accessory())
     }
 
@@ -48,6 +53,7 @@ struct GhostItemCardView: View {
             Rectangle()
                 .frame(maxWidth: dimension)
                 .aspectRatio(1, contentMode: .fill)
+                .renderedIf(showProductImage)
             VStack(alignment: .leading) {
                 Rectangle()
                     .frame(maxWidth: viewWidth * configuration.placeholderWidthMultiplier,

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
@@ -48,10 +48,10 @@ struct GhostItemCardView: View {
                 .aspectRatio(1, contentMode: .fit)
             VStack(alignment: .leading) {
                 Rectangle()
-                    .frame(width: viewWidth * 0.5, height: configuration.titleHeight * scale)
+                    .frame(width: viewWidth * 0.5, height: configuration.placeholderHeight * scale)
                     .cornerRadius(Layout.cornerRadius)
                 Rectangle()
-                    .frame(width: viewWidth * 0.1, height: configuration.priceHeight * scale)
+                    .frame(width: viewWidth * 0.1, height: configuration.placeholderHeight * scale)
                     .cornerRadius(Layout.cornerRadius)
             }
             .foregroundColor(.posOnSurfaceVariantLowest)
@@ -74,19 +74,16 @@ fileprivate enum Localization {
 }
 
 struct GhostItemCardViewConfiguration {
-    let titleHeight: CGFloat
-    let priceHeight: CGFloat
+    let placeholderHeight: CGFloat
     let bordered: Bool
 
     static let itemList = GhostItemCardViewConfiguration(
-        titleHeight: 32,
-        priceHeight: 32,
+        placeholderHeight: 32,
         bordered: true
     )
 
     static let cart = GhostItemCardViewConfiguration(
-        titleHeight: 20,
-        priceHeight: 20,
+        placeholderHeight: 24,
         bordered: false
     )
 }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
@@ -32,6 +32,7 @@ struct GhostItemCardView: View {
 
             if let accessory {
                 accessory
+                    .padding(Constants.accessoryButtonPadding * (1 / scale))
             }
         }
         .measureWidth { width in
@@ -39,7 +40,7 @@ struct GhostItemCardView: View {
         }
         .frame(maxWidth: .infinity, idealHeight: dimension)
         .background(Color.posSurfaceBright)
-        .if(configuration.bordered) { $0.posItemCardBorderStyles() }
+        .posItemCardBorderStyles()
     }
 
     @ViewBuilder var placeholders: some View {
@@ -75,16 +76,13 @@ fileprivate enum Localization {
 
 struct GhostItemCardViewConfiguration {
     let placeholderHeight: CGFloat
-    let bordered: Bool
 
     static let itemList = GhostItemCardViewConfiguration(
-        placeholderHeight: 32,
-        bordered: true
+        placeholderHeight: 32
     )
 
     static let cart = GhostItemCardViewConfiguration(
-        placeholderHeight: 24,
-        bordered: false
+        placeholderHeight: 24
     )
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
@@ -3,46 +3,94 @@ import SwiftUI
 struct GhostItemCardView: View {
     @ScaledMetric private var scale: CGFloat = 1.0
     @State private var viewWidth: CGFloat = 0.0
+    private let configuration: GhostItemCardViewConfiguration
+    private let accessory: AnyView?
 
     private var dimension: CGFloat {
         min(Constants.productCardSize * scale, Constants.maximumProductCardSize)
     }
 
+    init(configuration: GhostItemCardViewConfiguration = .itemList) {
+        self.configuration = configuration
+        self.accessory = nil
+    }
+
+    init<Accessory: View>(configuration: GhostItemCardViewConfiguration = .itemList,
+                         @ViewBuilder accessory: () -> Accessory) {
+        self.configuration = configuration
+        self.accessory = AnyView(accessory())
+    }
+
     var body: some View {
         HStack(alignment: .center, spacing: Constants.cardSpacing) {
-            Rectangle()
-                .frame(width: dimension, height: dimension)
-            VStack(alignment: .leading) {
-                Rectangle()
-                    .frame(width: viewWidth * 0.5, height: Layout.placeholderHeight * scale)
-                    .cornerRadius(Layout.cornerRadius)
-                Rectangle()
-                    .frame(width: viewWidth * 0.1, height: Layout.placeholderHeight * scale)
-                    .cornerRadius(Layout.cornerRadius)
-            }
-            .padding(.horizontal, Constants.horizontalTextPadding)
+            placeholders
+                .foregroundStyle(Color.posOnSurfaceVariantLowest)
+                .shimmering()
+
             Spacer()
+
+            if let accessory {
+                accessory
+            }
         }
         .measureWidth { width in
             viewWidth = width
         }
-        .foregroundColor(.posOnSurfaceVariantLowest)
-        .shimmering()
         .frame(maxWidth: .infinity, idealHeight: dimension)
         .background(Color.posSurfaceBright)
-        .posItemCardBorderStyles()
+        .if(configuration.bordered) { $0.posItemCardBorderStyles() }
+    }
+
+    @ViewBuilder var placeholders: some View {
+        HStack(alignment: .center, spacing: Constants.cardSpacing) {
+            Rectangle()
+                .aspectRatio(1, contentMode: .fit)
+            VStack(alignment: .leading) {
+                Rectangle()
+                    .frame(width: viewWidth * 0.5, height: configuration.titleHeight * scale)
+                    .cornerRadius(Layout.cornerRadius)
+                Rectangle()
+                    .frame(width: viewWidth * 0.1, height: configuration.priceHeight * scale)
+                    .cornerRadius(Layout.cornerRadius)
+            }
+            .foregroundColor(.posOnSurfaceVariantLowest)
+            .padding(.horizontal, Constants.horizontalTextPadding)
+        }
     }
 }
 
-private extension GhostItemCardView {
-    typealias Constants = PointOfSaleItemListCardConstants
+fileprivate typealias Constants = PointOfSaleItemListCardConstants
 
-    enum Layout {
-        static let placeholderHeight: CGFloat = 32
-        static let cornerRadius: CGFloat = POSCornerRadiusStyle.medium.value
-    }
+fileprivate enum Layout {
+    static let cornerRadius: CGFloat = POSCornerRadiusStyle.medium.value
+}
+
+struct GhostItemCardViewConfiguration {
+    let titleHeight: CGFloat
+    let priceHeight: CGFloat
+    let bordered: Bool
+
+    static let itemList = GhostItemCardViewConfiguration(
+        titleHeight: 32,
+        priceHeight: 32,
+        bordered: true
+    )
+
+    static let cart = GhostItemCardViewConfiguration(
+        titleHeight: 20,
+        priceHeight: 20,
+        bordered: false
+    )
 }
 
 #Preview {
-    GhostItemCardView()
+    VStack(spacing: 20) {
+        GhostItemCardView(configuration: .itemList) {
+            CartRowRemoveButton {}
+        }
+        GhostItemCardView(configuration: .cart) {
+            CartRowRemoveButton {}
+        }
+        GhostItemCardView(configuration: .itemList)
+    }
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -23,17 +23,9 @@ struct ItemRowView: View {
     }
 
     var body: some View {
-        HStack(spacing: Constants.horizontalElementSpacing) {
-            if case .loading = cartItem.state {
-                GhostItemCardView(configuration: .cart) {
-                    if let onCancelLoading {
-                        CartRowRemoveButton {
-                            onCancelLoading()
-                        }
-                    }
-                }
-                .frame(maxWidth: .infinity, idealHeight: Constants.productCardSize * scale)
-            } else {
+        switch cartItem.state {
+        case .loaded:
+            HStack(spacing: Constants.horizontalElementSpacing) {
                 productImage
 
                 VStack(alignment: .leading, spacing: Constants.itemTitleAndPriceSpacing * (1 / scale)) {
@@ -62,12 +54,23 @@ struct ItemRowView: View {
                     }
                 }
             }
+            .padding(.trailing, Constants.cardContentHorizontalPadding)
+            .frame(maxWidth: .infinity, idealHeight: Constants.productCardSize * scale)
+            .background(Color.posSurfaceContainerLowest)
+            .posItemCardBorderStyles()
+            .padding(.horizontal, Constants.horizontalPadding)
+        case .loading:
+            GhostItemCardView(configuration: .cart) {
+                if let onCancelLoading {
+                    CartRowRemoveButton {
+                        onCancelLoading()
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, idealHeight: Constants.productCardSize * scale)
+            .background(Color.posSurfaceContainerLowest)
+            .padding(.horizontal, Constants.horizontalPadding)
         }
-        .padding(.trailing, Constants.cardContentHorizontalPadding)
-        .frame(maxWidth: .infinity, idealHeight: Constants.productCardSize * scale)
-        .background(Color.posSurfaceContainerLowest)
-        .posItemCardBorderStyles()
-        .padding(.horizontal, Constants.horizontalPadding)
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ItemRowView: View {
     private let cartItem: Cart.PurchasableItem
     private let onItemRemoveTapped: (() -> Void)?
+    private let onCancelLoading: (() -> Void)?
 
     @ScaledMetric private var scale: CGFloat = 1.0
     @Binding private var showProductImage: Bool
@@ -11,48 +12,54 @@ struct ItemRowView: View {
         min(Constants.productCardSize * scale, Constants.maximumProductCardSize)
     }
 
-    init(cartItem: Cart.PurchasableItem, showImage: Binding<Bool> = .constant(true), onItemRemoveTapped: (() -> Void)? = nil) {
+    init(cartItem: Cart.PurchasableItem,
+         showImage: Binding<Bool> = .constant(true),
+         onItemRemoveTapped: (() -> Void)? = nil,
+         onCancelLoading: (() -> Void)? = nil) {
         self.cartItem = cartItem
         self._showProductImage = showImage
         self.onItemRemoveTapped = onItemRemoveTapped
+        self.onCancelLoading = onCancelLoading
     }
 
     var body: some View {
         HStack(spacing: Constants.horizontalElementSpacing) {
-            productImage
-
-            VStack(alignment: .leading, spacing: Constants.itemTitleAndPriceSpacing * (1 / scale)) {
-                Text(cartItem.title)
-                    .foregroundColor(PointOfSaleItemListCardConstants.titleColor)
-                    .font(Constants.itemTitleFont)
-                    .redacted(reason: cartItem.state.isLoading ? .placeholder : [])
-                if let subtitle = cartItem.subtitle {
-                    Text(subtitle)
-                        .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
-                        .font(Constants.itemSubtitleFont)
-                        .redacted(reason: cartItem.state.isLoading ? .placeholder : [])
+            if case .loading = cartItem.state {
+                GhostItemCardView(configuration: .cart) {
+                    if let onCancelLoading {
+                        CartRowRemoveButton {
+                            onCancelLoading()
+                        }
+                    }
                 }
+                .frame(maxWidth: .infinity, idealHeight: Constants.productCardSize * scale)
+            } else {
+                productImage
 
-                switch cartItem.state {
-                case .loaded(let item):
-                    Text(item.formattedPrice)
-                        .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
-                        .font(Constants.itemPriceFont)
-                case .loading:
-                    Text("$0.00")
-                        .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
-                        .font(Constants.itemPriceFont)
-                        .redacted(reason: .placeholder)
+                VStack(alignment: .leading, spacing: Constants.itemTitleAndPriceSpacing * (1 / scale)) {
+                    Text(cartItem.title)
+                        .foregroundColor(PointOfSaleItemListCardConstants.titleColor)
+                        .font(Constants.itemTitleFont)
+                    if let subtitle = cartItem.subtitle {
+                        Text(subtitle)
+                            .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
+                            .font(Constants.itemSubtitleFont)
+                    }
+
+                    if case .loaded(let item) = cartItem.state {
+                        Text(item.formattedPrice)
+                            .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
+                            .font(Constants.itemPriceFont)
+                    }
                 }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.leading, showProductImage ? 0 : Constants.cardContentHorizontalPadding)
-            .accessibilityElement(children: .combine)
-            .shimmering(active: cartItem.state.isLoading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.leading, showProductImage ? 0 : Constants.cardContentHorizontalPadding)
+                .accessibilityElement(children: .combine)
 
-            if let onItemRemoveTapped {
-                CartRowRemoveButton {
-                    onItemRemoveTapped()
+                if let onItemRemoveTapped {
+                    CartRowRemoveButton {
+                        onItemRemoveTapped()
+                    }
                 }
             }
         }
@@ -67,21 +74,11 @@ struct ItemRowView: View {
     private var productImage: some View {
         if !showProductImage {
             EmptyView()
-        } else {
-            switch cartItem.state {
-            case .loaded(let item):
-                POSItemImageView(imageSource: item.productImageSource,
-                                 imageSize: dimension,
-                                 scale: 1)
-                .frame(width: dimension, height: dimension)
-            case .loading:
-                POSItemImageView(imageSource: nil,
-                                 imageSize: dimension,
-                                 scale: 1)
-                .frame(width: dimension, height: dimension)
-                .redacted(reason: .placeholder)
-                .shimmering()
-            }
+        } else if case .loaded(let item) = cartItem.state {
+            POSItemImageView(imageSource: item.productImageSource,
+                             imageSize: dimension,
+                             scale: 1)
+            .frame(width: dimension, height: dimension)
         }
     }
 }
@@ -124,6 +121,6 @@ private extension ItemRowView {
 @available(iOS 17.0, *)
 #Preview(traits: .sizeThatFitsLayout) {
     ItemRowView(cartItem: Cart.PurchasableItem.loading(id: UUID()),
-                onItemRemoveTapped: { })
+                onCancelLoading: { })
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -31,7 +31,8 @@ struct ItemRowView: View {
                 .posItemCardBorderStyles()
                 .padding(.horizontal, Constants.horizontalPadding)
         case .loading:
-            GhostItemCardView(configuration: Constants.cartConfiguration) {
+            GhostItemCardView(configuration: Constants.cartConfiguration,
+                              showProductImage: $showProductImage) {
                 if let onCancelLoading {
                     CartRowRemoveButton {
                         onCancelLoading()

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -25,52 +25,56 @@ struct ItemRowView: View {
     var body: some View {
         switch cartItem.state {
         case .loaded:
-            HStack(spacing: Constants.horizontalElementSpacing) {
-                productImage
-
-                VStack(alignment: .leading, spacing: Constants.itemTitleAndPriceSpacing * (1 / scale)) {
-                    Text(cartItem.title)
-                        .foregroundColor(PointOfSaleItemListCardConstants.titleColor)
-                        .font(Constants.itemTitleFont)
-                    if let subtitle = cartItem.subtitle {
-                        Text(subtitle)
-                            .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
-                            .font(Constants.itemSubtitleFont)
-                    }
-
-                    if case .loaded(let item) = cartItem.state {
-                        Text(item.formattedPrice)
-                            .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
-                            .font(Constants.itemPriceFont)
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.leading, showProductImage ? 0 : Constants.cardContentHorizontalPadding)
-                .accessibilityElement(children: .combine)
-
-                if let onItemRemoveTapped {
-                    CartRowRemoveButton {
-                        onItemRemoveTapped()
-                    }
-                }
-            }
-            .padding(.trailing, Constants.cardContentHorizontalPadding)
-            .frame(maxWidth: .infinity, idealHeight: Constants.productCardSize * scale)
-            .background(Color.posSurfaceContainerLowest)
-            .posItemCardBorderStyles()
-            .padding(.horizontal, Constants.horizontalPadding)
+            productRow
+                .frame(maxWidth: .infinity, idealHeight: dimension)
+                .background(Color.posSurfaceContainerLowest)
+                .posItemCardBorderStyles()
+                .padding(.horizontal, Constants.horizontalPadding)
         case .loading:
-            GhostItemCardView(configuration: .cart) {
+            GhostItemCardView(configuration: Constants.cartConfiguration) {
                 if let onCancelLoading {
                     CartRowRemoveButton {
                         onCancelLoading()
                     }
                 }
             }
-            .frame(maxWidth: .infinity, idealHeight: Constants.productCardSize * scale)
             .background(Color.posSurfaceContainerLowest)
             .padding(.horizontal, Constants.horizontalPadding)
         }
+    }
+
+    @ViewBuilder
+    private var productRow: some View {
+        HStack(spacing: Constants.horizontalElementSpacing) {
+            productImage
+
+            VStack(alignment: .leading, spacing: Constants.itemTitleAndPriceSpacing * (1 / scale)) {
+                Text(cartItem.title)
+                    .foregroundColor(PointOfSaleItemListCardConstants.titleColor)
+                    .font(Constants.itemTitleFont)
+                if let subtitle = cartItem.subtitle {
+                    Text(subtitle)
+                        .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
+                        .font(Constants.itemSubtitleFont)
+                }
+
+                if case .loaded(let item) = cartItem.state {
+                    Text(item.formattedPrice)
+                        .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
+                        .font(Constants.itemPriceFont)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.leading, showProductImage ? 0 : Constants.cardContentHorizontalPadding)
+            .accessibilityElement(children: .combine)
+
+            if let onItemRemoveTapped {
+                CartRowRemoveButton {
+                    onItemRemoveTapped()
+                }
+            }
+        }
+        .padding(.trailing, Constants.cardContentHorizontalPadding)
     }
 
     @ViewBuilder
@@ -97,6 +101,13 @@ private extension ItemRowView {
         static let itemTitleFont: POSFontStyle = .posBodySmallBold
         static let itemSubtitleFont: POSFontStyle = .posBodySmallRegular()
         static let itemPriceFont: POSFontStyle = .posBodySmallRegular()
+
+        static let cartConfiguration = GhostItemCardViewConfiguration(
+            placeholderHeight: 24,
+            cardSize: Constants.productCardSize,
+            maximumCardSize: Constants.maximumProductCardSize,
+            placeholderWidthMultiplier: 0.3
+        )
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes: WOOPRD-561

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR makes the `GhostItemCardView` reusable in the cart, and replaces the barcode scan load state with it.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Enable the `pointOfSaleBarcodeScanningi1` feature flag
1. Launch the app and navigate to POS
2. Open the simulated barcode scanner
3. Enter a barcode and tap scan
4. Observe that the scan load state matches the main item list

Test the variations/products loading hasn't changed either – we added the ability to provide an accessory button, which isn't used in the item list.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

I've tested this on an iPad simulator running iOS 18.4

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/da59b49e-5661-42c3-807d-fde7b3e261fb


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
