### PR TITLE
Inject `Locale` and `TimeZone` in `ReceiptRenderer`

### DIFF
--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -5,17 +5,23 @@ import UIKit
 public final class ReceiptRenderer: UIPrintPageRenderer {
     private let content: ReceiptContent
 
-    private let dateFormatter: DateFormatter = {
+    private lazy var dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         formatter.timeStyle = .none
-        formatter.locale = Locale.current
+        formatter.locale = locale
+        formatter.timeZone = timeZone
 
         return formatter
     }()
 
-    public init(content: ReceiptContent) {
+    private let locale: Locale
+    private let timeZone: TimeZone
+
+    public init(content: ReceiptContent, locale: Locale = .current, timeZone: TimeZone = .current) {
         self.content = content
+        self.locale = locale
+        self.timeZone = timeZone
 
         super.init()
     }

--- a/Hardware/HardwareTests/AirPrintReceipt/ReceiptRendererTest.swift
+++ b/Hardware/HardwareTests/AirPrintReceipt/ReceiptRendererTest.swift
@@ -5,11 +5,14 @@ import Foundation
 import CryptoKit
 
 final class ReceiptRendererTest: XCTestCase {
+    let locale = Locale(identifier: "en_US_POSIX")
+    let timeZone = TimeZone(secondsFromGMT: 0)!
+
     func test_TextWithoutHtmlSymbols() {
         let expectedResultWithoutHtmlSymbolsMd5Description = "MD5 digest: 4eaaad801b2e0da0c113fb1db9267197"
         let content = generateReceiptContent()
 
-        let renderer = ReceiptRenderer(content: content)
+        let renderer = ReceiptRenderer(content: content, locale: locale, timeZone: timeZone)
 
         XCTAssertEqual(
             Insecure.MD5.hash(data: renderer.htmlContent().data(using: .utf8)!).description,
@@ -22,7 +25,7 @@ final class ReceiptRendererTest: XCTestCase {
         let stringWithHtml = "<tt><table></table></footer>"
         let content = generateReceiptContent(stringToAppend: stringWithHtml)
 
-        let renderer = ReceiptRenderer(content: content)
+        let renderer = ReceiptRenderer(content: content, locale: locale, timeZone: timeZone)
 
         XCTAssertEqual(
             Insecure.MD5.hash(data: renderer.htmlContent().data(using: .utf8)!).description,
@@ -36,7 +39,7 @@ final class ReceiptRendererTest: XCTestCase {
         let attributeTwo = ReceiptLineAttribute(name: "name_attr_2", value: "value_attr_2")
         let content = generateReceiptContent(attributes: [attributeOne, attributeTwo])
 
-        let renderer = ReceiptRenderer(content: content)
+        let renderer = ReceiptRenderer(content: content, locale: locale, timeZone: timeZone)
 
         print(renderer.htmlContent())
 

--- a/Hardware/HardwareTests/AirPrintReceipt/ReceiptRendererTest.swift
+++ b/Hardware/HardwareTests/AirPrintReceipt/ReceiptRendererTest.swift
@@ -41,8 +41,6 @@ final class ReceiptRendererTest: XCTestCase {
 
         let renderer = ReceiptRenderer(content: content, locale: locale, timeZone: timeZone)
 
-        print(renderer.htmlContent())
-
         XCTAssertEqual(
             Insecure.MD5.hash(data: renderer.htmlContent().data(using: .utf8)!).description,
             expectedResultWithHtmlSymbolsMd5Description


### PR DESCRIPTION


<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
I'm working on simplifying hardware to be a Swift package, but the tests fail in CI, https://github.com/woocommerce/woocommerce-ios/pull/15744

Investigating locally, I run into an unrelated test failure in `ReceiptRenderer`. 

![image](https://github.com/user-attachments/assets/a9c5f774-2e44-4671-821c-b186630b9b76)

The reason it fails on my machine but not in CI is that the MD5 we check against was generated based on a different locale and time zone. 

Once `Locale` and `TimeZone` are made static in the tests, everything is green again.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. — N.A.