### PR TITLE
[Shipping Labels] Remaining accessibility layout issues

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 22.8
 -----
 - [*] POS: icon button with confirmation step used for clearing the cart [https://github.com/woocommerce/woocommerce-ios/pull/15829]
+- [*] Shipping Labels: Fixed a portion of layout issues caused by bigger accessibility content size categories. [https://github.com/woocommerce/woocommerce-ios/pull/15844]
 
 22.7
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
@@ -212,7 +212,7 @@ private extension WooCarrierPackagesSelectionView {
             .padding(.horizontal, Layout.ctaPadding)
             Spacer()
         }
-
+        .scrollVerticallyIfNeeded()
     }
 
     func addPackageButtonTapped() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
@@ -202,10 +202,13 @@ private extension WooCarrierPackagesSelectionView {
             Text(Localization.emptyStateMessage)
                 .multilineTextAlignment(.center)
                 .bold()
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal)
             Button(Localization.createCustomPackageCTA) {
                 addingCustomPackageHandler()
             }
             .buttonStyle(PrimaryButtonStyle())
+            .fixedSize(horizontal: false, vertical: true)
             .padding(.horizontal, Layout.ctaPadding)
             Spacer()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooCarrierPackagesSelectionView.swift
@@ -136,6 +136,7 @@ struct WooCarrierPackagesSelectionView: View {
             Button(selectionButtonText) {
                 addPackageButtonTapped()
             }
+            .renderedIf(viewModel.carrierTabs.isNotEmpty)
             .disabled(selectionButtonDisabled)
             .if(viewModel.previousSelectedAndSelectedCarriersPackageAreSame) {
                 $0.buttonStyle(SecondaryButtonStyle())

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
@@ -214,7 +214,7 @@ private extension WooSavedPackagesSelectionView {
             .padding(.horizontal, Layout.ctaPadding)
             Spacer()
         }
-
+        .scrollVerticallyIfNeeded()
     }
 
     var selectionButtonDisabled: Bool {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
@@ -205,10 +205,12 @@ private extension WooSavedPackagesSelectionView {
             Text(Localization.emptyStateMessage)
                 .multilineTextAlignment(.center)
                 .bold()
+                .fixedSize(horizontal: false, vertical: true)
             Button(Localization.createCustomPackageCTA) {
                 addingCustomPackageHandler()
             }
             .buttonStyle(PrimaryButtonStyle())
+            .fixedSize(horizontal: false, vertical: true)
             .padding(.horizontal, Layout.ctaPadding)
             Spacer()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
@@ -157,6 +157,7 @@ struct WooSavedPackagesSelectionView: View {
                 addPackageButtonTapped()
             }
             .disabled(selectionButtonDisabled)
+            .renderedIf(viewModel.hasSavedPackages)
             .if(viewModel.previousSelectedAndSelectedSavedPackageAreSame) {
                 $0.buttonStyle(SecondaryButtonStyle())
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
@@ -3,6 +3,7 @@ import Yosemite
 
 struct WooShippingSplitShipmentsView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.sizeCategory) private var sizeCategory
 
     @ObservedObject var viewModel: ViewModel
 
@@ -17,7 +18,7 @@ struct WooShippingSplitShipmentsView: View {
 
     var body: some View {
         NavigationView {
-            VStack {
+            VStack(spacing: 0) {
                 if viewModel.shipments.count > 1 {
                     VStack(spacing: 0) {
                         topTabView
@@ -44,14 +45,20 @@ struct WooShippingSplitShipmentsView: View {
                                 CollapsibleShipmentItemCard(viewModel: item)
                             }
                         }
+
+                        if sizeCategory.isAccessibilityCategory {
+                            Spacer()
+                            noticeStack
+                        }
                     }
                     .padding(Layout.contentPadding)
                 }
 
-                Spacer()
-
-                noticeStack
-                    .padding(Layout.contentPadding)
+                if !sizeCategory.isAccessibilityCategory {
+                    Spacer()
+                    noticeStack
+                        .padding(Layout.contentPadding)
+                }
             }
             .disabled(viewModel.isSavingShipmentInfo)
             .navigationBarTitleDisplayMode(.inline)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsView.swift
@@ -275,6 +275,7 @@ private extension WooShippingSplitShipmentsView {
                                     Text(otherShipment.itemsDetailLabel)
                                 }
                                 .font(.subheadline)
+                                .frame(maxWidth: .infinity, alignment: .leading)
                             }
                         }
                         .padding(Layout.contentPadding)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -91,11 +91,6 @@ struct WooShippingEditAddressView: View {
                 previousFocusedField = newField
             }
             .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(Localization.cancel) {
-                        dismiss()
-                    }
-                }
                 ToolbarItemGroup(placement: .keyboard) {
                     Button(action: {
                         focusPreviousField()
@@ -118,36 +113,11 @@ struct WooShippingEditAddressView: View {
                     }
                 }
             }
-            .sheet(isPresented: $isPresentingCountrySelector) {
-                NavigationStack {
-                    FilterListSelector(viewModel: viewModel.countrySelectorVM)
-                        .navigationBarTitleDisplayMode(.inline)
-                        .toolbar {
-                            ToolbarItem(placement: .confirmationAction) {
-                                Button {
-                                    isPresentingCountrySelector = false
-                                } label: {
-                                    Text(Localization.done)
-                                        .bold()
-                                }
-                            }
-                        }
-                }
-            }
-            .sheet(isPresented: $isPresentingStateSelector) {
-                NavigationStack {
-                    FilterListSelector(viewModel: viewModel.stateSelectorVM)
-                        .navigationBarTitleDisplayMode(.inline)
-                        .toolbar {
-                            ToolbarItem(placement: .confirmationAction) {
-                                Button {
-                                    isPresentingStateSelector = false
-                                } label: {
-                                    Text(Localization.done)
-                                        .bold()
-                                }
-                            }
-                        }
+        }
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(Localization.cancel) {
+                    dismiss()
                 }
             }
         }
@@ -159,6 +129,38 @@ struct WooShippingEditAddressView: View {
         .sheet(item: $viewModel.normalizeAddressVM) { viewModel in
             NavigationStack {
                 WooShippingNormalizeAddressView(viewModel: viewModel)
+            }
+        }
+        .sheet(isPresented: $isPresentingCountrySelector) {
+            NavigationStack {
+                FilterListSelector(viewModel: viewModel.countrySelectorVM)
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button {
+                                isPresentingCountrySelector = false
+                            } label: {
+                                Text(Localization.done)
+                                    .bold()
+                            }
+                        }
+                    }
+            }
+        }
+        .sheet(isPresented: $isPresentingStateSelector) {
+            NavigationStack {
+                FilterListSelector(viewModel: viewModel.stateSelectorVM)
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button {
+                                isPresentingStateSelector = false
+                            } label: {
+                                Text(Localization.done)
+                                    .bold()
+                            }
+                        }
+                    }
             }
         }
         .alert(

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -20,6 +20,7 @@ struct WooShippingEditAddressView: View {
     @State private var previousFocusedField: WooShippingAddressFieldType?
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.sizeCategory) private var sizeCategory
 
     @State private var isPresentingCountrySelector: Bool = false
     @State private var isPresentingStateSelector: Bool = false
@@ -76,6 +77,10 @@ struct WooShippingEditAddressView: View {
                     Toggle(Localization.defaultAddress, isOn: $viewModel.isDefaultAddress)
                         .font(.subheadline)
                         .tint(Color(.accent))
+                }
+
+                if sizeCategory.isAccessibilityCategory {
+                    ctaFooter(isScrollViewEmbedded: true)
                 }
             }
             .padding()
@@ -147,33 +152,9 @@ struct WooShippingEditAddressView: View {
             }
         }
         .safeAreaInset(edge: .bottom) {
-            VStack(spacing: .zero) {
-                Divider().ignoresSafeArea(edges: [.horizontal])
-                VStack(spacing: Constants.verticalSpacing) {
-                    HStack {
-                        Image(systemName: viewModel.status == .verified ? "checkmark.circle" : "exclamationmark.circle")
-                        Text(viewModel.statusLabel)
-                    }
-                    .font(.subheadline)
-                    .foregroundStyle(viewModel.status == .verified ? Constants.green : Constants.red)
-                    Button(Localization.Button.label(for: viewModel.status)) {
-                        switch viewModel.status {
-                        case .verified:
-                            dismiss()
-                        case .unverified:
-                            Task { @MainActor in
-                                await viewModel.remotelyValidateAddress()
-                            }
-                        case .missingInformation:
-                            break
-                        }
-                    }
-                    .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isLoading))
-                    .disabled(viewModel.status == .missingInformation)
-                }
-                .padding()
+            if !sizeCategory.isAccessibilityCategory {
+                ctaFooter(isScrollViewEmbedded: false)
             }
