### PR TITLE
Empty bounds image view fallback to thumbnail size 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 - [internal] Reduced fields fetched for variations in Point of Sale [https://github.com/woocommerce/woocommerce-ios/pull/15712]
 - [*] Order List: Prevent last updated time being truncated at larger font sizes [https://github.com/woocommerce/woocommerce-ios/pull/15717]
 - [***] Creating shipping labels is now supported for stores with the WooCommerce Shipping extension [https://github.com/woocommerce/woocommerce-ios/pull/15738]
+- [internal] Optimized image handling with a fallback thumbnail size for image views that have empty bounds, preventing high memory usage. [https://github.com/woocommerce/woocommerce-ios/pull/15815]
 
 22.5
 -----

--- a/WooCommerce/Classes/Tools/ImageService/DefaultImageService.swift
+++ b/WooCommerce/Classes/Tools/ImageService/DefaultImageService.swift
@@ -59,7 +59,7 @@ struct DefaultImageService: ImageService {
         let targetSize: CGSize
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(
             .productImageOptimizedHandling
-        ) {
+        ) && !imageView.bounds.isEmpty {
             let scale = UIScreen.main.scale
             targetSize = CGSize(
                 width: imageView.bounds.width * scale,

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -101,6 +101,9 @@ extension ProductsTabProductTableViewCell {
             productImageView.layer.borderWidth = 0
         } else {
             configureProductImageViewForBigImages()
+            /// Make sure `productImageView` is laid out and gained bounds
+            productImageView.layoutIfNeeded()
+
             productImageView.image = .productsTabProductCellPlaceholderImage
             if let productURLString = viewModel.imageUrl {
                 imageService.downloadAndCacheImageForImageView(productImageView,

--- a/WooCommerce/WooCommerceTests/Mocks/MockKingfisherImageDownloader.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockKingfisherImageDownloader.swift
@@ -5,6 +5,8 @@ final class MockKingfisherImageDownloader: Kingfisher.ImageDownloader {
     // Mocks in-memory cache.
     private let imagesByKey: [String: UIImage]
 
+    private(set) var capturedProcessor: ImageProcessor?
+
     init(imagesByKey: [String: UIImage]) {
         self.imagesByKey = imagesByKey
         super.init(name: "Mock!")
@@ -14,6 +16,14 @@ final class MockKingfisherImageDownloader: Kingfisher.ImageDownloader {
                                 options: KingfisherOptionsInfo? = nil,
                                 progressBlock: DownloadProgressBlock?,
                                 completionHandler: ((Result<ImageLoadingResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
+        if let options = options {
+            for option in options {
+                if case .processor(let processor) = option {
+                    capturedProcessor = processor
+                    break
+                }
+            }
+        }
         if let image = imagesByKey[url.absoluteString] {
             completionHandler?(.success(.init(image: image, url: url, originalData: Data())))
         } else {
@@ -25,6 +35,7 @@ final class MockKingfisherImageDownloader: Kingfisher.ImageDownloader {
     override func downloadImage(with url: URL,
                                 options: KingfisherParsedOptionsInfo,
                                 completionHandler: ((Result<ImageLoadingResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
+        capturedProcessor = options.processor
         if let image = imagesByKey[url.absoluteString] {
             completionHandler?(.success(.init(image: image, url: url, originalData: Data())))
         } else {

--- a/WooCommerce/WooCommerceTests/Tools/DefaultImageServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/DefaultImageServiceTests.swift
@@ -265,4 +265,33 @@ final class DefaultImageServiceTests: XCTestCase {
 
         waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
     }
+
+    func testDownloadAndCacheImageForImageView_withEmptyBounds_usesDefaultThumbnailSize() {
+        // Given
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isProductImageOptimizedHandlingEnabled = true
+        ServiceLocator.setFeatureFlagService(featureFlagService)
+
+        let mockImageView = UIImageView(frame: .zero)
+        let mockCache = MockImageCache(name: "Testing")
+        let mockDownloader = MockKingfisherImageDownloader(imagesByKey: [url.absoluteString: testImage])
+        imageService = DefaultImageService(imageCache: mockCache, imageDownloader: mockDownloader)
+
+        // When
+        imageService.downloadAndCacheImageForImageView(
+            mockImageView,
+            with: url.absoluteString,
+            placeholder: nil,
+            progressBlock: nil,
+            completion: nil
+        )
+
+        // Then
+        guard let downsamplingProcessor = mockDownloader.capturedProcessor as? DownsamplingImageProcessor else {
+            XCTFail("DownsamplingImageProcessor not found or not the correct type")
+            return
+        }
+
+        XCTAssertEqual(downsamplingProcessor.size, CGSize(width: 800, height: 800))
+    }
 }

--- a/WooCommerce/WooCommerceTests/Tools/DefaultImageServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/DefaultImageServiceTests.swift
@@ -268,9 +268,16 @@ final class DefaultImageServiceTests: XCTestCase {
 
     func testDownloadAndCacheImageForImageView_withEmptyBounds_usesDefaultThumbnailSize() {
         // Given
-        let featureFlagService = MockFeatureFlagService()
-        featureFlagService.isProductImageOptimizedHandlingEnabled = true
-        ServiceLocator.setFeatureFlagService(featureFlagService)
+        let originalFeatureFlagService = ServiceLocator.featureFlagService
+        defer {
+            ServiceLocator.setFeatureFlagService(originalFeatureFlagService)
+        }
+
+        ServiceLocator.setFeatureFlagService(
+            MockFeatureFlagService(
+                isProductImageOptimizedHandlingEnabled: true
+            )
+        )
 
         let mockImageView = UIImageView(frame: .zero)
         let mockCache = MockImageCache(name: "Testing")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
**Fix: Optimize image handling with fallback for empty image views**

This is a follow-up PR to address the [WatchdogTermination](https://a8c.sentry.io/issues/4294572038/events/?project=1458804&query=release.version%3A22.5&referrer=issue-stream&statsPeriod=14d&stream_index=3)

WOOMOB-686

## Description
This PR addresses a potential memory issue in `DefaultImageService`. When `downloadAndCacheImageForImageView` was called on a `UIImageView` with empty bounds (e.g., `frame = .zero`), the `targetSize` for the `DownsamplingImageProcessor` was also calculated as zero. This could cause Kingfisher to load the full-resolution image into memory, leading to high memory pressure.

The fix is two-fold. First, we now call `imageView.layoutIfNeeded()` before checking the bounds. This ensures that any pending Auto Layout updates are applied, giving us the best chance to get an accurate, non-zero frame for the image view.

Second, as a robust fallback for cases where the bounds are *still* empty (e.g., the view is not yet in the hierarchy), we now use `Constants.defaultThumbnailSize` for the `targetSize` if the `productImageOptimizedHandling` feature flag is enabled. This ensures a sensible default for downsampling, preventing excessive memory consumption.

A new unit test, `testDownloadAndCacheImageForImageView_withEmptyBounds_usesDefaultThumbnailSize`, has been added to verify the fallback scenario.

## Steps to reproduce

- Run from release branch
- Navigate to a product with variations
- Navigate to variations list
- Use Xcode layout inspector
- Locate the variation cell image
- Check out the underlying image. It's gonna have an original resolution.
- Run from the current branch and repeat steps
- Make sure the variation image underlying image has downsized image. (usually it's the bounds size * 3 due to screen pixel density).

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.