### PR TITLE
[Woo POS][Barcodes] Dark mode: corners and background when loading

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
@@ -44,7 +44,7 @@ struct GhostItemCardView: View {
             viewWidth = width
         }
         .frame(maxWidth: .infinity, idealHeight: dimension)
-        .background(Color.posSurfaceBright)
+        .background(configuration.backgroundColor)
         .posItemCardBorderStyles()
     }
 
@@ -88,12 +88,14 @@ struct GhostItemCardViewConfiguration {
     let cardSize: CGFloat
     let maximumCardSize: CGFloat
     let placeholderWidthMultiplier: CGFloat
+    let backgroundColor: Color
 
     static let itemList = GhostItemCardViewConfiguration(
         placeholderHeight: 32,
         cardSize: Constants.productCardSize,
         maximumCardSize: Constants.maximumProductCardSize,
-        placeholderWidthMultiplier: 0.5
+        placeholderWidthMultiplier: 0.5,
+        backgroundColor: Color.posSurfaceBright
     )
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -23,13 +23,16 @@ struct ItemRowView: View {
     }
 
     var body: some View {
+        itemRow
+            .posItemCardBorderStyles()
+            .padding(.horizontal, Constants.horizontalPadding)
+    }
+
+    @ViewBuilder
+    private var itemRow: some View {
         switch cartItem.state {
         case .loaded, .error:
             productRow
-                .frame(maxWidth: .infinity, idealHeight: dimension)
-                .background(Color.posSurfaceContainerLowest)
-                .posItemCardBorderStyles()
-                .padding(.horizontal, Constants.horizontalPadding)
         case .loading:
             GhostItemCardView(configuration: Constants.cartConfiguration,
                               showProductImage: $showProductImage) {
@@ -39,8 +42,6 @@ struct ItemRowView: View {
                     }
                 }
             }
-            .background(Color.posSurfaceContainerLowest)
-            .padding(.horizontal, Constants.horizontalPadding)
         }
     }
 
@@ -76,6 +77,8 @@ struct ItemRowView: View {
             }
         }
         .padding(.trailing, Constants.cardContentHorizontalPadding)
+        .frame(maxWidth: .infinity, idealHeight: dimension)
+        .background(Color.posSurfaceContainerLowest)
     }
 
     @ViewBuilder
@@ -122,7 +125,8 @@ private extension ItemRowView {
             placeholderHeight: 24,
             cardSize: Constants.productCardSize,
             maximumCardSize: Constants.maximumProductCardSize,
-            placeholderWidthMultiplier: 0.3
+            placeholderWidthMultiplier: 0.3,
+            backgroundColor: Color.posSurfaceContainerLowest
         )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, the loading rows didn’t match the product rows, especially in dark mode.

This PR ensures that the rounded corners are shown, and a background shown in both modes.

The issue was that we relied on the ghost cell applying the border styles, but that was too low down the stack. We also relied on it for the background colour, which we now pass in through the configuration so it can be different for the cart and item list (which have different backgrounds themselves.)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

In dark mode, add a product by scanning a barcode (or mashing keys ending in the enter button.) 
Observe that you can see the rounded corners, and the background doesn't change in when it loads.

Also check the item list when opening a variable product or loading the next page – the loading cells should not have changed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/b40cc2c5-03d5-4f2d-9bca-8a502f75977f




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
