### PR TITLE
[POS Orders] Adds feature flag for `pointOfSaleOrdersi1`

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -93,6 +93,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return false
         case .pointOfSaleAsATabi1:
             return true
+        case .pointOfSaleOrdersi1:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -195,4 +195,8 @@ public enum FeatureFlag: Int {
     /// Enables displaying POS as a tab in the tab bar with the same eligibility as the previous entry point
     ///
     case pointOfSaleAsATabi1
+
+    /// Enables displaying Point Of Sale details in order list and order details
+    ///
+    case pointOfSaleOrdersi1
 }


### PR DESCRIPTION
Closes WOOMOB-700

## Description
Adds feature flag for `pointOfSaleOrdersi1`

## Testing information
Not used anywhere yet. CI should pass.