### PR TITLE
[POS as a tab i2] Refactor `SelectedSiteSettings` to replace `AsyncStream` with `CurrentValueSubject` publisher for more reliable subscription

### DIFF
--- a/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
+++ b/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import Yosemite
 import protocol Storage.StorageManagerType
@@ -20,7 +21,7 @@ enum SettingsUpdateSource {
 
 /// Protocol for accessing, refreshing, and observing site settings.
 protocol SelectedSiteSettingsProtocol {
-    var settingsStream: AsyncStream<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource)> { get }
+    var settingsStream: AnyPublisher<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource), Never> { get }
     var siteSettings: [SiteSetting] { get }
     func refresh()
 }
@@ -31,9 +32,11 @@ final class SelectedSiteSettings: NSObject, SelectedSiteSettingsProtocol {
     private let stores: StoresManager
     private let storageManager: StorageManagerType
 
-    /// Async stream for observing site settings changes.
-    private let settingsContinuation: AsyncStream<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource)>.Continuation
-    public let settingsStream: AsyncStream<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource)>
+    /// CurrentValueSubject for observing site settings changes with current value behavior.
+    private let settingsSubject = CurrentValueSubject<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource)?, Never>(nil)
+    public var settingsStream: AnyPublisher<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource), Never> {
+        settingsSubject.compactMap { $0 }.eraseToAnyPublisher()
+    }
 
     /// ResultsController: Whenever settings change, I will change. We both change. The world changes.
     ///
@@ -48,19 +51,8 @@ final class SelectedSiteSettings: NSObject, SelectedSiteSettingsProtocol {
         self.stores = stores
         self.storageManager = storageManager
 
-        // Sets up async stream with buffering to ensure current value is sent.
-        let (stream, continuation) = AsyncStream<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource)>.makeStream(
-            bufferingPolicy: .bufferingNewest(1)
-        )
-        self.settingsStream = stream
-        self.settingsContinuation = continuation
-
         super.init()
         configureResultsController()
-    }
-
-    deinit {
-        settingsContinuation.finish()
     }
 }
 
@@ -85,7 +77,7 @@ extension SelectedSiteSettings {
                 DDLogError("Error: no siteID found when setting site settings results.")
                 return
             }
-            settingsContinuation.yield((siteID: siteID, settings: siteSettings, source: .storageChange))
+            settingsSubject.send((siteID: siteID, settings: siteSettings, source: .storageChange))
         }
         refreshResultsPredicate(source: .initialLoad)
     }
@@ -106,7 +98,7 @@ extension SelectedSiteSettings {
             ServiceLocator.currencySettings.updateCurrencyOptions(with: $0)
         }
 
-        settingsContinuation.yield((siteID: siteID, settings: fetchedObjects, source: source))
+        settingsSubject.send((siteID: siteID, settings: fetchedObjects, source: source))
 
         NotificationCenter.default.post(name: .selectedSiteSettingsRefreshed, object: nil)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import UIKit
 import class WooFoundation.CurrencySettings
