### PR TITLE
Shipping Label: Fix incorrect height for predefined packages when unavailable

### DIFF
--- a/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -132,6 +132,7 @@ final class WooShippingRemoteTests: XCTestCase {
         let remote = WooShippingRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "label/rate", filename: "wooshipping-get-label-rates-success")
         let expectedDefaultRate = sampleLabelRate()
+        let expectedPackage = ShippingLabelPackageSelected.fake().copy(length: 12, width: 20, height: 0)
 
         // When
         let result: Result<[ShippingLabelCarriersAndRates], Error> = waitFor { promise in
@@ -139,7 +140,7 @@ final class WooShippingRemoteTests: XCTestCase {
                                   orderID: self.sampleOrderID,
                                   originAddress: WooShippingAddress.fake(),
                                   destinationAddress: WooShippingAddress.fake(),
-                                  packages: [ShippingLabelPackageSelected.fake()]) { (result) in
+                                  packages: [expectedPackage]) { (result) in
                 promise(result)
             }
         }
@@ -148,6 +149,9 @@ final class WooShippingRemoteTests: XCTestCase {
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
         let featuresParam = try XCTUnwrap(request.parameters["features_supported_by_client"] as? [String])
         XCTAssertEqual(featuresParam, ["upsdap"])
+        let packagesParam = try XCTUnwrap(request.parameters["packages"] as? [[String: Any]])
+        let package = try XCTUnwrap(packagesParam.first)
+        XCTAssertEqual(package["height"] as? Double, 0.25)
 
         let successResponse = try XCTUnwrap(result.get())
         XCTAssertEqual(successResponse.first?.defaultRates.first, expectedDefaultRate)

--- a/Networking/Sources/Extended/Model/ShippingLabel/Packages/CarriersAndRates/ShippingLabelPackageSelected.swift
+++ b/Networking/Sources/Extended/Model/ShippingLabel/Packages/CarriersAndRates/ShippingLabelPackageSelected.swift
@@ -46,7 +46,10 @@ extension ShippingLabelPackageSelected: Encodable {
         try container.encode(boxID.isEmpty ? "0" : boxID, forKey: .boxID)
         try container.encode(length, forKey: .length)
         try container.encode(width, forKey: .width)
-        try container.encode(height, forKey: .height)
+
+        // workaround because 0 would cause an error for the API request
+        try container.encode(height > 0 ? height : 0.25, forKey: .height)
+
         try container.encode(weight, forKey: .weight)
         try container.encode(isLetter, forKey: .isLetter)
         try container.encodeIfPresent(hazmatCategory, forKey: .hazmatCategory)

--- a/Networking/Sources/Extended/Model/ShippingLabel/Packages/PredefinedPackage/WooShippingPredefinedPackage.swift
+++ b/Networking/Sources/Extended/Model/ShippingLabel/Packages/PredefinedPackage/WooShippingPredefinedPackage.swift
@@ -38,7 +38,7 @@ public struct WooShippingPredefinedPackage: Equatable, GeneratedFakeable, Identi
     }
 
     public func getLength() -> Double {
-        let firstComponent = dimensions.components(separatedBy: " x ").first ?? ""
+        let firstComponent = dimensions.components(separatedBy: " x ")[safe: 0] ?? ""
         return Double(firstComponent) ?? 0
     }
 
@@ -48,7 +48,7 @@ public struct WooShippingPredefinedPackage: Equatable, GeneratedFakeable, Identi
     }
 
     public func getHeight() -> Double {
-        let lastComponent = dimensions.components(separatedBy: " x ").last ?? ""
+        let lastComponent = dimensions.components(separatedBy: " x ")[safe: 2] ?? ""
         return Double(lastComponent) ?? 0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
@@ -92,6 +92,9 @@ struct WooShippingPackageData: WooShippingPackageDataRepresentable {
 
 extension WooShippingPackageDataRepresentable {
     func dimensionsDescription(unit: String) -> String {
+        guard height.isNotEmpty, let numericHeight = Int(height), numericHeight > 0 else {
+            return "\(length) x \(width) \( unit)"
+        }
         return "\(length) x \(width) x \(height) \( unit)"
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
@@ -187,6 +187,43 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         XCTAssertEqual(updatedPackageData.id, "a")
     }
 
+    func test_packageData_does_not_show_height_if_height_is_unavailable() throws {
+        // Given
+        let dimensionUnit = "cm"
+        let weightUnit = "kg"
+        let siteID: Int64 = 1234
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID,
+                                                             stores: mockStores)
+        let length = "1"
+        let width = "2"
+        let height = "0"
+        let weight = "4"
+
+        let expectedDimensions = "\(length) x \(width) \(dimensionUnit)"
+        let expectedWeight = "\(weight) \(weightUnit)"
+
+        // When
+        viewModel.fieldValues[.length] = length
+        viewModel.fieldValues[.width] = width
+        viewModel.fieldValues[.height] = height
+        viewModel.fieldValues[.weight] = weight
+
+        // Then
+        let packageData = try XCTUnwrap(viewModel.packageData)
+        XCTAssertEqual(packageData.dimensionsDescription(unit: dimensionUnit), expectedDimensions)
+        XCTAssertEqual(packageData.weightDescription(unit: weightUnit), expectedWeight)
+        XCTAssertEqual(packageData.id, "custom_box")
+
+        // When: selecting a template
+        viewModel.showSaveTemplate = true
+        viewModel.packageTemplateName = "a"
+
+        // Then
+        let updatedPackageData = try XCTUnwrap(viewModel.packageData)
+        XCTAssertEqual(updatedPackageData.id, "a")
+    }
+
     @MainActor
     func test_save_package_as_template_action() async {
         // Given


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-682

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes the incorrect package dimensions when height is unavailable. 

Previously we were using the last dimension as the height. This is incorrect when the API response for packages doesn't include a height for a package.

The solution is to access dimensions by safe indices and return nil if unavailable. 

Another problem is when sending a 0 height, the label rates request would fail with an unexpected value error. This PR adds a workaround to set a default value of 0.25 in this case, the rates returned would still be the same for predefined packages [p1750923325060079-slack-C05VBLKHHV1].

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Log in to a store with Woo Shipping extension set up.
2. Navigate to the Orders tab and select a paid order with physical products.
3. Select Create shipping label and tap Add a package.
4. Switch to the Carrier tab > UPS and confirm that the UPS letter package doesn't display a height.
5. Select UPS letter package and confirm that the corresponding rates are loaded successfully.
6. Proceed to purchase the label and confirm that purchase completes successfully.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested and confirmed with simulator iPhone 16 iOS 18.4.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/43058031-50d8-4cd6-93d5-a7c5cac7b6af



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
