### PR TITLE
Decouple application password name logic from knowing the OS

### DIFF
--- a/Networking/Sources/Core/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Networking/Sources/Core/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -29,6 +29,25 @@ public protocol ApplicationPasswordUseCase {
     func deletePassword() async throws
 }
 
+/// A wrapper for the `UIDevice` `model` and `identifierForVendor` properties.
+///
+/// This is necessary because `UIDevice` is part of UIKit which we cannot use when targeting watchOS.
+/// So, to keep this package compatible with watchOS, we need to abstract UIKit away and delegate it to the consumers to provide us
+/// with the device information.
+///
+/// This approach is feasible because only the `applicationPasswordName` method in
+/// `DefaultApplicationPasswordUseCase` needs access to the information and watchOS does not need to create application
+/// passwords. We can therefore pass a `nil` value to it to satisfy the compilation without issues for the user experience.
+public struct DeviceModelIdentifierInfo {
+    let model: String
+    let identifierForVendor: String
+
+    public init(model: String, identifierForVendor: String) {
+        self.model = model
+        self.identifierForVendor = identifierForVendor
+    }
+}
+
 final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase {
     /// Site Address
     ///
@@ -46,30 +65,31 @@ final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
     ///
     private let storage: ApplicationPasswordStorage
 
+    private let deviceModelIdentifierInfo: DeviceModelIdentifierInfo?
+
     /// Used to name the password in wpadmin.
     ///
     private var applicationPasswordName: String {
-        get async {
-#if !os(watchOS)
+        get {
+            guard let deviceModelIdentifierInfo else {
+                return "" // This is not needed on watchOS as the watch does not create application passwords.
+            }
+
             let bundleIdentifier = Bundle.main.bundleIdentifier ?? "Unknown"
-            let model = await UIDevice.current.model
-            let identifierForVendor = await UIDevice.current.identifierForVendor?.uuidString ?? ""
-            return "\(bundleIdentifier).ios-app-client.\(model).\(identifierForVendor)"
-#endif
-#if os(watchOS)
-            return "" // This is not needed on watchOS as the watch does not create application passwords.
-#endif
+            return "\(bundleIdentifier).ios-app-client.\(deviceModelIdentifierInfo.model).\(deviceModelIdentifierInfo.identifierForVendor)"
         }
     }
 
     public init(username: String,
                 password: String,
                 siteAddress: String,
+                deviceModelIdentifierInfo: DeviceModelIdentifierInfo? = nil,
                 network: Network? = nil,
                 keychain: Keychain = Keychain(service: WooConstants.keychainServiceName)) throws {
         self.siteAddress = siteAddress
         self.username = username
         self.storage = ApplicationPasswordStorage(keychain: keychain)
+        self.deviceModelIdentifierInfo = deviceModelIdentifierInfo
 
         if let network {
             self.network = network

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -4,6 +4,7 @@ import KeychainAccess
 import WordPressAuthenticator
 import WordPressUI
 import Yosemite
+import UIKit
 import class Networking.UserAgent
 import enum Experiments.ABTest
 import struct Networking.Settings
@@ -751,7 +752,8 @@ private extension AuthenticationManager {
         guard let useCase = try? DefaultApplicationPasswordUseCase(
             username: siteCredentials.username,
             password: siteCredentials.password,
-            siteAddress: siteCredentials.siteURL
+            siteAddress: siteCredentials.siteURL,
+            deviceModelIdentifierInfo: UIDevice.current.deviceModelIdentifierInfo
         ) else {
             return assertionFailure("⛔️ Error creating application password use case")
         }

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -1,6 +1,7 @@
 import Combine
 import Foundation
 import Yosemite
+import UIKit
 import KeychainAccess
 import protocol Networking.ApplicationPasswordUseCase
 import class Networking.OneTimeApplicationPasswordUseCase
@@ -233,6 +234,7 @@ final class SessionManager: SessionManagerProtocol {
                 return try? DefaultApplicationPasswordUseCase(username: username,
                                                               password: password,
                                                               siteAddress: siteAddress,
+                                                              deviceModelIdentifierInfo: UIDevice.current.deviceModelIdentifierInfo,
                                                               keychain: keychain)
             case let .applicationPassword(_, _, siteAddress):
                 return OneTimeApplicationPasswordUseCase(siteAddress: siteAddress, keychain: keychain)

--- a/WooCommerce/Classes/System/UIDevice+DeviceModelIdentifierInfo.swift
+++ b/WooCommerce/Classes/System/UIDevice+DeviceModelIdentifierInfo.swift
@@ -1,0 +1,12 @@
+import Networking
+import UIKit
+
+extension UIDevice {
+
+    var deviceModelIdentifierInfo: DeviceModelIdentifierInfo {
+        DeviceModelIdentifierInfo(
+            model: model,
+            identifierForVendor: identifierForVendor?.uuidString ?? ""
+        )
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1304,6 +1304,7 @@
 		3F58701F281B947E004F7556 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F58701E281B947E004F7556 /* Main.storyboard */; };
 		3F587021281B9494004F7556 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F587020281B9494004F7556 /* LaunchScreen.storyboard */; };
 		3F587026281B9C19004F7556 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3F587028281B9C19004F7556 /* InfoPlist.strings */; };
+		3F88EC3F2DF8D4BC0023A6F4 /* UIDevice+DeviceModelIdentifierInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F88EC3E2DF8D4BC0023A6F4 /* UIDevice+DeviceModelIdentifierInfo.swift */; };
 		3FA96DF42C94043200CDA78F /* Yosemite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FA96DF32C94043200CDA78F /* Yosemite.framework */; };
 		3FF314E126FC74450012E68E /* UITestsFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FF314E026FC74450012E68E /* UITestsFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3FF314EA26FC751B0012E68E /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997173223DBCF2800592D8E /* XCTest+Extensions.swift */; };
@@ -4509,6 +4510,7 @@
 		3F587037281B9C50004F7556 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3F587038281B9C52004F7556 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3F64F76C2C06A3A50085DEEF /* WooCommerce.release-alpha.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "WooCommerce.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		3F88EC3E2DF8D4BC0023A6F4 /* UIDevice+DeviceModelIdentifierInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+DeviceModelIdentifierInfo.swift"; sourceTree = "<group>"; };
 		3FA96DF32C94043200CDA78F /* Yosemite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Yosemite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FF314D626FC55DE0012E68E /* ScreenObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScreenObject+Extension.swift"; sourceTree = "<group>"; };
 		3FF314DE26FC74450012E68E /* UITestsFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UITestsFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -11131,6 +11133,7 @@
 				DE6906E627D74A1900735E3B /* WooSplitViewController.swift */,
 				26A7C8782BE91F3D00382627 /* WatchDependenciesSynchronizer.swift */,
 				26B249702BEC801400730730 /* WatchDependencies.swift */,
+				3F88EC3E2DF8D4BC0023A6F4 /* UIDevice+DeviceModelIdentifierInfo.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -16512,6 +16515,7 @@
 				02CE4304276993DA0006EAEF /* CaptureDevicePermissionChecker.swift in Sources */,
 				205B7ECD2C19FD2F00D14A36 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel.swift in Sources */,
 				DEF8CF1F29AC870A00800A60 /* WPComEmailLoginViewModel.swift in Sources */,
+				3F88EC3F2DF8D4BC0023A6F4 /* UIDevice+DeviceModelIdentifierInfo.swift in Sources */,
 				74A33D8021C3F234009E25DE /* LicensesViewController.swift in Sources */,
 				454453CA27566CDE00464AC5 /* HubMenuViewModel.swift in Sources */,
 				934CB123224EAB150005CCB9 /* main.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
See https://linear.app/a8c/issue/AINFRA-730

Problem: When moving networking from framework to Swift package, the architecture checks no longer work. This is a problem for the current application password name logic:

https://github.com/woocommerce/woocommerce-ios/blob/ae05dab3f00e2be53a264c2cbbd641a0a5630f5e/Networking/Sources/Core/ApplicationPassword/ApplicationPasswordUseCase.swift#L51-L63

In practice, this means that when building the watch app we try to access `UIDevice` which is not available.

I tried replacing `#if !os(watchOS)` with `#if canImport(UIKit)` but got the same problem, surprisingly.

Solution: I pushed `UIDevice` off `DefaultApplicationPasswordUseCase`, leaving it up to the caller to pass the information. This way, the iOS app target can in a `DefaultApplicationPasswordUseCase` with the `UIDevice` data, and the watch code is none the wiser.

See also the documentation comment in the new `DeviceModelVersionInfo` data transfer object.

## Steps to reproduce & Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
I'm not too sure how to test this on device, can you help me with that? Notice CI is green in the meantime.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.