### PR TITLE
[Woo POS][Barcodes] Mention set up barcodes in HID scanner instruction

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerInformationModal.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerInformationModal.swift
@@ -82,8 +82,8 @@ private extension PointOfSaleBarcodeScannerInformationModal {
             comment: "Accessible version of more details link in barcode info modal, announcing it as a link for screen readers"
         )
         static let barcodeInfoSecondaryMessage = NSLocalizedString(
-            "pos.barcodeInfoModal.secondaryMessage",
-            value: "• Refer to your Bluetooth barcode scanner's instructions to set HID mode.",
+            "pos.barcodeInfoModal.secondaryMessage.2",
+            value: "• Refer to your Bluetooth barcode scanner's instructions to set HID mode. This usually requires scanning a special barcode in the manual.",
             comment: "Secondary bullet point in the barcode info modal in POS, instructing to set scanner to HID mode"
         )
         static let barcodeInfoTertiaryMessage = NSLocalizedString(
@@ -111,7 +111,7 @@ private extension PointOfSaleBarcodeScannerInformationModal {
         )
         static let barcodeInfoSecondaryMessageAccessible = NSLocalizedString(
             "pos.barcodeInfoModal.secondaryMessage.accessible",
-            value: "Second: Refer to your Bluetooth barcode scanner's instructions to set H-I-D mode.",
+            value: "Second: Refer to your Bluetooth barcode scanner's instructions to set H-I-D mode. This usually requires scanning a special barcode in the manual.",
             comment: "Accessible version of secondary bullet point in barcode info modal, without bullet character for screen readers"
         )
         static let barcodeInfoTertiaryMessageAccessible = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerInformationModal.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerInformationModal.swift
@@ -111,7 +111,7 @@ private extension PointOfSaleBarcodeScannerInformationModal {
             comment: "Accessible version of primary bullet point in barcode info modal, without bullet character for screen readers"
         )
         static let barcodeInfoSecondaryMessageAccessible = NSLocalizedString(
-            "pos.barcodeInfoModal.secondaryMessage.accessible",
+            "pos.barcodeInfoModal.secondaryMessage.accessible.2",
             value: "Second: Refer to your Bluetooth barcode scanner's instructions to set H-I-D mode. This usually " +
             "requires scanning a special barcode in the manual.",
             comment: "Accessible version of secondary bullet point in barcode info modal, without bullet character for screen readers"

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerInformationModal.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerInformationModal.swift
@@ -83,7 +83,8 @@ private extension PointOfSaleBarcodeScannerInformationModal {
         )
         static let barcodeInfoSecondaryMessage = NSLocalizedString(
             "pos.barcodeInfoModal.secondaryMessage.2",
-            value: "• Refer to your Bluetooth barcode scanner's instructions to set HID mode. This usually requires scanning a special barcode in the manual.",
+            value: "• Refer to your Bluetooth barcode scanner's instructions to set HID mode. This usually " +
+            "requires scanning a special barcode in the manual.",
             comment: "Secondary bullet point in the barcode info modal in POS, instructing to set scanner to HID mode"
         )
         static let barcodeInfoTertiaryMessage = NSLocalizedString(
@@ -111,7 +112,8 @@ private extension PointOfSaleBarcodeScannerInformationModal {
         )
         static let barcodeInfoSecondaryMessageAccessible = NSLocalizedString(
             "pos.barcodeInfoModal.secondaryMessage.accessible",
-            value: "Second: Refer to your Bluetooth barcode scanner's instructions to set H-I-D mode. This usually requires scanning a special barcode in the manual.",
+            value: "Second: Refer to your Bluetooth barcode scanner's instructions to set H-I-D mode. This usually " +
+            "requires scanning a special barcode in the manual.",
             comment: "Accessible version of secondary bullet point in barcode info modal, without bullet character for screen readers"
         )
         static let barcodeInfoTertiaryMessageAccessible = NSLocalizedString(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As discussed in i2 wireframes pdfdoF-7Am-p2#comment-8729, this PR updates the instruction for HID set up to make it less generic and mention set up barcodes.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Tap `... > Barcode Scanning`
3. Observe that the second bullet mentions setup barcodes.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![IMG_A9A34EF00928-1](https://github.com/user-attachments/assets/c94aebd3-3215-47e5-be43-f80be82d630d)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.