### PR TITLE
[Woo POS] Show chevrons for variable parent products

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ParentProductCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ParentProductCardView.swift
@@ -40,6 +40,12 @@ struct ParentProductCardView: View {
             .padding(.horizontal, Constants.horizontalTextPadding * (1 / scale))
             .padding(.vertical, Constants.verticalTextPadding * (1 / scale))
             Spacer()
+
+            Image(systemName: "chevron.forward")
+                .accessibilityHidden(true)
+                .font(.posButtonSymbolSmall)
+                .foregroundStyle(Color.posOnSurfaceVariantLowest)
+                .padding(.horizontal, POSPadding.medium * (1 / scale))
         }
         .frame(maxWidth: .infinity, idealHeight: dynamicTypeSize.isAccessibilitySize ? nil : dimension)
         .background(Constants.backgroundColor)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds chevrons to the parent product rows in the item lists, which open to show variations.

This matches the iOS design system.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and open POS
2. Scroll down to view a variable parent product, observe that it has a chevron
3. Search for a variable parent product, observe that it has a chevron.

I've tested with RTL languages, voiceover, and dynamic type.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/05ba8b8e-9407-4830-a9c9-ee8d0cd8df41


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