@@ -47,7 +48,6 @@ protocol POSEntryPointEligibilityCheckerProtocol {
 final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
     private var siteSettingsEligibility: POSEligibilityState?
     private var featureFlagEligibility: POSEligibilityState?
-    private var siteSettingsTask: Task<[SiteSetting], Never>?
 
     private let siteID: Int64
     private let userInterfaceIdiom: UIUserInterfaceIdiom
@@ -239,28 +239,14 @@ private extension POSTabEligibilityChecker {
     }
 
     func waitForSiteSettingsRefresh() async -> [SiteSetting] {
-        // Uses a shared task so that multiple calls can await the same result since site settings can be emitted only once.
-        if let existingTask = siteSettingsTask {
-            return await existingTask.value
-        }
-
-        let task = Task<[SiteSetting], Never> { [weak self] in
-            guard let self else { return [] }
-
-            for await siteSettings in siteSettings.settingsStream {
-                guard siteSettings.siteID == self.siteID, siteSettings.settings.isNotEmpty, siteSettings.source != .initialLoad else {
-                    continue
-                }
-                siteSettingsTask = nil
-                return siteSettings.settings
+        for await siteSettings in siteSettings.settingsStream.values {
+            guard siteSettings.siteID == siteID, siteSettings.settings.isNotEmpty, siteSettings.source != .initialLoad else {
+                continue
             }
-            // If we get here, the stream completed without yielding any values for our site ID which is unexpected.
-            siteSettingsTask = nil
-            return []
+            return siteSettings.settings
         }
-
-        siteSettingsTask = task
-        return await task.value
+        // If we get here, the stream completed without yielding any values for our site ID which is unexpected.
+        return []
     }
 
     func isEligibleFromCountryAndCurrencyCode(countryCode: CountryCode, currencyCode: CurrencyCode) -> POSEligibilityState {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import Testing
 import WooFoundation
@@ -314,29 +315,20 @@ struct POSTabEligibilityCheckerTests {
 
         // Initial settings (cached) - makes site eligible (US)
         let initialSettings = [
-            SiteSetting.fake().copy(
-                siteID: siteID, settingID: "woocommerce_default_country", value: Country.us.rawValue, settingGroupKey: SiteSettingGroup.general.rawValue
-            ),
-            SiteSetting.fake().copy(
-                siteID: siteID, settingID: "woocommerce_currency", value: CurrencyCode.USD.rawValue, settingGroupKey: SiteSettingGroup.general.rawValue
-            )
+            mockCountrySetting(country: .us),
+            mockCurrencySetting(currency: .USD)
         ]
         // New settings - makes site ineligible (Canada).
         let newSettings = [
-            SiteSetting.fake().copy(
-                siteID: siteID, settingID: "woocommerce_default_country", value: Country.ca.rawValue, settingGroupKey: SiteSettingGroup.general.rawValue
-            ),
-            SiteSetting.fake().copy(
-                siteID: siteID, settingID: "woocommerce_currency", value: CurrencyCode.USD.rawValue, settingGroupKey: SiteSettingGroup.general.rawValue
-            )
+            mockCountrySetting(country: .ca),
+            mockCurrencySetting(currency: .USD)
         ]
-        siteSettings.mockSettingsStream = AsyncStream { continuation in
+        siteSettings.mockSettingsStream = [
             // Emits cached settings first (should be skipped).
-            continuation.yield((siteID: siteID, settings: initialSettings, source: .initialLoad))
+            (siteID: siteID, settings: initialSettings, source: .initialLoad),
             // Emits new settings (should be used for eligibility check).
-            continuation.yield((siteID: siteID, settings: newSettings, source: .storageChange))
-            continuation.finish()
-        }
+            (siteID: siteID, settings: newSettings, source: .storageChange)
+        ].publisher.eraseToAnyPublisher()
 
         accountWhitelistedInBackend(true)
         let checker = POSTabEligibilityChecker(siteID: siteID,
@@ -360,32 +352,23 @@ struct POSTabEligibilityCheckerTests {
 
         // Settings for a different site.
         let wrongSiteSettings = [
-            SiteSetting.fake().copy(
-                siteID: 999, settingID: "woocommerce_default_country", value: Country.ca.rawValue, settingGroupKey: SiteSettingGroup.general.rawValue
-            ),
-            SiteSetting.fake().copy(
-                siteID: 999, settingID: "woocommerce_currency", value: CurrencyCode.CAD.rawValue, settingGroupKey: SiteSettingGroup.general.rawValue
-            )
+            mockCountrySetting(country: .ca, siteID: 999),
+            mockCurrencySetting(currency: .CAD, siteID: 999)
         ]
         // Settings for correct site.
         let correctSiteSettings = [
-            SiteSetting.fake().copy(
-                siteID: siteID, settingID: "woocommerce_default_country", value: Country.us.rawValue, settingGroupKey: SiteSettingGroup.general.rawValue
-            ),
-            SiteSetting.fake().copy(
-                siteID: siteID, settingID: "woocommerce_currency", value: CurrencyCode.USD.rawValue, settingGroupKey: SiteSettingGroup.general.rawValue
-            )
+            mockCountrySetting(country: .us),
+            mockCurrencySetting(currency: .USD)
         ]
 
-        siteSettings.mockSettingsStream = AsyncStream { continuation in
+        siteSettings.mockSettingsStream = [
             // Emits settings for a different site (should be filtered out).
-            continuation.yield((siteID: 999, settings: wrongSiteSettings, source: .storageChange))
+            (siteID: 999, settings: wrongSiteSettings, source: .storageChange),
             // Emits first settings for correct site (should be skipped).
-            continuation.yield((siteID: siteID, settings: [SiteSetting.fake().copy(siteID: siteID, settingID: "temp")], source: .initialLoad))
+            (siteID: siteID, settings: [SiteSetting.fake().copy(siteID: siteID, settingID: "temp")], source: .initialLoad),
             // Emits fresh settings for correct site (should be used).
-            continuation.yield((siteID: siteID, settings: correctSiteSettings, source: .storageChange))
-            continuation.finish()
-        }
+            (siteID: siteID, settings: correctSiteSettings, source: .storageChange)
+        ].publisher.eraseToAnyPublisher()
 
         accountWhitelistedInBackend(true)
         let checker = POSTabEligibilityChecker(siteID: siteID,
@@ -556,31 +539,54 @@ struct POSTabEligibilityCheckerTests {
         #expect(visibilityResult == true)
         #expect(eligibilityResult == .eligible)
     }
+
+    @Test func checkVisibility_and_checkEligibility_return_expected_result_after_site_settings_available() async throws {
+        // Given - no site settings are immediately available (empty stream that will emit values later)
+        let featureFlagService = MockFeatureFlagService(isPointOfSaleAsATabi2Enabled: true)
+        accountWhitelistedInBackend(true)
+
+        // Creates a publisher that will emit values after a delay to simulate site settings loading
+        let countrySetting = mockCountrySetting(country: .us)
+        let currencySetting = mockCurrencySetting(currency: .USD)
+        let settingsSubject = PassthroughSubject<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource), Never>()
+        siteSettings.mockSettingsStream = settingsSubject.eraseToAnyPublisher()
+
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               userInterfaceIdiom: .pad,
+                                               siteSettings: siteSettings,
+                                               pluginsService: pluginsService,
+                                               stores: stores,
+                                               featureFlagService: featureFlagService)
+
+        // When - Call checkVisibility and checkEligibility concurrently before site settings are available
+        async let visibilityTask = checker.checkVisibility()
+        async let eligibilityTask = checker.checkEligibility()
+
+        // Simulate site settings becoming available after methods are called
+        Task {
+            settingsSubject.send((siteID: siteID, settings: [countrySetting, currencySetting], source: .refresh))
+            settingsSubject.send(completion: .finished)
+        }
+
+        let visibilityResult = await visibilityTask
+        let eligibilityResult = await eligibilityTask
+
+        // Then - both methods should wait for site settings and return expected results.
+        #expect(visibilityResult == true)
+        #expect(eligibilityResult == .eligible)
+    }
 }
 
 private extension POSTabEligibilityCheckerTests {
     func setupCountry(country: Country, currency: CurrencyCode = .USD) {
-        let countrySetting = SiteSetting.fake()
-            .copy(
-                siteID: siteID,
-                settingID: "woocommerce_default_country",
-                value: country.rawValue,
-                settingGroupKey: SiteSettingGroup.general.rawValue
-            )
-        let currencySetting = SiteSetting.fake()
-            .copy(
-                siteID: siteID,
-                settingID: "woocommerce_currency",
-                value: currency.rawValue,
-                settingGroupKey: SiteSettingGroup.general.rawValue
-            )
-        siteSettings.mockSettingsStream = AsyncStream { continuation in
+        let countrySetting = mockCountrySetting(country: country)
+        let currencySetting = mockCurrencySetting(currency: currency)
+        siteSettings.mockSettingsStream = [
             // Emits cached settings first (should be skipped).
-            continuation.yield((siteID: siteID, settings: [], source: .storageChange))
+            (siteID: siteID, settings: [], source: .storageChange),
             // Emits fresh settings (should be used for eligibility check).
-            continuation.yield((siteID: siteID, settings: [countrySetting, currencySetting], source: .refresh))
-            continuation.finish()
-        }
+            (siteID: siteID, settings: [countrySetting, currencySetting], source: .refresh)
+        ].publisher.eraseToAnyPublisher()
     }
 
     func setupWooCommerceVersion(_ version: String = "9.6.0-beta") {
@@ -622,6 +628,26 @@ private extension POSTabEligibilityCheckerTests {
         case gb = "GB"
         case es = "ES"
     }
+
+    func mockCountrySetting(country: Country, siteID: Int64? = nil) -> SiteSetting {
+        SiteSetting.fake()
+            .copy(
+                siteID: siteID ?? siteID,
+                settingID: "woocommerce_default_country",
+                value: country.rawValue,
+                settingGroupKey: SiteSettingGroup.general.rawValue
+            )
+    }
+
+    func mockCurrencySetting(currency: CurrencyCode, siteID: Int64? = nil) -> SiteSetting {
+        SiteSetting.fake()
+            .copy(
+                siteID: siteID ?? siteID,
+                settingID: "woocommerce_currency",
+                value: currency.rawValue,
+                settingGroupKey: SiteSettingGroup.general.rawValue
+            )
+    }
 }
 
 private final class MockPluginsService: PluginsServiceProtocol {
@@ -633,11 +659,11 @@ private final class MockPluginsService: PluginsServiceProtocol {
 }
 
 private final class MockSelectedSiteSettings: SelectedSiteSettingsProtocol {
-    var mockSettingsStream: AsyncStream<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource)>?
+    var mockSettingsStream: AnyPublisher<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource), Never>?
     var siteSettings: [SiteSetting] = []
 
-    var settingsStream: AsyncStream<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource)> {
-        return mockSettingsStream ?? AsyncStream { _ in }
+    var settingsStream: AnyPublisher<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource), Never> {
+        return mockSettingsStream ?? Empty().eraseToAnyPublisher()
     }
 
     func refresh() {


### PR DESCRIPTION
For WOOMOB-724

## Why

The POS eligibility checker does not trigger the site settings remote sync, but relies on other parts of the app that trigger the site settings sync during site initialization through `SelectedSiteSettings.settingsStream` which is an `AsyncStream`.

After developing i1 and i2 for a few weeks now, some issues surfaced from the use of `AsyncStream` in `SelectedSiteSettings` especially for the i2 use case. There's no easy way to emit the latest value to every subscriber similar to how CurrentValueSubject in Combine works, and each value in the stream can only be consumed once i.e. it does not support multiple subscribers. As the app can check POS visibility once and eligibility any number of times at any time, both depending on the site settings, `AsyncStream` or anything available natively in Swift concurrency that I've looked does not meet the use case requirements. There are a few posts in online forums about `AsyncStream multiple consumers` but there are no native solutions yet.

## How

Refactors `SelectedSiteSettings.settingsStream` from `AsyncStream` to Combine `AnyPublisher` with `CurrentValueSubject` behavior to enable multiple stream consumers with current value support. The subscription remains async/await using the [publisher's native `values: AsyncPublisher`](https://developer.apple.com/documentation/combine/publisher/values-1dm9r).

### Changes Made
- **SelectedSiteSettings**: Replaced `AsyncStream` with `AnyPublisher<(siteID: Int64, settings: [SiteSetting], source: SettingsUpdateSource), Never>` using `CurrentValueSubject` internally
- **POSTabEligibilityChecker**: Updated to use `.values` on the publisher for async iteration with Combine import
- **POSTabEligibilityCheckerTests**: 
  - Updated mock implementations to use `AnyPublisher` instead of `AsyncStream`
  - Added test case for concurrent `checkVisibility`/`checkEligibility` calls before site settings are available
  - Added helper functions `mockCountrySetting` and `mockCurrencySetting` to reduce test code duplication

### Technical Details
- Uses `CurrentValueSubject` internally with `compactMap { $0 }` to filter out nil initial values
- Ensures subscribers always receive the current value when they subscribe
- Supports multiple concurrent subscribers without value loss

## Test plan

Prerequisite: have a store that is eligible for POS

- Log out and in to a store eligible for POS --> the POS tab should appear after a bit
- Tap on the POS tab --> POS should be launched full-screen, to the state where products are loaded
- Relaunch the app and tap on the POS tab immediately --> POS should be launched full-screen, to the state where products are loaded

## Testing information

- [x] @jaclync tests switching to a store ineligible for POS
- [x] @jaclync tests switching to a store eligible for POS