### PR TITLE
Shipping Labels: Better formatted surcharge for additional shipping services

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -174,7 +174,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
     ///
     @MainActor
     func refreshPackagesAndShippingRates() async throws {
-        guard let selectedPackage, let updatedPackage = try await refreshSelectedPackage(from: selectedPackage) else {
+        guard let selectedRate, let selectedPackage, let updatedPackage = try await refreshSelectedPackage(from: selectedPackage) else {
             throw WooShippingLabelPurchaseError.failedToRefreshSelectedPackage
         }
         self.selectedPackage = updatedPackage
@@ -185,7 +185,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
                                                 hazmatCategory: hazmatCategory,
                                                 customsForm: customsForm)
 
-        guard let shippingService, let selectedRate else {
+        guard let shippingService else {
             throw WooShippingLabelPurchaseError.failedToRefreshSelectedRate
         }
         try await withCheckedThrowingContinuation { continuation in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardView.swift
@@ -31,19 +31,19 @@ struct WooShippingServiceCardView: View {
                         Group {
                             VStack(alignment: .leading, spacing: 0) {
                                 if let tracking = viewModel.trackingLabel {
-                                    HStack(alignment: .firstTextBaseline) {
+                                    HStack {
                                         checkmark
                                         Text(tracking)
                                     }
                                 }
                                 if let insurance = viewModel.insuranceLabel {
-                                    HStack(alignment: .firstTextBaseline) {
+                                    HStack {
                                         checkmark
                                         Text(insurance)
                                     }
                                 }
                                 if let freePickup = viewModel.freePickupLabel {
-                                    HStack(alignment: .firstTextBaseline) {
+                                    HStack {
                                         checkmark
                                         Text(freePickup)
                                     }
@@ -52,7 +52,7 @@ struct WooShippingServiceCardView: View {
                             .fixedSize(horizontal: false, vertical: true)
 
                             if let signatureRequired = viewModel.signatureRequiredLabel {
-                                HStack(alignment: .firstTextBaseline) {
+                                HStack {
                                     selectionCircle(selected: viewModel.signatureRequirement == .signatureRequired)
                                     Text(signatureRequired)
                                 }
@@ -62,7 +62,7 @@ struct WooShippingServiceCardView: View {
                                 }
                             }
                             if let adultSignatureRequired = viewModel.adultSignatureRequiredLabel {
-                                HStack(alignment: .firstTextBaseline) {
+                                HStack {
                                     selectionCircle(selected: viewModel.signatureRequirement == .adultSignatureRequired)
                                     Text(adultSignatureRequired)
                                 }
@@ -72,7 +72,7 @@ struct WooShippingServiceCardView: View {
                                 }
                             }
                             if let carbonNeutralLabel = viewModel.carbonNeutralLabel {
-                                HStack(alignment: .firstTextBaseline) {
+                                HStack {
                                     selectionCircle(selected: viewModel.carbonNeutralSelected)
                                     Text(carbonNeutralLabel)
                                 }
@@ -81,24 +81,24 @@ struct WooShippingServiceCardView: View {
                                     viewModel.handleTap(on: .carbonNeutral)
                                 }
                             }
-                            if let saturdayDeliveryLabel = viewModel.saturdayDeliveryLabel {
-                                HStack(alignment: .firstTextBaseline) {
-                                    selectionCircle(selected: viewModel.saturdayDeliverySelected)
-                                    Text(saturdayDeliveryLabel)
-                                }
-                                .contentShape(Rectangle())
-                                .onTapGesture {
-                                    viewModel.handleTap(on: .saturdayDelivery)
-                                }
-                            }
                             if let additionalHandlingLabel = viewModel.additionalHandlingLabel {
-                                HStack(alignment: .firstTextBaseline) {
+                                HStack {
                                     selectionCircle(selected: viewModel.additionalHandlingSelected)
                                     Text(additionalHandlingLabel)
                                 }
                                 .contentShape(Rectangle())
                                 .onTapGesture {
                                     viewModel.handleTap(on: .additionalHandling)
+                                }
+                            }
+                            if let saturdayDeliveryLabel = viewModel.saturdayDeliveryLabel {
+                                HStack {
+                                    selectionCircle(selected: viewModel.saturdayDeliverySelected)
+                                    Text(saturdayDeliveryLabel)
+                                }
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    viewModel.handleTap(on: .saturdayDelivery)
                                 }
                             }
                         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceCardViewModel.swift
@@ -168,11 +168,19 @@ final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
         let extras = [trackingLabel, insuranceLabel?.localizedLowercase, freePickupLabel].compactMap { $0 }
         let extraInfoLabel = extras.isNotEmpty ? extras.joined(separator: ", ") : nil
 
+        func formatSurcharge(serviceRate: Double) -> String {
+            let amount = Decimal(serviceRate - rate.rate)
+            let isNegative = amount < 0
+            let formattedAmount = currencyFormatter.formatAmount(amount, isNegative: isNegative) ?? ""
+            let prefix = isNegative ? "" : "+"
+            return prefix + formattedAmount
+        }
+
         let signatureRequiredLabel: String? = {
             guard let signatureRate else {
                 return nil
             }
-            let amount = currencyFormatter.formatAmount(Decimal(signatureRate.rate - rate.rate)) ?? ""
+            let amount = formatSurcharge(serviceRate: signatureRate.rate)
             return String(format: Localization.signatureRequired, amount)
         }()
 
@@ -180,7 +188,7 @@ final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
             guard let adultSignatureRate else {
                 return nil
             }
-            let amount = currencyFormatter.formatAmount(Decimal(adultSignatureRate.rate - rate.rate)) ?? ""
+            let amount = formatSurcharge(serviceRate: adultSignatureRate.rate)
             return String(format: Localization.adultSignatureRequired, amount)
         }()
 
@@ -188,7 +196,7 @@ final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
             guard let carbonNeutralRate else {
                 return nil
             }
-            let amount = currencyFormatter.formatAmount(Decimal(carbonNeutralRate.rate - rate.rate)) ?? ""
+            let amount = formatSurcharge(serviceRate: carbonNeutralRate.rate)
             return String(format: Localization.carbonNeural, amount)
         }()
 
@@ -196,7 +204,7 @@ final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
             guard let saturdayDeliveryRate else {
                 return nil
             }
-            let amount = currencyFormatter.formatAmount(Decimal(saturdayDeliveryRate.rate - rate.rate)) ?? ""
+            let amount = formatSurcharge(serviceRate: saturdayDeliveryRate.rate)
             return String(format: Localization.saturdayDelivery, amount)
         }()
 
@@ -204,7 +212,7 @@ final class WooShippingServiceCardViewModel: Identifiable, ObservableObject {
             guard let additionalHandlingRate else {
                 return nil
             }
-            let amount = currencyFormatter.formatAmount(Decimal(additionalHandlingRate.rate - rate.rate)) ?? ""
+            let amount = formatSurcharge(serviceRate: additionalHandlingRate.rate)
             return String(format: Localization.additionalHandling, amount)
         }()
 
@@ -303,29 +311,29 @@ private extension WooShippingServiceCardViewModel {
         static let freePickup = NSLocalizedString("wooShipping.createLabels.shippingService.freePickup",
                                                   value: "Free pickup",
                                                   comment: "Label when shipping rate includes free pickup in Woo Shipping label creation flow.")
-        static let signatureRequired = NSLocalizedString("wooShipping.createLabels.shippingService.signatureRequired",
-                                                         value: "Signature Required (+%1$@)",
+        static let signatureRequired = NSLocalizedString("wooShipping.createLabels.shippingService.signatureRequiredLabel",
+                                                         value: "Signature Required (%1$@)",
                                                          comment: "Label when shipping rate has option to require a signature in " +
                                                          "Woo Shipping label creation flow. Reads like: 'Signature required (+$3.70)'")
-        static let adultSignatureRequired = NSLocalizedString("wooShipping.createLabels.shippingService.adultSignatureRequired",
-                                                              value: "Adult Signature Required (+%1$@)",
+        static let adultSignatureRequired = NSLocalizedString("wooShipping.createLabels.shippingService.adultSignatureRequiredLabel",
+                                                              value: "Adult Signature Required (%1$@)",
                                                               comment: "Label when shipping rate has option to require an adult signature in " +
                                                               "Woo Shipping label creation flow. Reads like: 'Adult signature required (+$9.35)'")
         static let carbonNeural = NSLocalizedString(
             "wooShipping.createLabels.shippingService.carbonNeural",
-            value: "Carbon Neutral (+%1$@)",
+            value: "Carbon Neutral (%1$@)",
             comment: "Label when shipping rate has option for carbon neutral delivery in " +
             "Woo Shipping label creation flow. Reads like: 'Carbon Neutral (+$9.35)'"
         )
         static let saturdayDelivery = NSLocalizedString(
             "wooShipping.createLabels.shippingService.saturdayDelivery",
-            value: "Saturday Delivery (+%1$@)",
+            value: "Saturday Delivery (%1$@)",
             comment: "Label when shipping rate has option for Saturday delivery in " +
             "Woo Shipping label creation flow. Reads like: 'Saturday Delivery (+$9.35)'"
         )
         static let additionalHandling = NSLocalizedString(
             "wooShipping.createLabels.shippingService.additionalHandling",
-            value: "Additional Handling (+%1$@)",
+            value: "Additional Handling (%1$@)",
             comment: "Label when shipping rate has option for additional handling in " +
             "Woo Shipping label creation flow. Reads like: 'Additional Handling (+$9.35)'"
         )

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceCardViewModelTests.swift
@@ -82,6 +82,39 @@ final class WooShippingServiceCardViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.additionalHandlingLabel, "Additional Handling (+$3.89)")
     }
 
+    func test_it_inits_with_expected_values_with_extra_services_negative_surcharge() {
+        // Given
+        let viewModel = WooShippingServiceCardViewModel(selected: true,
+                                                        signatureRequired: true,
+                                                        carbonNeutralSelected: true,
+                                                        saturdayDeliverySelected: false,
+                                                        additionalHandlingSelected: true,
+                                                        rate: MockShippingLabelCarrierRate.makeRate(rate: 25.95, insurance: "100"),
+                                                        signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 25.69),
+                                                        adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 33.05),
+                                                        carbonNeutralRate: MockShippingLabelCarrierRate.makeRate(rate: 26.15),
+                                                        saturdayDeliveryRate: MockShippingLabelCarrierRate.makeRate(rate: 25.69),
+                                                        additionalHandlingRate: MockShippingLabelCarrierRate.makeRate(rate: 38.9),
+                                                        currencySettings: CurrencySettings())
+
+        // Then
+        XCTAssertEqual(viewModel.selected, true)
+        XCTAssertEqual(viewModel.signatureRequirement, .signatureRequired)
+        XCTAssertEqual(viewModel.title, "USPS - Parcel Select Mail")
+        XCTAssertEqual(viewModel.daysToDeliveryLabel, "2 business days")
+        XCTAssertEqual(viewModel.rateLabel, "$38.58")
+        XCTAssertEqual(viewModel.carrierLogo, UIImage(named: "shipping-label-usps-logo"))
+        XCTAssertEqual(viewModel.trackingLabel, "Tracking")
+        XCTAssertEqual(viewModel.insuranceLabel, "Insurance (up to $100.00)")
+        XCTAssertEqual(viewModel.freePickupLabel, "Free pickup")
+        XCTAssertEqual(viewModel.extraInfoLabel, "Includes tracking, insurance (up to $100.00), free pickup")
+        XCTAssertEqual(viewModel.signatureRequiredLabel, "Signature Required (-$0.26)")
+        XCTAssertEqual(viewModel.adultSignatureRequiredLabel, "Adult Signature Required (+$7.10)")
+        XCTAssertEqual(viewModel.carbonNeutralLabel, "Carbon Neutral (+$0.20)")
+        XCTAssertEqual(viewModel.saturdayDeliveryLabel, "Saturday Delivery (-$0.26)")
+        XCTAssertEqual(viewModel.additionalHandlingLabel, "Additional Handling (+$12.95)")
+    }
+
     func test_insuranceLabel_shows_expected_value_for_non_number_insurance() {
         // Given
         let viewModel = WooShippingServiceCardViewModel(rate: MockShippingLabelCarrierRate.makeRate(insurance: "limited"))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceCardViewModelTests.swift
@@ -102,7 +102,7 @@ final class WooShippingServiceCardViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.signatureRequirement, .signatureRequired)
         XCTAssertEqual(viewModel.title, "USPS - Parcel Select Mail")
         XCTAssertEqual(viewModel.daysToDeliveryLabel, "2 business days")
-        XCTAssertEqual(viewModel.rateLabel, "$38.58")
+        XCTAssertEqual(viewModel.rateLabel, "$38.84")
         XCTAssertEqual(viewModel.carrierLogo, UIImage(named: "shipping-label-usps-logo"))
         XCTAssertEqual(viewModel.trackingLabel, "Tracking")
         XCTAssertEqual(viewModel.insuranceLabel, "Insurance (up to $100.00)")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
@@ -584,7 +584,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_refreshPackagesAndShippingRates_updates_selected_package() async {
+    func test_refreshPackagesAndShippingRates_updates_selected_package_and_rate() async throws {
         // Given
         let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
         let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
@@ -598,12 +598,19 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
                                                             stores: stores)
         let package = samplePackageData()
         viewModel.selectPackage(package)
-        viewModel.shippingService?.onSelectRate?(sampleSelectedRate())
+        let rate = ShippingLabelCarrierRate.fake().copy(
+            title: "Rate",
+            rate: 20.11,
+            serviceID: "test_rate"
+        )
+        viewModel.shippingService?.onSelectRate?(WooShippingSelectedRate(rate: rate))
 
         // Confidence check
         XCTAssertEqual(viewModel.selectedPackage?.id, package.id)
+        XCTAssertEqual(viewModel.selectedRate?.rate.rate, rate.rate)
 
         // When: package is refreshed
+        let expectedRate = rate.copy(rate: 22.11)
         let updatedPackage = WooShippingCustomPackage(id: "small_flat_box",
                                                       name: "custom",
                                                       rawType: "box",
@@ -617,15 +624,25 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
                                                                 savedPredefinedPackages: [],
                                                                 allPredefinedOptions: [])))
             case let .loadLabelRates(_, _, _, _, packages, completion):
-                completion(packages, .success([]))
+                let result = ShippingLabelCarriersAndRates(
+                    packageID: "0",
+                    defaultRates: [expectedRate],
+                    signatureRequired: [expectedRate.copy(rate: 23.33)],
+                    adultSignatureRequired: [expectedRate.copy(rate: 25.78)],
+                    carbonNeutral: [],
+                    saturdayDelivery: [],
+                    additionalHandling: []
+                )
+                completion(packages, .success([result]))
             default:
                 break
             }
         }
-        try? await viewModel.refreshPackagesAndShippingRates() // ignoring failure in refreshing rate for simplicity
+        try await viewModel.refreshPackagesAndShippingRates()
 
         // Then
         XCTAssertEqual(viewModel.selectedPackage?.name, updatedPackage.name)
+        XCTAssertEqual(viewModel.selectedRate?.rate.rate, expectedRate.rate)
     }
 
     func test_changing_origin_address_resets_selected_rate() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of WOOMOB-683

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I found an edge case where the surcharges for the add-ons are negative:

<img src="https://github.com/user-attachments/assets/b77e9938-853d-4686-9739-1d358eca217e" width=320 />


This PR updates the formatting of surcharges for addtional shipping services to account for negative values. This is most likely an edge case but the fix gives us more confidence in the code.

Also, I removed the added alignment for the HStacks for a better layout. The addtional handling service is also moved above Saturday delivery to match with the plugin.

Additionally, a small fix was added to mitigate the issue purchasing a label after accepting UPS TOS. This issue came from resetting `selectedRate` causing the refreshing of the rate after accepting TOS to fail. The solution is to keep hold of the rate before refreshing packages and rates.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with Woo Shipping plugin set up.
2. Navigate to the Orders tab and select a paid order with physical products.
3. Select Create shipping labels > Add a package > select a UPS package.
4. Select any shipping rates and confirm that the layout looks good and Addtional Handling is above Saturday Delivery.
5. The negative surcharges are likely a bug on the backend side and not easy to reproduce. Update the response of `POST /wcshipping/v1/label/rate` to make the rates of additional services lower than the standard rates.
6. Reload the rates and confirm that the negative values are displayed correctly.
7. Change the origin address to a new one that hasn't accepted UPS TOS.
8. Proceed to purchase a label. Confirm that after accepting UPS TOS, the purchase succeeds.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Tested and confirmed with simulator iPhone 16 iOS 18.4.
- Added unit test for the negative value case.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/user-attachments/assets/903c890b-f8d3-44d2-af54-1b044cb07749" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
