### PR TITLE
Disable `subscriptionsInOrderCreationUI` feature flag from dev builds

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -55,9 +55,10 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .splitViewInProductsTab:
             return true
         case .subscriptionsInOrderCreationUI:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            // Feature paused pdqJU4-4mn-p2#comment-2067
+            return false
         case .subscriptionsInOrderCreationCustomers:
-            // Feature paused pfoUAQ-zw-p2#comment-510.
+            // Feature paused pdqJU4-4mn-p2#comment-2067
             return false
         case .pointOfSale:
             return buildConfig == .localDeveloper || buildConfig == .alpha

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModel.swift
@@ -78,11 +78,12 @@ struct CollapsibleProductRowCardViewModel: Identifiable {
 
     private let currencyFormatter: CurrencyFormatter
     private let analytics: Analytics
+    private let featureFlagService: FeatureFlagService
 
     /// Determines if Subscription-type product details should be shown
     ///
     var shouldShowProductSubscriptionsDetails: Bool {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.subscriptionsInOrderCreationUI) &&
+        featureFlagService.isFeatureFlagEnabled(.subscriptionsInOrderCreationUI) &&
         productSubscriptionDetails != nil
     }
 
@@ -218,6 +219,7 @@ struct CollapsibleProductRowCardViewModel: Identifiable {
          stepperViewModel: ProductStepperViewModel,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          analytics: Analytics = ServiceLocator.analytics,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          configure: (() -> Void)? = nil) {
         self.id = id
         self.productOrVariationID = productOrVariationID
@@ -244,6 +246,7 @@ struct CollapsibleProductRowCardViewModel: Identifiable {
                                            price: price)
         self.currencyFormatter = currencyFormatter
         self.analytics = analytics
+        self.featureFlagService = featureFlagService
 
         observeProductQuantityFromStepperViewModel()
     }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -12,6 +12,7 @@ final class MockFeatureFlagService: FeatureFlagService {
     var productBundlesInOrderForm: Bool
     var isScanToUpdateInventoryEnabled: Bool
     var isSubscriptionsInOrderCreationCustomersEnabled: Bool
+    var isSubscriptionsInOrderCreationUIEnabled: Bool
     var isPointOfSaleEnabled: Bool
     var googleAdsCampaignCreationOnWebView: Bool
     var blazeEvergreenCampaigns: Bool
@@ -34,6 +35,7 @@ final class MockFeatureFlagService: FeatureFlagService {
          productBundlesInOrderForm: Bool = false,
          isScanToUpdateInventoryEnabled: Bool = false,
          isSubscriptionsInOrderCreationCustomersEnabled: Bool = false,
+         isSubscriptionsInOrderCreationUIEnabled: Bool = false,
          isPointOfSaleEnabled: Bool = false,
          googleAdsCampaignCreationOnWebView: Bool = false,
          blazeEvergreenCampaigns: Bool = false,
@@ -54,6 +56,7 @@ final class MockFeatureFlagService: FeatureFlagService {
         self.productBundlesInOrderForm = productBundlesInOrderForm
         self.isScanToUpdateInventoryEnabled = isScanToUpdateInventoryEnabled
         self.isSubscriptionsInOrderCreationCustomersEnabled = isSubscriptionsInOrderCreationCustomersEnabled
+        self.isSubscriptionsInOrderCreationUIEnabled = isSubscriptionsInOrderCreationUIEnabled
         self.isPointOfSaleEnabled = isPointOfSaleEnabled
         self.googleAdsCampaignCreationOnWebView = googleAdsCampaignCreationOnWebView
         self.blazeEvergreenCampaigns = blazeEvergreenCampaigns
@@ -94,6 +97,8 @@ final class MockFeatureFlagService: FeatureFlagService {
             return isScanToUpdateInventoryEnabled
         case .subscriptionsInOrderCreationCustomers:
             return isSubscriptionsInOrderCreationCustomersEnabled
+        case .subscriptionsInOrderCreationUI:
+            return isSubscriptionsInOrderCreationUIEnabled
         case .pointOfSale:
             return isPointOfSaleEnabled
         case .googleAdsCampaignCreationOnWebView:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModelTests.swift
@@ -303,16 +303,18 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
 
     func test_productRow_when_has_product_subscription_then_shouldShowProductSubscriptionsDetails() {
         // Given
+        let isSubscriptionsInOrderCreationUIEnabled = MockFeatureFlagService(isSubscriptionsInOrderCreationUIEnabled: true)
         let productSubscription: ProductSubscription = createFakeSubscription()
         let product = Product.fake().copy(productID: 12,
                                           name: "A subscription product",
                                           subscription: productSubscription)
 
         // When
-        let defaultViewModel = createViewModel()
+        let defaultViewModel = createViewModel(featureFlagService: isSubscriptionsInOrderCreationUIEnabled)
         let viewModelWithSubscriptionProduct = createViewModel(id: product.productID,
                                                                productSubscriptionDetails: product.subscription,
-                                                               name: product.name)
+                                                               name: product.name,
+                                                               featureFlagService: isSubscriptionsInOrderCreationUIEnabled)
 
         // Then
         XCTAssertFalse(defaultViewModel.shouldShowProductSubscriptionsDetails)
@@ -672,6 +674,7 @@ private extension CollapsibleProductRowCardViewModelTests {
                          stepperViewModel: ProductStepperViewModel = .init(quantity: 1, name: "", quantityUpdatedCallback: { _ in }),
                          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()),
                          analytics: Analytics = ServiceLocator.analytics,
+                         featureFlagService: MockFeatureFlagService = MockFeatureFlagService(),
                          configure: (() -> Void)? = nil) -> CollapsibleProductRowCardViewModel {
         CollapsibleProductRowCardViewModel(id: id,
                                            productOrVariationID: productOrVariationID,
@@ -692,6 +695,7 @@ private extension CollapsibleProductRowCardViewModelTests {
                                            stepperViewModel: stepperViewModel,
                                            currencyFormatter: currencyFormatter,
                                            analytics: analytics,
+                                           featureFlagService: featureFlagService,
                                            configure: configure)
     }
 


### PR DESCRIPTION
## Description

Showing product subscription details in the UI has been paused for 1+ year in favor of POS work, but we can still see the these in dev builds. I just happened to land on one of these when testing, let's turn the feature flag to `false` for the time being.

I've also updated the reference to the comment pausing the project.

## Testing information
- No visible changes for the merchant. 
- In dev builds, you shouldn't see additional subscription info in the product cards in the app if you add a subscription product in Order Creation

## Screenshots
| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 Plus - US store - 2025-06-25 at 17 46 47](https://github.com/user-attachments/assets/90d78234-366f-42a2-b07f-1ad8b5f729c2) | ![Simulator Screenshot - iPhone 16 Plus - US store - 2025-06-25 at 17 47 35](https://github.com/user-attachments/assets/d7ff9c0a-d898-4539-9374-9491fe68e883) | 
---

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
