### PR TITLE
Refactor PluginsService to use plugin file path for better stability

### DIFF
--- a/Modules/Sources/Yosemite/Tools/Plugins/PluginsService.swift
+++ b/Modules/Sources/Yosemite/Tools/Plugins/PluginsService.swift
@@ -7,10 +7,10 @@ public protocol PluginsServiceProtocol {
     /// Waits for a specific plugin to be available in storage.
     /// - Parameters:
     ///   - siteID: The site ID to search for the plugin.
-    ///   - plugin: The plugin's file path (e.g., "woocommerce/woocommerce.php" for WooCommerce).
+    ///   - pluginPath: The plugin's file path (e.g., "woocommerce/woocommerce.php" for WooCommerce).
     ///   - isActive: Whether the plugin is active or not.
     /// - Returns: The SystemPlugin when found in storage.
-    func waitForPluginInStorage(siteID: Int64, plugin: String, isActive: Bool) async -> SystemPlugin
+    func waitForPluginInStorage(siteID: Int64, pluginPath: String, isActive: Bool) async -> SystemPlugin
 }
 
 public class PluginsService: PluginsServiceProtocol {
@@ -21,8 +21,8 @@ public class PluginsService: PluginsServiceProtocol {
     }
 
     @MainActor
-    public func waitForPluginInStorage(siteID: Int64, plugin: String, isActive: Bool) async -> SystemPlugin {
-        let predicate = \StorageSystemPlugin.siteID == siteID && \StorageSystemPlugin.plugin == plugin && \StorageSystemPlugin.active == isActive
+    public func waitForPluginInStorage(siteID: Int64, pluginPath: String, isActive: Bool) async -> SystemPlugin {
+        let predicate = \StorageSystemPlugin.siteID == siteID && \StorageSystemPlugin.plugin == pluginPath && \StorageSystemPlugin.active == isActive
         let pluginDescriptor = NSSortDescriptor(keyPath: \StorageSystemPlugin.plugin, ascending: true)
         let resultsController = ResultsController<StorageSystemPlugin>(storageManager: storageManager,
                                                                        matching: predicate,
@@ -34,7 +34,7 @@ public class PluginsService: PluginsServiceProtocol {
                 return plugin
             }
         } catch {
-            DDLogError("Error loading plugin \(plugin) for site \(siteID) initially: \(error.localizedDescription)")
+            DDLogError("Error loading plugin \(pluginPath) for site \(siteID) initially: \(error.localizedDescription)")
         }
 
         return await withCheckedContinuation { continuation in

--- a/Modules/Sources/Yosemite/Tools/Plugins/PluginsService.swift
+++ b/Modules/Sources/Yosemite/Tools/Plugins/PluginsService.swift
@@ -8,7 +8,7 @@ public protocol PluginsServiceProtocol {
     /// - Parameters:
     ///   - siteID: The site ID to search for the plugin.
     ///   - plugin: The plugin's file path (e.g., "woocommerce/woocommerce.php" for WooCommerce).
-    ///   - isActive: Whether to wait for the plugin to be active or inactive.
+    ///   - isActive: Whether the plugin is active or not.
     /// - Returns: The SystemPlugin when found in storage.
     func waitForPluginInStorage(siteID: Int64, plugin: String, isActive: Bool) async -> SystemPlugin
 }

--- a/Modules/Sources/Yosemite/Tools/Plugins/PluginsService.swift
+++ b/Modules/Sources/Yosemite/Tools/Plugins/PluginsService.swift
@@ -5,7 +5,12 @@ import protocol Storage.StorageManagerType
 /// A service for system plugins.
 public protocol PluginsServiceProtocol {
     /// Waits for a specific plugin to be available in storage.
-    func waitForPluginInStorage(siteID: Int64, pluginName: String, isActive: Bool) async -> SystemPlugin
+    /// - Parameters:
+    ///   - siteID: The site ID to search for the plugin.
+    ///   - plugin: The plugin's file path (e.g., "woocommerce/woocommerce.php" for WooCommerce).
+    ///   - isActive: Whether to wait for the plugin to be active or inactive.
+    /// - Returns: The SystemPlugin when found in storage.
+    func waitForPluginInStorage(siteID: Int64, plugin: String, isActive: Bool) async -> SystemPlugin
 }
 
 public class PluginsService: PluginsServiceProtocol {
@@ -16,20 +21,20 @@ public class PluginsService: PluginsServiceProtocol {
     }
 
     @MainActor
-    public func waitForPluginInStorage(siteID: Int64, pluginName: String, isActive: Bool) async -> SystemPlugin {
-        let predicate = \StorageSystemPlugin.siteID == siteID && \StorageSystemPlugin.name == pluginName && \StorageSystemPlugin.active == isActive
-        let nameDescriptor = NSSortDescriptor(keyPath: \StorageSystemPlugin.name, ascending: true)
+    public func waitForPluginInStorage(siteID: Int64, plugin: String, isActive: Bool) async -> SystemPlugin {
+        let predicate = \StorageSystemPlugin.siteID == siteID && \StorageSystemPlugin.plugin == plugin && \StorageSystemPlugin.active == isActive
+        let pluginDescriptor = NSSortDescriptor(keyPath: \StorageSystemPlugin.plugin, ascending: true)
         let resultsController = ResultsController<StorageSystemPlugin>(storageManager: storageManager,
                                                                        matching: predicate,
                                                                        fetchLimit: 1,
-                                                                       sortedBy: [nameDescriptor])
+                                                                       sortedBy: [pluginDescriptor])
         do {
             try resultsController.performFetch()
             if let plugin = resultsController.fetchedObjects.first {
                 return plugin
             }
         } catch {
-            DDLogError("Error loading plugin \(pluginName) for site \(siteID) initially: \(error.localizedDescription)")
+            DDLogError("Error loading plugin \(plugin) for site \(siteID) initially: \(error.localizedDescription)")
         }
 
         return await withCheckedContinuation { continuation in

--- a/Modules/Tests/YosemiteTests/Tools/Plugins/PluginsServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/Plugins/PluginsServiceTests.swift
@@ -18,11 +18,11 @@ struct PluginsServiceTests {
         storageManager.insertWCPlugin(siteID: siteID, isActive: true, version: "1.0.0")
 
         // When
-        let result = await sut.waitForPluginInStorage(siteID: siteID, pluginName: PluginConstants.pluginName, isActive: true)
+        let result = await sut.waitForPluginInStorage(siteID: siteID, plugin: PluginConstants.plugin, isActive: true)
 
         // Then
         #expect(result.siteID == siteID)
-        #expect(result.name == PluginConstants.pluginName)
+        #expect(result.plugin == PluginConstants.plugin)
         #expect(result.active == true)
         #expect(result.version == "1.0.0")
     }
@@ -33,7 +33,7 @@ struct PluginsServiceTests {
         await storageManager.reset()
 
         // When
-        async let plugin = sut.waitForPluginInStorage(siteID: siteID, pluginName: PluginConstants.pluginName, isActive: true)
+        async let plugin = sut.waitForPluginInStorage(siteID: siteID, plugin: PluginConstants.plugin, isActive: true)
         #expect(storageManager.viewStorage.loadSystemPlugins(siteID: siteID).count == 0)
         storageManager.insertWCPlugin(siteID: siteID, isActive: true, version: "2.0.0")
         #expect(storageManager.viewStorage.loadSystemPlugins(siteID: siteID).count == 1)
@@ -41,6 +41,7 @@ struct PluginsServiceTests {
         // Then
         let result = await plugin
         #expect(result.siteID == siteID)
+        #expect(result.plugin == PluginConstants.plugin)
         #expect(result.name == PluginConstants.pluginName)
         #expect(result.active == true)
         #expect(result.version == "2.0.0")
@@ -50,7 +51,11 @@ struct PluginsServiceTests {
 private extension MockStorageManager {
     func insertWCPlugin(siteID: Int64, isActive: Bool, version: String? = nil) {
         performAndSave({ storage in
-            let plugin = SystemPlugin.fake().copy(siteID: siteID, name: PluginConstants.pluginName, version: version, active: isActive)
+            let plugin = SystemPlugin.fake().copy(siteID: siteID,
+                                                  plugin: PluginConstants.plugin,
+                                                  name: PluginConstants.pluginName,
+                                                  version: version,
+                                                  active: isActive)
             let newPlugin = storage.insertNewObject(ofType: StorageSystemPlugin.self)
             newPlugin.update(with: plugin)
         }, completion: nil, on: .main)
@@ -67,5 +72,6 @@ private extension MockStorageManager {
 
 // MARK: - Constants
 private enum PluginConstants {
+    static let plugin = "example-plugin/example-plugin.php"
     static let pluginName = "Example Plugin"
 }

--- a/Modules/Tests/YosemiteTests/Tools/Plugins/PluginsServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/Plugins/PluginsServiceTests.swift
@@ -18,7 +18,7 @@ struct PluginsServiceTests {
         storageManager.insertWCPlugin(siteID: siteID, isActive: true, version: "1.0.0")
 
         // When
-        let result = await sut.waitForPluginInStorage(siteID: siteID, plugin: PluginConstants.plugin, isActive: true)
+        let result = await sut.waitForPluginInStorage(siteID: siteID, pluginPath: PluginConstants.plugin, isActive: true)
 
         // Then
         #expect(result.siteID == siteID)
@@ -33,7 +33,7 @@ struct PluginsServiceTests {
         await storageManager.reset()
 
         // When
-        async let plugin = sut.waitForPluginInStorage(siteID: siteID, plugin: PluginConstants.plugin, isActive: true)
+        async let plugin = sut.waitForPluginInStorage(siteID: siteID, pluginPath: PluginConstants.plugin, isActive: true)
         #expect(storageManager.viewStorage.loadSystemPlugins(siteID: siteID).count == 0)
         storageManager.insertWCPlugin(siteID: siteID, isActive: true, version: "2.0.0")
         #expect(storageManager.viewStorage.loadSystemPlugins(siteID: siteID).count == 1)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/LegacyPOSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/LegacyPOSTabEligibilityChecker.swift
@@ -154,7 +154,7 @@ private extension LegacyPOSTabEligibilityChecker {
 
     @MainActor
     func fetchWooCommercePlugin(siteID: Int64) async -> SystemPlugin {
-        await pluginsService.waitForPluginInStorage(siteID: siteID, pluginName: Constants.wcPluginName, isActive: true)
+        await pluginsService.waitForPluginInStorage(siteID: siteID, plugin: Constants.wcPlugin, isActive: true)
     }
 
     @MainActor
@@ -254,7 +254,7 @@ private extension LegacyPOSTabEligibilityChecker {
 
 private extension LegacyPOSTabEligibilityChecker {
     enum Constants {
-        static let wcPluginName = "WooCommerce"
+        static let wcPlugin = "woocommerce/woocommerce.php"
         static let wcPluginMinimumVersion = "9.6.0-beta"
         static let wcPluginMinimumVersionWithFeatureSwitch = "10.0.0"
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/LegacyPOSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/LegacyPOSTabEligibilityChecker.swift
@@ -154,7 +154,7 @@ private extension LegacyPOSTabEligibilityChecker {
 
     @MainActor
     func fetchWooCommercePlugin(siteID: Int64) async -> SystemPlugin {
-        await pluginsService.waitForPluginInStorage(siteID: siteID, plugin: Constants.wcPlugin, isActive: true)
+        await pluginsService.waitForPluginInStorage(siteID: siteID, pluginPath: Constants.wcPlugin, isActive: true)
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -279,7 +279,6 @@ private extension POSTabEligibilityChecker {
 
 private extension POSTabEligibilityChecker {
     enum Constants {
-        static let wcPluginName = "WooCommerce"
         static let wcPlugin = "woocommerce/woocommerce.php"
         static let wcPluginMinimumVersion = "9.6.0-beta"
         static let wcPluginMinimumVersionWithFeatureSwitch = "10.0.0"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -195,7 +195,7 @@ private extension POSTabEligibilityChecker {
 
     @MainActor
     func fetchWooCommercePlugin(siteID: Int64) async -> SystemPlugin {
-        await pluginsService.waitForPluginInStorage(siteID: siteID, pluginName: Constants.wcPluginName, isActive: true)
+        await pluginsService.waitForPluginInStorage(siteID: siteID, plugin: Constants.wcPlugin, isActive: true)
     }
 
     @MainActor
@@ -304,6 +304,7 @@ private extension POSTabEligibilityChecker {
 private extension POSTabEligibilityChecker {
     enum Constants {
         static let wcPluginName = "WooCommerce"
+        static let wcPlugin = "woocommerce/woocommerce.php"
         static let wcPluginMinimumVersion = "9.6.0-beta"
         static let wcPluginMinimumVersionWithFeatureSwitch = "10.0.0"
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -140,7 +140,7 @@ private extension POSTabEligibilityChecker {
 
     @MainActor
     func fetchWooCommercePlugin(siteID: Int64) async -> SystemPlugin {
-        await pluginsService.waitForPluginInStorage(siteID: siteID, plugin: Constants.wcPlugin, isActive: true)
+        await pluginsService.waitForPluginInStorage(siteID: siteID, pluginPath: Constants.wcPlugin, isActive: true)
     }
 
     @MainActor

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/LegacyPOSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/LegacyPOSTabEligibilityCheckerTests.swift
@@ -426,7 +426,7 @@ private extension LegacyPOSTabEligibilityCheckerTests {
 private final class MockPluginsService: PluginsServiceProtocol {
     var pluginToReturn: SystemPlugin = .fake()
 
-    func waitForPluginInStorage(siteID: Int64, plugin: String, isActive: Bool) async -> SystemPlugin {
+    func waitForPluginInStorage(siteID: Int64, pluginPath: String, isActive: Bool) async -> SystemPlugin {
         pluginToReturn
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/LegacyPOSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/LegacyPOSTabEligibilityCheckerTests.swift
@@ -365,7 +365,7 @@ private extension LegacyPOSTabEligibilityCheckerTests {
     func setupWooCommerceVersion(_ version: String = "9.6.0-beta") {
         pluginsService.pluginToReturn = .fake().copy(
             siteID: siteID,
-            plugin: "WooCommerce",
+            plugin: "woocommerce/woocommerce.php",
             version: version,
             active: true
         )
@@ -426,7 +426,7 @@ private extension LegacyPOSTabEligibilityCheckerTests {
 private final class MockPluginsService: PluginsServiceProtocol {
     var pluginToReturn: SystemPlugin = .fake()
 
-    func waitForPluginInStorage(siteID: Int64, pluginName: String, isActive: Bool) async -> SystemPlugin {
+    func waitForPluginInStorage(siteID: Int64, plugin: String, isActive: Bool) async -> SystemPlugin {
         pluginToReturn
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -648,7 +648,7 @@ private extension POSTabEligibilityCheckerTests {
 private final class MockPluginsService: PluginsServiceProtocol {
     var pluginToReturn: SystemPlugin = .fake()
 
-    func waitForPluginInStorage(siteID: Int64, plugin: String, isActive: Bool) async -> SystemPlugin {
+    func waitForPluginInStorage(siteID: Int64, pluginPath: String, isActive: Bool) async -> SystemPlugin {
         pluginToReturn
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -595,7 +595,7 @@ private extension POSTabEligibilityCheckerTests {
     func setupWooCommerceVersion(_ version: String = "9.6.0-beta") {
         pluginsService.pluginToReturn = .fake().copy(
             siteID: siteID,
-            plugin: "WooCommerce",
+            plugin: "woocommerce/woocommerce.php",
             version: version,
             active: true
         )
@@ -656,7 +656,7 @@ private extension POSTabEligibilityCheckerTests {
 private final class MockPluginsService: PluginsServiceProtocol {
     var pluginToReturn: SystemPlugin = .fake()
 
-    func waitForPluginInStorage(siteID: Int64, pluginName: String, isActive: Bool) async -> SystemPlugin {
+    func waitForPluginInStorage(siteID: Int64, plugin: String, isActive: Bool) async -> SystemPlugin {
         pluginToReturn
     }
 }


### PR DESCRIPTION
For WOOMOB-760

Just one review is required.

## Description

Refactors the `PluginsService.waitForPluginInStorage` method to use the stable plugin file path identifier instead of the potentially changing plugin display name. This change improves reliability when querying for plugins in storage by using the plugin's file path (e.g., "woocommerce/woocommerce.php") which is less likely to change compared to display names.

The plugin file path is the stable identifier used by WordPress internally and returned by the WooCommerce REST API `/wp-json/wc/v3/system_status` endpoint in the `active_plugins.plugin` field.

## Steps to reproduce

- Run POS to ensure plugin detection in the eligibility check still works as expected

## Testing information

- [x] @jaclync tests that the correct ineligible UI is shown when the store is WC version 10.0+ and feature switch disabled

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.