### PR TITLE
[POS as a tab i1] Update POS tab icon and title based on design

### DIFF
--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -11,8 +11,8 @@ final class POSTabViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        tabBarItem.title = NSLocalizedString("pos.tab.title", value: "Point of Sale", comment: "Title for the Point of Sale tab.")
-        tabBarItem.image = .creditCardImage
+        tabBarItem.title = NSLocalizedString("pos.tab.title", value: "POS", comment: "Title for the Point of Sale tab.")
+        tabBarItem.image = UIImage(systemName: "cart")
         tabBarItem.accessibilityIdentifier = "tab-bar-pos-item"
     }
 }


### PR DESCRIPTION
Closes WOOMOB-666

- Just one reviewer is required.
- As the "NEW" badge behavior is still not confirmed pdfdoF-7tQ-p2#comment-8588, it will be handled in a separate issue WOOMOB-669.

## Description

This PR updates the POS tab icon and title to align with the i2 design specifications. The changes include updating the tab title from "Point of Sale" to "POS" and changing the icon from a credit card image to a system cart icon for better visual consistency.

### UI Changes:
* Updated POS tab title from "Point of Sale" to "POS" for a more concise display
* Changed tab icon from `.creditCardImage` to `UIImage(systemName: "cart")` to better represent the point of sale functionality

## Steps to reproduce

Prerequisite: a WPCOM account with a store eligible for POS tab functionality.

- Log in to an account with a POS-eligible store if needed --> the POS tab should display "POS" as the title with a cart icon instead of the previous "Point of Sale" title with credit card icon
- Tap the POS tab to ensure functionality remains unchanged

## Testing information

Tested on iOS simulator to verify the visual changes and tab functionality.

## Example screenshots

before | after
-- | --
![Simulator Screenshot - iPad (A16) - 2025-06-23 at 13 59 25](https://github.com/user-attachments/assets/f5166371-26ea-4fc9-aab6-b9f9c9770fe4) | ![Simulator Screenshot - iPad (A16) - 2025-06-23 at 13 50 11](https://github.com/user-attachments/assets/9b911ccf-8c29-4989-9cb0-c025ba8e2fc7)

dark mode | largest font size
-- | -- 
![Simulator Screenshot - iPad (A16) - 2025-06-23 at 13 50 18](https://github.com/user-attachments/assets/f2e16231-9af6-4c59-8a0d-9bd68f83279b) | ![Simulator Screenshot - iPad (A16) - 2025-06-23 at 13 50 47](https://github.com/user-attachments/assets/1c70740d-bf57-4f08-a661-c23202fc8fd4)

Confidence test: POS tab not shown in iPhone

<img src="https://github.com/user-attachments/assets/51f9d49e-2d86-46e9-a0ee-cf1f078b225b" width="200" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.