### PR TITLE
[Woo POS][Barcodes] Track when a barcode scanning menu item is tapped

### DIFF
--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -149,6 +149,7 @@ private extension TracksProvider {
             WooAnalyticsStat.pointOfSaleItemsNextPageLoaded,
             WooAnalyticsStat.pointOfSaleSearchRemoteResultsFetched,
             WooAnalyticsStat.pointOfSaleBarcodeScanningMenuItemTapped,
+            WooAnalyticsStat.pointOfSaleBarcodeScanningExplanationDialogShown,
 
             // Order
             WooAnalyticsStat.orderCreationSuccess,

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -148,6 +148,7 @@ private extension TracksProvider {
             WooAnalyticsStat.pointOfSaleKeyboardDismissedInSearch,
             WooAnalyticsStat.pointOfSaleItemsNextPageLoaded,
             WooAnalyticsStat.pointOfSaleSearchRemoteResultsFetched,
+            WooAnalyticsStat.pointOfSaleBarcodeScanningMenuItemTapped,
 
             // Order
             WooAnalyticsStat.orderCreationSuccess,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1302,6 +1302,7 @@ enum WooAnalyticsStat: String {
     case pointOfSaleKeyboardDismissedInSearch = "keyboard_dismissed_in_search"
     case pointOfSaleItemsNextPageLoaded = "items_next_page_loaded"
     case pointOfSaleSearchRemoteResultsFetched = "search_remote_results_fetched"
+    case pointOfSaleBarcodeScanningMenuItemTapped = "barcode_scanning_menu_item_tapped"
 
     // MARK: Custom Fields events
     case productDetailCustomFieldsTapped = "product_detail_custom_fields_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1303,6 +1303,7 @@ enum WooAnalyticsStat: String {
     case pointOfSaleItemsNextPageLoaded = "items_next_page_loaded"
     case pointOfSaleSearchRemoteResultsFetched = "search_remote_results_fetched"
     case pointOfSaleBarcodeScanningMenuItemTapped = "barcode_scanning_menu_item_tapped"
+    case pointOfSaleBarcodeScanningExplanationDialogShown = "barcode_scanning_explanation_dialog_shown"
 
     // MARK: Custom Fields events
     case productDetailCustomFieldsTapped = "product_detail_custom_fields_tapped"

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -60,6 +60,7 @@ struct POSFloatingControlView: View {
                 if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleBarcodeScanningi1) {
                     Button {
                         showBarcodeScanningInformation = true
+                        ServiceLocator.analytics.track(.pointOfSaleBarcodeScanningMenuItemTapped)
                     } label: {
                         Label(
                             title: { Text(Localization.barcodeScanning) },

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerInformationModal.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerInformationModal.swift
@@ -26,6 +26,9 @@ struct PointOfSaleBarcodeScannerInformationModal: View {
                 Text(AttributedString(Localization.barcodeInfoQuinaryMessage))
             }
         }
+        .onAppear(perform: {
+            ServiceLocator.analytics.track(.pointOfSaleBarcodeScanningExplanationDialogShown)
+        })
     }
 
     private var bulletPointWithLink: AttributedString {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds tracking for the barcode scanning menu item, so we can determine interest levels in barcode scanning.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Tap the `...` menu
3. Tap `Barcode scanning`
4. Observe that the `pos_barcode_scanning_menu_item_tapped` event is tracked.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![CleanShot 2025-06-26 at 11 01 18@2x](https://github.com/user-attachments/assets/0e24ab3b-eece-45a2-95b6-3efe1357a6ba)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.