### PR TITLE
[Shipping Labels] M4 accessibility layout issues

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerInfoTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerInfoTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -70,7 +70,7 @@
                                 <rect key="frame" x="0.0" y="92" width="288" height="0.0"/>
                                 <color key="backgroundColor" name="Red50"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" priority="999" constant="34" id="1vO-Pa-Rrp"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="999" constant="34" id="1vO-Pa-Rrp"/>
                                 </constraints>
                                 <state key="normal" title="Add Customer Note"/>
                             </button>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -49,17 +49,11 @@
                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8sO-TX-YXZ">
                                 <rect key="frame" x="0.0" y="68" width="288" height="0.0"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" priority="999" constant="38" id="JD7-UH-chp"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="999" constant="38" id="JD7-UH-chp"/>
                                 </constraints>
                                 <state key="normal" title="Add Customer Note"/>
                             </button>
                         </subviews>
-                        <constraints>
-                            <constraint firstItem="KMy-GB-2vj" firstAttribute="leading" secondItem="3Ns-D0-Lmm" secondAttribute="leading" id="1sf-8Q-Erz"/>
-                            <constraint firstItem="8sO-TX-YXZ" firstAttribute="leading" secondItem="3Ns-D0-Lmm" secondAttribute="leading" id="CXr-SC-scr"/>
-                            <constraint firstAttribute="trailing" secondItem="8sO-TX-YXZ" secondAttribute="trailing" id="db6-Qe-0lI"/>
-                            <constraint firstAttribute="trailing" secondItem="KMy-GB-2vj" secondAttribute="trailing" id="uSW-Ze-AEM"/>
-                        </constraints>
                     </stackView>
                 </subviews>
                 <constraints>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
