### PR TITLE
Remove Tap to Pay on iPhone in UK feature flag

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -52,8 +52,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .wooPaymentsPayoutsOverviewInPaymentsMenu:
             return true
-        case .tapToPayOnIPhoneInUK:
-            return true
         case .productBundlesInOrderForm:
             return true
         case .customLoginUIForAccountCreation:

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -120,10 +120,6 @@ public enum FeatureFlag: Int {
     ///
     case wooPaymentsPayoutsOverviewInPaymentsMenu
 
-    /// Enables Tap to Pay for UK Woo Payments stores
-    ///
-    case tapToPayOnIPhoneInUK
-
     /// Enables bundle product configuration support in order creation/editing.
     ///
     case productBundlesInOrderForm

--- a/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
+++ b/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
@@ -15,8 +15,7 @@ final class CardPresentConfigurationLoader {
         let countryCode = SiteAddress().countryCode
 
         return .init(
-            country: countryCode,
-            shouldAllowTapToPayInUK: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhoneInUK)
+            country: countryCode
         )
     }
 }

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -43,7 +43,7 @@ public struct CardPresentPaymentsConfiguration: Equatable {
         self.minimumOperatingSystemVersionForTapToPay = minimumOperatingSystemVersionForTapToPay
     }
 
-    public init(country: CountryCode, shouldAllowTapToPayInUK: Bool = false) {
+    public init(country: CountryCode) {
         /// Changing `minimumVersion` values here? You'll need to also update `CardPresentPaymentsOnboardingUseCaseTests`
         switch country {
         case .US:
@@ -96,7 +96,7 @@ public struct CardPresentPaymentsConfiguration: Equatable {
                 paymentMethods: [.cardPresent],
                 currencies: [.GBP],
                 paymentGateways: [WCPayAccount.gatewayID],
-                supportedReaders: shouldAllowTapToPayInUK ? [.wisepad3, .tapToPay] : [.wisepad3],
+                supportedReaders: [.wisepad3, .tapToPay],
                 supportedPluginVersions: [.init(plugin: .wcPay, minimumVersion: "4.4.0")],
                 minimumAllowedChargeAmount: NSDecimalNumber(string: "0.3"),
                 stripeSmallestCurrencyUnitMultiplier: 100,

--- a/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
+++ b/Yosemite/YosemiteTests/Model/CardPresentConfigurationTests.swift
@@ -41,7 +41,7 @@ class CardPresentConfigurationTests: XCTestCase {
 
     // MARK: - United Kingdom Tests
     func test_configuration_for_United_Kingdom() throws {
-        let configuration = CardPresentPaymentsConfiguration(country: .GB, shouldAllowTapToPayInUK: true)
+        let configuration = CardPresentPaymentsConfiguration(country: .GB)
         XCTAssertTrue(configuration.isSupportedCountry)
         XCTAssertEqual(configuration.currencies, [.GBP])
         XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We've supported Tap to Pay on iPhone in the UK for a long time. This PR belatedly removes the feature flag for it.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app on a phone which supports TTP (you must use an Xcode build to test TTP)
2. Select a UK store
3. Create an order
4. Observe that you can pay for the order with Tap to Pay

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

I tested on an iPhone 15 running iOS 18.5

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/62c51299-cf3e-42e8-a2bc-d6fb002741a9


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
