### PR TITLE
Shipping Labels: UPS flow bug fixes

### DIFF
--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
@@ -86,7 +86,11 @@ extension WooShippingPackagePurchase: Encodable {
         try container.encode(package.boxID, forKey: .boxID)
         try container.encode(package.length, forKey: .length)
         try container.encode(package.width, forKey: .width)
-        try container.encode(package.height, forKey: .height)
+
+        // workaround because 0 would cause an error for the API request
+        let packageHeight = package.height > 0 ? package.height : 0.25
+        try container.encode(packageHeight, forKey: .height)
+
         try container.encode(package.weight, forKey: .weight)
         try container.encode(package.isLetter, forKey: .isLetter)
         try container.encode(rate.shipmentID, forKey: .shipmentID)

--- a/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -364,13 +364,16 @@ final class WooShippingRemoteTests: XCTestCase {
         let remote = WooShippingRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "label/purchase/\(sampleOrderID)", filename: "wooshipping-purchase-success")
 
-        let package = WooShippingPackagePurchase.fake().copy(selectedRate: WooShippingSelectedRate(
-            rate: ShippingLabelCarrierRate.fake().copy(rate: 12.32),
-            adultSignatureRate: ShippingLabelCarrierRate.fake().copy(rate: 22.33),
-            carbonNeutralRate: ShippingLabelCarrierRate.fake().copy(rate: 18.02),
-            saturdayDeliveryRate: ShippingLabelCarrierRate.fake().copy(rate: 25.42),
-            additionalHandlingRate: ShippingLabelCarrierRate.fake().copy(rate: 20.01)
-        ))
+        let package = WooShippingPackagePurchase.fake().copy(
+            package: ShippingLabelPackageSelected.fake().copy(height: 0),
+            selectedRate: WooShippingSelectedRate(
+                rate: ShippingLabelCarrierRate.fake().copy(rate: 12.32),
+                adultSignatureRate: ShippingLabelCarrierRate.fake().copy(rate: 22.33),
+                carbonNeutralRate: ShippingLabelCarrierRate.fake().copy(rate: 18.02),
+                saturdayDeliveryRate: ShippingLabelCarrierRate.fake().copy(rate: 25.42),
+                additionalHandlingRate: ShippingLabelCarrierRate.fake().copy(rate: 20.01)
+            )
+        )
 
         // When
         let result: Result<[ShippingLabelPurchase], Error> = waitFor { promise in
@@ -405,6 +408,7 @@ final class WooShippingRemoteTests: XCTestCase {
 
         let packagesParam = try XCTUnwrap(request.parameters["packages"] as? [[String: Any]])
         let firstPackage = try XCTUnwrap(packagesParam.first)
+        XCTAssertEqual(firstPackage["height"] as? Double, 0.25)
         XCTAssertEqual(firstPackage["signature"] as? String, "adult")
         XCTAssertEqual(firstPackage["carbon_neutral"] as? Bool, true)
         XCTAssertEqual(firstPackage["saturday_delivery"] as? Bool, true)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -174,10 +174,18 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
     ///
     @MainActor
     func refreshPackagesAndShippingRates() async throws {
-        guard let selectedRate, let selectedPackage, let updatedPackage = try await refreshSelectedPackage(from: selectedPackage) else {
+        let currentShipmentWeight = shipmentWeight
+
+        guard let selectedRate, let selectedPackage,
+              let updatedPackage = try await refreshSelectedPackage(from: selectedPackage) else {
             throw WooShippingLabelPurchaseError.failedToRefreshSelectedPackage
         }
         self.selectedPackage = updatedPackage
+
+        /// If the shipment weight was manually entered, reuse it.
+        if currentShipmentWeight != shipmentWeight {
+            self.shipmentWeight = currentShipmentWeight
+        }
 
         let finalPackage = buildSelectedPackage(updatedPackage,
                                                 weight: Double(shipmentWeight) ?? 0,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -369,7 +369,22 @@ private extension WooShippingShipmentDetailsViewModel {
                         selectedRate.signatureRate.map { self.formatShippingRate(name: Localization.signatureRequired, rate: $0.rate, basedOn: baseRate) },
                         selectedRate.adultSignatureRate.map { self.formatShippingRate(name: Localization.adultSignatureRequired,
                                                                                       rate: $0.rate,
-                                                                                      basedOn: baseRate) }
+                                                                                      basedOn: baseRate) },
+                        selectedRate.carbonNeutralRate.map {
+                            self.formatShippingRate(name: Localization.carbonNeutral,
+                                                    rate: $0.rate,
+                                                    basedOn: baseRate)
+                        },
+                        selectedRate.additionalHandlingRate.map {
+                            self.formatShippingRate(name: Localization.additionalHandling,
+                                                    rate: $0.rate,
+                                                    basedOn: baseRate)
+                        },
+                        selectedRate.saturdayDeliveryRate.map {
+                            self.formatShippingRate(name: Localization.saturdayDelivery,
+                                                    rate: $0.rate,
+                                                    basedOn: baseRate)
+                        }
                     ].compacted()
                     return [formattedBaseRate] + formattedSignatureRate
                 } else {
@@ -499,5 +514,23 @@ private extension WooShippingShipmentDetailsViewModel {
                                                               value: "Adult Signature Required",
                                                               comment: "Label for row showing the additional cost to require an adult signature " +
                                                               "on the shipping label creation screen")
+        static let carbonNeutral = NSLocalizedString(
+            "wooShipping.createLabels.bottomSheet.carbonNeutral",
+            value: "Carbon Neutral",
+            comment: "Label for row showing the additional cost to require carbon neutral delivery " +
+            "on the shipping label creation screen"
+        )
+        static let additionalHandling = NSLocalizedString(
+            "wooShipping.createLabels.bottomSheet.additionalHandling",
+            value: "Additional Handling",
+            comment: "Label for row showing the additional cost to require additional handling " +
+            "on the shipping label creation screen"
+        )
+        static let saturdayDelivery = NSLocalizedString(
+            "wooShipping.createLabels.bottomSheet.saturdayDelivery",
+            value: "Saturday Delivery",
+            comment: "Label for row showing the additional cost to require Saturday delivery " +
+            "on the shipping label creation screen"
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -410,11 +410,7 @@ private extension WooShippingShipmentDetailsViewModel {
             .combineLatest(
                 $selectedPackage.removeDuplicates(by: { $0?.id == $1?.id })
             )
-            .combineLatest(
-                $shipmentWeight
-                    .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
-                    .removeDuplicates()
-            )
+            .combineLatest($shipmentWeight.removeDuplicates())
             .combineLatest($hazmatCategory.removeDuplicates())
             .combineLatest($customsForm.removeDuplicates())
             // Drop the initial values set on initialization, so we only react to changes.
@@ -509,7 +505,11 @@ private extension WooShippingShipmentDetailsViewModel {
             comment: "Button to undo a change on the shipping label creation screen"
         )
         static func baseRateLabel(for selectedRate: WooShippingSelectedRate) -> String {
-            if selectedRate.signatureRate == nil && selectedRate.adultSignatureRate == nil {
+            if selectedRate.signatureRate == nil &&
+                selectedRate.adultSignatureRate == nil &&
+                selectedRate.carbonNeutralRate == nil &&
+                selectedRate.additionalHandlingRate == nil &&
+                selectedRate.saturdayDeliveryRate == nil {
                 return selectedRate.rate.title
             } else {
                 return String.localizedStringWithFormat(baseFeeFormat, selectedRate.rate.title)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -373,7 +373,7 @@ private extension WooShippingShipmentDetailsViewModel {
                 } else if let selectedRate {
                     let baseRate = selectedRate.rate.rate
                     let formattedBaseRate = self.formatShippingRate(name: Localization.baseRateLabel(for: selectedRate), rate: baseRate)
-                    let formattedSignatureRate = [
+                    let formattedAdditionalRates = [
                         selectedRate.signatureRate.map { self.formatShippingRate(name: Localization.signatureRequired, rate: $0.rate, basedOn: baseRate) },
                         selectedRate.adultSignatureRate.map { self.formatShippingRate(name: Localization.adultSignatureRequired,
                                                                                       rate: $0.rate,
@@ -394,7 +394,7 @@ private extension WooShippingShipmentDetailsViewModel {
                                                     basedOn: baseRate)
                         }
                     ].compacted()
-                    return [formattedBaseRate] + formattedSignatureRate
+                    return [formattedBaseRate] + formattedAdditionalRates
                 } else {
                     return []
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -405,12 +405,18 @@ private extension WooShippingShipmentDetailsViewModel {
     /// Observes changes in shipment details and resets the selected rate.
     /// This is to prevent displaying a stale price when critical details that affect pricing have changed.
     func setupSelectedRateReset() {
-        $destinationAddress
-            .combineLatest($originAddress)
-            .combineLatest($selectedPackage)
-            .combineLatest($shipmentWeight)
-            .combineLatest($hazmatCategory)
-            .combineLatest($customsForm)
+        $destinationAddress.removeDuplicates()
+            .combineLatest($originAddress.removeDuplicates())
+            .combineLatest(
+                $selectedPackage.removeDuplicates(by: { $0?.id == $1?.id })
+            )
+            .combineLatest(
+                $shipmentWeight
+                    .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
+                    .removeDuplicates()
+            )
+            .combineLatest($hazmatCategory.removeDuplicates())
+            .combineLatest($customsForm.removeDuplicates())
             // Drop the initial values set on initialization, so we only react to changes.
             .dropFirst()
             .sink { [weak self] _ in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
@@ -131,6 +131,35 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.shippingRates[1].amount, "$6.90")
     }
 
+    func test_selecting_extra_shipping_rate_sets_expected_shippingRates() throws {
+        // Given
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleDestinationAddress(country: "US", state: "CA"))
+
+        // When
+        let viewModel = WooShippingShipmentDetailsViewModel(order: Order.fake(),
+                                                            shipment: sampleShipment,
+                                                            shippingLabel: nil,
+                                                            originAddress: originAddressSubject.eraseToAnyPublisher(),
+                                                            destinationAddress: destinationAddressSubject.eraseToAnyPublisher())
+
+        // When
+        viewModel.shippingService?.onSelectRate?(sampleSelectedRate(carbonNeutral: true,
+                                                                    saturdayDelivery: true,
+                                                                    additionalHandling: true))
+
+        // Then
+        XCTAssertEqual(viewModel.shippingRates.count, 4)
+        XCTAssertEqual(viewModel.shippingRates[0].title, "USPS - Parcel Select Mail (base fee)")
+        XCTAssertEqual(viewModel.shippingRates[0].amount, "$40.06")
+        XCTAssertEqual(viewModel.shippingRates[1].title, "Carbon Neutral")
+        XCTAssertEqual(viewModel.shippingRates[1].amount, "$5.50")
+        XCTAssertEqual(viewModel.shippingRates[2].title, "Additional Handling")
+        XCTAssertEqual(viewModel.shippingRates[2].amount, "$3.75")
+        XCTAssertEqual(viewModel.shippingRates[3].title, "Saturday Delivery")
+        XCTAssertEqual(viewModel.shippingRates[3].amount, "$8.25")
+    }
+
     @MainActor
     func test_purchaseLabel_sets_postPurchase_with_purchased_shipping_label() async throws {
         // Given
@@ -603,6 +632,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
             rate: 20.11,
             serviceID: "test_rate"
         )
+        viewModel.shipmentWeight = "1.5"
         viewModel.shippingService?.onSelectRate?(WooShippingSelectedRate(rate: rate))
 
         // Confidence check
@@ -641,6 +671,7 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
         try await viewModel.refreshPackagesAndShippingRates()
 
         // Then
+        XCTAssertEqual(viewModel.shipmentWeight, "1.5") // shipment weight is persisted if manually entered
         XCTAssertEqual(viewModel.selectedPackage?.name, updatedPackage.name)
         XCTAssertEqual(viewModel.selectedRate?.rate.rate, expectedRate.rate)
     }
@@ -805,50 +836,29 @@ private extension WooShippingShipmentDetailsViewModelTests {
                            postcode: "12345")
     }
 
-    func sampleSelectedRate(with signatureRequirement: WooShippingServiceCardViewModel.SignatureRequirement = .none) -> WooShippingSelectedRate {
-        WooShippingSelectedRate(rate: ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
-                                                               insurance: "100",
-                                                               retailRate: 40.06,
-                                                               rate: 40.06,
-                                                               rateID: "rate_a8a29d5f34984722942f466c30ea27eh",
-                                                               serviceID: "",
-                                                               carrierID: "usps",
-                                                               shipmentID: "",
-                                                               hasTracking: true,
-                                                               isSelected: false,
-                                                               isPickupFree: true,
-                                                               deliveryDays: 2,
-                                                               deliveryDateGuaranteed: false),
-                                signatureRate: signatureRequirement == .signatureRequired ?
-                                    ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
-                                                             insurance: "100",
-                                                             retailRate: 42.76,
-                                                             rate: 42.76,
-                                                             rateID: "rate_a8a29d5f34984722942f466c30ea27ei",
-                                                             serviceID: "",
-                                                             carrierID: "usps",
-                                                             shipmentID: "",
-                                                             hasTracking: true,
-                                                             isSelected: false,
-                                                             isPickupFree: true,
-                                                             deliveryDays: 2,
-                                                             deliveryDateGuaranteed: false) : nil,
-                                adultSignatureRate: signatureRequirement == .adultSignatureRequired ?
-                                    ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
-                                                             insurance: "100",
-                                                             retailRate: 46.96,
-                                                             rate: 46.96,
-                                                             rateID: "rate_a8a29d5f34984722942f466c30ea27ej",
-                                                             serviceID: "",
-                                                             carrierID: "usps",
-                                                             shipmentID: "",
-                                                             hasTracking: true,
-                                                             isSelected: false,
-                                                             isPickupFree: true,
-                                                             deliveryDays: 2,
-                                                             deliveryDateGuaranteed: false) : nil,
-                                carbonNeutralRate: nil,
-                                saturdayDeliveryRate: nil,
-                                additionalHandlingRate: nil)
+    func sampleSelectedRate(with signatureRequirement: WooShippingServiceCardViewModel.SignatureRequirement = .none,
+                           carbonNeutral: Bool = false,
+                           saturdayDelivery: Bool = false,
+                           additionalHandling: Bool = false) -> WooShippingSelectedRate {
+        WooShippingSelectedRate(
+            rate: ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+                                           insurance: "100",
+                                           retailRate: 40.06,
+                                           rate: 40.06,
+                                           rateID: "rate_a8a29d5f34984722942f466c30ea27eh",
+                                           serviceID: "",
+                                           carrierID: "usps",
+                                           shipmentID: "",
+                                           hasTracking: true,
+                                           isSelected: false,
+                                           isPickupFree: true,
+                                           deliveryDays: 2,
+                                           deliveryDateGuaranteed: false),
+            signatureRate: signatureRequirement == .signatureRequired ? ShippingLabelCarrierRate.fake().copy(rate: 42.76) : nil,
+            adultSignatureRate: signatureRequirement == .adultSignatureRequired ? ShippingLabelCarrierRate.fake().copy(rate: 46.96) : nil,
+            carbonNeutralRate: carbonNeutral ? ShippingLabelCarrierRate.fake().copy(rate: 45.56) : nil,
+            saturdayDeliveryRate: saturdayDelivery ? ShippingLabelCarrierRate.fake().copy(rate: 48.31) : nil,
+            additionalHandlingRate: additionalHandling ? ShippingLabelCarrierRate.fake().copy(rate: 43.81) : nil
+        )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-728

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a couple of bug fixes for the UPS flow:
- Fixes the issue of purchasing packages without height. The last fix in #15812 only fixed the display and loading rates for such packages, but the purchasing still fails. The same workaround for a zero height needs to be applied to the encoding of the purchased package as well.
- Fixes the issue with purchasing a label with zero weight for the items and selected packages after accepting TOS. The manually entered weight is now persisted and used when refreshing the selected package.
- Optimizes the reset of selected rates to avoid accidentally triggering the reset when the same data is selected.
- Displays the extra rates in the label cost section.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Log in to a test store with the Woo Shipping extension set up.
- Create an order with a product that has zero weight.
- Complete the order, then open the order from the Orders tab.
- Select Create shipping label > Add a package > switch the UPS tab > select UPS letter.
- Manually enter the weight of the package to load shipping rates.
- Select a service then pick one or more extra rates: signature requirements, carbon neutral, additional handling, or Saturday delivery.
- Open the Shipment details bottom sheet and confirm that all the selected rates are displayed with correct pricing.
- Select an origin address that you haven't used to agree to the TOS with UPS.
- Proceed to purchase a label. Accept the TOS and try again.
- Confirm that the purchase succeeds.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Tested and confirmed with simulator iPhone 16 iOS 18.4.
- Added unit tests to verify the new changes.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/e57b5ecd-da18-46d2-b3e4-f1905ca66209



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
