### PR TITLE
Shipping Labels: UI improvements for splitting shipment screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 22.8
 -----
+- [*] Shipping Labels: Improve UI of Split shipments screen. [https://github.com/woocommerce/woocommerce-ios/pull/15838]
 
 
 22.7

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/CollapsibleShipmentItemCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/CollapsibleShipmentItemCard.swift
@@ -60,7 +60,6 @@ private extension CollapsibleShipmentItemCard {
                         .foregroundColor(Color(.accent))
                 }
             })
-            .buttonStyle(PlainButtonStyle())
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/CollapsibleShipmentItemCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/CollapsibleShipmentItemCardViewModel.swift
@@ -76,7 +76,9 @@ private extension CollapsibleShipmentItemCardViewModel {
             $0.onSelectedChange = { [weak self] row in
                 guard let self else { return }
 
-                mainItemRow.setSelected(false)
+                // Check if all child items are selected
+                let allChildrenSelected = childItemRows.allSatisfy { $0.selected }
+                mainItemRow.setSelected(allChildrenSelected)
                 onSelectionChange?()
             }
         })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/SelectableShipmentItemRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/SelectableShipmentItemRow.swift
@@ -83,7 +83,7 @@ private extension SelectableShipmentItemRow {
         static let imageSize: CGFloat = 56.0
         static let imageCornerRadius: CGFloat = 4.0
         static let badgeOffset: CGFloat = 8.0
-        static let disabledOpacity: CGFloat = 0.7
+        static let disabledOpacity: CGFloat = 0.5
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/SelectableShipmentItemRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/SelectableShipmentItemRow.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// Row for a selectable shipment item to ship with the Woo Shipping extension.
 struct SelectableShipmentItemRow: View {
     @ObservedObject private var viewModel: SelectableShipmentItemRowViewModel
+    @Environment(\.isEnabled) private var isEnabled
 
     init(viewModel: SelectableShipmentItemRowViewModel) {
         self.viewModel = viewModel
@@ -50,6 +51,7 @@ struct SelectableShipmentItemRow: View {
             }
         }
         .frame(maxWidth: .infinity)
+        .opacity(isEnabled ? 1 : Layout.disabledOpacity)
     }
 }
 
@@ -81,6 +83,7 @@ private extension SelectableShipmentItemRow {
         static let imageSize: CGFloat = 56.0
         static let imageCornerRadius: CGFloat = 4.0
         static let badgeOffset: CGFloat = 8.0
+        static let disabledOpacity: CGFloat = 0.7
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
@@ -101,6 +101,9 @@ struct WooShippingSplitShipmentsView: View {
             Button(Localization.SaveShipmentError.retry) {
                 saveShipmentInfoAndDismiss()
             }
+            Button(Localization.SaveShipmentError.revertChanges) {
+                viewModel.revertChanges()
+            }
         }
     }
 }
@@ -494,6 +497,11 @@ fileprivate extension WooShippingSplitShipmentsView {
                 "wooShipping.createLabels.splitShipment.saveShipmentError.cancel",
                 value: "Cancel",
                 comment: "Cancel button title on the error alert when saving split shipment changes fails"
+            )
+            static let revertChanges = NSLocalizedString(
+                "wooShipping.createLabels.splitShipment.saveShipmentError.revertChanges",
+                value: "Revert changes",
+                comment: "Button on the error alert to revert changes when saving split shipment changes fails"
             )
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -137,7 +137,7 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
     }
 
     func onAppear() {
-        if shipments.isEmpty {
+        if shipments.count == 1 {
             showInstructionsNotice()
         }
         updateMoveToNotice()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -154,6 +154,11 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
         dismissedInstructions = true
     }
 
+    func revertChanges() {
+        shipments = shipmentsSavedInRemote
+        selectedShipmentIndex = 0
+    }
+
     func didPurchaseLabel(for shipmentIndex: Int, purchasedLabelID: Int64) {
         let currentShipment = shipments[shipmentIndex]
         let updatedContents = currentShipment.contents.map {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -137,7 +137,9 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
     }
 
     func onAppear() {
-        showInstructionsNotice()
+        if shipments.isEmpty {
+            showInstructionsNotice()
+        }
         updateMoveToNotice()
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2537,6 +2537,7 @@
 		DE02ABBE2B578D0E008E0AC4 /* CreditCardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE02ABBD2B578D0E008E0AC4 /* CreditCardType.swift */; };
 		DE02ABC02B57D333008E0AC4 /* BlazeConfirmPaymentViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE02ABBF2B57D333008E0AC4 /* BlazeConfirmPaymentViewModelTests.swift */; };
 		DE02ABC22B5903AB008E0AC4 /* BlazeCampaignCreationErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE02ABC12B5903AB008E0AC4 /* BlazeCampaignCreationErrorView.swift */; };
