### PR TITLE
[Woo POS] [Barcodes] Throw errors for invalid product use cases 

### DIFF
--- a/Networking/NetworkingTests/Responses/pos-products.json
+++ b/Networking/NetworkingTests/Responses/pos-products.json
@@ -15,7 +15,7 @@
             "manage_stock": true,
             "stock_quantity": 10,
             "stock_status": "instock",
-            "downloadable": true,
+            "downloadable": false,
             "parent_id": 0
         }
     ]

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -183,6 +183,7 @@ extension PointOfSaleAggregateModel {
                 let item = try await barcodeScanService.getItem(barcode: barcode)
                 cart.updateLoadingItem(id: placeholderItemID, with: item)
             } catch {
+                DDLogInfo("Failed to scan barcode: \(error)")
                 cart.removeItem(id: placeholderItemID)
             }
         }

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -19,6 +19,7 @@ import struct Yosemite.POSProductVariation
 import protocol Yosemite.POSSearchHistoryProviding
 import enum Yosemite.POSItemType
 import protocol Yosemite.PointOfSaleBarcodeScanServiceProtocol
+import enum Yosemite.PointOfSaleBarcodeScanError
 import Combine
 
 // MARK: - PreviewProvider helpers
@@ -233,7 +234,7 @@ struct POSPreviewHelpers {
 
 // MARK: - Barcode Scan Service
 final class PointOfSalePreviewBarcodeScanService: PointOfSaleBarcodeScanServiceProtocol {
-    func getItem(barcode: String) async throws -> POSItem {
+    func getItem(barcode: String) async throws(PointOfSaleBarcodeScanError) -> POSItem {
         return mockSimpleProductItem(id: 5, price: "35.50")
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleBarcodeScanService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleBarcodeScanService.swift
@@ -2,7 +2,7 @@ import Foundation
 import Yosemite
 
 struct MockPointOfSaleBarcodeScanService: PointOfSaleBarcodeScanServiceProtocol {
-    func getItem(barcode: String) async throws -> POSItem {
+    func getItem(barcode: String) async throws(PointOfSaleBarcodeScanError) -> POSItem {
         return .simpleProduct(POSSimpleProduct(
             id: UUID(),
             name: "Scanned Item",

--- a/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
@@ -17,7 +17,7 @@ struct POSProductOrVariationResolver {
         let items: [POSItem]
 
         guard productOrVariation.downloadable == false else {
-            throw PointOfSaleBarcodeScanError.downloadableProduct
+            throw .downloadableProduct
         }
 
         switch productOrVariation.productType {
@@ -29,18 +29,18 @@ struct POSProductOrVariationResolver {
             let variableProduct = try await parentProductForVariation(variation)
             items = itemMapper.mapVariationsToPOSItems(variations: [variation], parentProduct: variableProduct)
         default:
-            throw PointOfSaleBarcodeScanError.unsupportedProductType
+            throw .unsupportedProductType
         }
 
         guard let item = items.first else {
-            throw PointOfSaleBarcodeScanError.unknown
+            throw .unknown
         }
         return item
     }
 
     private func parentProductForVariation(_ variation: POSProductVariation) async throws(PointOfSaleBarcodeScanError) -> POSVariableParentProduct {
         guard variation.productID != 0 else {
-            throw PointOfSaleBarcodeScanError.noParentProductForVariation
+            throw .noParentProductForVariation
         }
 
         let parentProduct = try await loadParentProduct(variation)
@@ -48,7 +48,7 @@ struct POSProductOrVariationResolver {
 
         guard let mappedProduct = mappedProducts.first,
               case .variableParentProduct(let variableProduct) = mappedProduct else {
-            throw PointOfSaleBarcodeScanError.variationCouldNotBeConverted
+            throw .variationCouldNotBeConverted
         }
         return variableProduct
     }

--- a/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
@@ -13,11 +13,11 @@ struct POSProductOrVariationResolver {
         self.itemMapper = itemMapper ?? PointOfSaleItemMapper(currencySettings: currencySettings)
     }
 
-    func itemForProductOrVariation(_ productOrVariation: POSProduct) async throws(PointOfSaleBarcodeScanError) -> POSItem {
+    func itemForProductOrVariation(_ productOrVariation: POSProduct, scannedCode: String) async throws(PointOfSaleBarcodeScanError) -> POSItem {
         let items: [POSItem]
 
         guard productOrVariation.downloadable == false else {
-            throw .downloadableProduct
+            throw .downloadableProduct(scannedCode: scannedCode, productName: productOrVariation.name)
         }
 
         switch productOrVariation.productType {
@@ -25,47 +25,47 @@ struct POSProductOrVariationResolver {
             let product = productOrVariation
             items = itemMapper.mapProductsToPOSItems(products: [product])
         case .custom("variation"):
-            let variation = try productOrVariation.toProductVariation()
-            let variableProduct = try await parentProductForVariation(variation)
+            let variation = try productOrVariation.toProductVariation(scannedCode: scannedCode)
+            let variableProduct = try await parentProductForVariation(variation, scannedCode: scannedCode)
             items = itemMapper.mapVariationsToPOSItems(variations: [variation], parentProduct: variableProduct)
         default:
-            throw .unsupportedProductType
+            throw .unsupportedProductType(scannedCode: scannedCode, productName: productOrVariation.name)
         }
 
         guard let item = items.first else {
-            throw .unknown
+            throw .unknown(scannedCode: scannedCode)
         }
         return item
     }
 
-    private func parentProductForVariation(_ variation: POSProductVariation) async throws(PointOfSaleBarcodeScanError) -> POSVariableParentProduct {
+    private func parentProductForVariation(_ variation: POSProductVariation, scannedCode: String) async throws(PointOfSaleBarcodeScanError) -> POSVariableParentProduct {
         guard variation.productID != 0 else {
-            throw .noParentProductForVariation
+            throw .noParentProductForVariation(scannedCode: scannedCode)
         }
 
-        let parentProduct = try await loadParentProduct(variation)
+        let parentProduct = try await loadParentProduct(variation, scannedCode: scannedCode)
         let mappedProducts = itemMapper.mapProductsToPOSItems(products: [parentProduct])
 
         guard let mappedProduct = mappedProducts.first,
               case .variableParentProduct(let variableProduct) = mappedProduct else {
-            throw .variationCouldNotBeConverted
+            throw .variationCouldNotBeConverted(scannedCode: scannedCode)
         }
         return variableProduct
     }
 
-    private func loadParentProduct(_ variation: POSProductVariation) async throws(PointOfSaleBarcodeScanError) -> POSProduct {
+    private func loadParentProduct(_ variation: POSProductVariation, scannedCode: String) async throws(PointOfSaleBarcodeScanError) -> POSProduct {
         do {
             return try await productsRemote.loadPOSProduct(for: variation.siteID,
                                                            productID: variation.productID)
         } catch {
-            throw .loadingError(underlyingError: error)
+            throw .loadingError(scannedCode: scannedCode, underlyingError: error)
         }
     }
 }
 
 
 private extension POSProduct {
-    func toProductVariation() throws(PointOfSaleBarcodeScanError) -> POSProductVariation {
+    func toProductVariation(scannedCode: String) throws(PointOfSaleBarcodeScanError) -> POSProductVariation {
         do {
             return POSProductVariation(
                 siteID: siteID,
@@ -85,7 +85,7 @@ private extension POSProduct {
                 stockStatusKey: stockStatusKey
             )
         } catch {
-            throw .mappingError(underlyingError: error)
+            throw .mappingError(scannedCode: scannedCode, underlyingError: error)
         }
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
@@ -30,7 +30,9 @@ struct POSProductOrVariationResolver {
             let variableProduct = try await parentProductForVariation(variation, scannedCode: scannedCode)
             items = itemMapper.mapVariationsToPOSItems(variations: [variation], parentProduct: variableProduct)
         default:
-            throw .unsupportedProductType(scannedCode: scannedCode, productName: productOrVariation.name)
+            throw .unsupportedProductType(scannedCode: scannedCode,
+                                          productName: productOrVariation.name,
+                                          productType: productOrVariation.productType)
         }
 
         guard let item = items.first else {

--- a/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
@@ -13,8 +13,13 @@ struct POSProductOrVariationResolver {
         self.itemMapper = itemMapper ?? PointOfSaleItemMapper(currencySettings: currencySettings)
     }
 
-    func itemForProductOrVariation(_ productOrVariation: POSProduct) async throws -> POSItem {
+    func itemForProductOrVariation(_ productOrVariation: POSProduct) async throws(PointOfSaleBarcodeScanError) -> POSItem {
         let items: [POSItem]
+
+        guard productOrVariation.downloadable == false else {
+            throw PointOfSaleBarcodeScanError.downloadableProduct
+        }
+
         switch productOrVariation.productType {
         case .simple:
             let product = productOrVariation
@@ -24,7 +29,7 @@ struct POSProductOrVariationResolver {
             let variableProduct = try await parentProductForVariation(variation)
             items = itemMapper.mapVariationsToPOSItems(variations: [variation], parentProduct: variableProduct)
         default:
-            throw PointOfSaleBarcodeScanError.unknown
+            throw PointOfSaleBarcodeScanError.unsupportedProductType
         }
 
         guard let item = items.first else {
@@ -33,13 +38,12 @@ struct POSProductOrVariationResolver {
         return item
     }
 
-    private func parentProductForVariation(_ variation: POSProductVariation) async throws -> POSVariableParentProduct {
+    private func parentProductForVariation(_ variation: POSProductVariation) async throws(PointOfSaleBarcodeScanError) -> POSVariableParentProduct {
         guard variation.productID != 0 else {
             throw PointOfSaleBarcodeScanError.noParentProductForVariation
         }
 
-        let parentProduct = try await productsRemote.loadPOSProduct(for: variation.siteID,
-                                                                     productID: variation.productID)
+        let parentProduct = try await loadParentProduct(variation)
         let mappedProducts = itemMapper.mapProductsToPOSItems(products: [parentProduct])
 
         guard let mappedProduct = mappedProducts.first,
@@ -48,26 +52,40 @@ struct POSProductOrVariationResolver {
         }
         return variableProduct
     }
+
+    private func loadParentProduct(_ variation: POSProductVariation) async throws(PointOfSaleBarcodeScanError) -> POSProduct {
+        do {
+            return try await productsRemote.loadPOSProduct(for: variation.siteID,
+                                                           productID: variation.productID)
+        } catch {
+            throw .loadingError(underlyingError: error)
+        }
+    }
 }
 
 
 private extension POSProduct {
-    func toProductVariation() throws -> POSProductVariation {
-        POSProductVariation(
-            siteID: siteID,
-            productID: parentID,
-            productVariationID: productID,
-            attributes: try attributes.compactMap { try $0.toProductVariationAttribute() },
-            image: images.first,
-            sku: sku,
-            globalUniqueID: globalUniqueID,
-            price: price,
-            regularPrice: regularPrice,
-            salePrice: salePrice,
-            onSale: onSale,
-            downloadable: downloadable,
-            manageStock: manageStock,
-            stockQuantity: stockQuantity,
-            stockStatusKey: stockStatusKey)
+    func toProductVariation() throws(PointOfSaleBarcodeScanError) -> POSProductVariation {
+        do {
+            return POSProductVariation(
+                siteID: siteID,
+                productID: parentID,
+                productVariationID: productID,
+                attributes: try attributes.compactMap { try $0.toProductVariationAttribute() },
+                image: images.first,
+                sku: sku,
+                globalUniqueID: globalUniqueID,
+                price: price,
+                regularPrice: regularPrice,
+                salePrice: salePrice,
+                onSale: onSale,
+                downloadable: downloadable,
+                manageStock: manageStock,
+                stockQuantity: stockQuantity,
+                stockStatusKey: stockStatusKey
+            )
+        } catch {
+            throw .mappingError(underlyingError: error)
+        }
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
@@ -63,7 +63,12 @@ struct POSProductOrVariationResolver {
             return try await productsRemote.loadPOSProduct(for: variation.siteID,
                                                            productID: variation.productID)
         } catch {
-            throw .loadingError(scannedCode: scannedCode, underlyingError: error)
+            switch ProductLoadError(underlyingError: error) {
+            case .notFound:
+                throw .notFound(scannedCode: scannedCode)
+            default:
+                throw .loadingError(scannedCode: scannedCode, underlyingError: error)
+            }
         }
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
@@ -13,7 +13,8 @@ struct POSProductOrVariationResolver {
         self.itemMapper = itemMapper ?? PointOfSaleItemMapper(currencySettings: currencySettings)
     }
 
-    func itemForProductOrVariation(_ productOrVariation: POSProduct, scannedCode: String) async throws(PointOfSaleBarcodeScanError) -> POSItem {
+    func itemForProductOrVariation(_ productOrVariation: POSProduct,
+                                   scannedCode: String) async throws(PointOfSaleBarcodeScanError) -> POSItem {
         let items: [POSItem]
 
         guard productOrVariation.downloadable == false else {
@@ -38,7 +39,8 @@ struct POSProductOrVariationResolver {
         return item
     }
 
-    private func parentProductForVariation(_ variation: POSProductVariation, scannedCode: String) async throws(PointOfSaleBarcodeScanError) -> POSVariableParentProduct {
+    private func parentProductForVariation(_ variation: POSProductVariation,
+                                           scannedCode: String) async throws(PointOfSaleBarcodeScanError) -> POSVariableParentProduct {
         guard variation.productID != 0 else {
             throw .noParentProductForVariation(scannedCode: scannedCode)
         }
@@ -53,7 +55,8 @@ struct POSProductOrVariationResolver {
         return variableProduct
     }
 
-    private func loadParentProduct(_ variation: POSProductVariation, scannedCode: String) async throws(PointOfSaleBarcodeScanError) -> POSProduct {
+    private func loadParentProduct(_ variation: POSProductVariation,
+                                   scannedCode: String) async throws(PointOfSaleBarcodeScanError) -> POSProduct {
         do {
             return try await productsRemote.loadPOSProduct(for: variation.siteID,
                                                            productID: variation.productID)

--- a/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
@@ -9,31 +9,15 @@ public protocol PointOfSaleBarcodeScanServiceProtocol {
     func getItem(barcode: String) async throws(PointOfSaleBarcodeScanError) -> POSItem
 }
 
-public enum PointOfSaleBarcodeScanError: Error, Equatable {
-    case unknown
-    case noParentProductForVariation
-    case variationCouldNotBeConverted
-    case unsupportedProductType
-    case downloadableProduct
-    case notFound
-    case loadingError(underlyingError: Error)
-    case mappingError(underlyingError: Error)
-
-    public static func == (lhs: PointOfSaleBarcodeScanError, rhs: PointOfSaleBarcodeScanError) -> Bool {
-        switch (lhs, rhs) {
-        case (.unknown, .unknown),
-            (.noParentProductForVariation, .noParentProductForVariation),
-            (.variationCouldNotBeConverted, .variationCouldNotBeConverted),
-            (.unsupportedProductType, .unsupportedProductType),
-            (.downloadableProduct, .downloadableProduct),
-            (.notFound, .notFound),
-            (.loadingError, .loadingError),
-            (.mappingError, .mappingError):
-            return true
-        default:
-            return false
-        }
-    }
+public enum PointOfSaleBarcodeScanError: Error {
+    case unknown(scannedCode: String)
+    case noParentProductForVariation(scannedCode: String)
+    case variationCouldNotBeConverted(scannedCode: String)
+    case unsupportedProductType(scannedCode: String, productName: String)
+    case downloadableProduct(scannedCode: String, productName: String)
+    case notFound(scannedCode: String)
+    case loadingError(scannedCode: String, underlyingError: Error)
+    case mappingError(scannedCode: String, underlyingError: Error)
 }
 
 /// Service for handling barcode scanning in Point of Sale
@@ -65,7 +49,7 @@ public final class PointOfSaleBarcodeScanService: PointOfSaleBarcodeScanServiceP
     /// - Returns: A POSItem if found, or throws an error
     public func getItem(barcode: String) async throws(PointOfSaleBarcodeScanError) -> POSItem {
         let productOrVariation = try await loadPOSProduct(barcode: barcode)
-        return try await itemResolver.itemForProductOrVariation(productOrVariation)
+        return try await itemResolver.itemForProductOrVariation(productOrVariation, scannedCode: barcode)
     }
 
     private func loadPOSProduct(barcode: String) async throws(PointOfSaleBarcodeScanError) -> POSProduct {
@@ -73,9 +57,9 @@ public final class PointOfSaleBarcodeScanService: PointOfSaleBarcodeScanServiceP
             return try await productsRemote.loadPOSProductByGlobalUniqueIdentifier(for: siteID,
                                                                                    globalUniqueID: barcode)
         } catch NetworkError.notFound {
-            throw .notFound
+            throw .notFound(scannedCode: barcode)
         } catch {
-            throw .loadingError(underlyingError: error)
+            throw .loadingError(scannedCode: barcode, underlyingError: error)
         }
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
@@ -12,6 +12,25 @@ public enum PointOfSaleBarcodeScanError: Error, Equatable {
     case unknown
     case noParentProductForVariation
     case variationCouldNotBeConverted
+    case unsupportedProductType
+    case downloadableProduct
+    case loadingError(underlyingError: Error)
+    case mappingError(underlyingError: Error)
+
+    public static func == (lhs: PointOfSaleBarcodeScanError, rhs: PointOfSaleBarcodeScanError) -> Bool {
+        switch (lhs, rhs) {
+        case (.unknown, .unknown),
+             (.noParentProductForVariation, .noParentProductForVariation),
+             (.variationCouldNotBeConverted, .variationCouldNotBeConverted),
+             (.unsupportedProductType, .unsupportedProductType),
+             (.downloadableProduct, .downloadableProduct),
+             (.loadingError, .loadingError),
+             (.mappingError, .mappingError):
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 /// Service for handling barcode scanning in Point of Sale

--- a/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
@@ -13,7 +13,7 @@ public enum PointOfSaleBarcodeScanError: Error {
     case unknown(scannedCode: String)
     case noParentProductForVariation(scannedCode: String)
     case variationCouldNotBeConverted(scannedCode: String)
-    case unsupportedProductType(scannedCode: String, productName: String)
+    case unsupportedProductType(scannedCode: String, productName: String, productType: ProductType)
     case downloadableProduct(scannedCode: String, productName: String)
     case notFound(scannedCode: String)
     case loadingError(scannedCode: String, underlyingError: Error)

--- a/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
@@ -3,9 +3,10 @@ import protocol Networking.ProductsRemoteProtocol
 import class Networking.ProductsRemote
 import class WooFoundation.CurrencySettings
 import class Networking.AlamofireNetwork
+import enum Networking.NetworkError
 
 public protocol PointOfSaleBarcodeScanServiceProtocol {
-    func getItem(barcode: String) async throws -> POSItem
+    func getItem(barcode: String) async throws(PointOfSaleBarcodeScanError) -> POSItem
 }
 
 public enum PointOfSaleBarcodeScanError: Error, Equatable {
@@ -14,18 +15,20 @@ public enum PointOfSaleBarcodeScanError: Error, Equatable {
     case variationCouldNotBeConverted
     case unsupportedProductType
     case downloadableProduct
+    case notFound
     case loadingError(underlyingError: Error)
     case mappingError(underlyingError: Error)
 
     public static func == (lhs: PointOfSaleBarcodeScanError, rhs: PointOfSaleBarcodeScanError) -> Bool {
         switch (lhs, rhs) {
         case (.unknown, .unknown),
-             (.noParentProductForVariation, .noParentProductForVariation),
-             (.variationCouldNotBeConverted, .variationCouldNotBeConverted),
-             (.unsupportedProductType, .unsupportedProductType),
-             (.downloadableProduct, .downloadableProduct),
-             (.loadingError, .loadingError),
-             (.mappingError, .mappingError):
+            (.noParentProductForVariation, .noParentProductForVariation),
+            (.variationCouldNotBeConverted, .variationCouldNotBeConverted),
+            (.unsupportedProductType, .unsupportedProductType),
+            (.downloadableProduct, .downloadableProduct),
+            (.notFound, .notFound),
+            (.loadingError, .loadingError),
+            (.mappingError, .mappingError):
             return true
         default:
             return false
@@ -60,13 +63,19 @@ public final class PointOfSaleBarcodeScanService: PointOfSaleBarcodeScanServiceP
     /// Looks up a POSItem using a barcode scan string
     /// - Parameter barcode: The barcode string from a scan (global unique identifier)
     /// - Returns: A POSItem if found, or throws an error
-    public func getItem(barcode: String) async throws -> POSItem {
+    public func getItem(barcode: String) async throws(PointOfSaleBarcodeScanError) -> POSItem {
+        let productOrVariation = try await loadPOSProduct(barcode: barcode)
+        return try await itemResolver.itemForProductOrVariation(productOrVariation)
+    }
+
+    private func loadPOSProduct(barcode: String) async throws(PointOfSaleBarcodeScanError) -> POSProduct {
         do {
-            let productOrVariation = try await productsRemote.loadPOSProductByGlobalUniqueIdentifier(for: siteID,
-                                                                                                      globalUniqueID: barcode)
-            return try await itemResolver.itemForProductOrVariation(productOrVariation)
+            return try await productsRemote.loadPOSProductByGlobalUniqueIdentifier(for: siteID,
+                                                                                   globalUniqueID: barcode)
+        } catch NetworkError.notFound {
+            throw .notFound
         } catch {
-            throw PointOfSaleBarcodeScanError.unknown
+            throw .loadingError(underlyingError: error)
         }
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
@@ -7,16 +7,14 @@ public protocol PointOfSalePurchasableItemFetchStrategy {
     func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation>
 }
 
-extension PointOfSalePurchasableItemFetchStrategy {
-    var productTypes: [ProductType] { [.simple, .variable] }
-}
-
 public struct PointOfSaleDefaultPurchasableItemFetchStrategy: PointOfSalePurchasableItemFetchStrategy {
     private let siteID: Int64
 
     private let productsRemote: ProductsRemoteProtocol
     private let variationsRemote: ProductVariationsRemoteProtocol
     private let analytics: POSItemFetchAnalyticsTracking
+
+    static var defaultProductTypes: [ProductType] { [.simple, .variable] }
 
     init(siteID: Int64,
          productsRemote: ProductsRemoteProtocol,
@@ -29,9 +27,11 @@ public struct PointOfSaleDefaultPurchasableItemFetchStrategy: PointOfSalePurchas
     }
 
     public func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct> {
-        let pagedProducts = try await productsRemote.loadProductsForPointOfSale(for: siteID,
-                                                                                productTypes: productTypes,
-                                                                                pageNumber: pageNumber)
+        let pagedProducts = try await productsRemote.loadProductsForPointOfSale(
+            for: siteID,
+            productTypes: PointOfSaleDefaultPurchasableItemFetchStrategy.defaultProductTypes,
+            pageNumber: pageNumber
+        )
 
         if pageNumber == 1 {
             analytics.trackItemsFetchComplete(totalItems: pagedProducts.totalItems ?? 0)
@@ -71,10 +71,12 @@ public struct PointOfSaleSearchPurchasableItemFetchStrategy: PointOfSalePurchasa
 
     public func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct> {
         let startTime = Date()
-        let pagedProducts = try await productsRemote.searchProductsForPointOfSale(for: siteID,
-                                                                                  query: searchTerm,
-                                                                                  productTypes: productTypes,
-                                                                                  pageNumber: pageNumber)
+        let pagedProducts = try await productsRemote.searchProductsForPointOfSale(
+            for: siteID,
+            query: searchTerm,
+            productTypes: PointOfSaleDefaultPurchasableItemFetchStrategy.defaultProductTypes,
+            pageNumber: pageNumber
+        )
         if pageNumber == 1 {
             let milliseconds = Int(Date().timeIntervalSince(startTime) * Double(MSEC_PER_SEC))
             analytics.trackSearchRemoteResultsFetchComplete(millisecondsSinceRequestSent: milliseconds,
@@ -108,10 +110,12 @@ public struct PointOfSalePopularPurchasableItemFetchStrategy: PointOfSalePurchas
     }
 
     public func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct> {
-        let receivedItems = try await productsRemote.loadPopularProductsForPointOfSale(for: siteID,
-                                                                                       productTypes: productTypes,
-                                                                                       pageNumber: pageNumber,
-                                                                                       perPage: pageSize)
+        let receivedItems = try await productsRemote.loadPopularProductsForPointOfSale(
+            for: siteID,
+            productTypes: PointOfSaleDefaultPurchasableItemFetchStrategy.defaultProductTypes,
+            pageNumber: pageNumber,
+            perPage: pageSize
+        )
         let modifiedItems = PagedItems<POSProduct>(items: receivedItems.items,
                                                    hasMorePages: false,
                                                    totalItems: receivedItems.totalItems)

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import WooFoundation
 @testable import Yosemite
+@testable import Networking
 
 struct POSProductOrVariationResolverTests {
     private var mockProductsRemote: MockProductsRemote!
@@ -13,8 +14,8 @@ struct POSProductOrVariationResolverTests {
         mockItemMapper = MockPointOfSaleItemMapper()
         currencySettings = CurrencySettings()
         sut = POSProductOrVariationResolver(productsRemote: mockProductsRemote,
-                                          currencySettings: currencySettings,
-                                          itemMapper: mockItemMapper)
+                                            currencySettings: currencySettings,
+                                            itemMapper: mockItemMapper)
     }
 
     @Test("Resolves simple product correctly")
@@ -101,7 +102,7 @@ struct POSProductOrVariationResolverTests {
     }
 
     @Test("Throws error for downloadable product")
-    func testThrowsErrorForDownloadableProduct() async {
+    func testThrowsErrorForDownloadableProduct() async throws {
         // Given
         let downloadableProduct = POSProduct.fake().copy(
             productID: 321,
@@ -115,6 +116,8 @@ struct POSProductOrVariationResolverTests {
         await #expect(throws: PointOfSaleBarcodeScanError.downloadableProduct(scannedCode: scannedCode, productName: productName)) {
             _ = try await sut.itemForProductOrVariation(downloadableProduct, scannedCode: scannedCode)
         }
+
+        try await #expect(queryParametersForProductsRequest().contains("downloadable=false"))
     }
 
 
@@ -135,7 +138,7 @@ struct POSProductOrVariationResolverTests {
     }
 
     @Test("Throws error for unsupported product type")
-    func testThrowsErrorForUnsupportedProductType() async {
+    func testThrowsErrorForUnsupportedProductType() async throws {
         // Given
         let unsupportedProduct = POSProduct.fake().copy(
             productID: 789,
@@ -148,6 +151,7 @@ struct POSProductOrVariationResolverTests {
         await #expect(throws: PointOfSaleBarcodeScanError.unsupportedProductType(scannedCode: scannedCode, productName: productName)) {
             _ = try await sut.itemForProductOrVariation(unsupportedProduct, scannedCode: scannedCode)
         }
+        try await #expect(queryParametersForProductsRequest().contains("include_types=simple,variable"))
     }
 
     @Test("Throws loadingError when parent product loading fails")
@@ -225,6 +229,22 @@ struct POSProductOrVariationResolverTests {
         await #expect(throws: PointOfSaleBarcodeScanError.variationCouldNotBeConverted(scannedCode: scannedCode)) {
             _ = try await sut.itemForProductOrVariation(variation, scannedCode: scannedCode)
         }
+    }
+}
+
+// MARK: - Helpers
+
+private extension POSProductOrVariationResolverTests {
+    /// Verify that the query parameters for the POS products request include the expected parameter and match resolver logic.
+    func queryParametersForProductsRequest() async throws -> [String] {
+        let network = MockNetwork()
+        let remote = ProductsRemote(network: network)
+        _ = try? await remote.loadProductsForPointOfSale(
+            for: 1,
+            productTypes: PointOfSaleDefaultPurchasableItemFetchStrategy.defaultProductTypes,
+            pageNumber: 1
+        )
+        return network.queryParameters ?? []
     }
 }
 

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
@@ -153,8 +153,8 @@ struct POSProductOrVariationResolverTests {
         try await #expect(queryParametersForProductsRequest().contains("include_types=simple,variable"))
     }
 
-    @Test("Throws loadingError when parent product loading fails")
-    func testThrowsLoadingErrorWhenParentProductFails() async {
+    @Test("Throws notFound or loadingError when parent product loading fails")
+    func testThrowsErrorWhenParentProductFails() async {
         // Given
         let variation = POSProduct.fake().copy(
             productID: 456,
@@ -163,9 +163,16 @@ struct POSProductOrVariationResolverTests {
         )
         let scannedCode = "test-barcode-loading"
         let someError = NSError(domain: "Test", code: 1, userInfo: nil)
-        mockProductsRemote.whenLoadingProductForPointOfSale(siteID: variation.siteID, productID: variation.parentID, thenReturn: .failure(someError))
+        let dotcomNotFoundError = DotcomError.unknown(code: "woocommerce_rest_product_invalid_id", message: "Not found")
 
-        // When/Then
+        // NotFound case (simulate DotcomError for not found)
+        mockProductsRemote.whenLoadingProductForPointOfSale(siteID: variation.siteID, productID: variation.parentID, thenReturn: .failure(dotcomNotFoundError))
+        await #expect(throws: PointOfSaleBarcodeScanError.notFound(scannedCode: scannedCode)) {
+            _ = try await sut.itemForProductOrVariation(variation, scannedCode: scannedCode)
+        }
+
+        // LoadingError case
+        mockProductsRemote.whenLoadingProductForPointOfSale(siteID: variation.siteID, productID: variation.parentID, thenReturn: .failure(someError))
         await #expect(throws: PointOfSaleBarcodeScanError.loadingError(scannedCode: scannedCode, underlyingError: someError)) {
             _ = try await sut.itemForProductOrVariation(variation, scannedCode: scannedCode)
         }

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
@@ -98,17 +98,82 @@ struct POSProductOrVariationResolverTests {
         #expect(result == expectedVariationItem)
     }
 
-    @Test("Throws error for unknown product type")
-    func testThrowsErrorForUnknownProductType() async {
+    @Test("Throws error for downloadable product")
+    func testThrowsErrorForDownloadableProduct() async {
         // Given
-        let unknownProduct = POSProduct.fake().copy(
+        let downloadableProduct = POSProduct.fake().copy(
+            productID: 321,
+            productTypeKey: "simple",
+            downloadable: true
+        )
+
+        // When/Then
+        await #expect(throws: PointOfSaleBarcodeScanError.downloadableProduct) {
+            _ = try await sut.itemForProductOrVariation(downloadableProduct)
+        }
+    }
+
+
+    @Test("Throws error for unknown product type (no mapped item)")
+    func testThrowsErrorForUnknownProductTypeNoMappedItem() async {
+        // Given
+        let simpleProduct = POSProduct.fake().copy(
+            productID: 999,
+            productTypeKey: "simple"
+        )
+        mockItemMapper.mockMappedProducts = [] // Simulate no mapped item
+
+        // When/Then
+        await #expect(throws: PointOfSaleBarcodeScanError.unknown) {
+            _ = try await sut.itemForProductOrVariation(simpleProduct)
+        }
+    }
+
+    @Test("Throws error for unsupported product type")
+    func testThrowsErrorForUnsupportedProductType() async {
+        // Given
+        let unsupportedProduct = POSProduct.fake().copy(
             productID: 789,
             productTypeKey: "grouped"
         )
 
         // When/Then
-        await #expect(throws: PointOfSaleBarcodeScanError.unknown) {
-            _ = try await sut.itemForProductOrVariation(unknownProduct)
+        await #expect(throws: PointOfSaleBarcodeScanError.unsupportedProductType) {
+            _ = try await sut.itemForProductOrVariation(unsupportedProduct)
+        }
+    }
+
+    @Test("Throws loadingError when parent product loading fails")
+    func testThrowsLoadingErrorWhenParentProductFails() async {
+        // Given
+        let variation = POSProduct.fake().copy(
+            productID: 456,
+            productTypeKey: "variation",
+            parentID: 123
+        )
+        let someError = NSError(domain: "Test", code: 1, userInfo: nil)
+        mockProductsRemote.whenLoadingProductForPointOfSale(siteID: variation.siteID, productID: variation.parentID, thenReturn: .failure(someError))
+
+        // When/Then
+        await #expect(throws: PointOfSaleBarcodeScanError.loadingError(underlyingError: someError)) {
+            _ = try await sut.itemForProductOrVariation(variation)
+        }
+    }
+
+    @Test("Throws mappingError when toProductVariation fails")
+    func testThrowsMappingErrorWhenToProductVariationFails() async {
+        // Given: attributes with empty options will cause toProductVariationAttribute to throw
+        let badAttribute = ProductAttribute(siteID: 1, attributeID: 1, name: "Bad", position: 0, visible: true, variation: true, options: [])
+        let variation = POSProduct.fake().copy(
+            productID: 456,
+            productTypeKey: "variation",
+            parentID: 123,
+            attributes: [badAttribute]
+        )
+
+        // When/Then
+        await #expect(throws: PointOfSaleBarcodeScanError.mappingError(underlyingError: ProductAttribute.ProductAttributeError.notFromAVariationAsAProduct)) {
+            _ = try await sut.itemForProductOrVariation(variation)
         }
     }
 

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
@@ -37,9 +37,10 @@ struct POSProductOrVariationResolverTests {
             stockStatusKey: ""
         ))
         mockItemMapper.mockMappedProducts = [expectedItem]
+        let scannedCode = "test-barcode-simple"
 
         // When
-        let result = try await sut.itemForProductOrVariation(simpleProduct)
+        let result = try await sut.itemForProductOrVariation(simpleProduct, scannedCode: scannedCode)
 
         // Then
         #expect(mockItemMapper.mapProductsToPOSItemsCalled)
@@ -80,13 +81,14 @@ struct POSProductOrVariationResolverTests {
             variationID: 456,
             parentProductName: "Parent Product"
         ))
+        let scannedCode = "test-barcode-variation"
 
         mockProductsRemote.whenLoadingProductForPointOfSale(siteID: variation.siteID, productID: variation.parentID, thenReturn: .success(parentProduct))
         mockItemMapper.mockMappedProducts = [expectedParentItem]
         mockItemMapper.mockMappedVariations = [expectedVariationItem]
 
         // When
-        let result = try await sut.itemForProductOrVariation(variation)
+        let result = try await sut.itemForProductOrVariation(variation, scannedCode: scannedCode)
 
         // Then
         #expect(mockProductsRemote.invocationCountOfLoadPOSProduct == 1)
@@ -106,10 +108,12 @@ struct POSProductOrVariationResolverTests {
             productTypeKey: "simple",
             downloadable: true
         )
+        let scannedCode = "test-barcode-downloadable"
+        let productName = downloadableProduct.name
 
         // When/Then
-        await #expect(throws: PointOfSaleBarcodeScanError.downloadableProduct) {
-            _ = try await sut.itemForProductOrVariation(downloadableProduct)
+        await #expect(throws: PointOfSaleBarcodeScanError.downloadableProduct(scannedCode: scannedCode, productName: productName)) {
+            _ = try await sut.itemForProductOrVariation(downloadableProduct, scannedCode: scannedCode)
         }
     }
 
@@ -121,11 +125,12 @@ struct POSProductOrVariationResolverTests {
             productID: 999,
             productTypeKey: "simple"
         )
+        let scannedCode = "test-barcode-unknown"
         mockItemMapper.mockMappedProducts = [] // Simulate no mapped item
 
         // When/Then
-        await #expect(throws: PointOfSaleBarcodeScanError.unknown) {
-            _ = try await sut.itemForProductOrVariation(simpleProduct)
+        await #expect(throws: PointOfSaleBarcodeScanError.unknown(scannedCode: scannedCode)) {
+            _ = try await sut.itemForProductOrVariation(simpleProduct, scannedCode: scannedCode)
         }
     }
 
@@ -136,10 +141,12 @@ struct POSProductOrVariationResolverTests {
             productID: 789,
             productTypeKey: "grouped"
         )
+        let scannedCode = "test-barcode-unsupported"
+        let productName = unsupportedProduct.name
 
         // When/Then
-        await #expect(throws: PointOfSaleBarcodeScanError.unsupportedProductType) {
-            _ = try await sut.itemForProductOrVariation(unsupportedProduct)
+        await #expect(throws: PointOfSaleBarcodeScanError.unsupportedProductType(scannedCode: scannedCode, productName: productName)) {
+            _ = try await sut.itemForProductOrVariation(unsupportedProduct, scannedCode: scannedCode)
         }
     }
 
@@ -151,12 +158,13 @@ struct POSProductOrVariationResolverTests {
             productTypeKey: "variation",
             parentID: 123
         )
+        let scannedCode = "test-barcode-loading"
         let someError = NSError(domain: "Test", code: 1, userInfo: nil)
         mockProductsRemote.whenLoadingProductForPointOfSale(siteID: variation.siteID, productID: variation.parentID, thenReturn: .failure(someError))
 
         // When/Then
-        await #expect(throws: PointOfSaleBarcodeScanError.loadingError(underlyingError: someError)) {
-            _ = try await sut.itemForProductOrVariation(variation)
+        await #expect(throws: PointOfSaleBarcodeScanError.loadingError(scannedCode: scannedCode, underlyingError: someError)) {
+            _ = try await sut.itemForProductOrVariation(variation, scannedCode: scannedCode)
         }
     }
 
@@ -170,10 +178,12 @@ struct POSProductOrVariationResolverTests {
             parentID: 123,
             attributes: [badAttribute]
         )
+        let scannedCode = "test-barcode-mapping"
+        let error = ProductAttribute.ProductAttributeError.notFromAVariationAsAProduct
 
         // When/Then
-        await #expect(throws: PointOfSaleBarcodeScanError.mappingError(underlyingError: ProductAttribute.ProductAttributeError.notFromAVariationAsAProduct)) {
-            _ = try await sut.itemForProductOrVariation(variation)
+        await #expect(throws: PointOfSaleBarcodeScanError.mappingError(scannedCode: scannedCode, underlyingError: error)) {
+            _ = try await sut.itemForProductOrVariation(variation, scannedCode: scannedCode)
         }
     }
 
@@ -185,10 +195,11 @@ struct POSProductOrVariationResolverTests {
             productTypeKey: "variation",
             parentID: 0 // Invalid parent ID for a variation
         )
+        let scannedCode = "test-barcode-noparent"
 
         // When/Then
-        await #expect(throws: PointOfSaleBarcodeScanError.noParentProductForVariation) {
-            _ = try await sut.itemForProductOrVariation(variation)
+        await #expect(throws: PointOfSaleBarcodeScanError.noParentProductForVariation(scannedCode: scannedCode)) {
+            _ = try await sut.itemForProductOrVariation(variation, scannedCode: scannedCode)
         }
     }
 
@@ -205,13 +216,41 @@ struct POSProductOrVariationResolverTests {
             name: "Parent Product",
             productTypeKey: "simple" // Wrong type for parent
         )
+        let scannedCode = "test-barcode-cannotconvert"
 
         mockProductsRemote.whenLoadingProductForPointOfSale(siteID: variation.siteID, productID: variation.parentID, thenReturn: .success(parentProduct))
         mockItemMapper.mockMappedProducts = []
 
         // When/Then
-        await #expect(throws: PointOfSaleBarcodeScanError.variationCouldNotBeConverted) {
-            _ = try await sut.itemForProductOrVariation(variation)
+        await #expect(throws: PointOfSaleBarcodeScanError.variationCouldNotBeConverted(scannedCode: scannedCode)) {
+            _ = try await sut.itemForProductOrVariation(variation, scannedCode: scannedCode)
+        }
+    }
+}
+
+// MARK: - PointOfSaleBarcodeScanError equatable for testing
+
+extension PointOfSaleBarcodeScanError: @retroactive Equatable {
+    public static func == (lhs: PointOfSaleBarcodeScanError, rhs: PointOfSaleBarcodeScanError) -> Bool {
+        switch (lhs, rhs) {
+        case let (.unknown(lhsScannedCode), .unknown(rhsScannedCode)):
+            return lhsScannedCode == rhsScannedCode
+        case let (.noParentProductForVariation(lhsScannedCode), .noParentProductForVariation(rhsScannedCode)):
+            return lhsScannedCode == rhsScannedCode
+        case let (.variationCouldNotBeConverted(lhsScannedCode), .variationCouldNotBeConverted(rhsScannedCode)):
+            return lhsScannedCode == rhsScannedCode
+        case let (.notFound(lhsScannedCode), .notFound(rhsScannedCode)):
+            return lhsScannedCode == rhsScannedCode
+        case let (.unsupportedProductType(lhsScannedCode, lhsProductName), .unsupportedProductType(rhsScannedCode, rhsProductName)):
+            return lhsScannedCode == rhsScannedCode && lhsProductName == rhsProductName
+        case let (.downloadableProduct(lhsScannedCode, lhsProductName), .downloadableProduct(rhsScannedCode, rhsProductName)):
+            return lhsScannedCode == rhsScannedCode && lhsProductName == rhsProductName
+        case let (.loadingError(lhsScannedCode, _), .loadingError(rhsScannedCode, _)):
+            return lhsScannedCode == rhsScannedCode
+        case let (.mappingError(lhsScannedCode, _), .mappingError(rhsScannedCode, _)):
+            return lhsScannedCode == rhsScannedCode
+        default:
+            return false
         }
     }
 }

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
@@ -101,6 +101,22 @@ struct POSProductOrVariationResolverTests {
         #expect(result == expectedVariationItem)
     }
 
+    @Test("Throws unknown error for product with no mapped items")
+     func testThrowsErrorForUnknownProductType() async {
+         // Given
+         let unknownProduct = POSProduct.fake().copy(
+            productID: 321,
+            productTypeKey: "simple"
+         )
+         mockItemMapper.mockMappedProducts = []
+         let scannedCode = "test-unknown"
+
+         // When/Then
+         await #expect(throws: PointOfSaleBarcodeScanError.unknown(scannedCode: scannedCode)) {
+             _ = try await sut.itemForProductOrVariation(unknownProduct, scannedCode: scannedCode)
+         }
+     }
+
     @Test("Throws error for downloadable product")
     func testThrowsErrorForDownloadableProduct() async throws {
         // Given
@@ -118,23 +134,6 @@ struct POSProductOrVariationResolverTests {
         }
 
         try await #expect(queryParametersForProductsRequest().contains("downloadable=false"))
-    }
-
-
-    @Test("Throws error for unknown product type (no mapped item)")
-    func testThrowsErrorForUnknownProductTypeNoMappedItem() async {
-        // Given
-        let simpleProduct = POSProduct.fake().copy(
-            productID: 999,
-            productTypeKey: "simple"
-        )
-        let scannedCode = "test-barcode-unknown"
-        mockItemMapper.mockMappedProducts = [] // Simulate no mapped item
-
-        // When/Then
-        await #expect(throws: PointOfSaleBarcodeScanError.unknown(scannedCode: scannedCode)) {
-            _ = try await sut.itemForProductOrVariation(simpleProduct, scannedCode: scannedCode)
-        }
     }
 
     @Test("Throws error for unsupported product type")

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
@@ -147,7 +147,7 @@ struct POSProductOrVariationResolverTests {
         let productName = unsupportedProduct.name
 
         // When/Then
-        await #expect(throws: PointOfSaleBarcodeScanError.unsupportedProductType(scannedCode: scannedCode, productName: productName)) {
+        await #expect(throws: PointOfSaleBarcodeScanError.unsupportedProductType(scannedCode: scannedCode, productName: productName, productType: .grouped)) {
             _ = try await sut.itemForProductOrVariation(unsupportedProduct, scannedCode: scannedCode)
         }
         try await #expect(queryParametersForProductsRequest().contains("include_types=simple,variable"))
@@ -260,7 +260,7 @@ extension PointOfSaleBarcodeScanError: @retroactive Equatable {
             return lhsScannedCode == rhsScannedCode
         case let (.notFound(lhsScannedCode), .notFound(rhsScannedCode)):
             return lhsScannedCode == rhsScannedCode
-        case let (.unsupportedProductType(lhsScannedCode, lhsProductName), .unsupportedProductType(rhsScannedCode, rhsProductName)):
+        case let (.unsupportedProductType(lhsScannedCode, lhsProductName, _), .unsupportedProductType(rhsScannedCode, rhsProductName, _)):
             return lhsScannedCode == rhsScannedCode && lhsProductName == rhsProductName
         case let (.downloadableProduct(lhsScannedCode, lhsProductName), .downloadableProduct(rhsScannedCode, rhsProductName)):
             return lhsScannedCode == rhsScannedCode && lhsProductName == rhsProductName

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleBarcodeScanServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleBarcodeScanServiceTests.swift
@@ -47,7 +47,7 @@ struct PointOfSaleBarcodeScanServiceTests {
         network.simulateError(requestUrlSuffix: "products", error: NetworkError.notFound())
 
         // When/Then
-        await #expect(throws: PointOfSaleBarcodeScanError.unknown) {
+        await #expect(throws: PointOfSaleBarcodeScanError.notFound) {
             _ = try await sut.getItem(barcode: barcode)
         }
     }

--- a/Yosemite/YosemiteTests/PointOfSale/PointOfSaleBarcodeScanServiceTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/PointOfSaleBarcodeScanServiceTests.swift
@@ -47,7 +47,7 @@ struct PointOfSaleBarcodeScanServiceTests {
         network.simulateError(requestUrlSuffix: "products", error: NetworkError.notFound())
 
         // When/Then
-        await #expect(throws: PointOfSaleBarcodeScanError.notFound) {
+        await #expect(throws: PointOfSaleBarcodeScanError.notFound(scannedCode: barcode)) {
             _ = try await sut.getItem(barcode: barcode)
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

WOOPRD-560
<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Throw additional errors from `POSProductOrVariationResolver` with scanned code and product name
- Put as much logic as possible within `POSProductOrVariationResolver` and make it work with a single error type, so the logic wouldn't duplicate between the scan service and the resolver
- Handle `.notFound` error within `PointOfSaleBarcodeScanService`
- Add additional expectations to `POSProductOrVariationResolver` to verify that its logic matches the parameters we pass to `ProductsRemote` when loading POS products

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisites:
- Create various types of products with GTIN: simple, variations, affiliate, subscriptions, downloadable, etc...
- Enable `pointOfSaleBarcodeScanningi1` feature flag

1. Launch POS
2. Tap on the scan icon
3. Try adding a non-downlodable simple product or a variation using a simulated scanner
4. Confirm that the item is added
5. Try to add unsupported product - affiliate, grouped, subscription... using a simulated scanner
6. Confirm that the item is not added
7. Confirm `Failed to scan barcode: unsupportedProductType(scannedCode: "6-6", productName: "Variable 3")` is logged
8. Try to add a downloadable product
9.  Confirm`Failed to scan barcode: downloadableProduct(scannedCode: "3-3", productName: "Downloadable")` is logged
10. Try to add a non-existent product
11. Confirm `Failed to scan barcode: notFound(scannedCode: "3-312312")` is logged

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air 18.4 Simulator

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.