### PR TITLE
[Shipping Labels] Handle address array in `selected_destination` and `selected_origin`

### DIFF
--- a/Modules/Sources/Networking/Model/ShippingLabel/Shipments/WooShippingConfigResponse.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Shipments/WooShippingConfigResponse.swift
@@ -107,6 +107,7 @@ public struct WooShippingLabelData: Decodable, Equatable {
 
 public extension WooShippingLabelData {
     typealias WooShippingLabelAddressMap = [String: WooShippingAddress]
+    typealias WooShippingLabelAddressArray = [WooShippingAddress]
 
     struct StoredData: Decodable, Equatable {
         let selectedDestinations: WooShippingLabelAddressMap?
@@ -119,14 +120,37 @@ public extension WooShippingLabelData {
 
         public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            selectedDestinations = try? container.decodeIfPresent(
-                WooShippingLabelAddressMap.self,
-                forKey: CodingKeys.selectedDestination
+            selectedDestinations = Self.decodeAddresses(
+                from: container,
+                for: .selectedDestination
             )
-            selectedOrigins = try? container.decodeIfPresent(
-                WooShippingLabelAddressMap.self,
-                forKey: CodingKeys.selectedOrigin
+
+            selectedOrigins = Self.decodeAddresses(
+                from: container,
+                for: .selectedOrigin
             )
+        }
+
+        private static func decodeAddresses(
+            from container: KeyedDecodingContainer<CodingKeys>,
+            for key: CodingKeys
+        ) -> WooShippingLabelAddressMap? {
+            if let addressesMap = try? container.decodeIfPresent(
+                WooShippingLabelAddressMap.self,
+                forKey: key
+            ) {
+                return addressesMap
+            } else if let addressesArray = try? container.decodeIfPresent(
+                WooShippingLabelAddressArray.self,
+                forKey: key
+            ) {
+                return addressesArray.enumerated().reduce(into: [:]) { result, address in
+                    let formattedIDKey = WooShippingLabelData.formattedShipmentIDFromArrayIndex(address.offset)
+                    result[formattedIDKey] = address.element
+                }
+            }
+
+            return nil
         }
     }
 }

--- a/Modules/Sources/Networking/Model/ShippingLabel/Shipments/WooShippingLabelData+mapDestinations.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Shipments/WooShippingLabelData+mapDestinations.swift
@@ -21,4 +21,11 @@ extension WooShippingLabelData {
             )
         }
     }
+
+    static func formattedShipmentIDFromArrayIndex(_ index: Int) -> String {
+        /// ID indexing starts from `1`. So the ID would be the index incremented by `1`.
+        return WooShippingShipmentIDFormatter.formattedShipmentID(
+            String(index + 1)
+        )
+    }
 }

--- a/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -855,12 +855,33 @@ final class WooShippingRemoteTests: XCTestCase {
         XCTAssertNotNil(result.failure)
     }
 
-    // MARK: - Load Config With Destinations
+    // MARK: - Load Config With Addresses
 
-    func test_load_config_with_addresses_parses_success_response() throws {
+    func test_load_config_with_addresses_map_parses_success_response() throws {
         // Given
         let remote = WooShippingRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "config/label-purchase/\(sampleOrderID)", filename: "wooshipping-config-with-addresses")
+
+        // When
+        let result: Result<WooShippingConfig, Error> = waitFor { promise in
+            remote.loadConfig(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let config = try XCTUnwrap(result.get())
+        let label = try XCTUnwrap(config.shippingLabelData?.currentOrderLabels.first)
+        XCTAssertNotNil(label.destinationAddress)
+        XCTAssertEqual(label.destinationAddress.address1, "200 N SPRING ST")
+        XCTAssertNotNil(label.originAddress)
+        XCTAssertEqual(label.originAddress.address1, "Test origin address line")
+    }
+
+    func test_load_config_with_addresses_array_parses_success_response() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "config/label-purchase/\(sampleOrderID)", filename: "wooshipping-config-with-addresses-array")
 
         // When
         let result: Result<WooShippingConfig, Error> = waitFor { promise in

--- a/Modules/Tests/NetworkingTests/Responses/wooshipping-config-with-addresses-array.json
+++ b/Modules/Tests/NetworkingTests/Responses/wooshipping-config-with-addresses-array.json
@@ -1,0 +1,52 @@
+{
+    "data": {
+        "config": {
+            "shippingLabelData": {
+                "storedData": {
+                    "selected_destination": [
+                        {
+                            "address_1": "200 N SPRING ST",
+                            "city": "LOS ANGELES",
+                            "state": "CA",
+                            "postcode": "90012-4801",
+                            "country": "US"
+                        }
+                    ],
+                    "selected_origin": [
+                        {
+                            "address_1": "Test origin address line",
+                            "city": "Test origin city",
+                            "state": "CA",
+                            "postcode": "90012-4801",
+                            "country": "US"
+                        }
+                    ]
+                },
+                "currentOrderLabels": [
+                    {
+                      "label_id": 4871,
+                      "tracking": null,
+                      "refundable_amount": 0,
+                      "created": 1742292110723,
+                      "carrier_id": "usps",
+                      "service_name": "USPS - Priority Mail",
+                      "status": "PURCHASE_IN_PROGRESS",
+                      "commercial_invoice_url": "",
+                      "is_commercial_invoice_submitted_electronically": false,
+                      "package_name": "Small Flat Rate Box",
+                      "is_letter": false,
+                      "product_names": [
+                        "BG upload"
+                      ],
+                      "product_ids": [
+                        522
+                      ],
+                      "id": "1",
+                      "receipt_item_id": -1,
+                      "created_date": 1742292110000
+                    }
+                ]
+            }
+        }
+    }
+} 


### PR DESCRIPTION
WOOMOB-746

## Description

This is a follow up pr for the #15866 and #15872 correspondingly. Addressing the [suggestion](https://github.com/woocommerce/woocommerce-ios/pull/15866#discussion_r2188889731) to handle addresses array as a fallback to support older format. 

- Added `decodeAddresses` method to conditionally decode map or array of addresses.
- Added tests to cover the array format for addresses.

## Testing steps

I suggest testing on our shared testing store. The order 1951 contains 2 fulfilled shipments with the array format behind `selected_destination` and `selected_origin`. Or consider creating an order and purchase labels with the 22.6 prod version. For testing purposes make sure the purchased shipping labels origins / destinations are different. 

- Test on order with previously purchased shipping labels as mentioned above.
- Navigate to "Create shipping labels" flow
- Expand bottom sheet to reveal shipment details with origin and destination addresses
- Switch between fulfilled shipments and make sure that "ship from" and "ship to" display correct addresses.
- Consider using Proxyman: For reliability I suggest to also check and compare addresses returned in `config/label-purchase/{order_id}`. Addresses returned in the array format should be correctly presented in "ship from" and "ship to" fields of the corresponding fulfilled shipments.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.