### PR TITLE
[Woo POS] Set the minimum product row height and make other adjustments to fix regressions

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -26,9 +26,6 @@ struct ItemRowView: View {
 
     var body: some View {
         itemRow
-            .background(Color.posSurfaceContainerLowest)
-            .frame(maxWidth: .infinity, idealHeight: dynamicTypeSize.isAccessibilitySize ? nil : dimension)
-            .posItemCardBorderStyles()
             .padding(.horizontal, Constants.horizontalPadding)
             .geometryGroup()
             .accessibilityLabel(accessibilityLabel)
@@ -86,6 +83,9 @@ struct ItemRowView: View {
             }
         }
         .padding(.trailing, Constants.cardContentHorizontalPadding)
+        .frame(maxWidth: .infinity, minHeight: dimension, alignment: .leading)
+        .background(Color.posSurfaceContainerLowest)
+        .posItemCardBorderStyles()
     }
 
     @ViewBuilder
@@ -152,39 +152,84 @@ private extension ItemRowView {
 
 #if DEBUG
 @available(iOS 17.0, *)
-#Preview(traits: .sizeThatFitsLayout) {
-    ItemRowView(cartItem: Cart.PurchasableItem(id: UUID(),
-                                               item: PointOfSalePreviewItemService().providePointOfSaleItem(),
-                                               title: "Item Title",
-                                               subtitle: "Item Subtitle",
-                                               quantity: 2),
-                onItemRemoveTapped: { })
-}
+#Preview {
+    ScrollView {
+        ItemRowView(
+            cartItem: Cart.PurchasableItem(
+                id: UUID(),
+                item: PointOfSalePreviewItemService().providePointOfSaleItem(),
+                title: "Item Title",
+                subtitle: "Item Subtitle",
+                quantity: 2
+            ),
+            onItemRemoveTapped: { }
+        )
 
-@available(iOS 17.0, *)
-#Preview(traits: .sizeThatFitsLayout) {
-    ItemRowView(cartItem: Cart.PurchasableItem(id: UUID(),
-                                               item: PointOfSalePreviewItemService().providePointOfSaleItem(),
-                                               title: "Item Title",
-                                               subtitle: nil,
-                                               quantity: 2),
-                onItemRemoveTapped: { })
-}
+        ItemRowView(
+            cartItem: Cart.PurchasableItem(
+                id: UUID(),
+                item: PointOfSalePreviewItemService().providePointOfSaleItem(),
+                title: "Item Title With incredible long title that goes incredibly far and beyond",
+                subtitle: "Item Subtitle",
+                quantity: 2
+            ),
+            onItemRemoveTapped: { }
+        )
 
-@available(iOS 17.0, *)
-#Preview(traits: .sizeThatFitsLayout) {
-    ItemRowView(cartItem: Cart.PurchasableItem.loading(id: UUID()),
-                onCancelLoading: { })
-}
+        ItemRowView(
+            cartItem: Cart.PurchasableItem(
+                id: UUID(),
+                item: PointOfSalePreviewItemService().providePointOfSaleItem(),
+                title: "Item Title",
+                subtitle: nil,
+                quantity: 2
+            ),
+            onItemRemoveTapped: { }
+        )
 
-@available(iOS 17.0, *)
-#Preview(traits: .sizeThatFitsLayout) {
-    ItemRowView.init(cartItem: Cart.PurchasableItem(
-        id: UUID(),
-        title: "123-123-123",
-        subtitle: "Unspported product type",
-        quantity: 1,
-        state: .error
-    ))
+        ItemRowView(
+            cartItem: Cart.PurchasableItem.loading(id: UUID()),
+            onCancelLoading: { }
+        )
+
+        ItemRowView(
+            cartItem: Cart.PurchasableItem(
+                id: UUID(),
+                title: "123-123-123",
+                subtitle: "Unspported product type",
+                quantity: 1,
+                state: .error
+            )
+        )
+
+        ItemRowView(
+            cartItem: Cart.PurchasableItem(
+                id: UUID(),
+                title: "123-123-123",
+                subtitle: "Unspported product type with an incredibly long error message that goes on and on",
+                quantity: 1,
+                state: .error
+            )
+        )
+
+        ItemRowView(
+            cartItem: Cart.PurchasableItem(
+                id: UUID(),
+                item: PointOfSalePreviewItemService().providePointOfSaleItem(),
+                title: "Item Title",
+                subtitle: nil,
+                quantity: 2
+            ),
+            showImage: .constant(false),
+            onItemRemoveTapped: { }
+        )
+
+        ItemRowView(
+            cartItem: Cart.PurchasableItem.loading(id: UUID()),
+            showImage: .constant(false),
+            onCancelLoading: { }
+        )
+    }
+    .frame(width: 400)
 }
 #endif


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

WOOMOB-714

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

A product row without images doesn't have a minimum size, becoming larger than its shadow.

<img width="184" alt="image" src="https://github.com/user-attachments/assets/8a14c903-b8eb-45c1-adcf-447196eedd56" />

This is mainly an issue produced by the dynamic type improvements PR https://github.com/woocommerce/woocommerce-ios/pull/15791, which removed the row sizing logic for non-accessibility sizes.

## Solution

Make a few adjustments:
- Set min height to product row
- Move `posItemCardBorderStyles` and some other modifiers on `productRow` since `GhostItemCardView` already contain them
- Updated previews that allowed to reproduce and confirm the issue fixed

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Resize the window to a horizontal compact size to the product images would be hidden
3. Add items to the cart
4. Confirm they appear as expected
5. Experiment with different dynamic types, screen sizes. 
6. Add barcode scanned items, confirm loading and error views look as expected.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air M2 26 device, iOS 18.5 and iOS 17.5 simulators, previews

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Before
<img width="698" alt="before" src="https://github.com/user-attachments/assets/16e34e08-b395-423b-9d21-1506f0d8e052" />

### After

<img width="674" alt="image" src="https://github.com/user-attachments/assets/4dc98917-df74-4799-948e-14866698b725" />

![Simulator Screenshot - iPad Air 13-inch (M2) - 2025-06-27 at 17 00 33](https://github.com/user-attachments/assets/760da17b-bb35-40e4-9afa-2b4eb27dd1b8)

https://github.com/user-attachments/assets/60e25efd-e461-4e03-8f32-37b1c91ee8e1

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.