+		DE02B64F2E12766B00B79E0D /* CollapsibleShipmentItemCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE02B64E2E12766B00B79E0D /* CollapsibleShipmentItemCardViewModelTests.swift */; };
 		DE02C65C2D5A0B9F0089850D /* FailedProductImageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE02C65B2D5A0B9F0089850D /* FailedProductImageCollectionViewCell.swift */; };
 		DE02C65E2D5A0C5D0089850D /* FailedProductImageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = DE02C65D2D5A0C5D0089850D /* FailedProductImageCollectionViewCell.xib */; };
 		DE06D6602D64699D00419FFA /* AuthenticatedWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE06D65F2D64699D00419FFA /* AuthenticatedWebViewModelTests.swift */; };
@@ -5695,6 +5696,7 @@
 		DE02ABBD2B578D0E008E0AC4 /* CreditCardType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardType.swift; sourceTree = "<group>"; };
 		DE02ABBF2B57D333008E0AC4 /* BlazeConfirmPaymentViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeConfirmPaymentViewModelTests.swift; sourceTree = "<group>"; };
 		DE02ABC12B5903AB008E0AC4 /* BlazeCampaignCreationErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationErrorView.swift; sourceTree = "<group>"; };
+		DE02B64E2E12766B00B79E0D /* CollapsibleShipmentItemCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CollapsibleShipmentItemCardViewModelTests.swift; path = "WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/CollapsibleShipmentItemCardViewModelTests.swift"; sourceTree = "<group>"; };
 		DE02C65B2D5A0B9F0089850D /* FailedProductImageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailedProductImageCollectionViewCell.swift; sourceTree = "<group>"; };
 		DE02C65D2D5A0C5D0089850D /* FailedProductImageCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FailedProductImageCollectionViewCell.xib; sourceTree = "<group>"; };
 		DE06D65F2D64699D00419FFA /* AuthenticatedWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewModelTests.swift; sourceTree = "<group>"; };
@@ -10539,6 +10541,7 @@
 		B56DB3BD2049BFAA00D4AA8E = {
 			isa = PBXGroup;
 			children = (
+				DE02B64E2E12766B00B79E0D /* CollapsibleShipmentItemCardViewModelTests.swift */,
 				3F3689E22DCB1B470065B48F /* Modules */,
 				D8FBFF1622D4CC2F006E3336 /* docs */,
 				8CA4F6DC220B24EB00A47B5D /* config */,
