### PR TITLE
Testing https://github.com/Automattic/buildkite-ci/pull/672

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 ---
 
 agents:
-  queue: mac
+  queue: mac-staging
 
 env:
   IMAGE_ID: $IMAGE_ID


### PR DESCRIPTION
> [!IMPORTANT]
> DO NOT MERGE

This PR is solely for testing https://github.com/Automattic/buildkite-ci/pull/672
Relates to: AINFRA-701

This makes the pipeline of this repo temporarily use the `mac-staging` queue so we can validate that the re-provisioning of the `MV-MKE-ARM64-024` Mac using the `macos-hosts` playbook still works as expected even after all the refactoring that happened as part of AINFRA-701
