### PR TITLE
[POS Orders] Additional unit tests for `created_via`

### DIFF
--- a/Modules/Tests/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -48,6 +48,14 @@ final class OrdersRemoteTests: XCTestCase {
         XCTAssertFalse(fieldValues.contains(" "))
     }
 
+    func test_order_fields_parameter_includes_created_via_field() throws {
+        // When
+        let fieldValues = OrdersRemote.ParameterValues.fieldValues
+
+        // Then
+        XCTAssertTrue(fieldValues.contains("created_via"), "fieldValues should include 'created_via' field")
+    }
+
     // MARK: - Load All Orders Tests
 
     /// Verifies that loadAllOrders properly parses the `orders-load-all` sample response.

--- a/Modules/Tests/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -151,6 +151,36 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
         XCTAssertEqual(storageTaxLine.toReadOnly(), taxLine)
     }
 
+    func test_order_with_createdVia_field_when_upsert_to_storage_then_field_is_persisted_correctly() throws {
+        // Given
+        let order = makeOrder().copy(siteID: defaultSiteID, orderID: 123, createdVia: "pos-rest-api")
+        let useCase = OrdersUpsertUseCase(storage: viewStorage)
+
+        // When
+        useCase.upsert([order])
+
+        // Then
+        let persistedOrder = try XCTUnwrap(viewStorage.loadOrder(siteID: defaultSiteID, orderID: 123))
+        XCTAssertEqual(persistedOrder.createdVia, "pos-rest-api")
+        XCTAssertEqual(persistedOrder.toReadOnly().createdVia, "pos-rest-api")
+    }
+
+    func test_order_with_createdVia_field_when_updated_then_field_is_updated_correctly() throws {
+        // Given
+        let originalOrder = makeOrder().copy(siteID: defaultSiteID, orderID: 123, createdVia: nil)
+        let useCase = OrdersUpsertUseCase(storage: viewStorage)
+        useCase.upsert([originalOrder])
+
+        // When
+        let updatedOrder = originalOrder.copy(createdVia: "pos-rest-api")
+        useCase.upsert([updatedOrder])
+
+        // Then
+        let persistedOrder = try XCTUnwrap(viewStorage.loadOrder(siteID: defaultSiteID, orderID: 123))
+        XCTAssertEqual(persistedOrder.createdVia, "pos-rest-api")
+        XCTAssertEqual(persistedOrder.toReadOnly().createdVia, "pos-rest-api")
+    }
+
     func test_it_persists_order_item_attributes_in_storage() throws {
         // Given
         let attributes = [

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
@@ -85,7 +85,7 @@ struct OrderListCellViewModel {
 
         switch createdVia {
         case "pos-rest-api":
-            return "POS"
+            return Localization.salesChannelPOSText
         default:
             return nil
         }
@@ -113,18 +113,24 @@ struct OrderListCellViewModel {
 #endif
 }
 
-// MARK: - Constants
-
-private extension OrderListCellViewModel {
+extension OrderListCellViewModel {
     enum Localization {
         static func title(orderNumber: String, customerName: String) -> String {
-            let format = NSLocalizedString("#%@ %@", comment: "In Order List,"
+            let format = NSLocalizedString(
+                "orderlistcellviewmodel.cell.title",
+                value: "#%@ %@",
+                comment: "In Order List,"
                 + " the pattern to show the order number. For example, “#123456”."
                 + " The %@ placeholder is the order number.")
-
             return String.localizedStringWithFormat(format, orderNumber, customerName)
         }
-
-        static let guestName = NSLocalizedString("Guest", comment: "In Order List, the name of the billed person when there are no first and last name.")
+        static let guestName = NSLocalizedString(
+            "orderlistcellviewmodel.customerName.guestName",
+            value: "Guest",
+            comment: "In Order List, the name of the billed person when there are no first and last name.")
+        static let salesChannelPOSText = NSLocalizedString(
+            "orderlistcellviewmodel.salesChannel.salesChannelPOSText",
+            value: "POS",
+            comment: "In Order List, the acronym for 'Point of Sale' that is shown as a badge for certain orders.")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
@@ -61,4 +61,37 @@ final class OrderListCellViewModelTests: XCTestCase {
         XCTAssertEqual(accessoryView.image, expectedImage)
         XCTAssertEqual(accessoryView.tintColor, .tertiaryLabel)
     }
+
+    func test_salesChannel_when_createdVia_is_pos_rest_api_then_returns_POS() {
+        // Given
+        let order = MockOrders().sampleOrder().copy(createdVia: "pos-rest-api")
+
+        // When
+        let viewModel = OrderListCellViewModel(order: order, currencySettings: ServiceLocator.currencySettings)
+
+        // Then
+        XCTAssertEqual(viewModel.salesChannel, "POS")
+    }
+
+    func test_salesChannel_when_createdVia_is_nil_then_returns_nil() {
+        // Given
+        let order = MockOrders().sampleOrder().copy(createdVia: nil)
+
+        // When
+        let viewModel = OrderListCellViewModel(order: order, currencySettings: ServiceLocator.currencySettings)
+
+        // Then
+        XCTAssertNil(viewModel.salesChannel)
+    }
+
+    func test_salesChannel_when_createdVia_is_not_pos_rest_api_then_returns_nil() {
+        // Given
+        let order = MockOrders().sampleOrder().copy(createdVia: "checkout")
+
+        // When
+        let viewModel = OrderListCellViewModel(order: order, currencySettings: ServiceLocator.currencySettings)
+
+        // Then
+        XCTAssertNil(viewModel.salesChannel)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
@@ -70,7 +70,7 @@ final class OrderListCellViewModelTests: XCTestCase {
         let viewModel = OrderListCellViewModel(order: order, currencySettings: ServiceLocator.currencySettings)
 
         // Then
-        XCTAssertEqual(viewModel.salesChannel, "POS")
+        XCTAssertEqual(viewModel.salesChannel, OrderListCellViewModel.Localization.salesChannelPOSText)
     }
 
     func test_salesChannel_when_createdVia_is_nil_then_returns_nil() {


### PR DESCRIPTION
Continuation of WOOMOB-701

## Description
This PR adds additional unit testing to the usage of `created_via`. No functional changes have been added.

On a related note, I've tried the suggestion on https://github.com/woocommerce/woocommerce-ios/pull/15847/files#r2177500395 about extending the `Order` model, but I faced some build troubles which I'm still wondering about. More context here: p1751433227323889-slack-CGPNUU63E

## Testing information
No functional changes. CI should pass
