### PR TITLE
[Woo POS][Barcodes] Ignore empty scanner input

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
@@ -30,15 +30,12 @@ final class HIDBarcodeParser {
             return
         }
 
-        // If characters are entered too slowly, it's probably typing and we should ignore the old input.
-        // The key we just recieved is still considered for adding to the buffer – we may simply reset the buffer first.
-        checkForTimeoutBetweenKeystrokes()
-
         let character = key.characters
         if configuration.terminatingStrings.contains(character) {
             processScan()
         } else {
             guard !excludedKeys.contains(key.keyCode) else { return }
+            checkForTimeoutBetweenKeystrokes()
             buffer.append(character)
         }
     }
@@ -61,6 +58,8 @@ final class HIDBarcodeParser {
     }
 
     private func checkForTimeoutBetweenKeystrokes() {
+        // If characters are entered too slowly, it's probably typing and we should ignore the old input.
+        // The key we just recieved is still considered for adding to the buffer – we may simply reset the buffer first.
         let currentTime = timeProvider.now()
 
         if let lastTime = lastKeyPressTime,
@@ -164,6 +163,7 @@ final class HIDBarcodeParser {
     }
 
     private func processScan() {
+        checkForTimeoutBetweenKeystrokes()
         if buffer.count >= configuration.minimumBarcodeLength {
             onScan(.success(buffer))
         } else {

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
@@ -26,11 +26,7 @@ final class HIDBarcodeParser {
     /// Process a key press event
     /// - Parameter key: The key that was pressed
     func processKeyPress(_ key: UIKey) {
-        guard key.characters.isNotEmpty else {
-            // This was added to prevent a double-trigger-pull on a Star scanner from adding an error row –
-            // Star use this as a shortcut to switch to the software keyboard. They send keycode 174 0xAE,
-            // which is undefined and reserved in UIKeyboardHIDUsage. The scanner doesn't send a character with the code.
-            // There seems to be no reason to handle empty input when considering scans.
+        guard shouldRecogniseAsScanKeystroke(key) else {
             return
         }
 
@@ -52,6 +48,23 @@ final class HIDBarcodeParser {
             guard !excludedKeys.contains(key.keyCode) else { return }
             buffer.append(character)
         }
+    }
+
+    private func shouldRecogniseAsScanKeystroke(_ key: UIKey) -> Bool {
+        guard key.characters.isNotEmpty else {
+            // This prevents a double-trigger-pull on a Star scanner from adding an error row –
+            // Star use this as a shortcut to switch to the software keyboard. They send keycode 174 0xAE, which is
+            // undefined and reserved in UIKeyboardHIDUsage. The scanner doesn't send a character with the code.
+            // There seems to be no reason to handle empty input when considering scans.
+            return false
+        }
+
+        if buffer.isEmpty && configuration.terminatingStrings.contains(key.characters) {
+            // We prefer to show all partial scans, but if we just get an enter with no numbers, ignoring it makes testing easier
+            return false
+        }
+
+        return true
     }
 
     private let excludedKeys: [UIKeyboardHIDUsage] = [

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
@@ -30,16 +30,9 @@ final class HIDBarcodeParser {
             return
         }
 
-        let currentTime = timeProvider.now()
-
-        // If characters are entered too slowly, it's probably typing and we should ignore it
-        if let lastTime = lastKeyPressTime,
-           currentTime.timeIntervalSince(lastTime) > configuration.maximumInterCharacterTime {
-            onScan(.failure(HIDBarcodeParserError.timedOut(barcode: buffer)))
-            resetScan()
-        }
-
-        lastKeyPressTime = currentTime
+        // If characters are entered too slowly, it's probably typing and we should ignore the old input.
+        // The key we just recieved is still considered for adding to the buffer – we may simply reset the buffer first.
+        checkForTimeoutBetweenKeystrokes()
 
         let character = key.characters
         if configuration.terminatingStrings.contains(character) {
@@ -65,6 +58,18 @@ final class HIDBarcodeParser {
         }
 
         return true
+    }
+
+    private func checkForTimeoutBetweenKeystrokes() {
+        let currentTime = timeProvider.now()
+
+        if let lastTime = lastKeyPressTime,
+           currentTime.timeIntervalSince(lastTime) > configuration.maximumInterCharacterTime {
+            onScan(.failure(HIDBarcodeParserError.timedOut(barcode: buffer)))
+            resetScan()
+        }
+
+        lastKeyPressTime = currentTime
     }
 
     private let excludedKeys: [UIKeyboardHIDUsage] = [

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
@@ -26,6 +26,14 @@ final class HIDBarcodeParser {
     /// Process a key press event
     /// - Parameter key: The key that was pressed
     func processKeyPress(_ key: UIKey) {
+        guard key.characters.isNotEmpty else {
+            // This was added to prevent a double-trigger-pull on a Star scanner from adding an error row –
+            // Star use this as a shortcut to switch to the software keyboard. They send keycode 174 0xAE,
+            // which is undefined and reserved in UIKeyboardHIDUsage. The scanner doesn't send a character with the code.
+            // There seems to be no reason to handle empty input when considering scans.
+            return
+        }
+
         let currentTime = timeProvider.now()
 
         // If characters are entered too slowly, it's probably typing and we should ignore it

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/HIDBarcodeParser.swift
@@ -59,7 +59,7 @@ final class HIDBarcodeParser {
 
     private func checkForTimeoutBetweenKeystrokes() {
         // If characters are entered too slowly, it's probably typing and we should ignore the old input.
-        // The key we just recieved is still considered for adding to the buffer – we may simply reset the buffer first.
+        // The key we just received is still considered for adding to the buffer – we may simply reset the buffer first.
         let currentTime = timeProvider.now()
 
         if let lastTime = lastKeyPressTime,

--- a/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/HIDBarcodeParserTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/HIDBarcodeParserTests.swift
@@ -334,6 +334,65 @@ struct HIDBarcodeParserTests {
             Issue.record("Expected failure result")
         }
     }
+
+    @Test("Parser does not show an error row for empty scan")
+    func testEmptyScanDoesntError() {
+        var results: [Result<String, Error>] = []
+        let parser = HIDBarcodeParser(
+            configuration: testConfiguration,
+            onScan: { result in
+                results.append(result)
+            }
+        )
+
+        // Just send the terminator, no scan input
+        parser.processKeyPress(MockUIKey(character: "\r"))
+
+        #expect(results.isEmpty)
+    }
+
+    @Test("Parser does not start a timeout for an ignored character")
+    func testEmptyScanDoesntStartTimeoutForIgnoredCharacter() {
+        var results: [Result<String, Error>] = []
+        let mockTimeProvider = MockTimeProvider()
+        let parser = HIDBarcodeParser(
+            configuration: testConfiguration,
+            onScan: { result in
+                results.append(result)
+            },
+            timeProvider: mockTimeProvider
+        )
+
+        // Scan a barcode with two terminators, then scan another barcode – only the two codes should be parsed
+        parser.processKeyPress(MockUIKey(character: "1"))
+        parser.processKeyPress(MockUIKey(character: "2"))
+        parser.processKeyPress(MockUIKey(character: "3"))
+        parser.processKeyPress(MockUIKey(character: "\r")) // Scan is recognised here
+        parser.processKeyPress(MockUIKey(character: "\n", keyCode: .keyboardDownArrow)) // This is ignored
+
+        // Time between scans
+        mockTimeProvider.advance(by: 1.5)
+
+        // Scan the second barcode
+        parser.processKeyPress(MockUIKey(character: "4")) // Risk of an error row here if `\n` isn't ignored
+        parser.processKeyPress(MockUIKey(character: "5"))
+        parser.processKeyPress(MockUIKey(character: "6"))
+        parser.processKeyPress(MockUIKey(character: "\r"))
+        parser.processKeyPress(MockUIKey(character: "\n", keyCode: .keyboardDownArrow))
+
+
+        #expect(results.count == 2)
+        if case .success(let barcode1) = results[0] {
+            #expect(barcode1 == "123")
+        } else {
+            Issue.record("Expected success result for first scan")
+        }
+        if case .success(let barcode2) = results[1] {
+            #expect(barcode2 == "456")
+        } else {
+            Issue.record("Expected success result for second scan")
+        }
+    }
 }
 
 // MARK: - Test Helpers


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The Star scanner sends keycode 0xAE for a double trigger pull, used to switch between scanner and software keyboard. It doesn’t send a character, which seems like a good criterion to ignore input.

This PR stops us showing an error row for a double-pull on the trigger. @staskus – could you check whether this behaviour is also reproducible on the Inateck scanner please?

I've done this as a beta fix, but if you prefer we leave it to 22.8 I'm fine with that too.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and open POS
2. Connect a barcode scanner
3. Scan a barcode matching a product – confirm it's connected and working
4. Double pull the trigger – there should be no change in the app

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

I've also tested:
 - On the search screen, with the text field focused, double-pulling the trigger still switches between software keyboard and scanner input.
 - Partial input still shows an error row (easiest with an external keyboard and mashing keys)
 - Scanning other errors still work as normal

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/29116936-70ff-4bd1-b7da-d8242542ef3b


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
