### PR TITLE
[Woo POS][Barcodes] Implement barcode scan heuristics

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/BarcodeScannerContainer.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/BarcodeScannerContainer.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UIKit
 
 /// A SwiftUI view that provides barcode scanning functionality by capturing keyboard input.
 /// This container is designed to be invisible and non-interactive, serving as a bridge between

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/BarcodeScannerContainer.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/BarcodeScannerContainer.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// A SwiftUI view that provides barcode scanning functionality by capturing keyboard input.
 /// This container is designed to be invisible and non-interactive, serving as a bridge between
@@ -103,7 +104,7 @@ class BarcodeScannerHostingController: UIHostingController<EmptyView> {
         /// or change between the `began` call and the `ended` call.
         /// It's better practice for barcode scanning to only consider the presses when they end.
         for press in presses {
-            guard let key = press.key?.charactersIgnoringModifiers else { continue }
+            guard let key = press.key else { continue }
             scanner.processKeyPress(key)
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
@@ -196,6 +196,6 @@ struct HIDBarcodeParserConfiguration {
         terminatingStrings: ["\r", "\n"],
         minimumBarcodeLength: 4,
         maximumScanTime: 1.5,
-        maximumInterCharacterTime: 0.1
+        maximumInterCharacterTime: 0.2
     )
 }

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 /// Protocol for creating timers, allowing injection of test timers
 protocol TimerFactory {
@@ -37,7 +38,7 @@ final class HIDBarcodeParser {
 
     /// Process a key press event
     /// - Parameter key: The key that was pressed
-    func processKeyPress(_ key: String) {
+    func processKeyPress(_ key: UIKey) {
         let currentTime = Date()
 
         // If characters are entered too slowly, it's probably typing and we should ignore it
@@ -52,12 +53,96 @@ final class HIDBarcodeParser {
         }
         lastKeyPressTime = currentTime
 
-        if configuration.terminatingStrings.contains(key) {
+        let character = key.charactersIgnoringModifiers
+        if configuration.terminatingStrings.contains(character) {
             processScan()
         } else {
-            buffer.append(key)
+            guard !excludedKeys.contains(key.keyCode) else { return }
+            buffer.append(character)
         }
     }
+
+    private let excludedKeys: [UIKeyboardHIDUsage] = [
+        .keyboardCapsLock,
+        .keyboardF1,
+        .keyboardF2,
+        .keyboardF3,
+        .keyboardF4,
+        .keyboardF5,
+        .keyboardF6,
+        .keyboardF7,
+        .keyboardF8,
+        .keyboardF9,
+        .keyboardF10,
+        .keyboardF11,
+        .keyboardF12,
+        .keyboardPrintScreen,
+        .keyboardScrollLock,
+        .keyboardPause,
+        .keyboardInsert,
+        .keyboardHome,
+        .keyboardPageUp,
+        .keyboardDeleteForward,
+        .keyboardEnd,
+        .keyboardPageDown,
+        .keyboardRightArrow,
+        .keyboardLeftArrow,
+        .keyboardDownArrow,
+        .keyboardUpArrow,
+        .keypadNumLock,
+        .keyboardApplication,
+        .keyboardPower,
+        .keypadEqualSign,
+        .keyboardF13,
+        .keyboardF14,
+        .keyboardF15,
+        .keyboardF16,
+        .keyboardF17,
+        .keyboardF18,
+        .keyboardF19,
+        .keyboardF20,
+        .keyboardF21,
+        .keyboardF22,
+        .keyboardF23,
+        .keyboardF24,
+        .keyboardExecute,
+        .keyboardHelp,
+        .keyboardMenu,
+        .keyboardSelect,
+        .keyboardStop,
+        .keyboardAgain,
+        .keyboardUndo,
+        .keyboardCut,
+        .keyboardCopy,
+        .keyboardPaste,
+        .keyboardFind,
+        .keyboardMute,
+        .keyboardVolumeUp,
+        .keyboardVolumeDown,
+        .keyboardLockingCapsLock,
+        .keyboardLockingNumLock,
+        .keyboardLockingScrollLock,
+        .keyboardAlternateErase,
+        .keyboardSysReqOrAttention,
+        .keyboardCancel,
+        .keyboardClear,
+        .keyboardPrior,
+        .keyboardSeparator,
+        .keyboardOut,
+        .keyboardOper,
+        .keyboardClearOrAgain,
+        .keyboardCrSelOrProps,
+        .keyboardExSel,
+        .keyboardLeftControl,
+        .keyboardLeftShift,
+        .keyboardLeftAlt,
+        .keyboardLeftGUI,
+        .keyboardRightControl,
+        .keyboardRightShift,
+        .keyboardRightAlt,
+        .keyboardRightGUI,
+        .keyboard_Reserved
+    ]
 
     /// Cancel the current scan and clear the buffer
     func cancel() {

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
@@ -53,7 +53,7 @@ final class HIDBarcodeParser {
         }
         lastKeyPressTime = currentTime
 
-        let character = key.charactersIgnoringModifiers
+        let character = key.characters
         if configuration.terminatingStrings.contains(character) {
             processScan()
         } else {

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
@@ -10,6 +10,8 @@ final class HIDBarcodeParser {
     let onScan: (String) -> Void
 
     private var buffer = ""
+    private var lastKeyPressTime: Date?
+    private var scanTimer: Timer?
 
     init(configuration: HIDBarcodeParserConfiguration, onScan: @escaping (String) -> Void) {
         self.configuration = configuration
@@ -19,9 +21,22 @@ final class HIDBarcodeParser {
     /// Process a key press event
     /// - Parameter key: The key that was pressed
     func processKeyPress(_ key: String) {
+        let currentTime = Date()
+
+        // If characters are entered too slowly, it's probably typing and we should ignore it
+        if let lastTime = lastKeyPressTime,
+           currentTime.timeIntervalSince(lastTime) > configuration.maximumInterCharacterTime {
+            resetScan()
+        }
+
+        // Start timing if this is the first key press
+        if scanTimer == nil {
+            startScanTimer()
+        }
+        lastKeyPressTime = currentTime
+
         if configuration.terminatingStrings.contains(key) {
-            onScan(buffer)
-            buffer = ""
+            processScan()
         } else {
             buffer.append(key)
         }
@@ -29,7 +44,29 @@ final class HIDBarcodeParser {
 
     /// Cancel the current scan and clear the buffer
     func cancel() {
+        resetScan()
+    }
+
+    private func resetScan() {
         buffer = ""
+        lastKeyPressTime = nil
+        scanTimer?.invalidate()
+        scanTimer = nil
+    }
+
+    private func startScanTimer() {
+        scanTimer?.invalidate()
+        scanTimer = Timer.scheduledTimer(withTimeInterval: configuration.maximumScanTime, repeats: false) { [weak self] _ in
+            guard let self = self else { return }
+            processScan()
+        }
+    }
+
+    private func processScan() {
+        if buffer.count >= configuration.minimumBarcodeLength {
+            onScan(buffer)
+        }
+        resetScan()
     }
 }
 
@@ -38,8 +75,22 @@ struct HIDBarcodeParserConfiguration {
     /// Strings that indicate the end of a barcode scan
     let terminatingStrings: Set<String>
 
+    /// Minimum length to consider scanned input complete
+    let minimumBarcodeLength: Int
+
+    /// Maximum time to allow for scanned input.
+    /// After this time elapses from the first "keystroke", the scan will be checked
+    let maximumScanTime: TimeInterval
+
+    /// Maximum time between scanned keystrokes
+    /// After this time elapses, any further keystrokes result in the scan being rejected
+    let maximumInterCharacterTime: TimeInterval
+
     /// Default configuration suitable for most barcode scanners
     static let `default` = HIDBarcodeParserConfiguration(
-        terminatingStrings: ["\r", "\n"]
+        terminatingStrings: ["\r", "\n"],
+        minimumBarcodeLength: 4,
+        maximumScanTime: 1.5,
+        maximumInterCharacterTime: 0.1
     )
 }

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
@@ -1,18 +1,6 @@
 import Foundation
 import UIKit
 
-/// Protocol for creating timers, allowing injection of test timers
-protocol TimerFactory {
-    func createTimer(interval: TimeInterval, repeats: Bool, block: @escaping () -> Void) -> Timer
-}
-
-/// Default timer factory that creates real timers
-struct DefaultTimerFactory: TimerFactory {
-    func createTimer(interval: TimeInterval, repeats: Bool, block: @escaping () -> Void) -> Timer {
-        Timer.scheduledTimer(withTimeInterval: interval, repeats: repeats, block: { _ in block() })
-    }
-}
-
 /// Parses HID (Human Interface Device) keyboard input into barcode scans.
 /// This class handles the core logic for interpreting keyboard input as barcode data,
 /// particularly useful for physical barcode scanners that operate as keyboard input devices.
@@ -22,20 +10,16 @@ final class HIDBarcodeParser {
     /// Callback that is triggered when a barcode is successfully scanned
     let onScan: (String) -> Void
 
-    private let timerFactory: TimerFactory
     private let timeProvider: TimeProvider
 
     private var buffer = ""
     private var lastKeyPressTime: Date?
-    private var scanTimer: Timer?
 
     init(configuration: HIDBarcodeParserConfiguration,
          onScan: @escaping (String) -> Void,
-         timerFactory: TimerFactory = DefaultTimerFactory(),
          timeProvider: TimeProvider = DefaultTimeProvider()) {
         self.configuration = configuration
         self.onScan = onScan
-        self.timerFactory = timerFactory
         self.timeProvider = timeProvider
     }
 
@@ -50,10 +34,6 @@ final class HIDBarcodeParser {
             resetScan()
         }
 
-        // Start timing if this is the first key press
-        if scanTimer == nil {
-            startScanTimer()
-        }
         lastKeyPressTime = currentTime
 
         let character = key.characters
@@ -155,16 +135,6 @@ final class HIDBarcodeParser {
     private func resetScan() {
         buffer = ""
         lastKeyPressTime = nil
-        scanTimer?.invalidate()
-        scanTimer = nil
-    }
-
-    private func startScanTimer() {
-        scanTimer?.invalidate()
-        scanTimer = timerFactory.createTimer(interval: configuration.maximumScanTime, repeats: false) { [weak self] in
-            guard let self = self else { return }
-            self.processScan()
-        }
     }
 
     private func processScan() {
@@ -183,10 +153,6 @@ struct HIDBarcodeParserConfiguration {
     /// Minimum length to consider scanned input complete
     let minimumBarcodeLength: Int
 
-    /// Maximum time to allow for scanned input.
-    /// After this time elapses from the first "keystroke", the scan will be checked
-    let maximumScanTime: TimeInterval
-
     /// Maximum time between scanned keystrokes
     /// After this time elapses, any further keystrokes result in the scan being rejected
     let maximumInterCharacterTime: TimeInterval
@@ -195,7 +161,6 @@ struct HIDBarcodeParserConfiguration {
     static let `default` = HIDBarcodeParserConfiguration(
         terminatingStrings: ["\r", "\n"],
         minimumBarcodeLength: 4,
-        maximumScanTime: 1.5,
         maximumInterCharacterTime: 0.2
     )
 }

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
@@ -75,7 +75,6 @@ final class HIDBarcodeParser {
         .keypadNumLock,
         .keyboardApplication,
         .keyboardPower,
-        .keypadEqualSign,
         .keyboardF13,
         .keyboardF14,
         .keyboardF15,

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
@@ -1,5 +1,17 @@
 import Foundation
 
+/// Protocol for creating timers, allowing injection of test timers
+protocol TimerFactory {
+    func createTimer(interval: TimeInterval, repeats: Bool, block: @escaping () -> Void) -> Timer
+}
+
+/// Default timer factory that creates real timers
+struct DefaultTimerFactory: TimerFactory {
+    func createTimer(interval: TimeInterval, repeats: Bool, block: @escaping () -> Void) -> Timer {
+        Timer.scheduledTimer(withTimeInterval: interval, repeats: repeats, block: { _ in block() })
+    }
+}
+
 /// Parses HID (Human Interface Device) keyboard input into barcode scans.
 /// This class handles the core logic for interpreting keyboard input as barcode data,
 /// particularly useful for physical barcode scanners that operate as keyboard input devices.
@@ -9,13 +21,18 @@ final class HIDBarcodeParser {
     /// Callback that is triggered when a barcode is successfully scanned
     let onScan: (String) -> Void
 
+    private let timerFactory: TimerFactory
+
     private var buffer = ""
     private var lastKeyPressTime: Date?
     private var scanTimer: Timer?
 
-    init(configuration: HIDBarcodeParserConfiguration, onScan: @escaping (String) -> Void) {
+    init(configuration: HIDBarcodeParserConfiguration,
+         onScan: @escaping (String) -> Void,
+         timerFactory: TimerFactory = DefaultTimerFactory()) {
         self.configuration = configuration
         self.onScan = onScan
+        self.timerFactory = timerFactory
     }
 
     /// Process a key press event
@@ -56,9 +73,9 @@ final class HIDBarcodeParser {
 
     private func startScanTimer() {
         scanTimer?.invalidate()
-        scanTimer = Timer.scheduledTimer(withTimeInterval: configuration.maximumScanTime, repeats: false) { [weak self] _ in
+        scanTimer = timerFactory.createTimer(interval: configuration.maximumScanTime, repeats: false) { [weak self] in
             guard let self = self else { return }
-            processScan()
+            self.processScan()
         }
     }
 

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
@@ -23,6 +23,7 @@ final class HIDBarcodeParser {
     let onScan: (String) -> Void
 
     private let timerFactory: TimerFactory
+    private let timeProvider: TimeProvider
 
     private var buffer = ""
     private var lastKeyPressTime: Date?
@@ -30,16 +31,18 @@ final class HIDBarcodeParser {
 
     init(configuration: HIDBarcodeParserConfiguration,
          onScan: @escaping (String) -> Void,
-         timerFactory: TimerFactory = DefaultTimerFactory()) {
+         timerFactory: TimerFactory = DefaultTimerFactory(),
+         timeProvider: TimeProvider = DefaultTimeProvider()) {
         self.configuration = configuration
         self.onScan = onScan
         self.timerFactory = timerFactory
+        self.timeProvider = timeProvider
     }
 
     /// Process a key press event
     /// - Parameter key: The key that was pressed
     func processKeyPress(_ key: UIKey) {
-        let currentTime = Date()
+        let currentTime = timeProvider.now()
 
         // If characters are entered too slowly, it's probably typing and we should ignore it
         if let lastTime = lastKeyPressTime,

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/TimeProvider.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/TimeProvider.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+protocol TimeProvider {
+    func now() -> Date
+}
+
+struct DefaultTimeProvider: TimeProvider {
+    func now() -> Date {
+        Date()
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -910,6 +910,8 @@
 		20CC1EDB2AFA8381006BD429 /* InPersonPaymentsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */; };
 		20CC1EDD2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CC1EDC2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift */; };
 		20CCBF212B0E15C0003102E6 /* WooPaymentsPayoutsCurrencyOverviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CCBF202B0E15C0003102E6 /* WooPaymentsPayoutsCurrencyOverviewViewModelTests.swift */; };
+		20CEBF232E02C760001F3300 /* TimeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CEBF222E02C760001F3300 /* TimeProvider.swift */; };
+		20CEBF252E02C7E6001F3300 /* MockTimeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CEBF242E02C7E6001F3300 /* MockTimeProvider.swift */; };
 		20CF75BA2CF4E6A200ACCF4A /* PointOfSaleOrderController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CF75B92CF4E69000ACCF4A /* PointOfSaleOrderController.swift */; };
 		20D210BE2B14C9B90099E517 /* WooPaymentsPayoutStatusDisplayDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D210BD2B14C9B90099E517 /* WooPaymentsPayoutStatusDisplayDetails.swift */; };
 		20D2CCA32C7E175700051705 /* WavesProgressViewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D2CCA22C7E175700051705 /* WavesProgressViewStyle.swift */; };
@@ -4160,6 +4162,8 @@
 		20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenu.swift; sourceTree = "<group>"; };
 		20CC1EDC2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModel.swift; sourceTree = "<group>"; };
 		20CCBF202B0E15C0003102E6 /* WooPaymentsPayoutsCurrencyOverviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsCurrencyOverviewViewModelTests.swift; sourceTree = "<group>"; };
+		20CEBF222E02C760001F3300 /* TimeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeProvider.swift; sourceTree = "<group>"; };
+		20CEBF242E02C7E6001F3300 /* MockTimeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTimeProvider.swift; sourceTree = "<group>"; };
 		20CF75B92CF4E69000ACCF4A /* PointOfSaleOrderController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleOrderController.swift; sourceTree = "<group>"; };
 		20D210BD2B14C9B90099E517 /* WooPaymentsPayoutStatusDisplayDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutStatusDisplayDetails.swift; sourceTree = "<group>"; };
 		20D2CCA22C7E175700051705 /* WavesProgressViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WavesProgressViewStyle.swift; sourceTree = "<group>"; };
@@ -8441,6 +8445,7 @@
 			isa = PBXGroup;
 			children = (
 				202235F02DFAEAE500E13DE9 /* HIDBarcodeParser.swift */,
+				20CEBF222E02C760001F3300 /* TimeProvider.swift */,
 				20D5575C2DFADF5400D9EC8B /* BarcodeScannerContainer.swift */,
 				202240FB2DFAF41D00E13DE9 /* BarcodeScanningModifier.swift */,
 			);
@@ -8451,6 +8456,7 @@
 			isa = PBXGroup;
 			children = (
 				202235F22DFAEC2700E13DE9 /* HIDBarcodeParserTests.swift */,
+				20CEBF242E02C7E6001F3300 /* MockTimeProvider.swift */,
 			);
 			path = "Barcode Scanning";
 			sourceTree = "<group>";
@@ -16207,6 +16213,7 @@
 				B9CA4F352AB2F33200285AB9 /* SelectedStoredTaxRateFetcher.swift in Sources */,
 				DE4D23AA29B1B0CA003A4B5D /* WPCom2FALoginView.swift in Sources */,
 				027CCBCD2C23495E002CE572 /* PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView.swift in Sources */,
+				20CEBF232E02C760001F3300 /* TimeProvider.swift in Sources */,
 				023D1DD124AB2D05002B03A3 /* ProductListSelectorViewController.swift in Sources */,
 				2004E2D02C077D2800D62521 /* CardPresentPaymentTransaction.swift in Sources */,
 				0206483A23FA4160008441BB /* OrdersRootViewController.swift in Sources */,
@@ -17641,6 +17648,7 @@
 				CC2E72F727B6BFB800A62872 /* ProductVariationFormatterTests.swift in Sources */,
 				02B21C5529C84E4A00C5623B /* WPAdminWebViewModelTests.swift in Sources */,
 				D802547826551DB8001B2CC1 /* CardPresentModalDisplayMessageTests.swift in Sources */,
+				20CEBF252E02C7E6001F3300 /* MockTimeProvider.swift in Sources */,
 				02503C632538301400FD235D /* ProductVariationFormActionsFactory+ReadonlyVariationTests.swift in Sources */,
 				B9A5317F2D2FCC5600208304 /* WooShippingCustomsItemViewModelTests.swift in Sources */,
 				DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/HIDBarcodeParserTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/HIDBarcodeParserTests.swift
@@ -201,7 +201,12 @@ struct HIDBarcodeParserTests {
     @Test("Parser handles multiple terminating strings")
     func testMultipleTerminatingStrings() {
         var scannedCodes: [String] = []
-        let configuration = testConfiguration
+        let configuration = HIDBarcodeParserConfiguration(
+            terminatingStrings: ["\r", "\n", "\t"],
+            minimumBarcodeLength: 4,
+            maximumScanTime: 0.3,
+            maximumInterCharacterTime: 0.05
+        )
         let parser = HIDBarcodeParser(
             configuration: configuration,
             onScan: { code in

--- a/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/HIDBarcodeParserTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/HIDBarcodeParserTests.swift
@@ -15,7 +15,6 @@ struct HIDBarcodeParserTests {
         let customTerminators: Set<String> = ["\t", " "]
         let configuration = HIDBarcodeParserConfiguration(terminatingStrings: customTerminators,
                                                           minimumBarcodeLength: 1,
-                                                          maximumScanTime: 1,
                                                           maximumInterCharacterTime: 1)
         #expect(configuration.terminatingStrings == customTerminators)
     }
@@ -97,7 +96,6 @@ struct HIDBarcodeParserTests {
         let configuration = HIDBarcodeParserConfiguration(
             terminatingStrings: ["\r"],
             minimumBarcodeLength: 4,
-            maximumScanTime: 1.5,
             maximumInterCharacterTime: 0.1
         )
         let parser = HIDBarcodeParser(
@@ -114,37 +112,6 @@ struct HIDBarcodeParserTests {
         parser.processKeyPress(MockUIKey(character: "\r"))
 
         #expect(scannedCodes.isEmpty)
-    }
-
-    @Test("Parser processes scan after maximum scan time")
-    func testMaximumScanTime() {
-        var scannedCodes: [String] = []
-        var timerBlock: (() -> Void)?
-
-        let mockTimerFactory = MockTimerFactory { interval, repeats, block in
-            timerBlock = block
-            return Timer()
-        }
-
-        let configuration = testConfiguration
-        let parser = HIDBarcodeParser(
-            configuration: configuration,
-            onScan: { code in
-                scannedCodes.append(code)
-            },
-            timerFactory: mockTimerFactory
-        )
-
-        // Start a scan
-        parser.processKeyPress(MockUIKey(character: "1"))
-        parser.processKeyPress(MockUIKey(character: "2"))
-        parser.processKeyPress(MockUIKey(character: "3"))
-        parser.processKeyPress(MockUIKey(character: "4"))
-
-        // Simulate timer firing
-        timerBlock?()
-
-        #expect(scannedCodes == ["1234"])
     }
 
     @Test("Parser ignores slow typing")
@@ -204,7 +171,6 @@ struct HIDBarcodeParserTests {
         let configuration = HIDBarcodeParserConfiguration(
             terminatingStrings: ["\r", "\n", "\t"],
             minimumBarcodeLength: 4,
-            maximumScanTime: 0.3,
             maximumInterCharacterTime: 0.05
         )
         let parser = HIDBarcodeParser(
@@ -278,7 +244,6 @@ private extension HIDBarcodeParserTests {
     var testConfiguration: HIDBarcodeParserConfiguration {
         HIDBarcodeParserConfiguration(terminatingStrings: ["\r", "\n"],
                                       minimumBarcodeLength: 3,
-                                      maximumScanTime: 0.3,
                                       maximumInterCharacterTime: 0.05)
     }
 }
@@ -305,17 +270,5 @@ private class MockUIKey: UIKey {
 
     override var keyCode: UIKeyboardHIDUsage {
         mockKeyCode
-    }
-}
-
-private class MockTimerFactory: TimerFactory {
-    private let createTimerBlock: (TimeInterval, Bool, @escaping () -> Void) -> Timer
-
-    init(createTimerBlock: @escaping (TimeInterval, Bool, @escaping () -> Void) -> Timer) {
-        self.createTimerBlock = createTimerBlock
-    }
-
-    func createTimer(interval: TimeInterval, repeats: Bool, block: @escaping () -> Void) -> Timer {
-        createTimerBlock(interval, repeats, block)
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/HIDBarcodeParserTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/HIDBarcodeParserTests.swift
@@ -119,17 +119,25 @@ struct HIDBarcodeParserTests {
     @Test("Parser processes scan after maximum scan time")
     func testMaximumScanTime() {
         var scannedCodes: [String] = []
+        var timerBlock: (() -> Void)?
+
+        let mockTimerFactory = MockTimerFactory { interval, repeats, block in
+            timerBlock = block
+            return Timer()
+        }
+
         let configuration = HIDBarcodeParserConfiguration(
             terminatingStrings: ["\r"],
             minimumBarcodeLength: 4,
-            maximumScanTime: 0.1,
+            maximumScanTime: 0.01,
             maximumInterCharacterTime: 0.05
         )
         let parser = HIDBarcodeParser(
             configuration: configuration,
             onScan: { code in
                 scannedCodes.append(code)
-            }
+            },
+            timerFactory: mockTimerFactory
         )
 
         // Start a scan
@@ -138,8 +146,8 @@ struct HIDBarcodeParserTests {
         parser.processKeyPress("3")
         parser.processKeyPress("4")
 
-        // Run the run loop to allow the timer to fire
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.2))
+        // Simulate timer firing
+        timerBlock?()
 
         #expect(scannedCodes == ["1234"])
     }
@@ -272,5 +280,17 @@ private class MockUIKey: UIKey {
 
     override var charactersIgnoringModifiers: String {
         mockCharacter
+    }
+}
+
+private class MockTimerFactory: TimerFactory {
+    private let createTimerBlock: (TimeInterval, Bool, @escaping () -> Void) -> Timer
+
+    init(createTimerBlock: @escaping (TimeInterval, Bool, @escaping () -> Void) -> Timer) {
+        self.createTimerBlock = createTimerBlock
+    }
+
+    func createTimer(interval: TimeInterval, repeats: Bool, block: @escaping () -> Void) -> Timer {
+        createTimerBlock(interval, repeats, block)
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/HIDBarcodeParserTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/HIDBarcodeParserTests.swift
@@ -31,10 +31,10 @@ struct HIDBarcodeParserTests {
         )
 
         // Simulate a complete scan
-        parser.processKeyPress("1")
-        parser.processKeyPress("2")
-        parser.processKeyPress("3")
-        parser.processKeyPress("\r")
+        parser.processKeyPress(MockUIKey(character: "1"))
+        parser.processKeyPress(MockUIKey(character: "2"))
+        parser.processKeyPress(MockUIKey(character: "3"))
+        parser.processKeyPress(MockUIKey(character: "\r"))
 
         #expect(scannedCodes == ["123"])
     }
@@ -50,16 +50,16 @@ struct HIDBarcodeParserTests {
         )
 
         // First scan
-        parser.processKeyPress("1")
-        parser.processKeyPress("2")
-        parser.processKeyPress("3")
-        parser.processKeyPress("\r")
+        parser.processKeyPress(MockUIKey(character: "1"))
+        parser.processKeyPress(MockUIKey(character: "2"))
+        parser.processKeyPress(MockUIKey(character: "3"))
+        parser.processKeyPress(MockUIKey(character: "\r"))
 
         // Second scan
-        parser.processKeyPress("4")
-        parser.processKeyPress("5")
-        parser.processKeyPress("6")
-        parser.processKeyPress("\r")
+        parser.processKeyPress(MockUIKey(character: "4"))
+        parser.processKeyPress(MockUIKey(character: "5"))
+        parser.processKeyPress(MockUIKey(character: "6"))
+        parser.processKeyPress(MockUIKey(character: "\r"))
 
         #expect(scannedCodes == ["123", "456"])
     }
@@ -75,18 +75,18 @@ struct HIDBarcodeParserTests {
         )
 
         // Start a scan
-        parser.processKeyPress("1")
-        parser.processKeyPress("2")
-        parser.processKeyPress("3")
+        parser.processKeyPress(MockUIKey(character: "1"))
+        parser.processKeyPress(MockUIKey(character: "2"))
+        parser.processKeyPress(MockUIKey(character: "3"))
 
         // Cancel the scan
         parser.cancel()
 
         // Start a new scan
-        parser.processKeyPress("4")
-        parser.processKeyPress("5")
-        parser.processKeyPress("6")
-        parser.processKeyPress("\r")
+        parser.processKeyPress(MockUIKey(character: "4"))
+        parser.processKeyPress(MockUIKey(character: "5"))
+        parser.processKeyPress(MockUIKey(character: "6"))
+        parser.processKeyPress(MockUIKey(character: "\r"))
 
         #expect(scannedCodes == ["456"])
     }
@@ -108,10 +108,10 @@ struct HIDBarcodeParserTests {
         )
 
         // Try to scan a short barcode
-        parser.processKeyPress("1")
-        parser.processKeyPress("2")
-        parser.processKeyPress("3")
-        parser.processKeyPress("\r")
+        parser.processKeyPress(MockUIKey(character: "1"))
+        parser.processKeyPress(MockUIKey(character: "2"))
+        parser.processKeyPress(MockUIKey(character: "3"))
+        parser.processKeyPress(MockUIKey(character: "\r"))
 
         #expect(scannedCodes.isEmpty)
     }
@@ -141,10 +141,10 @@ struct HIDBarcodeParserTests {
         )
 
         // Start a scan
-        parser.processKeyPress("1")
-        parser.processKeyPress("2")
-        parser.processKeyPress("3")
-        parser.processKeyPress("4")
+        parser.processKeyPress(MockUIKey(character: "1"))
+        parser.processKeyPress(MockUIKey(character: "2"))
+        parser.processKeyPress(MockUIKey(character: "3"))
+        parser.processKeyPress(MockUIKey(character: "4"))
 
         // Simulate timer firing
         timerBlock?()
@@ -169,12 +169,12 @@ struct HIDBarcodeParserTests {
         )
 
         // Simulate slow typing
-        parser.processKeyPress("1")
-        parser.processKeyPress("2")
-        parser.processKeyPress("3")
-        Thread.sleep(forTimeInterval: 0.06)
-        parser.processKeyPress("4")
-        parser.processKeyPress("\r")
+        parser.processKeyPress(MockUIKey(character: "1"))
+        parser.processKeyPress(MockUIKey(character: "2"))
+        parser.processKeyPress(MockUIKey(character: "3"))
+        Thread.sleep(forTimeInterval: 0.06) // Just over maximumInterCharacterTime
+        parser.processKeyPress(MockUIKey(character: "4"))
+        parser.processKeyPress(MockUIKey(character: "\r"))
 
         #expect(scannedCodes.isEmpty)
     }
@@ -196,15 +196,15 @@ struct HIDBarcodeParserTests {
         )
 
         // Simulate slow typing
-        parser.processKeyPress("1")
+        parser.processKeyPress(MockUIKey(character: "1"))
         Thread.sleep(forTimeInterval: 0.03)
-        parser.processKeyPress("2")
+        parser.processKeyPress(MockUIKey(character: "2"))
         Thread.sleep(forTimeInterval: 0.03)
-        parser.processKeyPress("3")
+        parser.processKeyPress(MockUIKey(character: "3"))
         Thread.sleep(forTimeInterval: 0.03)
-        parser.processKeyPress("4")
+        parser.processKeyPress(MockUIKey(character: "4"))
         Thread.sleep(forTimeInterval: 0.03)
-        parser.processKeyPress("\r")
+        parser.processKeyPress(MockUIKey(character: "\r"))
 
         #expect(scannedCodes == ["1234"])
     }
@@ -215,8 +215,8 @@ struct HIDBarcodeParserTests {
         let configuration = HIDBarcodeParserConfiguration(
             terminatingStrings: ["\r", "\n", "\t"],
             minimumBarcodeLength: 4,
-            maximumScanTime: 1.5,
-            maximumInterCharacterTime: 0.1
+            maximumScanTime: 0.3,
+            maximumInterCharacterTime: 0.05
         )
         let parser = HIDBarcodeParser(
             configuration: configuration,
@@ -226,19 +226,60 @@ struct HIDBarcodeParserTests {
         )
 
         // Test with different terminating strings
-        parser.processKeyPress("1")
-        parser.processKeyPress("2")
-        parser.processKeyPress("3")
-        parser.processKeyPress("4")
-        parser.processKeyPress("\n")
+        parser.processKeyPress(MockUIKey(character: "1"))
+        parser.processKeyPress(MockUIKey(character: "2"))
+        parser.processKeyPress(MockUIKey(character: "3"))
+        parser.processKeyPress(MockUIKey(character: "4"))
+        parser.processKeyPress(MockUIKey(character: "\n"))
 
-        parser.processKeyPress("5")
-        parser.processKeyPress("6")
-        parser.processKeyPress("7")
-        parser.processKeyPress("8")
-        parser.processKeyPress("\t")
+        parser.processKeyPress(MockUIKey(character: "5"))
+        parser.processKeyPress(MockUIKey(character: "6"))
+        parser.processKeyPress(MockUIKey(character: "7"))
+        parser.processKeyPress(MockUIKey(character: "8"))
+        parser.processKeyPress(MockUIKey(character: "\t"))
 
         #expect(scannedCodes == ["1234", "5678"])
+    }
+
+    @Test("Parser ignores excluded keys as input")
+    func testExcludedKeysInput() {
+        var scannedCodes: [String] = []
+        let parser = HIDBarcodeParser(
+            configuration: testConfiguration,
+            onScan: { code in
+                scannedCodes.append(code)
+            }
+        )
+
+        // Try to scan with some excluded keys mixed in
+        parser.processKeyPress(MockUIKey(character: "1"))
+        parser.processKeyPress(MockUIKey(character: "2"))
+        parser.processKeyPress(MockUIKey(character: "3"))
+        parser.processKeyPress(MockUIKey(character: "4", keyCode: .keyboardLeftShift))
+        parser.processKeyPress(MockUIKey(character: "5", keyCode: .keyboardCapsLock))
+        parser.processKeyPress(MockUIKey(character: "6", keyCode: .keyboardDownArrow))
+        parser.processKeyPress(MockUIKey(character: "\r"))
+
+        #expect(scannedCodes == ["123"])
+    }
+
+    @Test("Parser allows excluded keys as terminators")
+    func testExcludedKeysTerminators() {
+        var scannedCodes: [String] = []
+        let parser = HIDBarcodeParser(
+            configuration: testConfiguration,
+            onScan: { code in
+                scannedCodes.append(code)
+            }
+        )
+
+        // Try to scan with some excluded keys mixed in
+        parser.processKeyPress(MockUIKey(character: "1"))
+        parser.processKeyPress(MockUIKey(character: "2"))
+        parser.processKeyPress(MockUIKey(character: "3"))
+        parser.processKeyPress(MockUIKey(character: "\n", keyCode: .keyboardDownArrow))
+
+        #expect(scannedCodes == ["123"])
     }
 }
 
@@ -246,31 +287,22 @@ struct HIDBarcodeParserTests {
 
 private extension HIDBarcodeParserTests {
     var testConfiguration: HIDBarcodeParserConfiguration {
-        HIDBarcodeParserConfiguration(terminatingStrings: ["\r"],
-                                      minimumBarcodeLength: 3,
-                                      maximumScanTime: 0.3,
-                                      maximumInterCharacterTime: 0.05)
-    }
-}
-
-private class MockUIPress: UIPress {
-    private let mockCharacter: String
-
-    init(character: String) {
-        self.mockCharacter = character
-        super.init()
-    }
-
-    override var key: UIKey? {
-        MockUIKey(character: mockCharacter)
+        HIDBarcodeParserConfiguration(terminatingStrings: ["\r", "\n"],
+                                       minimumBarcodeLength: 3,
+                                       maximumScanTime: 0.3,
+                                       maximumInterCharacterTime: 0.05)
     }
 }
 
 private class MockUIKey: UIKey {
     private let mockCharacter: String
 
-    init(character: String) {
+    // We use a default which won't be ignored when the key is evaluated. Control keys are ignored.
+    private let mockKeyCode: UIKeyboardHIDUsage
+
+    init(character: String, keyCode: UIKeyboardHIDUsage = .keypad0) {
         self.mockCharacter = character
+        self.mockKeyCode = keyCode
         super.init()
     }
 
@@ -280,6 +312,10 @@ private class MockUIKey: UIKey {
 
     override var charactersIgnoringModifiers: String {
         mockCharacter
+    }
+
+    override var keyCode: UIKeyboardHIDUsage {
+        mockKeyCode
     }
 }
 

--- a/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/HIDBarcodeParserTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/HIDBarcodeParserTests.swift
@@ -126,12 +126,7 @@ struct HIDBarcodeParserTests {
             return Timer()
         }
 
-        let configuration = HIDBarcodeParserConfiguration(
-            terminatingStrings: ["\r"],
-            minimumBarcodeLength: 4,
-            maximumScanTime: 0.01,
-            maximumInterCharacterTime: 0.05
-        )
+        let configuration = testConfiguration
         let parser = HIDBarcodeParser(
             configuration: configuration,
             onScan: { code in
@@ -155,24 +150,21 @@ struct HIDBarcodeParserTests {
     @Test("Parser ignores slow typing")
     func testSlowTyping() {
         var scannedCodes: [String] = []
-        let configuration = HIDBarcodeParserConfiguration(
-            terminatingStrings: ["\r"],
-            minimumBarcodeLength: 4,
-            maximumScanTime: 0.3,
-            maximumInterCharacterTime: 0.05
-        )
+        let configuration = HIDBarcodeParserConfiguration.default
+        let mockTimeProvider = MockTimeProvider()
         let parser = HIDBarcodeParser(
             configuration: configuration,
             onScan: { code in
                 scannedCodes.append(code)
-            }
+            },
+            timeProvider: mockTimeProvider
         )
 
         // Simulate slow typing
         parser.processKeyPress(MockUIKey(character: "1"))
         parser.processKeyPress(MockUIKey(character: "2"))
         parser.processKeyPress(MockUIKey(character: "3"))
-        Thread.sleep(forTimeInterval: 0.06) // Just over maximumInterCharacterTime
+        mockTimeProvider.advance(by: 0.101) // Just over maximumInterCharacterTime
         parser.processKeyPress(MockUIKey(character: "4"))
         parser.processKeyPress(MockUIKey(character: "\r"))
 
@@ -182,28 +174,25 @@ struct HIDBarcodeParserTests {
     @Test("Parser accepts slowish scans")
     func testSlowScans() {
         var scannedCodes: [String] = []
-        let configuration = HIDBarcodeParserConfiguration(
-            terminatingStrings: ["\r"],
-            minimumBarcodeLength: 4,
-            maximumScanTime: 0.3,
-            maximumInterCharacterTime: 0.05
-        )
+        let configuration = HIDBarcodeParserConfiguration.default
+        let mockTimeProvider = MockTimeProvider()
         let parser = HIDBarcodeParser(
             configuration: configuration,
             onScan: { code in
                 scannedCodes.append(code)
-            }
+            },
+            timeProvider: mockTimeProvider
         )
 
         // Simulate slow typing
         parser.processKeyPress(MockUIKey(character: "1"))
-        Thread.sleep(forTimeInterval: 0.03)
+        mockTimeProvider.advance(by: 0.099) // Just under maximumInterCharacterTime
         parser.processKeyPress(MockUIKey(character: "2"))
-        Thread.sleep(forTimeInterval: 0.03)
+        mockTimeProvider.advance(by: 0.099)
         parser.processKeyPress(MockUIKey(character: "3"))
-        Thread.sleep(forTimeInterval: 0.03)
+        mockTimeProvider.advance(by: 0.099)
         parser.processKeyPress(MockUIKey(character: "4"))
-        Thread.sleep(forTimeInterval: 0.03)
+        mockTimeProvider.advance(by: 0.099)
         parser.processKeyPress(MockUIKey(character: "\r"))
 
         #expect(scannedCodes == ["1234"])
@@ -212,12 +201,7 @@ struct HIDBarcodeParserTests {
     @Test("Parser handles multiple terminating strings")
     func testMultipleTerminatingStrings() {
         var scannedCodes: [String] = []
-        let configuration = HIDBarcodeParserConfiguration(
-            terminatingStrings: ["\r", "\n", "\t"],
-            minimumBarcodeLength: 4,
-            maximumScanTime: 0.3,
-            maximumInterCharacterTime: 0.05
-        )
+        let configuration = testConfiguration
         let parser = HIDBarcodeParser(
             configuration: configuration,
             onScan: { code in

--- a/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/HIDBarcodeParserTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/HIDBarcodeParserTests.swift
@@ -164,7 +164,7 @@ struct HIDBarcodeParserTests {
         parser.processKeyPress(MockUIKey(character: "1"))
         parser.processKeyPress(MockUIKey(character: "2"))
         parser.processKeyPress(MockUIKey(character: "3"))
-        mockTimeProvider.advance(by: 0.101) // Just over maximumInterCharacterTime
+        mockTimeProvider.advance(by: 0.201) // Just over maximumInterCharacterTime
         parser.processKeyPress(MockUIKey(character: "4"))
         parser.processKeyPress(MockUIKey(character: "\r"))
 
@@ -186,13 +186,13 @@ struct HIDBarcodeParserTests {
 
         // Simulate slow typing
         parser.processKeyPress(MockUIKey(character: "1"))
-        mockTimeProvider.advance(by: 0.099) // Just under maximumInterCharacterTime
+        mockTimeProvider.advance(by: 0.199) // Just under maximumInterCharacterTime
         parser.processKeyPress(MockUIKey(character: "2"))
-        mockTimeProvider.advance(by: 0.099)
+        mockTimeProvider.advance(by: 0.199)
         parser.processKeyPress(MockUIKey(character: "3"))
-        mockTimeProvider.advance(by: 0.099)
+        mockTimeProvider.advance(by: 0.199)
         parser.processKeyPress(MockUIKey(character: "4"))
-        mockTimeProvider.advance(by: 0.099)
+        mockTimeProvider.advance(by: 0.199)
         parser.processKeyPress(MockUIKey(character: "\r"))
 
         #expect(scannedCodes == ["1234"])

--- a/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/HIDBarcodeParserTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/HIDBarcodeParserTests.swift
@@ -288,9 +288,9 @@ struct HIDBarcodeParserTests {
 private extension HIDBarcodeParserTests {
     var testConfiguration: HIDBarcodeParserConfiguration {
         HIDBarcodeParserConfiguration(terminatingStrings: ["\r", "\n"],
-                                       minimumBarcodeLength: 3,
-                                       maximumScanTime: 0.3,
-                                       maximumInterCharacterTime: 0.05)
+                                      minimumBarcodeLength: 3,
+                                      maximumScanTime: 0.3,
+                                      maximumInterCharacterTime: 0.05)
     }
 }
 
@@ -310,7 +310,7 @@ private class MockUIKey: UIKey {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override var charactersIgnoringModifiers: String {
+    override var characters: String {
         mockCharacter
     }
 

--- a/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/HIDBarcodeParserTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/HIDBarcodeParserTests.swift
@@ -13,7 +13,10 @@ struct HIDBarcodeParserTests {
     @Test("Custom configuration uses specified terminating strings")
     func testCustomConfiguration() {
         let customTerminators: Set<String> = ["\t", " "]
-        let configuration = HIDBarcodeParserConfiguration(terminatingStrings: customTerminators)
+        let configuration = HIDBarcodeParserConfiguration(terminatingStrings: customTerminators,
+                                                          minimumBarcodeLength: 1,
+                                                          maximumScanTime: 1,
+                                                          maximumInterCharacterTime: 1)
         #expect(configuration.terminatingStrings == customTerminators)
     }
 
@@ -21,7 +24,7 @@ struct HIDBarcodeParserTests {
     func testCompleteScan() {
         var scannedCodes: [String] = []
         let parser = HIDBarcodeParser(
-            configuration: .default,
+            configuration: testConfiguration,
             onScan: { code in
                 scannedCodes.append(code)
             }
@@ -33,15 +36,14 @@ struct HIDBarcodeParserTests {
         parser.processKeyPress("3")
         parser.processKeyPress("\r")
 
-        #expect(scannedCodes.count == 1)
-        #expect(scannedCodes[0] == "123")
+        #expect(scannedCodes == ["123"])
     }
 
     @Test("Parser processes multiple scans")
     func testMultipleScans() {
         var scannedCodes: [String] = []
         let parser = HIDBarcodeParser(
-            configuration: .default,
+            configuration: testConfiguration,
             onScan: { code in
                 scannedCodes.append(code)
             }
@@ -59,16 +61,14 @@ struct HIDBarcodeParserTests {
         parser.processKeyPress("6")
         parser.processKeyPress("\r")
 
-        #expect(scannedCodes.count == 2)
-        #expect(scannedCodes[0] == "123")
-        #expect(scannedCodes[1] == "456")
+        #expect(scannedCodes == ["123", "456"])
     }
 
     @Test("Parser handles cancelled scan")
     func testCancelledScan() {
         var scannedCodes: [String] = []
         let parser = HIDBarcodeParser(
-            configuration: .default,
+            configuration: testConfiguration,
             onScan: { code in
                 scannedCodes.append(code)
             }
@@ -88,12 +88,162 @@ struct HIDBarcodeParserTests {
         parser.processKeyPress("6")
         parser.processKeyPress("\r")
 
-        #expect(scannedCodes.count == 1)
-        #expect(scannedCodes[0] == "456")
+        #expect(scannedCodes == ["456"])
+    }
+
+    @Test("Parser ignores scans below minimum length")
+    func testMinimumLength() {
+        var scannedCodes: [String] = []
+        let configuration = HIDBarcodeParserConfiguration(
+            terminatingStrings: ["\r"],
+            minimumBarcodeLength: 4,
+            maximumScanTime: 1.5,
+            maximumInterCharacterTime: 0.1
+        )
+        let parser = HIDBarcodeParser(
+            configuration: configuration,
+            onScan: { code in
+                scannedCodes.append(code)
+            }
+        )
+
+        // Try to scan a short barcode
+        parser.processKeyPress("1")
+        parser.processKeyPress("2")
+        parser.processKeyPress("3")
+        parser.processKeyPress("\r")
+
+        #expect(scannedCodes.isEmpty)
+    }
+
+    @Test("Parser processes scan after maximum scan time")
+    func testMaximumScanTime() {
+        var scannedCodes: [String] = []
+        let configuration = HIDBarcodeParserConfiguration(
+            terminatingStrings: ["\r"],
+            minimumBarcodeLength: 4,
+            maximumScanTime: 0.1,
+            maximumInterCharacterTime: 0.05
+        )
+        let parser = HIDBarcodeParser(
+            configuration: configuration,
+            onScan: { code in
+                scannedCodes.append(code)
+            }
+        )
+
+        // Start a scan
+        parser.processKeyPress("1")
+        parser.processKeyPress("2")
+        parser.processKeyPress("3")
+        parser.processKeyPress("4")
+
+        // Run the run loop to allow the timer to fire
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.2))
+
+        #expect(scannedCodes == ["1234"])
+    }
+
+    @Test("Parser ignores slow typing")
+    func testSlowTyping() {
+        var scannedCodes: [String] = []
+        let configuration = HIDBarcodeParserConfiguration(
+            terminatingStrings: ["\r"],
+            minimumBarcodeLength: 4,
+            maximumScanTime: 0.3,
+            maximumInterCharacterTime: 0.05
+        )
+        let parser = HIDBarcodeParser(
+            configuration: configuration,
+            onScan: { code in
+                scannedCodes.append(code)
+            }
+        )
+
+        // Simulate slow typing
+        parser.processKeyPress("1")
+        parser.processKeyPress("2")
+        parser.processKeyPress("3")
+        Thread.sleep(forTimeInterval: 0.06)
+        parser.processKeyPress("4")
+        parser.processKeyPress("\r")
+
+        #expect(scannedCodes.isEmpty)
+    }
+
+    @Test("Parser accepts slowish scans")
+    func testSlowScans() {
+        var scannedCodes: [String] = []
+        let configuration = HIDBarcodeParserConfiguration(
+            terminatingStrings: ["\r"],
+            minimumBarcodeLength: 4,
+            maximumScanTime: 0.3,
+            maximumInterCharacterTime: 0.05
+        )
+        let parser = HIDBarcodeParser(
+            configuration: configuration,
+            onScan: { code in
+                scannedCodes.append(code)
+            }
+        )
+
+        // Simulate slow typing
+        parser.processKeyPress("1")
+        Thread.sleep(forTimeInterval: 0.03)
+        parser.processKeyPress("2")
+        Thread.sleep(forTimeInterval: 0.03)
+        parser.processKeyPress("3")
+        Thread.sleep(forTimeInterval: 0.03)
+        parser.processKeyPress("4")
+        Thread.sleep(forTimeInterval: 0.03)
+        parser.processKeyPress("\r")
+
+        #expect(scannedCodes == ["1234"])
+    }
+
+    @Test("Parser handles multiple terminating strings")
+    func testMultipleTerminatingStrings() {
+        var scannedCodes: [String] = []
+        let configuration = HIDBarcodeParserConfiguration(
+            terminatingStrings: ["\r", "\n", "\t"],
+            minimumBarcodeLength: 4,
+            maximumScanTime: 1.5,
+            maximumInterCharacterTime: 0.1
+        )
+        let parser = HIDBarcodeParser(
+            configuration: configuration,
+            onScan: { code in
+                scannedCodes.append(code)
+            }
+        )
+
+        // Test with different terminating strings
+        parser.processKeyPress("1")
+        parser.processKeyPress("2")
+        parser.processKeyPress("3")
+        parser.processKeyPress("4")
+        parser.processKeyPress("\n")
+
+        parser.processKeyPress("5")
+        parser.processKeyPress("6")
+        parser.processKeyPress("7")
+        parser.processKeyPress("8")
+        parser.processKeyPress("\t")
+
+        #expect(scannedCodes == ["1234", "5678"])
     }
 }
 
 // MARK: - Test Helpers
+
+private extension HIDBarcodeParserTests {
+    var testConfiguration: HIDBarcodeParserConfiguration {
+        HIDBarcodeParserConfiguration(terminatingStrings: ["\r"],
+                                      minimumBarcodeLength: 3,
+                                      maximumScanTime: 0.3,
+                                      maximumInterCharacterTime: 0.05)
+    }
+}
 
 private class MockUIPress: UIPress {
     private let mockCharacter: String

--- a/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/MockTimeProvider.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/MockTimeProvider.swift
@@ -1,0 +1,18 @@
+import Foundation
+@testable import WooCommerce
+
+final class MockTimeProvider: TimeProvider {
+    private var currentTime: Date
+
+    init(startTime: Date = Date()) {
+        self.currentTime = startTime
+    }
+
+    func now() -> Date {
+        currentTime
+    }
+
+    func advance(by interval: TimeInterval) {
+        currentTime = currentTime.addingTimeInterval(interval)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds scan heuristics to ensure we're handling input from a scanner, not an external keyboard.

I've matched the implementation in https://github.com/woocommerce/woocommerce-android/pull/14162

### Heuristics
- No more than 100ms between keystrokes
- No more than 1.5s to complete the scan – at the end of the time, we consider it a scan in case a terminator isn't sent
- Barcode must have at least 4 characters

Beyond the Android implementation, I added special handling for iOS sending us control codes.

Without this, if the scanner's configured with `CRLF` as the terminator, we get `UIKeyInputDownArrow` as a barcode input after a successful scan – obviously this fails.

We have a 1.5s timeout, at which point we try to process input. I've opened a discussion about this because I don't think it's necessarily the best thing for the product, but for the now we match Android. We may decide to ignore scans if they hit the timeout, instead.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Enable the `pointOfSaleBarcodeScanningi1` feature flag

Open Point of Sale and test barcodes using a hardware scanner. They should work as expected. 

Try with the terminator turned off – scanning should still work, it's just slower because of the timeout.

Very long barcodes may not complete in time – these will cause errors, possibly multiple, rather than being ignored.

Try with different combinations of `\r \n` as terminators – they should work.

Try typing on an external keyboard – it should be difficult to get that to register as a scan.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

I've tested with an iPad Air on iOS 17.7.2, a Star BSH-20B, and an external keyboard.

Note that the barcode scan simulator doesn't test this – it bypasses the `HIDBarcodeParser`, and it'd be a bit of a challenge to make it work through that now, as we need to get the keypresses, not just the characters to do it properly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/34901256-2978-4007-8dbb-982022305697

There's a lot of me rambling at the end about keyboard layouts. I tested it, and the best case for QR codes is to set the scanner up in US English, and the Hardware Keyboard layout in iOS Settings in US English, and then kill and restart the app for good measure. If you do that, it starts giving the expected barcodes!

Fortunately this doesn't make much difference for normal barcodes, the numbers are pretty universal... though we'll have to check it in Arabic when we expand POS internationally.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
