### PR TITLE
Shipping Labels: Prevent label purchase without payment methods

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -39,7 +39,6 @@ struct WooShippingCreateLabelsView: View {
 
     @State private var showingCustomsForm = false
     @State private var showingSplitShipments = false
-    @State private var showingPaymentMethods = false
 
     /// Whether the destination address is verified.
     private var isDestinationAddressVerified: Bool {
@@ -106,12 +105,12 @@ struct WooShippingCreateLabelsView: View {
                     isShipmentDetailsExpanded = false
                 }
             }
-            .sheet(isPresented: $showingPaymentMethods) {
+            .sheet(isPresented: $viewModel.showingPaymentMethods) {
                 if let paymentMethodsViewModel = viewModel.paymentMethodsViewModel {
                     WooShippingPaymentMethodsView(viewModel: paymentMethodsViewModel,
                                                   onAccountSettingsUpdate: { settings in
                         viewModel.didUpdateAccountSettings(settings)
-                        showingPaymentMethods = false
+                        viewModel.showingPaymentMethods = false
                     })
                     .presentationDetents([.fraction(0.7), .large])
                 }
@@ -468,7 +467,7 @@ private extension WooShippingCreateLabelsView {
 
     var addPaymentMethodLine: some View {
         Button(action: {
-            showingPaymentMethods = true
+            viewModel.showingPaymentMethods = true
         }) {
             HStack {
                 Image(systemName: "plus")
@@ -487,7 +486,7 @@ private extension WooShippingCreateLabelsView {
         _ cardLineViewModel: WooShippingPaymentMethodLine.CardPaymentMethodLineViewModel
     ) -> some View {
         Button(action: {
-            showingPaymentMethods = true
+            viewModel.showingPaymentMethods = true
         }) {
             HStack {
                 Text(cardLineViewModel.title)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -182,6 +182,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Closure to execute after the label is successfully purchased.
     let onLabelPurchase: ((_ markOrderComplete: Bool) -> Void)?
 
+    @Published var showingPaymentMethods = false
     @Published private var paymentMethod: ShippingLabelPaymentMethod?
     @Published private(set) var paymentMethodLine: WooShippingPaymentMethodLine?
 
@@ -296,6 +297,10 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Purchases a shipping label with the provided label details and settings.
     @MainActor
     func purchaseLabel(shouldRefreshPackageAndRate: Bool) async {
+        guard paymentMethod != nil else {
+            showingPaymentMethods = true
+            return
+        }
         isPurchasingLabel = true
         labelPurchaseErrorNotice = nil
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-612

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Label purchase is not possible without payment methods. This PR adds a simple fix to show the payment method sheet when one attempts to purchase a label without a payment method. 

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Pre-requisite: For simplicity with testing payment method, please use a test store with the Woo Shipping extenstion set up in non-testing mode.
1. Remove all payment methods set to your WP.com account. This account should be the owner of your test store. Note: ensure to remove the payment methods in non-testing mode.
2. Log in to your test store using the owner account.
3. Navigate to the Orders tab and select a paid order with physical products and unfulfilled shipments.
4. Select Create shipping labels and proceed to enter details for purchasing a label.
5. When the Purchase label button is enabled, tap it to proceed. 
6. Confirm that the payment method sheet is displayed.
7. Add a payment method to your account or switch to a test store with existing payment method.
8. Confirm that you can purchase a label successfully.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested and confirmed the fix with simulator iPhone 16 iOS 18.4

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/112aeb78-f089-433b-8945-1e41e6214a68



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