@@ -16803,6 +16806,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DE02B64F2E12766B00B79E0D /* CollapsibleShipmentItemCardViewModelTests.swift in Sources */,
 				45C8B2692316B2440002FA77 /* BillingAddressTableViewCellTests.swift in Sources */,
 				B95A45EC2A77D7A60073A91F /* CustomerSelectorViewModelTests.swift in Sources */,
 				3178C1FD26409360000D771A /* BluetoothCardReaderSettingsConnectedViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/CollapsibleShipmentItemCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/CollapsibleShipmentItemCardViewModelTests.swift
@@ -1,0 +1,223 @@
+import XCTest
+@testable import WooCommerce
+import WooFoundation
+import Yosemite
+
+final class CollapsibleShipmentItemCardViewModelTests: XCTestCase {
+
+    // MARK: - observeSelection Tests
+
+    func test_observeSelection_when_main_item_selected_then_all_children_are_selected() {
+        // Given
+        let packageItem = samplePackageItem(quantity: 3)
+        let viewModel = CollapsibleShipmentItemCardViewModel(item: packageItem, currency: "USD")
+
+        var selectionChangeCallCount = 0
+        viewModel.onSelectionChange = {
+            selectionChangeCallCount += 1
+        }
+
+        // When
+        viewModel.mainItemRow.handleTap() // Select main item
+
+        // Then
+        XCTAssertTrue(viewModel.mainItemRow.selected)
+        XCTAssertTrue(viewModel.childItemRows.allSatisfy { $0.selected })
+        XCTAssertEqual(selectionChangeCallCount, 1)
+    }
+
+    func test_observeSelection_when_main_item_deselected_then_all_children_are_deselected() {
+        // Given
+        let packageItem = samplePackageItem(quantity: 3)
+        let viewModel = CollapsibleShipmentItemCardViewModel(item: packageItem, currency: "USD")
+
+        // First select the main item
+        viewModel.mainItemRow.handleTap()
+
+        var selectionChangeCallCount = 0
+        viewModel.onSelectionChange = {
+            selectionChangeCallCount += 1
+        }
+
+        // When
+        viewModel.mainItemRow.handleTap() // Deselect main item
+
+        // Then
+        XCTAssertFalse(viewModel.mainItemRow.selected)
+        XCTAssertTrue(viewModel.childItemRows.allSatisfy { !$0.selected })
+        XCTAssertEqual(selectionChangeCallCount, 1)
+    }
+
+    func test_observeSelection_when_all_children_selected_then_main_item_is_selected() {
+        // Given
+        let packageItem = samplePackageItem(quantity: 3)
+        let viewModel = CollapsibleShipmentItemCardViewModel(item: packageItem, currency: "USD")
+
+        var selectionChangeCallCount = 0
+        viewModel.onSelectionChange = {
+            selectionChangeCallCount += 1
+        }
+
+        // When - Select all child items one by one
+        viewModel.childItemRows[0].handleTap()
+        viewModel.childItemRows[1].handleTap()
+        viewModel.childItemRows[2].handleTap()
+
+        // Then
+        XCTAssertTrue(viewModel.mainItemRow.selected)
+        XCTAssertTrue(viewModel.childItemRows.allSatisfy { $0.selected })
+        XCTAssertEqual(selectionChangeCallCount, 3)
+    }
+
+    func test_observeSelection_when_some_children_selected_then_main_item_is_not_selected() {
+        // Given
+        let packageItem = samplePackageItem(quantity: 3)
+        let viewModel = CollapsibleShipmentItemCardViewModel(item: packageItem, currency: "USD")
+
+        var selectionChangeCallCount = 0
+        viewModel.onSelectionChange = {
+            selectionChangeCallCount += 1
+        }
+
+        // When - Select only some child items
+        viewModel.childItemRows[0].handleTap()
+        viewModel.childItemRows[1].handleTap()
+        // Note: childItemRows[2] is not selected
+
+        // Then
+        XCTAssertFalse(viewModel.mainItemRow.selected)
+        XCTAssertTrue(viewModel.childItemRows[0].selected)
+        XCTAssertTrue(viewModel.childItemRows[1].selected)
+        XCTAssertFalse(viewModel.childItemRows[2].selected)
+        XCTAssertEqual(selectionChangeCallCount, 2)
+    }
+
+    func test_observeSelection_when_all_children_selected_then_one_deselected_then_main_item_is_deselected() {
+        // Given
+        let packageItem = samplePackageItem(quantity: 3)
+        let viewModel = CollapsibleShipmentItemCardViewModel(item: packageItem, currency: "USD")
+
+        // First select all children
+        viewModel.childItemRows.forEach { $0.handleTap() }
+
+        // Verify all are selected initially
+        XCTAssertTrue(viewModel.mainItemRow.selected)
+        XCTAssertTrue(viewModel.childItemRows.allSatisfy { $0.selected })
+
+        var selectionChangeCallCount = 0
+        viewModel.onSelectionChange = {
+            selectionChangeCallCount += 1
+        }
+
+        // When - Deselect one child item
+        viewModel.childItemRows[1].handleTap()
+
+        // Then
+        XCTAssertFalse(viewModel.mainItemRow.selected)
+        XCTAssertTrue(viewModel.childItemRows[0].selected)
+        XCTAssertFalse(viewModel.childItemRows[1].selected)
+        XCTAssertTrue(viewModel.childItemRows[2].selected)
+        XCTAssertEqual(selectionChangeCallCount, 1)
+    }
+
+    func test_observeSelection_with_single_quantity_item_has_no_children() {
+        // Given
+        let packageItem = samplePackageItem(quantity: 1)
+        let viewModel = CollapsibleShipmentItemCardViewModel(item: packageItem, currency: "USD")
+
+        // Then
+        XCTAssertTrue(viewModel.childItemRows.isEmpty)
+        XCTAssertFalse(viewModel.mainItemRow.selected)
+    }
+
+    // MARK: - numberOfSelectedItems Tests
+
+    func test_numberOfSelectedItems_with_single_quantity_item() {
+        // Given
+        let packageItem = samplePackageItem(quantity: 1)
+        let viewModel = CollapsibleShipmentItemCardViewModel(item: packageItem, currency: "USD")
+
+        // When not selected
+        XCTAssertEqual(viewModel.numberOfSelectedItems, 0)
+
+        // When selected
+        viewModel.mainItemRow.handleTap()
+        XCTAssertEqual(viewModel.numberOfSelectedItems, 1)
+    }
+
+    func test_numberOfSelectedItems_with_multiple_quantity_item() {
+        // Given
+        let packageItem = samplePackageItem(quantity: 3)
+        let viewModel = CollapsibleShipmentItemCardViewModel(item: packageItem, currency: "USD")
+
+        // When no children selected
+        XCTAssertEqual(viewModel.numberOfSelectedItems, 0)
+
+        // When some children selected
+        viewModel.childItemRows[0].handleTap()
+        viewModel.childItemRows[1].handleTap()
+        XCTAssertEqual(viewModel.numberOfSelectedItems, 2)
+
+        // When all children selected
+        viewModel.childItemRows[2].handleTap()
+        XCTAssertEqual(viewModel.numberOfSelectedItems, 3)
+    }
+
+    // MARK: - selectAll Tests
+
+    func test_selectAll_selects_main_and_all_children() {
+        // Given
+        let packageItem = samplePackageItem(quantity: 3)
+        let viewModel = CollapsibleShipmentItemCardViewModel(item: packageItem, currency: "USD")
+
+        var selectionChangeCallCount = 0
+        viewModel.onSelectionChange = {
+            selectionChangeCallCount += 1
+        }
+
+        // When
+        viewModel.selectAll()
+
+        // Then
+        XCTAssertTrue(viewModel.mainItemRow.selected)
+        XCTAssertTrue(viewModel.childItemRows.allSatisfy { $0.selected })
+        XCTAssertEqual(selectionChangeCallCount, 1)
+    }
+
+    func test_selectAll_with_single_quantity_item() {
+        // Given
+        let packageItem = samplePackageItem(quantity: 1)
+        let viewModel = CollapsibleShipmentItemCardViewModel(item: packageItem, currency: "USD")
+
+        var selectionChangeCallCount = 0
+        viewModel.onSelectionChange = {
+            selectionChangeCallCount += 1
+        }
+
+        // When
+        viewModel.selectAll()
+
+        // Then
+        XCTAssertTrue(viewModel.mainItemRow.selected)
+        XCTAssertTrue(viewModel.childItemRows.isEmpty)
+        XCTAssertEqual(selectionChangeCallCount, 1)
+    }
+}
+
+// MARK: - Helper Methods
+
+private extension CollapsibleShipmentItemCardViewModelTests {
+    func samplePackageItem(quantity: Decimal) -> ShippingLabelPackageItem {
+        ShippingLabelPackageItem(
+            productOrVariationID: 123,
+            orderItemID: 456,
+            name: "Test Item",
+            weight: 1.5,
+            quantity: quantity,
+            value: 10.0,
+            dimensions: ProductDimensions(length: "10", width: "10", height: "10"),
+            attributes: [],
+            imageURL: nil
+        )
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
@@ -1100,6 +1100,8 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isShipmentDeleteOptionAvailable(for: unfulfilledShipment))
     }
 
+    // MARK: - `instructions`
+
     func test_instructions_is_nil_when_there_exists_more_than_one_shipment() {
         // Given
         let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
@@ -1147,6 +1149,43 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(viewModel.instructions)
+    }
+
+    // MARK: - `revertChanges`
+
+    func test_revertChanges_restores_shipments_and_resets_selected_index() {
+        // Given
+        let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
+                     sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)]
+
+        let viewModel = WooShippingSplitShipmentsViewModel(
+            order: sampleOrder,
+            config: WooShippingConfig.fake(),
+            items: items,
+            currencySettings: currencySettings,
+            shippingSettingsService: shippingSettingsService
+        )
+
+        // Store the initial state
+        let initialShipmentCount = viewModel.shipments.count
+        let initialFirstShipmentContentsCount = viewModel.shipments.first?.contents.count
+
+        // When - Make changes to shipments
+        viewModel.shipments.first?.contents.first?.childItemRows.first?.handleTap()
+        viewModel.moveSelectedItems(to: .newShipment)
+        viewModel.selectedShipmentIndex = 1
+
+        // Verify changes were made
+        XCTAssertEqual(viewModel.shipments.count, 2)
+        XCTAssertEqual(viewModel.selectedShipmentIndex, 1)
+
+        // When - Revert changes
+        viewModel.revertChanges()
+
+        // Then - Verify state is restored
+        XCTAssertEqual(viewModel.shipments.count, initialShipmentCount)
+        XCTAssertEqual(viewModel.shipments.first?.contents.count, initialFirstShipmentContentsCount)
+        XCTAssertEqual(viewModel.selectedShipmentIndex, 0)
     }
 
     // MARK: - `isMergeAllUnfulfilledAvailable`

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
@@ -1100,6 +1100,55 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isShipmentDeleteOptionAvailable(for: unfulfilledShipment))
     }
 
+    func test_instructions_is_nil_when_there_exists_more_than_one_shipment() {
+        // Given
+        let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
+                     sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)]
+
+        let config = WooShippingConfig(
+            siteID: 123,
+            shipments: [
+                "0": [WooShippingShipmentItem(id: 1, subItems: ["sub-1", "sub-2"])],
+                "1": [WooShippingShipmentItem(id: 2, subItems: [])]
+            ],
+            shippingLabelData: WooShippingLabelData(currentOrderLabels: [])
+        )
+
+        let viewModel = WooShippingSplitShipmentsViewModel(
+            order: sampleOrder,
+            config: config,
+            items: items,
+            currencySettings: currencySettings,
+            shippingSettingsService: shippingSettingsService
+        )
+
+        // When
+        viewModel.onAppear()
+
+        // Then
+        XCTAssertNil(viewModel.instructions)
+    }
+
+    func test_instructions_is_not_nil_when_there_exists_only_one_shipment() {
+        // Given
+        let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 2),
+                     sampleItem(id: 2, weight: 3, value: 2.5, quantity: 1)]
+
+        let viewModel = WooShippingSplitShipmentsViewModel(
+            order: sampleOrder,
+            config: WooShippingConfig.fake(),
+            items: items,
+            currencySettings: currencySettings,
+            shippingSettingsService: shippingSettingsService
+        )
+
+        // When
+        viewModel.onAppear()
+
+        // Then
+        XCTAssertNotNil(viewModel.instructions)
+    }
+
     // MARK: - `isMergeAllUnfulfilledAvailable`
 
     func test_isMergeAllUnfulfilledAvailable_returns_false_when_no_unfulfilled_shipments() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-636
Also closes WOOMOB-637
Also closes WOOMOB-658

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a few small improvements on the Split shipments screen:
- Mark parent items as selected when all child items are selected.
- Show splitting shipment instruction only when there exists only one shipment when the screen is opened.
- Add a new button for reverting changes when saving shipments fails. This is necessary because we have no Cancel button to dismiss changes on this screen.
- Fix inconsistent opacity of items when saving is in progress.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with the Woo Shipping extension set up.
2. Navigate to the Orders tab and select a completed order with several physical products.
3. Tap Create shipping label > tap Split shipment.
4. If there is only one shipment, confirm that there's an instruction at the bottom for how to split shipments.
5. Move items into separate shipments. Ensure to leave one item with no child item and another with a few child items.
6. Disconnect the Internet connection, then tap the  Done button.
7. Confirm that the items are disabled and have similar opacity.
8. When the saving request times out, confirm that there's a new button on the error alert for reverting changes.
9. Tap the Revert change button and confirm that shipments are reset to the previous state matching the remote state.
10. Move items again,  enable the Internet connection, and save the changes.
11. Tap the pencil button to open the Split shipments screen again. Confirm that the instructions are hidden now that we have more than 1 shipment.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Tested and confirmed with simulator iPhone 16 iOS 18.4.
- Added unit tests to confirm the changes.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Hide instructions when there are multiple shipments:

https://github.com/user-attachments/assets/c6c20d6b-88db-42d5-85b6-98c3eb900608


Mark parent item as selected when all child items are selected:


https://github.com/user-attachments/assets/89bd2513-8c20-42d5-a7bf-74bdc4d87f7f

New button for reverting changes:

<img src="https://github.com/user-attachments/assets/f450dff1-87ef-4a82-b5e4-bd6b06914c24" width=320 />

Disabled states:

Before | After 
--- | ---
<img src="https://github.com/user-attachments/assets/b2f8434d-625e-4987-8db8-e697e4f7f6c9" width=320 /> | <img src="https://github.com/user-attachments/assets/bf3da4d0-e5f5-4ab4-a8b7-dc5917cb7e6f" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
