### PR TITLE
[Woo POS][Coupons] Remove `searchCouponsInPOS` flag

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -97,8 +97,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .searchProductsInPOSPt2PopularProducts:
             return true
-        case .searchCouponsInPOS:
-            return true
         case .inventoryProductLabelsInPOS:
             return false
         case .pointOfSaleReceipts:

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -209,10 +209,6 @@ public enum FeatureFlag: Int {
     ///
     case searchProductsInPOSPt2PopularProducts
 
-    /// Allows searching coupons in POS
-    ///
-    case searchCouponsInPOS
-
     /// Enables optimized handling of product images
     ///
     case productImageOptimizedHandling

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -54,10 +54,6 @@ struct ItemListView: View {
         ServiceLocator.featureFlagService.isFeatureFlagEnabled(.searchProductsInPOS)
     }
 
-    private var isSearchCouponsFeatureEnabled: Bool {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.searchCouponsInPOS)
-    }
-
     private var isBarcodeScani1FeatureEnabled: Bool {
         ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleBarcodeScanningi1)
     }
@@ -77,7 +73,7 @@ struct ItemListView: View {
         case .products:
             return isSearchProductsFeatureEnabled
         case .coupons:
-            return isSearchCouponsFeatureEnabled
+            return true
         }
     }
 


### PR DESCRIPTION
Addition to WOOMOB-613 and continuation of https://github.com/woocommerce/woocommerce-ios/pull/15751

## Description
This PR cleans up the `searchCouponsInPOS` feature flag.

## Testing information
In POS ( now in a new tab!) there should be no difference on how the coupons search button is rendered, it always appear when we navigate to the Coupons header, and searches for coupons on usage.