@@ -10,7 +10,7 @@ struct WooShippingCustomsRow: View {
     @State private var showCustomsForm: Bool = false
 
     var body: some View {
-        AdaptiveStack {
+        HStack {
             Text(Localization.customsTitle)
                 .headlineStyle()
                 .foregroundColor(.primary)
@@ -22,7 +22,7 @@ struct WooShippingCustomsRow: View {
                 .captionStyle()
                 .padding(.horizontal, Layout.statusBadgeHorizontalPadding)
                 .padding(.vertical, Layout.statusBadgeVerticalPadding)
-                .frame(height: Layout.statusBadgeHeight * scale)
+                .frame(minHeight: Layout.statusBadgeHeight * scale)
                 .background(
                     RoundedRectangle(cornerRadius: Layout.statusBadgeCornerRadius)
                         .fill(informationIsCompleted ?

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRow.swift
@@ -10,36 +10,65 @@ struct WooShippingCustomsRow: View {
     @State private var showCustomsForm: Bool = false
 
     var body: some View {
-        HStack {
-            Text(Localization.customsTitle)
-                .headlineStyle()
-                .foregroundColor(.primary)
-
-            Spacer()
-
-            Text(informationIsCompleted ? Localization.completedStatus : Localization.missingInfoStatus)
-                .foregroundColor(.black)
-                .captionStyle()
-                .padding(.horizontal, Layout.statusBadgeHorizontalPadding)
-                .padding(.vertical, Layout.statusBadgeVerticalPadding)
-                .frame(minHeight: Layout.statusBadgeHeight * scale)
-                .background(
-                    RoundedRectangle(cornerRadius: Layout.statusBadgeCornerRadius)
-                        .fill(informationIsCompleted ?
-                              Color.withColorStudio(name: .green, shade: .shade5) :
-                                Color.withColorStudio(name: .red, shade: .shade10))
-                )
-
-            PencilEditButton {
-                showCustomsForm.toggle()
+        ViewThatFits(in: .horizontal) {
+            /// Layout option #1
+            /// View fits in a given width
+            HStack {
+                customsRowTitleView
+                Spacer()
+                customsRowStatusBadgeView
+                customsRowEditButtonView
             }
-            .accessibilityLabel(Text(Localization.editButtonAccessibilityLabel))
+
+            /// Layout option #2 that fits in given width
+            /// View doesn't fit in a given width
+            HStack {
+                VStack(
+                    alignment: .center,
+                    spacing: Layout.customsRowVerticalLayoutSpacing
+                ) {
+                    customsRowTitleView
+                    customsRowStatusBadgeView
+                }
+                Spacer()
+                customsRowEditButtonView
+            }
         }
         .padding(Layout.borderPadding)
         .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderWidth)
         .sheet(isPresented: $showCustomsForm) {
             WooShippingCustomsForm(viewModel: customsFormViewModel)
         }
+    }
+}
+
+private extension WooShippingCustomsRow {
+    var customsRowTitleView: some View {
+        Text(Localization.customsTitle)
+            .headlineStyle()
+            .foregroundColor(.primary)
+    }
+
+    var customsRowStatusBadgeView: some View {
+        Text(informationIsCompleted ? Localization.completedStatus : Localization.missingInfoStatus)
+            .foregroundColor(.black)
+            .captionStyle()
+            .padding(.horizontal, Layout.statusBadgeHorizontalPadding)
+            .padding(.vertical, Layout.statusBadgeVerticalPadding)
+            .frame(minHeight: Layout.statusBadgeHeight * scale)
+            .background(
+                RoundedRectangle(cornerRadius: Layout.statusBadgeCornerRadius)
+                    .fill(informationIsCompleted ?
+                          Color.withColorStudio(name: .green, shade: .shade5) :
+                            Color.withColorStudio(name: .red, shade: .shade10))
+            )
+    }
+
+    var customsRowEditButtonView: some View {
+        PencilEditButton {
+            showCustomsForm.toggle()
+        }
+        .accessibilityLabel(Text(Localization.editButtonAccessibilityLabel))
     }
 }
 
@@ -52,6 +81,7 @@ private extension WooShippingCustomsRow {
         static let statusBadgeCornerRadius: CGFloat = 6
         static let statusBadgeHorizontalPadding: CGFloat = 12
         static let statusBadgeVerticalPadding: CGFloat = 4
+        static let customsRowVerticalLayoutSpacing: CGFloat = 6
         static let statusBadgeHeight: CGFloat = 24
         static let borderPadding: CGFloat = 16
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Hazmat Section/WooShippingHazmatRow.swift
@@ -19,7 +19,7 @@ struct WooShippingHazmatRow: View {
             Button(action: {
                 isShowingDetailView = true
             }) {
-                AdaptiveStack {
+                HStack {
                     Text(Localization.hazmatLabel)
                         .bodyStyle()
                     Spacer()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageView.swift
@@ -26,6 +26,7 @@ struct WooShippingAddPackageView: View {
 
     @Environment(\.shippingWeightUnit) private var weightUnit
     @Environment(\.shippingDimensionsUnit) private var dimensionsUnit
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     init(selectedPackage: WooShippingPackageDataRepresentable? = nil,
          addPackageAction: @escaping (WooShippingPackageDataRepresentable) -> Void) {
@@ -44,13 +45,7 @@ struct WooShippingAddPackageView: View {
     var body: some View {
         NavigationView {
             VStack {
-                Picker("", selection: $packagesViewModel.selectedPackageType) {
-                    ForEach(PackageProviderType.allCases, id: \.self) {
-                        Text($0.name)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .padding()
+                packageTypeSelectorView
                 selectedPackageTypeView
             }
             .toolbar {
@@ -70,6 +65,27 @@ struct WooShippingAddPackageView: View {
             await packagesViewModel.loadPackages()
         }
         .notice($packagesViewModel.notice)
+    }
+
+    // MARK: - Computed Properties
+
+    private var selectedPackageTypeIndex: Binding<Int> {
+        Binding(
+            get: {
+                PackageProviderType.allCases.firstIndex(of: packagesViewModel.selectedPackageType) ?? 0
+            },
+            set: { newIndex in
+                if let newType = PackageProviderType.allCases[safe: newIndex] {
+                    packagesViewModel.selectedPackageType = newType
+                }
+            }
+        )
+    }
+
+    private var packageTypeTabs: [TopTabItem<EmptyView>] {
+        PackageProviderType.allCases.map { packageType in
+            TopTabItem(name: packageType.name, content: { EmptyView() })
+        }
     }
 
     // MARK: UI components
@@ -92,6 +108,35 @@ struct WooShippingAddPackageView: View {
                                           addingCustomPackageHandler: {
                 packagesViewModel.selectedPackageType = .custom
             })
+        }
+    }
+
+    private var packageTypeSelectorView: some View {
+        Group {
+            if dynamicTypeSize.isAccessibilitySize {
+                TopTabView(
+                    tabs: packageTypeTabs,
+                    showContent: false,
+                    selectedTabIndex: selectedPackageTypeIndex,
+                    tabsContainerHorizontalPadding: nil,
+                    selectedStateColor: .accentColor,
+                    unselectedStateColor: .secondary,
+                    selectedTabIndicatorHeight: 3.0,
+                    tabPadding: 0,
+                    tabsNameFont: .subheadline.bold(),
+                    tabItemContentHorizontalPadding: 16.0,
+                    tabItemContentVerticalPadding: 9.0
+                )
+                .padding(.vertical)
+            } else {
+                Picker("", selection: $packagesViewModel.selectedPackageType) {
+                    ForEach(PackageProviderType.allCases, id: \.self) {
+                        Text($0.name)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding()
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -273,6 +273,9 @@ private extension WooShippingCreateLabelsView {
             Text(Localization.BottomSheet.shipmentDetails)
                 .foregroundStyle(Color(.primary))
                 .bold()
+                .lineLimit(1)
+                .scaledToFill()
+                .minimumScaleFactor(0.5)
 
             if viewModel.shouldShowNotices {
                 // Unverified notice for origin address

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -23,6 +23,7 @@ struct WooShippingCreateLabelsView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.verticalSizeClass) private var verticalSizeClass
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.sizeCategory) private var sizeCategory
 
     private var isiPhonePortrait: Bool {
         verticalSizeClass == .regular && horizontalSizeClass == .compact
@@ -544,6 +545,9 @@ private extension WooShippingCreateLabelsView {
         }
         .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isPurchasingLabel))
         .disabled(!viewModel.isPurchaseButtonEnabled)
+        .renderedIf(
+            !sizeCategory.isAccessibilityCategory || viewModel.isPurchaseButtonEnabled
+        )
     }
 
     /// View showing the address verification status for a destination address.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -551,6 +551,9 @@ private extension WooShippingCreateLabelsView {
             }
         } label: {
             Text(Localization.BottomSheet.purchaseLabel(with: viewModel.totalCost))
+                .lineLimit(1)
+                .scaledToFill()
+                .minimumScaleFactor(0.5)
         }
         .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isPurchasingLabel))
         .disabled(!viewModel.isPurchaseButtonEnabled)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -569,6 +569,7 @@ private extension WooShippingCreateLabelsView {
             Image(systemName: isVerified ? "checkmark.circle" : "exclamationmark.circle")
             Text(label)
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
             Button(action: onDismiss) {
                 Image(systemName: "xmark")
                     .renderedIf(!isVerified)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -46,6 +46,13 @@ struct WooShippingCreateLabelsView: View {
         viewModel.destinationAddressStatus == .verified
     }
 
+    /// Whether the "Purchase" button should be rendered
+    private var shouldShowPurchaseButton: Bool {
+        return isShipmentDetailsExpanded ||
+        !sizeCategory.isAccessibilityCategory ||
+        viewModel.isPurchaseButtonEnabled
+    }
+
     var body: some View {
         NavigationStack {
             Group {
@@ -335,7 +342,7 @@ private extension WooShippingCreateLabelsView {
                         }
                         .tint(Color(.primary))
                     }
-                    if isShipmentDetailsExpanded || viewModel.currentShipmentDetailsViewModel.selectedPackage != nil {
+                    if shouldShowPurchaseButton || viewModel.currentShipmentDetailsViewModel.selectedPackage != nil {
                         purchaseButton
                     }
                 }
@@ -351,7 +358,10 @@ private extension WooShippingCreateLabelsView {
                         }
                         .tint(Color(.primary))
                         .fixedSize(horizontal: false, vertical: true)
-                        purchaseButton
+
+                        if shouldShowPurchaseButton {
+                            purchaseButton
+                        }
                     }
                 }
             }
@@ -544,9 +554,6 @@ private extension WooShippingCreateLabelsView {
         }
         .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isPurchasingLabel))
         .disabled(!viewModel.isPurchaseButtonEnabled)
-        .renderedIf(
-            !sizeCategory.isAccessibilityCategory || viewModel.isPurchaseButtonEnabled
-        )
     }
 
     /// View showing the address verification status for a destination address.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -278,8 +278,8 @@ private extension WooShippingCreateLabelsView {
                 .minimumScaleFactor(0.5)
 
             if viewModel.shouldShowNotices {
-                // Unverified notice for origin address
                 if let originAddressUnverifiedNoticeLabel = viewModel.originAddressUnverifiedNoticeLabel {
+                    // Unverified notice for origin address
                     verificationNotice(with: originAddressUnverifiedNoticeLabel,
                                        isVerified: false,
                                        onDismiss: {
@@ -290,10 +290,8 @@ private extension WooShippingCreateLabelsView {
                                        onTap: {
                         viewModel.editSelectedOriginAddress()
                     })
-                }
-
-                // Verification notice for destination address
-                if let destinationAddressStatusNoticeLabel = viewModel.destinationAddressStatusNoticeLabel {
+                } else if let destinationAddressStatusNoticeLabel = viewModel.destinationAddressStatusNoticeLabel {
+                    // Verification notice for destination address
                     verificationNotice(with: destinationAddressStatusNoticeLabel,
                                        isVerified: isDestinationAddressVerified,
                                        onDismiss: {
@@ -306,10 +304,8 @@ private extension WooShippingCreateLabelsView {
                             viewModel.editDestinationAddress()
                         }
                     })
-                }
-
-                // Verification notice for missing ITN in customs form
-                if let itnMissingNoticeLabel = viewModel.currentShipmentDetailsViewModel.itnMissingNoticeLabel {
+                } else if let itnMissingNoticeLabel = viewModel.currentShipmentDetailsViewModel.itnMissingNoticeLabel {
+                    // Verification notice for missing ITN in customs form
                     verificationNotice(with: itnMissingNoticeLabel,
                                        isVerified: false,
                                        onDismiss: {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

WOOMOB-617

## Description

Addresses accessibility **Shipping Labels** layout issues listed in 1nxDAV51DK_l8opZ2ZznqaA3FpfiYPoWZPd38HA4TTys-gdoc

## Known / Remaining issues

- For the "Add package" screen the scrollable area is barely reachable with the max accessibility font size and phone landscape mode (height is compact).
- "Create Shipping Label" button in Order details screen sometimes clipped by the 1st line. Happens rarely and during manual font scaling during debugging runtime.
- Rasterized grid icons aren't scalable, for example, the "pencil" icon in order details screen.

## Steps to reproduce
- Fixes the layout constraints inside `CustomerNoteTableViewCell.xib`. Removes redundant constraints and removes height restriction to unlock multiline content for accessibility scales.
- Same for CustomerInfoTableViewCell.
- Maintains horizontal components distribution for "Hazmat" even for compact width environment to keep content readable.
- Maintains horizontal components distribution for "Customs" row even for compact width environment to keep content readable.
- Makes sure the address verification notice toast content always fits. Makes it multiline.
- Addresses the issue where native `Picker` is not scalable according to dynamic font sizes. Replaces the `Picker` conditionally with `TopTabView` when the `dynamicSize` becomes `isAccessibility`

## Testing information

The testing requires Shipping plugin and the accessibility font size adjustment.

----
- Go to an order details screen. 
- Find the "CUSTOMER" section and the "+ Add Customer Note".
- Toggle bigger font sizes up to maximum size.
- Make sure the "+ Add Customer Note" resizes and scales content normally. The label should wrap to next line when needed.

Before | After
---|---
<img width="377" alt="Снимок экрана 2025-06-19 в 13 34 56" src="https://github.com/user-attachments/assets/f020c968-4c6b-43dc-9648-2962bb540ffd" /> | <img width="375" alt="Снимок экрана 2025-06-19 в 13 44 28" src="https://github.com/user-attachments/assets/969f9809-6e3d-4a6a-b20b-32324eccc6c5" />

----
- Go to an order with an unfulfilled shipment
- Open "Create Shipping Labels" flow and select that shipment
- Locate the "Are you shipping dangerous goods or hazardous materials?" row
- Increase the font size up to max.
- Make sure the row content scaled properly. Make sure the label wraps lines properly.
- Make sure the label and `No >` positioned horizontally.

Before | After
---|---
<img width="378" alt="Снимок экрана 2025-06-19 в 13 34 07" src="https://github.com/user-attachments/assets/be6756cf-a659-473f-9f18-bb833adbe6c2" /> | <img width="393" alt="Снимок экрана 2025-06-19 в 13 28 32" src="https://github.com/user-attachments/assets/1f319641-ce7d-4f7c-a72a-61f4e1ebcf8d" />

----
- Stay on same screen of the "Create Shipping Labels" flow.
- Enter the foreign destination address to have customs row visible
- Increase the font size up to max
- Make sure the customs row elements distributed horizontally.
- Make sure the row elements (including status badge) scaled and wraps lines properly.

Before | After
---|---
<img width="375" alt="Снимок экрана 2025-06-19 в 13 34 15" src="https://github.com/user-attachments/assets/53e8e068-8580-4b53-851f-27ca95930659" /> | <img width="386" alt="Снимок экрана 2025-06-19 в 13 29 12" src="https://github.com/user-attachments/assets/c8233dbf-d6fd-416c-8c9b-5e06096fbaff" />

----
- Go to an order that contains a shipment with a missing/unverified destination address
- Open "Create Shipping Labels" flow and select that shipment
- Locate the bottom notice toast saying "Destination address missing"
- Increase the font size up to max
- Make sure the toast notice content is not truncated. Make sure it's scaled and wraps lines properly.

Before | After
---|---
<img width="378" alt="Снимок экрана 2025-06-19 в 13 34 26" src="https://github.com/user-attachments/assets/d5c979f1-0d13-4f0b-a624-1df6844d9e90" /> | <img width="387" alt="Снимок экрана 2025-06-19 в 13 29 30" src="https://github.com/user-attachments/assets/7b67273a-977e-4658-b0bf-8dfcf856708d" />

----
- Go to an order with an unfulfilled shipment without a package selected
- Open "Create Shipping Labels" flow and select that shipment
- Tap on "Select a Package"
- Increase the font size up to max
- Make sure the native segmented picker turns into a tab view when font size increases reaching the accessibility mode
- Make sure the tab view is scaling normally according to the font dynamic size
- Make sure the tab view is functional and actually switches tabs
- Decrease the font size back
- Make sure the picker turns back into a native segmented control
- Make sure the picker maintains the state through transformation

**Before:**
<img width="378" alt="Снимок экрана 2025-06-19 в 13 34 36" src="https://github.com/user-attachments/assets/07c61b3c-d8d2-4b6e-9be1-af11ceb616c7" />

**After:**

https://github.com/user-attachments/assets/9bfcd5d2-fcb4-45b3-a899-e797551654fe

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.