### PR TITLE
Restore Wormholy, now installed via a fork supporting latest SPM

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "36cb7c58a55e60b67effa7f634f88d83b562c5df9e5218552354ff93f590fbfa",
+  "originHash" : "3f91f4fe3ba570ba7c5696a40578f1e68793bb8d4e40f77bf2820c3a626465df",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -348,6 +348,15 @@
       "state" : {
         "revision" : "788e7879d38a839c4e348ab0762dcc0364e646a2",
         "version" : "0.10.1"
+      }
+    },
+    {
+      "identity" : "wormholy",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pmusolino/Wormholy",
+      "state" : {
+        "revision" : "54fdf4d01ccffc8276faf9be32d7d375a0321cab",
+        "version" : "2.1.1"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -89,6 +89,7 @@ let package = Package(
         .package(url: "https://github.com/markiv/SwiftUI-Shimmer", from: "1.0.0"),
         .package(url: "https://github.com/nalexn/ViewInspector", from: "0.10.0"),
         .package(url: "https://github.com/onevcat/Kingfisher", from: "7.6.2"),
+        .package(url: "https://github.com/pmusolino/Wormholy", from: "2.0.0"),
         .package(url: "https://github.com/pavolkmet/ScrollViewSectionKit", from: "1.2.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "13.0.0"),
         .package(url: "https://github.com/simibac/ConfettiSwiftUI.git", from: "1.0.0"),
@@ -375,6 +376,7 @@ enum XcodeSupport {
                     .product(name: "Shimmer", package: "SwiftUI-Shimmer"),
                     .product(name: "StripeTerminal", package: "stripe-terminal-ios"),
                     .product(name: "WordPressEditor", package: "AztecEditor-iOS"),
+                    .product(name: "Wormholy", package: "Wormholy"),
                     .product(name: "ZendeskSupportSDK", package: "support_sdk_ios"),
                 ]
             ),

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "36cb7c58a55e60b67effa7f634f88d83b562c5df9e5218552354ff93f590fbfa",
+  "originHash" : "3f91f4fe3ba570ba7c5696a40578f1e68793bb8d4e40f77bf2820c3a626465df",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -348,6 +348,15 @@
       "state" : {
         "revision" : "5acfa0a3c095ac9ad050abe51c60d1831e8321da",
         "version" : "0.10.0"
+      }
+    },
+    {
+      "identity" : "wormholy",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pmusolino/Wormholy",
+      "state" : {
+        "revision" : "54fdf4d01ccffc8276faf9be32d7d375a0321cab",
+        "version" : "2.1.1"
       }
     },
     {

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -19,6 +19,10 @@ import class Yosemite.ScreenshotStoresManager
 // In that way, Inject will be available in the entire target.
 @_exported import Inject
 
+#if DEBUG
+import WormholySwift
+#endif
+
 // MARK: - Woo's App Delegate!
 //
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -77,6 +81,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         setupLogLevel(.verbose)
         setupPushNotificationsManagerIfPossible(pushNotesManager, stores: stores)
         setupAppRatingManager()
+        setupWormholy()
         setupKeyboardStateProvider()
         handleLaunchArguments()
         setupUserNotificationCenter()
@@ -405,6 +410,15 @@ private extension AppDelegate {
         appRating.register(section: "notifications", significantEventCount: WooConstants.notificationEventCount)
         appRating.systemWideSignificantEventCountRequiredForPrompt = WooConstants.systemEventCount
         appRating.setVersion(version)
+    }
+
+    /// Set up Wormholy only in Debug build configuration
+    ///
+    func setupWormholy() {
+#if DEBUG
+        // We want to activate it programmatically, not using the shake.
+        Wormholy.shakeEnabled = false
+#endif
     }
 
     /// Set up `KeyboardStateProvider`

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -164,6 +164,8 @@ private extension SettingsViewController {
             configureWhatsNew(cell: cell)
         case let cell as BasicTableViewCell where row == .deviceSettings:
             configureAppSettings(cell: cell)
+        case let cell as BasicTableViewCell where row == .wormholy:
+            configureWormholy(cell: cell)
         case let cell as BasicTableViewCell where row == .accountSettings:
             configureAccountSettings(cell: cell)
         case let cell as BasicTableViewCell where row == .logout:
@@ -262,6 +264,12 @@ private extension SettingsViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = Localization.openDeviceSettings
+    }
+
+    func configureWormholy(cell: BasicTableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = Localization.launchWormHolyDebug
     }
 
     func configureWhatsNew(cell: BasicTableViewCell) {
@@ -481,6 +489,11 @@ private extension SettingsViewController {
         UIApplication.shared.open(targetURL)
     }
 
+    func wormholyWasPressed() {
+        // Fire a local notification, which fires Wormholy if enabled.
+        NotificationCenter.default.post(name: NSNotification.Name(rawValue: "wormholy_fire"), object: nil)
+    }
+
     func whatsNewWasPressed() {
         ServiceLocator.analytics.track(event: .featureAnnouncementShown(source: .appSettings))
         guard let announcement = viewModel.announcement else { return }
@@ -634,6 +647,8 @@ extension SettingsViewController: UITableViewDelegate {
             aboutWasPressed()
         case .deviceSettings:
             deviceSettingsWasPressed()
+        case .wormholy:
+            wormholyWasPressed()
         case .whatsNew:
             whatsNewWasPressed()
         case .accountSettings:
@@ -721,6 +736,7 @@ extension SettingsViewController {
 
         // Other
         case deviceSettings
+        case wormholy
 
         // Account settings
         case accountSettings
@@ -764,6 +780,8 @@ extension SettingsViewController {
             case .about:
                 return BasicTableViewCell.self
             case .deviceSettings:
+                return BasicTableViewCell.self
+            case .wormholy:
                 return BasicTableViewCell.self
             case .whatsNew:
                 return BasicTableViewCell.self
@@ -869,6 +887,11 @@ private extension SettingsViewController {
         static let openDeviceSettings = NSLocalizedString(
             "Open Device Settings",
             comment: "Opens iOS's Device Settings for the app"
+        )
+
+        static let launchWormHolyDebug = NSLocalizedString(
+            "Launch Wormholy Debug",
+            comment: "Opens an internal library called Wormholy. Not visible to users."
         )
 
         static let whatsNew = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -314,8 +314,15 @@ private extension SettingsViewModel {
 
         // Other
         let otherSection: Section = {
+            let rows: [Row]
+#if DEBUG
+            rows = [.deviceSettings, .wormholy]
+#else
+            rows = [.deviceSettings]
+#endif
+
             return Section(title: Localization.otherTitle,
-                           rows: [.deviceSettings],
+                           rows: rows,
                            footerHeight: UITableView.automaticDimension)
         }()
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
See removal PR https://github.com/woocommerce/woocommerce-ios/pull/15668 and Wormholy PR https://github.com/pmusolino/Wormholy/pull/154

https://linear.app/a8c/issue/AINFRA-606

## Steps to reproduce & Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Run on a device to verify it works

<table>
<tr>
<td>

![image](https://github.com/user-attachments/assets/b4b9ad62-6661-4cfa-a82a-e24e7ecd435a)

</td>
<td>



![image](https://github.com/user-attachments/assets/0685b035-af47-42d5-9384-ce7639136ca0)

</td>
</tr>
</table>



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.