### PR TITLE
[Woo POS][Barcodes] Handle error state after a barcode is scanned

### DIFF
--- a/WooCommerce/Classes/POS/Models/Cart+BarcodeScanError.swift
+++ b/WooCommerce/Classes/POS/Models/Cart+BarcodeScanError.swift
@@ -6,7 +6,7 @@ extension Cart {
         guard let index = purchasableItems.firstIndex(where: { $0.id == id }) else { return }
 
         purchasableItems[index] = Cart.PurchasableItem(
-            id: UUID(),
+            id: id,
             title: title(for: error),
             subtitle: subtitle(for: error),
             quantity: 1,

--- a/WooCommerce/Classes/POS/Models/Cart+BarcodeScanError.swift
+++ b/WooCommerce/Classes/POS/Models/Cart+BarcodeScanError.swift
@@ -1,0 +1,82 @@
+import Foundation
+import enum Yosemite.PointOfSaleBarcodeScanError
+
+extension Cart {
+    mutating func updateLoadingItem(id: UUID, with error: PointOfSaleBarcodeScanError) {
+        guard let index = purchasableItems.firstIndex(where: { $0.id == id }) else { return }
+
+        purchasableItems[index] = Cart.PurchasableItem(
+            id: UUID(),
+            title: title(for: error),
+            subtitle: subtitle(for: error),
+            quantity: 1,
+            state: .error
+        )
+    }
+
+    private func title(for error: PointOfSaleBarcodeScanError) -> String {
+        switch error {
+        case .unknown(let scannedCode),
+                .noParentProductForVariation(let scannedCode),
+                .variationCouldNotBeConverted(let scannedCode),
+                .notFound(let scannedCode),
+                .loadingError(let scannedCode, _),
+                .mappingError(let scannedCode, _):
+            return scannedCode
+        case .unsupportedProductType(_, let productName, _),
+                .downloadableProduct(_, let productName):
+            return productName
+        }
+    }
+
+    private func subtitle(for error: PointOfSaleBarcodeScanError) -> String {
+        switch error {
+        case .notFound, .unknown:
+            return Localization.notFound
+        case .downloadableProduct, .unsupportedProductType:
+            return Localization.unsupportedProductType
+        case .noParentProductForVariation, .variationCouldNotBeConverted:
+            return Localization.noParentProduct
+        case let .loadingError(_, underlyingError), let .mappingError(_, underlyingError):
+            if underlyingError.isConnectivityError {
+                return Localization.noInternetConnection
+            } else {
+                return Localization.networkRequestFailed
+            }
+        }
+    }
+}
+
+private extension Cart {
+    enum Localization {
+        static let notFound = NSLocalizedString(
+            "pointOfSale.barcodeScan.error.notFound",
+            value: "Unknown scanned item",
+            comment: "Error message shown when a scanned item is not found in the store."
+        )
+
+        static let unsupportedProductType = NSLocalizedString(
+            "pointOfSale.barcodeScan.error.unsupportedProductType",
+            value: "Unsupported item type",
+            comment: "Error message shown when a scanned item is of an unsupported type."
+        )
+
+        static let noInternetConnection = NSLocalizedString(
+            "pointOfSale.barcodeScan.error.noInternetConnection",
+            value: "No internet connection",
+            comment: "Error message shown when there is an internet connection error while scanning a barcode."
+        )
+
+        static let networkRequestFailed = NSLocalizedString(
+            "pointOfSale.barcodeScan.error.network",
+            value: "Network request failed",
+            comment: "Error message shown when there is an unknown networking error while scanning a barcode."
+        )
+
+        static let noParentProduct = NSLocalizedString(
+            "pointOfSale.barcodeScan.error.noParentProduct",
+            value: "Parent product not found for variation",
+            comment: "Error message shown when parent product is not found for a variation."
+        )
+    }
+}

--- a/WooCommerce/Classes/POS/Models/Cart.swift
+++ b/WooCommerce/Classes/POS/Models/Cart.swift
@@ -1,6 +1,7 @@
 import Foundation
 import protocol Yosemite.POSOrderableItem
 import enum Yosemite.POSItem
+import enum Yosemite.PointOfSaleBarcodeScanError
 
 struct Cart {
     var purchasableItems: [Cart.PurchasableItem] = []
@@ -29,6 +30,7 @@ extension Cart {
         enum ItemState {
             case loaded(POSOrderableItem)
             case loading
+            case error
 
             var isLoading: Bool {
                 switch self {

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -12,6 +12,7 @@ import enum Yosemite.SystemStatusAction
 import protocol Yosemite.POSSearchHistoryProviding
 import enum Yosemite.POSItemType
 import protocol Yosemite.PointOfSaleBarcodeScanServiceProtocol
+import enum Yosemite.PointOfSaleBarcodeScanError
 
 @available(iOS 17.0, *)
 protocol PointOfSaleAggregateModelProtocol {
@@ -183,12 +184,12 @@ extension PointOfSaleAggregateModel {
     func barcodeScanned(_ barcode: String) {
         Task {
             let placeholderItemID = cart.addLoadingItem()
-            do {
+            do throws(PointOfSaleBarcodeScanError) {
                 let item = try await barcodeScanService.getItem(barcode: barcode)
                 cart.updateLoadingItem(id: placeholderItemID, with: item)
             } catch {
-                DDLogInfo("Failed to scan barcode: \(error)")
-                cart.removeItem(id: placeholderItemID)
+                DDLogInfo("Failed to find item by barcode: \(error)")
+                cart.updateLoadingItem(id: placeholderItemID, with: error)
             }
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -24,7 +24,7 @@ struct ItemRowView: View {
 
     var body: some View {
         switch cartItem.state {
-        case .loaded:
+        case .loaded, .error:
             productRow
                 .frame(maxWidth: .infinity, idealHeight: dimension)
                 .background(Color.posSurfaceContainerLowest)
@@ -55,7 +55,7 @@ struct ItemRowView: View {
                     .font(Constants.itemTitleFont)
                 if let subtitle = cartItem.subtitle {
                     Text(subtitle)
-                        .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
+                        .foregroundColor(subtitleColor)
                         .font(Constants.itemSubtitleFont)
                 }
 
@@ -87,6 +87,21 @@ struct ItemRowView: View {
                              imageSize: dimension,
                              scale: 1)
             .frame(width: dimension, height: dimension)
+        } else if case .error = cartItem.state {
+            POSItemImageView(imageSource: nil,
+                             imageSize: dimension,
+                             scale: 1,
+                             state: .error)
+            .frame(width: dimension, height: dimension)
+        }
+    }
+
+    private var subtitleColor: Color {
+        switch cartItem.state {
+        case .loaded, .loading:
+            return PointOfSaleItemListCardConstants.detailColor
+        case .error:
+            return .posError
         }
     }
 }
@@ -137,5 +152,16 @@ private extension ItemRowView {
 #Preview(traits: .sizeThatFitsLayout) {
     ItemRowView(cartItem: Cart.PurchasableItem.loading(id: UUID()),
                 onCancelLoading: { })
+}
+
+@available(iOS 17.0, *)
+#Preview(traits: .sizeThatFitsLayout) {
+    ItemRowView.init(cartItem: Cart.PurchasableItem(
+        id: UUID(),
+        title: "123-123-123",
+        subtitle: "Unspported product type",
+        quantity: 1,
+        state: .error
+    ))
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSItemImageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSItemImageView.swift
@@ -1,19 +1,25 @@
 import SwiftUI
 
+enum POSItemImageState {
+    case normal
+    case error
+}
+
 /// A view that displays an image in a POS item view.
 struct POSItemImageView: View {
     let imageSource: String?
     let imageSize: CGFloat
     let scale: CGFloat
+    var state: POSItemImageState = .normal
 
     private var placeholderView: some View {
         Rectangle()
-            .foregroundColor(Constants.placeholderBackgroundColor)
+            .foregroundColor(foregroundColor)
             .overlay {
                 Image(systemName: "archivebox")
                     .accessibilityHidden(true)
                     .font(.posButtonSymbolLarge)
-                    .foregroundColor(Constants.placeholderIconColor)
+                    .foregroundColor(imageColor)
             }
     }
 
@@ -22,7 +28,7 @@ struct POSItemImageView: View {
             ProductImageThumbnail(productImageURL: URL(string: imageSource),
                                   productImageSize: imageSize,
                                   scale: scale,
-                                  foregroundColor: Constants.placeholderIconColor,
+                                  foregroundColor: imageColor,
                                   cachesOriginalImage: true) {
                 placeholderView
             }
@@ -30,13 +36,29 @@ struct POSItemImageView: View {
             placeholderView
         }
     }
+
+    private var foregroundColor: Color {
+        switch state {
+        case .normal:
+            return .posSurfaceDim
+        case .error:
+            return .posError
+        }
+    }
+
+    private var imageColor: Color {
+        switch state {
+        case .normal:
+            return .posOnSurfaceVariantLowest
+        case .error:
+            return .posOnError
+        }
+    }
 }
 
 private extension POSItemImageView {
     enum Constants {
         static let placeholderIconDimension: CGFloat = 38
-        static let placeholderIconColor: Color = .posOnSurfaceVariantLowest
-        static let placeholderBackgroundColor: Color = .posSurfaceDim
     }
 }
 

--- a/WooCommerce/Classes/POS/ViewHelpers/CartViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/CartViewHelper.swift
@@ -30,10 +30,12 @@ struct CartViewHelper {
 
     func hasUnresolvedItems(cart: Cart) -> Bool {
         cart.purchasableItems.contains { item in
-            if case .loading = item.state {
+            switch item.state {
+            case .loading, .error:
                 return true
+            case .loaded:
+                return false
             }
-            return false
         }
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		01BE94042DDCC7670063541C /* PointOfSaleEmptyErrorStateViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BE94032DDCC7650063541C /* PointOfSaleEmptyErrorStateViewLayout.swift */; };
 		01C9C59F2DA3D98400CD81D8 /* CartRowRemoveButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C9C59E2DA3D97E00CD81D8 /* CartRowRemoveButton.swift */; };
 		01D082402C5B9EAB007FE81F /* POSBackgroundAppearanceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D0823F2C5B9EAB007FE81F /* POSBackgroundAppearanceKey.swift */; };
+		01E62EC82DFADF56003A6D9E /* Cart+BarcodeScanError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E62EC72DFADF4B003A6D9E /* Cart+BarcodeScanError.swift */; };
 		01F067ED2D0C5D59001C5805 /* MockLocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F067EC2D0C5D56001C5805 /* MockLocationService.swift */; };
 		01F42C162CE34AB8003D0A5A /* CardPresentModalTapToPaySuccessEmailSent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F42C152CE34AB3003D0A5A /* CardPresentModalTapToPaySuccessEmailSent.swift */; };
 		01F42C182CE34AD2003D0A5A /* CardPresentModalSuccessEmailSent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F42C172CE34AD1003D0A5A /* CardPresentModalSuccessEmailSent.swift */; };
@@ -3331,6 +3332,7 @@
 		01BE94032DDCC7650063541C /* PointOfSaleEmptyErrorStateViewLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleEmptyErrorStateViewLayout.swift; sourceTree = "<group>"; };
 		01C9C59E2DA3D97E00CD81D8 /* CartRowRemoveButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartRowRemoveButton.swift; sourceTree = "<group>"; };
 		01D0823F2C5B9EAB007FE81F /* POSBackgroundAppearanceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSBackgroundAppearanceKey.swift; sourceTree = "<group>"; };
+		01E62EC72DFADF4B003A6D9E /* Cart+BarcodeScanError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Cart+BarcodeScanError.swift"; sourceTree = "<group>"; };
 		01F067EC2D0C5D56001C5805 /* MockLocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLocationService.swift; sourceTree = "<group>"; };
 		01F42C152CE34AB3003D0A5A /* CardPresentModalTapToPaySuccessEmailSent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalTapToPaySuccessEmailSent.swift; sourceTree = "<group>"; };
 		01F42C172CE34AD1003D0A5A /* CardPresentModalSuccessEmailSent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalSuccessEmailSent.swift; sourceTree = "<group>"; };
@@ -10011,6 +10013,7 @@
 				20C909952D3151FA0013BCCF /* ItemListBaseItem.swift */,
 				20D4AE002D133B43004555B2 /* ItemsStackState.swift */,
 				68F151E02C0DA7910082AEC8 /* Cart.swift */,
+				01E62EC72DFADF4B003A6D9E /* Cart+BarcodeScanError.swift */,
 				20D920E92CEF86520023B089 /* PointOfSaleErrorState.swift */,
 				2044158C2CE4DB480070BF54 /* PointOfSaleOrderStage.swift */,
 				2044158E2CE6181E0070BF54 /* PointOfSaleOrderState.swift */,
@@ -15971,6 +15974,7 @@
 				028AFFB32484ED2800693C09 /* Dictionary+Logging.swift in Sources */,
 				026CAF802AC2B7FF002D23BB /* ConfigurableBundleProductView.swift in Sources */,
 				45BBFBC1274FD94300213001 /* HubMenuCoordinator.swift in Sources */,
+				01E62EC82DFADF56003A6D9E /* Cart+BarcodeScanError.swift in Sources */,
 				D8652E582630BFF500350F37 /* OrderDetailsPaymentAlerts.swift in Sources */,
 				B5A56BF0219F2CE90065A902 /* VerticalButton.swift in Sources */,
 				D831E2DC230E0558000037D0 /* Authentication.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/ViewHelpers/CartViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewHelpers/CartViewHelperTests.swift
@@ -240,6 +240,21 @@ struct CartViewHelperTests {
         #expect(sut.hasUnresolvedItems(cart: cart) == true)
     }
 
+    @Test func hasUnresolvedItems_when_cart_has_error_item_returns_true() async throws {
+        // Given
+        let errorItem = Cart.PurchasableItem(
+            id: UUID(),
+            title: "",
+            subtitle: "",
+            quantity: 1,
+            state: .error
+        )
+        let cart = Cart(purchasableItems: [errorItem])
+
+        // When, Then
+        #expect(sut.hasUnresolvedItems(cart: cart) == true)
+    }
+
     @Test func hasUnresolvedItems_when_cart_has_mixed_items_returns_true() async throws {
         // Given
         let loadingItem = Cart.PurchasableItem.loading(id: UUID())

--- a/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
+++ b/Yosemite/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
@@ -65,7 +65,7 @@ struct POSProductOrVariationResolver {
         } catch {
             switch ProductLoadError(underlyingError: error) {
             case .notFound:
-                throw .notFound(scannedCode: scannedCode)
+                throw .noParentProductForVariation(scannedCode: scannedCode)
             default:
                 throw .loadingError(scannedCode: scannedCode, underlyingError: error)
             }

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
@@ -167,7 +167,7 @@ struct POSProductOrVariationResolverTests {
 
         // NotFound case (simulate DotcomError for not found)
         mockProductsRemote.whenLoadingProductForPointOfSale(siteID: variation.siteID, productID: variation.parentID, thenReturn: .failure(dotcomNotFoundError))
-        await #expect(throws: PointOfSaleBarcodeScanError.notFound(scannedCode: scannedCode)) {
+        await #expect(throws: PointOfSaleBarcodeScanError.noParentProductForVariation(scannedCode: scannedCode)) {
             _ = try await sut.itemForProductOrVariation(variation, scannedCode: scannedCode)
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

WOOPRD-562
<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

### Error Messages
Displaying an error after the item is scanned. Based on conversations, I tried to keep it simple but distinguish between the errors that happen due to unsupported products, wrong product configuration, or other network-related issues. Three main ones are:
- Unknown scanned item (when the product is not found)
- Unsupported item type (when product is variable parent, downloadable, or any other unsupported type)
- No internet connection (when the request failed due to no internet connection)

I matched error messages with Android.

I also added two additional ones to cover all the error cases, which should be much rarer:
- Network request failed (when network request failed due to another issue - e.g server error)
- Parent product not found for variation (when there's a misconfiguration between variable products and its variations)

I continue logging the scanning error to more transparency within logs.

### Error row

Updated item row style to support error state.

### Checkout button

Disabling the checkout button if there's at least one row with an error state

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Enable `pointOfSaleBarcodeScanningi1` feature flag

1. Launch POS
2. Use a simulated barcode scanner to add valid and invalid products with barcodes
3. Confirm the appropriate error is shown
4. Confirm "Check out" button is disabled if there's at least one invalid row

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air 18.4 Simulator

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="1346" alt="Error types" src="https://github.com/user-attachments/assets/02abae59-6012-40da-9969-a27c6c5b4044" />=

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.