### PR TITLE
[AINFRA-855] Fix Prototype version number

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -2,6 +2,8 @@
 
 import PackageDescription
 
+// Dummy change to force Prototype build
+
 let package = Package(
     name: "Modules",
     platforms: [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -2,8 +2,6 @@
 
 import PackageDescription
 
-// Dummy change to force Prototype build
-
 let package = Package(
     name: "Modules",
     platforms: [

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -785,14 +785,15 @@ platform :ios do
     update_certs_and_profiles_enterprise if fetch_code_signing
 
     build_number = ENV.fetch('BUILDKITE_BUILD_NUMBER', '0')
-    pr_or_branch = pull_request_number&.then { |num| "PR ##{num}" } || ENV.fetch('BUILDKITE_BRANCH', nil)
 
     gym(
       scheme: 'WooCommerce Alpha',
       workspace: WORKSPACE_PATH,
       export_method: 'enterprise',
       clean: true,
-      xcargs: { BUILD_CODE_KEY => build_number, 'VERSION_SHORT' => pr_or_branch }.compact,
+      # Note that we don't want to override the `VERSION_SHORT` (with `PR #nn` or something) because that's the `.marketingVersion` and is used in API calls
+      # so we need to keep it unchanged; we still update the `VERSION_LONG` (build number) to make it easy to associate it with the Buildkite build in Firebase.
+      xcargs: { BUILD_CODE_KEY => build_number }.compact,
       output_directory: 'build',
       export_team_id: get_required_env('INT_EXPORT_TEAM_ID'),
       export_options: {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -794,7 +794,7 @@ platform :ios do
       export_method: 'enterprise',
       clean: true,
       # Note that we don't want to override the `VERSION_SHORT` (with `PR #nn` or something) because that's the `.marketingVersion` and is used in API calls
-      # so we need to keep it unchanged; we still update the `VERSION_LONG` (build number) to make it easy to associate it with the Buildkite build in Firebase.
+      # so we need to keep it unchanged; we still update the `VERSION_LONG` (build number) to make it easy to associate it with the right PR and commit in Firebase.
       xcargs: { BUILD_CODE_KEY => build_number }.compact,
       output_directory: 'build',
       export_team_id: get_required_env('INT_EXPORT_TEAM_ID'),

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -785,8 +785,8 @@ platform :ios do
     update_certs_and_profiles_enterprise if fetch_code_signing
 
     pr_prefix = pull_request_number&.then { |num| "pr#{num}" }
-    buildkite_build_number = ENV.fetch('BUILDKITE_BUILD_NUMBER', '0')
-    build_number = [pr_prefix, buildkite_build_number].compact.join('-')
+    commit_short_hash = ENV.fetch('BUILDKITE_COMMIT', '0')[0...7]
+    build_number = [pr_prefix, commit_short_hash].compact.join('-')
 
     gym(
       scheme: 'WooCommerce Alpha',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -784,7 +784,9 @@ platform :ios do
   lane :build_for_prototype_build do |fetch_code_signing: true|
     update_certs_and_profiles_enterprise if fetch_code_signing
 
-    build_number = ENV.fetch('BUILDKITE_BUILD_NUMBER', '0')
+    pr_prefix = pull_request_number&.then { |num| "pr#{num}" }
+    buildkite_build_number = ENV.fetch('BUILDKITE_BUILD_NUMBER', '0')
+    build_number = [pr_prefix, buildkite_build_number].compact.join('-')
 
     gym(
       scheme: 'WooCommerce Alpha',


### PR DESCRIPTION
Closes AINFRA-855

## Description

For Firebase App Distribution, we were overriding the `VERSION_SHORT` to `"PR #<num>` so that it'd be easy to make the connection between the "version number" listed in Firebase's web UI listing all the available builds, and the PR each of those builds were built for.

But the `VERSION_SHORT` / `CFBundleShortVersionString` is also used by the app at runtime when sending API calls. So overriding this `VERSION_SHORT` for Prototype builds had the side effect of sending strings like `PR #123` in the API calls, which were considered invalid by the backend.

To avoid breaking things, we're not overriding the `VERSION_SHORT` for Prototype Builds anymore (and instead keep the actualy version value that was present at the time the PR was cut)

## Steps to reproduce

Install a previous Prototype Build from a previous PR and observe that API calls are sending a version of `PR #…` in the API call and that it makes the API call be rejected due to unrecognised version string.

## Testing information

Check that the Prototype Build generated by this PR uses the proper valid Marketing Version
 - By looking at the comment on this PR showing the metadata of the Prototype Build that will be created
 - By installing and testing this Prototype Build and validating that the API calls that are made by this Prototype Build are not rejected anymore and are now sending the correct and valid `.marketingVersion` to the API calls.

---
- [x] ~~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~~