### PR TITLE
[POS as a tab i1] Create a separate POS tab eligibility checker (no usage yet)

### DIFF
--- a/Networking/Sources/Extended/Remote/SiteSettingsRemote.swift
+++ b/Networking/Sources/Extended/Remote/SiteSettingsRemote.swift
@@ -124,7 +124,7 @@ public class SiteSettingsRemote: Remote {
     }
 }
 
-private extension SiteSettingsFeature {
+public extension SiteSettingsFeature {
     var rawValue: String {
         switch self {
         case .pointOfSale:

--- a/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
+++ b/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
@@ -13,7 +13,7 @@ extension Notification.Name {
 
 /// Settings for the selected Site
 ///
-final class SelectedSiteSettings: NSObject {
+final class SelectedSiteSettings: NSObject, @unchecked Sendable {
     private let stores: StoresManager
     private let storageManager: StorageManagerType
 

--- a/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
+++ b/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Yosemite
-import Storage
+import protocol Storage.StorageManagerType
 import WooFoundation
 
 
@@ -13,9 +13,13 @@ extension Notification.Name {
 
 /// Settings for the selected Site
 ///
-final class SelectedSiteSettings: NSObject, @unchecked Sendable {
+final class SelectedSiteSettings: NSObject {
     private let stores: StoresManager
     private let storageManager: StorageManagerType
+
+    /// Async stream for observing site settings changes.
+    private let settingsContinuation: AsyncStream<(siteID: Int64, settings: [SiteSetting])>.Continuation
+    public let settingsStream: AsyncStream<(siteID: Int64, settings: [SiteSetting])>
 
     /// ResultsController: Whenever settings change, I will change. We both change. The world changes.
     ///
@@ -29,8 +33,20 @@ final class SelectedSiteSettings: NSObject, @unchecked Sendable {
     init(stores: StoresManager = ServiceLocator.stores, storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.stores = stores
         self.storageManager = storageManager
+
+        // Sets up async stream with buffering to ensure current value is sent.
+        let (stream, continuation) = AsyncStream<(siteID: Int64, settings: [SiteSetting])>.makeStream(
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        self.settingsStream = stream
+        self.settingsContinuation = continuation
+
         super.init()
         configureResultsController()
+    }
+
+    deinit {
+        settingsContinuation.finish()
     }
 }
 
@@ -51,6 +67,11 @@ extension SelectedSiteSettings {
             guard let self = self else { return }
             ServiceLocator.currencySettings.updateCurrencyOptions(with: object)
             self.siteSettings = self.resultsController.fetchedObjects
+            guard let siteID = stores.sessionManager.defaultStoreID else {
+                DDLogError("Error: no siteID found when setting site settings results.")
+                return
+            }
+            settingsContinuation.yield((siteID: siteID, settings: siteSettings))
         }
         refreshResultsPredicate()
     }
@@ -70,6 +91,8 @@ extension SelectedSiteSettings {
         fetchedObjects.forEach {
             ServiceLocator.currencySettings.updateCurrencyOptions(with: $0)
         }
+
+        settingsContinuation.yield((siteID: siteID, settings: fetchedObjects))
 
         NotificationCenter.default.post(name: .selectedSiteSettingsRefreshed, object: nil)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -146,7 +146,7 @@ private extension POSTabEligibilityChecker {
                 case .success(let isEnabled):
                     continuation.resume(returning: isEnabled ? .eligible : .ineligible(reason: .featureSwitchDisabled))
                 case .failure:
-                    continuation.resume(returning: .ineligible(reason: .featureSwitchDisabled))
+                    continuation.resume(returning: .ineligible(reason: .featureSwitchSyncFailure))
                 }
             }
             stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -2,21 +2,20 @@ import Foundation
 import UIKit
 import class WooFoundation.CurrencySettings
 import enum WooFoundation.CountryCode
+import enum WooFoundation.CurrencyCode
 import protocol Experiments.FeatureFlagService
 import struct Yosemite.SiteSetting
 import protocol Yosemite.StoresManager
 import struct Yosemite.SystemPlugin
 import enum Yosemite.SystemStatusAction
 import enum Yosemite.FeatureFlagAction
-import enum Yosemite.SiteSettingsFeature
 import enum Yosemite.SettingAction
-import enum WooFoundation.CurrencyCode
 
 enum POSIneligibleReason: Equatable {
     case notTablet
     case unsupportedIOSVersion
     case unsupportedWooCommerceVersion
-    case systemInformationNotAvailable
+    case siteSettingsNotAvailable
     case wooCommercePluginNotFound
     case featureFlagDisabled
     case featureSwitchDisabled
@@ -48,20 +47,26 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
 
         async let siteSettingsEligibility = checkSiteSettingsEligibility()
         async let featureFlagEligibility = isPointOfSaleFeatureFlagEnabled()
+        async let pluginEligibility = isEligibleFromPluginChecks()
 
-        // Waits for both results.
-        let (siteSettingsResult, featureFlagResult) = await (siteSettingsEligibility, featureFlagEligibility)
-
-        // Checks feature flag first.
-        switch featureFlagResult {
+        // Checks site settings first since it's likely to complete fastest.
+        switch await siteSettingsEligibility {
         case .eligible:
             break
         case .ineligible(let reason):
             return .ineligible(reason: reason)
         }
 
-        // Then checks site settings.
-        switch siteSettingsResult {
+        // Then checks feature flag.
+        switch await featureFlagEligibility {
+        case .eligible:
+            break
+        case .ineligible(let reason):
+            return .ineligible(reason: reason)
+        }
+
+        // Finally checks plugin eligibility.
+        switch await pluginEligibility {
         case .eligible:
             return .eligible
         case .ineligible(let reason):
@@ -92,6 +97,80 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
 }
 
 private extension POSTabEligibilityChecker {
+    func isEligibleFromPluginChecks() async -> POSEligibilityState {
+        let wcPlugin = await fetchWooCommercePlugin(siteID: siteID)
+
+        guard let wcPlugin, wcPlugin.active else {
+            return .ineligible(reason: .wooCommercePluginNotFound)
+        }
+
+        guard VersionHelpers.isVersionSupported(version: wcPlugin.version,
+                                                minimumRequired: Constants.wcPluginMinimumVersion) else {
+            return .ineligible(reason: .unsupportedWooCommerceVersion)
+        }
+
+        // For versions below 10.0.0, the feature is enabled by default.
+        let isFeatureSwitchSupported = VersionHelpers.isVersionSupported(version: wcPlugin.version,
+                                                                         minimumRequired: Constants.wcPluginMinimumVersionWithFeatureSwitch,
+                                                                         includesDevAndBetaVersions: true)
+        if !isFeatureSwitchSupported {
+            return .eligible
+        }
+
+        // For versions that support the feature switch, checks if the feature switch is enabled.
+        return await checkFeatureSwitchEnabled(siteID: siteID)
+    }
+
+    func fetchWooCommercePlugin(siteID: Int64) async -> SystemPlugin? {
+        await withCheckedContinuation { continuation in
+            let action = SystemStatusAction.fetchSystemPlugin(siteID: siteID, systemPluginName: Constants.wcPluginName) { wcPlugin in
+                continuation.resume(returning: wcPlugin)
+            }
+            stores.dispatch(action)
+        }
+    }
+
+    func checkFeatureSwitchEnabled(siteID: Int64) async -> POSEligibilityState {
+        await withCheckedContinuation { continuation in
+            let action = SettingAction.isFeatureEnabled(siteID: siteID, feature: .pointOfSale) { result in
+                switch result {
+                case .success(let isEnabled):
+                    continuation.resume(returning: isEnabled ? .eligible : .ineligible(reason: .featureSwitchDisabled))
+                case .failure:
+                    continuation.resume(returning: .ineligible(reason: .featureSwitchDisabled))
+                }
+            }
+            stores.dispatch(action)
+        }
+    }
+}
+
+private extension POSTabEligibilityChecker {
+    func checkSiteSettingsEligibility() async -> POSEligibilityState {
+        // Waits for the first site settings that matches the given site ID.
+        let siteSettings = await waitForSiteSettingsRefresh()
+        guard siteSettings.isNotEmpty else {
+            return .ineligible(reason: .siteSettingsNotAvailable)
+        }
+
+        // Conditions that can change if site settings are synced during the lifetime.
+        let countryCode = SiteAddress(siteSettings: siteSettings).countryCode
+        let currencyCode = currencySettings.currencyCode
+
+        return isEligibleFromCountryAndCurrencyCode(countryCode: countryCode, currencyCode: currencyCode)
+    }
+
+    func waitForSiteSettingsRefresh() async -> [SiteSetting] {
+        for await siteSettings in siteSettings.settingsStream {
+            guard siteSettings.siteID == siteID else {
+                continue
+            }
+            return siteSettings.settings
+        }
+        // If we get here, the stream completed without yielding any values for our site ID which is unexpected.
+        return []
+    }
+
     func isEligibleFromCountryAndCurrencyCode(countryCode: CountryCode, currencyCode: CurrencyCode) -> POSEligibilityState {
         // Checks country first.
         switch countryCode {
@@ -107,65 +186,6 @@ private extension POSTabEligibilityChecker {
             return .eligible
         default:
             return .ineligible(reason: .unsupportedCurrency)
-        }
-    }
-
-    func isEligibleFromPluginChecks(systemPlugins: [SystemPlugin], enabledFeatures: [String]?) -> POSEligibilityState {
-        guard let wcPlugin = systemPlugins.first(where: { $0.name == Constants.wcPluginName && $0.active }) else {
-            return .ineligible(reason: .wooCommercePluginNotFound)
-        }
-
-        guard VersionHelpers.isVersionSupported(version: wcPlugin.version,
-                                                minimumRequired: Constants.wcPluginMinimumVersion) else {
-            return .ineligible(reason: .unsupportedWooCommerceVersion)
-        }
-
-        if VersionHelpers.isVersionSupported(version: wcPlugin.version,
-                                             minimumRequired: Constants.wcPluginMinimumVersionWithFeatureSwitch,
-                                             includesDevAndBetaVersions: true) {
-            // For versions that support the feature switch, checks if the feature switch is enabled.
-            guard let enabledFeatures,
-                  enabledFeatures.contains(SiteSettingsFeature.pointOfSale.rawValue) else {
-                return .ineligible(reason: .featureSwitchDisabled)
-            }
-            return .eligible
-        } else {
-            // For versions below 10.0.0, the feature is enabled by default.
-            return .eligible
-        }
-    }
-}
-
-private extension POSTabEligibilityChecker {
-    func checkSiteSettingsEligibility() async -> POSEligibilityState {
-        // Wait for the first site settings refresh
-        await waitForSiteSettingsRefresh()
-        
-        // Conditions that can change if site settings are synced during the lifetime.
-        let countryCode = SiteAddress(siteSettings: siteSettings.siteSettings).countryCode
-        let currency = currencySettings.currencyCode
-
-        // Checks country first.
-        switch countryCode {
-        case .US, .GB:
-            break
-        default:
-            return .ineligible(reason: .unsupportedCountry)
-        }
-
-        // Then checks currency.
-        switch currency {
-        case .USD, .GBP:
-            return .eligible
-        default:
-            return .ineligible(reason: .unsupportedCurrency)
-        }
-    }
-
-    @MainActor
-    func waitForSiteSettingsRefresh() async {
-        for await _ in NotificationCenter.default.notifications(named: .selectedSiteSettingsRefreshed, object: siteSettings).map( { $0.name } ) {
-            break // Exit after first notification
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -10,6 +10,8 @@ import struct Yosemite.SystemPlugin
 import enum Yosemite.SystemStatusAction
 import enum Yosemite.FeatureFlagAction
 import enum Yosemite.SettingAction
+import protocol Yosemite.PluginsServiceProtocol
+import class Yosemite.PluginsService
 
 /// Represents the reasons why a site may be ineligible for POS.
 enum POSIneligibleReason: Equatable {
@@ -42,6 +44,7 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
     private let userInterfaceIdiom: UIUserInterfaceIdiom
     private let siteSettings: SelectedSiteSettings
     private let currencySettings: CurrencySettings
+    private let pluginsService: PluginsServiceProtocol
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
 
@@ -49,12 +52,14 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
          userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
          siteSettings: SelectedSiteSettings = ServiceLocator.selectedSiteSettings,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         pluginsService: PluginsServiceProtocol = PluginsService(storageManager: ServiceLocator.storageManager),
          stores: StoresManager = ServiceLocator.stores,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.siteID = siteID
         self.userInterfaceIdiom = userInterfaceIdiom
         self.siteSettings = siteSettings
         self.currencySettings = currencySettings
+        self.pluginsService = pluginsService
         self.stores = stores
         self.featureFlagService = featureFlagService
     }
@@ -103,10 +108,6 @@ private extension POSTabEligibilityChecker {
     func checkPluginEligibility() async -> POSEligibilityState {
         let wcPlugin = await fetchWooCommercePlugin(siteID: siteID)
 
-        guard let wcPlugin, wcPlugin.active else {
-            return .ineligible(reason: .wooCommercePluginNotFound)
-        }
-
         guard VersionHelpers.isVersionSupported(version: wcPlugin.version,
                                                 minimumRequired: Constants.wcPluginMinimumVersion) else {
             return .ineligible(reason: .unsupportedWooCommerceVersion)
@@ -125,16 +126,8 @@ private extension POSTabEligibilityChecker {
     }
 
     @MainActor
-    func fetchWooCommercePlugin(siteID: Int64) async -> SystemPlugin? {
-        await withCheckedContinuation { [weak self] continuation in
-            guard let self else {
-                return continuation.resume(returning: nil)
-            }
-            let action = SystemStatusAction.fetchSystemPlugin(siteID: siteID, systemPluginName: Constants.wcPluginName) { wcPlugin in
-                continuation.resume(returning: wcPlugin)
-            }
-            stores.dispatch(action)
-        }
+    func fetchWooCommercePlugin(siteID: Int64) async -> SystemPlugin {
+        await pluginsService.waitForPluginInStorage(siteID: siteID, pluginName: Constants.wcPluginName, isActive: true)
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -1,0 +1,206 @@
+import Foundation
+import UIKit
+import class WooFoundation.CurrencySettings
+import enum WooFoundation.CountryCode
+import protocol Experiments.FeatureFlagService
+import struct Yosemite.SiteSetting
+import protocol Yosemite.StoresManager
+import struct Yosemite.SystemPlugin
+import enum Yosemite.SystemStatusAction
+import enum Yosemite.FeatureFlagAction
+import enum Yosemite.SiteSettingsFeature
+import enum Yosemite.SettingAction
+import enum WooFoundation.CurrencyCode
+
+enum POSIneligibleReason: Equatable {
+    case notTablet
+    case unsupportedIOSVersion
+    case unsupportedWooCommerceVersion
+    case systemInformationNotAvailable
+    case wooCommercePluginNotFound
+    case featureFlagDisabled
+    case featureSwitchDisabled
+    case featureSwitchSyncFailure
+    case unsupportedCountry
+    case unsupportedCurrency
+    case selfDeallocated
+}
+
+enum POSEligibilityState: Equatable {
+    case eligible
+    case ineligible(reason: POSIneligibleReason)
+}
+
+protocol POSEntryPointEligibilityCheckerProtocol {
+    func checkEligibility() async -> POSEligibilityState
+}
+
+/// Determines whether the POS entry point can be shown based on the selected store and feature gates.
+final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
+    func checkEligibility() async -> POSEligibilityState {
+        guard #available(iOS 17.0, *) else {
+            return .ineligible(reason: .unsupportedIOSVersion)
+        }
+
+        guard userInterfaceIdiom == .pad else {
+            return .ineligible(reason: .notTablet)
+        }
+
+        async let siteSettingsEligibility = checkSiteSettingsEligibility()
+        async let featureFlagEligibility = isPointOfSaleFeatureFlagEnabled()
+
+        // Waits for both results.
+        let (siteSettingsResult, featureFlagResult) = await (siteSettingsEligibility, featureFlagEligibility)
+
+        // Checks feature flag first.
+        switch featureFlagResult {
+        case .eligible:
+            break
+        case .ineligible(let reason):
+            return .ineligible(reason: reason)
+        }
+
+        // Then checks site settings.
+        switch siteSettingsResult {
+        case .eligible:
+            return .eligible
+        case .ineligible(let reason):
+            return .ineligible(reason: reason)
+        }
+    }
+
+    private let siteID: Int64
+    private let userInterfaceIdiom: UIUserInterfaceIdiom
+    private let siteSettings: SelectedSiteSettings
+    private let currencySettings: CurrencySettings
+    private let stores: StoresManager
+    private let featureFlagService: FeatureFlagService
+
+    init(siteID: Int64,
+         userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
+         siteSettings: SelectedSiteSettings = ServiceLocator.selectedSiteSettings,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         stores: StoresManager = ServiceLocator.stores,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+        self.siteID = siteID
+        self.userInterfaceIdiom = userInterfaceIdiom
+        self.siteSettings = siteSettings
+        self.currencySettings = currencySettings
+        self.stores = stores
+        self.featureFlagService = featureFlagService
+    }
+}
+
+private extension POSTabEligibilityChecker {
+    func isEligibleFromCountryAndCurrencyCode(countryCode: CountryCode, currencyCode: CurrencyCode) -> POSEligibilityState {
+        // Checks country first.
+        switch countryCode {
+        case .US, .GB:
+            break
+        default:
+            return .ineligible(reason: .unsupportedCountry)
+        }
+
+        // Then checks currency.
+        switch currencyCode {
+        case .USD, .GBP:
+            return .eligible
+        default:
+            return .ineligible(reason: .unsupportedCurrency)
+        }
+    }
+
+    func isEligibleFromPluginChecks(systemPlugins: [SystemPlugin], enabledFeatures: [String]?) -> POSEligibilityState {
+        guard let wcPlugin = systemPlugins.first(where: { $0.name == Constants.wcPluginName && $0.active }) else {
+            return .ineligible(reason: .wooCommercePluginNotFound)
+        }
+
+        guard VersionHelpers.isVersionSupported(version: wcPlugin.version,
+                                                minimumRequired: Constants.wcPluginMinimumVersion) else {
+            return .ineligible(reason: .unsupportedWooCommerceVersion)
+        }
+
+        if VersionHelpers.isVersionSupported(version: wcPlugin.version,
+                                             minimumRequired: Constants.wcPluginMinimumVersionWithFeatureSwitch,
+                                             includesDevAndBetaVersions: true) {
+            // For versions that support the feature switch, checks if the feature switch is enabled.
+            guard let enabledFeatures,
+                  enabledFeatures.contains(SiteSettingsFeature.pointOfSale.rawValue) else {
+                return .ineligible(reason: .featureSwitchDisabled)
+            }
+            return .eligible
+        } else {
+            // For versions below 10.0.0, the feature is enabled by default.
+            return .eligible
+        }
+    }
+}
+
+private extension POSTabEligibilityChecker {
+    func checkSiteSettingsEligibility() async -> POSEligibilityState {
+        // Wait for the first site settings refresh
+        await waitForSiteSettingsRefresh()
+        
+        // Conditions that can change if site settings are synced during the lifetime.
+        let countryCode = SiteAddress(siteSettings: siteSettings.siteSettings).countryCode
+        let currency = currencySettings.currencyCode
+
+        // Checks country first.
+        switch countryCode {
+        case .US, .GB:
+            break
+        default:
+            return .ineligible(reason: .unsupportedCountry)
+        }
+
+        // Then checks currency.
+        switch currency {
+        case .USD, .GBP:
+            return .eligible
+        default:
+            return .ineligible(reason: .unsupportedCurrency)
+        }
+    }
+
+    @MainActor
+    func waitForSiteSettingsRefresh() async {
+        for await _ in NotificationCenter.default.notifications(named: .selectedSiteSettingsRefreshed, object: siteSettings).map( { $0.name } ) {
+            break // Exit after first notification
+        }
+    }
+}
+
+private extension POSTabEligibilityChecker {
+    func isPointOfSaleFeatureFlagEnabled() async -> POSEligibilityState {
+        // Only whitelisted accounts in WPCOM have the Point of Sale remote feature flag enabled. These can be found at D159901-code
+        // If the account is whitelisted, then the remote value takes preference over the local feature flag configuration
+        return await withCheckedContinuation { [weak self] continuation in
+            guard let self else {
+                return continuation.resume(returning: .ineligible(reason: .selfDeallocated))
+            }
+            let action = FeatureFlagAction.isRemoteFeatureFlagEnabled(.pointOfSale, defaultValue: false) { [weak self] result in
+                guard let self else {
+                    return continuation.resume(returning: .ineligible(reason: .selfDeallocated))
+                }
+                switch result {
+                case true:
+                    // The site is whitelisted.
+                    continuation.resume(returning: .eligible)
+                case false:
+                    // When the site is not whitelisted, check the local feature flag configuration.
+                    let localFeatureFlag = featureFlagService.isFeatureFlagEnabled(.pointOfSale)
+                    continuation.resume(returning: localFeatureFlag ? .eligible : .ineligible(reason: .featureFlagDisabled))
+                }
+            }
+            self.stores.dispatch(action)
+        }
+    }
+}
+
+private extension POSTabEligibilityChecker {
+    enum Constants {
+        static let wcPluginName = "WooCommerce"
+        static let wcPluginMinimumVersion = "9.6.0-beta"
+        static let wcPluginMinimumVersionWithFeatureSwitch = "10.0.0"
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -191,9 +191,9 @@ private extension POSTabEligibilityChecker {
             return .ineligible(reason: .unsupportedCountry)
         }
 
-        // Then checks currency.
-        switch currencyCode {
-        case .USD, .GBP:
+        // Then checks currency based on the country.
+        switch (countryCode, currencyCode) {
+        case (.US, .USD), (.GB, .GBP):
             return .eligible
         default:
             return .ineligible(reason: .unsupportedCurrency)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -173,7 +173,7 @@ private extension POSTabEligibilityChecker {
 
     func waitForSiteSettingsRefresh() async -> [SiteSetting] {
         for await siteSettings in siteSettings.settingsStream {
-            guard siteSettings.siteID == siteID else {
+            guard siteSettings.siteID == siteID, siteSettings.settings.isNotEmpty else {
                 continue
             }
             return siteSettings.settings

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -11,6 +11,7 @@ import enum Yosemite.SystemStatusAction
 import enum Yosemite.FeatureFlagAction
 import enum Yosemite.SettingAction
 
+/// Represents the reasons why a site may be ineligible for POS.
 enum POSIneligibleReason: Equatable {
     case notTablet
     case unsupportedIOSVersion
@@ -25,17 +26,40 @@ enum POSIneligibleReason: Equatable {
     case selfDeallocated
 }
 
+/// Represents the eligibility state for POS.
 enum POSEligibilityState: Equatable {
     case eligible
     case ineligible(reason: POSIneligibleReason)
 }
 
 protocol POSEntryPointEligibilityCheckerProtocol {
+    /// Determines whether the site is eligible for POS.
     func checkEligibility() async -> POSEligibilityState
 }
 
-/// Determines whether the POS entry point can be shown based on the selected store and feature gates.
 final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
+    private let siteID: Int64
+    private let userInterfaceIdiom: UIUserInterfaceIdiom
+    private let siteSettings: SelectedSiteSettings
+    private let currencySettings: CurrencySettings
+    private let stores: StoresManager
+    private let featureFlagService: FeatureFlagService
+
+    init(siteID: Int64,
+         userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
+         siteSettings: SelectedSiteSettings = ServiceLocator.selectedSiteSettings,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         stores: StoresManager = ServiceLocator.stores,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+        self.siteID = siteID
+        self.userInterfaceIdiom = userInterfaceIdiom
+        self.siteSettings = siteSettings
+        self.currencySettings = currencySettings
+        self.stores = stores
+        self.featureFlagService = featureFlagService
+    }
+
+    /// Determines whether the POS entry point can be shown based on the selected store and feature gates.
     func checkEligibility() async -> POSEligibilityState {
         guard #available(iOS 17.0, *) else {
             return .ineligible(reason: .unsupportedIOSVersion)
@@ -46,8 +70,8 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
         }
 
         async let siteSettingsEligibility = checkSiteSettingsEligibility()
-        async let featureFlagEligibility = isPointOfSaleFeatureFlagEnabled()
-        async let pluginEligibility = isEligibleFromPluginChecks()
+        async let featureFlagEligibility = checkRemoteFeatureEligibility()
+        async let pluginEligibility = checkPluginEligibility()
 
         // Checks site settings first since it's likely to complete fastest.
         switch await siteSettingsEligibility {
@@ -73,31 +97,10 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
             return .ineligible(reason: reason)
         }
     }
-
-    private let siteID: Int64
-    private let userInterfaceIdiom: UIUserInterfaceIdiom
-    private let siteSettings: SelectedSiteSettings
-    private let currencySettings: CurrencySettings
-    private let stores: StoresManager
-    private let featureFlagService: FeatureFlagService
-
-    init(siteID: Int64,
-         userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
-         siteSettings: SelectedSiteSettings = ServiceLocator.selectedSiteSettings,
-         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
-         stores: StoresManager = ServiceLocator.stores,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
-        self.siteID = siteID
-        self.userInterfaceIdiom = userInterfaceIdiom
-        self.siteSettings = siteSettings
-        self.currencySettings = currencySettings
-        self.stores = stores
-        self.featureFlagService = featureFlagService
-    }
 }
 
 private extension POSTabEligibilityChecker {
-    func isEligibleFromPluginChecks() async -> POSEligibilityState {
+    func checkPluginEligibility() async -> POSEligibilityState {
         let wcPlugin = await fetchWooCommercePlugin(siteID: siteID)
 
         guard let wcPlugin, wcPlugin.active else {
@@ -122,7 +125,10 @@ private extension POSTabEligibilityChecker {
     }
 
     func fetchWooCommercePlugin(siteID: Int64) async -> SystemPlugin? {
-        await withCheckedContinuation { continuation in
+        await withCheckedContinuation { [weak self] continuation in
+            guard let self else {
+                return continuation.resume(returning: nil)
+            }
             let action = SystemStatusAction.fetchSystemPlugin(siteID: siteID, systemPluginName: Constants.wcPluginName) { wcPlugin in
                 continuation.resume(returning: wcPlugin)
             }
@@ -131,7 +137,10 @@ private extension POSTabEligibilityChecker {
     }
 
     func checkFeatureSwitchEnabled(siteID: Int64) async -> POSEligibilityState {
-        await withCheckedContinuation { continuation in
+        await withCheckedContinuation { [weak self] continuation in
+            guard let self else {
+                return continuation.resume(returning: .ineligible(reason: .selfDeallocated))
+            }
             let action = SettingAction.isFeatureEnabled(siteID: siteID, feature: .pointOfSale) { result in
                 switch result {
                 case .success(let isEnabled):
@@ -191,10 +200,10 @@ private extension POSTabEligibilityChecker {
 }
 
 private extension POSTabEligibilityChecker {
-    func isPointOfSaleFeatureFlagEnabled() async -> POSEligibilityState {
+    func checkRemoteFeatureEligibility() async -> POSEligibilityState {
         // Only whitelisted accounts in WPCOM have the Point of Sale remote feature flag enabled. These can be found at D159901-code
         // If the account is whitelisted, then the remote value takes preference over the local feature flag configuration
-        return await withCheckedContinuation { [weak self] continuation in
+        await withCheckedContinuation { [weak self] continuation in
             guard let self else {
                 return continuation.resume(returning: .ineligible(reason: .selfDeallocated))
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -124,6 +124,7 @@ private extension POSTabEligibilityChecker {
         return await checkFeatureSwitchEnabled(siteID: siteID)
     }
 
+    @MainActor
     func fetchWooCommercePlugin(siteID: Int64) async -> SystemPlugin? {
         await withCheckedContinuation { [weak self] continuation in
             guard let self else {
@@ -136,6 +137,7 @@ private extension POSTabEligibilityChecker {
         }
     }
 
+    @MainActor
     func checkFeatureSwitchEnabled(siteID: Int64) async -> POSEligibilityState {
         await withCheckedContinuation { [weak self] continuation in
             guard let self else {
@@ -200,6 +202,7 @@ private extension POSTabEligibilityChecker {
 }
 
 private extension POSTabEligibilityChecker {
+    @MainActor
     func checkRemoteFeatureEligibility() async -> POSEligibilityState {
         // Only whitelisted accounts in WPCOM have the Point of Sale remote feature flag enabled. These can be found at D159901-code
         // If the account is whitelisted, then the remote value takes preference over the local feature flag configuration

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -368,6 +368,7 @@
 		026A50282D2F6BD1002C42C2 /* InfiniteScrollTriggerDeterminable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026A50272D2F6BD1002C42C2 /* InfiniteScrollTriggerDeterminable.swift */; };
 		026A502C2D2F6CC3002C42C2 /* View+Measurements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026A502B2D2F6CC3002C42C2 /* View+Measurements.swift */; };
 		026A50302D2F80B5002C42C2 /* ThresholdInfiniteScrollTriggerDeterminerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026A502F2D2F80B5002C42C2 /* ThresholdInfiniteScrollTriggerDeterminerTests.swift */; };
+		026B2D172DF92291005B8CAA /* POSTabEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026B2D162DF92290005B8CAA /* POSTabEligibilityChecker.swift */; };
 		026B3C57249A046E00F7823C /* TextFieldTextAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026B3C56249A046E00F7823C /* TextFieldTextAlignment.swift */; };
 		026CAF7E2AC2B76C002D23BB /* ConfigurableBundleProductViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CAF7D2AC2B76C002D23BB /* ConfigurableBundleProductViewModel.swift */; };
 		026CAF802AC2B7FF002D23BB /* ConfigurableBundleProductView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CAF7F2AC2B7FF002D23BB /* ConfigurableBundleProductView.swift */; };
@@ -3616,6 +3617,7 @@
 		026A50272D2F6BD1002C42C2 /* InfiniteScrollTriggerDeterminable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfiniteScrollTriggerDeterminable.swift; sourceTree = "<group>"; };
 		026A502B2D2F6CC3002C42C2 /* View+Measurements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Measurements.swift"; sourceTree = "<group>"; };
 		026A502F2D2F80B5002C42C2 /* ThresholdInfiniteScrollTriggerDeterminerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThresholdInfiniteScrollTriggerDeterminerTests.swift; sourceTree = "<group>"; };
+		026B2D162DF92290005B8CAA /* POSTabEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSTabEligibilityChecker.swift; sourceTree = "<group>"; };
 		026B3C56249A046E00F7823C /* TextFieldTextAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTextAlignment.swift; sourceTree = "<group>"; };
 		026CAF7D2AC2B76C002D23BB /* ConfigurableBundleProductViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableBundleProductViewModel.swift; sourceTree = "<group>"; };
 		026CAF7F2AC2B7FF002D23BB /* ConfigurableBundleProductView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableBundleProductView.swift; sourceTree = "<group>"; };
@@ -7920,6 +7922,7 @@
 		02E4A0842BFB1D1F006D4F87 /* POS */ = {
 			isa = PBXGroup;
 			children = (
+				026B2D162DF92290005B8CAA /* POSTabEligibilityChecker.swift */,
 				02E4A0822BFB1C4F006D4F87 /* POSEligibilityChecker.swift */,
 			);
 			path = POS;
@@ -16938,6 +16941,7 @@
 				EE5EEDEB2D6F32FE00E1EC05 /* WooShippingDestinationAddress+Woo.swift in Sources */,
 				AEE9A880293A3E5500227C92 /* RefreshablePlainList.swift in Sources */,
 				203163B72C1C5EDF001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift in Sources */,
+				026B2D172DF92291005B8CAA /* POSTabEligibilityChecker.swift in Sources */,
 				2004E2ED2C0F5DD800D62521 /* CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift in Sources */,
 				026A502C2D2F6CC3002C42C2 /* View+Measurements.swift in Sources */,
 				868029532C184E6C00CB64A1 /* BottomSheetProductCategory.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -389,6 +389,7 @@
 		0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */; };
 		0273707E24C0047800167204 /* SequenceHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0273707D24C0047800167204 /* SequenceHelpersTests.swift */; };
 		0273708024C0094500167204 /* ProductListMultiSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0273707F24C0094500167204 /* ProductListMultiSelectorDataSource.swift */; };
+		0277889E2DF928E3006F5B8C /* POSTabEligibilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0277889D2DF928E3006F5B8C /* POSTabEligibilityCheckerTests.swift */; };
 		0277AE9B256CA8A200F45C4A /* AggregatedShippingLabelOrderItemsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0277AE9A256CA8A200F45C4A /* AggregatedShippingLabelOrderItemsTests.swift */; };
 		0277AEA5256CAA4200F45C4A /* MockShippingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0277AEA4256CAA4200F45C4A /* MockShippingLabel.swift */; };
 		0277AEAB256CAA5300F45C4A /* MockShippingLabelAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0277AEAA256CAA5300F45C4A /* MockShippingLabelAddress.swift */; };
@@ -3639,6 +3640,7 @@
 		0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionary.swift; sourceTree = "<group>"; };
 		0273707D24C0047800167204 /* SequenceHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceHelpersTests.swift; sourceTree = "<group>"; };
 		0273707F24C0094500167204 /* ProductListMultiSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListMultiSelectorDataSource.swift; sourceTree = "<group>"; };
+		0277889D2DF928E3006F5B8C /* POSTabEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSTabEligibilityCheckerTests.swift; sourceTree = "<group>"; };
 		0277AE9A256CA8A200F45C4A /* AggregatedShippingLabelOrderItemsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregatedShippingLabelOrderItemsTests.swift; sourceTree = "<group>"; };
 		0277AEA4256CAA4200F45C4A /* MockShippingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShippingLabel.swift; sourceTree = "<group>"; };
 		0277AEAA256CAA5300F45C4A /* MockShippingLabelAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShippingLabelAddress.swift; sourceTree = "<group>"; };
@@ -6962,6 +6964,7 @@
 			isa = PBXGroup;
 			children = (
 				023BD58A2BFDCFCB00A10D7B /* POSEligibilityCheckerTests.swift */,
+				0277889D2DF928E3006F5B8C /* POSTabEligibilityCheckerTests.swift */,
 			);
 			path = POS;
 			sourceTree = "<group>";
@@ -17921,6 +17924,7 @@
 				02BC5AA524D27F8900C43326 /* ProductVariationFormViewModel+UpdatesTests.swift in Sources */,
 				D8736B5122EB69E300A14A29 /* OrderDetailsViewModelTests.swift in Sources */,
 				207E71CB2C60F765008540FC /* MockPOSOrderService.swift in Sources */,
+				0277889E2DF928E3006F5B8C /* POSTabEligibilityCheckerTests.swift in Sources */,
 				02C0CD2E23B5E3AE00F880B1 /* DefaultImageServiceTests.swift in Sources */,
 				B993051E2B7CC2A400456E35 /* LocallyStoredStateNameRetrieverTests.swift in Sources */,
 				DE7E5E8A2B4D4015002E28D2 /* BlazeTargetDeviceViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -37,7 +37,7 @@ struct POSTabEligibilityCheckerTests {
         #expect(result == .eligible)
     }
 
-    @Test func is_eligible_when_account_not_whitelisted_and_feature_flag_disabled() async throws {
+    @Test func is_ineligible_when_account_not_whitelisted_and_feature_flag_disabled() async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: false)
         setupCountry(country: .us)
@@ -56,7 +56,7 @@ struct POSTabEligibilityCheckerTests {
         #expect(result == .ineligible(reason: .featureFlagDisabled))
     }
 
-    @Test func is_eligible_when_non_iPad_device() async throws {
+    @Test func is_ineligible_when_device_is_not_iPad() async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
         setupCountry(country: .us)
@@ -76,7 +76,7 @@ struct POSTabEligibilityCheckerTests {
     }
 
     @Test(arguments: [(country: Country.us, currency: CurrencyCode.USD), (country: Country.gb, currency: .GBP)])
-    fileprivate func is_eligible_when_country_is_supported(country: Country, currency: CurrencyCode) async throws {
+    fileprivate func is_eligible_when_country_and_currency_are_supported(country: Country, currency: CurrencyCode) async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
         setupCountry(country: country)
@@ -125,15 +125,24 @@ struct POSTabEligibilityCheckerTests {
         #expect(result == .ineligible(reason: .unsupportedCountry))
     }
 
-    @Test func is_eligible_when_non_usd_currency() async throws {
+    @Test(arguments: [(country: Country.us, currency: CurrencyCode.GBP),
+                      (country: Country.us, currency: CurrencyCode.CAD),
+                      (country: Country.gb, currency: CurrencyCode.EUR),
+                      (country: Country.gb, currency: CurrencyCode.USD)])
+    fileprivate func is_ineligible_when_currency_is_not_supported(country: Country, currency: CurrencyCode) async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
-        setupCountry(country: .us)
+        setupCountry(country: country)
         accountWhitelistedInBackend(true)
+        let currencySettings = CurrencySettings(currencyCode: currency,
+                                                currencyPosition: .leftSpace,
+                                                thousandSeparator: "",
+                                                decimalSeparator: ".",
+                                                numberOfDecimals: 3)
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
-                                               currencySettings: Fixtures.nonUSDCurrencySettings,
+                                               currencySettings: currencySettings,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
 
@@ -144,7 +153,7 @@ struct POSTabEligibilityCheckerTests {
         #expect(result == .ineligible(reason: .unsupportedCurrency))
     }
 
-    @Test func is_eligible_when_woocommerce_version_below_minimum() async throws {
+    @Test func is_ineligible_when_woocommerce_version_is_below_minimum() async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
         setupCountry(country: .us)
@@ -185,7 +194,7 @@ struct POSTabEligibilityCheckerTests {
         #expect(result == .eligible)
     }
 
-    @Test func is_eligible_when_core_version_is_10_0_0_and_POS_feature_disabled() async throws {
+    @Test func is_ineligible_when_core_version_is_10_0_0_and_POS_feature_disabled() async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
         setupCountry(country: .us)
@@ -206,7 +215,7 @@ struct POSTabEligibilityCheckerTests {
         #expect(result == .ineligible(reason: .featureSwitchDisabled))
     }
 
-    @Test func is_eligible_when_core_version_is_10_0_0_and_POS_feature_check_fails() async throws {
+    @Test func is_ineligible_when_core_version_is_10_0_0_and_POS_feature_check_fails() async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
         setupCountry(country: .us)
@@ -227,7 +236,7 @@ struct POSTabEligibilityCheckerTests {
         #expect(result == .ineligible(reason: .featureSwitchSyncFailure))
     }
 
-    @Test func is_eligible_when_core_version_is_smaller_than_10_0_0_and_POS_feature_disabled() async throws {
+    @Test func is_eligible_when_core_version_is_below_10_0_0_and_POS_feature_disabled() async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
         setupCountry(country: .us)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -1,5 +1,4 @@
 import Testing
-import XCTest
 import WooFoundation
 import Yosemite
 @testable import WooCommerce
@@ -19,8 +18,7 @@ struct POSTabEligibilityCheckerTests {
         siteSettings = SelectedSiteSettings(stores: stores, storageManager: storageManager)
     }
 
-    @Test("When all conditions are satisfied, returns eligible")
-    func test_is_eligible_when_all_conditions_satisfied() async throws {
+    @Test func is_eligible_when_all_conditions_satisfied() async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
         setupCountry(country: .us)
@@ -39,8 +37,7 @@ struct POSTabEligibilityCheckerTests {
         #expect(result == .eligible)
     }
 
-    @Test("When account is not whitelisted and feature flag is disabled, returns ineligible")
-    func test_is_eligible_when_account_not_whitelisted_and_feature_flag_disabled() async throws {
+    @Test func is_eligible_when_account_not_whitelisted_and_feature_flag_disabled() async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: false)
         setupCountry(country: .us)
@@ -59,8 +56,7 @@ struct POSTabEligibilityCheckerTests {
         #expect(result == .ineligible(reason: .featureFlagDisabled))
     }
 
-    @Test("When non-iPad device, returns ineligible")
-    func test_is_eligible_when_non_ipad_device() async throws {
+    @Test func is_eligible_when_non_iPad_device() async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
         setupCountry(country: .us)
@@ -79,16 +75,46 @@ struct POSTabEligibilityCheckerTests {
         #expect(result == .ineligible(reason: .notTablet))
     }
 
-    @Test("When non-US site, returns ineligible")
-    func test_is_eligible_when_non_us_site() async throws {
+    @Test(arguments: [(country: Country.us, currency: CurrencyCode.USD), (country: Country.gb, currency: .GBP)])
+    fileprivate func is_eligible_when_country_is_supported(country: Country, currency: CurrencyCode) async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
-        setupCountry(country: .ca)
+        setupCountry(country: country)
         accountWhitelistedInBackend(true)
+        let currencySettings = CurrencySettings(currencyCode: currency,
+                                                currencyPosition: .leftSpace,
+                                                thousandSeparator: "",
+                                                decimalSeparator: ".",
+                                                numberOfDecimals: 3)
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
-                                               currencySettings: Fixtures.usdCurrencySettings,
+                                               currencySettings: currencySettings,
+                                               stores: stores,
+                                               featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        #expect(result == .eligible)
+    }
+
+    @Test(arguments: [(country: Country.ca, currency: CurrencyCode.CAD), (country: Country.es, currency: CurrencyCode.EUR)])
+    fileprivate func is_ineligible_when_country_is_not_supported(country: Country, currency: CurrencyCode) async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
+        setupCountry(country: country)
+        accountWhitelistedInBackend(true)
+        let currencySettings = CurrencySettings(currencyCode: currency,
+                                                currencyPosition: .leftSpace,
+                                                thousandSeparator: "",
+                                                decimalSeparator: ".",
+                                                numberOfDecimals: 3)
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               userInterfaceIdiom: .pad,
+                                               siteSettings: siteSettings,
+                                               currencySettings: currencySettings,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
 
@@ -99,8 +125,7 @@ struct POSTabEligibilityCheckerTests {
         #expect(result == .ineligible(reason: .unsupportedCountry))
     }
 
-    @Test("When non-USD currency, returns ineligible")
-    func test_is_eligible_when_non_usd_currency() async throws {
+    @Test func is_eligible_when_non_usd_currency() async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
         setupCountry(country: .us)
@@ -119,8 +144,7 @@ struct POSTabEligibilityCheckerTests {
         #expect(result == .ineligible(reason: .unsupportedCurrency))
     }
 
-    @Test("When WooCommerce version is below minimum, returns ineligible")
-    func test_is_eligible_when_woocommerce_version_below_minimum() async throws {
+    @Test func is_eligible_when_woocommerce_version_below_minimum() async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
         setupCountry(country: .us)
@@ -138,6 +162,90 @@ struct POSTabEligibilityCheckerTests {
 
         // Then
         #expect(result == .ineligible(reason: .unsupportedWooCommerceVersion))
+    }
+
+    @Test func is_eligible_when_core_version_is_10_0_0_and_POS_feature_enabled() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
+        setupCountry(country: .us)
+        accountWhitelistedInBackend(true)
+        setupWooCommerceVersion("10.0.0")
+        setupPOSFeatureEnabled(.success(true))
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               userInterfaceIdiom: .pad,
+                                               siteSettings: siteSettings,
+                                               currencySettings: Fixtures.usdCurrencySettings,
+                                               stores: stores,
+                                               featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        #expect(result == .eligible)
+    }
+
+    @Test func is_eligible_when_core_version_is_10_0_0_and_POS_feature_disabled() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
+        setupCountry(country: .us)
+        accountWhitelistedInBackend(true)
+        setupWooCommerceVersion("10.0.0")
+        setupPOSFeatureEnabled(.success(false))
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               userInterfaceIdiom: .pad,
+                                               siteSettings: siteSettings,
+                                               currencySettings: Fixtures.usdCurrencySettings,
+                                               stores: stores,
+                                               featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        #expect(result == .ineligible(reason: .featureSwitchDisabled))
+    }
+
+    @Test func is_eligible_when_core_version_is_10_0_0_and_POS_feature_check_fails() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
+        setupCountry(country: .us)
+        accountWhitelistedInBackend(true)
+        setupWooCommerceVersion("10.0.0")
+        setupPOSFeatureEnabled(.failure(NSError(domain: "test", code: 0)))
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               userInterfaceIdiom: .pad,
+                                               siteSettings: siteSettings,
+                                               currencySettings: Fixtures.usdCurrencySettings,
+                                               stores: stores,
+                                               featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        #expect(result == .ineligible(reason: .featureSwitchSyncFailure))
+    }
+
+    @Test func is_eligible_when_core_version_is_smaller_than_10_0_0_and_POS_feature_disabled() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
+        setupCountry(country: .us)
+        accountWhitelistedInBackend(true)
+        setupWooCommerceVersion("9.9.9")
+        setupPOSFeatureEnabled(.success(false))
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               userInterfaceIdiom: .pad,
+                                               siteSettings: siteSettings,
+                                               currencySettings: Fixtures.usdCurrencySettings,
+                                               stores: stores,
+                                               featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        #expect(result == .eligible)
     }
 }
 
@@ -170,6 +278,17 @@ private extension POSTabEligibilityCheckerTests {
             switch action {
             case .isRemoteFeatureFlagEnabled(_, _, completion: let completion):
                 completion(isAllowed)
+            }
+        }
+    }
+
+    func setupPOSFeatureEnabled(_ result: Result<Bool, Error>) {
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case .isFeatureEnabled(_, _, let completion):
+                completion(result)
+            default:
+                break
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -1,0 +1,196 @@
+import Testing
+import XCTest
+import WooFoundation
+import Yosemite
+@testable import WooCommerce
+
+@MainActor
+struct POSTabEligibilityCheckerTests {
+    private var stores: MockStoresManager!
+    private var storageManager: MockStorageManager!
+    private var siteSettings: SelectedSiteSettings!
+    private let siteID: Int64 = 2
+
+    init() async throws {
+        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.updateDefaultStore(storeID: siteID)
+        setupWooCommerceVersion()
+        storageManager = MockStorageManager()
+        siteSettings = SelectedSiteSettings(stores: stores, storageManager: storageManager)
+    }
+
+    @Test("When all conditions are satisfied, returns eligible")
+    func test_is_eligible_when_all_conditions_satisfied() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
+        setupCountry(country: .us)
+        accountWhitelistedInBackend(true)
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               userInterfaceIdiom: .pad,
+                                               siteSettings: siteSettings,
+                                               currencySettings: Fixtures.usdCurrencySettings,
+                                               stores: stores,
+                                               featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        #expect(result == .eligible)
+    }
+
+    @Test("When account is not whitelisted and feature flag is disabled, returns ineligible")
+    func test_is_eligible_when_account_not_whitelisted_and_feature_flag_disabled() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: false)
+        setupCountry(country: .us)
+        accountWhitelistedInBackend(false)
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               userInterfaceIdiom: .pad,
+                                               siteSettings: siteSettings,
+                                               currencySettings: Fixtures.usdCurrencySettings,
+                                               stores: stores,
+                                               featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        #expect(result == .ineligible(reason: .featureFlagDisabled))
+    }
+
+    @Test("When non-iPad device, returns ineligible")
+    func test_is_eligible_when_non_ipad_device() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
+        setupCountry(country: .us)
+        accountWhitelistedInBackend(true)
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               userInterfaceIdiom: .phone,
+                                               siteSettings: siteSettings,
+                                               currencySettings: Fixtures.usdCurrencySettings,
+                                               stores: stores,
+                                               featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        #expect(result == .ineligible(reason: .notTablet))
+    }
+
+    @Test("When non-US site, returns ineligible")
+    func test_is_eligible_when_non_us_site() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
+        setupCountry(country: .ca)
+        accountWhitelistedInBackend(true)
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               userInterfaceIdiom: .pad,
+                                               siteSettings: siteSettings,
+                                               currencySettings: Fixtures.usdCurrencySettings,
+                                               stores: stores,
+                                               featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        #expect(result == .ineligible(reason: .unsupportedCountry))
+    }
+
+    @Test("When non-USD currency, returns ineligible")
+    func test_is_eligible_when_non_usd_currency() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
+        setupCountry(country: .us)
+        accountWhitelistedInBackend(true)
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               userInterfaceIdiom: .pad,
+                                               siteSettings: siteSettings,
+                                               currencySettings: Fixtures.nonUSDCurrencySettings,
+                                               stores: stores,
+                                               featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        #expect(result == .ineligible(reason: .unsupportedCurrency))
+    }
+
+    @Test("When WooCommerce version is below minimum, returns ineligible")
+    func test_is_eligible_when_woocommerce_version_below_minimum() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
+        setupCountry(country: .us)
+        accountWhitelistedInBackend(true)
+        setupWooCommerceVersion("9.5.0")
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               userInterfaceIdiom: .pad,
+                                               siteSettings: siteSettings,
+                                               currencySettings: Fixtures.usdCurrencySettings,
+                                               stores: stores,
+                                               featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        #expect(result == .ineligible(reason: .unsupportedWooCommerceVersion))
+    }
+}
+
+private extension POSTabEligibilityCheckerTests {
+    func setupCountry(country: Country) {
+        let setting = SiteSetting.fake()
+            .copy(
+                siteID: siteID,
+                settingID: "woocommerce_default_country",
+                value: country.rawValue,
+                settingGroupKey: SiteSettingGroup.general.rawValue
+            )
+        storageManager.insertSampleSiteSetting(readOnlySiteSetting: setting)
+        siteSettings.refresh()
+    }
+
+    func setupWooCommerceVersion(_ version: String = "9.6.0-beta") {
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case .fetchSystemPlugin(_, _, let completion):
+                completion(SystemPlugin.fake().copy(name: "WooCommerce", version: version, active: true))
+            default:
+                break
+            }
+        }
+    }
+
+    func accountWhitelistedInBackend(_ isAllowed: Bool = false) {
+        stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            switch action {
+            case .isRemoteFeatureFlagEnabled(_, _, completion: let completion):
+                completion(isAllowed)
+            }
+        }
+    }
+
+    enum Fixtures {
+        static let usdCurrencySettings = CurrencySettings(currencyCode: .USD,
+                                                          currencyPosition: .leftSpace,
+                                                          thousandSeparator: "",
+                                                          decimalSeparator: ".",
+                                                          numberOfDecimals: 3)
+        static let nonUSDCurrencySettings = CurrencySettings(currencyCode: .CAD,
+                                                             currencyPosition: .leftSpace,
+                                                             thousandSeparator: "",
+                                                             decimalSeparator: ".",
+                                                             numberOfDecimals: 3)
+    }
+
+    enum Country: String {
+        case us = "US:CA"
+        case ca = "CA:NS"
+        case gb = "GB"
+        case es = "ES"
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -8,13 +8,15 @@ struct POSTabEligibilityCheckerTests {
     private var stores: MockStoresManager!
     private var storageManager: MockStorageManager!
     private var siteSettings: SelectedSiteSettings!
+    private var pluginsService: MockPluginsService!
     private let siteID: Int64 = 2
 
     init() async throws {
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.updateDefaultStore(storeID: siteID)
-        setupWooCommerceVersion()
         storageManager = MockStorageManager()
+        pluginsService = MockPluginsService()
+        setupWooCommerceVersion()
         siteSettings = SelectedSiteSettings(stores: stores, storageManager: storageManager)
     }
 
@@ -27,6 +29,7 @@ struct POSTabEligibilityCheckerTests {
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
                                                currencySettings: Fixtures.usdCurrencySettings,
+                                               pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
 
@@ -46,6 +49,7 @@ struct POSTabEligibilityCheckerTests {
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
                                                currencySettings: Fixtures.usdCurrencySettings,
+                                               pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
 
@@ -65,6 +69,7 @@ struct POSTabEligibilityCheckerTests {
                                                userInterfaceIdiom: .phone,
                                                siteSettings: siteSettings,
                                                currencySettings: Fixtures.usdCurrencySettings,
+                                               pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
 
@@ -90,6 +95,7 @@ struct POSTabEligibilityCheckerTests {
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
                                                currencySettings: currencySettings,
+                                               pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
 
@@ -115,6 +121,7 @@ struct POSTabEligibilityCheckerTests {
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
                                                currencySettings: currencySettings,
+                                               pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
 
@@ -143,6 +150,7 @@ struct POSTabEligibilityCheckerTests {
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
                                                currencySettings: currencySettings,
+                                               pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
 
@@ -163,6 +171,7 @@ struct POSTabEligibilityCheckerTests {
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
                                                currencySettings: Fixtures.usdCurrencySettings,
+                                               pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
 
@@ -184,6 +193,7 @@ struct POSTabEligibilityCheckerTests {
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
                                                currencySettings: Fixtures.usdCurrencySettings,
+                                               pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
 
@@ -205,6 +215,7 @@ struct POSTabEligibilityCheckerTests {
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
                                                currencySettings: Fixtures.usdCurrencySettings,
+                                               pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
 
@@ -226,6 +237,7 @@ struct POSTabEligibilityCheckerTests {
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
                                                currencySettings: Fixtures.usdCurrencySettings,
+                                               pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
 
@@ -247,6 +259,7 @@ struct POSTabEligibilityCheckerTests {
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
                                                currencySettings: Fixtures.usdCurrencySettings,
+                                               pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
 
@@ -272,14 +285,12 @@ private extension POSTabEligibilityCheckerTests {
     }
 
     func setupWooCommerceVersion(_ version: String = "9.6.0-beta") {
-        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
-            switch action {
-            case .fetchSystemPlugin(_, _, let completion):
-                completion(SystemPlugin.fake().copy(name: "WooCommerce", version: version, active: true))
-            default:
-                break
-            }
-        }
+        pluginsService.pluginToReturn = .fake().copy(
+            siteID: siteID,
+            plugin: "WooCommerce",
+            version: version,
+            active: true
+        )
     }
 
     func accountWhitelistedInBackend(_ isAllowed: Bool = false) {
@@ -320,5 +331,13 @@ private extension POSTabEligibilityCheckerTests {
         case ca = "CA:NS"
         case gb = "GB"
         case es = "ES"
+    }
+}
+
+private final class MockPluginsService: PluginsServiceProtocol {
+    var pluginToReturn: SystemPlugin = .fake()
+
+    func waitForPluginInStorage(siteID: Int64, pluginName: String, isActive: Bool) async -> SystemPlugin {
+        pluginToReturn
     }
 }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -104,6 +104,8 @@
 		02E3B623290267D3007E0F13 /* AccountCreationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E3B622290267D3007E0F13 /* AccountCreationStore.swift */; };
 		02E3B625290267F2007E0F13 /* AccountCreationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E3B624290267F2007E0F13 /* AccountCreationAction.swift */; };
 		02E3B62A290622DE007E0F13 /* AccountCreationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E3B629290622DE007E0F13 /* AccountCreationStoreTests.swift */; };
+		02E45D882DFA772100CA9433 /* PluginsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E45D872DFA772000CA9433 /* PluginsService.swift */; };
+		02E45D8C2DFA788600CA9433 /* PluginsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E45D8B2DFA788600CA9433 /* PluginsServiceTests.swift */; };
 		02E4F5E423CD5628003B0010 /* NSOrderedSet+Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4F5E323CD5628003B0010 /* NSOrderedSet+Array.swift */; };
 		02E7FFD52562226B00C53030 /* ShippingLabelStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E7FFD42562226B00C53030 /* ShippingLabelStoreTests.swift */; };
 		02E7FFD92562234F00C53030 /* MockShippingLabelRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E7FFD82562234F00C53030 /* MockShippingLabelRemote.swift */; };
@@ -677,6 +679,8 @@
 		02E3B622290267D3007E0F13 /* AccountCreationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationStore.swift; sourceTree = "<group>"; };
 		02E3B624290267F2007E0F13 /* AccountCreationAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationAction.swift; sourceTree = "<group>"; };
 		02E3B629290622DE007E0F13 /* AccountCreationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationStoreTests.swift; sourceTree = "<group>"; };
+		02E45D872DFA772000CA9433 /* PluginsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginsService.swift; sourceTree = "<group>"; };
+		02E45D8B2DFA788600CA9433 /* PluginsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginsServiceTests.swift; sourceTree = "<group>"; };
 		02E4F5E323CD5628003B0010 /* NSOrderedSet+Array.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSOrderedSet+Array.swift"; sourceTree = "<group>"; };
 		02E7FFD42562226B00C53030 /* ShippingLabelStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelStoreTests.swift; sourceTree = "<group>"; };
 		02E7FFD82562234F00C53030 /* MockShippingLabelRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShippingLabelRemote.swift; sourceTree = "<group>"; };
@@ -1326,6 +1330,22 @@
 			path = ShippingSettings;
 			sourceTree = "<group>";
 		};
+		02E45D862DFA771300CA9433 /* Plugins */ = {
+			isa = PBXGroup;
+			children = (
+				02E45D872DFA772000CA9433 /* PluginsService.swift */,
+			);
+			path = Plugins;
+			sourceTree = "<group>";
+		};
+		02E45D8A2DFA786B00CA9433 /* Plugins */ = {
+			isa = PBXGroup;
+			children = (
+				02E45D8B2DFA788600CA9433 /* PluginsServiceTests.swift */,
+			);
+			path = Plugins;
+			sourceTree = "<group>";
+		};
 		02F6AAA827055655002425D0 /* Copiable */ = {
 			isa = PBXGroup;
 			children = (
@@ -1819,6 +1839,7 @@
 				0212AC60242C689600C51F6C /* Products */,
 				02E262BB238CE45300B79588 /* ShippingSettings */,
 				209AD3CA2AC1A65700825D76 /* Payments */,
+				02E45D862DFA771300CA9433 /* Plugins */,
 				B52E002C2119E6C000700FDE /* Internal */,
 				B5631ECC2114DF8C008D3535 /* EntityListener.swift */,
 				B56C1EBD20EABD2B00D749F9 /* ResultsController.swift */,
@@ -2193,6 +2214,7 @@
 				20D210BF2B177EDB0099E517 /* Payments */,
 				E18FDAFF28F98360008519BA /* InAppPurchases */,
 				02FF055723D984500058E6E7 /* Media */,
+				02E45D8A2DFA786B00CA9433 /* Plugins */,
 				0212AC65242C798500C51F6C /* Products */,
 				02E262BE238CE7EA00B79588 /* ShippingSettings */,
 				B54EAF2021188C470029C35E /* EntityListenerTests.swift */,
@@ -2411,6 +2433,7 @@
 				B5C9DE152087FF0E006B910A /* Dispatcher.swift in Sources */,
 				247CE8402582F39900F9D9D1 /* MockActionHandler.swift in Sources */,
 				247CE7C82582DF5500F9D9D1 /* MockStoresManager.swift in Sources */,
+				02E45D882DFA772100CA9433 /* PluginsService.swift in Sources */,
 				BAB3737927964A9500837B4A /* OrderTaxLine+ReadOnlyConvertible.swift in Sources */,
 				20B9F7842DB0FDDB00512EF5 /* SiteSpecificAppSettingsStoreMethods.swift in Sources */,
 				D83B093525DECFCC00B21F45 /* CardPresentPaymentAction.swift in Sources */,
@@ -2771,6 +2794,7 @@
 				0212AC64242C6FC300C51F6C /* ProductStore+ProductsSortOrderTests.swift in Sources */,
 				578CE7942475F52F00492EBF /* MockNote.swift in Sources */,
 				02E3B62A290622DE007E0F13 /* AccountCreationStoreTests.swift in Sources */,
+				02E45D8C2DFA788600CA9433 /* PluginsServiceTests.swift in Sources */,
 				0202B6992387B01500F3EBE0 /* AppSettingsStoreTests+ProductsFeatureSwitch.swift in Sources */,
 				5779A0CD250042B600E35AF2 /* FetchResultSnapshotsProviderTests.swift in Sources */,
 				02616F942921E1CD0095BC00 /* MockSiteRemote.swift in Sources */,

--- a/Yosemite/Yosemite/Tools/Plugins/PluginsService.swift
+++ b/Yosemite/Yosemite/Tools/Plugins/PluginsService.swift
@@ -1,0 +1,47 @@
+import Foundation
+import WooFoundation
+import protocol Storage.StorageManagerType
+
+/// A service for system plugins.
+public protocol PluginsServiceProtocol {
+    /// Waits for a specific plugin to be available in storage.
+    func waitForPluginInStorage(siteID: Int64, pluginName: String, isActive: Bool) async -> SystemPlugin
+}
+
+public class PluginsService: PluginsServiceProtocol {
+    private let storageManager: StorageManagerType
+
+    public init(storageManager: StorageManagerType) {
+        self.storageManager = storageManager
+    }
+
+    @MainActor
+    public func waitForPluginInStorage(siteID: Int64, pluginName: String, isActive: Bool) async -> SystemPlugin {
+        let predicate = \StorageSystemPlugin.siteID == siteID && \StorageSystemPlugin.name == pluginName && \StorageSystemPlugin.active == isActive
+        let nameDescriptor = NSSortDescriptor(keyPath: \StorageSystemPlugin.name, ascending: true)
+        let resultsController = ResultsController<StorageSystemPlugin>(storageManager: storageManager,
+                                                                       matching: predicate,
+                                                                       fetchLimit: 1,
+                                                                       sortedBy: [nameDescriptor])
+        do {
+            try resultsController.performFetch()
+            if let plugin = resultsController.fetchedObjects.first {
+                return plugin
+            }
+        } catch {
+            DDLogError("Error loading plugin \(pluginName) for site \(siteID) initially: \(error.localizedDescription)")
+        }
+
+        return await withCheckedContinuation { continuation in
+            var hasResumed = false
+            resultsController.onDidChangeContent = {
+                guard let plugin = resultsController.fetchedObjects.first,
+                      !hasResumed else {
+                    return
+                }
+                hasResumed = true
+                continuation.resume(returning: plugin)
+            }
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Tools/Plugins/PluginsServiceTests.swift
+++ b/Yosemite/YosemiteTests/Tools/Plugins/PluginsServiceTests.swift
@@ -1,0 +1,71 @@
+import Testing
+import WooFoundation
+@testable import Yosemite
+
+struct PluginsServiceTests {
+    private var storageManager: MockStorageManager!
+    private var sut: PluginsService!
+    private let siteID: Int64 = 134
+
+    init() async throws {
+        storageManager = MockStorageManager()
+        sut = PluginsService(storageManager: storageManager)
+    }
+
+    @Test func waitForPluginInStorage_returns_plugin_when_already_in_storage() async {
+        // Given
+        await storageManager.reset()
+        storageManager.insertWCPlugin(siteID: siteID, isActive: true, version: "1.0.0")
+
+        // When
+        let result = await sut.waitForPluginInStorage(siteID: siteID, pluginName: PluginConstants.pluginName, isActive: true)
+
+        // Then
+        #expect(result.siteID == siteID)
+        #expect(result.name == PluginConstants.pluginName)
+        #expect(result.active == true)
+        #expect(result.version == "1.0.0")
+    }
+
+    @Test func waitForPluginInStorage_waits_to_return_plugin_when_not_in_storage_initially() async {
+        // Given
+        // Resets any existing state, otherwise test might fail if run multiple times.
+        await storageManager.reset()
+
+        // When
+        async let plugin = sut.waitForPluginInStorage(siteID: siteID, pluginName: PluginConstants.pluginName, isActive: true)
+        #expect(storageManager.viewStorage.loadSystemPlugins(siteID: siteID).count == 0)
+        storageManager.insertWCPlugin(siteID: siteID, isActive: true, version: "2.0.0")
+        #expect(storageManager.viewStorage.loadSystemPlugins(siteID: siteID).count == 1)
+
+        // Then
+        let result = await plugin
+        #expect(result.siteID == siteID)
+        #expect(result.name == PluginConstants.pluginName)
+        #expect(result.active == true)
+        #expect(result.version == "2.0.0")
+    }
+}
+
+private extension MockStorageManager {
+    func insertWCPlugin(siteID: Int64, isActive: Bool, version: String? = nil) {
+        performAndSave({ storage in
+            let plugin = SystemPlugin.fake().copy(siteID: siteID, name: PluginConstants.pluginName, version: version, active: isActive)
+            let newPlugin = storage.insertNewObject(ofType: StorageSystemPlugin.self)
+            newPlugin.update(with: plugin)
+        }, completion: nil, on: .main)
+    }
+
+    func reset() async {
+        await withCheckedContinuation { continuation in
+            reset {
+                continuation.resume()
+            }
+        }
+    }
+}
+
+// MARK: - Constants
+private enum PluginConstants {
+    static let pluginName = "Example Plugin"
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-584

Just one reviewer is required.

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request adds a new eligibility checker for the POS tab, focusing on keeping the same eligibility check as the Menu tab, but with async/await interface especially because the tab visibility does not change over time for the same site app session.

### Enhancements to Site Settings Management

* Introduced an `AsyncStream` to `SelectedSiteSettings` for observing site settings changes, enabling asynchronous updates with buffering for the latest values. This includes adding `settingsStream` and `settingsContinuation` properties, initializing the stream in the constructor, and ensuring it is properly finalized in `deinit`. These changes are not expected to affect existing functionality. [[1]](diffhunk://#diff-e718b581b4f75d59fb1547420b8fd0162b6bd121e666b0476fd12785d11ab7ebR20-R23) [[2]](diffhunk://#diff-e718b581b4f75d59fb1547420b8fd0162b6bd121e666b0476fd12785d11ab7ebR36-R50)
* Updated site settings refresh logic to yield changes to the async stream, ensuring the latest site settings are provided to observers. This way, we do not have to rely on `NotificationCenter`, which later observers will miss. [[1]](diffhunk://#diff-e718b581b4f75d59fb1547420b8fd0162b6bd121e666b0476fd12785d11ab7ebR70-R74) [[2]](diffhunk://#diff-e718b581b4f75d59fb1547420b8fd0162b6bd121e666b0476fd12785d11ab7ebR95-R96)

### Addition of POS Tab Eligibility Checker

* Added a new `POSTabEligibilityChecker` class to determine the eligibility of a site for POS functionality. This includes checks for device type, iOS version, WooCommerce plugin version, feature flags, and site settings (currency code and country code).
* Defined supporting enumerations (`POSIneligibleReason`, `POSEligibilityState`) and protocols (`POSEntryPointEligibilityCheckerProtocol`) to encapsulate eligibility logic.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

CI is sufficient for this PR with newly added unit tests, as the new eligibility checker isn't used in this PR. However, if you'd like to test out the usage, you can check out the branch of the next PR https://github.com/woocommerce/woocommerce-ios/pull/15726 that uses this checker for tab visibility. The POS tab should appear for eligible stores.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested in https://github.com/woocommerce/woocommerce-ios/pull/15726 to ensure that the POS tab is shown for eligible sites.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.