### PR TITLE
[POS Orders] Order details improvements in larger accessibility sizes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.xib
@@ -17,7 +17,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="108"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="3xk-nT-znM">
+                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="3xk-nT-znM">
                         <rect key="frame" x="16" y="8" width="288" height="40"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="249" text="Created eons ago at 9:51" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kz9-1h-fRY">
@@ -27,7 +27,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Sales Channel" textAlignment="right" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kU8-dT-4zl" userLabel="Sales Channel Label" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
-                                <rect key="frame" x="146" y="0.0" width="142" height="40"/>
+                                <rect key="frame" x="146" y="0.0" width="142" height="19"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.xib
@@ -20,13 +20,13 @@
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="3xk-nT-znM">
                         <rect key="frame" x="16" y="8" width="288" height="40"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Created eons ago at 9:51" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kz9-1h-fRY">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="249" text="Created eons ago at 9:51" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kz9-1h-fRY">
                                 <rect key="frame" x="0.0" y="0.0" width="142" height="40"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="255" verticalHuggingPriority="255" text="Sales Channel" textAlignment="right" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kU8-dT-4zl" userLabel="Sales Channel Label" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Sales Channel" textAlignment="right" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kU8-dT-4zl" userLabel="Sales Channel Label" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
                                 <rect key="frame" x="146" y="0.0" width="142" height="40"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <nil key="textColor"/>


### PR DESCRIPTION
Part of WOOMOB-751

## Description
When using the app in large accessibility sizes, both order details and order list have shown some wonkiness, which among other issues cuts/truncates the `POS` badge. 

This PR addresses the order details side (only) by adjusting `SummaryTableViewCell`'s xib file hugging and compression priorities for the subtitle label for the date and the sales channel label, so now it does not truncate but both are kept on screen.

| Before | After |
|--------|--------|
| <img width="671" alt="Screenshot 2025-07-08 at 17 32 20" src="https://github.com/user-attachments/assets/c6a153cc-af02-4191-b690-3b6efc63733e" /> | <img width="705" alt="Screenshot 2025-07-08 at 17 33 02" src="https://github.com/user-attachments/assets/8348daf2-c40a-43c2-804e-ce12a397acee" /> |

I've [attempted to adjust order details](https://github.com/woocommerce/woocommerce-ios/tree/task/WOOMOB-751-a11y-improvements-pos-badges-order-list) as well in this PR but is quite messier, and while it leaves us 80% there is still not quite right. I'll give it another go using a different approach separately via a `HostingTableViewCell` and rewriting the cell in SwiftUI to see if that is better.

## Testing information
- If no POS orders have been processed yet in your test store after we added the `created_via` property, go to the POS tab and pay for a POS order.
- Navigate to orders, and tap on the POS order, you should see the badge in order details. 
- Increase the font size and observe that both date and POS badge are visible in order details to the right (still needs work on the order list to the left).

https://github.com/user-attachments/assets/a9247d00-ebfb-478c-adc6-9bc3d687530a

In phone:

<img width="500" src="https://github.com/user-attachments/assets/8a425877-fed2-4a5c-ade0-b5d452bec5cf" />
