### PR TITLE
[Shipping Labels] Reset shipping rates on address change

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 22.7
 -----
+- [*] Shipping Labels: Fixed an issue where the purchase button would display a stale price after changing the origin address. [https://github.com/woocommerce/woocommerce-ios/pull/15795]
 - [*] Order Details: Fix crash when reloading data [https://github.com/woocommerce/woocommerce-ios/pull/15764]
 - [*] Shipping Labels: Improved shipment management UI by hiding remove/merge options instead of disabling them, hiding merge option for orders with 2 or fewer unfulfilled shipments, and hiding the ellipsis menu when no remove/merge actions are available [https://github.com/woocommerce/woocommerce-ios/pull/15760]
 - [**] POS: a POS tab in the tab bar is now available in the app for stores eligible for Point of Sale, instead of the previous entry point in the Menu tab. [https://github.com/woocommerce/woocommerce-ios/pull/15766]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -156,6 +156,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
         observeCustomsForm()
         observeHAZMATChanges()
         observeShippingRates()
+        setupSelectedRateReset()
     }
 
     /// Handles package selection for the shipping label.
@@ -264,21 +265,16 @@ private extension WooShippingShipmentDetailsViewModel {
             .store(in: &subscriptions)
 
         $originAddress.combineLatest($destinationAddress)
-            .sink { [weak self] originAddress, destinationAddress in
-                guard let self else { return }
-                // When the origin address changes, the old pricing based on the previous rate is no longer valid.
-                // We reset `selectedRate` here to stop displaying the stale price until a new rate is selected.
-                self.selectedRate = nil
-                self.shippingService = WooShippingServiceViewModel(
-                    order: self.order,
-                    originAddress: originAddress,
-                    destinationAddress: destinationAddress,
-                    stores: self.stores
-                ) { [weak self] selectedRate in
+            .map { [weak self] originAddress, destinationAddress in
+                guard let self else { return nil }
+                return WooShippingServiceViewModel(order: order,
+                                                   originAddress: originAddress,
+                                                   destinationAddress: destinationAddress,
+                                                   stores: stores) { [weak self] selectedRate in
                     self?.selectedRate = selectedRate
                 }
             }
-            .store(in: &subscriptions)
+            .assign(to: &$shippingService)
 
         $originAddress.combineLatest($destinationAddress)
             .map { (originAddress, destinationAddress) -> Bool in
@@ -381,6 +377,23 @@ private extension WooShippingShipmentDetailsViewModel {
                 }
             }
             .assign(to: &$shippingRates)
+    }
+
+    /// Observes changes in shipment details and resets the selected rate.
+    /// This is to prevent displaying a stale price when critical details that affect pricing have changed.
+    func setupSelectedRateReset() {
+        $destinationAddress
+            .combineLatest(
+                $originAddress,
+                $selectedPackage,
+                $shipmentWeight
+            )
+            // Drop the initial values set on initialization, so we only react to changes.
+            .dropFirst()
+            .sink { [weak self] _, _, _, _ in
+                self?.selectedRate = nil
+            }
+            .store(in: &subscriptions)
     }
 
     /// Converts the package data to a `ShippingLabelPackageSelected` object.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -392,6 +392,7 @@ private extension WooShippingShipmentDetailsViewModel {
             .dropFirst()
             .sink { [weak self] _ in
                 self?.selectedRate = nil
+                self?.shippingService?.clearSelectedRate()
             }
             .store(in: &subscriptions)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -102,23 +102,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
     }
 
     /// Shipping rates for the purchased label, with formatted amount.
-    var shippingRates: [(title: String, amount: String)] {
-        if let shippingLabel {
-            return [formatShippingRate(name: shippingLabel.serviceName, rate: shippingLabel.rate)]
-        } else if let selectedRate {
-            let baseRate = selectedRate.rate.rate
-            let formattedBaseRate = formatShippingRate(name: Localization.baseRateLabel(for: selectedRate), rate: baseRate)
-            let formattedSignatureRate = [
-                selectedRate.signatureRate.map { self.formatShippingRate(name: Localization.signatureRequired, rate: $0.rate, basedOn: baseRate) },
-                selectedRate.adultSignatureRate.map { self.formatShippingRate(name: Localization.adultSignatureRequired,
-                                                                              rate: $0.rate,
-                                                                              basedOn: baseRate) }
-            ].compacted()
-            return [formattedBaseRate] + formattedSignatureRate
-        } else {
-            return []
-        }
-    }
+    @Published private(set) var shippingRates: [(title: String, amount: String)] = []
 
     var currentPackage: ShippingLabelPackageSelected? {
         guard let selectedPackage else {
@@ -171,6 +155,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
         observeLabelRates()
         observeCustomsForm()
         observeHAZMATChanges()
+        observeShippingRates()
     }
 
     /// Handles package selection for the shipping label.
@@ -368,6 +353,29 @@ private extension WooShippingShipmentDetailsViewModel {
                 requiredInfoIsEntered && customsFormRequired
             }
             .assign(to: &$customsInformationIsCompleted)
+    }
+
+    private func observeShippingRates() {
+        $shippingLabel.combineLatest($selectedRate)
+            .map { [weak self] shippingLabel, selectedRate -> [(title: String, amount: String)] in
+                guard let self else { return [] }
+                if let shippingLabel {
+                    return [self.formatShippingRate(name: shippingLabel.serviceName, rate: shippingLabel.rate)]
+                } else if let selectedRate {
+                    let baseRate = selectedRate.rate.rate
+                    let formattedBaseRate = self.formatShippingRate(name: Localization.baseRateLabel(for: selectedRate), rate: baseRate)
+                    let formattedSignatureRate = [
+                        selectedRate.signatureRate.map { self.formatShippingRate(name: Localization.signatureRequired, rate: $0.rate, basedOn: baseRate) },
+                        selectedRate.adultSignatureRate.map { self.formatShippingRate(name: Localization.adultSignatureRequired,
+                                                                                      rate: $0.rate,
+                                                                                      basedOn: baseRate) }
+                    ].compacted()
+                    return [formattedBaseRate] + formattedSignatureRate
+                } else {
+                    return []
+                }
+            }
+            .assign(to: &$shippingRates)
     }
 
     /// Converts the package data to a `ShippingLabelPackageSelected` object.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -264,16 +264,21 @@ private extension WooShippingShipmentDetailsViewModel {
             .store(in: &subscriptions)
 
         $originAddress.combineLatest($destinationAddress)
-            .map { [weak self] originAddress, destinationAddress in
-                guard let self else { return nil }
-                return WooShippingServiceViewModel(order: order,
-                                                   originAddress: originAddress,
-                                                   destinationAddress: destinationAddress,
-                                                   stores: stores) { [weak self] selectedRate in
+            .sink { [weak self] originAddress, destinationAddress in
+                guard let self else { return }
+                // When the origin address changes, the old pricing based on the previous rate is no longer valid.
+                // We reset `selectedRate` here to stop displaying the stale price until a new rate is selected.
+                self.selectedRate = nil
+                self.shippingService = WooShippingServiceViewModel(
+                    order: self.order,
+                    originAddress: originAddress,
+                    destinationAddress: destinationAddress,
+                    stores: self.stores
+                ) { [weak self] selectedRate in
                     self?.selectedRate = selectedRate
                 }
             }
-            .assign(to: &$shippingService)
+            .store(in: &subscriptions)
 
         $originAddress.combineLatest($destinationAddress)
             .map { (originAddress, destinationAddress) -> Bool in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -383,14 +383,14 @@ private extension WooShippingShipmentDetailsViewModel {
     /// This is to prevent displaying a stale price when critical details that affect pricing have changed.
     func setupSelectedRateReset() {
         $destinationAddress
-            .combineLatest(
-                $originAddress,
-                $selectedPackage,
-                $shipmentWeight
-            )
+            .combineLatest($originAddress)
+            .combineLatest($selectedPackage)
+            .combineLatest($shipmentWeight)
+            .combineLatest($hazmatCategory)
+            .combineLatest($customsForm)
             // Drop the initial values set on initialization, so we only react to changes.
             .dropFirst()
-            .sink { [weak self] _, _, _, _ in
+            .sink { [weak self] _ in
                 self?.selectedRate = nil
             }
             .store(in: &subscriptions)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -79,6 +79,11 @@ final class WooShippingServiceViewModel: ObservableObject {
         analytics.track(event: .WooShipping.rateSelectionStep(state: .selected))
     }
 
+    /// Clears the selected rate.
+    func clearSelectedRate() {
+        selectedRate = nil
+    }
+
     func refreshSelectedRate(from oldRate: WooShippingSelectedRate) -> WooShippingSelectedRate? {
         let updatedStandardRate = standardRates.first(where: {
             $0.serviceID == oldRate.rate.serviceID

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -48,6 +48,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
             observeHAZMATNotices()
             observeSelectedPackage()
             observeSelectedRates()
+            observeShippingRates()
         }
     }
 
@@ -139,9 +140,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     let shippingLines: [WooShipping_ShippingLineViewModel]
 
     /// Shipping rates for the purchased label, with formatted amount.
-    var shippingRates: [(title: String, amount: String)] {
-        currentShipmentDetailsViewModel.shippingRates
-    }
+    @Published private(set) var shippingRates: [(title: String, amount: String)] = []
 
     /// Total cost of the shipping label, formatted for display.
     var totalCost: String? {
@@ -488,6 +487,11 @@ private extension WooShippingCreateLabelsViewModel {
             .assign(to: &$selectedRate)
     }
 
+    func observeShippingRates() {
+        currentShipmentDetailsViewModel.$shippingRates
+            .assign(to: &$shippingRates)
+    }
+
     func updateShipmentDetailsViewModels() {
         shipmentDetailViewModels = shipments.map { shipment in
             let matchingShippingLabel = shippingLabels.first(where: { $0.shippingLabelID == shipment.purchasedLabelID })
@@ -510,6 +514,7 @@ private extension WooShippingCreateLabelsViewModel {
         observeHAZMATNotices()
         observeSelectedPackage()
         observeSelectedRates()
+        observeShippingRates()
     }
 
     func handleLabelPurchaseSuccess(newLabel: ShippingLabel, in shipment: Shipment) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
@@ -57,8 +57,8 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isPurchaseButtonEnabled)
 
         // When
-        viewModel.shippingService?.onSelectRate?(sampleSelectedRate())
         viewModel.selectPackage(samplePackageData())
+        viewModel.shippingService?.onSelectRate?(sampleSelectedRate())
 
         // Then
         XCTAssertTrue(viewModel.isPurchaseButtonEnabled)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
@@ -615,6 +615,46 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.selectedPackage?.name, updatedPackage.name)
     }
+
+    func test_changing_origin_address_resets_selected_rate() throws {
+        // Given
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
+        let viewModel = WooShippingShipmentDetailsViewModel(order: Order.fake(),
+                                                            shipment: sampleShipment,
+                                                            shippingLabel: nil,
+                                                            originAddress: originAddressSubject.eraseToAnyPublisher(),
+                                                            destinationAddress: destinationAddressSubject.eraseToAnyPublisher())
+
+        viewModel.shippingService?.onSelectRate?(sampleSelectedRate())
+        XCTAssertNotNil(viewModel.selectedRate, "Precondition failed: selectedRate should not be nil")
+
+        // When
+        originAddressSubject.send(sampleOriginAddress(country: "US", state: "FL"))
+
+        // Then
+        XCTAssertNil(viewModel.selectedRate)
+    }
+
+    func test_changing_destination_address_resets_selected_rate() throws {
+        // Given
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
+        let viewModel = WooShippingShipmentDetailsViewModel(order: Order.fake(),
+                                                            shipment: sampleShipment,
+                                                            shippingLabel: nil,
+                                                            originAddress: originAddressSubject.eraseToAnyPublisher(),
+                                                            destinationAddress: destinationAddressSubject.eraseToAnyPublisher())
+
+        viewModel.shippingService?.onSelectRate?(sampleSelectedRate())
+        XCTAssertNotNil(viewModel.selectedRate, "Precondition failed: selectedRate should not be nil")
+
+        // When
+        destinationAddressSubject.send(sampleDestinationAddress(country: "US", state: "FL"))
+
+        // Then
+        XCTAssertNil(viewModel.selectedRate)
+    }
 }
 
 private extension WooShippingShipmentDetailsViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
@@ -634,6 +634,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNil(viewModel.selectedRate)
+        XCTAssertNil(viewModel.shippingService?.selectedRate)
     }
 
     func test_changing_destination_address_resets_selected_rate() throws {
@@ -654,6 +655,71 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNil(viewModel.selectedRate)
+        XCTAssertNil(viewModel.shippingService?.selectedRate)
+    }
+
+    func test_changing_shipment_weight_resets_selected_rate() throws {
+        // Given
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
+        let viewModel = WooShippingShipmentDetailsViewModel(order: Order.fake(),
+                                                            shipment: sampleShipment,
+                                                            shippingLabel: nil,
+                                                            originAddress: originAddressSubject.eraseToAnyPublisher(),
+                                                            destinationAddress: destinationAddressSubject.eraseToAnyPublisher())
+
+        viewModel.shippingService?.onSelectRate?(sampleSelectedRate())
+        XCTAssertNotNil(viewModel.selectedRate, "Precondition failed: selectedRate should not be nil")
+
+        // When
+        viewModel.shipmentWeight = "10"
+
+        // Then
+        XCTAssertNil(viewModel.selectedRate)
+        XCTAssertNil(viewModel.shippingService?.selectedRate)
+    }
+
+    func test_changing_hazmat_category_resets_selected_rate() throws {
+        // Given
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
+        let viewModel = WooShippingShipmentDetailsViewModel(order: Order.fake(),
+                                                            shipment: sampleShipment,
+                                                            shippingLabel: nil,
+                                                            originAddress: originAddressSubject.eraseToAnyPublisher(),
+                                                            destinationAddress: destinationAddressSubject.eraseToAnyPublisher())
+
+        viewModel.shippingService?.onSelectRate?(sampleSelectedRate())
+        XCTAssertNotNil(viewModel.selectedRate, "Precondition failed: selectedRate should not be nil")
+
+        // When
+        viewModel.hazmatCategory = .class1
+
+        // Then
+        XCTAssertNil(viewModel.selectedRate)
+        XCTAssertNil(viewModel.shippingService?.selectedRate)
+    }
+
+    func test_changing_customs_form_resets_selected_rate() throws {
+        // Given
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
+        let viewModel = WooShippingShipmentDetailsViewModel(order: Order.fake(),
+                                                            shipment: sampleShipment,
+                                                            shippingLabel: nil,
+                                                            originAddress: originAddressSubject.eraseToAnyPublisher(),
+                                                            destinationAddress: destinationAddressSubject.eraseToAnyPublisher())
+
+        viewModel.shippingService?.onSelectRate?(sampleSelectedRate())
+        XCTAssertNotNil(viewModel.selectedRate, "Precondition failed: selectedRate should not be nil")
+
+        // When
+        viewModel.customsFormViewModel.returnToSenderIfNotDelivered = true
+        viewModel.customsFormViewModel.onDismiss()
+
+        // Then
+        XCTAssertNil(viewModel.selectedRate)
+        XCTAssertNil(viewModel.shippingService?.selectedRate)
     }
 }
 


### PR DESCRIPTION
WOOMOB-639

## Description
This PR fixes a UI bug that caused the "Purchase Label" button to display a stale price after changing the origin address.

The root cause was that the `selectedRate` was not being reset when the origin or destination address changed. This led to the UI retaining the old, now invalid, price while new shipping rates were being fetched.

The fix involves a few key changes:
1.  In `WooShippingShipmentDetailsViewModel`, the `selectedRate` is now explicitly set to `nil` whenever the origin or destination address changes. This ensures the UI is cleared of stale data.
2.  The `shippingRates` properties in both `WooShippingCreateLabelsViewModel` and `WooShippingShipmentDetailsViewModel` have been converted from computed properties to reactive `@Published` properties to better handle state updates.
3.  Unit tests have been added to verify that `selectedRate` is correctly reset when the origin and destination addresses are changed.

## Steps to reproduce
1.  Navigate to an order and begin creating a shipping label.
2.  Select a package for the shipment.
3.  Select a shipping rate. Note that the "Purchase" button becomes enabled and displays the price for the selected rate.
4.  Change the origin address.
5.  **Before this fix:** Notice that the "Purchase" button remains enabled and shows the price from the *previous* origin address while new rates are loading.
6.  **With this fix:** The "Purchase" button should become disabled and its price should disappear until a new rate is selected.

## Testing information
-   Please follow the "Steps to reproduce" to perform manual testing.
-   Verify the fix works for changes to both the **Origin Address** and the **Destination Address**.
-   Confirm that the added unit tests (`test_changing_origin_address_resets_selected_rate` and `test_changing_destination_address_resets_selected_rate`) pass successfully.

## Demo

https://github.com/user-attachments/assets/cabb3888-c445-42d0-a149-a444f60e4dae

**Before:** The purchase button retains the old price after the origin address is changed.
**After:** The purchase button's price is cleared and it becomes disabled until a new rate is selected.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
