### PR TITLE
[POS as a tab i2] Update POS ineligible UI with detailed text and design updates

### DIFF
--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -135,16 +135,26 @@ struct POSIneligibleView: View {
             return NSLocalizedString("pos.ineligible.suggestion.featureSwitchSyncFailure",
                                      value: "Try relaunching the app or check your internet connection and try again.",
                                      comment: "Suggestion for feature switch sync failure: relaunch or check connection")
-        case .unsupportedCountry:
-            // TODO: DI countries
-            return NSLocalizedString("pos.ineligible.suggestion.unsupportedCountry",
-                                     value: "POS is currently only available in select countries. Check back later for availability in your region.",
-                                     comment: "Suggestion for unsupported country: check back later")
-        case .unsupportedCurrency:
-            // TODO: DI currencies
-            return NSLocalizedString("pos.ineligible.suggestion.unsupportedCurrency",
-                                     value: "Change your store's currency to USD, EUR, GBP, or CAD in WooCommerce settings.",
-                                     comment: "Suggestion for unsupported currency: change currency")
+        case let .unsupportedCountry(supportedCountries):
+            let countryNames = supportedCountries.map { $0.readableCountry }
+            let formattedCountryList = ListFormatter.localizedString(byJoining: countryNames)
+            let format = NSLocalizedString(
+                "pos.ineligible.suggestion.unsupportedCountry",
+                value: "POS is currently only available in %1$@. Check back later for availability in your region.",
+                comment: "Suggestion for unsupported country with list of supported countries. " +
+                "%1$@ is a placeholder for the localized list of supported country names."
+            )
+            return String.localizedStringWithFormat(format, formattedCountryList)
+        case let .unsupportedCurrency(supportedCurrencies):
+            let currencyList = supportedCurrencies.map { $0.rawValue }
+            let formattedCurrencyList = ListFormatter.localizedString(byJoining: currencyList)
+            let format = NSLocalizedString(
+                "pos.ineligible.suggestion.unsupportedCurrency",
+                value: "The POS system is not available for your store’s currency. It currently supports only %1$@. Please check your store currency settings or contact support for assistance.",
+                comment: "Suggestion for unsupported currency with list of supported currencies. " +
+                "%1$@ is a placeholder for the localized list of supported currency codes."
+            )
+            return String.localizedStringWithFormat(format, formattedCurrencyList)
         case .siteSettingsNotAvailable:
             return NSLocalizedString("pos.ineligible.suggestion.siteSettingsNotAvailable",
                                      value: "Check your internet connection and try relaunching the app. If the issue persists, please contact support.",
@@ -178,9 +188,76 @@ private extension POSIneligibleView {
     }
 }
 
-#Preview {
+#if DEBUG
+
+#Preview("Unsupported currency") {
     POSIneligibleView(
-        reason: .unsupportedCurrency,
+        reason: .unsupportedCurrency(supportedCurrencies: [.USD]),
         onRefresh: {}
     )
 }
