### PR TITLE
[POS Orders] Update order details POS label

### DIFF
--- a/WooCommerce/Classes/Extensions/UILabel+SalesChannel.swift
+++ b/WooCommerce/Classes/Extensions/UILabel+SalesChannel.swift
@@ -23,7 +23,7 @@ private extension UILabel {
     enum Layout {
         static let borderWidth = CGFloat(0.0)
         static let cornerRadius = CGFloat(4.0)
-        static let salesChannelLabelTextColor = UIColor(.posPrimary)
-        static let salesChannelLabelBackgroundColor = UIColor(.posSecondary)
+        static let salesChannelLabelTextColor = UIColor(color: .wooCommercePurple(.shade80))
+        static let salesChannelLabelBackgroundColor = UIColor(color: .wooCommercePurple(.shade10))
     }
 }

--- a/WooCommerce/Classes/Extensions/UILabel+SalesChannel.swift
+++ b/WooCommerce/Classes/Extensions/UILabel+SalesChannel.swift
@@ -23,7 +23,7 @@ private extension UILabel {
     enum Layout {
         static let borderWidth = CGFloat(0.0)
         static let cornerRadius = CGFloat(4.0)
-        static let salesChannelLabelTextColor = UIColor(named: "posPrimary")
-        static let salesChannelLabelBackgroundColor = UIColor(named: "posSecondary")
+        static let salesChannelLabelTextColor = UIColor(.posPrimary)
+        static let salesChannelLabelBackgroundColor = UIColor(.posSecondary)
     }
 }

--- a/WooCommerce/Classes/Extensions/UILabel+SalesChannel.swift
+++ b/WooCommerce/Classes/Extensions/UILabel+SalesChannel.swift
@@ -6,8 +6,8 @@ extension UILabel {
     func applySalesChannelStyle() {
         applyFootnoteStyle()
         applyLayerSettings()
-        backgroundColor = .lightGray
-        textColor = .black
+        backgroundColor = Layout.salesChannelLabelBackgroundColor
+        textColor = Layout.salesChannelLabelTextColor
     }
 
     /// Setup: Layer
@@ -23,5 +23,7 @@ private extension UILabel {
     enum Layout {
         static let borderWidth = CGFloat(0.0)
         static let cornerRadius = CGFloat(4.0)
+        static let salesChannelLabelTextColor = UIColor(named: "posPrimary")
+        static let salesChannelLabelBackgroundColor = UIColor(named: "posSecondary")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
@@ -14,7 +14,7 @@ final class SummaryTableViewCell: UITableViewCell {
 
     /// Shows the sales channel if appropiate, at the moment only Point of Sale
     ///
-    @IBOutlet private weak var salesChannelLabel: UILabel!
+    @IBOutlet private weak var salesChannelLabel: PaddedLabel!
 
     /// Label: Payment Status
     ///
@@ -104,8 +104,7 @@ private extension SummaryTableViewCell {
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleOrdersi1) {
             salesChannelLabel.isHidden = false
-            salesChannelLabel.applyFootnoteStyle()
-            salesChannelLabel.accessibilityIdentifier = "summary-table-view-cell-sales-channel-label"
+            configureSalesChannelLabel()
         } else {
             salesChannelLabel.isHidden = true
         }
@@ -117,6 +116,13 @@ private extension SummaryTableViewCell {
         updateStatusButton.addTarget(self, action: #selector(editWasTapped), for: .touchUpInside)
 
         configureIconForVoiceOver()
+    }
+
+    func configureSalesChannelLabel() {
+        salesChannelLabel.numberOfLines = 1
+        salesChannelLabel.textInsets = UIEdgeInsets(top: 4, left: 8, bottom: 4, right: 8)
+        salesChannelLabel.applySalesChannelStyle()
+        salesChannelLabel.accessibilityIdentifier = "summary-table-view-cell-sales-channel-label"
     }
 
     @objc func editWasTapped() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.xib
@@ -26,7 +26,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sales Channel" textAlignment="right" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kU8-dT-4zl" userLabel="Sales Channel Label">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="255" verticalHuggingPriority="255" text="Sales Channel" textAlignment="right" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kU8-dT-4zl" userLabel="Sales Channel Label" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
                                 <rect key="frame" x="146" y="0.0" width="142" height="40"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <nil key="textColor"/>


### PR DESCRIPTION
## Description

This PR updates the "POS" text at the top right corder of Order Details to appear as a badge, using POS colors. Ref: C070SJRA8DP/p1751347733351649-slack-C070SJRA8DP

## Testing information
- If no orders are marked as POS yet in your order list, process a new POS order. 
- Tap on the order to open its details
- Observe the badge in the top right corner, along the order date 

## Screenshots
| Phone | Tablet |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 Plus - US store - 2025-07-03 at 17 46 14](https://github.com/user-attachments/assets/f2a25d34-7c5e-4624-af9e-a7e650e814b6) | ![Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-07-03 at 17 49 09](https://github.com/user-attachments/assets/78a4f479-9fd5-4a93-907a-1f4a9215819e) | 
