### PR TITLE
[POS as a tab i1] Remove unused POS eligibility checker use case in Experimental Features

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesConfigurationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesConfigurationViewModel.swift
@@ -6,42 +6,22 @@ final class BetaFeaturesConfigurationViewModel: ObservableObject {
     @Published private(set) var availableFeatures: [BetaFeature] = []
     private let appSettings: GeneralAppSettingsStorage
     private let featureFlagService: FeatureFlagService
-    private let posEligibilityChecker: POSEligibilityCheckerProtocol
 
     init(appSettings: GeneralAppSettingsStorage = ServiceLocator.generalAppSettings,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-         posEligibilityChecker: POSEligibilityCheckerProtocol = POSEligibilityChecker(
-            siteSettings: ServiceLocator.selectedSiteSettings,
-            currencySettings: ServiceLocator.currencySettings,
-            featureFlagService: ServiceLocator.featureFlagService
-         )) {
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.appSettings = appSettings
         self.featureFlagService = featureFlagService
-        self.posEligibilityChecker = posEligibilityChecker
-        observePOSEligibilityForAvailableFeatures()
+        availableFeatures = BetaFeature.allCases.filter { betaFeature in
+            switch betaFeature {
+                case .viewAddOns:
+                    return true
+                case .inAppPurchases:
+                    return featureFlagService.isFeatureFlagEnabled(.inAppPurchasesDebugMenu)
+            }
+        }
     }
 
     func isOn(feature: BetaFeature) -> Binding<Bool> {
         appSettings.betaFeatureEnabledBinding(feature)
-    }
-}
-
-private extension BetaFeaturesConfigurationViewModel {
-    func observePOSEligibilityForAvailableFeatures() {
-        posEligibilityChecker.isEligible
-            .map { [weak self] isEligibleForPOS in
-                guard let self else {
-                    return []
-                }
-                return BetaFeature.allCases.filter { betaFeature in
-                    switch betaFeature {
-                        case .viewAddOns:
-                            return true
-                        case .inAppPurchases:
-                            return self.featureFlagService.isFeatureFlagEnabled(.inAppPurchasesDebugMenu)
-                    }
-                }
-            }
-            .assign(to: &$availableFeatures)
     }
 }

--- a/WooCommerce/WooCommerceTests/Model/BetaFeaturesConfigurationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/BetaFeaturesConfigurationViewModelTests.swift
@@ -16,22 +16,9 @@ final class BetaFeaturesConfigurationViewModelTests: XCTestCase {
 
     func test_availableFeatures_include_viewAddOns() {
         // Given
-        let viewModel = BetaFeaturesConfigurationViewModel(appSettings: appSettings,
-                                                           posEligibilityChecker: MockPOSEligibilityChecker(isEligibleValue: true))
+        let viewModel = BetaFeaturesConfigurationViewModel(appSettings: appSettings)
 
         // Then
         XCTAssertTrue(viewModel.availableFeatures.contains(.viewAddOns))
-    }
-}
-
-private final class MockPOSEligibilityChecker: POSEligibilityCheckerProtocol {
-    @Published var isEligibleValue: Bool
-
-    init(isEligibleValue: Bool) {
-        self.isEligibleValue = isEligibleValue
-    }
-
-    var isEligible: AnyPublisher<Bool, Never> {
-        $isEligibleValue.eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-587

Just one reviewer is required.

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request removes the unused `POSEligibilityChecker` dependency in `BetaFeaturesConfigurationViewModel` as we might be making changes to it for the POS as a tab project. I'm separating the diffs from https://github.com/woocommerce/woocommerce-ios/pull/15726 so that these changes are easier to review and test.

### Code simplification and dependency removal:

* Removed the `POSEligibilityCheckerProtocol` dependency from `BetaFeaturesConfigurationViewModel` and its initializer. The logic for filtering `availableFeatures` no longer relies on POS eligibility checks, simplifying the class and reducing dependency coupling. (`BetaFeaturesConfigurationViewModel.swift`, [WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesConfigurationViewModel.swiftL9-R25](diffhunk://#diff-c864347ec531a32c632eef4f04127565f2a92187483468d53ca4a7b60110596eL9-R25))
* Updated the `availableFeatures` filtering logic to directly check feature flags without involving the `POSEligibilityChecker`. (`BetaFeaturesConfigurationViewModel.swift`, [WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesConfigurationViewModel.swiftL9-R25](diffhunk://#diff-c864347ec531a32c632eef4f04127565f2a92187483468d53ca4a7b60110596eL9-R25))

### Unit test updates:

* Removed the `MockPOSEligibilityChecker` class and its usage in `BetaFeaturesConfigurationViewModelTests`. Updated the test cases to align with the changes in the `BetaFeaturesConfigurationViewModel` initializer and logic. (`BetaFeaturesConfigurationViewModelTests.swift`, [WooCommerce/WooCommerceTests/Model/BetaFeaturesConfigurationViewModelTests.swiftL19-L37](diffhunk://#diff-876b4a7aa6068ca15ec1dfcd6f42e167214e331d21b4ec337eeae3738b20d9baL19-L37))

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Go to Menu > Settings > Experimental Features --> there should be two features, add-ons and IAP (unrelated to this PR, we probably want to revisit these features to either fully launch or remove them)
- Try toggling the switch then re-enter this screen to make sure the switch state is persisted

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


<img src="https://github.com/user-attachments/assets/03871a8c-343e-47b0-ad08-889bc9c6e1e6" width="400" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.