### PR TITLE
[Shipping Labels] Prefill customs form origin country

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -18,6 +18,7 @@
 - [*] POS: Prevent card reader connection success alert flashing when connecting during a payment [https://github.com/woocommerce/woocommerce-ios/pull/15784]
 - [**] Shipping Labels: Support UPS extra services [https://github.com/woocommerce/woocommerce-ios/pull/15819, https://github.com/woocommerce/woocommerce-ios/pull/15821]
 - [*] Shipping Labels: Pre-fill custom forms with item description, value, and weight [https://github.com/woocommerce/woocommerce-ios/pull/15811]
+- [*] Shipping Labels: Pre-fill custom forms with item origin country [https://github.com/woocommerce/woocommerce-ios/pull/15835]
 - [internal] POS: Improved scrolling and animation performance by refactoring the shadow implementation and updating the cart and checkout views. [https://github.com/woocommerce/woocommerce-ios/pull/15817]
 
 22.6

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -64,9 +64,13 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
     @Published private var customsForm: ShippingLabelCustomsForm?
 
     lazy private(set) var customsFormViewModel: WooShippingCustomsFormViewModel = {
-        WooShippingCustomsFormViewModel(order: order, shipment: shipment, onCompletion: { [weak self] form in
+        return WooShippingCustomsFormViewModel(
+            order: order,
+            shipment: shipment,
+            originCountryCode: originCountryCodePublisher()
+        ) { [weak self] form in
             self?.customsForm = form
-        })
+        }
     }()
 
     /// Whether the custom information is completed or not.
@@ -452,6 +456,12 @@ private extension WooShippingShipmentDetailsViewModel {
             }
         }
         return foundCarrierPackage
+    }
+
+    func originCountryCodePublisher() -> AnyPublisher<String?, Never> {
+        $originAddress
+            .map(\.?.country)
+            .eraseToAnyPublisher()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -2,11 +2,13 @@ import Foundation
 import Yosemite
 import WooFoundation
 import Combine
+import protocol Storage.StorageManagerType
 
 final class WooShippingShipmentDetailsViewModel: ObservableObject {
 
     private let order: Order
     private let stores: StoresManager
+    private let storageManager: StorageManagerType
     private let currencyFormatter: CurrencyFormatter
     private let onLabelPurchase: ((ShippingLabel) -> Void)?
     private let onLabelRefund: ((Int64) -> Void)?
@@ -67,7 +69,9 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
         return WooShippingCustomsFormViewModel(
             order: order,
             shipment: shipment,
-            originCountryCode: originCountryCodePublisher()
+            originCountryCode: originCountryCodePublisher(),
+            stores: stores,
+            storageManager: storageManager
         ) { [weak self] form in
             self?.customsForm = form
         }
@@ -134,6 +138,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
          originAddress: AnyPublisher<WooShippingAddress?, Never>,
          destinationAddress: AnyPublisher<WooShippingAddress?, Never>,
          stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
          analytics: Analytics = ServiceLocator.analytics,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          debounceDuration: Double = 1,
@@ -141,6 +146,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
          onLabelRefund: ((Int64) -> Void)? = nil) {
         self.order = order
         self.stores = stores
+        self.storageManager = storageManager
         self.analytics = analytics
         self.shipment = shipment
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import Yosemite
 import Combine
 import WooFoundation
+import protocol Storage.StorageManagerType
 
 final class WooShippingCustomsFormViewModel: ObservableObject {
     enum ITNValidationError {
@@ -34,6 +35,8 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
     init(order: Order,
          shipment: Shipment,
          originCountryCode: AnyPublisher<String?, Never>? = nil,
+         stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
          onCompletion: @escaping (ShippingLabelCustomsForm) -> ()) {
         self.onCompletion = onCompletion
 
@@ -44,7 +47,9 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
                                             itemValue: $0.value,
                                             itemWeight: $0.weight,
                                             currencySymbol: currencySymbol(from: order),
-                                            originCountryCode: originCountryCode)
+                                            originCountryCode: originCountryCode,
+                                            storageManager: storageManager,
+                                            stores: stores)
         }
 
         listenToItemsRequiredInformationValues()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -31,7 +31,10 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private let onCompletion: (ShippingLabelCustomsForm) -> ()
 
-    init(order: Order, shipment: Shipment, onCompletion: @escaping (ShippingLabelCustomsForm) -> ()) {
+    init(order: Order,
+         shipment: Shipment,
+         originCountryCode: AnyPublisher<String?, Never>? = nil,
+         onCompletion: @escaping (ShippingLabelCustomsForm) -> ()) {
         self.onCompletion = onCompletion
 
         itemsViewModels = shipment.items.map {
@@ -40,7 +43,8 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
                                             itemQuantity: $0.quantity,
                                             itemValue: $0.value,
                                             itemWeight: $0.weight,
-                                            currencySymbol: currencySymbol(from: order))
+                                            currencySymbol: currencySymbol(from: order),
+                                            originCountryCode: originCountryCode)
         }
 
         listenToItemsRequiredInformationValues()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -92,7 +92,7 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
             .assign(to: &$originCountryCode)
 
         fetchCountries()
-        
+
         combineToPreselectCountry()
         combineRequiredInformationIsEntered()
         combineHSTariffNumberTotalValue()
@@ -102,6 +102,7 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
 private extension WooShippingCustomsItemViewModel {
     func combineToPreselectCountry() {
         $originCountryCode
+            .compactMap { $0 }
             .first() /// Make sure to only handle the initial value
             .combineLatest($countries)
             .map { code, countries in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -12,6 +12,8 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
     // Useful to determine externally if the shipping requires an ITN
     @Published var hsTariffNumberTotalValue: (String, Decimal)?
 
+    @Published private var originCountryCode: String?
+
     private let storageManager: StorageManagerType
     private let stores: StoresManager
     private let siteID: Int64
@@ -29,9 +31,7 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
 
     @Published private(set) var selectedCountry: Country?
 
-    var countries: [Country] {
-        resultsController.fetchedObjects
-    }
+    @Published private(set) var countries: [Country] = []
 
     var totalValue: Decimal {
         guard currencySymbol == "$",
@@ -74,6 +74,7 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
          itemValue: Double,
          itemWeight: Double,
          currencySymbol: String,
+         originCountryCode: AnyPublisher<String?, Never>? = nil,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores) {
         self.title = itemName
@@ -87,20 +88,38 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
         self.stores = stores
         self.siteID = stores.sessionManager.defaultStoreID ?? Int64.min
 
+        originCountryCode?
+            .assign(to: &$originCountryCode)
+
         fetchCountries()
+        
+        combineToPreselectCountry()
         combineRequiredInformationIsEntered()
         combineHSTariffNumberTotalValue()
     }
 }
 
 private extension WooShippingCustomsItemViewModel {
+    func combineToPreselectCountry() {
+        $originCountryCode
+            .first() /// Make sure to only handle the initial value
+            .combineLatest($countries)
+            .map { code, countries in
+                return countries.first(where: { $0.code == code })
+            }
+            .assign(to: &$selectedCountry)
+    }
+
     func fetchCountries() {
         try? resultsController.performFetch()
+        countries = resultsController.fetchedObjects
+
         let action = DataAction.synchronizeCountries(siteID: siteID) { [weak self] (result) in
             guard let self = self else { return }
             switch result {
             case .success:
                 try? self.resultsController.performFetch()
+                self.countries = self.resultsController.fetchedObjects
             case .failure:
                 break
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
@@ -330,6 +330,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
             quantity: 2,
             value: 9.99,
             weight: 0.5,
+            originCountry: "US",
             productID: 1
         )
 
@@ -339,6 +340,8 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
                                                                        items: [expectedItem])
         var sentCustomsForm: ShippingLabelCustomsForm?
         let stores = MockStoresManager(sessionManager: .testingInstance)
+        let storageManager = MockStorageManager()
+
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             switch action {
             case let .loadLabelRates(_, _, _, _, packages, _):
@@ -352,16 +355,37 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
             }
         }
 
-        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
-        let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
-        let viewModel = WooShippingShipmentDetailsViewModel(order: Order.fake(),
-                                                            shipment: sampleShipment,
-                                                            shippingLabel: nil,
-                                                            originAddress: originAddressSubject.eraseToAnyPublisher(),
-                                                            destinationAddress: destinationAddressSubject.eraseToAnyPublisher(),
-                                                            stores: stores,
-                                                            debounceDuration: 0)
+        let countries = [
+            Country(code: "US", name: "United States", states: []),
+            Country(code: "CA", name: "Canada", states: [])
+        ]
 
+        stores.whenReceivingAction(ofType: DataAction.self) { action in
+            switch action {
+            case let .synchronizeCountries(_, onCompletion):
+                storageManager.insertSampleCountries(readOnlyCountries: countries)
+                onCompletion(.success(countries))
+            }
+        }
+
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(
+            sampleOriginAddress(country: "US", state: "NY")
+        )
+
+        let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(
+            sampleDestinationAddress(country: "US", state: "CA")
+        )
+
+        let viewModel = WooShippingShipmentDetailsViewModel(
+            order: Order.fake(),
+            shipment: sampleShipment,
+            shippingLabel: nil,
+            originAddress: originAddressSubject.eraseToAnyPublisher(),
+            destinationAddress: destinationAddressSubject.eraseToAnyPublisher(),
+            stores: stores,
+            storageManager: storageManager,
+            debounceDuration: 0
+        )
 
         // When
         viewModel.selectPackage(samplePackageData())
@@ -749,6 +773,49 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
         // Then
         XCTAssertNil(viewModel.selectedRate)
         XCTAssertNil(viewModel.shippingService?.selectedRate)
+    }
+
+    // MARK: - Customs
+    func test_preselects_customs_origin_country() throws {
+        // Setup
+        let originAddressSubject = PassthroughSubject<WooShippingAddress?, Never>()
+        let destinationAddressSubject = PassthroughSubject<WooShippingAddress?, Never>()
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let storageManager = MockStorageManager()
+
+        // Given
+        let expectedCountry = "US"
+
+        let countries = [
+            Country(code: "US", name: "United States", states: []),
+            Country(code: "CA", name: "Canada", states: [])
+        ]
+
+        stores.whenReceivingAction(ofType: DataAction.self) { action in
+            switch action {
+            case let .synchronizeCountries(_, onCompletion):
+                storageManager.insertSampleCountries(readOnlyCountries: countries)
+                onCompletion(.success(countries))
+            }
+        }
+
+        let viewModel = WooShippingShipmentDetailsViewModel(
+            order: Order.fake(),
+            shipment: sampleShipment,
+            shippingLabel: nil,
+            originAddress: originAddressSubject.eraseToAnyPublisher(),
+            destinationAddress: destinationAddressSubject.eraseToAnyPublisher(),
+            stores: stores,
+            storageManager: storageManager
+        )
+
+        let customsItemViewModel = try XCTUnwrap(viewModel.customsFormViewModel.itemsViewModels.first)
+
+        // When
+        originAddressSubject.send(sampleOriginAddress(country: expectedCountry, state: ""))
+
+        // Then
+        XCTAssertEqual(customsItemViewModel.selectedCountry?.code, expectedCountry)
     }
 }
 


### PR DESCRIPTION
[WOOMOB-638](https://linear.app/a8c/issue/WOOMOB-638)

This is a follow up PR for the [[Shipping Labels] Pre-fill shipping item customs details](https://github.com/woocommerce/woocommerce-ios/pull/15811)

## Description
- Prefills origin country for package items in customs form. The value is taken from the `WooShippingShipmentDetailsViewModel`.
- Injects the origin country code publisher into customs form view model and further into `WooShippingCustomsItemViewModel`. This reactive approach is required because the origin country address is loaded asynchronously.
- Only listen for the 1st non-nil country code since we only interested in the initial value. 
- `countries` in `WooShippingCustomsItemViewModel` made `@Published` to combine with `originCountryCode` and emit a selected country instance
- Updated tests

## Testing steps
- Navigate to a completed order that contains an unfulfilled shipment.
- Setup the shipment destination country to be different from origin (to reveal customs form option).
- Open customs form and navigate to a shipment item.
- Make sure the "Origin country" is pre-filled. The country should be the same as the shipment origin address.

## Demo

https://github.com/user-attachments/assets/492700a0-b6e7-4af9-a444-db71aaf4376d

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.