### PR TITLE
[POS Orders] Move sales channel representation to Networking

### DIFF
--- a/Modules/Sources/NetworkingCore/Model/Order.swift
+++ b/Modules/Sources/NetworkingCore/Model/Order.swift
@@ -68,7 +68,7 @@ public struct Order: Decodable, Sendable, GeneratedCopiable, GeneratedFakeable {
     /// Set to orders created via specific sources (e.g. checkout, store-api, Point of Sale, ...)
     ///
     public let createdVia: String?
-    
+
     public var salesChannel: SalesChannelType? {
         guard let createdVia else { return nil }
         return SalesChannelType(rawValue: createdVia)

--- a/Modules/Sources/NetworkingCore/Model/Order.swift
+++ b/Modules/Sources/NetworkingCore/Model/Order.swift
@@ -69,9 +69,9 @@ public struct Order: Decodable, Sendable, GeneratedCopiable, GeneratedFakeable {
     ///
     public let createdVia: String?
 
-    public var salesChannel: SalesChannelType? {
+    public var salesChannel: SalesChannel? {
         guard let createdVia else { return nil }
-        return SalesChannelType(rawValue: createdVia)
+        return SalesChannel(rawValue: createdVia)
     }
 
     /// Order struct initializer.

--- a/Modules/Sources/NetworkingCore/Model/Order.swift
+++ b/Modules/Sources/NetworkingCore/Model/Order.swift
@@ -1,6 +1,37 @@
 import Foundation
 import Codegen
 
+public enum SalesChannelType {
+    case pointOfSale
+}
+
+extension SalesChannelType: RawRepresentable {
+    public init?(rawValue: String) {
+        switch rawValue {
+        case "pos-rest-api":
+            self = .pointOfSale
+        default:
+            return nil
+        }
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .pointOfSale:
+            return description
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .pointOfSale:
+            return NSLocalizedString("",
+                                     value: "POS",
+                                     comment: "The acronym for 'Point of Sale' that is shown for certain orders.")
+        }
+    }
+}
+
 /// Represents an Order Entity.
 ///
 public struct Order: Decodable, Sendable, GeneratedCopiable, GeneratedFakeable {
@@ -68,6 +99,11 @@ public struct Order: Decodable, Sendable, GeneratedCopiable, GeneratedFakeable {
     /// Set to orders created via specific sources (e.g. checkout, store-api, Point of Sale, ...)
     ///
     public let createdVia: String?
+    
+    public var salesChannel: SalesChannelType? {
+        guard let createdVia else { return nil }
+        return SalesChannelType(rawValue: createdVia)
+    }
 
     /// Order struct initializer.
     ///

--- a/Modules/Sources/NetworkingCore/Model/Order.swift
+++ b/Modules/Sources/NetworkingCore/Model/Order.swift
@@ -1,37 +1,6 @@
 import Foundation
 import Codegen
 
-public enum SalesChannelType {
-    case pointOfSale
-}
-
-extension SalesChannelType: RawRepresentable {
-    public init?(rawValue: String) {
-        switch rawValue {
-        case "pos-rest-api":
-            self = .pointOfSale
-        default:
-            return nil
-        }
-    }
-
-    public var rawValue: String {
-        switch self {
-        case .pointOfSale:
-            return description
-        }
-    }
-
-    public var description: String {
-        switch self {
-        case .pointOfSale:
-            return NSLocalizedString("",
-                                     value: "POS",
-                                     comment: "The acronym for 'Point of Sale' that is shown for certain orders.")
-        }
-    }
-}
-
 /// Represents an Order Entity.
 ///
 public struct Order: Decodable, Sendable, GeneratedCopiable, GeneratedFakeable {

--- a/Modules/Sources/NetworkingCore/Model/SalesChannel.swift
+++ b/Modules/Sources/NetworkingCore/Model/SalesChannel.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-public enum SalesChannelType {
+public enum SalesChannel {
     case pointOfSale
 }
 
-extension SalesChannelType: RawRepresentable {
+extension SalesChannel: RawRepresentable {
     public init?(rawValue: String) {
         switch rawValue {
         case "pos-rest-api":
@@ -24,7 +24,7 @@ extension SalesChannelType: RawRepresentable {
     public var description: String {
         switch self {
         case .pointOfSale:
-            return NSLocalizedString("saleschanneltype.pos.description",
+            return NSLocalizedString("salesChannel.pos.description",
                                      value: "POS",
                                      comment: "The acronym for 'Point of Sale'.")
         }

--- a/Modules/Sources/NetworkingCore/Model/SalesChannelType.swift
+++ b/Modules/Sources/NetworkingCore/Model/SalesChannelType.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+public enum SalesChannelType {
+    case pointOfSale
+}
+
+extension SalesChannelType: RawRepresentable {
+    public init?(rawValue: String) {
+        switch rawValue {
+        case "pos-rest-api":
+            self = .pointOfSale
+        default:
+            return nil
+        }
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .pointOfSale:
+            return description
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .pointOfSale:
+            return NSLocalizedString("saleschanneltype.pos.description",
+                                     value: "POS",
+                                     comment: "The acronym for 'Point of Sale'.")
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
@@ -79,16 +79,7 @@ struct OrderListCellViewModel {
     /// Textual representation of the sales channel
     ///
     var salesChannel: String? {
-        guard let createdVia = order.createdVia else {
-            return nil
-        }
-
-        switch createdVia {
-        case "pos-rest-api":
-            return Localization.salesChannelPOSText
-        default:
-            return nil
-        }
+        order.salesChannel?.description
     }
 
     /// The localized unabbreviated total for a given order item, which includes the currency.
@@ -128,9 +119,5 @@ extension OrderListCellViewModel {
             "orderlistcellviewmodel.customerName.guestName",
             value: "Guest",
             comment: "In Order List, the name of the billed person when there are no first and last name.")
-        static let salesChannelPOSText = NSLocalizedString(
-            "orderlistcellviewmodel.salesChannel.salesChannelPOSText",
-            value: "POS",
-            comment: "In Order List, the acronym for 'Point of Sale' that is shown as a badge for certain orders.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
@@ -31,7 +31,7 @@ final class SummaryTableViewCell: UITableViewCell {
     func configure(_ viewModel: SummaryTableViewCellViewModel) {
         titleLabel.text = viewModel.billedPersonName
         subtitleLabel.text = viewModel.subtitle
-        salesChannelLabel.text = viewModel.formattedSalesChannel
+        salesChannelLabel.text = viewModel.salesChannel
         salesChannelLabel.isHidden = (salesChannelLabel.text == nil)
         display(presentation: viewModel.presentation)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCellViewModel.swift
@@ -9,21 +9,19 @@ struct SummaryTableViewCellViewModel {
 
     private let billingAddress: Address?
     private let dateCreated: Date
-    private let salesChannel: String?
+    private(set) var salesChannel: String?
 
     let presentation: OrderStatusPresentation
 
     private let calendar: Calendar
-    private let order: Order
 
     init(order: Order,
          status: OrderStatus?,
          calendar: Calendar = .current) {
-        self.order = order
 
         billingAddress = order.billingAddress
         dateCreated = order.dateCreated
-        salesChannel = order.createdVia
+        salesChannel = order.salesChannel?.description
 
         presentation = OrderStatusPresentation(
             style: status?.status ?? order.status,
@@ -49,12 +47,6 @@ struct SummaryTableViewCellViewModel {
         let formatter = DateFormatter.dateAndTimeFormatter
         formatter.timeZone = .siteTimezone
         return formatter.string(from: dateCreated)
-    }
-
-    /// Textual representation of the sales channel
-    ///
-    var formattedSalesChannel: String? {
-        order.salesChannel?.description
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCellViewModel.swift
@@ -14,13 +14,11 @@ struct SummaryTableViewCellViewModel {
     let presentation: OrderStatusPresentation
 
     private let calendar: Calendar
-    
     private let order: Order
 
     init(order: Order,
          status: OrderStatus?,
          calendar: Calendar = .current) {
-        
         self.order = order
 
         billingAddress = order.billingAddress

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCellViewModel.swift
@@ -14,10 +14,14 @@ struct SummaryTableViewCellViewModel {
     let presentation: OrderStatusPresentation
 
     private let calendar: Calendar
+    
+    private let order: Order
 
     init(order: Order,
          status: OrderStatus?,
          calendar: Calendar = .current) {
+        
+        self.order = order
 
         billingAddress = order.billingAddress
         dateCreated = order.dateCreated
@@ -52,15 +56,7 @@ struct SummaryTableViewCellViewModel {
     /// Textual representation of the sales channel
     ///
     var formattedSalesChannel: String? {
-        guard let salesChannel = salesChannel else {
-            return nil
-        }
-        switch salesChannel {
-        case "pos-rest-api":
-            return "POS"
-        default:
-            return nil
-        }
+        order.salesChannel?.description
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
@@ -70,7 +70,7 @@ final class OrderListCellViewModelTests: XCTestCase {
         let viewModel = OrderListCellViewModel(order: order, currencySettings: ServiceLocator.currencySettings)
 
         // Then
-        XCTAssertEqual(viewModel.salesChannel, OrderListCellViewModel.Localization.salesChannelPOSText)
+        XCTAssertEqual(viewModel.salesChannel, "POS")
     }
 
     func test_salesChannel_when_createdVia_is_nil_then_returns_nil() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
As follow-up from p1751433227323889-slack-CGPNUU63E , we move the sales channel representation from WooCommerce to Networking, removing some code duplication, and avoiding having to handle the `pos-rest-api` raw value directly in the app layer. 

> "_how about adding the calculated property for order.salesChannel similar to [product.productType](https://github.com/woocommerce/woocommerce-ios/blob/ea2d1b5428f37cf1c8ab2731cdcd2cffd7f13548/Modules/Sources/Networking/Model/Product/Product.swift#L155-L157) so that the use cases don't have to work with the raw value? The sales channel can be an enum too like the product type._"

Let me know if this is what you had in mind @jaclync , happy to iterate further! 

## Changes
- Declared a `SalesChannelType` , where the `created_via` value  is passed directly and returns the specific associated case and it's description ( for now, only `.pointOfSale` - `"POS"` is handled, any other value will return nil)
- Access this description directly from the appropriate cells.

## Testing information

- Navigate to your orders, POS badges should render both in order list and order details when a POS order is processed (there is no backfilling, you might need to process a fresh POS order if created_via hasn't been set yet)

![Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-07-03 at 17 49 09](https://github.com/user-attachments/assets/78a4f479-9fd5-4a93-907a-1f4a9215819e)