### PR TITLE
[POS as a tab i1] Fix tab visibility using cached site settings when the values change remotely

### DIFF
--- a/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
+++ b/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
@@ -11,9 +11,16 @@ extension Notification.Name {
     public static let selectedSiteSettingsRefreshed = Notification.Name(rawValue: "selectedSiteSettingsRefreshed")
 }
 
+/// Source of site settings update.
+enum SettingsUpdateSource {
+    case initialLoad
+    case storageChange
+    case refresh
+}
+
 /// Protocol for accessing, refreshing, and observing site settings.
 protocol SelectedSiteSettingsProtocol {
-    var settingsStream: AsyncStream<(siteID: Int64, settings: [SiteSetting])> { get }
+    var settingsStream: AsyncStream<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource)> { get }
     var siteSettings: [SiteSetting] { get }
     func refresh()
 }
@@ -25,8 +32,8 @@ final class SelectedSiteSettings: NSObject, SelectedSiteSettingsProtocol {
     private let storageManager: StorageManagerType
 
     /// Async stream for observing site settings changes.
-    private let settingsContinuation: AsyncStream<(siteID: Int64, settings: [SiteSetting])>.Continuation
-    public let settingsStream: AsyncStream<(siteID: Int64, settings: [SiteSetting])>
+    private let settingsContinuation: AsyncStream<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource)>.Continuation
+    public let settingsStream: AsyncStream<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource)>
 
     /// ResultsController: Whenever settings change, I will change. We both change. The world changes.
     ///
@@ -42,7 +49,7 @@ final class SelectedSiteSettings: NSObject, SelectedSiteSettingsProtocol {
         self.storageManager = storageManager
 
         // Sets up async stream with buffering to ensure current value is sent.
-        let (stream, continuation) = AsyncStream<(siteID: Int64, settings: [SiteSetting])>.makeStream(
+        let (stream, continuation) = AsyncStream<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource)>.makeStream(
             bufferingPolicy: .bufferingNewest(1)
         )
         self.settingsStream = stream
@@ -64,7 +71,7 @@ extension SelectedSiteSettings {
     /// Refreshes the currency settings for the current default site
     ///
     func refresh() {
-        refreshResultsPredicate()
+        refreshResultsPredicate(source: .refresh)
     }
 
     /// Setup: ResultsController
@@ -78,12 +85,12 @@ extension SelectedSiteSettings {
                 DDLogError("Error: no siteID found when setting site settings results.")
                 return
             }
-            settingsContinuation.yield((siteID: siteID, settings: siteSettings))
+            settingsContinuation.yield((siteID: siteID, settings: siteSettings, source: .storageChange))
         }
-        refreshResultsPredicate()
+        refreshResultsPredicate(source: .initialLoad)
     }
 
