### PR TITLE
Error Handling When Splitting Shipment Fails

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
@@ -76,15 +76,7 @@ struct WooShippingSplitShipmentsView: View {
                                 return
                             }
 
-                            Task {
-                                do {
-                                    try await viewModel.saveShipmentInfo()
-                                    onShipmentUpdate(viewModel.shipments)
-                                    dismiss()
-                                } catch {
-                                    // TODO: 15309 Show error
-                                }
-                            }
+                            saveShipmentInfoAndDismiss()
                         }
                     }
                 }
@@ -98,6 +90,17 @@ struct WooShippingSplitShipmentsView: View {
         }
         .sheet(item: $shipmentToRemove) { shipment in
             removeShipmentSheet(for: shipment)
+        }
+        .alert(
+            Localization.SaveShipmentError.title,
+            isPresented: $viewModel.shouldShowSaveShipmentErrorAlert
+        ) {
+            Button(Localization.SaveShipmentError.cancel, role: .cancel) {
+                // User chose to cancel, do nothing
+            }
+            Button(Localization.SaveShipmentError.retry) {
+                saveShipmentInfoAndDismiss()
+            }
         }
     }
 }
@@ -305,6 +308,19 @@ private extension WooShippingSplitShipmentsView {
             shipmentToMergeInto = nil
         }
     }
+
+    /// Saves shipment info and dismisses the view on success
+    private func saveShipmentInfoAndDismiss() {
+        Task {
+            do {
+                try await viewModel.saveShipmentInfo()
+                onShipmentUpdate(viewModel.shipments)
+                dismiss()
+            } catch {
+                // Error is handled by the ViewModel.
+            }
+        }
+    }
 }
 
 private struct MessageSnackBar<IconContent: View>: View {
@@ -459,6 +475,24 @@ fileprivate extension WooShippingSplitShipmentsView {
                 "wooShippingSplitShipmentsDetailView.purchasedShipment.subtitle",
                 value: "You can't move products into or out of it.",
                 comment: "Subtitle label displayed on a shipment whose label is purchased in the shipping label creation flow."
+            )
+        }
+
+        enum SaveShipmentError {
+            static let title = NSLocalizedString(
+                "wooShipping.createLabels.splitShipment.saveShipmentError.title",
+                value: "Unable to save changes. Please try again.",
+                comment: "Title of the error alert when saving split shipment changes fails"
+            )
+            static let retry = NSLocalizedString(
+                "wooShipping.createLabels.splitShipment.saveShipmentError.retry",
+                value: "Retry",
+                comment: "Retry button title on the error alert when saving split shipment changes fails"
+            )
+            static let cancel = NSLocalizedString(
+                "wooShipping.createLabels.splitShipment.saveShipmentError.cancel",
+                value: "Cancel",
+                comment: "Cancel button title on the error alert when saving split shipment changes fails"
             )
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -103,6 +103,9 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
 
     @Published private(set) var isSavingShipmentInfo = false
 
+    /// Whether to show the error alert for saving shipment info
+    @Published var shouldShowSaveShipmentErrorAlert = false
+
     init(order: Order,
          config: WooShippingConfig?,
          items: [ShippingLabelPackageItem],
@@ -294,8 +297,16 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
     @MainActor
     func saveShipmentInfo() async throws {
         isSavingShipmentInfo = true
-        try await updateShipment()
-        isSavingShipmentInfo = false
+        defer {
+            isSavingShipmentInfo = false
+        }
+
+        do {
+            try await updateShipment()
+        } catch {
+            shouldShowSaveShipmentErrorAlert = true
+            throw error
+        }
     }
 
     func mergeAllUnfulfilledShipments() {


### PR DESCRIPTION
## Add error handling for split shipments save operation

WOOMOB-583

## Description

Adds proper error handling to the split shipments screen when users save their shipment configurations. Previously, when the "Done" button was pressed and the API request failed, there was no user feedback - the loading state would disappear but users wouldn't know the operation failed.

**What this PR does:**
- Adds `@Published var shouldShowSaveShipmentErrorAlert` to control error alert visibility
- Implements proper error handling in `saveShipmentInfo()` with user-friendly error messaging
- Shows a SwiftUI alert with "Unable to save changes. Please try again." message
- Provides Retry and Cancel options for users
- Refactors duplicate save logic into reusable `saveShipmentInfoAndDismiss()` method
- Uses `defer` pattern for proper cleanup of loading state
- Uses existing global localized strings for Retry/Cancel buttons to maintain consistency

## Steps to reproduce

1. Navigate to an order with shipping labels
2. Tap "Create shipping labels" 
3. Proceed to the split shipments screen
4. Make changes to shipment configurations
5. **To test error handling:** Disconnect from internet or simulate network failure
6. Tap "Done" button
7. Verify error alert appears with appropriate message and Retry/Cancel options
8. **To test retry:** Restore internet connection and tap "Retry" - should successfully save and dismiss
9. **To test cancel:** Tap "Cancel" - should dismiss alert and remain on screen

## Screenshots

![Снимок экрана 2025-06-11 в 15 11 34](https://github.com/user-attachments/assets/4daca1fe-4f19-4c54-9b33-3186c1173392)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.