### PR TITLE
[POS as a tab] Optimize the timing when global site settings are refreshed

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -435,7 +435,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     var storeCountryCode: CountryCode {
-        let siteSettings = SelectedSiteSettings(stores: stores, storageManager: storageManager).siteSettings
+        let siteSettings = ServiceLocator.selectedSiteSettings.siteSettings
         let storeAddress = SiteAddress(siteSettings: siteSettings)
         return storeAddress.countryCode
     }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -425,6 +425,7 @@ private extension DefaultStoresManager {
 
         group.enter()
         let generalSettingsAction = SettingAction.synchronizeGeneralSiteSettings(siteID: siteID) { error in
+            ServiceLocator.selectedSiteSettings.refresh()
             if let error = error {
                 errors.append(error)
             }
@@ -653,7 +654,6 @@ private extension DefaultStoresManager {
         }
 
         synchronizeSettings(with: siteID) {
-            ServiceLocator.selectedSiteSettings.refresh()
             ServiceLocator.shippingSettingsService.update(siteID: siteID)
         }
         synchronizePaymentGateways(siteID: siteID)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-595

Just one review is required.

## Why

I've been exploring ways to optimize the time to check POS eligibility for the first time (this value is cached for future tab visibility initial values for the same site). From measuring the time for the 3 async checks from my test stores hosted on WPCOM:

- Remote feature flag eligibility check: 0.2-0.9s
- Site settings eligibility check:
  - The first time could be long from the general site settings API request ~1-2s
  - After the first time, ~0s from storage
- Plugin eligibility check:
  - The first time:
    - For WC version < 10.0 (without feature switch) from system status API request: ~1.5-3s
    - For WC version >= 10.0 with one more feature switch API request: ~4-5s
  - After the first time:
    - For WC version < 10.0 (without feature switch): ~0.05s from storage
    - For WC version >= 10.0 with one feature switch API request: ~1-2s

I haven't seen a lot of clear opportunities to optimize the time, because of the necessary API requests for the first time. In i2, only the site settings eligibility check (~1-2s for the first time) and remote feature flag eligibility check (~0.2-0.9s, which we can move to be after the tab tap check) are required for the tab visibility.

## How
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I just found some small optimizations for some edge cases:

- In `DefaultStoresManager`, `ServiceLocator.selectedSiteSettings.refresh()` is previously refreshed not just after syncing general site settings, but also [up to 2 other API requests](https://github.com/woocommerce/woocommerce-ios/blob/71913fdf765ec5f153ecff4a2e5d68df4b9f9946/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift#L435-L455). Now, it's refreshed right after the general site settings sync that `SelectedSiteSettings` depends on. This could be helpful when the other 2 API requests take a long time.
- From breakpoints, I noticed that [site settings are actually synced in `CardPresentPaymentsOnboardingUseCase`](https://github.com/woocommerce/woocommerce-ios/blob/71913fdf765ec5f153ecff4a2e5d68df4b9f9946/WooCommerce/Classes/AppDelegate.swift#L104) before `DefaultStoresManager.restoreSessionSiteIfPossible`. The use case creates a new `SelectedSiteSettings` instance and the refreshed values won't be propagated to the POS tab eligibility checker that depends on the global `ServiceLocator.selectedSiteSettings`. This PR updates the `SelectedSiteSettings` usage in `CardPresentPaymentsOnboardingUseCase` to use the global site settings (which refreshes it during initialization).

Please feel free to share any thoughts on these optimizations, I'm fine with not making them as well.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: a WPCOM account that has at least two connected stores, one eligible for POS and the other one not eligible.

- Log in to the account in the prerequisite with the store that is **eligible for POS** --> the POS tab should be shown shortly as before, I don't think we will see noticeable improvement
- Go to Menu tab and switch to a store **ineligible for POS** --> after switching stores, the POS tab should not appear even after a while just to make sure it works as expected


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.