### PR TITLE
Shipping Labels: Update purchase request payload with correct shipment IDs

### DIFF
--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
@@ -73,6 +73,11 @@ extension WooShippingPackagePurchase {
 
         return rates
     }
+
+    /// shipment ID to set for hazmat and customs form
+    var formattedShipmentID: String {
+        Values.shipmentIDPrefix + shipmentID
+    }
 }
 
 // MARK: Enodable
@@ -99,6 +104,10 @@ extension WooShippingPackagePurchase: Encodable {
         try container.encode(rate.carrierID, forKey: .carrierID)
         try container.encode(rate.title, forKey: .serviceName)
         try container.encode(productIDs, forKey: .products)
+
+        if let hazmat = package.hazmatCategory {
+            try container.encode(package.hazmatCategory, forKey: .hazmat)
+        }
 
         if selectedRate.signatureRate != nil {
             try container.encode(Values.yes, forKey: .signature)
@@ -144,7 +153,7 @@ extension WooShippingPackagePurchase: Encodable {
     /// Converts the hazmat settings to a dictionary as the API expects it.
     /// Includes the shipment ID if there are hazmat settings to report.
     public func encodedHazmat() -> [String: Any] {
-        [shipmentID: [
+        [formattedShipmentID: [
             ParameterKeys.isHazmat: package.hazmatCategory != nil,
             ParameterKeys.category: package.hazmatCategory ?? String()
         ]]
@@ -156,7 +165,7 @@ extension WooShippingPackagePurchase: Encodable {
         guard let form = package.customsForm else {
             return [shipmentID: [:]]
         }
-        return [shipmentID: [
+        return [formattedShipmentID: [
             ParameterKeys.items: try form.items.map { try $0.toDictionary() },
             ParameterKeys.contentsType: form.contentsType.rawValue,
             ParameterKeys.contentsExplanation: form.contentExplanation,
@@ -185,6 +194,7 @@ extension WooShippingPackagePurchase: Encodable {
         case carbonNeutral = "carbon_neutral"
         case saturdayDelivery = "saturday_delivery"
         case additionalHandling = "additional_handling"
+        case hazmat
     }
 
     private enum ParameterKeys {
@@ -209,5 +219,6 @@ extension WooShippingPackagePurchase: Encodable {
         static let adult = "adult"
         static let signatureRequired = "signatureRequired"
         static let adultSignatureRequired = "adultSignatureRequired"
+        static let shipmentIDPrefix = "shipment_"
     }
 }

--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
@@ -163,7 +163,7 @@ extension WooShippingPackagePurchase: Encodable {
     /// Includes the shipment ID with the encoded customs form.
     public func encodedCustomsForm() throws -> [String: Any] {
         guard let form = package.customsForm else {
-            return [shipmentID: [:]]
+            return [formattedShipmentID: [:]]
         }
         return [formattedShipmentID: [
             ParameterKeys.items: try form.items.map { try $0.toDictionary() },

--- a/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -364,8 +364,17 @@ final class WooShippingRemoteTests: XCTestCase {
         let remote = WooShippingRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "label/purchase/\(sampleOrderID)", filename: "wooshipping-purchase-success")
 
+        let shipmentID = "1"
+        let hazmatCategory = "test-hazmat"
+        let customsForm = ShippingLabelCustomsForm.fake().copy(items: [.fake(), .fake()])
+
         let package = WooShippingPackagePurchase.fake().copy(
-            package: ShippingLabelPackageSelected.fake().copy(height: 0),
+            shipmentID: shipmentID,
+            package: ShippingLabelPackageSelected.fake().copy(
+                height: 0,
+                hazmatCategory: hazmatCategory,
+                customsForm: customsForm
+            ),
             selectedRate: WooShippingSelectedRate(
                 rate: ShippingLabelCarrierRate.fake().copy(rate: 12.32),
                 adultSignatureRate: ShippingLabelCarrierRate.fake().copy(rate: 22.33),
@@ -413,6 +422,7 @@ final class WooShippingRemoteTests: XCTestCase {
         XCTAssertEqual(firstPackage["carbon_neutral"] as? Bool, true)
         XCTAssertEqual(firstPackage["saturday_delivery"] as? Bool, true)
         XCTAssertEqual(firstPackage["additional_handling"] as? Bool, true)
+        XCTAssertEqual(firstPackage["hazmat"] as? String, hazmatCategory)
 
         let selectedRateParam = try XCTUnwrap(request.parameters["selected_rate"] as? [String: Any])
         let parentValue = try XCTUnwrap(selectedRateParam["parent"] as? [String: Any])
@@ -421,6 +431,14 @@ final class WooShippingRemoteTests: XCTestCase {
         let childValue = try XCTUnwrap(selectedRateParam["rate"] as? [String: Any])
         XCTAssertEqual(childValue["rate"] as? Double, package.selectedRate.adultSignatureRate?.rate)
         XCTAssertEqual(childValue["type"] as? String, "adultSignatureRequired")
+
+        let hazmatValue = try XCTUnwrap(request.parameters["hazmat"] as? [String: Any])
+        let hazmatShipment = try XCTUnwrap(hazmatValue["shipment_" + shipmentID] as? [String: Any])
+        XCTAssertEqual(hazmatShipment["category"] as? String, hazmatCategory)
+
+        let customsValue = try XCTUnwrap(request.parameters["customs"] as? [String: Any])
+        let customsShipment = try XCTUnwrap(customsValue["shipment_" + shipmentID] as? [String: Any])
+        XCTAssertEqual((try XCTUnwrap(customsShipment["items"] as? [Any])).count, 2)
 
         let labels = try XCTUnwrap(result.get())
         XCTAssertEqual(labels.count, 1)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
@@ -234,7 +234,8 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
         try await viewModel.purchaseLabel()
 
         // Then
-        let shipmentDetails = encodedHazmat?[viewModel.shipment.index.description] as? [String: Any]
+        let index = "shipment_" + viewModel.shipment.index.description
+        let shipmentDetails = encodedHazmat?[index] as? [String: Any]
         XCTAssertEqual(shipmentDetails?["isHazmat"] as? Bool, true)
         XCTAssertEqual(shipmentDetails?["category"] as? String, ShippingLabelHazmatCategory.class3.rawValue)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-752

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the request payload for label purchase to use the correct shipment ID format for the `hazmat` and `customs` fields.

Also, I added the `hazmat` field inside of `package` dictionary following the web to avoid any potential issues of missing this.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Test label purchase with or without a non-nil HAZMAT category or customs form or both.
- Confirm with Proxyman that the purchase request sends the correct shipment ID with the `shipment_` prefix.
- Confirm that the purchase succeeds.
- Check the response to the `GET config/label-purchase` endpoint and confirm that `selected_destinations` returns results as a dictionary with shipment indices as keys instead of an array.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested and confirmed with simulator iPhone 16 iOS 18.4

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

No UI changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
