### PR TITLE
Fix `TopTabView` binding

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
@@ -99,7 +99,7 @@ struct WooCarrierPackagesSelectionView: View {
             if viewModel.carrierTabs.isNotEmpty {
                 TopTabView(tabs: viewModel.carrierTabs,
                            showContent: false,
-                           selectedTabIndex: viewModel.selectedCarriersTabIndex,
+                           selectedTabIndex: $viewModel.selectedCarriersTabIndex,
                            tabsContainerHorizontalPadding: nil,
                            selectedStateColor: Color.accentColor,
                            unselectedStateColor: .secondary,
@@ -107,8 +107,7 @@ struct WooCarrierPackagesSelectionView: View {
                            tabPadding: Constants.tabPadding,
                            tabsNameFont: Font.subheadline.bold(),
                            tabItemContentHorizontalPadding: Constants.tabItemContentHorizontalPadding,
-                           tabItemContentVerticalPadding: Constants.tabItemContentVerticalPadding,
-                           onTabChange: { viewModel.selectedCarriersTabIndex = $0 })
+                           tabItemContentVerticalPadding: Constants.tabItemContentVerticalPadding)
             } else if viewModel.isLoadingPackages {
                 // Loading state
                 loadingStateView

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -85,8 +85,7 @@ struct WooShippingServiceView: View {
                        unselectedStateColor: .secondary,
                        tabsNameFont: .subheadline.bold(),
                        tabItemContentHorizontalPadding: 6,
-                       tabItemContentVerticalPadding: 12,
-                       onTabChange: { viewModel.selectedTabIndex = $0 })
+                       tabItemContentVerticalPadding: 12)
             WooShippingServiceCardListView(cards: viewModel.displayedServiceCards)
         }
         .padding(.horizontal, Layout.padding * -1) // Offset the additional padding in TopTabView

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -81,6 +81,7 @@ struct WooShippingServiceView: View {
         VStack(spacing: 0) {
             TopTabView(tabs: carriers,
                        showContent: false,
+                       selectedTabIndex: $viewModel.selectedTabIndex,
                        tabsContainerHorizontalPadding: 16,
                        unselectedStateColor: .secondary,
                        tabsNameFont: .subheadline.bold(),

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
@@ -108,7 +108,7 @@ private extension WooShippingSplitShipmentsView {
             TopTabView(tabs: viewModel.topTabItems,
                        showContent: false,
                        showDividerBelowTabs: false,
-                       selectedTabIndex: viewModel.selectedShipmentIndex,
+                       selectedTabIndex: $viewModel.selectedShipmentIndex,
                        tabsContainerHorizontalPadding: nil,
                        selectedStateColor: .accentColor,
                        unselectedStateColor: .secondary,
@@ -119,8 +119,7 @@ private extension WooShippingSplitShipmentsView {
                        tabsIconAlignment: .trailing,
                        tabsIconForegroundColor: Layout.green,
                        tabItemContentHorizontalPadding: Layout.tabItemContentHorizontalPadding,
-                       tabItemContentVerticalPadding: Layout.tabItemContentVerticalPadding,
-                       onTabChange: { viewModel.selectedShipmentIndex = $0 })
+                       tabItemContentVerticalPadding: Layout.tabItemContentVerticalPadding)
             .overlay(alignment: .trailing) {
                 LinearGradient(gradient: Gradient(colors: [.clear, Color(.basicBackground)]), startPoint: .leading, endPoint: .center)
                     .frame(width: Layout.gradientViewWidth)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -147,7 +147,7 @@ private extension WooShippingCreateLabelsView {
             TopTabView(tabs: tabs,
                        showContent: false,
                        showDividerBelowTabs: false,
-                       selectedTabIndex: viewModel.selectedShipmentIndex,
+                       selectedTabIndex: $viewModel.selectedShipmentIndex,
                        tabsContainerHorizontalPadding: nil,
                        selectedStateColor: .accentColor,
                        unselectedStateColor: .secondary,
@@ -158,8 +158,7 @@ private extension WooShippingCreateLabelsView {
                        tabsIconAlignment: .trailing,
                        tabsIconForegroundColor: Layout.green,
                        tabItemContentHorizontalPadding: Layout.tabItemContentHorizontalPadding,
-                       tabItemContentVerticalPadding: Layout.tabItemContentVerticalPadding,
-                       onTabChange: { viewModel.selectedShipmentIndex = $0 })
+                       tabItemContentVerticalPadding: Layout.tabItemContentVerticalPadding)
             .overlay(alignment: .trailing) {
                 LinearGradient(gradient: Gradient(colors: [.clear, Color(.basicBackground)]), startPoint: .leading, endPoint: .center)
                     .frame(width: Layout.gradientViewWidth)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/OptionalBinding.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/OptionalBinding.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+/// A property wrapper that provides optional binding functionality for SwiftUI views.
+///
+/// `OptionalBinding` allows a SwiftUI view to work with either:
+/// - An external binding (when provided) - for two-way data synchronization with parent views
+/// - Internal state management (when no binding is provided) - for self-contained components
+///
+/// This is particularly useful for reusable components that need to support both use cases:
+/// standalone usage and integration with external state management.
+///
+/// ## Usage Examples
+///
+/// ### Basic usage with internal state management:
+/// ```swift
+/// struct MyView: View {
+///     @OptionalBinding private var selectedIndex: Int = 0
+///
+///     init() {
+///         // When no external binding is provided, the component manages its own state
+///         self._selectedIndex = OptionalBinding(nil, default: 0)
+///     }
+/// }
+/// ```
+///
+/// ### Usage with external binding:
+/// ```swift
+/// struct ParentView: View {
+///     @State private var currentIndex = 1
+///
+///     var body: some View {
+///         MyView(selectedIndex: $currentIndex) // Two-way binding
+///     }
+/// }
+///
+/// struct MyView: View {
+///     @OptionalBinding private var selectedIndex: Int = 0
+///
+///     init(selectedIndex: Binding<Int>? = nil) {
+///         // When external binding is provided, syncs with parent state
+///         self._selectedIndex = OptionalBinding(selectedIndex, default: 0)
+///     }
+/// }
+/// ```
+///
+/// ## Key Features
+///
+/// - **Automatic fallback**: Uses internal state when no external binding is provided
+/// - **Seamless integration**: Works exactly like `@State` or `@Binding` from the view's perspective
+/// - **Two-way synchronization**: Changes are automatically propagated to external bindings when present
+/// - **Type safety**: Maintains full type safety with generic value types
+/// - **SwiftUI compliance**: Conforms to `DynamicProperty` for proper SwiftUI lifecycle integration
+///
+/// ## Implementation Details
+///
+/// The property wrapper maintains both an internal `@State` and an optional external `Binding<Value>`.
+/// The `wrappedValue` getter/setter automatically routes to the appropriate storage based on whether
+/// an external binding was provided during initialization.
+///
+/// The `projectedValue` returns a `Binding<Value>` that can be passed to child views, maintaining
+/// the same behavior regardless of whether the component is using internal or external state.
+@propertyWrapper
+struct OptionalBinding<Value>: DynamicProperty {
+    @State private var internalValue: Value
+    private var external: Binding<Value>?
+
+    var wrappedValue: Value {
+        get { external?.wrappedValue ?? internalValue }
+        nonmutating set {
+            if external != nil {
+                external?.wrappedValue = newValue
+            } else {
+                internalValue = newValue
+            }
+        }
+    }
+
+    var projectedValue: Binding<Value> {
+        Binding(
+            get: { wrappedValue },
+            set: { wrappedValue = $0 }
+        )
+    }
+
+    init(wrappedValue: Value) {
+        self._internalValue = State(initialValue: wrappedValue)
+        self.external = nil
+    }
+
+    init(_ binding: Binding<Value>?, default defaultValue: Value) {
+        if let binding = binding {
+            self.external = binding
+            self._internalValue = State(initialValue: binding.wrappedValue)
+        } else {
+            self.external = nil
+            self._internalValue = State(initialValue: defaultValue)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -23,7 +23,7 @@ struct TopTabView<Content: View>: View {
         case trailing
     }
 
-    @State private var selectedTab: Int = 0
+    @Binding private var selectedTab: Int
     @State private var underlineOffset: CGFloat = 0
     @State private var tabWidths: [CGFloat]
     @GestureState private var dragState: DragState = .inactive
@@ -61,13 +61,11 @@ struct TopTabView<Content: View>: View {
     let tabItemContentHorizontalPadding: CGFloat?
     let tabItemContentVerticalPadding: CGFloat?
 
-    let onTabChange: (Int) -> Void
-
     init(tabs: [TopTabItem<Content>],
          showTabs: Binding<Bool> = .constant(true),
          showContent: Bool = true,
          showDividerBelowTabs: Bool = true,
-         selectedTabIndex: Int = 0,
+         selectedTabIndex: Binding<Int> = .constant(0),
          tabsContainerHorizontalPadding: CGFloat? = 0.0,
          selectedStateColor: Color = Colors.selected,
          unselectedStateColor: Color = .primary,
@@ -78,13 +76,12 @@ struct TopTabView<Content: View>: View {
          tabsIconAlignment: TabsIconAlignment = .leading,
          tabsIconForegroundColor: Color? = nil,
          tabItemContentHorizontalPadding: CGFloat? = nil,
-         tabItemContentVerticalPadding: CGFloat? = nil,
-         onTabChange: @escaping (Int) -> Void = { _ in }) {
+         tabItemContentVerticalPadding: CGFloat? = nil) {
         self.tabs = tabs
         self._showTabs = showTabs
         self.showContent = showContent
         self.showDividerBelowTabs = showDividerBelowTabs
-        self.selectedTab = selectedTabIndex
+        self._selectedTab = selectedTabIndex
         _tabWidths = State(initialValue: [CGFloat](repeating: 0, count: tabs.count))
         self.tabsContainerHorizontalPadding = tabsContainerHorizontalPadding
         self.selectedStateColor = selectedStateColor
@@ -97,7 +94,6 @@ struct TopTabView<Content: View>: View {
         self.tabsIconForegroundColor = tabsIconForegroundColor
         self.tabItemContentHorizontalPadding = tabItemContentHorizontalPadding
         self.tabItemContentVerticalPadding = tabItemContentVerticalPadding
-        self.onTabChange = onTabChange
     }
 
     private func tabItemContentView(_ index: Int, selected: Bool) -> some View {
@@ -193,7 +189,6 @@ struct TopTabView<Content: View>: View {
                                 withAnimation {
                                     selectTab(in: scrollViewProxy, at: newSelectedTab)
                                 }
-                                onTabChange(newSelectedTab)
                             })
                             .coordinateSpace(name: Constants.tabsHorizontalStackNameSpace)
                         }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -23,7 +23,7 @@ struct TopTabView<Content: View>: View {
         case trailing
     }
 
-    @Binding private var selectedTab: Int
+    @OptionalBinding private var selectedTab: Int = 0
     @State private var underlineOffset: CGFloat = 0
     @State private var tabWidths: [CGFloat]
     @GestureState private var dragState: DragState = .inactive
@@ -65,7 +65,7 @@ struct TopTabView<Content: View>: View {
          showTabs: Binding<Bool> = .constant(true),
          showContent: Bool = true,
          showDividerBelowTabs: Bool = true,
-         selectedTabIndex: Binding<Int> = .constant(0),
+         selectedTabIndex: Binding<Int>? = nil,
          tabsContainerHorizontalPadding: CGFloat? = 0.0,
          selectedStateColor: Color = Colors.selected,
          unselectedStateColor: Color = .primary,
@@ -81,7 +81,7 @@ struct TopTabView<Content: View>: View {
         self._showTabs = showTabs
         self.showContent = showContent
         self.showDividerBelowTabs = showDividerBelowTabs
-        self._selectedTab = selectedTabIndex
+        self._selectedTab = OptionalBinding(selectedTabIndex, default: 0)
         _tabWidths = State(initialValue: [CGFloat](repeating: 0, count: tabs.count))
         self.tabsContainerHorizontalPadding = tabsContainerHorizontalPadding
         self.selectedStateColor = selectedStateColor

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1203,6 +1203,7 @@
 		26FE09E124DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */; };
 		26FFC50C2BED7C5A0067B3A4 /* WatchDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B249702BEC801400730730 /* WatchDependencies.swift */; };
 		26FFC50D2BED7C5B0067B3A4 /* WatchDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B249702BEC801400730730 /* WatchDependencies.swift */; };
+		2D880B492DFB2F3F00A6FB2C /* OptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D880B482DFB2F3D00A6FB2C /* OptionalBinding.swift */; };
 		310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */; };
 		311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */; };
 		311D21E8264AEDB900102316 /* CardPresentModalScanningForReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */; };
@@ -4425,6 +4426,7 @@
 		26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCoordinatorControllerTests.swift; sourceTree = "<group>"; };
 		26FFD32628C6A0A4002E5E5E /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		26FFD32928C6A0F4002E5E5E /* UIImage+Widgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Widgets.swift"; sourceTree = "<group>"; };
+		2D880B482DFB2F3D00A6FB2C /* OptionalBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalBinding.swift; sourceTree = "<group>"; };
 		310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLiveSiteInTestModeView.swift; sourceTree = "<group>"; };
 		311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalDisplayMessage.swift; sourceTree = "<group>"; };
 		311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReader.swift; sourceTree = "<group>"; };
@@ -9579,6 +9581,7 @@
 		45D875D72611EA3D00226C3F /* SwiftUI Components */ = {
 			isa = PBXGroup;
 			children = (
+				2D880B482DFB2F3D00A6FB2C /* OptionalBinding.swift */,
 				EE3B17B52AA03837004D3E0C /* CelebrationView.swift */,
 				DE7E5E8B2B4E9353002E28D2 /* ErrorStateView.swift */,
 				D449C51926DE6B5000D75B02 /* IconListItem.swift */,
@@ -16318,6 +16321,7 @@
 				013D2FB42CFEFEC600845D75 /* TapToPayCardReaderMerchantEducationPresenter.swift in Sources */,
 				B541B21C2189F3D8008FE7C1 /* StringStyles.swift in Sources */,
 				B58B4AB82108F14700076FDD /* NoticeNotificationInfo.swift in Sources */,
+				2D880B492DFB2F3F00A6FB2C /* OptionalBinding.swift in Sources */,
 				DA4080722CC2967C002A4577 /* WooShippingAddCustomPackageViewModel.swift in Sources */,
 				02038C5C2AF0E7FC00CD36D9 /* ConfigurableVariableBundleAttributePickerViewModel.swift in Sources */,
 				CE24BCD8212F25D4001CD12E /* StorageOrder+Woo.swift in Sources */,


### PR DESCRIPTION
## Description

This PR fixes the broken binding behavior in `TopTabView` that was introduced in PR #15718. The previous fix replaced the binding-based approach with a callback-based one, but this created issues for components that need proper two-way data binding with external state.

**Problem**: The current implementation uses `selectedTab: Int` and `onTabChange: (Int) -> Void`, which doesn't provide true two-way binding. This means:
- External state changes don't automatically update the tab view
- The component can't be used seamlessly with `@State` variables in parent views
- It breaks the expected SwiftUI binding patterns

**Solution**: Introduced a new `OptionalBinding` property wrapper that provides the best of both worlds:
- **Internal state management**: When no external binding is provided, the component manages its own state
- **External binding support**: When a binding is provided, it maintains full two-way synchronization
- **Backward compatibility**: Existing code continues to work without changes
- **SwiftUI compliance**: Follows proper SwiftUI patterns and lifecycle management

The `OptionalBinding` property wrapper automatically routes between internal `@State` and external `Binding<Value>` based on what's provided during initialization, making the component both self-contained and externally controllable.

## Testing steps

- Navigate to an order with several shipments that also contain unfulfilled shipment.
- Switch between tabs and make sure it works fine.
- For the unfulfilled shipment select a package to have package rates loaded and displayed
- Make sure rates list tabs are switching properly (UPS, USPS)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.