### PR TITLE
[Shipping Labels] Fix purchased labels not presenting destination address

### DIFF
--- a/Modules/Sources/Networking/Mapper/WooShippingConfigMapper.swift
+++ b/Modules/Sources/Networking/Mapper/WooShippingConfigMapper.swift
@@ -44,5 +44,5 @@ private struct WooShippingConfigMapperEnvelope: Decodable {
 extension WooShippingConfigMapper {
     /// Load only the relevant fields from remote
     ///
-    static let fieldsToLoad = "config.shipments, config.shippingLabelData.currentOrderLabels"
+    static let fieldsToLoad = "config.shipments, config.shippingLabelData.currentOrderLabels, config.shippingLabelData.storedData.selected_destination"
 }

--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
@@ -219,6 +219,5 @@ extension WooShippingPackagePurchase: Encodable {
         static let adult = "adult"
         static let signatureRequired = "signatureRequired"
         static let adultSignatureRequired = "adultSignatureRequired"
-        static let shipmentIDPrefix = "shipment_"
     }
 }

--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
@@ -76,7 +76,7 @@ extension WooShippingPackagePurchase {
 
     /// shipment ID to set for hazmat and customs form
     var formattedShipmentID: String {
-        Values.shipmentIDPrefix + shipmentID
+        return WooShippingShipmentIDFormatter.formattedShipmentID(shipmentID)
     }
 }
 

--- a/Modules/Sources/Networking/Model/ShippingLabel/Shipments/WooShippingConfigResponse.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Shipments/WooShippingConfigResponse.swift
@@ -74,11 +74,19 @@ public struct WooShippingLabelData: Decodable, Equatable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let currentOrderLabels = try container.decodeIfPresent([ShippingLabel].self, forKey: .currentOrderLabels) ?? []
         let storedData = try container.decodeIfPresent(StoredData.self, forKey: .storedData)
+        let decodedOrderLabels = try container.decodeIfPresent([ShippingLabel].self, forKey: .currentOrderLabels) ?? []
+
+        /// Inject destination addresses into labels if present
+        let orderLabels: [ShippingLabel]
+        if let destinations = storedData?.selectedDestinations, !destinations.isEmpty {
+            orderLabels = WooShippingLabelData.mapDestinations(destinations, into: decodedOrderLabels)
+        } else {
+            orderLabels = decodedOrderLabels
+        }
 
         self.init(
-            currentOrderLabels: currentOrderLabels,
+            currentOrderLabels: orderLabels,
             storedData: storedData
         )
     }
@@ -86,6 +94,26 @@ public struct WooShippingLabelData: Decodable, Equatable {
     private enum CodingKeys: String, CodingKey {
         case currentOrderLabels
         case storedData
+    }
+}
+
+private extension WooShippingLabelData {
+    static func mapDestinations(
+        _ destinations: WooShippingLabelDestinations,
+        into labels: [ShippingLabel]
+    ) -> [ShippingLabel] {
+        return labels.map { label in
+            guard
+                let shipmentID = label.shipmentID,
+                let destinationAddress = destinations[
+                    WooShippingShipmentIDFormatter.formattedShipmentID(shipmentID)
+                ]
+            else {
+                return label
+            }
+
+            return label.copy(destinationAddress: destinationAddress.toShippingLabelAddress())
+        }
     }
 }
 

