### PR TITLE
Shipping Labels: Enable done button even when no changes are made in payment settings

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Shipping Labels: Improve UI of Split shipments screen. [https://github.com/woocommerce/woocommerce-ios/pull/15838]
 - [*] POS: icon button with confirmation step used for clearing the cart [https://github.com/woocommerce/woocommerce-ios/pull/15829]
 - [*] Shipping Labels: Fixed a portion of layout issues caused by bigger accessibility content size categories. [https://github.com/woocommerce/woocommerce-ios/pull/15844]
+- [*] Shipping Labels: Enable the confirm button on the payment method sheet even when there are no changes. [https://github.com/woocommerce/woocommerce-ios/pull/15856]
 
 22.7
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethodsViewModel.swift
@@ -16,7 +16,7 @@ final class ShippingLabelPaymentMethodsViewModel: ObservableObject {
 
     /// Shipping Label account settings from the remote API
     ///
-    private var accountSettings: ShippingLabelAccountSettings
+    private(set) var accountSettings: ShippingLabelAccountSettings
 
     @Published var selectedPaymentMethodID: Int64
     @Published var isEmailReceiptsEnabled: Bool

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingPaymentMethod/WooShippingPaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingPaymentMethod/WooShippingPaymentMethodsView.swift
@@ -62,12 +62,15 @@ struct WooShippingPaymentMethodsView: View {
                     .toggleStyle(.switch)
 
                     Button(Localization.confirmButton) {
-                        Task {
-                            await confirmPaymentMethod()
+                        if viewModel.isDoneButtonEnabled() {
+                            Task {
+                                await confirmPaymentMethod()
+                            }
+                        } else {
+                            onAccountSettingsUpdate(viewModel.accountSettings)
                         }
                     }
                     .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isUpdating))
-                    .disabled(viewModel.isDoneButtonEnabled() == false)
                 }
             }
         }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -5704,7 +5704,7 @@
 		DE02ABBD2B578D0E008E0AC4 /* CreditCardType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardType.swift; sourceTree = "<group>"; };
 		DE02ABBF2B57D333008E0AC4 /* BlazeConfirmPaymentViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeConfirmPaymentViewModelTests.swift; sourceTree = "<group>"; };
 		DE02ABC12B5903AB008E0AC4 /* BlazeCampaignCreationErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationErrorView.swift; sourceTree = "<group>"; };
-		DE02B64E2E12766B00B79E0D /* CollapsibleShipmentItemCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CollapsibleShipmentItemCardViewModelTests.swift; path = "WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/CollapsibleShipmentItemCardViewModelTests.swift"; sourceTree = "<group>"; };
+		DE02B64E2E12766B00B79E0D /* CollapsibleShipmentItemCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleShipmentItemCardViewModelTests.swift; sourceTree = "<group>"; };
 		DE02C65B2D5A0B9F0089850D /* FailedProductImageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailedProductImageCollectionViewCell.swift; sourceTree = "<group>"; };
 		DE02C65D2D5A0C5D0089850D /* FailedProductImageCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FailedProductImageCollectionViewCell.xib; sourceTree = "<group>"; };
 		DE06D65F2D64699D00419FFA /* AuthenticatedWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewModelTests.swift; sourceTree = "<group>"; };
@@ -10552,7 +10552,6 @@
 		B56DB3BD2049BFAA00D4AA8E = {
 			isa = PBXGroup;
 			children = (
-				DE02B64E2E12766B00B79E0D /* CollapsibleShipmentItemCardViewModelTests.swift */,
 				3F3689E22DCB1B470065B48F /* Modules */,
 				D8FBFF1622D4CC2F006E3336 /* docs */,
 				8CA4F6DC220B24EB00A47B5D /* config */,
@@ -13975,6 +13974,7 @@
 		EEBB9B3E2D8FE5AC008D6CE5 /* Split shipments */ = {
 			isa = PBXGroup;
 			children = (
+				DE02B64E2E12766B00B79E0D /* CollapsibleShipmentItemCardViewModelTests.swift */,
 				EEBB9B3F2D8FE5B4008D6CE5 /* WooShippingSplitShipmentsViewModelTests.swift */,
 			);
 			path = "Split shipments";


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-633

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the payment method view to enable the Confirm button even when there are no changes. Update requests are triggered only when there are changes.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with Woo Shipping set up as the store owner.
2. Navigate to the Orders tab and select a completed order with at least one unfulfilled shipment.
3. Select Create shipping label button and expand the Shipment details bottom sheet.
4. Select the payment method row. Add a new payment method if there is no existing method and save the change.
5. Open the payment method view again. Confirm that that the Confirm button is enabled before any changes are made.
6. Tap the Use this card button and confirm that the screen is closed immediately without any loading state.
7. Open the payment method again and toggle the email receipt switch.
8. Tap the Use this card button and confirm that the setting is updated before the screen is dismissed.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested and confirm with iPhone 16 Pro iOS 18.3.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->



https://github.com/user-attachments/assets/22ef4333-5158-4306-8109-28ff9f04c877



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