+
+#Preview("Unsupported country") {
+    POSIneligibleView(
+        reason: .unsupportedCountry(supportedCountries: [.US, .GB]),
+        onRefresh: {}
+    )
+}
+
+#Preview("Not a tablet") {
+    POSIneligibleView(
+        reason: .notTablet,
+        onRefresh: {}
+    )
+}
+
+#Preview("Unsupported iOS version") {
+    POSIneligibleView(
+        reason: .unsupportedIOSVersion,
+        onRefresh: {}
+    )
+}
+
+#Preview("WooCommerce plugin not found") {
+    POSIneligibleView(
+        reason: .wooCommercePluginNotFound,
+        onRefresh: {}
+    )
+}
+
+#Preview("Feature flag disabled") {
+    POSIneligibleView(
+        reason: .featureFlagDisabled,
+        onRefresh: {}
+    )
+}
+
+#Preview("Feature switch disabled") {
+    POSIneligibleView(
+        reason: .featureSwitchDisabled,
+        onRefresh: {}
+    )
+}
+
+#Preview("Site settings unavailable") {
+    POSIneligibleView(
+        reason: .siteSettingsNotAvailable,
+        onRefresh: {}
+    )
+}
+
+#Preview("Feature switch sync failure") {
+    POSIneligibleView(
+        reason: .featureSwitchSyncFailure,
+        onRefresh: {}
+    )
+}
+
+#Preview("Unsupported WooCommerce version") {
+    POSIneligibleView(
+        reason: .unsupportedWooCommerceVersion,
+        onRefresh: {}
+    )
+}
+
+#endif

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -34,6 +34,11 @@ struct POSIneligibleView: View {
                     .multilineTextAlignment(.center)
                     .foregroundColor(Color.posOnSurface)
 
+                Text(suggestionText)
+                    .font(POSFontStyle.posCaptionRegular.font())
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(Color.posOnSurface)
+
                 Button {
                     Task { @MainActor in
                         do {
@@ -41,7 +46,7 @@ struct POSIneligibleView: View {
                             try await onRefresh()
                             isLoading = false
                         } catch {
-                            // TODO-jc: handle error if needed, e.g., show an error message
+                            // TODO: WOOMOB-720 - handle error if needed, e.g., show an error message
                             print("Error refreshing eligibility: \(error)")
                             isLoading = false
                         }
@@ -101,6 +106,57 @@ struct POSIneligibleView: View {
                                      comment: "Ineligible reason: feature flag disabled")
         case .selfDeallocated:
             return Localization.defaultReason
+        }
+    }
+
+    private var suggestionText: String {
+        switch reason {
+        case .notTablet:
+            return NSLocalizedString("pos.ineligible.suggestion.notTablet",
+                                     value: "Please use an iPad to access POS features.",
+                                     comment: "Suggestion for not tablet: use iPad")
+        case .unsupportedIOSVersion:
+            return NSLocalizedString("pos.ineligible.suggestion.unsupportedIOSVersion",
+                                     value: "Update your device to iOS 17 or later in Settings > General > Software Update.",
+                                     comment: "Suggestion for unsupported iOS version: update iOS")
+        case .unsupportedWooCommerceVersion:
+            return NSLocalizedString("pos.ineligible.suggestion.unsupportedWooCommerceVersion",
+                                     value: "Go to your WordPress admin and update WooCommerce to the latest version.",
+                                     comment: "Suggestion for unsupported WooCommerce version: update plugin")
+        case .wooCommercePluginNotFound:
+            return NSLocalizedString("pos.ineligible.suggestion.wooCommercePluginNotFound",
+                                     value: "Install and activate the WooCommerce plugin from your WordPress admin.",
+                                     comment: "Suggestion for missing WooCommerce plugin: install plugin")
+        case .featureSwitchDisabled:
+            return NSLocalizedString("pos.ineligible.suggestion.featureSwitchDisabled",
+                                     value: "Enable the POS feature from your WordPress admin under WooCommerce settings > Advanced > Features.",
+                                     comment: "Suggestion for disabled feature switch: enable feature in WooCommerce settings")
+        case .featureSwitchSyncFailure:
+            return NSLocalizedString("pos.ineligible.suggestion.featureSwitchSyncFailure",
+                                     value: "Try relaunching the app or check your internet connection and try again.",
+                                     comment: "Suggestion for feature switch sync failure: relaunch or check connection")
+        case .unsupportedCountry:
+            // TODO: DI countries
+            return NSLocalizedString("pos.ineligible.suggestion.unsupportedCountry",
+                                     value: "POS is currently only available in select countries. Check back later for availability in your region.",
+                                     comment: "Suggestion for unsupported country: check back later")
+        case .unsupportedCurrency:
+            // TODO: DI currencies
+            return NSLocalizedString("pos.ineligible.suggestion.unsupportedCurrency",
+                                     value: "Change your store's currency to USD, EUR, GBP, or CAD in WooCommerce settings.",
+                                     comment: "Suggestion for unsupported currency: change currency")
+        case .siteSettingsNotAvailable:
+            return NSLocalizedString("pos.ineligible.suggestion.siteSettingsNotAvailable",
+                                     value: "Check your internet connection and try relaunching the app. If the issue persists, please contact support.",
+                                     comment: "Suggestion for site settings unavailable: check connection or contact support")
+        case .featureFlagDisabled:
+            return NSLocalizedString("pos.ineligible.suggestion.featureFlagDisabled",
+                                     value: "POS is currently disabled.",
+                                     comment: "Suggestion for disabled feature flag: notify that POS is disabled remotely")
+        case .selfDeallocated:
+            return NSLocalizedString("pos.ineligible.suggestion.selfDeallocated",
+                                     value: "Try relaunching the app to resolve this issue.",
+                                     comment: "Suggestion for self deallocated: relaunch")
         }
     }
 }

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -49,7 +49,7 @@ struct POSIneligibleView: View {
                                 isLoading = false
                             } catch {
                                 // TODO: WOOMOB-720 - handle error if needed, e.g., show an error message
-                                print("Error refreshing eligibility: \(error)")
+                                DDLogError("Error refreshing eligibility: \(error)")
                                 isLoading = false
                             }
                         }

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -10,10 +10,10 @@ struct POSIneligibleView: View {
     @State private var isLoading: Bool = false
 
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: POSSpacing.none) {
             Spacer()
 
-            VStack(alignment: .center, spacing: 0) {
+            VStack(alignment: .center, spacing: POSSpacing.none) {
                 Image(PointOfSaleAssets.exclamationMark.imageName)
                     .resizable()
                     .frame(width: POSErrorAndAlertIconSize.large.dimension,

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// A view that displays when the Point of Sale (POS) feature is not available for the current store.
 /// Shows the specific reason why POS is ineligible and provides a button to re-check eligibility.
+@available(iOS 17.0, *)
 struct POSIneligibleView: View {
     let reason: POSIneligibleReason
     let onRefresh: () async throws -> Void
@@ -37,32 +38,34 @@ struct POSIneligibleView: View {
                 Spacer()
                     .frame(height: POSSpacing.large)
 
-                Button {
-                    Task { @MainActor in
-                        do {
-                            isLoading = true
-                            try await onRefresh()
-                            isLoading = false
-                        } catch {
-                            // TODO: WOOMOB-720 - handle error if needed, e.g., show an error message
-                            print("Error refreshing eligibility: \(error)")
-                            isLoading = false
+                VStack(spacing: POSSpacing.medium) {
+                    Button {
+                        Task { @MainActor in
+                            do {
+                                isLoading = true
+                                try await onRefresh()
+                                isLoading = false
+                            } catch {
+                                // TODO: WOOMOB-720 - handle error if needed, e.g., show an error message
+                                print("Error refreshing eligibility: \(error)")
+                                isLoading = false
+                            }
                         }
+                    } label: {
+                        Text(Localization.refreshEligibility)
                     }
-                } label: {
-                    Text(Localization.refreshEligibility)
-                }
-                .buttonStyle(POSFilledButtonStyle(size: .normal, isLoading: isLoading))
+                    .buttonStyle(POSFilledButtonStyle(size: .normal, isLoading: isLoading))
 
-                Spacer()
-                    .frame(height: POSSpacing.medium)
-
-                Button {
-                    dismiss()
-                } label: {
-                    Text(Localization.dismiss)
+                    Button {
+                        dismiss()
+                    } label: {
+                        Text(Localization.dismiss)
+                    }
+                    .buttonStyle(POSOutlinedButtonStyle(size: .normal))
                 }
-                .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+                .containerRelativeFrame(.horizontal) { length, _ in
+                    length * 0.5
+                }
             }
 
             Spacer()
@@ -134,6 +137,7 @@ struct POSIneligibleView: View {
     }
 }
 
+@available(iOS 17.0, *)
 private extension POSIneligibleView {
     enum Localization {
         static let title = NSLocalizedString(
@@ -159,73 +163,93 @@ private extension POSIneligibleView {
 #if DEBUG
 
 #Preview("Unsupported currency") {
-    POSIneligibleView(
-        reason: .unsupportedCurrency(supportedCurrencies: [.USD]),
-        onRefresh: {}
-    )
+    if #available(iOS 17.0, *) {
+        POSIneligibleView(
+            reason: .unsupportedCurrency(supportedCurrencies: [.USD]),
+            onRefresh: {}
+        )
+    }
 }
 
 #Preview("Unsupported country") {
-    POSIneligibleView(
-        reason: .unsupportedCountry(supportedCountries: [.US, .GB]),
-        onRefresh: {}
-    )
+    if #available(iOS 17.0, *) {
+        POSIneligibleView(
+            reason: .unsupportedCountry(supportedCountries: [.US, .GB]),
+            onRefresh: {}
+        )
+    }
 }
 
 #Preview("Not a tablet") {
-    POSIneligibleView(
-        reason: .notTablet,
-        onRefresh: {}
-    )
+    if #available(iOS 17.0, *) {
+        POSIneligibleView(
+            reason: .notTablet,
+            onRefresh: {}
+        )
+    }
 }
 
 #Preview("Unsupported iOS version") {
-    POSIneligibleView(
-        reason: .unsupportedIOSVersion,
-        onRefresh: {}
-    )
+    if #available(iOS 17.0, *) {
+        POSIneligibleView(
+            reason: .unsupportedIOSVersion,
+            onRefresh: {}
+        )
+    }
 }
 
 #Preview("WooCommerce plugin not found") {
-    POSIneligibleView(
-        reason: .wooCommercePluginNotFound,
-        onRefresh: {}
-    )
+    if #available(iOS 17.0, *) {
+        POSIneligibleView(
+            reason: .wooCommercePluginNotFound,
+            onRefresh: {}
+        )
+    }
 }
 
 #Preview("Feature flag disabled") {
-    POSIneligibleView(
-        reason: .featureFlagDisabled,
-        onRefresh: {}
-    )
+    if #available(iOS 17.0, *) {
+        POSIneligibleView(
+            reason: .featureFlagDisabled,
+            onRefresh: {}
+        )
+    }
 }
 
 #Preview("Feature switch disabled") {
