### PR TITLE
[Woo POS] Allow refreshing empty product list state

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Shipping Labels: Improved shipment management UI by hiding remove/merge options instead of disabling them, hiding merge option for orders with 2 or fewer unfulfilled shipments, and hiding the ellipsis menu when no remove/merge actions are available [https://github.com/woocommerce/woocommerce-ios/pull/15760]
 - [**] POS: a POS tab in the tab bar is now available in the app for stores eligible for Point of Sale, instead of the previous entry point in the Menu tab. [https://github.com/woocommerce/woocommerce-ios/pull/15766]
 - [***] POS: Barcode scanning using Bluetooth scanners in Point of Sale (HID-based scanners are supported) [https://github.com/woocommerce/woocommerce-ios/pull/15776]
+- [*] POS: Support refreshing product list when it's empty [https://github.com/woocommerce/woocommerce-ios/pull/15782]
 
 22.6
 -----

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -153,7 +153,7 @@ struct PointOfSaleItemListEmptyViewModel {
         case (.root, .products(search: false)):
             return Localization.emptyProductsButtonTitle
         case (.parent, .products):
-            return Localization.emptyVariationsButtonTitle
+            return Localization.emptyProductsButtonTitle
         default:
             return nil
         }
@@ -238,11 +238,6 @@ struct PointOfSaleItemListEmptyViewModel {
             "pos.pointOfSaleItemListEmptyView.emptyProductsButtonTitle",
             value: "Refresh",
             comment: "Text for the button appearing on the products list screen when there are no products found."
-        )
-        static let emptyVariationsButtonTitle = NSLocalizedString(
-            "pos.pointOfSaleItemListEmptyView.emptyVariationsButtonTitle",
-            value: "Refresh",
-            comment: "Text for the button appearing on the variations list screen when there are no variations found."
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -147,11 +147,13 @@ struct PointOfSaleItemListEmptyViewModel {
     }
 
     var buttonTitle: String? {
-        switch itemListType {
-        case .coupons(search: false):
+        switch (baseItem, itemListType) {
+        case (.root, .coupons(search: false)):
             return Localization.emptyCouponsButtonTitle
-        case .products(search: false):
+        case (.root, .products(search: false)):
             return Localization.emptyProductsButtonTitle
+        case (.parent, .products):
+            return Localization.emptyVariationsButtonTitle
         default:
             return nil
         }
@@ -236,6 +238,11 @@ struct PointOfSaleItemListEmptyViewModel {
             "pos.pointOfSaleItemListEmptyView.emptyProductsButtonTitle",
             value: "Refresh",
             comment: "Text for the button appearing on the products list screen when there are no products found."
+        )
+        static let emptyVariationsButtonTitle = NSLocalizedString(
+            "pos.pointOfSaleItemListEmptyView.emptyVariationsButtonTitle",
+            value: "Refresh",
+            comment: "Text for the button appearing on the variations list screen when there are no variations found."
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -150,6 +150,8 @@ struct PointOfSaleItemListEmptyViewModel {
         switch itemListType {
         case .coupons(search: false):
             return Localization.emptyCouponsButtonTitle
+        case .products(search: false):
+            return Localization.emptyProductsButtonTitle
         default:
             return nil
         }
@@ -229,6 +231,11 @@ struct PointOfSaleItemListEmptyViewModel {
             "pos.pointOfSaleItemListEmptyView.emptyCouponSearchSubtitle.2",
             value: "We couldn’t find any coupons with that name — try adjusting your search term.",
             comment: "Text appearing on the coupons list screen as subtitle when there's no coupons found."
+        )
+        static let emptyProductsButtonTitle = NSLocalizedString(
+            "pos.pointOfSaleItemListEmptyView.emptyProductsButtonTitle",
+            value: "Refresh",
+            comment: "Text for the button appearing on the products list screen when there are no products found."
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -92,7 +92,11 @@ private extension ChildItemList {
             PointOfSaleItemListEmptyView(
                 viewModel: PointOfSaleItemListEmptyViewModel(
                     itemListType: .products(search: false),
-                    baseItem: node))
+                    baseItem: node)) {
+                Task {
+                    await itemsController.loadItems(base: node)
+                }
+            }
         }
     }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -338,7 +338,11 @@ private extension ItemListView {
             PointOfSaleItemListEmptyView(
                 viewModel: PointOfSaleItemListEmptyViewModel(
                     itemListType: selectedItemListType,
-                    baseItem: .root))
+                    baseItem: .root)) {
+                Task {
+                    await itemsController(selectedItemListType).loadItems(base: .root)
+                }
+            }
         case .coupons:
             PointOfSaleItemListEmptyView(
                 viewModel: PointOfSaleItemListEmptyViewModel(


### PR DESCRIPTION
WOOMOB-87

Allow refreshing empty product list state in POS. When there are no eligible products, POS shows a full-screen empty view with "No supported products found" message. However, there was no way to refresh the state without exiting and reopening POS.

The solution adds a "Refresh" button to empty states that reloads the list:
- Added refresh button to empty product list view (root level)
- Added refresh button to empty variations list view (child level)  
- Used consistent design pattern like "Create coupon" button
- Added localized strings following POS naming conventions
- Refresh action calls the same `loadItems(base:)` method used by error retry functionality

## Steps to reproduce

Prerequisites:
- Have no products or return empty list from `PointOfSaleItemsController`

### Products
1. Open POS
2. Observe empty product list with "No supported products found"
3. Tap "Refresh" button
4. Confirm products reload

### Variations
1. Open POS with variable products
2. Navigate to a variable product with no supported variations
3. Observe empty variations list with "No supported variations found"
4. Tap "Refresh" button  
5. Confirm variations reload

## Testing information

Tested on iPad Air 18.4 Simulator

## Screenshots
<\!-- Include before and after images or gifs when appropriate. -->

### Products
https://github.com/user-attachments/assets/7af16e41-01f8-4372-a164-6a43cd3eb673


### Variations
https://github.com/user-attachments/assets/84727346-8c7a-4ed0-8b79-0d1a25e591eb


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.