### PR TITLE
Update `ProductsRemote.loadAllProducts` to call async/await enqueue method for response parsing to be in a background thread

### DIFF
--- a/Networking/NetworkingTests/Extensions/URLRequestConvertible+PathTests.swift
+++ b/Networking/NetworkingTests/Extensions/URLRequestConvertible+PathTests.swift
@@ -12,10 +12,10 @@ final class URLRequestConvertible_PathTests: XCTestCase {
     // MARK: - `pathForAnalytics`
 
     // Example from `ProductsRemote.loadAllProducts`.
-    func test_pathForAnalytics_returns_path_of_JetpackRequest() throws {
+    func test_pathForAnalytics_returns_path_of_JetpackRequest() async throws {
         // Given
         let productsRemote = ProductsRemote(network: network)
-        productsRemote.loadAllProducts(for: 134, completion: { _ in })
+        _ = try? await productsRemote.loadAllProducts(for: 134)
 
         // When
         let request = try XCTUnwrap(network.requestsForResponseData.first)

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -256,39 +256,28 @@ final class ProductsRemoteTests: XCTestCase {
 
     /// Verifies that loadAllProducts properly parses the `products-load-all` sample response.
     ///
-    func testLoadAllProductsProperlyReturnsParsedProducts() {
+    func test_loadAllProducts_properly_returns_parsed_products() async throws {
+        // Given
         let remote = ProductsRemote(network: network)
-        let expectation = self.expectation(description: "Load All Products")
-
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
 
-        remote.loadAllProducts(for: sampleSiteID) { result in
-            switch result {
-            case .success(let products):
-                XCTAssertEqual(products.count, 10)
-            default:
-                XCTFail("Unexpected result: \(result)")
-            }
-            expectation.fulfill()
-        }
+        // When
+        let products = try await remote.loadAllProducts(for: sampleSiteID)
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertEqual(products.count, 10)
     }
 
     /// Verifies that loadAllProducts with `excludedProductIDs` makes a network request with the corresponding parameter.
     ///
-    func testLoadAllProductsWithExcludedIDsIncludesAnExcludeParamInNetworkRequest() throws {
+    func test_loadAllProducts_with_excluded_ids_includes_an_exclude_param_in_network_request() async throws {
         // Arrange
         let remote = ProductsRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
         let excludedProductIDs: [Int64] = [17, 671]
 
         // Action
-        waitForExpectation { expectation in
-            remote.loadAllProducts(for: sampleSiteID, excludedProductIDs: excludedProductIDs) { result in
-                expectation.fulfill()
-            }
-        }
+        _ = try await remote.loadAllProducts(for: sampleSiteID, excludedProductIDs: excludedProductIDs)
 
         // Assert
         let queryParameters = try XCTUnwrap(network.queryParameters)
@@ -298,18 +287,14 @@ final class ProductsRemoteTests: XCTestCase {
 
     /// Verifies that loadAllProducts with `productIDs` makes a network request with the `include` parameter.
     ///
-    func test_loadAllProducts_with_productIDs_adds_a_include_param_in_network_request() throws {
+    func test_loadAllProducts_with_productIDs_adds_a_include_param_in_network_request() async throws {
         // Given
         let remote = ProductsRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
         let productIDs: [Int64] = [13, 61]
 
         // When
-        waitForExpectation { expectation in
-            remote.loadAllProducts(for: sampleSiteID, productIDs: productIDs) { result in
-                expectation.fulfill()
-            }
-        }
+        _ = try await remote.loadAllProducts(for: sampleSiteID, productIDs: productIDs)
 
         // Then
         let queryParameters = try XCTUnwrap(network.queryParameters)
@@ -319,17 +304,13 @@ final class ProductsRemoteTests: XCTestCase {
 
     /// Verifies that loadAllProducts with empty `productIDs` makes a network request without the `include` parameter.
     ///
-    func test_loadAllProducts_with_empty_productIDs_does_not_add_include_param_in_network_request() throws {
+    func test_loadAllProducts_with_empty_productIDs_does_not_add_include_param_in_network_request() async throws {
         // Given
         let remote = ProductsRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
 
         // When
-        waitForExpectation { expectation in
-            remote.loadAllProducts(for: sampleSiteID, productIDs: []) { result in
-                expectation.fulfill()
-            }
-        }
+        _ = try await remote.loadAllProducts(for: sampleSiteID, productIDs: [])
 
         // Then
         let queryParameters = try XCTUnwrap(network.queryParameters)
@@ -339,21 +320,16 @@ final class ProductsRemoteTests: XCTestCase {
 
     /// Verifies that loadAllProducts properly relays Networking Layer errors.
     ///
-    func test_loadAllProducts_properly_relays_netwoking_errors() {
+    func test_loadAllProducts_properly_relays_netwoking_errors() async {
+        // Given
         let remote = ProductsRemote(network: network)
-        let expectation = self.expectation(description: "Load all products returns error")
 
-        remote.loadAllProducts(for: sampleSiteID) { result in
-            switch result {
-            case .failure:
-                break
-            default:
-                XCTFail("Unexpected result: \(result)")
-            }
-            expectation.fulfill()
+        do {
+            _ = try await remote.loadAllProducts(for: sampleSiteID)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual(error as? NetworkError, .notFound())
         }
-
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
 

--- a/Networking/Sources/Extended/Remote/ProductsRemote.swift
+++ b/Networking/Sources/Extended/Remote/ProductsRemote.swift
@@ -20,8 +20,7 @@ public protocol ProductsRemoteProtocol {
                          orderBy: ProductsRemote.OrderKey,
                          order: ProductsRemote.Order,
                          productIDs: [Int64],
-                         excludedProductIDs: [Int64],
-                         completion: @escaping (Result<[Product], Error>) -> Void)
+                         excludedProductIDs: [Int64]) async throws -> [Product]
     func searchProducts(for siteID: Int64,
                         keyword: String,
                         pageNumber: Int,
@@ -179,8 +178,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
                                 orderBy: OrderKey = .name,
                                 order: Order = .ascending,
                                 productIDs: [Int64] = [],
-                                excludedProductIDs: [Int64] = [],
-                                completion: @escaping (Result<[Product], Error>) -> Void) {
+                                excludedProductIDs: [Int64] = []) async throws -> [Product] {
         let stringOfExcludedProductIDs = excludedProductIDs.map { String($0) }
             .joined(separator: ",")
         let stringOfProductIDs: String = {
@@ -213,7 +211,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
         let mapper = ProductListMapper(siteID: siteID)
 
-        enqueue(request, mapper: mapper, completion: completion)
+        return try await enqueue(request, mapper: mapper)
     }
 
     /// Retrieves products for the Point of Sale. Simple and variable products are loaded for WC version 9.6+, otherwise only simple products are loaded.

--- a/Networking/Sources/Extended/Remote/ProductsRemote.swift
+++ b/Networking/Sources/Extended/Remote/ProductsRemote.swift
@@ -209,7 +209,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
 
         let path = Path.products
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
-        let mapper = ProductListMapper(siteID: siteID)
+        let mapper = ListMapper<Product>(siteID: siteID)
 
         return try await enqueue(request, mapper: mapper)
     }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -90,18 +90,24 @@ public class ProductStore: Store {
                                   let excludedProductIDs,
                                   let shouldDeleteStoredProductsOnFirstPage,
                                   let onCompletion):
-            synchronizeProducts(siteID: siteID,
-                                pageNumber: pageNumber,
-                                pageSize: pageSize,
-                                stockStatus: stockStatus,
-                                productStatus: productStatus,
-                                productType: productType,
-                                productCategory: productCategory,
-                                sortOrder: sortOrder,
-                                productIDs: productIDs,
-                                excludedProductIDs: excludedProductIDs,
-                                shouldDeleteStoredProductsOnFirstPage: shouldDeleteStoredProductsOnFirstPage,
-                                onCompletion: onCompletion)
+            Task { @MainActor in
+                do {
+                    let hasNextPage = try await synchronizeProducts(siteID: siteID,
+                                                                    pageNumber: pageNumber,
+                                                                    pageSize: pageSize,
+                                                                    stockStatus: stockStatus,
+                                                                    productStatus: productStatus,
+                                                                    productType: productType,
+                                                                    productCategory: productCategory,
+                                                                    sortOrder: sortOrder,
+                                                                    productIDs: productIDs,
+                                                                    excludedProductIDs: excludedProductIDs,
+                                                                    shouldDeleteStoredProductsOnFirstPage: shouldDeleteStoredProductsOnFirstPage)
+                    onCompletion(.success(hasNextPage))
+                } catch {
+                    onCompletion(.failure(error))
+                }
+            }
         case .requestMissingProducts(let order, let onCompletion):
             requestMissingProducts(for: order, onCompletion: onCompletion)
         case .updateProduct(let product, let onCompletion):
@@ -287,43 +293,35 @@ private extension ProductStore {
                              sortOrder: ProductsSortOrder,
                              productIDs: [Int64],
                              excludedProductIDs: [Int64],
-                             shouldDeleteStoredProductsOnFirstPage: Bool,
-                             onCompletion: @escaping (Result<Bool, Error>) -> Void) {
-        remote.loadAllProducts(for: siteID,
-                               context: nil,
-                               pageNumber: pageNumber,
-                               pageSize: pageSize,
-                               stockStatus: stockStatus,
-                               productStatus: productStatus,
-                               productType: productType,
-                               productCategory: productCategory,
-                               orderBy: sortOrder.remoteOrderKey,
-                               order: sortOrder.remoteOrder,
-                               productIDs: productIDs,
-                               excludedProductIDs: excludedProductIDs) { [weak self] result in
-                                switch result {
-                                case .failure(let error):
-                                    if let productType,
-                                        let error = error as? DotcomError,
-                                        case let .unknown(code, message) = error,
-                                        code == "rest_invalid_param",
-                                        message == "Invalid parameter(s): type",
-                                        ProductType.coreTypes.contains(productType) == false {
-                                        return onCompletion(.success(false))
-                                    }
-                                    onCompletion(.failure(error))
-                                case .success(let products):
-                                    guard let self = self else {
-                                        return
-                                    }
-                                    let shouldDeleteExistingProducts = pageNumber == Default.firstPageNumber && shouldDeleteStoredProductsOnFirstPage
-                                    self.upsertStoredProductsInBackground(readOnlyProducts: products,
-                                                                          siteID: siteID,
-                                                                          shouldDeleteExistingProducts: shouldDeleteExistingProducts) {
-                                        let hasNextPage = products.count == pageSize
-                                        onCompletion(.success(hasNextPage))
-                                    }
-                                }
+                             shouldDeleteStoredProductsOnFirstPage: Bool) async throws -> Bool {
+        do {
+            let products = try await remote.loadAllProducts(for: siteID,
+                                                            context: nil,
+                                                            pageNumber: pageNumber,
+                                                            pageSize: pageSize,
+                                                            stockStatus: stockStatus,
+                                                            productStatus: productStatus,
+                                                            productType: productType,
+                                                            productCategory: productCategory,
+                                                            orderBy: sortOrder.remoteOrderKey,
+                                                            order: sortOrder.remoteOrder,
+                                                            productIDs: productIDs,
+                                                            excludedProductIDs: excludedProductIDs)
+
+            let shouldDeleteExistingProducts = pageNumber == Default.firstPageNumber && shouldDeleteStoredProductsOnFirstPage
+            await upsertStoredProductsInBackground(readOnlyProducts: products,
+                                                   siteID: siteID,
+                                                   shouldDeleteExistingProducts: shouldDeleteExistingProducts)
+            let hasNextPage = products.count == pageSize
+            return hasNextPage
+        } catch let error as DotcomError where error == .unknown(code: "rest_invalid_param", message: "Invalid parameter(s): type") {
+            if let productType,
+               ProductType.coreTypes.contains(productType) == false {
+                return false
+            }
+            throw error
+        } catch {
+            throw error
         }
     }
 
@@ -852,6 +850,23 @@ extension ProductStore {
         }, completion: onCompletion, on: .main)
     }
 
+    /// Updates (OR Inserts) the specified ReadOnly Product Entities *in a background thread* async.
+    /// Also deletes existing products if requested.
+    func upsertStoredProductsInBackground(readOnlyProducts: [Networking.Product],
+                                          siteID: Int64,
+                                          shouldDeleteExistingProducts: Bool = false) async {
+        await withCheckedContinuation { [weak self] continuation in
+            guard let self else {
+                return continuation.resume()
+            }
+            upsertStoredProductsInBackground(readOnlyProducts: readOnlyProducts,
+                                             siteID: siteID,
+                                             shouldDeleteExistingProducts: shouldDeleteExistingProducts) {
+                continuation.resume()
+            }
+        }
+    }
+
     /// Updates (OR Inserts) the specified ReadOnly Product Entities *in a background thread*.
     /// Also deletes existing products if requested.
     /// `onCompletion` will be called on the main thread!
@@ -861,7 +876,9 @@ extension ProductStore {
                                           shouldDeleteExistingProducts: Bool = false,
                                           onCompletion: @escaping () -> Void) {
         storageManager.performAndSave({ [weak self] storage in
-            guard let self else { return }
+            guard let self else {
+                return onCompletion()
+            }
             if shouldDeleteExistingProducts {
                 storage.deleteProducts(siteID: siteID)
             }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -260,8 +260,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
                          orderBy: ProductsRemote.OrderKey,
                          order: ProductsRemote.Order,
                          productIDs: [Int64],
-                         excludedProductIDs: [Int64],
-                         completion: @escaping (Result<[Product], Error>) -> Void) {
+                         excludedProductIDs: [Int64]) async throws -> [Product] {
         synchronizeProductsTriggered = true
         synchronizeProductsWithStockStatus = stockStatus
         synchronizeProductsWithProductStatus = productStatus
@@ -271,10 +270,16 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         synchronizeProductsOrder = order
         synchronizeProductsProductIDs = productIDs
         synchronizeProductsExcludedProductIDs = excludedProductIDs
-        if let result = loadAllProductsResultsBySiteID[siteID] {
-            completion(result)
-        } else {
+        guard let result = loadAllProductsResultsBySiteID[siteID] else {
             XCTFail("\(String(describing: self)) Could not find Result for \(siteID)")
+            throw NetworkError.notFound()
+        }
+        
+        switch result {
+        case let .success(products):
+            return products
+        case let .failure(error):
+            throw error
         }
     }
 

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -274,7 +274,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
             XCTFail("\(String(describing: self)) Could not find Result for \(siteID)")
             throw NetworkError.notFound()
         }
-        
+
         switch result {
         case let .success(products):
             return products

--- a/Yosemite/YosemiteTests/Stores/ProductStore+FilterProductsTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStore+FilterProductsTests.swift
@@ -285,18 +285,21 @@ final class ProductStore_FilterProductsTests: XCTestCase {
         remote.whenLoadingAllProducts(siteID: sampleSiteID, thenReturn: .success([Product.fake()]))
 
         // When
-        let synchronizeAction = ProductAction.synchronizeProducts(siteID: sampleSiteID,
-                                                             pageNumber: defaultPageNumber,
-                                                             pageSize: defaultPageSize,
-                                                             stockStatus: filteredStockStatus,
-                                                             productStatus: filteredProductStatus,
-                                                             productType: filteredProductType,
-                                                             productCategory: filteredProductCategory,
-                                                             sortOrder: filteredProductSortOrder,
-                                                             productIDs: [1, 2],
-                                                             excludedProductIDs: [30, 45],
-                                                             onCompletion: { _ in })
-        productStore.onAction(synchronizeAction)
+        waitFor { promise in
+            productStore.onAction(ProductAction.synchronizeProducts(siteID: self.sampleSiteID,
+                                                                    pageNumber: self.defaultPageNumber,
+                                                                    pageSize: self.defaultPageSize,
+                                                                    stockStatus: filteredStockStatus,
+                                                                    productStatus: filteredProductStatus,
+                                                                    productType: filteredProductType,
+                                                                    productCategory: filteredProductCategory,
+                                                                    sortOrder: filteredProductSortOrder,
+                                                                    productIDs: [1, 2],
+                                                                    excludedProductIDs: [30, 45],
+                                                                    onCompletion: { _ in
+                promise(())
+            }))
+        }
 
         // Then
         XCTAssertTrue(remote.synchronizeProductsTriggered)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Fixes WOOMOB-607

Just one reviewer is required.

## Why

In most of the network calls except for the `enqueue<M: Mapper>(_ request: Request, mapper: M) async throws -> M.Output` version, the response is parsed by a mapper on the main thread. When the response size is large like in the support case in WOOMOB-607 with a large amount of product metadata, the UI could become unresponsive. This PR just updates the `ProductsRemote.loadAllProducts` network call from the previous Combine/completion block based `enqueue` method to the `enqueue<M: Mapper>(_ request: Request, mapper: M) async throws` method, so that the response parsing along with other network related tasks can be performed in the background thread. There are already several use cases of `enqueue<M: Mapper>(_ request: Request, mapper: M) async throws` for a while that we can consider it stable.

I'm prioritizing network calls for entities with potentially large amount of data like from metadata or some collection fields. Each change like this takes 200+ diffs, so I'm making changes one at a time.

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This pull request refactors several methods in the `ProductsRemote` class and its related components to adopt Swift's async/await syntax, improving readability, simplifying asynchronous code, and for the response parsing to be in a background thread. It also updates corresponding unit tests and mock implementations to align with these changes.

### Refactoring to async/await in `ProductsRemote`:

* [`Networking/Sources/Extended/Remote/ProductsRemote.swift`](diffhunk://#diff-d33d9ce5430a9276f75e178006d1b25780a4c1159c4ec5986873ec035f3519f5L23-R23): Replaced the completion handler in `loadAllProducts` with async/await and updated the method signature to return `[Product]`. The `enqueue` method now directly returns the result instead of using a completion handler. It also adopts the generic `ListMapper` so that we can change limit the response size for more use cases in WOOMOB-608. [[1]](diffhunk://#diff-d33d9ce5430a9276f75e178006d1b25780a4c1159c4ec5986873ec035f3519f5L23-R23) [[2]](diffhunk://#diff-d33d9ce5430a9276f75e178006d1b25780a4c1159c4ec5986873ec035f3519f5L182-R181) [[3]](diffhunk://#diff-d33d9ce5430a9276f75e178006d1b25780a4c1159c4ec5986873ec035f3519f5L216-R214)

### Updates to dependent classes and methods:

* [`Yosemite/Yosemite/Stores/ProductStore.swift`](diffhunk://#diff-2e6147f83e5c53fe36dba042353e12fabda27770f2f8e360b006eccdef95e77fL93-R95): Refactored `synchronizeProducts` and `upsertStoredProductsInBackground` methods to use async/await. Added a new async version of `upsertStoredProductsInBackground` to handle product updates in a background thread. [[1]](diffhunk://#diff-2e6147f83e5c53fe36dba042353e12fabda27770f2f8e360b006eccdef95e77fL93-R95) [[2]](diffhunk://#diff-2e6147f83e5c53fe36dba042353e12fabda27770f2f8e360b006eccdef95e77fL103-R110) [[3]](diffhunk://#diff-2e6147f83e5c53fe36dba042353e12fabda27770f2f8e360b006eccdef95e77fL290-R298) [[4]](diffhunk://#diff-2e6147f83e5c53fe36dba042353e12fabda27770f2f8e360b006eccdef95e77fL303-R324) [[5]](diffhunk://#diff-2e6147f83e5c53fe36dba042353e12fabda27770f2f8e360b006eccdef95e77fR853-R869) [[6]](diffhunk://#diff-2e6147f83e5c53fe36dba042353e12fabda27770f2f8e360b006eccdef95e77fL864-R881)

### Unit test updates:

* [`Networking/NetworkingTests/Remote/ProductsRemoteTests.swift`](diffhunk://#diff-01c6287fe6f095c7bdd598502a7d5a4d5b7c42b9291b20a415e3a242d2691dafL259-R280): Updated all tests for `loadAllProducts` to use async/await syntax, removing the need for expectations and completion handlers. This includes tests for parsing responses, handling excluded IDs, and relaying errors. [[1]](diffhunk://#diff-01c6287fe6f095c7bdd598502a7d5a4d5b7c42b9291b20a415e3a242d2691dafL259-R280) [[2]](diffhunk://#diff-01c6287fe6f095c7bdd598502a7d5a4d5b7c42b9291b20a415e3a242d2691dafL301-R297) [[3]](diffhunk://#diff-01c6287fe6f095c7bdd598502a7d5a4d5b7c42b9291b20a415e3a242d2691dafL322-R313) [[4]](diffhunk://#diff-01c6287fe6f095c7bdd598502a7d5a4d5b7c42b9291b20a415e3a242d2691dafL342-L356)

### Mock implementation updates:

* [`Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift`](diffhunk://#diff-8d3fccdc3b7a8122e3bb16378b88949fd65b71a19e2fe2f058ceac717f729a6eL263-R263): Refactored the mock implementation of `loadAllProducts` to support async/await, replacing completion handlers with direct return values or throwing errors. [[1]](diffhunk://#diff-8d3fccdc3b7a8122e3bb16378b88949fd65b71a19e2fe2f058ceac717f729a6eL263-R263) [[2]](diffhunk://#diff-8d3fccdc3b7a8122e3bb16378b88949fd65b71a19e2fe2f058ceac717f729a6eL274-R282)

### Additional test refactor:

* [`Networking/NetworkingTests/Extensions/URLRequestConvertible+PathTests.swift`](diffhunk://#diff-219d9f1d3afd9fb0caafc744345ce18d5e661657d4a32a0406f6ac7d787803e0L15-R18): Updated a test method to use async/await for verifying analytics path generation.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: put a breakpoint in `ListMapper` decode calls in Xcode

- Launch the app and wait for the breakpoint in the prerequisite triggered by `ProductStore.synchronizeProducts` --> it should be in a background thread
- Remove breakpoint and continue with the app
- Go to the Products tab --> the products should be loaded correctly as before

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="1624" alt="Screenshot 2025-06-13 at 4 32 25 PM" src="https://github.com/user-attachments/assets/4b3b11c2-1152-499a-96c3-fa5fa5ecaa81" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.