### PR TITLE
[Woo POS][Coupons] Remove enableCouponsInPointOfSale

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -69,8 +69,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return false
         case .pointOfSale:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .enableCouponsInPointOfSale:
-            return true
         case .googleAdsCampaignCreationOnWebView:
             return true
         case .backgroundTasks:

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -153,10 +153,6 @@ public enum FeatureFlag: Int {
     ///
     case pointOfSale
 
-    /// Enables coupons in Point of Sale
-    ///
-    case enableCouponsInPointOfSale
-
     /// Enables Google ads campaign creation on web view
     ///
     case googleAdsCampaignCreationOnWebView

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -26,7 +26,7 @@ struct CartView: View {
     @State private var shouldShowItemImages: Bool = false
 
     private var shouldShowCoupons: Bool {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enableCouponsInPointOfSale) && posModel.cart.coupons.isNotEmpty
+        posModel.cart.coupons.isNotEmpty
     }
 
     var body: some View {

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -50,10 +50,6 @@ struct ItemListView: View {
     @State private var searchTask: Task<Void, Never>?
     @State private var didFinishSearch = true
 
-    private var isCouponsFeatureEnabled: Bool {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enableCouponsInPointOfSale)
-    }
-
     private var isSearchProductsFeatureEnabled: Bool {
         ServiceLocator.featureFlagService.isFeatureFlagEnabled(.searchProductsInPOS)
     }
@@ -114,9 +110,7 @@ struct ItemListView: View {
 
             TabView(selection: $selectedItemListType) {
                 itemListTabContent(.products(search: false))
-                if isCouponsFeatureEnabled {
-                    itemListTabContent(.coupons(search: false))
-                }
+                itemListTabContent(.coupons(search: false))
             }
             .tabViewStyle(.page(indexDisplayMode: .never))
             .animation(.none, value: selectedItemListType)
@@ -266,7 +260,6 @@ private extension ItemListView {
                             .transition(.opacity.combined(with: .move(edge: .trailing)))
                         } else {
                             createCouponButton
-                                .renderedIf(isCouponsFeatureEnabled)
 
                             simulatedScanButton
                                 .renderedIf(isBarcodeScanSimulatorEnabled && isBarcodeScani1FeatureEnabled)
@@ -279,7 +272,6 @@ private extension ItemListView {
                         }
                     } else {
                         createCouponButton
-                            .renderedIf(isCouponsFeatureEnabled)
                     }
                 }
             })
@@ -306,17 +298,15 @@ private extension ItemListView {
             )
         ]
 
-        if isCouponsFeatureEnabled {
-            items.append(
-                POSPageHeaderItem(
-                    title: Localization.couponsTitle,
-                    isSelected: selectedItemListType.isCoupons,
-                    action: {
-                        displayItemListType(.coupons(search: false))
-                    }
-                )
+        items.append(
+            POSPageHeaderItem(
+                title: Localization.couponsTitle,
+                isSelected: selectedItemListType.isCoupons,
+                action: {
+                    displayItemListType(.coupons(search: false))
+                }
             )
-        }
+        )
 
         return items
     }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -110,9 +110,8 @@ struct PointOfSaleDashboardView: View {
         }
         .task {
             await posModel.purchasableItemsController.loadItems(base: .root)
-            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enableCouponsInPointOfSale) {
-                await posModel.couponsController.loadItems(base: .root)
-            }
+            await posModel.couponsController.loadItems(base: .root)
+
             if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.searchProductsInPOS),
                ServiceLocator.featureFlagService.isFeatureFlagEnabled(.searchProductsInPOSPt2PopularProducts) {
                 await posModel.popularPurchasableItemsController.loadItems(base: .root)


### PR DESCRIPTION
Closes WOOMOB-613

## Description
This PR cleans up the `enableCouponsInPointOfSale` feature flag.

## Testing information
In POS ( now in a new tab!) there should be no changes in rendering the Coupons navigation, "create coupon" button, or display coupons in the cart. The checkout button should still only work when items have been added to cart, not only coupons.

Will clean up search separately to keep things encapsulated, or we can do it here as well. Whatever you prefer 🙇 