-    private func refreshResultsPredicate() {
+    private func refreshResultsPredicate(source: SettingsUpdateSource) {
         guard let siteID = stores.sessionManager.defaultStoreID else {
             DDLogError("Error: no siteID found when attempting to refresh CurrencySettings results predicate.")
             return
@@ -99,7 +106,7 @@ extension SelectedSiteSettings {
             ServiceLocator.currencySettings.updateCurrencyOptions(with: $0)
         }
 
-        settingsContinuation.yield((siteID: siteID, settings: fetchedObjects))
+        settingsContinuation.yield((siteID: siteID, settings: fetchedObjects, source: source))
 
         NotificationCenter.default.post(name: .selectedSiteSettingsRefreshed, object: nil)
 

--- a/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
+++ b/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
@@ -11,9 +11,16 @@ extension Notification.Name {
     public static let selectedSiteSettingsRefreshed = Notification.Name(rawValue: "selectedSiteSettingsRefreshed")
 }
 
+/// Protocol for accessing, refreshing, and observing site settings.
+protocol SelectedSiteSettingsProtocol {
+    var settingsStream: AsyncStream<(siteID: Int64, settings: [SiteSetting])> { get }
+    var siteSettings: [SiteSetting] { get }
+    func refresh()
+}
+
 /// Settings for the selected Site
 ///
-final class SelectedSiteSettings: NSObject {
+final class SelectedSiteSettings: NSObject, SelectedSiteSettingsProtocol {
     private let stores: StoresManager
     private let storageManager: StorageManagerType
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -46,7 +46,6 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
     private let siteID: Int64
     private let userInterfaceIdiom: UIUserInterfaceIdiom
     private let siteSettings: SelectedSiteSettingsProtocol
-    private let currencySettings: CurrencySettings
     private let pluginsService: PluginsServiceProtocol
     private let eligibilityService: POSEligibilityServiceProtocol
     private let stores: StoresManager
@@ -55,7 +54,6 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
     init(siteID: Int64,
          userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
          siteSettings: SelectedSiteSettingsProtocol = ServiceLocator.selectedSiteSettings,
-         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          pluginsService: PluginsServiceProtocol = PluginsService(storageManager: ServiceLocator.storageManager),
          eligibilityService: POSEligibilityServiceProtocol = POSEligibilityService(),
          stores: StoresManager = ServiceLocator.stores,
@@ -63,7 +61,6 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
         self.siteID = siteID
         self.userInterfaceIdiom = userInterfaceIdiom
         self.siteSettings = siteSettings
-        self.currencySettings = currencySettings
         self.pluginsService = pluginsService
         self.eligibilityService = eligibilityService
         self.stores = stores
@@ -170,30 +167,17 @@ private extension POSTabEligibilityChecker {
 
         // Conditions that can change if site settings are synced during the lifetime.
         let countryCode = SiteAddress(siteSettings: siteSettings).countryCode
-        let currencyCode = currencySettings.currencyCode
+        let currencyCode = CurrencySettings(siteSettings: siteSettings).currencyCode
 
         return isEligibleFromCountryAndCurrencyCode(countryCode: countryCode, currencyCode: currencyCode)
     }
 
     func waitForSiteSettingsRefresh() async -> [SiteSetting] {
-        var isFirstValue = true
-        for await streamSettings in siteSettings.settingsStream {
-            guard streamSettings.siteID == siteID else {
+        for await siteSettings in siteSettings.settingsStream {
+            guard siteSettings.siteID == siteID, siteSettings.settings.isNotEmpty, siteSettings.source != .initialLoad else {
                 continue
             }
-
-            // Skips the first value (the initial value from storage, could be empty or not) and waits for the next one.
-            if isFirstValue {
-                isFirstValue = false
-                continue
-            }
-
-            // Returns the next non-empty value.
-            guard streamSettings.settings.isNotEmpty else {
-                continue
-            }
-
-            return streamSettings.settings
+            return siteSettings.settings
         }
         // If we get here, the stream completed without yielding any values for our site ID which is unexpected.
         return []

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -176,11 +176,24 @@ private extension POSTabEligibilityChecker {
     }
 
     func waitForSiteSettingsRefresh() async -> [SiteSetting] {
-        for await siteSettings in siteSettings.settingsStream {
-            guard siteSettings.siteID == siteID, siteSettings.settings.isNotEmpty else {
+        var isFirstValue = true
+        for await streamSettings in siteSettings.settingsStream {
+            guard streamSettings.siteID == siteID else {
                 continue
             }
-            return siteSettings.settings
+
+            // Skips the first value (the initial value from storage, could be empty or not) and waits for the next one.
+            if isFirstValue {
+                isFirstValue = false
+                continue
+            }
+
+            // Returns the next non-empty value.
+            guard streamSettings.settings.isNotEmpty else {
+                continue
+            }
+
+            return streamSettings.settings
         }
         // If we get here, the stream completed without yielding any values for our site ID which is unexpected.
         return []

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -45,7 +45,7 @@ protocol POSEntryPointEligibilityCheckerProtocol {
 final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
     private let siteID: Int64
     private let userInterfaceIdiom: UIUserInterfaceIdiom
-    private let siteSettings: SelectedSiteSettings
+    private let siteSettings: SelectedSiteSettingsProtocol
     private let currencySettings: CurrencySettings
     private let pluginsService: PluginsServiceProtocol
     private let eligibilityService: POSEligibilityServiceProtocol
@@ -54,7 +54,7 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
 
     init(siteID: Int64,
          userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
-         siteSettings: SelectedSiteSettings = ServiceLocator.selectedSiteSettings,
+         siteSettings: SelectedSiteSettingsProtocol = ServiceLocator.selectedSiteSettings,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          pluginsService: PluginsServiceProtocol = PluginsService(storageManager: ServiceLocator.storageManager),
          eligibilityService: POSEligibilityServiceProtocol = POSEligibilityService(),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -8,7 +8,7 @@ import Yosemite
 struct POSTabEligibilityCheckerTests {
     private var stores: MockStoresManager!
     private var storageManager: MockStorageManager!
-    private var siteSettings: SelectedSiteSettings!
+    private var siteSettings: MockSelectedSiteSettings!
     private var pluginsService: MockPluginsService!
     private var eligibilityService: MockPOSEligibilityService!
     private let siteID: Int64 = 2
@@ -20,7 +20,7 @@ struct POSTabEligibilityCheckerTests {
         pluginsService = MockPluginsService()
         eligibilityService = MockPOSEligibilityService()
         setupWooCommerceVersion()
-        siteSettings = SelectedSiteSettings(stores: stores, storageManager: storageManager)
+        siteSettings = MockSelectedSiteSettings()
     }
 
     @Test func is_eligible_when_all_conditions_satisfied() async throws {
@@ -308,6 +308,81 @@ struct POSTabEligibilityCheckerTests {
         // Then
         #expect(result == false)
     }
+
+    @Test func checkEligibility_skips_first_cached_settings_and_uses_fresh_settings() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
+
+        // Initial settings (cached) - makes site eligible (US)
+        let cachedSettings = [
+            SiteSetting.fake().copy(siteID: siteID, settingID: "woocommerce_default_country", value: "US:CA", settingGroupKey: SiteSettingGroup.general.rawValue)
+        ]
+        // New settings - makes site ineligible (Canada).
+        let newSettings = [
+            SiteSetting.fake().copy(siteID: siteID, settingID: "woocommerce_default_country", value: "CA:NS", settingGroupKey: SiteSettingGroup.general.rawValue)
+        ]
+        siteSettings.mockSettingsStream = AsyncStream { continuation in
+            // Emits cached settings first (should be skipped).
+            continuation.yield((siteID: siteID, settings: cachedSettings))
+            // Emits new settings (should be used for eligibility check).
+            continuation.yield((siteID: siteID, settings: newSettings))
+            continuation.finish()
+        }
+
+        accountWhitelistedInBackend(true)
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               userInterfaceIdiom: .pad,
+                                               siteSettings: siteSettings,
+                                               currencySettings: Fixtures.usdCurrencySettings,
+                                               pluginsService: pluginsService,
+                                               stores: stores,
+                                               featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then - Should be ineligible because fresh settings show CA (not cached US)
+        #expect(result == .ineligible(reason: .unsupportedCountry))
+    }
+
+    @Test func checkEligibility_filters_by_correct_siteID_when_waiting_for_fresh_settings() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
+
+        // Settings for a different site.
+        let wrongSiteSettings = [
+            SiteSetting.fake().copy(siteID: 999, settingID: "woocommerce_default_country", value: "CA:NS", settingGroupKey: SiteSettingGroup.general.rawValue)
+        ]
+        // Settings for correct site.
+        let correctSiteSettings = [
+            SiteSetting.fake().copy(siteID: siteID, settingID: "woocommerce_default_country", value: "US:CA", settingGroupKey: SiteSettingGroup.general.rawValue)
+        ]
+
+        siteSettings.mockSettingsStream = AsyncStream { continuation in
+            // Emits settings for a different site (should be filtered out).
+            continuation.yield((siteID: 999, settings: wrongSiteSettings))
+            // Emits first settings for correct site (should be skipped).
+            continuation.yield((siteID: siteID, settings: [SiteSetting.fake().copy(siteID: siteID, settingID: "temp")]))
+            // Emits fresh settings for correct site (should be used).
+            continuation.yield((siteID: siteID, settings: correctSiteSettings))
+            continuation.finish()
+        }
+
+        accountWhitelistedInBackend(true)
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               userInterfaceIdiom: .pad,
+                                               siteSettings: siteSettings,
+                                               currencySettings: Fixtures.usdCurrencySettings,
+                                               pluginsService: pluginsService,
+                                               stores: stores,
+                                               featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        #expect(result == .eligible)
+    }
 }
 
 private extension POSTabEligibilityCheckerTests {
@@ -319,8 +394,13 @@ private extension POSTabEligibilityCheckerTests {
                 value: country.rawValue,
                 settingGroupKey: SiteSettingGroup.general.rawValue
             )
-        storageManager.insertSampleSiteSetting(readOnlySiteSetting: setting)
-        siteSettings.refresh()
+        siteSettings.mockSettingsStream = AsyncStream { continuation in
+            // Emits cached settings first (should be skipped).
+            continuation.yield((siteID: siteID, settings: []))
+            // Emits fresh settings (should be used for eligibility check).
+            continuation.yield((siteID: siteID, settings: [setting]))
+            continuation.finish()
+        }
     }
 
     func setupWooCommerceVersion(_ version: String = "9.6.0-beta") {
@@ -382,5 +462,18 @@ private final class MockPluginsService: PluginsServiceProtocol {
 
     func waitForPluginInStorage(siteID: Int64, pluginName: String, isActive: Bool) async -> SystemPlugin {
         pluginToReturn
+    }
+}
+
+private final class MockSelectedSiteSettings: SelectedSiteSettingsProtocol {
+    var mockSettingsStream: AsyncStream<(siteID: Int64, settings: [SiteSetting])>?
+    var siteSettings: [SiteSetting] = []
+
+    var settingsStream: AsyncStream<(siteID: Int64, settings: [SiteSetting])> {
+        return mockSettingsStream ?? AsyncStream { _ in }
+    }
+
+    func refresh() {
+        // Mock implementation - no action needed.
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -31,7 +31,6 @@ struct POSTabEligibilityCheckerTests {
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
-                                               currencySettings: Fixtures.usdCurrencySettings,
                                                pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
@@ -51,7 +50,6 @@ struct POSTabEligibilityCheckerTests {
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
-                                               currencySettings: Fixtures.usdCurrencySettings,
                                                pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
@@ -71,7 +69,6 @@ struct POSTabEligibilityCheckerTests {
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                userInterfaceIdiom: .phone,
                                                siteSettings: siteSettings,
-                                               currencySettings: Fixtures.usdCurrencySettings,
                                                pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
@@ -87,17 +84,11 @@ struct POSTabEligibilityCheckerTests {
     fileprivate func is_eligible_when_country_and_currency_are_supported(country: Country, currency: CurrencyCode) async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
-        setupCountry(country: country)
+        setupCountry(country: country, currency: currency)
         accountWhitelistedInBackend(true)
-        let currencySettings = CurrencySettings(currencyCode: currency,
-                                                currencyPosition: .leftSpace,
-                                                thousandSeparator: "",
-                                                decimalSeparator: ".",
-                                                numberOfDecimals: 3)
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
-                                               currencySettings: currencySettings,
                                                pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
@@ -113,17 +104,11 @@ struct POSTabEligibilityCheckerTests {
     fileprivate func is_ineligible_when_country_is_not_supported(country: Country, currency: CurrencyCode) async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
-        setupCountry(country: country)
+        setupCountry(country: country, currency: currency)
         accountWhitelistedInBackend(true)
-        let currencySettings = CurrencySettings(currencyCode: currency,
-                                                currencyPosition: .leftSpace,
-                                                thousandSeparator: "",
-                                                decimalSeparator: ".",
-                                                numberOfDecimals: 3)
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
-                                               currencySettings: currencySettings,
                                                pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
@@ -142,17 +127,11 @@ struct POSTabEligibilityCheckerTests {
     fileprivate func is_ineligible_when_currency_is_not_supported(country: Country, currency: CurrencyCode) async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
-        setupCountry(country: country)
+        setupCountry(country: country, currency: currency)
         accountWhitelistedInBackend(true)
-        let currencySettings = CurrencySettings(currencyCode: currency,
-                                                currencyPosition: .leftSpace,
-                                                thousandSeparator: "",
-                                                decimalSeparator: ".",
-                                                numberOfDecimals: 3)
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
-                                               currencySettings: currencySettings,
                                                pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
@@ -173,7 +152,6 @@ struct POSTabEligibilityCheckerTests {
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
-                                               currencySettings: Fixtures.usdCurrencySettings,
                                                pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
@@ -195,7 +173,6 @@ struct POSTabEligibilityCheckerTests {
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
-                                               currencySettings: Fixtures.usdCurrencySettings,
                                                pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
@@ -217,7 +194,6 @@ struct POSTabEligibilityCheckerTests {
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
-                                               currencySettings: Fixtures.usdCurrencySettings,
                                                pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
@@ -239,7 +215,6 @@ struct POSTabEligibilityCheckerTests {
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
-                                               currencySettings: Fixtures.usdCurrencySettings,
                                                pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
@@ -261,7 +236,6 @@ struct POSTabEligibilityCheckerTests {
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
-                                               currencySettings: Fixtures.usdCurrencySettings,
                                                pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
@@ -309,23 +283,33 @@ struct POSTabEligibilityCheckerTests {
         #expect(result == false)
     }
 
-    @Test func checkEligibility_skips_first_cached_settings_and_uses_fresh_settings() async throws {
+    @Test func checkEligibility_skips_settings_from_initialLoad() async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
 
         // Initial settings (cached) - makes site eligible (US)
-        let cachedSettings = [
-            SiteSetting.fake().copy(siteID: siteID, settingID: "woocommerce_default_country", value: "US:CA", settingGroupKey: SiteSettingGroup.general.rawValue)
+        let initialSettings = [
+            SiteSetting.fake().copy(
+                siteID: siteID, settingID: "woocommerce_default_country", value: Country.us.rawValue, settingGroupKey: SiteSettingGroup.general.rawValue
+            ),
+            SiteSetting.fake().copy(
+                siteID: siteID, settingID: "woocommerce_currency", value: CurrencyCode.USD.rawValue, settingGroupKey: SiteSettingGroup.general.rawValue
+            )
         ]
         // New settings - makes site ineligible (Canada).
         let newSettings = [
-            SiteSetting.fake().copy(siteID: siteID, settingID: "woocommerce_default_country", value: "CA:NS", settingGroupKey: SiteSettingGroup.general.rawValue)
+            SiteSetting.fake().copy(
+                siteID: siteID, settingID: "woocommerce_default_country", value: Country.ca.rawValue, settingGroupKey: SiteSettingGroup.general.rawValue
+            ),
+            SiteSetting.fake().copy(
+                siteID: siteID, settingID: "woocommerce_currency", value: CurrencyCode.USD.rawValue, settingGroupKey: SiteSettingGroup.general.rawValue
+            )
         ]
         siteSettings.mockSettingsStream = AsyncStream { continuation in
             // Emits cached settings first (should be skipped).
-            continuation.yield((siteID: siteID, settings: cachedSettings))
+            continuation.yield((siteID: siteID, settings: initialSettings, source: .initialLoad))
             // Emits new settings (should be used for eligibility check).
-            continuation.yield((siteID: siteID, settings: newSettings))
+            continuation.yield((siteID: siteID, settings: newSettings, source: .storageChange))
             continuation.finish()
         }
 
@@ -333,7 +317,6 @@ struct POSTabEligibilityCheckerTests {
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
-                                               currencySettings: Fixtures.usdCurrencySettings,
                                                pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
@@ -345,26 +328,36 @@ struct POSTabEligibilityCheckerTests {
         #expect(result == .ineligible(reason: .unsupportedCountry))
     }
 
-    @Test func checkEligibility_filters_by_correct_siteID_when_waiting_for_fresh_settings() async throws {
+    @Test func checkEligibility_filters_by_correct_siteID() async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleEnabled: true)
 
         // Settings for a different site.
         let wrongSiteSettings = [
-            SiteSetting.fake().copy(siteID: 999, settingID: "woocommerce_default_country", value: "CA:NS", settingGroupKey: SiteSettingGroup.general.rawValue)
+            SiteSetting.fake().copy(
+                siteID: 999, settingID: "woocommerce_default_country", value: Country.ca.rawValue, settingGroupKey: SiteSettingGroup.general.rawValue
+            ),
+            SiteSetting.fake().copy(
+                siteID: 999, settingID: "woocommerce_currency", value: CurrencyCode.CAD.rawValue, settingGroupKey: SiteSettingGroup.general.rawValue
+            )
         ]
         // Settings for correct site.
         let correctSiteSettings = [
-            SiteSetting.fake().copy(siteID: siteID, settingID: "woocommerce_default_country", value: "US:CA", settingGroupKey: SiteSettingGroup.general.rawValue)
+            SiteSetting.fake().copy(
+                siteID: siteID, settingID: "woocommerce_default_country", value: Country.us.rawValue, settingGroupKey: SiteSettingGroup.general.rawValue
+            ),
+            SiteSetting.fake().copy(
+                siteID: siteID, settingID: "woocommerce_currency", value: CurrencyCode.USD.rawValue, settingGroupKey: SiteSettingGroup.general.rawValue
+            )
         ]
 
         siteSettings.mockSettingsStream = AsyncStream { continuation in
             // Emits settings for a different site (should be filtered out).
-            continuation.yield((siteID: 999, settings: wrongSiteSettings))
+            continuation.yield((siteID: 999, settings: wrongSiteSettings, source: .storageChange))
             // Emits first settings for correct site (should be skipped).
-            continuation.yield((siteID: siteID, settings: [SiteSetting.fake().copy(siteID: siteID, settingID: "temp")]))
+            continuation.yield((siteID: siteID, settings: [SiteSetting.fake().copy(siteID: siteID, settingID: "temp")], source: .initialLoad))
             // Emits fresh settings for correct site (should be used).
-            continuation.yield((siteID: siteID, settings: correctSiteSettings))
+            continuation.yield((siteID: siteID, settings: correctSiteSettings, source: .storageChange))
             continuation.finish()
         }
 
@@ -372,7 +365,6 @@ struct POSTabEligibilityCheckerTests {
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                userInterfaceIdiom: .pad,
                                                siteSettings: siteSettings,
-                                               currencySettings: Fixtures.usdCurrencySettings,
                                                pluginsService: pluginsService,
                                                stores: stores,
                                                featureFlagService: featureFlagService)
@@ -386,19 +378,26 @@ struct POSTabEligibilityCheckerTests {
 }
 
 private extension POSTabEligibilityCheckerTests {
-    func setupCountry(country: Country) {
-        let setting = SiteSetting.fake()
+    func setupCountry(country: Country, currency: CurrencyCode = .USD) {
+        let countrySetting = SiteSetting.fake()
             .copy(
                 siteID: siteID,
                 settingID: "woocommerce_default_country",
                 value: country.rawValue,
                 settingGroupKey: SiteSettingGroup.general.rawValue
             )
+        let currencySetting = SiteSetting.fake()
+            .copy(
+                siteID: siteID,
+                settingID: "woocommerce_currency",
+                value: currency.rawValue,
+                settingGroupKey: SiteSettingGroup.general.rawValue
+            )
         siteSettings.mockSettingsStream = AsyncStream { continuation in
             // Emits cached settings first (should be skipped).
-            continuation.yield((siteID: siteID, settings: []))
+            continuation.yield((siteID: siteID, settings: [], source: .storageChange))
             // Emits fresh settings (should be used for eligibility check).
-            continuation.yield((siteID: siteID, settings: [setting]))
+            continuation.yield((siteID: siteID, settings: [countrySetting, currencySetting], source: .refresh))
             continuation.finish()
         }
     }
@@ -436,19 +435,6 @@ private extension POSTabEligibilityCheckerTests {
         eligibilityService.cachedTabVisibility[siteID] = isVisible
     }
 
-    enum Fixtures {
-        static let usdCurrencySettings = CurrencySettings(currencyCode: .USD,
-                                                          currencyPosition: .leftSpace,
-                                                          thousandSeparator: "",
-                                                          decimalSeparator: ".",
-                                                          numberOfDecimals: 3)
-        static let nonUSDCurrencySettings = CurrencySettings(currencyCode: .CAD,
-                                                             currencyPosition: .leftSpace,
-                                                             thousandSeparator: "",
-                                                             decimalSeparator: ".",
-                                                             numberOfDecimals: 3)
-    }
-
     enum Country: String {
         case us = "US:CA"
         case ca = "CA:NS"
@@ -466,10 +452,10 @@ private final class MockPluginsService: PluginsServiceProtocol {
 }
 
 private final class MockSelectedSiteSettings: SelectedSiteSettingsProtocol {
-    var mockSettingsStream: AsyncStream<(siteID: Int64, settings: [SiteSetting])>?
+    var mockSettingsStream: AsyncStream<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource)>?
     var siteSettings: [SiteSetting] = []
 
-    var settingsStream: AsyncStream<(siteID: Int64, settings: [SiteSetting])> {
+    var settingsStream: AsyncStream<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource)> {
         return mockSettingsStream ?? AsyncStream { _ in }
     }
 


### PR DESCRIPTION
Closes WOOMOB-676

Just one reviewer is required.

## Issue

As reported in the call for testing pdfdoF-7qM-p2#comment-8591 and a pdfdoF-7rI-p2#comment-8557, if the POS tab is visible before (store eligible for POS) and then the store currency/country changes remotely, the POS tab remains visible on the next launch.

## Cause

It is because the POS tab visibility check is [using the first non-empty cached site settings in storage](https://github.com/woocommerce/woocommerce-ios/blob/09b40021e3eb2303fb386e7f0984cf0cd4b97a03/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift#L179-L184). For the first check for each store, it waits for the site settings sync as the cached value is empty. But for later checks, it uses the cached value while site settings are synced later after the site settings API request elsewhere. That's why the second launch works, since the site settings in storage are updated from the site settings API request in the previous launch.

## Proposed fix

There are a few things that complicate how we can wait for the "refreshed" site settings. Firstly, the site settings async stream can be emitted from initial load of each app logged-in session for the `ServiceLocator.selectedSiteSettings` (which stays the same after switching stores until logout or app relaunch), manual refresh from API sync anywhere, and storage change when objects are upserted. Secondly, the currency settings are updated by any `SelectedSiteSettings` instance, but in a separate global singleton `ServiceLocator.currencySettings`.

The checker now skips the site settings value from initial load by introducing a `SettingsUpdateSource` enum to track the source of site settings updates. It also does not depend on `ServiceLocator.currencySettings` but get the currency code from the latest site settings as I found issues where `ServiceLocator.currencySettings` currency code wasn't up-to-date.  

I also thought about subscribing to the [notification when the site settings are refreshed](https://github.com/woocommerce/woocommerce-ios/blob/09b40021e3eb2303fb386e7f0984cf0cd4b97a03/WooCommerce/Classes/Tools/Shared%20Site%20Settings/SelectedSiteSettings.swift#L97), but I was hoping not to depend on notifications given its unknown subscribers and unexpected side effects. There are instances outside `ServiceLocator.selectedSiteSettings` that can post the notification. Also, if the checker is initialized after the notification is triggered, it will never receive a value. The PR implementation is still based on the assumed behavior of new values replacing the initial value during site initialization, but the checker can be initialized independently of the site settings refresh timing. Please feel free to share different thoughts about the implementation. Making a separate API request to sync site settings would certainly be easier, but given the many API requests already made during app launch, I don't think we want to add another one.

## Changes

### Refactoring `SelectedSiteSettings`:

* Introduced `SettingsUpdateSource` enum to represent the source of settings updates (`initialLoad`, `storageChange`, `refresh`).
* Added `SelectedSiteSettingsProtocol` to define methods and properties for accessing, refreshing, and observing site settings.
* Modified `SelectedSiteSettings` to conform to `SelectedSiteSettingsProtocol` and updated the `settingsStream` to include the `SettingsUpdateSource`. [[1]](diffhunk://#diff-e718b581b4f75d59fb1547420b8fd0162b6bd121e666b0476fd12785d11ab7ebR14-R36) [[2]](diffhunk://#diff-e718b581b4f75d59fb1547420b8fd0162b6bd121e666b0476fd12785d11ab7ebL38-R52)
* Updated methods to use the `SettingsUpdateSource` enum, ensuring the source of updates is passed and handled consistently. [[1]](diffhunk://#diff-e718b581b4f75d59fb1547420b8fd0162b6bd121e666b0476fd12785d11ab7ebL60-R74) [[2]](diffhunk://#diff-e718b581b4f75d59fb1547420b8fd0162b6bd121e666b0476fd12785d11ab7ebL74-R93) [[3]](diffhunk://#diff-e718b581b4f75d59fb1547420b8fd0162b6bd121e666b0476fd12785d11ab7ebL95-R109)

### Updates to `POSTabEligibilityChecker`:

* Replaced direct dependency on `SelectedSiteSettings` with `SelectedSiteSettingsProtocol` for better abstraction and flexibility.
* Removed dependency on `CurrencySettings` and replaced it with dynamic currency code retrieval using `SiteSettings`.
* Updated the `waitForSiteSettingsRefresh` method to ignore updates from the `initialLoad` source.

### Changes to Tests:

* Replaced `SelectedSiteSettings` with `MockSelectedSiteSettings` in `POSTabEligibilityCheckerTests` to align with the protocol-based refactor. [[1]](diffhunk://#diff-fcc52f9859ab77f1e447409e22476742185e3ce1f5ed6af514da6c4b3b79e37eL11-R11) [[2]](diffhunk://#diff-fcc52f9859ab77f1e447409e22476742185e3ce1f5ed6af514da6c4b3b79e37eL23-R23)
* Removed references to `CurrencySettings` in test cases and adjusted setup methods to use dynamic currency settings. [[1]](diffhunk://#diff-fcc52f9859ab77f1e447409e22476742185e3ce1f5ed6af514da6c4b3b79e37eL90-L100) [[2]](diffhunk://#diff-fcc52f9859ab77f1e447409e22476742185e3ce1f5ed6af514da6c4b3b79e37eL116-L126) [[3]](diffhunk://#diff-fcc52f9859ab77f1e447409e22476742185e3ce1f5ed6af514da6c4b3b79e37eL145-L155)
* Simplified test cases by removing unnecessary `currencySettings` dependencies. [[1]](diffhunk://#diff-fcc52f9859ab77f1e447409e22476742185e3ce1f5ed6af514da6c4b3b79e37eL34) [[2]](diffhunk://#diff-fcc52f9859ab77f1e447409e22476742185e3ce1f5ed6af514da6c4b3b79e37eL54) [[3]](diffhunk://#diff-fcc52f9859ab77f1e447409e22476742185e3ce1f5ed6af514da6c4b3b79e37eL176) [[4]](diffhunk://#diff-fcc52f9859ab77f1e447409e22476742185e3ce1f5ed6af514da6c4b3b79e37eL264)

## Testing steps

Prerequisite: logged in with a WPCOM connected to at least 2 stores

- Log in to a store in the prerequisite –> the POS tab should be shown after a bit
- In core, update the store configurations to make the store ineligible for POS
- Relaunch the app and tap on the POS tab quickly -> POS should be shown in full screen
- Do a few things in POS
- Exit POS --> the POS tab should be hidden
- Switch to another store
- In core, update the store configurations to make the store eligible for POS again
- Switch to the first store --> the POS tab should appear shortly

## Example screencast

https://github.com/user-attachments/assets/163b998a-e25c-45ad-a030-f06ef757e7c4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.