### PR TITLE
Shipping Labels: Send extra rates for label purchase

### DIFF
--- a/Modules/Sources/Fakes/Networking.generated.swift
+++ b/Modules/Sources/Fakes/Networking.generated.swift
@@ -2406,7 +2406,7 @@ extension Networking.WooShippingPackagePurchase {
         .init(
             shipmentID: .fake(),
             package: .fake(),
-            rate: .fake(),
+            selectedRate: .fake(),
             productIDs: .fake()
         )
     }

--- a/Modules/Sources/Fakes/Networking.generated.swift
+++ b/Modules/Sources/Fakes/Networking.generated.swift
@@ -2469,6 +2469,20 @@ extension Networking.WooShippingSavedPredefinedPackage {
         )
     }
 }
+extension Networking.WooShippingSelectedRate {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.WooShippingSelectedRate {
+        .init(
+            rate: .fake(),
+            signatureRate: .fake(),
+            adultSignatureRate: .fake(),
+            carbonNeutralRate: .fake(),
+            saturdayDeliveryRate: .fake(),
+            additionalHandlingRate: .fake()
+        )
+    }
+}
 extension Networking.WooShippingShipmentItem {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -3638,18 +3638,18 @@ extension Networking.WooShippingPackagePurchase {
     public func copy(
         shipmentID: CopiableProp<String> = .copy,
         package: CopiableProp<ShippingLabelPackageSelected> = .copy,
-        rate: CopiableProp<ShippingLabelCarrierRate> = .copy,
+        selectedRate: CopiableProp<WooShippingSelectedRate> = .copy,
         productIDs: CopiableProp<[Int64]> = .copy
     ) -> Networking.WooShippingPackagePurchase {
         let shipmentID = shipmentID ?? self.shipmentID
         let package = package ?? self.package
-        let rate = rate ?? self.rate
+        let selectedRate = selectedRate ?? self.selectedRate
         let productIDs = productIDs ?? self.productIDs
 
         return Networking.WooShippingPackagePurchase(
             shipmentID: shipmentID,
             package: package,
-            rate: rate,
+            selectedRate: selectedRate,
             productIDs: productIDs
         )
     }

--- a/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -2458,6 +2458,54 @@ extension Networking.ShippingLabelAccountSettings {
     }
 }
 
+extension Networking.ShippingLabelCarrierRate {
+    public func copy(
+        title: CopiableProp<String> = .copy,
+        insurance: CopiableProp<String> = .copy,
+        retailRate: CopiableProp<Double> = .copy,
+        rate: CopiableProp<Double> = .copy,
+        rateID: CopiableProp<String> = .copy,
+        serviceID: CopiableProp<String> = .copy,
+        carrierID: CopiableProp<String> = .copy,
+        shipmentID: CopiableProp<String> = .copy,
+        hasTracking: CopiableProp<Bool> = .copy,
+        isSelected: CopiableProp<Bool> = .copy,
+        isPickupFree: CopiableProp<Bool> = .copy,
+        deliveryDays: NullableCopiableProp<Int64> = .copy,
+        deliveryDateGuaranteed: CopiableProp<Bool> = .copy
+    ) -> Networking.ShippingLabelCarrierRate {
+        let title = title ?? self.title
+        let insurance = insurance ?? self.insurance
+        let retailRate = retailRate ?? self.retailRate
+        let rate = rate ?? self.rate
+        let rateID = rateID ?? self.rateID
+        let serviceID = serviceID ?? self.serviceID
+        let carrierID = carrierID ?? self.carrierID
+        let shipmentID = shipmentID ?? self.shipmentID
+        let hasTracking = hasTracking ?? self.hasTracking
+        let isSelected = isSelected ?? self.isSelected
+        let isPickupFree = isPickupFree ?? self.isPickupFree
+        let deliveryDays = deliveryDays ?? self.deliveryDays
+        let deliveryDateGuaranteed = deliveryDateGuaranteed ?? self.deliveryDateGuaranteed
+
+        return Networking.ShippingLabelCarrierRate(
+            title: title,
+            insurance: insurance,
+            retailRate: retailRate,
+            rate: rate,
+            rateID: rateID,
+            serviceID: serviceID,
+            carrierID: carrierID,
+            shipmentID: shipmentID,
+            hasTracking: hasTracking,
+            isSelected: isSelected,
+            isPickupFree: isPickupFree,
+            deliveryDays: deliveryDays,
+            deliveryDateGuaranteed: deliveryDateGuaranteed
+        )
+    }
+}
+
 extension Networking.ShippingLabelCustomsForm {
     public func copy(
         packageID: CopiableProp<String> = .copy,

--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/CarriersAndRates/ShippingLabelCarrierRate.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/CarriersAndRates/ShippingLabelCarrierRate.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents the rate for a specific shipping carrier
 ///
-public struct ShippingLabelCarrierRate: Equatable, GeneratedFakeable {
+public struct ShippingLabelCarrierRate: Equatable, GeneratedFakeable, GeneratedCopiable {
 
     public let title: String
     public let insurance: String

--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/CarriersAndRates/WooShippingSelectedRate.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/CarriersAndRates/WooShippingSelectedRate.swift
@@ -1,5 +1,7 @@
+import Codegen
+
 /// Represents a selected shipping rate with the Woo Shipping extension.
-public struct WooShippingSelectedRate: Equatable {
+public struct WooShippingSelectedRate: Equatable, GeneratedFakeable {
 
     /// Basic rate for the selected carrier without additional service.
     public let rate: ShippingLabelCarrierRate

--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/CarriersAndRates/WooShippingSelectedRate.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/CarriersAndRates/WooShippingSelectedRate.swift
@@ -1,27 +1,40 @@
-import Yosemite
-
 /// Represents a selected shipping rate with the Woo Shipping extension.
-struct WooShippingSelectedRate {
+public struct WooShippingSelectedRate: Equatable {
+
     /// Basic rate for the selected carrier without additional service.
-    let rate: ShippingLabelCarrierRate
+    public let rate: ShippingLabelCarrierRate
 
     /// Rate for shipping with signature, if selected.
-    let signatureRate: ShippingLabelCarrierRate?
+    public let signatureRate: ShippingLabelCarrierRate?
 
     /// Rate for shipping with adult signature, if selected.
-    let adultSignatureRate: ShippingLabelCarrierRate?
+    public let adultSignatureRate: ShippingLabelCarrierRate?
 
     /// Rate for shipping with carbon neutral, if selected.
-    let carbonNeutralRate: ShippingLabelCarrierRate?
+    public let carbonNeutralRate: ShippingLabelCarrierRate?
 
     /// Rate for shipping with Saturday delivery, if selected.
-    let saturdayDeliveryRate: ShippingLabelCarrierRate?
+    public let saturdayDeliveryRate: ShippingLabelCarrierRate?
 
     /// Rate for shipping with additional handling, if selected.
-    let additionalHandlingRate: ShippingLabelCarrierRate?
+    public let additionalHandlingRate: ShippingLabelCarrierRate?
+
+    public init(rate: ShippingLabelCarrierRate,
+                signatureRate: ShippingLabelCarrierRate? = nil,
+                adultSignatureRate: ShippingLabelCarrierRate? = nil,
+                carbonNeutralRate: ShippingLabelCarrierRate? = nil,
+                saturdayDeliveryRate: ShippingLabelCarrierRate? = nil,
+                additionalHandlingRate: ShippingLabelCarrierRate? = nil) {
+        self.rate = rate
+        self.signatureRate = signatureRate
+        self.adultSignatureRate = adultSignatureRate
+        self.carbonNeutralRate = carbonNeutralRate
+        self.saturdayDeliveryRate = saturdayDeliveryRate
+        self.additionalHandlingRate = additionalHandlingRate
+    }
 }
 
-extension WooShippingSelectedRate {
+public extension WooShippingSelectedRate {
     var purchaseRate: ShippingLabelCarrierRate {
         if let signatureRate = signatureRate {
             return signatureRate
@@ -50,7 +63,21 @@ extension WooShippingSelectedRate {
     }
 }
 
-private extension WooShippingSelectedRate {
+extension WooShippingSelectedRate {
+    var surchargeForSignatureRequirement: Double {
+        guard let signatureRate else {
+            return 0
+        }
+        return signatureRate.rate - rate.rate
+    }
+
+    var surchargeForAdultSignatureRequirement: Double {
+        guard let adultSignatureRate else {
+            return 0
+        }
+        return adultSignatureRate.rate - rate.rate
+    }
+
     var surchargeForCarbonNeutralRate: Double {
         guard let carbonNeutralRate else {
             return 0

--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
@@ -119,7 +119,17 @@ extension WooShippingPackagePurchase: Encodable {
     /// Includes the shipment ID with the encoded rate.
     ///
     public func encodedShipmentRate() throws -> [String: Any] {
-        var rates = [ParameterKeys.rate: try selectedRate.purchaseRate.toDictionary()]
+        var purchaseRate = try selectedRate.purchaseRate.toDictionary()
+
+        // Extra `type` param if a signature rate was selected
+        if selectedRate.adultSignatureRate != nil {
+            purchaseRate[ParameterKeys.type] = Values.adultSignatureRequired
+        } else if selectedRate.signatureRate != nil {
+            purchaseRate[ParameterKeys.type] = Values.signatureRequired
+        }
+
+        var rates = [ParameterKeys.rate: purchaseRate]
+
         // If a signature rate was selected, send the standard rate as the parent rate.
         if selectedRate.purchaseRate != selectedRate.rate {
             rates[ParameterKeys.parent] = try selectedRate.rate.toDictionary()
@@ -187,10 +197,13 @@ extension WooShippingPackagePurchase: Encodable {
         static let items = "items"
         static let value = "value"
         static let surcharge = "surcharge"
+        static let type = "type"
     }
 
     private enum Values {
         static let yes = "yes"
         static let adult = "adult"
+        static let signatureRequired = "signatureRequired"
+        static let adultSignatureRequired = "adultSignatureRequired"
     }
 }

--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
@@ -12,20 +12,71 @@ public struct WooShippingPackagePurchase: Equatable, GeneratedFakeable, Generate
     public let package: ShippingLabelPackageSelected
 
     /// Selected rate for the shipping label
-    public let rate: ShippingLabelCarrierRate
+    public let selectedRate: WooShippingSelectedRate
 
     /// IDs for the products to be shipped
     public let productIDs: [Int64]
 
-    public init(shipmentID: String, package: ShippingLabelPackageSelected, rate: ShippingLabelCarrierRate, productIDs: [Int64]) {
+    public init(shipmentID: String,
+                package: ShippingLabelPackageSelected,
+                selectedRate: WooShippingSelectedRate,
+                productIDs: [Int64]) {
         self.shipmentID = shipmentID
         self.package = package
-        self.rate = rate
+        self.selectedRate = selectedRate
         self.productIDs = productIDs
     }
 }
 
-// MARK: Codable
+// MARK: Helpers
+
+extension WooShippingPackagePurchase {
+
+    var rate: ShippingLabelCarrierRate {
+        selectedRate.purchaseRate
+    }
+
+    var selectedRateOptions: [String: Any] {
+        var rates: [String: Any] = [:]
+        if selectedRate.signatureRate != nil {
+            rates[CodingKeys.signature.rawValue] = [
+                ParameterKeys.value: Values.yes,
+                ParameterKeys.surcharge: selectedRate.surchargeForSignatureRequirement
+            ]
+        } else if selectedRate.adultSignatureRate != nil {
+            rates[CodingKeys.signature.rawValue] = [
+                ParameterKeys.value: Values.adult,
+                ParameterKeys.surcharge: selectedRate.surchargeForAdultSignatureRequirement
+            ]
+        }
+
+        if selectedRate.carbonNeutralRate != nil {
+            rates[CodingKeys.carbonNeutral.rawValue] = [
+                ParameterKeys.value: true,
+                ParameterKeys.surcharge: selectedRate.surchargeForCarbonNeutralRate
+            ]
+        }
+
+        if selectedRate.saturdayDeliveryRate != nil {
+            rates[CodingKeys.saturdayDelivery.rawValue] = [
+                ParameterKeys.value: true,
+                ParameterKeys.surcharge: selectedRate.surchargeForSaturdayDeliveryRate
+            ]
+        }
+
+        if selectedRate.additionalHandlingRate != nil {
+            rates[CodingKeys.additionalHandling.rawValue] = [
+                ParameterKeys.value: true,
+                ParameterKeys.surcharge: selectedRate.surchargeForAdditionalHandlingRate
+            ]
+        }
+
+        return rates
+    }
+}
+
+// MARK: Enodable
+
 extension WooShippingPackagePurchase: Encodable {
 
     public func encode(to encoder: Encoder) throws {
@@ -44,6 +95,24 @@ extension WooShippingPackagePurchase: Encodable {
         try container.encode(rate.carrierID, forKey: .carrierID)
         try container.encode(rate.title, forKey: .serviceName)
         try container.encode(productIDs, forKey: .products)
+
+        if selectedRate.signatureRate != nil {
+            try container.encode(Values.yes, forKey: .signature)
+        } else if selectedRate.adultSignatureRate != nil {
+            try container.encode(Values.adult, forKey: .signature)
+        }
+
+        if selectedRate.carbonNeutralRate != nil {
+            try container.encode(true, forKey: .carbonNeutral)
+        }
+
+        if selectedRate.saturdayDeliveryRate != nil {
+            try container.encode(true, forKey: .saturdayDelivery)
+        }
+
+        if selectedRate.additionalHandlingRate != nil {
+            try container.encode(true, forKey: .additionalHandling)
+        }
     }
 
     /// Converts the shipment rate to a dictionary as the API expects it.
@@ -93,6 +162,10 @@ extension WooShippingPackagePurchase: Encodable {
         case carrierID = "carrier_id"
         case serviceName = "service_name"
         case products
+        case signature
+        case carbonNeutral = "carbon_neutral"
+        case saturdayDelivery = "saturday_delivery"
+        case additionalHandling = "additional_handling"
     }
 
     private enum ParameterKeys {
@@ -106,5 +179,12 @@ extension WooShippingPackagePurchase: Encodable {
         static let isReturnToSender = "isReturnToSender"
         static let itn = "itn"
         static let items = "items"
+        static let value = "value"
+        static let surcharge = "surcharge"
+    }
+
+    private enum Values {
+        static let yes = "yes"
+        static let adult = "adult"
     }
 }

--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
@@ -119,7 +119,12 @@ extension WooShippingPackagePurchase: Encodable {
     /// Includes the shipment ID with the encoded rate.
     ///
     public func encodedShipmentRate() throws -> [String: Any] {
-        [shipmentID: [ParameterKeys.rate: try rate.toDictionary()]]
+        var rates = [ParameterKeys.rate: try selectedRate.purchaseRate.toDictionary()]
+        // If a signature rate was selected, send the standard rate as the parent rate.
+        if selectedRate.purchaseRate != selectedRate.rate {
+            rates[ParameterKeys.parent] = try selectedRate.rate.toDictionary()
+        }
+        return rates
     }
 
     /// Converts the hazmat settings to a dictionary as the API expects it.
@@ -170,6 +175,7 @@ extension WooShippingPackagePurchase: Encodable {
 
     private enum ParameterKeys {
         static let rate = "rate"
+        static let parent = "parent"
         static let isHazmat = "isHazmat"
         static let category = "category"
         static let contentsType = "contentsType"

--- a/Modules/Sources/Networking/Remote/WooShippingRemote.swift
+++ b/Modules/Sources/Networking/Remote/WooShippingRemote.swift
@@ -270,8 +270,7 @@ public final class WooShippingRemote: Remote, WooShippingRemoteProtocol {
                 ParameterKey.destinationAddress: try destinationAddress.toDictionary(),
                 ParameterKey.packages: [ try package.toDictionary() ],
                 ParameterKey.selectedRate: try package.encodedShipmentRate(),
-                // TODO: `selected_rate_options` will be updated while adding UPS support PaJDVv-2Gf-p2
-                ParameterKey.selectedRateOptions: [:],
+                ParameterKey.selectedRateOptions: package.selectedRateOptions,
                 ParameterKey.featuresSupported: [Values.upsdap],
                 ParameterKey.hazmat: package.encodedHazmat(),
                 ParameterKey.customs: try package.encodedCustomsForm(),

--- a/Modules/Sources/Yosemite/Model/Model.swift
+++ b/Modules/Sources/Yosemite/Model/Model.swift
@@ -201,6 +201,7 @@ public typealias WooShippingConfig = Networking.WooShippingConfig
 public typealias WooShippingUpdateShipment = Networking.WooShippingUpdateShipment
 public typealias WooShippingShipmentItem = Networking.WooShippingShipmentItem
 public typealias WooShippingShipments = Networking.WooShippingShipments
+public typealias WooShippingSelectedRate = Networking.WooShippingSelectedRate
 public typealias WPComPlan = Networking.WPComPlan
 public typealias WPComSitePlan = Networking.WPComSitePlan
 public typealias LoadSiteCurrentPlanError = Networking.LoadSiteCurrentPlanError

--- a/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -373,6 +373,7 @@ final class WooShippingRemoteTests: XCTestCase {
 
         let childValue = try XCTUnwrap(selectedRateParam["rate"] as? [String: Any])
         XCTAssertEqual(childValue["rate"] as? Double, package.selectedRate.adultSignatureRate?.rate)
+        XCTAssertEqual(childValue["type"] as? String, "adultSignatureRequired")
 
         let labels = try XCTUnwrap(result.get())
         XCTAssertEqual(labels.count, 1)

--- a/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -342,7 +342,7 @@ final class WooShippingRemoteTests: XCTestCase {
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
-        
+
         let selectedRateOptions = try XCTUnwrap(request.parameters["selected_rate_options"] as? [String: Any])
         let signatureObject = try XCTUnwrap(selectedRateOptions["signature"] as? [String: Any])
         XCTAssertEqual(signatureObject["value"] as? String, "adult")

--- a/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -316,6 +316,68 @@ final class WooShippingRemoteTests: XCTestCase {
         XCTAssertNotNil(result.failure)
     }
 
+    func test_purchaseShippingLabel_sends_correct_parameters() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "label/purchase/\(sampleOrderID)", filename: "wooshipping-purchase-success")
+
+        let package = WooShippingPackagePurchase.fake().copy(selectedRate: WooShippingSelectedRate(
+            rate: ShippingLabelCarrierRate.fake().copy(rate: 12.32),
+            adultSignatureRate: ShippingLabelCarrierRate.fake().copy(rate: 22.33),
+            carbonNeutralRate: ShippingLabelCarrierRate.fake().copy(rate: 18.02),
+            saturdayDeliveryRate: ShippingLabelCarrierRate.fake().copy(rate: 25.42),
+            additionalHandlingRate: ShippingLabelCarrierRate.fake().copy(rate: 20.01)
+        ))
+
+        // When
+        let result: Result<[ShippingLabelPurchase], Error> = waitFor { promise in
+            remote.purchaseShippingLabel(siteID: self.sampleSiteID,
+                                         orderID: self.sampleOrderID,
+                                         originAddress: WooShippingAddress.fake(),
+                                         destinationAddress: WooShippingAddress.fake(),
+                                         package: package) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        
+        let selectedRateOptions = try XCTUnwrap(request.parameters["selected_rate_options"] as? [String: Any])
+        let signatureObject = try XCTUnwrap(selectedRateOptions["signature"] as? [String: Any])
+        XCTAssertEqual(signatureObject["value"] as? String, "adult")
+        XCTAssertEqual(signatureObject["surcharge"] as? Double, package.selectedRate.surchargeForAdultSignatureRequirement)
+
+        let carbonNeutralObject = try XCTUnwrap(selectedRateOptions["carbon_neutral"] as? [String: Any])
+        XCTAssertEqual(carbonNeutralObject["value"] as? Bool, true)
+        XCTAssertEqual(carbonNeutralObject["surcharge"] as? Double, package.selectedRate.surchargeForCarbonNeutralRate)
+
+        let saturdayDeliveryObject = try XCTUnwrap(selectedRateOptions["saturday_delivery"] as? [String: Any])
+        XCTAssertEqual(saturdayDeliveryObject["value"] as? Bool, true)
+        XCTAssertEqual(saturdayDeliveryObject["surcharge"] as? Double, package.selectedRate.surchargeForSaturdayDeliveryRate)
+
+        let additionalHandlingObject = try XCTUnwrap(selectedRateOptions["additional_handling"] as? [String: Any])
+        XCTAssertEqual(additionalHandlingObject["value"] as? Bool, true)
+        XCTAssertEqual(additionalHandlingObject["surcharge"] as? Double, package.selectedRate.surchargeForAdditionalHandlingRate)
+
+        let packagesParam = try XCTUnwrap(request.parameters["packages"] as? [[String: Any]])
+        let firstPackage = try XCTUnwrap(packagesParam.first)
+        XCTAssertEqual(firstPackage["signature"] as? String, "adult")
+        XCTAssertEqual(firstPackage["carbon_neutral"] as? Bool, true)
+        XCTAssertEqual(firstPackage["saturday_delivery"] as? Bool, true)
+        XCTAssertEqual(firstPackage["additional_handling"] as? Bool, true)
+
+        let selectedRateParam = try XCTUnwrap(request.parameters["selected_rate"] as? [String: Any])
+        let parentValue = try XCTUnwrap(selectedRateParam["parent"] as? [String: Any])
+        XCTAssertEqual(parentValue["rate"] as? Double, package.selectedRate.rate.rate)
+
+        let childValue = try XCTUnwrap(selectedRateParam["rate"] as? [String: Any])
+        XCTAssertEqual(childValue["rate"] as? Double, package.selectedRate.adultSignatureRate?.rate)
+
+        let labels = try XCTUnwrap(result.get())
+        XCTAssertEqual(labels.count, 1)
+    }
+
     func test_purchaseShippingLabel_parses_success_response() throws {
         // Given
         let remote = WooShippingRemote(network: network)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -211,7 +211,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
         analytics.track(event: .WooShipping.purchaseStep(state: .started))
         let packagePurchase = WooShippingPackagePurchase(shipmentID: shipment.index.description,
                                                          package: package,
-                                                         rate: selectedRate.purchaseRate,
+                                                         selectedRate: selectedRate,
                                                          productIDs: shipment.items.map(\.productOrVariationID))
         let purchasedLabel = try await withCheckedThrowingContinuation { continuation in
             let action = WooShippingAction.purchaseShippingLabel(siteID: order.siteID,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2284,7 +2284,6 @@
 		CE24BCCF212DE8A6001CD12E /* HeadlineLabelTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE24BCCD212DE8A6001CD12E /* HeadlineLabelTableViewCell.swift */; };
 		CE24BCD0212DE8A6001CD12E /* HeadlineLabelTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE24BCCE212DE8A6001CD12E /* HeadlineLabelTableViewCell.xib */; };
 		CE24BCD8212F25D4001CD12E /* StorageOrder+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE24BCD7212F25D4001CD12E /* StorageOrder+Woo.swift */; };
-		CE26360E2CCFC78100BE59E2 /* WooShippingSelectedRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE26360D2CCFC78100BE59E2 /* WooShippingSelectedRate.swift */; };
 		CE263DE8206ACE3E0015A693 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE263DE7206ACE3E0015A693 /* MainTabBarController.swift */; };
 		CE27257C21924A8C002B22EB /* HelpAndSupportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27257B21924A8C002B22EB /* HelpAndSupportViewController.swift */; };
 		CE27257F21925AE8002B22EB /* ValueOneTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27257D21925AE8002B22EB /* ValueOneTableViewCell.swift */; };
@@ -5486,7 +5485,6 @@
 		CE24BCCD212DE8A6001CD12E /* HeadlineLabelTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadlineLabelTableViewCell.swift; sourceTree = "<group>"; };
 		CE24BCCE212DE8A6001CD12E /* HeadlineLabelTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HeadlineLabelTableViewCell.xib; sourceTree = "<group>"; };
 		CE24BCD7212F25D4001CD12E /* StorageOrder+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StorageOrder+Woo.swift"; sourceTree = "<group>"; };
-		CE26360D2CCFC78100BE59E2 /* WooShippingSelectedRate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingSelectedRate.swift; sourceTree = "<group>"; };
 		CE263DE7206ACE3E0015A693 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
 		CE27257B21924A8C002B22EB /* HelpAndSupportViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpAndSupportViewController.swift; sourceTree = "<group>"; };
 		CE27257D21925AE8002B22EB /* ValueOneTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueOneTableViewCell.swift; sourceTree = "<group>"; };
@@ -12606,7 +12604,6 @@
 			isa = PBXGroup;
 			children = (
 				CE315DC52CC93CCE00A06748 /* WooShippingCarrier.swift */,
-				CE26360D2CCFC78100BE59E2 /* WooShippingSelectedRate.swift */,
 				CECEFA6C2CA2CEB50071C7DB /* WooShippingPackageAndRatePlaceholder.swift */,
 				DAB4099E2CA5A329008EE1F2 /* WooShippingAddPackageView.swift */,
 				CE2DF92B2CC162EB001AA394 /* WooShippingServiceView.swift */,
@@ -15289,7 +15286,6 @@
 				0205021E27C8B6C600FB1C6B /* InboxEligibilityUseCase.swift in Sources */,
 				26E7EE6E29300E8100793045 /* AnalyticsTopPerformersCard.swift in Sources */,
 				03E471DA29424E82001A58AD /* CardPresentModalTapToPaySuccess.swift in Sources */,
-				CE26360E2CCFC78100BE59E2 /* WooShippingSelectedRate.swift in Sources */,
 				26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */,
 				DE7B479027A153C20018742E /* CouponSearchUICommand.swift in Sources */,
 				026826B52BF59E330036F959 /* CardReaderConnectionStatusView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-683

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR wraps up the support for extra rates in UPS. Now we need to send the info about the new rates when requesting for a label purchase. Changes include: 
- Moving the `WooShippingSelectedRate` file to the `Networking` layer.
- Updating `WooShippingPackagePurchase`:
  - Replace the single rate with the selected rate that include all the extra options.
  - Construct the `selected_rate_options` object to include the extra options.
  - Update the `package` object to include the extra options.
  - Update the `selected_rate` object to follow the format used by the Woo Shipping plugin.
- Updating the `WooShippingRemote` to send the non-empty `selected_rate_options`.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with Woo Shipping set up.
2. Navigate to the Orders tab and select a paid order with physical items.
3. Select Create shipping label > Add a package > select a UPS package.
4. After label rates are loaded, select a rate with any options.
5. Proceed to purchase the label. Confirm that the purchase succeeds.
6. Check the label on the web. Confirm that the signature rate details are included on the right side bar. The extra rates are not displayed though - this may be a bug on the plugin.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested and confirm with simulator iPhone 16 iOS 18.4

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/2452c549-f5b9-4db0-bfe1-a9819adfcda9



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
