### PR TITLE
[POS Orders] Display POS label in order details

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -96,7 +96,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .pointOfSaleAsATabi2:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .pointOfSaleOrdersi1:
-            return false
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
@@ -32,7 +32,7 @@ final class SummaryTableViewCell: UITableViewCell {
         titleLabel.text = viewModel.billedPersonName
         subtitleLabel.text = viewModel.subtitle
         salesChannelLabel.text = viewModel.formattedSalesChannel
-
+        salesChannelLabel.isHidden = (salesChannelLabel.text == nil)
         display(presentation: viewModel.presentation)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
@@ -2,59 +2,6 @@ import UIKit
 import Yosemite
 import Gridicons
 
-/// The ViewModel for `SummaryTableViewCell`.
-///
-/// TODO This and that cell class should be renamed to be less ambiguous.
-///
-struct SummaryTableViewCellViewModel {
-    fileprivate struct OrderStatusPresentation {
-        let style: OrderStatusEnum
-        let title: String
-    }
-
-    private let billingAddress: Address?
-    private let dateCreated: Date
-
-    fileprivate let presentation: OrderStatusPresentation
-
-    private let calendar: Calendar
-
-    init(order: Order,
-         status: OrderStatus?,
-         calendar: Calendar = .current) {
-
-        billingAddress = order.billingAddress
-        dateCreated = order.dateCreated
-
-        presentation = OrderStatusPresentation(
-            style: status?.status ?? order.status,
-            title: status?.name ?? order.status.rawValue
-        )
-
-        self.calendar = calendar
-    }
-
-    /// The full name from the billing address
-    ///
-    var billedPersonName: String {
-        if let fullName = billingAddress?.fullName, fullName.isNotEmpty {
-            return fullName
-        } else {
-            return Localization.guestName
-        }
-    }
-
-    /// The date, time, and the order number concatenated together. Example, “Jan 22, 2018, 11:23 AM”.
-    ///
-    var subtitle: String {
-        let formatter = DateFormatter.dateAndTimeFormatter
-        formatter.timeZone = .siteTimezone
-        return formatter.string(from: dateCreated)
-    }
-}
-
-// MARK: - SummaryTableViewCell
-//
 final class SummaryTableViewCell: UITableViewCell {
 
     /// Label: Title
@@ -64,6 +11,10 @@ final class SummaryTableViewCell: UITableViewCell {
     /// Shows the dateCreated and order number.
     ///
     @IBOutlet private weak var subtitleLabel: UILabel!
+
+    ///
+    ///
+    @IBOutlet private weak var salesChannelLabel: UILabel!
 
     /// Label: Payment Status
     ///
@@ -80,6 +31,7 @@ final class SummaryTableViewCell: UITableViewCell {
     func configure(_ viewModel: SummaryTableViewCellViewModel) {
         titleLabel.text = viewModel.billedPersonName
         subtitleLabel.text = viewModel.subtitle
+        salesChannelLabel.text = viewModel.formattedSalesChannel
 
         display(presentation: viewModel.presentation)
     }
@@ -90,8 +42,6 @@ final class SummaryTableViewCell: UITableViewCell {
         paymentStatusLabel.applyStyle(for: presentation.style)
         paymentStatusLabel.text = presentation.title
     }
-
-    // MARK: - Overridden Methods
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -124,9 +74,6 @@ final class SummaryTableViewCell: UITableViewCell {
     }
 }
 
-
-// MARK: - Private
-//
 private extension SummaryTableViewCell {
 
     /// Preserves the current Payment BG Color
@@ -154,6 +101,14 @@ private extension SummaryTableViewCell {
         subtitleLabel.accessibilityIdentifier = "summary-table-view-cell-created-label"
         paymentStatusLabel.applyPaddedLabelDefaultStyles()
         paymentStatusLabel.accessibilityIdentifier = "summary-table-view-cell-payment-status-label"
+
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleOrdersi1) {
+            salesChannelLabel.isHidden = false
+            salesChannelLabel.applyFootnoteStyle()
+            salesChannelLabel.accessibilityIdentifier = ""
+        } else {
+            salesChannelLabel.isHidden = true
+        }
     }
 
     func configureIcon() {
@@ -169,9 +124,6 @@ private extension SummaryTableViewCell {
     }
 }
 
-
-// MARK: - VoiceOver
-///
 private extension SummaryTableViewCell {
     func configureIconForVoiceOver() {
         updateStatusButton.accessibilityLabel = NSLocalizedString("Update Order Status",
@@ -179,14 +131,5 @@ private extension SummaryTableViewCell {
         updateStatusButton.accessibilityTraits = .button
         updateStatusButton.accessibilityHint = NSLocalizedString("Opens a list of available statuses.",
                                                                  comment: "Accessibility hint for the button to update the order status")
-    }
-}
-
-// MARK: - Localization
-
-private extension SummaryTableViewCellViewModel {
-    enum Localization {
-        static let guestName: String = NSLocalizedString("Guest",
-                                                         comment: "In Order Details, the name of the billed person when there are no name and last name.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
@@ -12,7 +12,7 @@ final class SummaryTableViewCell: UITableViewCell {
     ///
     @IBOutlet private weak var subtitleLabel: UILabel!
 
-    ///
+    /// Shows the sales channel if appropiate, at the moment only Point of Sale
     ///
     @IBOutlet private weak var salesChannelLabel: UILabel!
 
@@ -105,7 +105,7 @@ private extension SummaryTableViewCell {
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleOrdersi1) {
             salesChannelLabel.isHidden = false
             salesChannelLabel.applyFootnoteStyle()
-            salesChannelLabel.accessibilityIdentifier = ""
+            salesChannelLabel.accessibilityIdentifier = "summary-table-view-cell-sales-channel-label"
         } else {
             salesChannelLabel.isHidden = true
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.xib
@@ -26,7 +26,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sales Channel" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kU8-dT-4zl" userLabel="Sales Channel Label">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sales Channel" textAlignment="right" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kU8-dT-4zl" userLabel="Sales Channel Label">
                                 <rect key="frame" x="146" y="0.0" width="142" height="40"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <nil key="textColor"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,26 +17,37 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="108"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Created eons ago at 9:51" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kz9-1h-fRY">
-                        <rect key="frame" x="16" y="16" width="288" height="16"/>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="3xk-nT-znM">
+                        <rect key="frame" x="16" y="8" width="288" height="40"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Created eons ago at 9:51" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kz9-1h-fRY">
+                                <rect key="frame" x="0.0" y="0.0" width="142" height="40"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sales Channel" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kU8-dT-4zl" userLabel="Sales Channel Label">
+                                <rect key="frame" x="146" y="0.0" width="142" height="40"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                    </stackView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="#00 Jane Doe" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VuR-wG-Bbc">
-                        <rect key="frame" x="16" y="40" width="288" height="28"/>
+                        <rect key="frame" x="16" y="56" width="288" height="24.5"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="740" text="Processing" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uIV-Sn-Yeh" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
-                        <rect key="frame" x="16" y="76" width="67" height="16"/>
+                        <rect key="frame" x="16" y="88.5" width="67" height="3.5"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0jq-dU-DSt">
-                        <rect key="frame" x="284" y="74" width="20" height="20"/>
+                        <rect key="frame" x="284" y="80.5" width="20" height="20"/>
                         <constraints>
                             <constraint firstAttribute="width" secondItem="0jq-dU-DSt" secondAttribute="height" multiplier="1:1" id="JlF-NG-SGG"/>
                             <constraint firstAttribute="width" constant="20" id="weV-me-Oj4"/>
@@ -46,22 +57,23 @@
                 </subviews>
                 <constraints>
                     <constraint firstItem="0jq-dU-DSt" firstAttribute="centerY" secondItem="uIV-Sn-Yeh" secondAttribute="centerY" id="0cI-jv-Lbj"/>
-                    <constraint firstItem="Kz9-1h-fRY" firstAttribute="leading" secondItem="VuR-wG-Bbc" secondAttribute="leading" id="0iO-Eg-LvT"/>
                     <constraint firstAttribute="bottom" secondItem="uIV-Sn-Yeh" secondAttribute="bottom" constant="16" id="3OU-Nl-wcg"/>
                     <constraint firstItem="uIV-Sn-Yeh" firstAttribute="top" secondItem="VuR-wG-Bbc" secondAttribute="bottom" constant="8" id="4yW-xe-vMw"/>
                     <constraint firstAttribute="trailingMargin" secondItem="VuR-wG-Bbc" secondAttribute="trailing" id="ALe-dT-Iae"/>
-                    <constraint firstItem="VuR-wG-Bbc" firstAttribute="top" secondItem="Kz9-1h-fRY" secondAttribute="bottom" constant="8" id="B6Q-cI-ASJ"/>
                     <constraint firstItem="0jq-dU-DSt" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="uIV-Sn-Yeh" secondAttribute="trailing" constant="16" id="GXV-DS-eh5"/>
-                    <constraint firstItem="Kz9-1h-fRY" firstAttribute="trailing" secondItem="VuR-wG-Bbc" secondAttribute="trailing" id="H8X-uc-vIl"/>
+                    <constraint firstItem="3xk-nT-znM" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="L58-GD-bWI"/>
+                    <constraint firstItem="3xk-nT-znM" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="TnO-xe-26W"/>
+                    <constraint firstItem="VuR-wG-Bbc" firstAttribute="top" secondItem="3xk-nT-znM" secondAttribute="bottom" constant="8" id="V2y-BO-1WX"/>
+                    <constraint firstAttribute="trailing" secondItem="3xk-nT-znM" secondAttribute="trailing" constant="16" id="VFI-lp-YIc"/>
                     <constraint firstItem="0jq-dU-DSt" firstAttribute="trailing" secondItem="VuR-wG-Bbc" secondAttribute="trailing" id="Yrn-9W-9Dw"/>
                     <constraint firstItem="uIV-Sn-Yeh" firstAttribute="leading" secondItem="VuR-wG-Bbc" secondAttribute="leading" id="h9K-qI-gKu"/>
                     <constraint firstItem="VuR-wG-Bbc" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="mSL-pS-fig"/>
-                    <constraint firstItem="Kz9-1h-fRY" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="uxx-qn-5Vc"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="paymentStatusLabel" destination="uIV-Sn-Yeh" id="7Go-fW-UgK"/>
+                <outlet property="salesChannelLabel" destination="kU8-dT-4zl" id="xwb-3Z-ADx"/>
                 <outlet property="subtitleLabel" destination="Kz9-1h-fRY" id="NEV-D0-Rfz"/>
                 <outlet property="titleLabel" destination="VuR-wG-Bbc" id="d7c-2Y-FFD"/>
                 <outlet property="updateStatusButton" destination="0jq-dU-DSt" id="f15-0P-cBB"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCellViewModel.swift
@@ -49,7 +49,7 @@ struct SummaryTableViewCellViewModel {
         return formatter.string(from: dateCreated)
     }
 
-    ///
+    /// Textual representation of the sales channel
     ///
     var formattedSalesChannel: String? {
         guard let salesChannel = salesChannel else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCellViewModel.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Yosemite
+
+struct SummaryTableViewCellViewModel {
+    struct OrderStatusPresentation {
+        let style: OrderStatusEnum
+        let title: String
+    }
+
+    private let billingAddress: Address?
+    private let dateCreated: Date
+    private let salesChannel: String?
+
+    let presentation: OrderStatusPresentation
+
+    private let calendar: Calendar
+
+    init(order: Order,
+         status: OrderStatus?,
+         calendar: Calendar = .current) {
+
+        billingAddress = order.billingAddress
+        dateCreated = order.dateCreated
+        salesChannel = order.createdVia
+
+        presentation = OrderStatusPresentation(
+            style: status?.status ?? order.status,
+            title: status?.name ?? order.status.rawValue
+        )
+
+        self.calendar = calendar
+    }
+
+    /// The full name from the billing address
+    ///
+    var billedPersonName: String {
+        if let fullName = billingAddress?.fullName, fullName.isNotEmpty {
+            return fullName
+        } else {
+            return Localization.guestName
+        }
+    }
+
+    /// The date, time, and the order number concatenated together. Example, “Jan 22, 2018, 11:23 AM”.
+    ///
+    var subtitle: String {
+        let formatter = DateFormatter.dateAndTimeFormatter
+        formatter.timeZone = .siteTimezone
+        return formatter.string(from: dateCreated)
+    }
+
+    ///
+    ///
+    var formattedSalesChannel: String? {
+        guard let salesChannel = salesChannel else {
+            return nil
+        }
+        switch salesChannel {
+        case "pos-rest-api":
+            return "POS"
+        default:
+            return nil
+        }
+    }
+}
+
+private extension SummaryTableViewCellViewModel {
+    enum Localization {
+        static let guestName: String = NSLocalizedString("SummaryTableViewCellViewModel.guestName",
+                                                         value: "Guest",
+                                                         comment: "In Order Details, the name of the billed person when there are no name and last name.")
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1594,6 +1594,7 @@
 		68C7E5C42C69B3CD00856513 /* PointOfSaleItemListErrorLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68C7E5C32C69B3CD00856513 /* PointOfSaleItemListErrorLayout.swift */; };
 		68D1BEDB28FFEDC20074A29E /* OrderCustomerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D1BEDA28FFEDC20074A29E /* OrderCustomerListView.swift */; };
 		68D1BEDD2900E4180074A29E /* CustomerSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D1BEDC2900E4180074A29E /* CustomerSearchUICommand.swift */; };
+		68D23B5B2E14FD1C00316BA6 /* SummaryTableViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D23B5A2E14FD1A00316BA6 /* SummaryTableViewCellViewModel.swift */; };
 		68D3E98D2C7C371B005B6278 /* POSEdgeShadowViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D3E98C2C7C371B005B6278 /* POSEdgeShadowViewModifier.swift */; };
 		68D5094E2AD39BC900B6FFD5 /* DiscountLineDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D5094D2AD39BC900B6FFD5 /* DiscountLineDetailsView.swift */; };
 		68D8FBD12BFEF9C700477C42 /* TotalsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D8FBD02BFEF9C700477C42 /* TotalsView.swift */; };
@@ -4728,6 +4729,7 @@
 		68C7E5C32C69B3CD00856513 /* PointOfSaleItemListErrorLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleItemListErrorLayout.swift; sourceTree = "<group>"; };
 		68D1BEDA28FFEDC20074A29E /* OrderCustomerListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomerListView.swift; sourceTree = "<group>"; };
 		68D1BEDC2900E4180074A29E /* CustomerSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSearchUICommand.swift; sourceTree = "<group>"; };
+		68D23B5A2E14FD1A00316BA6 /* SummaryTableViewCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryTableViewCellViewModel.swift; sourceTree = "<group>"; };
 		68D3E98C2C7C371B005B6278 /* POSEdgeShadowViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSEdgeShadowViewModifier.swift; sourceTree = "<group>"; };
 		68D5094D2AD39BC900B6FFD5 /* DiscountLineDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscountLineDetailsView.swift; sourceTree = "<group>"; };
 		68D8FBD02BFEF9C700477C42 /* TotalsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalsView.swift; sourceTree = "<group>"; };
@@ -12138,6 +12140,7 @@
 			isa = PBXGroup;
 			children = (
 				CEE006032077D1280079161F /* SummaryTableViewCell.swift */,
+				68D23B5A2E14FD1A00316BA6 /* SummaryTableViewCellViewModel.swift */,
 				CEE006042077D1280079161F /* SummaryTableViewCell.xib */,
 				CE35F10C2343E5B3007B2A6B /* Edit Order Status */,
 			);
@@ -15834,6 +15837,7 @@
 				B9DC770329F18A8D0013B191 /* TopProductsFromCachedOrdersProvider.swift in Sources */,
 				86023FB12B199F6200A28F07 /* ThemesCarouselView.swift in Sources */,
 				EE19058C2B5F744300617C53 /* BlazeAddPaymentMethodWebView.swift in Sources */,
+				68D23B5B2E14FD1C00316BA6 /* SummaryTableViewCellViewModel.swift in Sources */,
 				D83F5933225B2EB900626E75 /* ManualTrackingViewController.swift in Sources */,
 				3142663F2645E2AB00500598 /* PaymentSettingsFlowViewModelPresenter.swift in Sources */,
 				68E141DB2D13107400A70D5B /* PointOfSaleCollectCashView.swift in Sources */,


### PR DESCRIPTION
Closes WOOMOB-707 , only 1 review is needed!

## Description
This PR adds the `POS` label to the order details view, for those orders which their `created_via` property is `pos-rest-api`. As with the badge, there are no final designs yet, so we just render the text as the kick-off proposal in pdfdoF-7rY-p2

## Changes
- Switched the feature flag from false to `buildConfig == .localDeveloper || buildConfig == .alpha`, since POS labels now show only when appropriate.
- Moved `SummaryTableViewCellViewModel` to its own file
- Added a new `salesChannelLabel` label property to the .xib file for the cell, and wrapped it into an horizontal stack along with the existing `subtitleLabel`

## Testing information
- On a store with POS orders (fresh orders, backfilling the `created_via` property is not supported), observe how the `POS` label appears in the top right corner of order details view, along the order date.
- Switch `pointOfSaleOrdersi1` flag to `false`, re-run the app, we should see no POS labels in order details, nor in order list.

## Screenshots
| Order List | Order Details |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 Plus - US store - 2025-07-02 at 15 54 36](https://github.com/user-attachments/assets/5cc83dc3-cece-4dbc-9ccd-588989cbe5a0) | ![Simulator Screenshot - iPhone 16 Plus - US store - 2025-07-02 at 15 54 42](https://github.com/user-attachments/assets/25202fb9-02dd-4d03-970e-6ddd795e5a9f) | 

![Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-07-02 at 15 52 15](https://github.com/user-attachments/assets/862c1b48-aa30-4973-94f4-0ea49b4cf5f5)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
