### PR TITLE
[Woo POS] [Barcodes] Ensure the cart is updated on a main thread after scanning

### DIFF
--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -186,7 +186,8 @@ extension PointOfSaleAggregateModel {
 @available(iOS 17.0, *)
 extension PointOfSaleAggregateModel {
     func barcodeScanned(_ barcode: String) {
-        Task {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
             let placeholderItemID = cart.addLoadingItem().id
 
             analytics.track(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I encountered occasional issues where the loading row wouldn't appear after scanning. It happens quite rarely and I couldn't find a good way to reproduce it.

https://github.com/user-attachments/assets/76d838dd-8903-4acc-88cd-cadfd2500cf5

The only thing that caught my attention is that we're updating the cart items in a background thread. After executing the cart update on the main thread, I wasn't able to reproduce the issue anymore, but I'll continue observing.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Scan an item
3. Confirm the loading row appears
4. Clear cart and repeat several times
5. Confirm the loading row always appears

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air 18.3 Device

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.