### PR TITLE
Shipping Label: Enable feature flag for the revamped flow

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -80,7 +80,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .blazeEvergreenCampaigns:
             return true
         case .revampedShippingLabelCreation:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .blazeCampaignObjective:
             return true
         case .favoriteProducts:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Orders: Updated edit icons design to be consistent: [https://github.com/woocommerce/woocommerce-ios/pull/15685]
 - [internal] Reduced fields fetched for variations in Point of Sale [https://github.com/woocommerce/woocommerce-ios/pull/15712]
 - [*] Order List: Prevent last updated time being truncated at larger font sizes [https://github.com/woocommerce/woocommerce-ios/pull/15717]
+- [***] Creating shipping labels is now supported for stores with the WooCommerce Shipping extension [https://github.com/woocommerce/woocommerce-ios/pull/15738]
 
 22.5
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR enables the feature flag for the revamped shipping label creation flow to make it available in production builds starting version 22.6.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Ensure that the shipping label creation button is now available on the order details screen for paid orders of stores with the Woo Shipping plugin set up.

Feature announcement testing:
- If building the app with Xcode: change the app version to 22.6 before building.
- When the app launches, confirm that you see a feature announcement regarding label creation for stores with Woo Shipping.

For feature testing, follow the test plans:
- M2: pe5sF9-43S-p2
- M3: pe5sF9-457-p2
- M4: pe5sF9-4nk-p2

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested and confirmed with simulator iPhone 16 iOS 18.4.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Feature announcement:

<img src="https://github.com/user-attachments/assets/a2afcc6d-2eb4-4a84-b759-73486cf06b42" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
