### PR TITLE
[Shipping Labels] Make sure UPS TOS sheet confirmation button visible

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTOS/UPSTermsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTOS/UPSTermsView.swift
@@ -12,69 +12,76 @@ struct UPSTermsView: View {
     @State private var externalURL: URL?
 
     var body: some View {
-        ScrollableVStack(alignment: .leading,
-                         padding: Layout.contentPadding,
-                         spacing: Layout.sectionSpacing) {
-            Text(Localization.title)
-                .font(.title3)
-                .bold()
+        VStack(spacing: 0) {
+            ScrollableVStack(alignment: .leading,
+                             padding: Layout.contentPadding,
+                             spacing: Layout.sectionSpacing) {
+                Text(Localization.title)
+                    .font(.title3)
+                    .bold()
 
-            VStack(alignment: .leading, spacing: Layout.contentSpacing) {
-                Text(Localization.shippingFrom)
-                    .headlineStyle()
-                Text(viewModel.displayedOriginAddress)
-                    .foregroundStyle(Color.primary)
-                    .subheadlineStyle()
+                VStack(alignment: .leading, spacing: Layout.contentSpacing) {
+                    Text(Localization.shippingFrom)
+                        .headlineStyle()
+                    Text(viewModel.displayedOriginAddress)
+                        .foregroundStyle(Color.primary)
+                        .subheadlineStyle()
+                    Divider()
+                }
+                .accessibilityElement(children: .combine)
+
+                Text(Localization.message)
+
+                VStack(alignment: .leading, spacing: Layout.contentPadding) {
+                    Toggle(isOn: $viewModel.isTOSAccepted) {
+                        Text(
+                            AttributedString.withEmbeddedLink(
+                                mainContent: Localization.checkbox1,
+                                linkText: Localization.termsOfService,
+                                link: Links.termsOfService
+                            )
+                        )
+                    }
+                    .toggleStyle(CheckboxToggleStyle())
+
+                    Toggle(isOn: $viewModel.isProhibitedItemsAccepted) {
+                        Text(
+                            AttributedString.withEmbeddedLink(
+                                mainContent: Localization.checkbox2,
+                                linkText: Localization.prohibitedItems,
+                                link: Links.prohibitedItems
+                            )
+                        )
+                    }
+                    .toggleStyle(CheckboxToggleStyle())
+
+                    Toggle(isOn: $viewModel.isTechnologyAgreementAccepted) {
+                        Text(
+                            AttributedString.withEmbeddedLink(
+                                mainContent: Localization.checkbox3,
+                                linkText: Localization.technologyAgreement,
+                                link: Links.techAgreement
+                            )
+                        )
+                    }
+                    .toggleStyle(CheckboxToggleStyle())
+                }
+
+                Spacer()
+            }
+
+            VStack(spacing: 0) {
                 Divider()
+
+                Button(Localization.confirmButton, action: {
+                    Task { @MainActor in
+                        await confirmAcceptance()
+                    }
+                })
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isConfirming))
+                .padding(Layout.contentPadding)
+                .disabled(!viewModel.shouldEnableConfirmButton)
             }
-            .accessibilityElement(children: .combine)
-
-            Text(Localization.message)
-
-            VStack(alignment: .leading, spacing: Layout.contentPadding) {
-                Toggle(isOn: $viewModel.isTOSAccepted) {
-                    Text(
-                        AttributedString.withEmbeddedLink(
-                            mainContent: Localization.checkbox1,
-                            linkText: Localization.termsOfService,
-                            link: Links.termsOfService
-                        )
-                    )
-                }
-                .toggleStyle(CheckboxToggleStyle())
-
-                Toggle(isOn: $viewModel.isProhibitedItemsAccepted) {
-                    Text(
-                        AttributedString.withEmbeddedLink(
-                            mainContent: Localization.checkbox2,
-                            linkText: Localization.prohibitedItems,
-                            link: Links.prohibitedItems
-                        )
-                    )
-                }
-                .toggleStyle(CheckboxToggleStyle())
-
-                Toggle(isOn: $viewModel.isTechnologyAgreementAccepted) {
-                    Text(
-                        AttributedString.withEmbeddedLink(
-                            mainContent: Localization.checkbox3,
-                            linkText: Localization.technologyAgreement,
-                            link: Links.techAgreement
-                        )
-                    )
-                }
-                .toggleStyle(CheckboxToggleStyle())
-            }
-
-            Spacer()
-
-            Button(Localization.confirmButton, action: {
-                Task { @MainActor in
-                    await confirmAcceptance()
-                }
-            })
-            .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isConfirming))
-            .disabled(!viewModel.shouldEnableConfirmButton)
         }
         .padding(.top, Layout.contentPadding)
         .alert(Localization.errorTitle, isPresented: $didFailToConfirmAcceptance) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

WOOMOB-649

## Description

In IPad layout the "Confirm and continue" button goes out of bound for TOS sheet. As a solution the button is moved out of scrollable stack and positioned as last subview in a parent `VStack`

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

## Testing information

- Find a completed order with unfulfilled shipments
- Go to "Create Shipping Labels"
- Choose a UPS package and rate. Make sure the UPS TOS aren't yet accepted for a selected origin address. Otherwise input a new address. Or in `WooShippingCreateLabelsViewModel` change the `@Published var shouldShowUPSTermsAndConditions = false` default value to `true`. This will make TOS sheet appear instantly. 
- Make sure the confirmation button sticks to the sheet bottom and always visible
- Test both in iPad and iPhone
- Toggle accessibility font sizes while testing TOS sheet 

## Demo

https://github.com/user-attachments/assets/74a2e3a2-84e7-4e68-949e-b9cda7c2f11b

https://github.com/user-attachments/assets/ed59cd59-8272-4252-adf9-9cfe04d2f617

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.