### PR TITLE
Shipping Labels: Send customs form details in the `package` field of purchase payload

### DIFF
--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagePurchase.swift
@@ -106,7 +106,17 @@ extension WooShippingPackagePurchase: Encodable {
         try container.encode(productIDs, forKey: .products)
 
         if let hazmat = package.hazmatCategory {
-            try container.encode(package.hazmatCategory, forKey: .hazmat)
+            try container.encode(hazmat, forKey: .hazmat)
+        }
+
+        if let form = package.customsForm {
+            try container.encode(form.contentsType.rawValue, forKey: .contentsType)
+            try container.encode(form.contentExplanation, forKey: .contentsExplanation)
+            try container.encode(form.restrictionType.rawValue, forKey: .restrictionType)
+            try container.encode(form.restrictionComments, forKey: .restrictionComments)
+            try container.encode(form.nonDeliveryOption.rawValue, forKey: .nonDeliveryOption)
+            try container.encode(form.itn, forKey: .itn)
+            try container.encode(form.items, forKey: .items)
         }
 
         if selectedRate.signatureRate != nil {
@@ -195,6 +205,13 @@ extension WooShippingPackagePurchase: Encodable {
         case saturdayDelivery = "saturday_delivery"
         case additionalHandling = "additional_handling"
         case hazmat
+        case contentsType = "contents_type"
+        case contentsExplanation = "contents_explanation"
+        case restrictionType = "restriction_type"
+        case restrictionComments = "restriction_comments"
+        case nonDeliveryOption = "non_delivery_option"
+        case itn
+        case items
     }
 
     private enum ParameterKeys {

--- a/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -366,7 +366,15 @@ final class WooShippingRemoteTests: XCTestCase {
 
         let shipmentID = "1"
         let hazmatCategory = "test-hazmat"
-        let customsForm = ShippingLabelCustomsForm.fake().copy(items: [.fake(), .fake()])
+        let customsForm = ShippingLabelCustomsForm(packageID: "test",
+                                                   packageName: "ups-test",
+                                                   contentsType: .merchandise,
+                                                   contentExplanation: "",
+                                                   restrictionType: .none,
+                                                   restrictionComments: "",
+                                                   nonDeliveryOption: .return,
+                                                   itn: "",
+                                                   items: [.fake(), .fake()])
 
         let package = WooShippingPackagePurchase.fake().copy(
             shipmentID: shipmentID,
@@ -423,6 +431,14 @@ final class WooShippingRemoteTests: XCTestCase {
         XCTAssertEqual(firstPackage["saturday_delivery"] as? Bool, true)
         XCTAssertEqual(firstPackage["additional_handling"] as? Bool, true)
         XCTAssertEqual(firstPackage["hazmat"] as? String, hazmatCategory)
+
+        /// customs form details need to be present in package
+        XCTAssertEqual(try XCTUnwrap(firstPackage["items"] as? [Any]).count, 2)
+        XCTAssertEqual(firstPackage["contents_type"] as? String, "merchandise")
+        XCTAssertEqual(firstPackage["restriction_type"] as? String, "none")
+        XCTAssertEqual(firstPackage["non_delivery_option"] as? String, "return")
+        XCTAssertEqual(firstPackage["restriction_comments"] as? String, "")
+        XCTAssertEqual(firstPackage["contents_explanation"] as? String, "")
 
         let selectedRateParam = try XCTUnwrap(request.parameters["selected_rate"] as? [String: Any])
         let parentValue = try XCTUnwrap(selectedRateParam["parent"] as? [String: Any])


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-782

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes failures when purchasing shipping labels with customs forms. The error was: " Unable to proceed, 'customs_info' is required for international shipments, shipments bound for US military bases, or US territories. Please see https://docs.easypost.com/docs/customs-infos for more information."

It's unclear to me why this error did not happen in 22.6. My understanding is since we're sending more details to the `package` field, we should include customs form details as well to match with the web.

I also see that the web plugin sends a slightly different format of data in the `customs` field - they send details in a `customs_info` dictionary to a `meta` field, together with order item details. I'm not updating this as the current change still works and it follows their [API doc](https://github.com/woocommerce/woocommerce-shipping/blob/trunk/docs/api/label-purchase.md).

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Log in to a test store with Woo Shipping set up.
- Navigate to the Orders tab and select a paid order with physical items. 
- Tap Create shipping label > update the destination address to be outside of the US.
- Fill the customs form and proceed to purchase a label.
- Confirm that the purchase succeeds.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Tested with simulator iPhone 16 iOS 18.4.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

No UI changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
