### PR TITLE
Shipping Labels: Display label size from account settings as default

### DIFF
--- a/Modules/Sources/Yosemite/Stores/WooShippingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/WooShippingStore.swift
@@ -192,7 +192,17 @@ private extension WooShippingStore {
 
     func loadAccountSettings(siteID: Int64,
                              completion: @escaping (Result<WooShippingAccountSettings, Error>) -> Void) {
-        remote.loadAccountSettings(siteID: siteID, completion: completion)
+        remote.loadAccountSettings(siteID: siteID, completion: { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let settings):
+                upsertShippingLabelAccountSettingsInBackground(siteID: siteID, accountSettings: settings.accountSettings) {
+                    completion(.success(settings))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        })
     }
 
     func updateAccountSettings(siteID: Int64,
@@ -731,6 +741,29 @@ private extension WooShippingStore {
         } else {
             storageShippingLabel.refund = nil
         }
+    }
+
+    /// Updates/inserts the specified readonly shipping label account settings entity *in a background thread*.
+    /// `onCompletion` will be called on the main thread!
+    ///
+    func upsertShippingLabelAccountSettingsInBackground(siteID: Int64,
+                                                        accountSettings: ShippingLabelAccountSettings,
+                                                        onCompletion: @escaping () -> Void) {
+        storageManager.performAndSave({ storage in
+            let storageAccountSettings = storage.loadShippingLabelAccountSettings(siteID: siteID) ??
+                storage.insertNewObject(ofType: Storage.ShippingLabelAccountSettings.self)
+            storageAccountSettings.update(with: accountSettings)
+
+            // Remove all previous payment methods
+            storageAccountSettings.paymentMethods?.removeAll()
+
+            // Insert the payment methods from the read-only account settings
+            for paymentMethod in accountSettings.paymentMethods {
+                let newStoragePaymentMethod = storage.insertNewObject(ofType: Storage.ShippingLabelPaymentMethod.self)
+                newStoragePaymentMethod.update(with: paymentMethod)
+                storageAccountSettings.addToPaymentMethods(newStoragePaymentMethod)
+            }
+        }, completion: onCompletion, on: .main)
     }
 }
 

--- a/Modules/Tests/YosemiteTests/Stores/WooShippingStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/WooShippingStoreTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import Yosemite
 @testable import Networking
 import protocol Storage.StorageType