--- a/Modules/Sources/Networking/Model/ShippingLabel/Shipments/WooShippingConfigResponse.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Shipments/WooShippingConfigResponse.swift
@@ -65,7 +65,7 @@ public struct WooShippingLabelData: Decodable, Equatable {
 
     public init(
         currentOrderLabels: [ShippingLabel],
-        storedData: StoredData?
+        storedData: StoredData? = nil
     ) {
         self.currentOrderLabels = currentOrderLabels
         self.storedData = storedData

--- a/Modules/Sources/Networking/Model/ShippingLabel/Shipments/WooShippingConfigResponse.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Shipments/WooShippingConfigResponse.swift
@@ -97,26 +97,6 @@ public struct WooShippingLabelData: Decodable, Equatable {
     }
 }
 
-private extension WooShippingLabelData {
-    static func mapDestinations(
-        _ destinations: WooShippingLabelDestinations,
-        into labels: [ShippingLabel]
-    ) -> [ShippingLabel] {
-        return labels.map { label in
-            guard
-                let shipmentID = label.shipmentID,
-                let destinationAddress = destinations[
-                    WooShippingShipmentIDFormatter.formattedShipmentID(shipmentID)
-                ]
-            else {
-                return label
-            }
-
-            return label.copy(destinationAddress: destinationAddress.toShippingLabelAddress())
-        }
-    }
-}
-
 public extension WooShippingLabelData {
     typealias WooShippingLabelDestinations = [String: WooShippingAddress]
 

--- a/Modules/Sources/Networking/Model/ShippingLabel/Shipments/WooShippingConfigResponse.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Shipments/WooShippingConfigResponse.swift
@@ -60,18 +60,52 @@ public struct WooShippingLabelData: Decodable, Equatable {
     /// Labels purchased for the current order
     public let currentOrderLabels: [ShippingLabel]
 
-    public init(currentOrderLabels: [ShippingLabel]) {
+    /// Contains destination addresses
+    public let storedData: StoredData?
+
+    public init(
+        currentOrderLabels: [ShippingLabel],
+        storedData: StoredData?
+    ) {
         self.currentOrderLabels = currentOrderLabels
+        self.storedData = storedData
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+
         let currentOrderLabels = try container.decodeIfPresent([ShippingLabel].self, forKey: .currentOrderLabels) ?? []
-        self.init(currentOrderLabels: currentOrderLabels)
+        let storedData = try container.decodeIfPresent(StoredData.self, forKey: .storedData)
+
+        self.init(
+            currentOrderLabels: currentOrderLabels,
+            storedData: storedData
+        )
     }
 
     private enum CodingKeys: String, CodingKey {
         case currentOrderLabels
+        case storedData
+    }
+}
+
+public extension WooShippingLabelData {
+    typealias WooShippingLabelDestinations = [String: WooShippingAddress]
+
+    struct StoredData: Decodable, Equatable {
+        let selectedDestinations: WooShippingLabelDestinations?
+
+        public enum CodingKeys: String, CodingKey {
+            case selectedDestination = "selected_destination"
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.selectedDestinations = try? container.decodeIfPresent(
+                WooShippingLabelDestinations.self,
+                forKey: CodingKeys.selectedDestination
+            )
+        }
     }
 }
 

--- a/Modules/Sources/Networking/Model/ShippingLabel/Shipments/WooShippingLabelData+mapDestinations.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Shipments/WooShippingLabelData+mapDestinations.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension WooShippingLabelData {
+    static func mapDestinations(
+        _ destinations: WooShippingLabelDestinations,
+        into labels: [ShippingLabel]
+    ) -> [ShippingLabel] {
+        return labels.map { label in
+            guard
+                let shipmentID = label.shipmentID,
+                let destinationAddress = destinations[
+                    WooShippingShipmentIDFormatter.formattedShipmentID(shipmentID)
+                ]
+            else {
+                return label
+            }
+
+            return label.copy(destinationAddress: destinationAddress.toShippingLabelAddress())
+        }
+    }
+}

--- a/Modules/Sources/Networking/Model/ShippingLabel/Shipments/WooShippingLabelData+mapDestinations.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Shipments/WooShippingLabelData+mapDestinations.swift
@@ -10,7 +10,7 @@ extension WooShippingLabelData {
                 let shipmentID = label.shipmentID,
                 let destinationAddress = destinations[
                     WooShippingShipmentIDFormatter.formattedShipmentID(shipmentID)
-                ]
+                ] ?? destinations[shipmentID] /// Fallback for ids previously submitted without `shipment_<id>` formatting
             else {
                 return label
             }

--- a/Modules/Sources/Networking/Model/ShippingLabel/WooShippingAddress.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/WooShippingAddress.swift
@@ -59,12 +59,12 @@ extension WooShippingAddress: Codable {
         // If no name is sent to validation address request, no name will be received in response.
         // So make sure to decode it only if it's present.
         let name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
-        let company = try container.decode(String.self, forKey: .company)
-        let phone = try container.decode(String.self, forKey: .phone)
+        let company = try container.decodeIfPresent(String.self, forKey: .company) ?? ""
+        let phone = try container.decodeIfPresent(String.self, forKey: .phone) ?? ""
         let country = try container.decode(String.self, forKey: .country)
         let state = try container.decode(String.self, forKey: .state)
         let address1 = try container.decodeIfPresent(String.self, forKey: .address1) ?? container.decode(String.self, forKey: .alternateAddress1)
-        let address2 = try container.decode(String.self, forKey: .address2)
+        let address2 = try container.decodeIfPresent(String.self, forKey: .address2) ?? ""
         let city = try container.decode(String.self, forKey: .city)
         let postcode = try container.decode(String.self, forKey: .postcode)
 

--- a/Modules/Sources/Networking/Model/ShippingLabel/WooShippingShipmentIDFormatter.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/WooShippingShipmentIDFormatter.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum WooShippingShipmentIDFormatter {
+    /// Turns numeric shipment ID into formatted as `shipment_<id>`
+    /// - Parameter shipmentID: numeric shipment id
+    /// - Returns: formated id string
+    static func formattedShipmentID(_ shipmentID: String) -> String {
+        return isArgumentIDValid(shipmentID) ?
+        Values.shipmentIDPrefix + shipmentID :
+        shipmentID
+    }
+}
+
+private extension WooShippingShipmentIDFormatter {
+    private enum Values {
+        static let shipmentIDPrefix = "shipment_"
+    }
+
+    /// Make sure we are formatting incoming numeric ID string
+    private static func isArgumentIDValid(_ argumentID: String) -> Bool {
+        return Int(argumentID) != nil
+    }
+}

--- a/Modules/Sources/NetworkingCore/Model/ShippingLabel/ShippingLabelAddress.swift
+++ b/Modules/Sources/NetworkingCore/Model/ShippingLabel/ShippingLabelAddress.swift
@@ -117,4 +117,16 @@ extension ShippingLabelAddress {
     init() {
         self.init(company: "", name: "", phone: "", country: "", state: "", address1: "", address2: "", city: "", postcode: "")
     }
+
+    var isEmpty: Bool {
+        return company.isEmpty &&
+        name.isEmpty &&
+        phone.isEmpty &&
+        country.isEmpty &&
+        state.isEmpty &&
+        address1.isEmpty &&
+        address2.isEmpty &&
+        city.isEmpty &&
+        postcode.isEmpty
+    }
 }

--- a/Modules/Tests/NetworkingTests/Model/WooShippingShipmentIDFormatterTests.swift
+++ b/Modules/Tests/NetworkingTests/Model/WooShippingShipmentIDFormatterTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import XCTest
+@testable import Networking
+
+final class WooShippingShipmentIDFormatterTests: XCTestCase {
+
+    // MARK: - formattedShipmentID
+
+    func test_formatted_shipment_id_when_id_is_numeric_should_return_formatted_id() {
+        // Given
+        let sut = WooShippingShipmentIDFormatter.self
+        let id = "123456"
+
+        // When
+        let formattedID = sut.formattedShipmentID(id)
+
+        // Then
+        XCTAssertEqual(formattedID, "shipment_123456")
+    }
+
+    func test_formatted_shipment_id_when_id_is_already_formatted_should_return_same_id() {
+        // Given
+        let sut = WooShippingShipmentIDFormatter.self
+        let id = "shipment_123456"
+
+        // When
+        let formattedID = sut.formattedShipmentID(id)
+
+        // Then
+        XCTAssertEqual(formattedID, "shipment_123456")
+    }
+
+    func test_formatted_shipment_id_when_non_numeric_should_return_same_id() {
+        // Given
+        let sut = WooShippingShipmentIDFormatter.self
+        let id = "non-numeric-id"
+
+        // When
+        let formattedID = sut.formattedShipmentID(id)
+
+        // Then
+        XCTAssertEqual(formattedID, id)
+    }
+} 

--- a/Modules/Tests/NetworkingTests/Model/WooShippingShipmentIDFormatterTests.swift
+++ b/Modules/Tests/NetworkingTests/Model/WooShippingShipmentIDFormatterTests.swift
@@ -41,4 +41,4 @@ final class WooShippingShipmentIDFormatterTests: XCTestCase {
         // Then
         XCTAssertEqual(formattedID, id)
     }
-} 
+}

--- a/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -855,6 +855,63 @@ final class WooShippingRemoteTests: XCTestCase {
         XCTAssertNotNil(result.failure)
     }
 
+    // MARK: - Load Config With Destinations
+
+    func test_loadConfig_withDestinations_parses_success_response() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "config/label-purchase/\(sampleOrderID)", filename: "wooshipping-config-with-destinations")
+
+        // When
+        let result: Result<WooShippingConfig, Error> = waitFor { promise in
+            remote.loadConfig(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let config = try XCTUnwrap(result.get())
+        let label = try XCTUnwrap(config.shippingLabelData?.currentOrderLabels.first)
+        XCTAssertNotNil(label.destinationAddress)
+        XCTAssertEqual(label.destinationAddress.address1, "200 N SPRING ST")
+    }
+
+    func test_loadConfig_withoutDestinations_parses_success_response() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "config/label-purchase/\(sampleOrderID)", filename: "wooshipping-config-without-destinations")
+
+        // When
+        let result: Result<WooShippingConfig, Error> = waitFor { promise in
+            remote.loadConfig(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let config = try XCTUnwrap(result.get())
+        let label = try XCTUnwrap(config.shippingLabelData?.currentOrderLabels.first)
+        XCTAssertTrue(label.destinationAddress.isEmpty)
+    }
+
+    func test_loadConfig_withInvalidDestinations_parses_success_response() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "config/label-purchase/\(sampleOrderID)", filename: "wooshipping-config-with-invalid-destinations")
+
+        // When
+        let result: Result<WooShippingConfig, Error> = waitFor { promise in
+            remote.loadConfig(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let config = try XCTUnwrap(result.get())
+        let label = try XCTUnwrap(config.shippingLabelData?.currentOrderLabels.first)
+        XCTAssertTrue(label.destinationAddress.isEmpty)
+    }
+
     // MARK: Update shipment
 
     func test_updateShipment_parses_success_response() throws {

--- a/Modules/Tests/NetworkingTests/Responses/wooshipping-config-with-destinations.json
+++ b/Modules/Tests/NetworkingTests/Responses/wooshipping-config-with-destinations.json
@@ -1,0 +1,43 @@
+{
+    "data": {
+        "config": {
+            "shippingLabelData": {
+                "storedData": {
+                    "selected_destination": {
+                        "shipment_1": {
+                            "address_1": "200 N SPRING ST",
+                            "city": "LOS ANGELES",
+                            "state": "CA",
+                            "postcode": "90012-4801",
+                            "country": "US"
+                        }
+                    }
+                },
+                "currentOrderLabels": [
+                    {
+                      "label_id": 4871,
+                      "tracking": null,
+                      "refundable_amount": 0,
+                      "created": 1742292110723,
+                      "carrier_id": "usps",
+                      "service_name": "USPS - Priority Mail",
+                      "status": "PURCHASE_IN_PROGRESS",
+                      "commercial_invoice_url": "",
+                      "is_commercial_invoice_submitted_electronically": false,
+                      "package_name": "Small Flat Rate Box",
+                      "is_letter": false,
+                      "product_names": [
+                        "BG upload"
+                      ],
+                      "product_ids": [
+                        522
+                      ],
+                      "id": "1",
+                      "receipt_item_id": -1,
+                      "created_date": 1742292110000
+                    }
+                ]
+            }
+        }
+    }
+} 

--- a/Modules/Tests/NetworkingTests/Responses/wooshipping-config-with-invalid-destinations.json
+++ b/Modules/Tests/NetworkingTests/Responses/wooshipping-config-with-invalid-destinations.json
@@ -1,0 +1,39 @@
+{
+    "data": {
+        "config": {
+            "shippingLabelData": {
+                "storedData": {
+                    "selected_destination": [
+                        {
+                            "address_1": "200 N SPRING ST"
+                        }
+                    ]
+                },
+                "currentOrderLabels": [
+                  {
+                    "label_id": 4871,
+                    "tracking": null,
+                    "refundable_amount": 0,
+                    "created": 1742292110723,
+                    "carrier_id": "usps",
+                    "service_name": "USPS - Priority Mail",
+                    "status": "PURCHASE_IN_PROGRESS",
+                    "commercial_invoice_url": "",
+                    "is_commercial_invoice_submitted_electronically": false,
+                    "package_name": "Small Flat Rate Box",
+                    "is_letter": false,
+                    "product_names": [
+                      "BG upload"
+                    ],
+                    "product_ids": [
+                      522
+                    ],
+                    "id": "1",
+                    "receipt_item_id": -1,
+                    "created_date": 1742292110000
+                  }
+                ]
+            }
+        }
+    }
+} 

--- a/Modules/Tests/NetworkingTests/Responses/wooshipping-config-without-destinations.json
+++ b/Modules/Tests/NetworkingTests/Responses/wooshipping-config-without-destinations.json
@@ -1,0 +1,32 @@
+{
+    "data": {
+        "config": {
+            "shippingLabelData": {
+                "currentOrderLabels": [
+                  {
+                    "label_id": 4871,
+                    "tracking": null,
+                    "refundable_amount": 0,
+                    "created": 1742292110723,
+                    "carrier_id": "usps",
+                    "service_name": "USPS - Priority Mail",
+                    "status": "PURCHASE_IN_PROGRESS",
+                    "commercial_invoice_url": "",
+                    "is_commercial_invoice_submitted_electronically": false,
+                    "package_name": "Small Flat Rate Box",
+                    "is_letter": false,
+                    "product_names": [
+                      "BG upload"
+                    ],
+                    "product_ids": [
+                      522
+                    ],
+                    "id": "1",
+                    "receipt_item_id": -1,
+                    "created_date": 1742292110000
+                  }
+                ]
+            }
+        }
+    }
+} 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 
 22.7
 -----
+- [*] Shipping Labels: Fixed an issue where the destination address was missing for previously purchased shipping labels. [https://github.com/woocommerce/woocommerce-ios/pull/15866]
 - [*] Shipping Labels: Fixed an issue where the purchase button would display a stale price after changing the origin address. [https://github.com/woocommerce/woocommerce-ios/pull/15795]
 - [*] Order Details: Fix crash when reloading data [https://github.com/woocommerce/woocommerce-ios/pull/15764]
 - [*] Shipping Labels: Improved shipment management UI by hiding remove/merge options instead of disabling them, hiding merge option for orders with 2 or fewer unfulfilled shipments, and hiding the ellipsis menu when no remove/merge actions are available [https://github.com/woocommerce/woocommerce-ios/pull/15760]


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
**Fix: Display destination address for purchased shipping labels**

WOOMOB-746

## Description
This pull request fixes a bug where the destination address for previously purchased shipping labels was not being displayed to the user.

The root cause was that the `config/label-purchase/{order_id}` endpoint returns shipping label objects and their corresponding destination addresses in separate parts of the JSON payload. The `ShippingLabel` model itself did not contain the address, and the app was not performing the necessary association between the two datasets.

This PR introduces a client-side solution to correctly populate the address information:
1.  **Enhanced Response Parsing**: The app's data models have been updated to correctly parse the `selected_destination` dictionary from the `config.shippingLabelData.storedData` path in the API response. The `config.shippingLabelData.storedData.selected_destination` request parameter was added to obtain the `selected_destination` payload.
2.  **Client-Side Address Mapping**: A new mapping mechanism has been implemented. After the config response is decoded, this logic iterates through the `currentOrderLabels` and injects the correct destination address from the `selected_destination` dictionary.
3.  **Standardized Shipment ID**: The address-to-label mapping relies on a standardized `shipment_<id>` format for the dictionary key. A new `WooShippingShipmentIDFormatter` utility was created to handle this formatting consistently. It was extracted from the recently added in for reusability `WooShippingPackagePurchase.swift`
4.  **Backward Compatibility**: To support labels created before this change (which may not use the new key format), the mapping logic includes a fallback that attempts to look up the destination address using the original, non-formatted numeric `shipmentID`.

## Testing steps
- Create a new order with a bunch of physical products. Make it completed.
- Split the order into 2+ shipments.
- Setup shipments with different hazmat, customs and destination country configurations. For example - the 1st shipment has non foreign destination address, no customs data, but has hazmat. The second shipment has foreign destination address and customs data.
- Purchase labels for both shipments.
- Close order details and then navigate back to this order from order list.
- Expand bottom sheet to reveal destination address details.
- Check out each fulfilled shipment you've just purchased.
- Each shipment should present the correct destination address.
- Consider comparing with web behaviour. Web version should display same addresses for those shipments.

## Testing information
This PR is thoroughly covered by new automated tests to ensure the mapping logic is correct and to prevent regressions.

*   **`WooShippingShipmentIDFormatterTests`**: A new test file was created to unit test the ID formatting logic, covering various input scenarios.
*   **`WooShippingRemoteTests`**: The existing remote tests were refactored to use the established `waitFor` and `simulateResponse` pattern. The new tests validate the end-to-end flow by mocking the `loadConfig` API call with different JSON fixtures:
    *   **`wooshipping-config-with-destinations.json`**: Simulates a response containing destination addresses and asserts that they are correctly mapped to the label objects.
    *   **`wooshipping-config-without-destinations.json`**: Ensures the app handles responses without destination data gracefully.
    *   **`wooshipping-config-with-invalid-destinations.json`**: Confirms that a malformed `selected_destination` object (i.e., an array instead of a dictionary) does not cause a crash.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.