### PR TITLE
[Woo POS] [Barcodes] Don't block a main thread when playing a sound

### DIFF
--- a/WooCommerce/Classes/POS/Utils/Audio/PointOfSaleSoundPlayer.swift
+++ b/WooCommerce/Classes/POS/Utils/Audio/PointOfSaleSoundPlayer.swift
@@ -14,11 +14,9 @@ protocol PointOfSaleSoundPlayerProtocol {
     func playSound(_ sound: PointOfSaleSound) async
 }
 
-final class PointOfSaleSoundPlayer: PointOfSaleSoundPlayerProtocol {
-    private var audioPlayer: AVAudioPlayer?
+actor PointOfSaleSoundPlayer: PointOfSaleSoundPlayerProtocol {
     private var playerCache: [PointOfSaleSound: AVAudioPlayer] = [:]
 
-    @MainActor
     func playSound(_ sound: PointOfSaleSound) async {
         guard let url = Bundle.main.url(forResource: sound.name, withExtension: sound.type) else {
             DDLogError("Sound file not found: \(sound.name).\(sound.type)")
@@ -34,9 +32,9 @@ final class PointOfSaleSoundPlayer: PointOfSaleSoundPlayerProtocol {
          }
 
         do {
-            audioPlayer = try AVAudioPlayer(contentsOf: url)
-            audioPlayer?.prepareToPlay()
-            audioPlayer?.play()
+            let audioPlayer = try AVAudioPlayer(contentsOf: url)
+            audioPlayer.prepareToPlay()
+            audioPlayer.play()
             playerCache[sound] = audioPlayer
         } catch {
             DDLogError("Failed to play sound: \(error)")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “ See original issue” – clarify what the problem was and how you’ve fixed it. -->

Continuation of https://github.com/woocommerce/woocommerce-ios/pull/15746

As @joshheald noticed, my "optimizations" to reuse `AVAudioPlayer` have resulted in sound playing blocking the main thread. 

To avoid that, we can turn `PointOfSaleSoundPlayer` into `actor`. It ensures that `playerCache` is accessed synchronously and at the same time the player creation can happen in a background thread. 

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Add invalid barcode items
3. Observe that the cart row loading shimmering animation doesn't get stalled before transitioning to the error state
4. Confirm the failure sound plays

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air 18.3 Device

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.