### PR TITLE
Add build phase script to remove Wormholy files

### DIFF
--- a/Scripts/build-phases/strip-wormholy-from-release.sh
+++ b/Scripts/build-phases/strip-wormholy-from-release.sh
@@ -1,9 +1,11 @@
 #!/bin/bash -eu
 
-if [ "${CONFIGURATION}" != "Release" ]; then
-  echo "info: Skipping Wormholy removal – not a Release build."
-  exit 0
-fi
+# if [ "${CONFIGURATION}" != "Release" ]; then
+#   echo "info: Skipping Wormholy removal – not a Release build."
+#   exit 0
+# fi
+
+# FIXME: Delete from all builds to test the implementation
 
 BUILT_PRODUCTS_DIR=${BUILT_PRODUCTS_DIR:-"$TARGET_BUILD_DIR"}
 

--- a/Scripts/build-phases/strip-wormholy-from-release.sh
+++ b/Scripts/build-phases/strip-wormholy-from-release.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -eu
+
+if [ "${CONFIGURATION}" != "Release" ]; then
+  echo "info: Skipping Wormholy removal – not a Release build."
+  exit 0
+fi
+
+BUILT_PRODUCTS_DIR=${BUILT_PRODUCTS_DIR:-"$TARGET_BUILD_DIR"}
+
+# Crude way to remove all the Wormholy files from the build.
+rm -rf "$BUILT_PRODUCTS_DIR/Wormholy*"

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -19,9 +19,9 @@ import class Yosemite.ScreenshotStoresManager
 // In that way, Inject will be available in the entire target.
 @_exported import Inject
 
-#if DEBUG
-import WormholySwift
-#endif
+//#if DEBUG
+//import WormholySwift
+//#endif
 
 // MARK: - Woo's App Delegate!
 //
@@ -415,10 +415,10 @@ private extension AppDelegate {
     /// Set up Wormholy only in Debug build configuration
     ///
     func setupWormholy() {
-#if DEBUG
-        // We want to activate it programmatically, not using the shake.
-        Wormholy.shakeEnabled = false
-#endif
+//#if DEBUG
+//        // We want to activate it programmatically, not using the shake.
+//        Wormholy.shakeEnabled = false
+//#endif
     }
 
     /// Set up `KeyboardStateProvider`

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -14487,6 +14487,7 @@
 				B5650B1020A4CD7F009702D0 /* Embed Frameworks */,
 				3F1FA85028B60126009E246C /* Embed Foundation Extensions */,
 				26F81B232BE433A4009EC58E /* Embed Watch Content */,
+				3F76AD982E0A849700984880 /* Strip Wormholy from Release build */,
 			);
 			buildRules = (
 			);
@@ -15075,6 +15076,24 @@
 			shellPath = /bin/sh;
 			shellScript = "\"$SRCROOT/../Scripts/build-phases/LintAppLocalizedStringsUsage.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		3F76AD982E0A849700984880 /* Strip Wormholy from Release build */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Strip Wormholy from Release build";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "$SRCROOT/../Scripts/build-phases/strip-wormholy-from-release.sh\n";
 		};
 		57CCFFD4249D2A5700825FCF /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Builds on top of https://github.com/woocommerce/woocommerce-ios/pull/15771 to try and remove Wormholy from the Release build.

<!-- blue -->
> [!NOTE]  
> Currently strips from all builds, so we can test.

Run on device from Xcode or via Prototype Build and verify it... does not crash?