### PR TITLE
Fix the logic in how we determine BuildConfiguration.current

### DIFF
--- a/Modules/Sources/Experiments/BuildConfiguration.swift
+++ b/Modules/Sources/Experiments/BuildConfiguration.swift
@@ -12,20 +12,20 @@ public enum BuildConfiguration: String {
     case appStore
 
     public static var current: BuildConfiguration {
-        #if DEBUG
-        return testingOverride ?? .localDeveloper
-        #elseif ALPHA
-        return .alpha
-        #else
-        return .appStore
-        #endif
+        let appConfigName = Bundle.main.object(forInfoDictionaryKey: "BuildConfigurationName") as? String
+        if appConfigName == "Debug" {
+            return testingOverride ?? .localDeveloper
+        } else if appConfigName == "Release-Alpha" {
+            return .alpha
+        } else {
+            return .appStore
+        }
     }
 
     static func ~=(a: BuildConfiguration, b: Set<BuildConfiguration>) -> Bool {
         return b.contains(a)
     }
 
-    #if DEBUG
     private static var testingOverride: BuildConfiguration?
 
     func test(_ closure: () -> ()) {
@@ -33,5 +33,4 @@ public enum BuildConfiguration: String {
         closure()
         BuildConfiguration.testingOverride = nil
     }
-    #endif
 }

--- a/Modules/Sources/Experiments/BuildConfiguration.swift
+++ b/Modules/Sources/Experiments/BuildConfiguration.swift
@@ -14,7 +14,11 @@ public enum BuildConfiguration: String {
     public static var current: BuildConfiguration {
         let appConfigName = Bundle.main.object(forInfoDictionaryKey: "BuildConfigurationName") as? String
         if appConfigName == "Debug" {
+            #if DEBUG
             return testingOverride ?? .localDeveloper
+            #else
+            return .localDeveloper
+            #endif
         } else if appConfigName == "Release-Alpha" {
             return .alpha
         } else {
@@ -26,6 +30,7 @@ public enum BuildConfiguration: String {
         return b.contains(a)
     }
 
+    #if DEBUG
     private static var testingOverride: BuildConfiguration?
 
     func test(_ closure: () -> ()) {
@@ -33,4 +38,5 @@ public enum BuildConfiguration: String {
         closure()
         BuildConfiguration.testingOverride = nil
     }
+    #endif
 }

--- a/WooCommerce/Resources/Info.plist
+++ b/WooCommerce/Resources/Info.plist
@@ -151,5 +151,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>BuildConfigurationName</key>
+	<string>$(CONFIGURATION)</string>
 </dict>
 </plist>

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce Alpha.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce Alpha.xcscheme
@@ -51,7 +51,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release-Alpha"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -789,6 +789,7 @@ platform :ios do
 
     gym(
       scheme: 'WooCommerce Alpha',
+      configuration: 'Release-Alpha',
       workspace: WORKSPACE_PATH,
       export_method: 'enterprise',
       clean: true,


### PR DESCRIPTION
See AINFRA-856

## Description

We can't rely on `#if ALPHA` anymore  in `BuildConfiguration.swift`'s code now that this file have been moved to `Modules/Sources/Experiments` as a SwiftPM module. This is because, in this context, SwiftPM does not apply any custom Build Conditional Settings from the Xcode project to the SwiftPM dependencies it builds (and instead the Modules are built with build settings that are independent from the consuming target / project using them)

So we have to rely on a different trick instead, which is to read the configuration from the `Info.plist` file of the app bundle.

### How

 - We added a new `BuildConfigurationName` key to the app's `Info.plist` and set its value to `$(CONFIGURATION)`, letting Xcode do the substitution during the pre-processing of the `Info.plist` to replace it with the build settings's value
 - The `BuildConfiguration.current` implementation now relies on reading the value from that new `Info.plist` key, instead of relying on `#if` conditions

### What's Next

> [!IMPORTANT]
> Note that `BuildConfiguration.swift` is probably not the only code in `Modules/` that rely on `#if ALPHA`. I've at least noticed `Modules/Sources/Yosemite/Stores/JustInTimeMessageStore.swift` is also relying on it, and will thus also likely be broken since this is compiled as a separate module by SwiftPM. You'll have to find a similar solution for this one too, and any potential other occurrences of `#if` conditions in `Modules/`.

## Steps to reproduce

Run the prototype build of a previous PR and observe that anything that relied on the `BuildConfiguration.current` used `.appStore` value

## Testing information

Run the prototype build of the current PR and validate that anything that relies on the `BuildConfiguration.current` use `.alpha` value and not `.appStore` anymore in this Prototype Build context.

> [!WARNING]
> On my end I have only tested this by running the `WooCommerce Alpha` in Xcode with a breakpoint, but haven't checked the Prototype Build on the PR (as I don't have the knowledge on how to test this on a WCiOS Prototype Build running in a device, as I'm assuming it involves setting up a proxy to intercept API requests or something like that where the `BuildConfiguration.current` value might appear somewhere? So cc @jaclync I'll let you test this more thoroughly

---
- [x] ~~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~~