### PR TITLE
[POS Orders] Woo version eligibility checker

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -45,6 +45,10 @@ final class OrderDetailsDataSource: NSObject {
     ///
     var isEligibleForWooShipping: Bool = false
 
+    /// Whether the order is eligible for displaying sales channel POS badge
+    ///
+    var isEligibleForDisplayingSalesChannelPOSBadge: Bool = false
+
     /// Whether the order is eligible for card present payment.
     ///
     var isEligibleForPayment: Bool {
@@ -1088,7 +1092,8 @@ private extension OrderDetailsDataSource {
     private func configureSummary(cell: SummaryTableViewCell) {
         let cellViewModel = SummaryTableViewCellViewModel(
             order: order,
-            status: lookUpOrderStatus(for: order)
+            status: lookUpOrderStatus(for: order),
+            isEligibleForDisplayingSalesChannelPOSBadge: isEligibleForDisplayingSalesChannelPOSBadge
         )
 
         cell.configure(cellViewModel)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -282,6 +282,14 @@ extension OrderDetailsViewModel {
 
                     taskGroup.addTask { [weak self] in
                         guard let self else { return }
+                        // Check sales channel eligibility
+                        let checker = OrderSalesChannelEligibilityChecker()
+                        let isEligible = await checker.performEligibilityCheck(siteID: order.siteID)
+                        dataSource.isEligibleForDisplayingSalesChannelPOSBadge = isEligible
+                    }
+
+                    taskGroup.addTask { [weak self] in
+                        guard let self else { return }
                         // Sync shipping labels and update order with the result if available
                         let shippingLabels = await syncShippingLabels()
                         // Update the order with the newly synced shipping labels

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
@@ -19,9 +19,14 @@ struct OrderListCellViewModel {
     private let order: Order
     private let currencyFormatter: CurrencyFormatter
 
-    init(order: Order, currencySettings: CurrencySettings) {
+    /// Whether the order is eligible for displaying sales channel POS badge
+    ///
+    let isEligibleForDisplayingSalesChannelPOSBadge: Bool
+
+    init(order: Order, currencySettings: CurrencySettings, isEligibleForDisplayingSalesChannelPOSBadge: Bool = false) {
         self.order = order
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        self.isEligibleForDisplayingSalesChannelPOSBadge = isEligibleForDisplayingSalesChannelPOSBadge
     }
 
     /// For example, #560 Pamela Nguyen

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -57,11 +57,14 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
         paymentStatusLabel.applyStyle(for: viewModel.status)
         paymentStatusLabel.text = viewModel.statusString
 
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleOrdersi1),
-           let salesChannel = viewModel.salesChannel {
-            salesChannelLabel.isHidden = false
-            salesChannelLabel.applySalesChannelStyle()
-            salesChannelLabel.text = salesChannel
+        if SalesChannelEligibilityChecker.isEligible {
+            if let salesChannel = viewModel.salesChannel {
+                salesChannelLabel.isHidden = false
+                salesChannelLabel.applySalesChannelStyle()
+                salesChannelLabel.text = salesChannel
+            } else {
+                salesChannelLabel.isHidden = true
+            }
         } else {
             salesChannelLabel.isHidden = true
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -57,7 +57,7 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
         paymentStatusLabel.applyStyle(for: viewModel.status)
         paymentStatusLabel.text = viewModel.statusString
 
-        if SalesChannelEligibilityChecker.isEligible, let salesChannel = viewModel.salesChannel {
+        if viewModel.isEligibleForDisplayingSalesChannelPOSBadge, let salesChannel = viewModel.salesChannel {
                 salesChannelLabel.isHidden = false
                 salesChannelLabel.applySalesChannelStyle()
                 salesChannelLabel.text = salesChannel

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -57,14 +57,10 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
         paymentStatusLabel.applyStyle(for: viewModel.status)
         paymentStatusLabel.text = viewModel.statusString
 
-        if SalesChannelEligibilityChecker.isEligible {
-            if let salesChannel = viewModel.salesChannel {
+        if SalesChannelEligibilityChecker.isEligible, let salesChannel = viewModel.salesChannel {
                 salesChannelLabel.isHidden = false
                 salesChannelLabel.applySalesChannelStyle()
                 salesChannelLabel.text = salesChannel
-            } else {
-                salesChannelLabel.isHidden = true
-            }
         } else {
             salesChannelLabel.isHidden = true
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
@@ -43,7 +43,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="260" verticalHuggingPriority="240" verticalCompressionResistancePriority="749" text="Sales Channel" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="euM-g3-iWq" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="260" verticalHuggingPriority="240" verticalCompressionResistancePriority="749" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="euM-g3-iWq" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
                                                 <rect key="frame" x="103" y="0.0" width="108" height="18"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
@@ -31,7 +31,7 @@ final class SummaryTableViewCell: UITableViewCell {
     func configure(_ viewModel: SummaryTableViewCellViewModel) {
         titleLabel.text = viewModel.billedPersonName
         subtitleLabel.text = viewModel.subtitle
-        if SalesChannelEligibilityChecker.isEligible {
+        if viewModel.isEligibleForDisplayingSalesChannelPOSBadge {
             salesChannelLabel.text = viewModel.salesChannel
             salesChannelLabel.isHidden = (salesChannelLabel.text == nil)
         } else {
@@ -106,12 +106,9 @@ private extension SummaryTableViewCell {
         paymentStatusLabel.applyPaddedLabelDefaultStyles()
         paymentStatusLabel.accessibilityIdentifier = "summary-table-view-cell-payment-status-label"
 
-        if SalesChannelEligibilityChecker.isEligible {
-            salesChannelLabel.isHidden = false
-            configureSalesChannelLabel()
-        } else {
-            salesChannelLabel.isHidden = true
-        }
+        // Hide label by default, it will be toggled in configure as needed
+        salesChannelLabel.isHidden = true
+        configureSalesChannelLabel()
     }
 
     func configureIcon() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
@@ -31,8 +31,12 @@ final class SummaryTableViewCell: UITableViewCell {
     func configure(_ viewModel: SummaryTableViewCellViewModel) {
         titleLabel.text = viewModel.billedPersonName
         subtitleLabel.text = viewModel.subtitle
-        salesChannelLabel.text = viewModel.formattedSalesChannel
-        salesChannelLabel.isHidden = (salesChannelLabel.text == nil)
+        if SalesChannelEligibilityChecker.isEligible {
+            salesChannelLabel.text = viewModel.formattedSalesChannel
+            salesChannelLabel.isHidden = (salesChannelLabel.text == nil)
+        } else {
+            salesChannelLabel.isHidden = true
+        }
         display(presentation: viewModel.presentation)
     }
 
@@ -102,7 +106,7 @@ private extension SummaryTableViewCell {
         paymentStatusLabel.applyPaddedLabelDefaultStyles()
         paymentStatusLabel.accessibilityIdentifier = "summary-table-view-cell-payment-status-label"
 
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleOrdersi1) {
+        if SalesChannelEligibilityChecker.isEligible {
             salesChannelLabel.isHidden = false
             salesChannelLabel.applyFootnoteStyle()
             salesChannelLabel.accessibilityIdentifier = "summary-table-view-cell-sales-channel-label"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCellViewModel.swift
@@ -11,17 +11,23 @@ struct SummaryTableViewCellViewModel {
     private let dateCreated: Date
     private(set) var salesChannel: String?
 
+    /// Whether the order is eligible for displaying sales channel POS badge
+    ///
+    let isEligibleForDisplayingSalesChannelPOSBadge: Bool
+
     let presentation: OrderStatusPresentation
 
     private let calendar: Calendar
 
     init(order: Order,
          status: OrderStatus?,
+         isEligibleForDisplayingSalesChannelPOSBadge: Bool = false,
          calendar: Calendar = .current) {
 
         billingAddress = order.billingAddress
         dateCreated = order.dateCreated
         salesChannel = order.salesChannel?.description
+        self.isEligibleForDisplayingSalesChannelPOSBadge = isEligibleForDisplayingSalesChannelPOSBadge
 
         presentation = OrderStatusPresentation(
             style: status?.status ?? order.status,

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -10,24 +10,27 @@ import protocol WooFoundation.Analytics
 final class SalesChannelEligibilityChecker {
     private(set) static var isEligible: Bool = false
 
-    static func checkEligibility() async {
+    static func checkEligibility(siteID: Int64) async {
         let checker = SalesChannelEligibilityChecker()
-        isEligible = await checker.performEligibilityCheck()
+        isEligible = await checker.performEligibilityCheck(siteID: siteID)
     }
 
-    private func performEligibilityCheck() async -> Bool {
-        guard checkFeatureFlagEligibility(), await checkPluginEligibility() else {
+    private func performEligibilityCheck(siteID: Int64) async -> Bool {
+        guard checkFeatureFlagEligibility(), await checkPluginEligibility(siteID: siteID) else {
             return false
         }
         return true
     }
 
-    private func checkPluginEligibility() async -> Bool {
-        let siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? 0
+    private func checkPluginEligibility(siteID: Int64) async -> Bool {
         let pluginsService = PluginsService(storageManager: ServiceLocator.storageManager)
-        let wcPlugin = await pluginsService.waitForPluginInStorage(siteID: siteID, pluginName: "WooCommerce", isActive: true)
+        let pluginName = "WooCommerce"
+        let pluginMinimumVersion = "9.9.0"
+        let wcPlugin = await pluginsService.waitForPluginInStorage(siteID: siteID,
+                                                                   pluginName: pluginName ,
+                                                                   isActive: true)
 
-        guard VersionHelpers.isVersionSupported(version: wcPlugin.version, minimumRequired: "9.9.0") else {
+        guard VersionHelpers.isVersionSupported(version: wcPlugin.version, minimumRequired: pluginMinimumVersion) else {
             return false
         }
         return true
@@ -173,6 +176,11 @@ final class OrderListViewModel {
         self.snapshotsProvider = FetchResultSnapshotsProvider<StorageOrder>(storageManager: storageManager,
                                                                             query: Self.createQuery(siteID: siteID,
                                                                                                     filters: filters))
+        
+        Task {
+            // TODO: Pass feature flag
+            await SalesChannelEligibilityChecker.checkEligibility(siteID: siteID)
+        }
     }
 
     deinit {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -7,6 +7,37 @@ import class AutomatticTracks.CrashLogging
 import protocol Storage.StorageManagerType
 import protocol WooFoundation.Analytics
 
+final class SalesChannelEligibilityChecker {
+    private(set) static var isEligible: Bool = false
+
+    static func checkEligibility() async {
+        let checker = SalesChannelEligibilityChecker()
+        isEligible = await checker.performEligibilityCheck()
+    }
+
+    private func performEligibilityCheck() async -> Bool {
+        guard checkFeatureFlagEligibility(), await checkPluginEligibility() else {
+            return false
+        }
+        return true
+    }
+
+    private func checkPluginEligibility() async -> Bool {
+        let siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? 0
+        let pluginsService = PluginsService(storageManager: ServiceLocator.storageManager)
+        let wcPlugin = await pluginsService.waitForPluginInStorage(siteID: siteID, pluginName: "WooCommerce", isActive: true)
+
+        guard VersionHelpers.isVersionSupported(version: wcPlugin.version, minimumRequired: "9.9.0") else {
+            return false
+        }
+        return true
+    }
+
+    private func checkFeatureFlagEligibility() -> Bool {
+        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleOrdersi1)
+    }
+}
+
 /// ViewModel for `OrderListViewController`.
 ///
 /// This is an incremental WIP. Eventually, we should move all the data loading in here.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -7,40 +7,6 @@ import class AutomatticTracks.CrashLogging
 import protocol Storage.StorageManagerType
 import protocol WooFoundation.Analytics
 
-final class SalesChannelEligibilityChecker {
-    private(set) static var isEligible: Bool = false
-
-    static func checkEligibility(siteID: Int64) async {
-        let checker = SalesChannelEligibilityChecker()
-        isEligible = await checker.performEligibilityCheck(siteID: siteID)
-    }
-
-    private func performEligibilityCheck(siteID: Int64) async -> Bool {
-        guard checkFeatureFlagEligibility(), await checkPluginEligibility(siteID: siteID) else {
-            return false
-        }
-        return true
-    }
-
-    private func checkPluginEligibility(siteID: Int64) async -> Bool {
-        let pluginsService = PluginsService(storageManager: ServiceLocator.storageManager)
-        let pluginName = "WooCommerce"
-        let pluginMinimumVersion = "9.9.0"
-        let wcPlugin = await pluginsService.waitForPluginInStorage(siteID: siteID,
-                                                                   pluginName: pluginName ,
-                                                                   isActive: true)
-
-        guard VersionHelpers.isVersionSupported(version: wcPlugin.version, minimumRequired: pluginMinimumVersion) else {
-            return false
-        }
-        return true
-    }
-
-    private func checkFeatureFlagEligibility() -> Bool {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleOrdersi1)
-    }
-}
-
 /// ViewModel for `OrderListViewController`.
 ///
 /// This is an incremental WIP. Eventually, we should move all the data loading in here.
@@ -53,6 +19,10 @@ final class OrderListViewModel {
     private let notificationCenter: NotificationCenter
     private let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
     private let featureFlagService: FeatureFlagService
+
+    /// Whether orders are eligible for displaying sales channel POS badge
+    ///
+    private var isEligibleForDisplayingSalesChannelPOSBadge: Bool = false
 
     /// Used for cancelling the observer for Remote Notifications when `self` is deallocated.
     ///
@@ -176,10 +146,9 @@ final class OrderListViewModel {
         self.snapshotsProvider = FetchResultSnapshotsProvider<StorageOrder>(storageManager: storageManager,
                                                                             query: Self.createQuery(siteID: siteID,
                                                                                                     filters: filters))
-        
         Task {
-            // TODO: Pass feature flag
-            await SalesChannelEligibilityChecker.checkEligibility(siteID: siteID)
+            let checker = OrderSalesChannelEligibilityChecker(featureFlagService: featureFlagService, storageManager: storageManager)
+            self.isEligibleForDisplayingSalesChannelPOSBadge = await checker.performEligibilityCheck(siteID: siteID)
         }
     }
 
@@ -369,7 +338,9 @@ extension OrderListViewModel {
             return nil
         }
 
-        return OrderListCellViewModel(order: order, currencySettings: ServiceLocator.currencySettings)
+        return OrderListCellViewModel(order: order,
+                                      currencySettings: ServiceLocator.currencySettings,
+                                      isEligibleForDisplayingSalesChannelPOSBadge: isEligibleForDisplayingSalesChannelPOSBadge)
     }
 
     /// Creates an `OrderDetailsViewModel` for the `Order` pointed to by `objectID`.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderSalesChannelEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderSalesChannelEligibilityChecker.swift
@@ -1,0 +1,43 @@
+import Yosemite
+import Experiments
+import protocol Storage.StorageManagerType
+
+final class OrderSalesChannelEligibilityChecker {
+    private let featureFlagService: FeatureFlagService
+    private let storageManager: StorageManagerType
+
+    init(featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         storageManager: StorageManagerType = ServiceLocator.storageManager) {
+        self.featureFlagService = featureFlagService
+        self.storageManager = storageManager
+    }
+
+    func performEligibilityCheck(siteID: Int64) async -> Bool {
+        guard checkFeatureFlagEligibility(), await checkPluginEligibility(siteID: siteID) else {
+            return false
+        }
+        return true
+    }
+
+    private func checkPluginEligibility(siteID: Int64) async -> Bool {
+        let pluginsService = PluginsService(storageManager: storageManager)
+        let wcPlugin = await pluginsService.waitForPluginInStorage(siteID: siteID,
+                                                                   pluginName: Constants.pluginName,
+                                                                   isActive: true)
+        guard VersionHelpers.isVersionSupported(version: wcPlugin.version, minimumRequired: Constants.pluginMinimumVersion) else {
+            return false
+        }
+        return true
+    }
+
+    private func checkFeatureFlagEligibility() -> Bool {
+        featureFlagService.isFeatureFlagEnabled(.pointOfSaleOrdersi1)
+    }
+}
+
+private extension OrderSalesChannelEligibilityChecker {
+    enum Constants {
+        static let pluginName = "WooCommerce"
+        static let pluginMinimumVersion = "9.9.0"
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -89,6 +89,11 @@ final class OrdersRootViewController: UIViewController {
         super.init(nibName: Self.nibName, bundle: nil)
 
         configureTitle()
+
+        Task {
+            // WIP: Call the static check before rendering the cells
+            await SalesChannelEligibilityChecker.checkEligibility()
+        }
     }
 
     required init?(coder: NSCoder) {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -89,11 +89,6 @@ final class OrdersRootViewController: UIViewController {
         super.init(nibName: Self.nibName, bundle: nil)
 
         configureTitle()
-
-        Task {
-            // WIP: Call the static check before rendering the cells
-            await SalesChannelEligibilityChecker.checkEligibility()
-        }
     }
 
     required init?(coder: NSCoder) {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1550,6 +1550,7 @@
 		683988A72C7D82E70084B85A /* POSHeaderLayoutConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683988A62C7D82E60084B85A /* POSHeaderLayoutConstants.swift */; };
 		683AA9D62A303CB70099F7BA /* UpgradesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683AA9D52A303CB70099F7BA /* UpgradesViewModelTests.swift */; };
 		683AC4AC2CEF019A00FF0A5E /* POSSendReceiptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683AC4AB2CEF019700FF0A5E /* POSSendReceiptView.swift */; };
+		683CE98A2E1B826D00AD52B8 /* OrderSalesChannelEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683CE9892E1B826C00AD52B8 /* OrderSalesChannelEligibilityChecker.swift */; };
 		683DF5FF2C6AF46500A5CDC6 /* POSHeaderTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683DF5FE2C6AF46500A5CDC6 /* POSHeaderTitleView.swift */; };
 		684AB83A2870677F003DFDD1 /* CardReaderManualsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684AB8392870677F003DFDD1 /* CardReaderManualsView.swift */; };
 		684AB83C2873DF04003DFDD1 /* CardReaderManualsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684AB83B2873DF04003DFDD1 /* CardReaderManualsViewModel.swift */; };
@@ -4689,6 +4690,7 @@
 		683988A62C7D82E60084B85A /* POSHeaderLayoutConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSHeaderLayoutConstants.swift; sourceTree = "<group>"; };
 		683AA9D52A303CB70099F7BA /* UpgradesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesViewModelTests.swift; sourceTree = "<group>"; };
 		683AC4AB2CEF019700FF0A5E /* POSSendReceiptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSendReceiptView.swift; sourceTree = "<group>"; };
+		683CE9892E1B826C00AD52B8 /* OrderSalesChannelEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSalesChannelEligibilityChecker.swift; sourceTree = "<group>"; };
 		683DF5FE2C6AF46500A5CDC6 /* POSHeaderTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSHeaderTitleView.swift; sourceTree = "<group>"; };
 		684AB8392870677F003DFDD1 /* CardReaderManualsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsView.swift; sourceTree = "<group>"; };
 		684AB83B2873DF04003DFDD1 /* CardReaderManualsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsViewModel.swift; sourceTree = "<group>"; };
@@ -11890,6 +11892,7 @@
 				57A49127250A7EB2000FEF21 /* OrderListViewController.swift */,
 				DE653EAC2A70D09F00937C78 /* CreateTestOrderView.swift */,
 				57C5FF7D250925000074EC26 /* OrderListViewModel.swift */,
+				683CE9892E1B826C00AD52B8 /* OrderSalesChannelEligibilityChecker.swift */,
 				DE6906E427D7439B00735E3B /* OrdersSplitViewWrapperController.swift */,
 				4546E095271F08CD003836F3 /* Order Filters */,
 				B946881329B8DD6A000646B0 /* OrderListViewController+Activity.swift */,
@@ -15976,6 +15979,7 @@
 				CC857C7729B25FAF00E19D1E /* FooterNotice.swift in Sources */,
 				0202B68D23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift in Sources */,
 				2677B559299F322300862180 /* SupportForm+Presentation.swift in Sources */,
+				683CE98A2E1B826D00AD52B8 /* OrderSalesChannelEligibilityChecker.swift in Sources */,
 				D8B4D5F426C30E7C00F34E94 /* InPersonPaymentsStripeRejectedView.swift in Sources */,
 				DE0A2EAD281BA1FA007A8015 /* ProductCategorySelector.swift in Sources */,
 				2026ECE92C25D21F00BEF7E4 /* CardPresentPaymentInvalidatablePaymentOrchestrator.swift in Sources */,


### PR DESCRIPTION
Closes WOOMOB-704

## Description
This PR adds an eligibility checker that will handle if we should show the POS badge in order list and order details summary. The only requirement is that the minimum WooCommerce version is 9.9.0, as it's where `created_via` [was introduced](https://github.com/woocommerce/woocommerce/pull/57225).

Initially this check was set directly in the cells for simplicity, as we only checked for feature flag, however as soon we introduced checking the WooCommerce version as well, this would trigger an unnecessary trip to disk for each cell render, so I moved the check up to the view models/datasource.

## Testing information
- On a site with WooCommerce 9.9.0+, process a POS order. 
- Navigate to orders
- You should see the badge both in order list and order details (this takes a bit to load due other async tasks in the task group) 

https://github.com/user-attachments/assets/2b196ff3-e233-4b3b-8e52-9ebc928a03a3

- Turning off `pointOfSaleOrdersi1` should hide the POS labels:

![Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-07-07 at 12 14 45](https://github.com/user-attachments/assets/407c0a41-1fc3-4537-a068-ed8ce70eec89)