+import class Storage.ShippingLabelPaymentMethod
 
 final class WooShippingStoreTests: XCTestCase {
 
@@ -363,6 +364,90 @@ final class WooShippingStoreTests: XCTestCase {
 
         // Then
         XCTAssertEqual(receivedValue, [samplePackage])
+    }
+
+    // MARK: `loadAccountSettings`
+
+    func test_loadAccountSettings_returns_success_response() throws {
+        // Given
+        let remote = MockWooShippingRemote()
+        let expectedSettings = WooShippingAccountSettings.fake()
+        remote.whenLoadAccountSettings(siteID: sampleSiteID, thenReturn: .success(expectedSettings))
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let result: Result<WooShippingAccountSettings, Error> = waitFor { promise in
+            let action = WooShippingAction.loadAccountSettings(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let actualSettings = try result.get()
+        XCTAssertEqual(actualSettings, expectedSettings)
+    }
+
+    func test_loadAccountSettings_returns_error_on_failure() throws {
+        // Given
+        let remote = MockWooShippingRemote()
+        let expectedError = NetworkError.notFound()
+        remote.whenLoadAccountSettings(siteID: sampleSiteID, thenReturn: .failure(expectedError))
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let result: Result<WooShippingAccountSettings, Error> = waitFor { promise in
+            let action = WooShippingAction.loadAccountSettings(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error as? NetworkError, expectedError)
+    }
+
+    func test_loadAccountSettings_when_successful_then_upserts_settings_into_storage() throws {
+        // Given
+        let remote = MockWooShippingRemote()
+        let paymentMethod = Yosemite.ShippingLabelPaymentMethod(
+            paymentMethodID: 1434,
+            name: "James Dean",
+            cardType: .visa,
+            cardDigits: "2352",
+            expiry: DateFormatter.Defaults.yearMonthDayDateFormatter.date(from: "2030-12-31")
+        )
+        let accountSettings = ShippingLabelAccountSettings.fake().copy(
+            siteID: sampleSiteID,
+            paymentMethods: [paymentMethod],
+            isEmailReceiptsEnabled: true,
+            paperSize: .a4
+        )
+        let expectedSettings = WooShippingAccountSettings.fake().copy(accountSettings: accountSettings)
+        remote.whenLoadAccountSettings(siteID: sampleSiteID, thenReturn: .success(expectedSettings))
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // Confidence check
+        XCTAssertEqual(storageManager.viewStorage.countObjects(ofType: StorageShippingLabelAccountSettings.self), 0)
+
+        // When
+        let onSuccess: Bool = waitFor { promise in
+            let action = WooShippingAction.loadAccountSettings(siteID: self.sampleSiteID) { result in
+                promise(result.isSuccess)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(onSuccess)
+        XCTAssertEqual(storageManager.viewStorage.countObjects(ofType: StorageShippingLabelAccountSettings.self), 1)
+        let storedSettings = try XCTUnwrap(storageManager.viewStorage.loadShippingLabelAccountSettings(siteID: sampleSiteID))
+        XCTAssertEqual(storedSettings.siteID, sampleSiteID)
+        XCTAssertEqual(storedSettings.toReadOnly(), accountSettings)
+        XCTAssertEqual(storageManager.viewStorage.countObjects(ofType: Storage.ShippingLabelPaymentMethod.self), 1)
     }
 
     // MARK: `loadPackages`

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [*] Shipping Labels: Fixed a portion of layout issues caused by bigger accessibility content size categories. [https://github.com/woocommerce/woocommerce-ios/pull/15844]
 - [*] Shipping Labels: Enable the confirm button on the payment method sheet even when there are no changes. [https://github.com/woocommerce/woocommerce-ios/pull/15856]
 - [*] Watch app: Fixed connection issue upon fresh install [https://github.com/woocommerce/woocommerce-ios/pull/15867]
+- [*] Shipping Labels: Display label size from account settings as default [https://github.com/woocommerce/woocommerce-ios/pull/15873]
 
 22.7
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
@@ -3,9 +3,11 @@ import Foundation
 import UIKit
 import Yosemite
 import WooFoundation
+import protocol Storage.StorageManagerType
 
 final class WooShippingPostPurchaseViewModel: ObservableObject {
     private let stores: StoresManager
+    private let storageManager: StorageManagerType
     private let siteID: Int64
     private let labelID: Int64
 
@@ -26,6 +28,13 @@ final class WooShippingPostPurchaseViewModel: ObservableObject {
     /// Customs form URL for the shipping label
     let commercialInvoiceURL: URL?
 
+    /// Shipping Label Account Settings ResultsController
+    ///
+    private lazy var accountSettingsResultsController: ResultsController<StorageShippingLabelAccountSettings> = {
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+        return ResultsController<StorageShippingLabelAccountSettings>(storageManager: storageManager, matching: predicate, sortedBy: [])
+    }()
+
     init(siteID: Int64,
          labelID: Int64,
          labelSizes: [ShippingLabelPaperSize],
@@ -33,7 +42,8 @@ final class WooShippingPostPurchaseViewModel: ObservableObject {
          trackingURL: URL?,
          pickupURL: URL?,
          commercialInvoiceURL: URL?,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.siteID = siteID
         self.labelID = labelID
         self.labelSizes = labelSizes
@@ -42,11 +52,15 @@ final class WooShippingPostPurchaseViewModel: ObservableObject {
         self.pickupURL = pickupURL
         self.commercialInvoiceURL = commercialInvoiceURL
         self.stores = stores
+        self.storageManager = storageManager
+
+        configureAccountSettingsResultsController()
     }
 
     convenience init(shippingLabel: ShippingLabel,
                      siteAddress: SiteAddress = SiteAddress(),
-                     stores: StoresManager = ServiceLocator.stores) {
+                     stores: StoresManager = ServiceLocator.stores,
+                     storageManager: StorageManagerType = ServiceLocator.storageManager) {
         // Label sizes aren't provided by the API, so we can hard-code them to match the extension behavior:
         let labelSizes = {
             var availableLabelSizes: [ShippingLabelPaperSize] = [.label, .letter]
@@ -71,7 +85,8 @@ final class WooShippingPostPurchaseViewModel: ObservableObject {
                   trackingURL: trackingURL,
                   pickupURL: pickupURL,
                   commercialInvoiceURL: commercialInvoiceURL,
-                  stores: stores)
+                  stores: stores,
+                  storageManager: storageManager)
     }
 
     /// Fetches the shipping label in the selected paper size and presents the print dialog.
@@ -89,6 +104,26 @@ final class WooShippingPostPurchaseViewModel: ObservableObject {
 }
 
 private extension WooShippingPostPurchaseViewModel {
+    /// Shipping Label Account Settings ResultsController monitoring
+    ///
+    func configureAccountSettingsResultsController() {
+        accountSettingsResultsController.onDidChangeContent = { [weak self] in
+            self?.updateSelectedLabelSize()
+        }
+
+        accountSettingsResultsController.onDidResetContent = { [weak self] in
+            self?.updateSelectedLabelSize()
+        }
+
+        try? accountSettingsResultsController.performFetch()
+        updateSelectedLabelSize()
+    }
+
+    func updateSelectedLabelSize() {
+        guard let fetchedAccountSettings = accountSettingsResultsController.fetchedObjects.first else { return }
+        selectedLabelSize = fetchedAccountSettings.paperSize
+    }
+
     /// Requests the shipping label data for printing.
     @MainActor
     func requestPrintData() async throws -> ShippingLabelPrintData {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
@@ -62,9 +62,10 @@ final class WooShippingPostPurchaseViewModel: ObservableObject {
                      stores: StoresManager = ServiceLocator.stores,
                      storageManager: StorageManagerType = ServiceLocator.storageManager) {
         // Label sizes aren't provided by the API, so we can hard-code them to match the extension behavior:
+        // Ref: https://github.com/woocommerce/woocommerce-shipping/blob/trunk/client/components/label-purchase/label/utils.ts
         let labelSizes = {
             var availableLabelSizes: [ShippingLabelPaperSize] = [.label, .letter]
-            if [.US, .CA, .MX, .DO].contains(siteAddress.countryCode) {
+            if [.US, .CA, .MX, .DO].contains(siteAddress.countryCode) == false {
                 availableLabelSizes.append(.a4)
             }
             return availableLabelSizes

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Post-Purchase/WooShippingPostPurchaseViewModel.swift
@@ -32,7 +32,12 @@ final class WooShippingPostPurchaseViewModel: ObservableObject {
     ///
     private lazy var accountSettingsResultsController: ResultsController<StorageShippingLabelAccountSettings> = {
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
-        return ResultsController<StorageShippingLabelAccountSettings>(storageManager: storageManager, matching: predicate, sortedBy: [])
+        return ResultsController<StorageShippingLabelAccountSettings>(
+            storageManager: storageManager,
+            matching: predicate,
+            fetchLimit: 1,
+            sortedBy: []
+        )
     }()
 
     init(siteID: Int64,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingPostPurchaseViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingPostPurchaseViewModelTests.swift
@@ -34,30 +34,40 @@ final class WooShippingPostPurchaseViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.commercialInvoiceURL, customsFormURL)
     }
 
-    func test_labelSizes_includes_expected_default_values() {
-        // Given
-        let countrySetting = SiteSetting.fake().copy(settingID: "woocommerce_default_country",
-                                                  value: "GB")
-        let siteAddress = SiteAddress(siteSettings: [countrySetting])
+    func test_labelSizes_excludes_a4_for_north_american_countries() {
+        let northAmericanCountries = ["US", "CA", "MX", "DO"]
 
-        // When
-        let viewModel = WooShippingPostPurchaseViewModel(shippingLabel: ShippingLabel.fake(), siteAddress: siteAddress)
+        for countryCode in northAmericanCountries {
+            // Given
+            let countrySetting = SiteSetting.fake().copy(settingID: "woocommerce_default_country",
+                                                      value: countryCode)
+            let siteAddress = SiteAddress(siteSettings: [countrySetting])
 
-        // Then
-        assertEqual([.label, .letter], viewModel.labelSizes)
+            // When
+            let viewModel = WooShippingPostPurchaseViewModel(shippingLabel: ShippingLabel.fake(),
+                                                             siteAddress: siteAddress)
+
+            // Then
+            assertEqual([.label, .letter], viewModel.labelSizes)
+        }
     }
 
-    func test_labelSizes_includes_expected_values_for_country_with_a4_label_size() {
-        // Given
-        let countrySetting = SiteSetting.fake().copy(settingID: "woocommerce_default_country",
-                                                  value: "US:NY")
-        let siteAddress = SiteAddress(siteSettings: [countrySetting])
+    func test_labelSizes_includes_a4_for_non_north_american_countries() {
+        let nonNorthAmericanCountries = ["GB", "FR", "DE", "IT", "ES", "NL", "AU", "JP"]
 
-        // When
-        let viewModel = WooShippingPostPurchaseViewModel(shippingLabel: ShippingLabel.fake(), siteAddress: siteAddress)
+        for countryCode in nonNorthAmericanCountries {
+            // Given
+            let countrySetting = SiteSetting.fake().copy(settingID: "woocommerce_default_country",
+                                                      value: countryCode)
+            let siteAddress = SiteAddress(siteSettings: [countrySetting])
 
-        // Then
-        assertEqual([.label, .letter, .a4], viewModel.labelSizes)
+            // When
+            let viewModel = WooShippingPostPurchaseViewModel(shippingLabel: ShippingLabel.fake(),
+                                                             siteAddress: siteAddress)
+
+            // Then
+            assertEqual([.label, .letter, .a4], viewModel.labelSizes)
+        }
     }
 
     func test_trackingURL_parsed_from_shipping_label() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingPostPurchaseViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingPostPurchaseViewModelTests.swift
@@ -4,6 +4,13 @@ import Yosemite
 
 final class WooShippingPostPurchaseViewModelTests: XCTestCase {
 
+    private var storageManager: MockStorageManager!
+
+    override func setUp() {
+        super.setUp()
+        storageManager = MockStorageManager()
+    }
+
     func test_inits_with_provided_properties() {
         // Given
         let labelSizes: [ShippingLabelPaperSize] = [.label, .letter, .a4]
@@ -110,5 +117,38 @@ final class WooShippingPostPurchaseViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(printData)
+    }
+
+    func test_selectedLabelSize_defaults_to_label() {
+        // Given & When
+        let viewModel = WooShippingPostPurchaseViewModel(shippingLabel: ShippingLabel.fake(), storageManager: storageManager)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedLabelSize, .label)
+    }
+
+    func test_selectedLabelSize_initialized_from_account_settings() {
+        // Given
+        let siteID: Int64 = 123
+
+        // Insert account settings with A4 paper size
+        let settings = ShippingLabelAccountSettings.fake().copy(siteID: siteID, paperSize: .a4)
+        insertShippingLabelAccountSettings(readonlySettings: settings)
+
+        // When
+        let viewModel = WooShippingPostPurchaseViewModel(
+            shippingLabel: ShippingLabel.fake().copy(siteID: siteID),
+            storageManager: storageManager
+        )
+
+        // Then
+        XCTAssertEqual(viewModel.selectedLabelSize, .a4)
+    }
+}
+
+private extension WooShippingPostPurchaseViewModelTests {
+    func insertShippingLabelAccountSettings(readonlySettings: ShippingLabelAccountSettings) {
+        let storageSettings = storageManager.viewStorage.insertNewObject(ofType: StorageShippingLabelAccountSettings.self)
+        storageSettings.update(with: readonlySettings)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-647

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds some updates to the purchased label view:
- Fixes the logic in paper size list following the web.
- Saves account settings to storage upon loading settings.
- Fetch the paper size from the stored account settings to display on the purchased label view.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with Woo Shipping set up.
2. Navigate to the Orders tab and open an order with a purchased label.
3. Confirm that the default paper size displayed matches the selected size in the Woo Shipping settings.
4. Confirm that the paper size list doesn't contain the A4 option for a US store.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Tested with simulator iPhone 16 iOS 18.4
- Added unit tests to verify updated logic.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/f878d822-8c3d-4b9d-8b34-ec7325788962



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