-    POSIneligibleView(
-        reason: .featureSwitchDisabled,
-        onRefresh: {}
-    )
+    if #available(iOS 17.0, *) {
+        POSIneligibleView(
+            reason: .featureSwitchDisabled,
+            onRefresh: {}
+        )
+    }
 }
 
 #Preview("Site settings unavailable") {
-    POSIneligibleView(
-        reason: .siteSettingsNotAvailable,
-        onRefresh: {}
-    )
+    if #available(iOS 17.0, *) {
+        POSIneligibleView(
+            reason: .siteSettingsNotAvailable,
+            onRefresh: {}
+        )
+    }
 }
 
 #Preview("Feature switch sync failure") {
-    POSIneligibleView(
-        reason: .featureSwitchSyncFailure,
-        onRefresh: {}
-    )
+    if #available(iOS 17.0, *) {
+        POSIneligibleView(
+            reason: .featureSwitchSyncFailure,
+            onRefresh: {}
+        )
+    }
 }
 
 #Preview("Unsupported WooCommerce version") {
-    POSIneligibleView(
-        reason: .unsupportedWooCommerceVersion,
-        onRefresh: {}
-    )
+    if #available(iOS 17.0, *) {
+        POSIneligibleView(
+            reason: .unsupportedWooCommerceVersion,
+            onRefresh: {}
+        )
+    }
 }
 
 #endif

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -83,7 +83,7 @@ struct POSIneligibleView: View {
                                      comment: "Suggestion for not tablet: use iPad")
         case .unsupportedIOSVersion:
             return NSLocalizedString("pos.ineligible.suggestion.unsupportedIOSVersion",
-                                     value: "The POS system requires iOS 17 or later. Please update your device to iOS 17+ to use this feature.",
+                                     value: "Point of Sale requires iOS 17 or later. Please update your device to iOS 17+ to use this feature.",
                                      comment: "Suggestion for unsupported iOS version: update iOS")
         case let .unsupportedWooCommerceVersion(minimumVersion):
             let format = NSLocalizedString("pos.ineligible.suggestion.unsupportedWooCommerceVersion",
@@ -98,7 +98,7 @@ struct POSIneligibleView: View {
                                      comment: "Suggestion for missing WooCommerce plugin: install plugin")
         case .featureSwitchDisabled:
             return NSLocalizedString("pos.ineligible.suggestion.featureSwitchDisabled",
-                                     value: "The POS core feature must be enabled to proceed. " +
+                                     value: "Point of Sale must be enabled to proceed. " +
                                      "Please enable the POS feature from your WordPress admin under WooCommerce settings > Advanced > Features.",
                                      comment: "Suggestion for disabled feature switch: enable feature in WooCommerce settings")
         case .featureSwitchSyncFailure:

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -22,18 +22,20 @@ struct POSIneligibleView: View {
                 Spacer()
                     .frame(height: POSSpacing.medium)
 
-                Text(Localization.title)
-                    .font(POSFontStyle.posHeadingBold.font())
-                    .multilineTextAlignment(.center)
-                    .foregroundColor(Color.posOnSurface)
+                VStack(spacing: POSSpacing.small) {
+                    Text(Localization.title)
+                        .font(POSFontStyle.posHeadingBold.font())
+                        .multilineTextAlignment(.center)
+                        .foregroundColor(Color.posOnSurface)
 
-                Spacer()
-                    .frame(height: POSSpacing.small)
-
-                Text(suggestionText)
-                    .font(POSFontStyle.posBodyLargeRegular().font())
-                    .multilineTextAlignment(.center)
-                    .foregroundColor(Color.posOnSurface)
+                    Text(suggestionText)
+                        .font(POSFontStyle.posBodyLargeRegular().font())
+                        .multilineTextAlignment(.center)
+                        .foregroundColor(Color.posOnSurface)
+                }
+                .containerRelativeFrame(.horizontal) { length, _ in
+                    length * 0.5
+                }
 
                 Spacer()
                     .frame(height: POSSpacing.large)
@@ -64,7 +66,7 @@ struct POSIneligibleView: View {
                     .buttonStyle(POSOutlinedButtonStyle(size: .normal))
                 }
                 .containerRelativeFrame(.horizontal) { length, _ in
-                    length * 0.5
+                    length * 0.5 - 132
                 }
             }
 

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -83,12 +83,13 @@ struct POSIneligibleView: View {
             return NSLocalizedString("pos.ineligible.suggestion.unsupportedIOSVersion",
                                      value: "The POS system requires iOS 17 or later. Please update your device to iOS 17+ to use this feature.",
                                      comment: "Suggestion for unsupported iOS version: update iOS")
-        case .unsupportedWooCommerceVersion:
-            // TODO: DI min WC version
-            return NSLocalizedString("pos.ineligible.suggestion.unsupportedWooCommerceVersion",
+        case let .unsupportedWooCommerceVersion(minimumVersion):
+            let format = NSLocalizedString("pos.ineligible.suggestion.unsupportedWooCommerceVersion",
                                      value: "Your WooCommerce version is not supported. " +
-                                     "The POS system requires WooCommerce version ### or above. Please update WooCommerce to the latest version.",
-                                     comment: "Suggestion for unsupported WooCommerce version: update plugin")
+                                     "The POS system requires WooCommerce version %1$@ or above. Please update WooCommerce to the latest version.",
+                                     comment: "Suggestion for unsupported WooCommerce version: update plugin. " +
+                                     "%1$@ is a placeholder for the minimum required version.")
+            return String.localizedStringWithFormat(format, minimumVersion)
         case .wooCommercePluginNotFound:
             return NSLocalizedString("pos.ineligible.suggestion.wooCommercePluginNotFound",
                                      value: "Install and activate the WooCommerce plugin from your WordPress admin.",
@@ -248,7 +249,7 @@ private extension POSIneligibleView {
 #Preview("Unsupported WooCommerce version") {
     if #available(iOS 17.0, *) {
         POSIneligibleView(
-            reason: .unsupportedWooCommerceVersion,
+            reason: .unsupportedWooCommerceVersion(minimumVersion: "9.6.0"),
             onRefresh: {}
         )
     }

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -113,15 +113,17 @@ struct POSIneligibleView: View {
         switch reason {
         case .notTablet:
             return NSLocalizedString("pos.ineligible.suggestion.notTablet",
-                                     value: "Please use an iPad to access POS features.",
+                                     value: "Please use a tablet to access POS features.",
                                      comment: "Suggestion for not tablet: use iPad")
         case .unsupportedIOSVersion:
             return NSLocalizedString("pos.ineligible.suggestion.unsupportedIOSVersion",
-                                     value: "Update your device to iOS 17 or later in Settings > General > Software Update.",
+                                     value: "The POS system requires iOS 17 or later. Please update your device to iOS 17+ to use this feature.",
                                      comment: "Suggestion for unsupported iOS version: update iOS")
         case .unsupportedWooCommerceVersion:
+            // TODO: DI min WC version
             return NSLocalizedString("pos.ineligible.suggestion.unsupportedWooCommerceVersion",
-                                     value: "Go to your WordPress admin and update WooCommerce to the latest version.",
+                                     value: "Your WooCommerce version is not supported. " +
+                                     "The POS system requires WooCommerce version ### or above. Please update WooCommerce to the latest version.",
                                      comment: "Suggestion for unsupported WooCommerce version: update plugin")
         case .wooCommercePluginNotFound:
             return NSLocalizedString("pos.ineligible.suggestion.wooCommercePluginNotFound",
@@ -129,7 +131,7 @@ struct POSIneligibleView: View {
                                      comment: "Suggestion for missing WooCommerce plugin: install plugin")
         case .featureSwitchDisabled:
             return NSLocalizedString("pos.ineligible.suggestion.featureSwitchDisabled",
-                                     value: "Enable the POS feature from your WordPress admin under WooCommerce settings > Advanced > Features.",
+                                     value: "The POS core feature must be enabled to proceed. Please enable the POS feature from your WordPress admin under WooCommerce settings > Advanced > Features.",
                                      comment: "Suggestion for disabled feature switch: enable feature in WooCommerce settings")
         case .featureSwitchSyncFailure:
             return NSLocalizedString("pos.ineligible.suggestion.featureSwitchSyncFailure",
@@ -175,7 +177,7 @@ private extension POSIneligibleView {
     enum Localization {
         static let refreshEligibility = NSLocalizedString(
             "pos.ineligible.refresh.button.title",
-            value: "Check Eligibility Again",
+            value: "Retry",
             comment: "Button title to refresh POS eligibility check"
         )
 

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -34,7 +34,7 @@ struct POSIneligibleView: View {
                         .foregroundColor(Color.posOnSurface)
                 }
                 .containerRelativeFrame(.horizontal) { length, _ in
-                    length * 0.5
+                    max(length * 0.5, 300)
                 }
 
                 Spacer()
@@ -66,7 +66,7 @@ struct POSIneligibleView: View {
                     .buttonStyle(POSOutlinedButtonStyle(size: .normal))
                 }
                 .containerRelativeFrame(.horizontal) { length, _ in
-                    length * 0.5 - 132
+                    max(length * 0.5 - 132, 300)
                 }
             }
 

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -95,7 +95,8 @@ struct POSIneligibleView: View {
                                      comment: "Suggestion for missing WooCommerce plugin: install plugin")
         case .featureSwitchDisabled:
             return NSLocalizedString("pos.ineligible.suggestion.featureSwitchDisabled",
-                                     value: "The POS core feature must be enabled to proceed. Please enable the POS feature from your WordPress admin under WooCommerce settings > Advanced > Features.",
+                                     value: "The POS core feature must be enabled to proceed. " +
+                                     "Please enable the POS feature from your WordPress admin under WooCommerce settings > Advanced > Features.",
                                      comment: "Suggestion for disabled feature switch: enable feature in WooCommerce settings")
         case .featureSwitchSyncFailure:
             return NSLocalizedString("pos.ineligible.suggestion.featureSwitchSyncFailure",
@@ -116,7 +117,8 @@ struct POSIneligibleView: View {
             let formattedCurrencyList = ListFormatter.localizedString(byJoining: currencyList)
             let format = NSLocalizedString(
                 "pos.ineligible.suggestion.unsupportedCurrency",
-                value: "The POS system is not available for your store’s currency. It currently supports only %1$@. Please check your store currency settings or contact support for assistance.",
+                value: "The POS system is not available for your store’s currency. It currently supports only %1$@. " +
+                "Please check your store currency settings or contact support for assistance.",
                 comment: "Suggestion for unsupported currency with list of supported currencies. " +
                 "%1$@ is a placeholder for the localized list of supported currency codes."
             )

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -9,35 +9,33 @@ struct POSIneligibleView: View {
     @State private var isLoading: Bool = false
 
     var body: some View {
-        VStack(spacing: POSSpacing.large) {
-            HStack {
-                Spacer()
-                Button {
-                    dismiss()
-                } label: {
-                    Text(Image(systemName: "xmark"))
-                        .font(POSFontStyle.posButtonSymbolLarge.font())
-                }
-                .foregroundColor(Color.posOnSurfaceVariantLowest)
-            }
-
+        VStack(spacing: 0) {
             Spacer()
 
-            VStack(spacing: POSSpacing.medium) {
+            VStack(alignment: .center, spacing: 0) {
                 Image(PointOfSaleAssets.exclamationMark.imageName)
                     .resizable()
                     .frame(width: POSErrorAndAlertIconSize.large.dimension,
                            height: POSErrorAndAlertIconSize.large.dimension)
 
-                Text(reasonText)
+                Spacer()
+                    .frame(height: POSSpacing.medium)
+
+                Text(Localization.title)
                     .font(POSFontStyle.posHeadingBold.font())
                     .multilineTextAlignment(.center)
                     .foregroundColor(Color.posOnSurface)
 
+                Spacer()
+                    .frame(height: POSSpacing.small)
+
                 Text(suggestionText)
-                    .font(POSFontStyle.posCaptionRegular.font())
+                    .font(POSFontStyle.posBodyLargeRegular().font())
                     .multilineTextAlignment(.center)
                     .foregroundColor(Color.posOnSurface)
+
+                Spacer()
+                    .frame(height: POSSpacing.large)
 
                 Button {
                     Task { @MainActor in
@@ -55,58 +53,21 @@ struct POSIneligibleView: View {
                     Text(Localization.refreshEligibility)
                 }
                 .buttonStyle(POSFilledButtonStyle(size: .normal, isLoading: isLoading))
+
+                Spacer()
+                    .frame(height: POSSpacing.medium)
+
+                Button {
+                    dismiss()
+                } label: {
+                    Text(Localization.dismiss)
+                }
+                .buttonStyle(POSOutlinedButtonStyle(size: .normal))
             }
 
             Spacer()
         }
         .padding(POSPadding.large)
-    }
-
-    private var reasonText: String {
-        switch reason {
-        case .notTablet:
-            return NSLocalizedString("pos.ineligible.reason.notTablet",
-                                     value: "POS is only available on iPad.",
-                                     comment: "Ineligible reason: not a tablet")
-        case .unsupportedIOSVersion:
-            return NSLocalizedString("pos.ineligible.reason.unsupportedIOSVersion",
-                                     value: "POS requires a newer version of iOS 17 and above.",
-                                     comment: "Ineligible reason: iOS version too low")
-        case .unsupportedWooCommerceVersion:
-            return NSLocalizedString("pos.ineligible.reason.unsupportedWooCommerceVersion",
-                                     value: "Please update WooCommerce plugin to use POS.",
-                                     comment: "Ineligible reason: WooCommerce version too low")
-        case .wooCommercePluginNotFound:
-            return NSLocalizedString("pos.ineligible.reason.wooCommercePluginNotFound",
-                                     value: "WooCommerce plugin not found.",
-                                     comment: "Ineligible reason: plugin missing")
-        case .featureSwitchDisabled:
-            return NSLocalizedString("pos.ineligible.reason.featureSwitchDisabled",
-                                     value: "POS feature is not enabled for your store.",
-                                     comment: "Ineligible reason: feature switch off")
-        case .featureSwitchSyncFailure:
-            return NSLocalizedString("pos.ineligible.reason.featureSwitchSyncFailure",
-                                     value: "Could not verify POS feature status.",
-                                     comment: "Ineligible reason: feature switch sync failed")
-        case .unsupportedCountry:
-            return NSLocalizedString("pos.ineligible.reason.unsupportedCountry",
-                                     value: "POS is not available in your country.",
-                                     comment: "Ineligible reason: country not supported")
-        case .unsupportedCurrency:
-            return NSLocalizedString("pos.ineligible.reason.unsupportedCurrency",
-                                     value: "POS is not available for your store's currency.",
-                                     comment: "Ineligible reason: currency not supported")
-        case .siteSettingsNotAvailable:
-            return NSLocalizedString("pos.ineligible.reason.siteSettingsNotAvailable",
-                                     value: "Unable to load store settings for POS.",
-                                     comment: "Ineligible reason: site settings unavailable")
-        case .featureFlagDisabled:
-            return NSLocalizedString("pos.ineligible.reason.featureFlagDisabled",
-                                     value: "POS feature is currently disabled.",
-                                     comment: "Ineligible reason: feature flag disabled")
-        case .selfDeallocated:
-            return Localization.defaultReason
-        }
     }
 
     private var suggestionText: String {
@@ -175,17 +136,22 @@ struct POSIneligibleView: View {
 
 private extension POSIneligibleView {
     enum Localization {
+        static let title = NSLocalizedString(
+            "pos.ineligible.title",
+            value: "Unable to load",
+            comment: "Title shown in POS ineligible view"
+        )
+
         static let refreshEligibility = NSLocalizedString(
             "pos.ineligible.refresh.button.title",
             value: "Retry",
             comment: "Button title to refresh POS eligibility check"
         )
 
-        /// Default message shown when POS eligibility reason is not available.
-        static let defaultReason = NSLocalizedString(
-            "pos.ineligible.default.reason",
-            value: "Your store is not eligible for POS at this time.",
-            comment: "Default message shown when POS eligibility reason is not available"
+        static let dismiss = NSLocalizedString(
+            "pos.ineligible.dismiss.button.title",
+            value: "Exit POS",
+            comment: "Button title to dismiss POS ineligible view"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -25,8 +25,8 @@ enum POSIneligibleReason: Equatable {
     case featureFlagDisabled
     case featureSwitchDisabled
     case featureSwitchSyncFailure
-    case unsupportedCountry
-    case unsupportedCurrency
+    case unsupportedCountry(supportedCountries: [CountryCode])
+    case unsupportedCurrency(supportedCurrencies: [CurrencyCode])
     case selfDeallocated
 }
 
@@ -153,7 +153,7 @@ private extension POSTabEligibilityChecker {
         case .eligible:
             break
         case let .ineligible(reason):
-            if reason == .unsupportedCurrency {
+            if case .unsupportedCurrency = reason {
                 break
             } else {
                 return false
@@ -250,21 +250,20 @@ private extension POSTabEligibilityChecker {
     }
 
     func isEligibleFromCountryAndCurrencyCode(countryCode: CountryCode, currencyCode: CurrencyCode) -> POSEligibilityState {
+        let supportedCountries: [CountryCode] = [.US, .GB]
+        let supportedCurrencies: [CountryCode: [CurrencyCode]] = [.US: [.USD],
+                                                                  .GB: [.GBP]]
+
         // Checks country first.
-        switch countryCode {
-        case .US, .GB:
-            break
-        default:
-            return .ineligible(reason: .unsupportedCountry)
+        guard supportedCountries.contains(countryCode) else {
+            return .ineligible(reason: .unsupportedCountry(supportedCountries: supportedCountries))
         }
 
-        // Then checks currency based on the country.
-        switch (countryCode, currencyCode) {
-        case (.US, .USD), (.GB, .GBP):
-            return .eligible
-        default:
-            return .ineligible(reason: .unsupportedCurrency)
+        let supportedCurrenciesForCountry = supportedCurrencies[countryCode] ?? []
+        guard supportedCurrenciesForCountry.contains(currencyCode) else {
+            return .ineligible(reason: .unsupportedCurrency(supportedCurrencies: supportedCurrenciesForCountry))
         }
+        return .eligible
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -19,7 +19,7 @@ import class Yosemite.PluginsService
 enum POSIneligibleReason: Equatable {
     case notTablet
     case unsupportedIOSVersion
-    case unsupportedWooCommerceVersion
+    case unsupportedWooCommerceVersion(minimumVersion: String)
     case siteSettingsNotAvailable
     case wooCommercePluginNotFound
     case featureFlagDisabled
@@ -178,7 +178,7 @@ private extension POSTabEligibilityChecker {
 
         guard VersionHelpers.isVersionSupported(version: wcPlugin.version,
                                                 minimumRequired: Constants.wcPluginMinimumVersion) else {
-            return .ineligible(reason: .unsupportedWooCommerceVersion)
+            return .ineligible(reason: .unsupportedWooCommerceVersion(minimumVersion: Constants.wcPluginMinimumVersion))
         }
 
         // For versions below 10.0.0, the feature is enabled by default.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -131,20 +131,23 @@ struct POSTabEligibilityCheckerTests {
         let result = await checker.checkEligibility()
 
         // Then
-        #expect(result == .ineligible(reason: .unsupportedCountry))
+        #expect(result == .ineligible(reason: .unsupportedCountry(supportedCountries: [.US, .GB])))
     }
 
     @Test(arguments: [
-        (country: Country.us, currency: CurrencyCode.GBP, isPointOfSaleAsATabi2Enabled: true),
-        (country: Country.us, currency: CurrencyCode.GBP, isPointOfSaleAsATabi2Enabled: false),
-        (country: Country.us, currency: CurrencyCode.CAD, isPointOfSaleAsATabi2Enabled: true),
-        (country: Country.us, currency: CurrencyCode.CAD, isPointOfSaleAsATabi2Enabled: false),
-        (country: Country.gb, currency: CurrencyCode.EUR, isPointOfSaleAsATabi2Enabled: true),
-        (country: Country.gb, currency: CurrencyCode.EUR, isPointOfSaleAsATabi2Enabled: false),
-        (country: Country.gb, currency: CurrencyCode.USD, isPointOfSaleAsATabi2Enabled: true),
-        (country: Country.gb, currency: CurrencyCode.USD, isPointOfSaleAsATabi2Enabled: false)
+        (country: Country.us, currency: CurrencyCode.GBP, expectedSupportedCurrencies: [CurrencyCode.USD], isPointOfSaleAsATabi2Enabled: true),
+        (country: Country.us, currency: CurrencyCode.GBP, expectedSupportedCurrencies: [CurrencyCode.USD], isPointOfSaleAsATabi2Enabled: false),
+        (country: Country.us, currency: CurrencyCode.CAD, expectedSupportedCurrencies: [CurrencyCode.USD], isPointOfSaleAsATabi2Enabled: true),
+        (country: Country.us, currency: CurrencyCode.CAD, expectedSupportedCurrencies: [CurrencyCode.USD], isPointOfSaleAsATabi2Enabled: false),
+        (country: Country.gb, currency: CurrencyCode.EUR, expectedSupportedCurrencies: [CurrencyCode.GBP], isPointOfSaleAsATabi2Enabled: true),
+        (country: Country.gb, currency: CurrencyCode.EUR, expectedSupportedCurrencies: [CurrencyCode.GBP], isPointOfSaleAsATabi2Enabled: false),
+        (country: Country.gb, currency: CurrencyCode.USD, expectedSupportedCurrencies: [CurrencyCode.GBP], isPointOfSaleAsATabi2Enabled: true),
+        (country: Country.gb, currency: CurrencyCode.USD, expectedSupportedCurrencies: [CurrencyCode.GBP], isPointOfSaleAsATabi2Enabled: false)
     ])
-    fileprivate func is_ineligible_when_currency_is_not_supported(country: Country, currency: CurrencyCode, isPointOfSaleAsATabi2Enabled: Bool) async throws {
+    fileprivate func is_ineligible_when_currency_is_not_supported(country: Country,
+                                                                  currency: CurrencyCode,
+                                                                  expectedSupportedCurrencies: [CurrencyCode],
+                                                                  isPointOfSaleAsATabi2Enabled: Bool) async throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isPointOfSaleAsATabi2Enabled: isPointOfSaleAsATabi2Enabled)
         setupCountry(country: country, currency: currency)
@@ -160,7 +163,7 @@ struct POSTabEligibilityCheckerTests {
         let result = await checker.checkEligibility()
 
         // Then
-        #expect(result == .ineligible(reason: .unsupportedCurrency))
+        #expect(result == .ineligible(reason: .unsupportedCurrency(supportedCurrencies: expectedSupportedCurrencies)))
     }
 
     @Test(arguments: [true, false])
@@ -342,7 +345,7 @@ struct POSTabEligibilityCheckerTests {
         let result = await checker.checkEligibility()
 
         // Then - Should be ineligible because fresh settings show CA (not cached US)
-        #expect(result == .ineligible(reason: .unsupportedCountry))
+        #expect(result == .ineligible(reason: .unsupportedCountry(supportedCountries: [.US, .GB])))
     }
 
     @Test(arguments: [true, false])

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -184,7 +184,7 @@ struct POSTabEligibilityCheckerTests {
         let result = await checker.checkEligibility()
 
         // Then
-        #expect(result == .ineligible(reason: .unsupportedWooCommerceVersion))
+        #expect(result == .ineligible(reason: .unsupportedWooCommerceVersion(minimumVersion: "9.6.0-beta")))
     }
 
     @Test(arguments: [true, false])


### PR DESCRIPTION
For WOOMOB-743

Just one review is required.

## Description

Now that the design is available in y0zZLi1kqybNUUUd8lmvYG-fi-4133_4658, this PR updates the POS ineligible UI based on the design.

### POS ineligible UI changes

* [`WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift`](diffhunk://#diff-45ccd52c657ec8f18fe0b9be647d4e1eefa6fc31fe081fc65c5a5b43f1429aa5R5-R51): Updated the `POSIneligibleView` to show detailed suggestions instead of generic reasons for POS ineligibility. For example, unsupported countries now display a list of supported countries, and unsupported currencies show the supported currencies for the store settings. [[1]](diffhunk://#diff-45ccd52c657ec8f18fe0b9be647d4e1eefa6fc31fe081fc65c5a5b43f1429aa5R5-R51) [[2]](diffhunk://#diff-45ccd52c657ec8f18fe0b9be647d4e1eefa6fc31fe081fc65c5a5b43f1429aa5R60-R260)

### Eligibility updates

* [`WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift`](diffhunk://#diff-c17e8dbfb52562a157337395575a7e666264d27ffc3f86c06a75a4f8a6863e61L22-R29): Refactored the `POSIneligibleReason` enum to include additional context, such as supported countries and currencies. Updated the eligibility checker logic to use these new properties for more precise ineligibility handling. [[1]](diffhunk://#diff-c17e8dbfb52562a157337395575a7e666264d27ffc3f86c06a75a4f8a6863e61L22-R29) [[2]](diffhunk://#diff-c17e8dbfb52562a157337395575a7e666264d27ffc3f86c06a75a4f8a6863e61R253-R266)

### Test updates

* [`WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift`](diffhunk://#diff-fcc52f9859ab77f1e447409e22476742185e3ce1f5ed6af514da6c4b3b79e37eL134-R150): Updated existing test cases to validate the associated values for unsupported countries, currencies, and WooCommerce versions. [[1]](diffhunk://#diff-fcc52f9859ab77f1e447409e22476742185e3ce1f5ed6af514da6c4b3b79e37eL134-R150) [[2]](diffhunk://#diff-fcc52f9859ab77f1e447409e22476742185e3ce1f5ed6af514da6c4b3b79e37eL163-R166) [[3]](diffhunk://#diff-fcc52f9859ab77f1e447409e22476742185e3ce1f5ed6af514da6c4b3b79e37eL184-R187) [[4]](diffhunk://#diff-fcc52f9859ab77f1e447409e22476742185e3ce1f5ed6af514da6c4b3b79e37eL345-R348)

## Steps to reproduce

Prerequisite: logged in to a WPCOM account connected to a store not eligible for POS (e.g. WooCommerce version below 9.6.0-beta, unsupported currency) but in an eligible country (US/UK), and a store eligible for POS

1. Open the WooCommerce app on an iPad
2. Navigate to a store not eligible for POS as in the prerequisite
3. Tap on the POS tab --> after the loading UI, the ineligible view should show the reason why it's ineligible (if there are multiple reasons, the order follows the checks in `POSTabEligibilityChecker.checkPluginEligibility`) and how to fix it
4. Switch to a store eligible for POS
5. Tap on the POS tab --> POS should be launched as expected, to the state where products are loaded

## Testing information

- [x] @jaclync tests on large font sizes (known issue WOOMOB-750)
- [ ] @jaclync tests with WC version ineligible case
- [x] @jaclync tests with unsupported currency case
- [x] @jaclync tests with feature switch disabled case

## Screenshots

light | dark
-- | --
![Simulator Screenshot - iPad Air 13-inch (M3) - 2025-07-02 at 15 05 47](https://github.com/user-attachments/assets/74948d16-9d42-412a-af2e-ac1dd8f992f0) | ![Simulator Screenshot - iPad Air 13-inch (M3) - 2025-07-02 at 15 05 50](https://github.com/user-attachments/assets/2795092a-7402-44fe-b003-ec36fb787215)


https://github.com/user-attachments/assets/26aefd71-1e20-4351-bdf6-b74e32c0150e



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.