### PR TITLE
Attempt fixing watch app crash

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -358,6 +358,7 @@ enum XcodeSupport {
                 XcodeTargetNames.wooCommerceWatchApp,
                 dependencies: [
                     "WooFoundationCore",
+                    .product(name: "Alamofire", package: "Alamofire"),
                     .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
                     .product(name: "KeychainAccess", package: "KeychainAccess"),
                     .product(name: "Sentry", package: "sentry-cocoa"),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-614

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Thanks to @joshheald, we got the crash log for the crashes in the watch app in versions 22.5 and 22.6: 

```
{"code":1,"namespace":"DYLD","indicator":"Library missing","details":["(terminated at launch; ignore backtrace)"],"flags":518,"reasons":["Library not loaded: @rpath\/Alamofire_-213FC01918BCE467_PackageProduct.framework\/Alamofire_-213FC01918BCE467_PackageProduct","Referenced from: <D4E3C49D-923C-3CE9-975E-1814C25DFE26> \/Volumes\/VOLUME\/*\/Woo Watch App.app\/Frameworks\/NetworkingWatchOS.framework\/NetworkingWatchOS","Reason: tried: '\/private\/var\/containers\/Bundle\/Application\/00CC1AA8-D595-4FAD-92B3-2A92CBEF9691\/Woo Watch App.app\/Frameworks\/Alamofire_-213FC01918BCE467_PackageProduct.framework\/Alamofire_-213FC01918BCE467_PackageProduct' (no such file), '\/private\/var\/containers\/Bundle\/Application\/00CC1AA8-D595-4FAD-92B3-2A92CBEF9691\/Woo Watch App.app\/Frameworks\/Alamofire_-213FC01918BCE467_PackageProduct.framework\/Alamofire_-213FC01918BCE467_PackageProduct' (no such file), '\/private\/var\/containers\/Bundle\/Application\/00CC1AA8-D595-4FAD-92B3-2A92CBEF9691\/Woo Watch App.app\/Frameworks\/Alamofire_-213FC01918BCE467_PackageProduct.framework\/Alamofire_-213FC01918BCE467_PackageProduct' (no such file), '"]},
```

This looks like the Woo Watch App target is looking for the Alamofire library referenced in NetworkingWatchOS module, but it does not have the library embedded. 

This PR is my attempted fix by adding Alamofire as an explicit dependency for the Woo Watch App target. This is what we're already doing with the WooCommerce target, so I suppose it would solve the problem.

**Note**: I'm unsure why the app does not crash on 22.7 given that the watch app target [doesn't have Alamofile as its dependency](https://github.com/woocommerce/woocommerce-ios/blob/f65a3952f5da30396262d00af52c7b4f8198a475/Modules/Package.swift#L425-L434). Still, it should not hurt to backmerge this PR for safety.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Build and run the watch app to see that there is no compile or runtime issues.
- Try the prototype (alpha) build in the PR to ensure that it doesn't crash on the watch.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested and confirmed the fix with the prototype build with my phone and watch.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