-            .background(Color(uiColor: .systemBackground))
         }
         .sheet(item: $viewModel.normalizeAddressVM) { viewModel in
             NavigationStack {
@@ -204,6 +185,44 @@ struct WooShippingEditAddressView: View {
                 Text(viewModel.addressErrorState?.message ?? "")
             }
         )
+    }
+
+    private func ctaFooter(isScrollViewEmbedded: Bool) -> some View {
+        VStack(spacing: .zero) {
+            Divider()
+                .ignoresSafeArea(edges: [.horizontal])
+                .padding(
+                    /// When embedded in scroll view
+                    /// we use a negative value to neglect the parent padding for the divider
+                    isScrollViewEmbedded ? .horizontal : [],
+                    -Constants.defaultPadding
+                )
+
+            VStack(spacing: Constants.verticalSpacing) {
+                HStack {
+                    Image(systemName: viewModel.status == .verified ? "checkmark.circle" : "exclamationmark.circle")
+                    Text(viewModel.statusLabel)
+                }
+                .font(.subheadline)
+                .foregroundStyle(viewModel.status == .verified ? Constants.green : Constants.red)
+                Button(Localization.Button.label(for: viewModel.status)) {
+                    switch viewModel.status {
+                    case .verified:
+                        dismiss()
+                    case .unverified:
+                        Task { @MainActor in
+                            await viewModel.remotelyValidateAddress()
+                        }
+                    case .missingInformation:
+                        break
+                    }
+                }
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isLoading))
+                .disabled(viewModel.status == .missingInformation)
+            }
+            .padding(isScrollViewEmbedded ? .vertical : .all)
+        }
+        .background(Color(uiColor: .systemBackground))
     }
 
     private struct AddressTextField: View {
@@ -345,6 +364,7 @@ extension WooShippingEditAddressView {
 private extension WooShippingEditAddressView {
     enum Constants {
         static let verticalSpacing: CGFloat = 16
+        static let defaultPadding: CGFloat = 16
         static let innerSpacing: CGFloat = 8
         static let extraPadding: CGFloat = 24
         static let cornerRadius: CGFloat = 8

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -370,7 +370,11 @@ private extension WooShippingCreateLabelsView {
 
     /// View showing the origin ("Ship From") address.
     var shipFromAddress: some View {
-        HStack(alignment: .firstTextBaseline, spacing: Layout.bottomSheetSpacing) {
+        AdaptiveStack(
+            horizontalAlignment: .leading,
+            verticalAlignment: .firstTextBaseline,
+            spacing: Layout.bottomSheetSpacing
+        ) {
             Text(Localization.BottomSheet.shipFrom)
                 .trackSize(size: $shipmentDetailsShipFromSize)
 
@@ -379,7 +383,10 @@ private extension WooShippingCreateLabelsView {
                 AddressLinesView(addressLines: addressLines)
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else {
-                VStack(alignment: .leading) {
+                VStack(
+                    alignment: .leading,
+                    spacing: Layout.verticalSpacing
+                ) {
                     Button {
                         isOriginAddressListPresented = true
                     } label: {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -412,10 +412,17 @@ private extension WooShippingCreateLabelsView {
 
     /// View showing the destination ("Ship To") address.
     var shipToAddress: some View {
-        HStack(alignment: .firstTextBaseline, spacing: Layout.bottomSheetSpacing) {
+        AdaptiveStack(
+            horizontalAlignment: .leading,
+            verticalAlignment: .firstTextBaseline,
+            spacing: Layout.bottomSheetSpacing
+        ) {
             Text(Localization.BottomSheet.shipTo)
                 .frame(width: shipmentDetailsShipFromSize.width, alignment: .leading)
-            VStack(alignment: .leading) {
+            VStack(
+                alignment: .leading,
+                spacing: Layout.verticalSpacing
+            ) {
                 if let addressLines = viewModel.destinationAddressLines {
                     AddressLinesView(addressLines: addressLines)
                 }


### PR DESCRIPTION
WOOMOB-617

## Description
This is a follow up PR to fix remaining accessibility layout issues listed in doc: 1nxDAV51DK_l8opZ2ZznqaA3FpfiYPoWZPd38HA4TTys-gdoc

- Fixes the issue where "Missing information" notice + CTA button footer take too much vertical space when bigger accessibility font size is toggled. The notice and button footer content is extracted and conditionally placed in bottom safe are for normal font sizes and embedded into general scrolling container in case of bigger accessibility font size
- Fixes the issue where the destination address cell content was messed up for bigger font sizes. The content was redistributed vertically using `AdaptiveStackVIew`.
- Fixes the weird layout for empty state in "Carrier" and "Saved" package selection tabs. Text and button label made multiline.
- In split shipments view the the instruction notice and "selected" action pill were taking up too much space when bigger accessibility fonts were enabled. To fix that the notice + pill content was conditionally embedded into outer scrolling container.
- Fixed the issue with the stale keyboard "prev/next + done" accessory toolbar. Re-arranged `.toolbar` and `.sheet` modifiers so the toolbar items were applied to views only where if was needed.

## Testing steps

Consider testing on iOS Simulator for easier font size toggling.

- Go to a completed order with an unfulfilled shipment.
- Start editing the destination address. Delete information from one of required fields.
- Make sure the "Missing information" notice label is presented above bottom cta button.
- Scroll the sheet content and make sure the notice and the CTA button are attached to the bottom.
- Increase the font size up to max.
- Make sure the notice and CTA button are moved to the scroll view content bottom.

https://github.com/user-attachments/assets/18d01ebe-2e24-4e6d-945b-31fb9fea4755

- Go to a completed order with an unfulfilled shipment.
- Expand the "Shipment details" bottom sheet.
- Increase the font size up to max.
- Make sure the "Ship to" section content is vertically redistributed for larger fonts and looks OK.

https://github.com/user-attachments/assets/c5602d0c-31ea-4a52-bc19-7445ed4bf3a7

- For the package empty state checking I suggest to adjust code a bit:
    - Comment out the following lines in `WooCarrierPackagesSelectionView.swift`
    ```
    self.carrierPackages = carrierPackages
    self.carrierTabs = carrierTabs
    ```
    - Return `false` for `hasSavedPackages` in `WooSavedPackagesSelectionView.swift`
- Go to a completed order with an unfulfilled shipment.
- Navigate to a package selection
- For "Carrier" and "Saved" sections make sure the empty state content (label + button) are properly scaled for bigger fonts and don't have truncated wording.

https://github.com/user-attachments/assets/4605d7f8-5d6f-49a7-a7b2-4ea50164581b

- Go to a completed order with an unfulfilled shipment.
- Tap on "pencil" to start editing existing shipment (Split shipments)
- Select the unfulfilled shipment.
- Select an item.
- Make sure the instructions toast and the "N selected + move to" action pill is displayed.
- Make sure the instructions and action pill are attached to bottom.
- Increase the font size up to max.
- Make sure the content is properly scaled.
- Make sure the instructions and action pill are moved to the parent scrolling container for bigger accessibility font sizes.

https://github.com/user-attachments/assets/c0de20b5-1364-428f-b909-c6a2f3bb172f

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.