### PR TITLE
[Woo POS][Barcodes] Set up flow: choose a scanner

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -99,6 +99,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .pointOfSaleOrdersi1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .pointOfSaleBarcodeScanningi2:
+            return false
         default:
             return true
         }

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -203,4 +203,8 @@ public enum FeatureFlag: Int {
     /// Enables displaying Point Of Sale details in order list and order details
     ///
     case pointOfSaleOrdersi1
+
+    /// Enables the Point of Sale Barcode Scanner set up flows, as part of i2
+    ///
+    case pointOfSaleBarcodeScanningi2
 }

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -150,6 +150,7 @@ private extension TracksProvider {
             WooAnalyticsStat.pointOfSaleSearchRemoteResultsFetched,
             WooAnalyticsStat.pointOfSaleBarcodeScanningMenuItemTapped,
             WooAnalyticsStat.pointOfSaleBarcodeScanningExplanationDialogShown,
+            WooAnalyticsStat.pointOfSaleBarcodeScannerSetupFlowShown,
 
             // Order
             WooAnalyticsStat.orderCreationSuccess,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1305,6 +1305,7 @@ enum WooAnalyticsStat: String {
     case pointOfSaleSearchRemoteResultsFetched = "search_remote_results_fetched"
     case pointOfSaleBarcodeScanningMenuItemTapped = "barcode_scanning_menu_item_tapped"
     case pointOfSaleBarcodeScanningExplanationDialogShown = "barcode_scanning_explanation_dialog_shown"
+    case pointOfSaleBarcodeScannerSetupFlowShown = "barcode_scanner_setup_flow_shown"
 
     // MARK: Custom Fields events
     case productDetailCustomFieldsTapped = "product_detail_custom_fields_tapped"

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -9,7 +9,7 @@ struct POSFloatingControlView: View {
     @Binding private var showSupport: Bool
     @Binding private var showDocumentation: Bool
     @State private var showProductRestrictionsModal: Bool = false
-    @State private var showBarcodeScanningInformation: Bool = false
+    @State private var showBarcodeScanningModal: Bool = false
 
     init(showExitPOSModal: Binding<Bool>,
          showSupport: Binding<Bool>,
@@ -59,7 +59,7 @@ struct POSFloatingControlView: View {
                 }
                 if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleBarcodeScanningi1) {
                     Button {
-                        showBarcodeScanningInformation = true
+                        showBarcodeScanningModal = true
                         ServiceLocator.analytics.track(.pointOfSaleBarcodeScanningMenuItemTapped)
                     } label: {
                         Label(
@@ -92,8 +92,8 @@ struct POSFloatingControlView: View {
         .posModal(isPresented: $showProductRestrictionsModal) {
             SimpleProductsOnlyInformation(isPresented: $showProductRestrictionsModal)
         }
-        .posModal(isPresented: $showBarcodeScanningInformation) {
-            PointOfSaleBarcodeScannerInformationModal(isPresented: $showBarcodeScanningInformation)
+        .posModal(isPresented: $showBarcodeScanningModal) {
+            PointOfSaleBarcodeScannerInformationModal(isPresented: $showBarcodeScanningModal)
         }
         .frame(height: Constants.size)
         .background(Color.clear)

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -93,7 +93,11 @@ struct POSFloatingControlView: View {
             SimpleProductsOnlyInformation(isPresented: $showProductRestrictionsModal)
         }
         .posModal(isPresented: $showBarcodeScanningModal) {
-            PointOfSaleBarcodeScannerInformationModal(isPresented: $showBarcodeScanningModal)
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleBarcodeScanningi2) {
+                PointOfSaleBarcodeScannerSetUpFlow(isPresented: $showBarcodeScanningModal)
+            } else {
+                PointOfSaleBarcodeScannerInformationModal(isPresented: $showBarcodeScanningModal)
+            }
         }
         .frame(height: Constants.size)
         .background(Color.clear)

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerInformationModal.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerInformationModal.swift
@@ -58,7 +58,7 @@ struct BarcodeScannerInformationContent: View {
     }
 }
 
-private extension PointOfSaleBarcodeScannerInformationModal {
+extension PointOfSaleBarcodeScannerInformationModal {
     enum Localization {
         static let barcodeInfoHeading = NSLocalizedString(
             "pos.barcodeInfoModal.heading",

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerInformationModal.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerInformationModal.swift
@@ -10,6 +10,14 @@ struct PointOfSaleBarcodeScannerInformationModal: View {
 
     var body: some View {
         PointOfSaleInformationModal(isPresented: $isPresented, title: AttributedString(Localization.barcodeInfoHeading)) {
+            BarcodeScannerInformationContent()
+        }
+    }
+}
+
+struct BarcodeScannerInformationContent: View {
+    var body: some View {
+        VStack(spacing: POSSpacing.medium) {
             PointOfSaleInformationModalParagraphView {
                 Text(AttributedString(Localization.barcodeInfoIntroMessage))
             }
@@ -51,16 +59,21 @@ struct PointOfSaleBarcodeScannerInformationModal: View {
 }
 
 private extension PointOfSaleBarcodeScannerInformationModal {
-    enum Constants {
-        static let detailsLink = URL(string: "https://woocommerce.com/document/barcode-and-qr-code-scanner/")
-    }
-
     enum Localization {
         static let barcodeInfoHeading = NSLocalizedString(
             "pos.barcodeInfoModal.heading",
             value: "Barcode scanning",
             comment: "Heading for the barcode info modal in POS, introducing barcode scanning feature"
         )
+    }
+}
+
+private extension BarcodeScannerInformationContent {
+    enum Constants {
+        static let detailsLink = URL(string: "https://woocommerce.com/document/barcode-and-qr-code-scanner/")
+    }
+
+    enum Localization {
         static let barcodeInfoIntroMessage = NSLocalizedString(
             "pos.barcodeInfoModal.introMessage",
             value: "You can scan barcodes using an external scanner to quickly build a cart.",

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerSetUpFlow.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerSetUpFlow.swift
@@ -32,89 +32,37 @@ struct ScannerSelectionView: View {
                 VStack(spacing: POSSpacing.small) {
                     // Socket S720
                     NavigationLink(destination: EmptyView()) {
-                        HStack {
-                            VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
-                                Text(Localization.socketS720Title)
-                                    .font(.posBodyLargeBold)
-                                    .foregroundColor(.posOnSurface)
-                                Text(Localization.socketS720Subtitle)
-                                    .font(.posBodyMediumRegular())
-                                    .foregroundColor(.posOnSurfaceVariantHighest)
-                            }
-                            Spacer()
-                            Image(systemName: "chevron.right")
-                                .font(.posBodyMediumBold)
-                                .foregroundColor(.posOnSurfaceVariantHighest)
-                        }
-                        .padding(POSPadding.medium)
-                        .background(Color.posSurfaceDim)
-                        .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.medium.value))
+                        ScannerOptionView(
+                            title: Localization.socketS720Title,
+                            subtitle: Localization.socketS720Subtitle
+                        )
                     }
                     .buttonStyle(PlainButtonStyle())
 
                     // Star BSH-20B
                     NavigationLink(destination: EmptyView()) {
-                        HStack {
-                            VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
-                                Text(Localization.starBSH20BTitle)
-                                    .font(.posBodyLargeBold)
-                                    .foregroundColor(.posOnSurface)
-                                Text(Localization.starBSH20BSubtitle)
-                                    .font(.posBodyMediumRegular())
-                                    .foregroundColor(.posOnSurfaceVariantHighest)
-                            }
-                            Spacer()
-                            Image(systemName: "chevron.right")
-                                .font(.posBodyMediumBold)
-                                .foregroundColor(.posOnSurfaceVariantHighest)
-                        }
-                        .padding(POSPadding.medium)
-                        .background(Color.posSurfaceDim)
-                        .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.medium.value))
+                        ScannerOptionView(
+                            title: Localization.starBSH20BTitle,
+                            subtitle: Localization.starBSH20BSubtitle
+                        )
                     }
                     .buttonStyle(PlainButtonStyle())
 
                     // TBC Scanner
                     NavigationLink(destination: EmptyView()) {
-                        HStack {
-                            VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
-                                Text(Localization.tbcScannerTitle)
-                                    .font(.posBodyLargeBold)
-                                    .foregroundColor(.posOnSurface)
-                                Text(Localization.tbcScannerSubtitle)
-                                    .font(.posBodyMediumRegular())
-                                    .foregroundColor(.posOnSurfaceVariantHighest)
-                            }
-                            Spacer()
-                            Image(systemName: "chevron.right")
-                                .font(.posBodyMediumBold)
-                                .foregroundColor(.posOnSurfaceVariantHighest)
-                        }
-                        .padding(POSPadding.medium)
-                        .background(Color.posSurfaceDim)
-                        .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.medium.value))
+                        ScannerOptionView(
+                            title: Localization.tbcScannerTitle,
+                            subtitle: Localization.tbcScannerSubtitle
+                        )
                     }
                     .buttonStyle(PlainButtonStyle())
 
                     // Other
                     NavigationLink(destination: BarcodeScannerInformationView()) {
-                        HStack {
-                            VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
-                                Text(Localization.otherTitle)
-                                    .font(.posBodyLargeBold)
-                                    .foregroundColor(.posOnSurface)
-                                Text(Localization.otherSubtitle)
-                                    .font(.posBodyMediumRegular())
-                                    .foregroundColor(.posOnSurfaceVariantHighest)
-                            }
-                            Spacer()
-                            Image(systemName: "chevron.right")
-                                .font(.posBodyMediumBold)
-                                .foregroundColor(.posOnSurfaceVariantHighest)
-                        }
-                        .padding(POSPadding.medium)
-                        .background(Color.posSurfaceDim)
-                        .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.medium.value))
+                        ScannerOptionView(
+                            title: Localization.otherTitle,
+                            subtitle: Localization.otherSubtitle
+                        )
                     }
                     .buttonStyle(PlainButtonStyle())
                 }
@@ -123,34 +71,36 @@ struct ScannerSelectionView: View {
     }
 }
 
+struct ScannerOptionView: View {
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
+                Text(title)
+                    .font(.posBodyLargeBold)
+                    .foregroundColor(.posOnSurface)
+                Text(subtitle)
+                    .font(.posBodyMediumRegular())
+                    .foregroundColor(.posOnSurfaceVariantHighest)
+            }
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.posBodyMediumBold)
+                .foregroundColor(.posOnSurfaceVariantHighest)
+        }
+        .padding(POSPadding.medium)
+        .background(Color.posSurfaceDim)
+        .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.medium.value))
+    }
+}
+
 struct BarcodeScannerInformationView: View {
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        PointOfSaleInformationModal(isPresented: .constant(true), title: AttributedString(Localization.barcodeInfoHeading)) {
-            PointOfSaleInformationModalParagraphView {
-                Text(AttributedString(Localization.barcodeInfoIntroMessage))
-            }
-
-            PointOfSaleInformationModalParagraphView {
-                Text(bulletPointWithLink)
-                    .accessibilityLabel(bulletPointWithLinkAccessibilityLabel)
-                Text(AttributedString(Localization.barcodeInfoSecondaryMessage))
-                    .accessibilityLabel(Localization.barcodeInfoSecondaryMessageAccessible)
-                Text(AttributedString(Localization.barcodeInfoTertiaryMessage))
-                    .accessibilityLabel(Localization.barcodeInfoTertiaryMessageAccessible)
-                Text(AttributedString(Localization.barcodeInfoQuaternaryMessage))
-                    .accessibilityLabel(Localization.barcodeInfoQuaternaryMessageAccessible)
-            }
-            .padding(.leading, POSSpacing.medium)
-
-            PointOfSaleInformationModalParagraphView(style: .outlined) {
-                Text(AttributedString(Localization.barcodeInfoQuinaryMessage))
-            }
-        }
-        .onAppear(perform: {
-            ServiceLocator.analytics.track(.pointOfSaleBarcodeScanningExplanationDialogShown)
-        })
+        PointOfSaleBarcodeScannerInformationModal(isPresented: .constant(true))
         .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
@@ -167,20 +117,6 @@ struct BarcodeScannerInformationView: View {
                 }
             }
         }
-    }
-
-    private var bulletPointWithLink: AttributedString {
-        var secondary = AttributedString(Localization.barcodeInfoPrimaryMessage + " ")
-        var moreDetails = AttributedString(Localization.barcodeInfoMoreDetailsLink)
-        moreDetails.link = Constants.detailsLink
-        moreDetails.foregroundColor = .posPrimary
-        moreDetails.underlineStyle = .single
-        secondary.append(moreDetails)
-        return secondary
-    }
-
-    private var bulletPointWithLinkAccessibilityLabel: String {
-        return Localization.barcodeInfoPrimaryMessageAccessible + " " + Localization.barcodeInfoMoreDetailsLinkAccessible
     }
 }
 
@@ -241,84 +177,7 @@ private enum Localization {
         value: "Back",
         comment: "Title for the back button in barcode scanner setup navigation"
     )
-
-    // Barcode info localization (reused from existing modal)
-    static let barcodeInfoHeading = NSLocalizedString(
-        "pos.barcodeInfoModal.heading",
-        value: "Barcode scanning",
-        comment: "Heading for the barcode info modal in POS, introducing barcode scanning feature"
-    )
-    static let barcodeInfoIntroMessage = NSLocalizedString(
-        "pos.barcodeInfoModal.introMessage",
-        value: "You can scan barcodes using an external scanner to quickly build a cart.",
-        comment: "Introductory message in the barcode info modal in POS, explaining the use of external barcode scanners"
-    )
-    static let barcodeInfoPrimaryMessage = NSLocalizedString(
-        "pos.barcodeInfoModal.primaryMessage",
-        value: "• Set up barcodes in the \"GTIN, UPC, EAN, ISBN\" field in Products > Product Details > Inventory. ",
-        comment: "Primary bullet point in the barcode info modal in POS, instructing where to set up barcodes in product details"
-    )
-    static let barcodeInfoMoreDetailsLink = NSLocalizedString(
-        "pos.barcodeInfoModal.moreDetailsLink",
-        value: "More details.",
-        comment: "Link text in the barcode info modal in POS, leading to more details about barcode setup"
-    )
-    static let barcodeInfoMoreDetailsLinkAccessible = NSLocalizedString(
-        "pos.barcodeInfoModal.moreDetailsLink.accessible",
-        value: "More details, link.",
-        comment: "Accessible version of more details link in barcode info modal, announcing it as a link for screen readers"
-    )
-    static let barcodeInfoSecondaryMessage = NSLocalizedString(
-        "pos.barcodeInfoModal.secondaryMessage.2",
-        value: "• Refer to your Bluetooth barcode scanner's instructions to set HID mode. This usually " +
-        "requires scanning a special barcode in the manual.",
-        comment: "Secondary bullet point in the barcode info modal in POS, instructing to set scanner to HID mode"
-    )
-    static let barcodeInfoTertiaryMessage = NSLocalizedString(
-        "pos.barcodeInfoModal.tertiaryMessage",
-        value: "• Connect your barcode scanner in iOS Bluetooth settings.",
-        comment: "Tertiary bullet point in the barcode info modal in POS, instructing to connect scanner via Bluetooth settings"
-    )
-    static let barcodeInfoQuaternaryMessage = NSLocalizedString(
-        "pos.barcodeInfoModal.quaternaryMessage",
-        value: "• Scan barcodes while on the item list to add products to the cart.",
-        comment: "Quaternary bullet point in the barcode info modal in POS, instructing to scan barcodes on item list to add to cart"
-    )
-    static let barcodeInfoQuinaryMessage = NSLocalizedString(
-        "pos.barcodeInfoModal.quinaryMessage",
-        value: "The scanner emulates a keyboard, so sometimes it will prevent the software keyboard from showing, e.g. in search. " +
-            "Tap on the keyboard icon to show it again.",
-        comment: "Quinary message in the barcode info modal in POS, explaining scanner keyboard emulation and how to show software keyboard again"
-    )
-
-    // Accessibility-friendly versions without bullet points
-    static let barcodeInfoPrimaryMessageAccessible = NSLocalizedString(
-        "pos.barcodeInfoModal.primaryMessage.accessible",
-        value: "First: Set up barcodes in the \"G-T-I-N, U-P-C, E-A-N, I-S-B-N\" field by navigating to Products, then Product Details, then Inventory.",
-        comment: "Accessible version of primary bullet point in barcode info modal, without bullet character for screen readers"
-    )
-    static let barcodeInfoSecondaryMessageAccessible = NSLocalizedString(
-        "pos.barcodeInfoModal.secondaryMessage.accessible.2",
-        value: "Second: Refer to your Bluetooth barcode scanner's instructions to set H-I-D mode. This usually " +
-        "requires scanning a special barcode in the manual.",
-        comment: "Accessible version of secondary bullet point in barcode info modal, without bullet character for screen readers"
-    )
-    static let barcodeInfoTertiaryMessageAccessible = NSLocalizedString(
-        "pos.barcodeInfoModal.tertiaryMessage.accessible",
-        value: "Third: Connect your barcode scanner in iOS Bluetooth settings.",
-        comment: "Accessible version of tertiary bullet point in barcode info modal, without bullet character for screen readers"
-    )
-    static let barcodeInfoQuaternaryMessageAccessible = NSLocalizedString(
-        "pos.barcodeInfoModal.quaternaryMessage.accessible",
-        value: "Fourth: Scan barcodes while on the item list to add products to the cart.",
-        comment: "Accessible version of quaternary bullet point in barcode info modal, without bullet character for screen readers"
-    )
 }
-
-private enum Constants {
-    static let detailsLink = URL(string: "https://woocommerce.com/document/barcode-and-qr-code-scanner/")
-}
-
 
 #Preview {
     PointOfSaleBarcodeScannerSetUpFlow(isPresented: .constant(true))

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerSetUpFlow.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerSetUpFlow.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@available(iOS 17.0, *)
 struct PointOfSaleBarcodeScannerSetUpFlow: View {
     @Binding var isPresented: Bool
 
@@ -9,7 +10,22 @@ struct PointOfSaleBarcodeScannerSetUpFlow: View {
 
     var body: some View {
         NavigationStack {
-            ScannerSelectionView(isPresented: $isPresented)
+            VStack(spacing: POSSpacing.xxLarge) {
+                PointOfSaleModalHeader(isPresented: $isPresented,
+                                       title: .constant(AttributedString(Localization.setupHeading)))
+
+                VStack {
+                    ScannerSelectionView(isPresented: $isPresented)
+                    Spacer()
+                }
+                .scrollVerticallyIfNeeded()
+            }
+            .toolbar(.hidden, for: .navigationBar)
+        }
+        .padding(POSPadding.xxLarge)
+        .background(Color.posSurfaceBright)
+        .containerRelativeFrame([.horizontal, .vertical]) { length, _ in
+            max(length * 0.75, Constants.modalFrameMaxSmallDimension)
         }
         .onAppear {
             ServiceLocator.analytics.track(.pointOfSaleBarcodeScannerSetupFlowShown)
@@ -19,53 +35,50 @@ struct PointOfSaleBarcodeScannerSetUpFlow: View {
 
 struct ScannerSelectionView: View {
     @Binding var isPresented: Bool
-
     var body: some View {
-        PointOfSaleInformationModal(isPresented: $isPresented, title: AttributedString(Localization.setupHeading)) {
-            VStack(spacing: POSSpacing.medium) {
-                Text(AttributedString(Localization.setupIntroMessage))
-                    .font(.posBodyLargeRegular())
-                    .foregroundStyle(Color.posOnSurface)
-                    .multilineTextAlignment(.leading)
-                    .fixedSize(horizontal: false, vertical: true)
+        VStack(spacing: POSSpacing.medium) {
+            Text(Localization.setupIntroMessage)
+                .font(.posBodyLargeRegular())
+                .foregroundStyle(Color.posOnSurface)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
 
-                VStack(spacing: POSSpacing.small) {
-                    // Socket S720
-                    NavigationLink(destination: EmptyView()) {
-                        ScannerOptionView(
-                            title: Localization.socketS720Title,
-                            subtitle: Localization.socketS720Subtitle
-                        )
-                    }
-                    .buttonStyle(PlainButtonStyle())
-
-                    // Star BSH-20B
-                    NavigationLink(destination: EmptyView()) {
-                        ScannerOptionView(
-                            title: Localization.starBSH20BTitle,
-                            subtitle: Localization.starBSH20BSubtitle
-                        )
-                    }
-                    .buttonStyle(PlainButtonStyle())
-
-                    // TBC Scanner
-                    NavigationLink(destination: EmptyView()) {
-                        ScannerOptionView(
-                            title: Localization.tbcScannerTitle,
-                            subtitle: Localization.tbcScannerSubtitle
-                        )
-                    }
-                    .buttonStyle(PlainButtonStyle())
-
-                    // Other
-                    NavigationLink(destination: BarcodeScannerInformationView()) {
-                        ScannerOptionView(
-                            title: Localization.otherTitle,
-                            subtitle: Localization.otherSubtitle
-                        )
-                    }
-                    .buttonStyle(PlainButtonStyle())
+            VStack(spacing: POSSpacing.small) {
+                // Socket S720
+                NavigationLink(destination: EmptyView()) {
+                    ScannerOptionView(
+                        title: Localization.socketS720Title,
+                        subtitle: Localization.socketS720Subtitle
+                    )
                 }
+                .buttonStyle(PlainButtonStyle())
+
+                // Star BSH-20B
+                NavigationLink(destination: EmptyView()) {
+                    ScannerOptionView(
+                        title: Localization.starBSH20BTitle,
+                        subtitle: Localization.starBSH20BSubtitle
+                    )
+                }
+                .buttonStyle(PlainButtonStyle())
+
+                // TBC Scanner
+                NavigationLink(destination: EmptyView()) {
+                    ScannerOptionView(
+                        title: Localization.tbcScannerTitle,
+                        subtitle: Localization.tbcScannerSubtitle
+                    )
+                }
+                .buttonStyle(PlainButtonStyle())
+
+                // Other
+                NavigationLink(destination: BarcodeScannerInformationView(isPresented: $isPresented)) {
+                    ScannerOptionView(
+                        title: Localization.otherTitle,
+                        subtitle: Localization.otherSubtitle
+                    )
+                }
+                .buttonStyle(PlainButtonStyle())
             }
         }
     }
@@ -86,7 +99,7 @@ struct ScannerOptionView: View {
                     .foregroundColor(.posOnSurfaceVariantHighest)
             }
             Spacer()
-            Image(systemName: "chevron.right")
+            Image(systemName: "chevron.forward")
                 .font(.posBodyMediumBold)
                 .foregroundColor(.posOnSurfaceVariantHighest)
         }
@@ -97,27 +110,25 @@ struct ScannerOptionView: View {
 }
 
 struct BarcodeScannerInformationView: View {
-    @Environment(\.dismiss) private var dismiss
+    @Binding var isPresented: Bool
 
     var body: some View {
-        PointOfSaleBarcodeScannerInformationModal(isPresented: .constant(true))
-        .navigationBarBackButtonHidden(true)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button(action: {
-                    dismiss()
-                }) {
-                    HStack(spacing: POSSpacing.xSmall) {
-                        Image(systemName: "chevron.left")
-                            .font(.posBodyMediumBold)
-                        Text(Localization.backButtonTitle)
-                            .font(.posBodyMediumBold)
-                    }
-                    .foregroundColor(.posOnSurface)
-                }
+        VStack(spacing: POSSpacing.xxLarge) {
+            PointOfSaleModalHeader(isPresented: $isPresented,
+                                   title: .constant(AttributedString(PointOfSaleBarcodeScannerInformationModal.Localization.barcodeInfoHeading)))
+            VStack {
+                BarcodeScannerInformationContent()
+                Spacer()
             }
+            .scrollVerticallyIfNeeded()
         }
+        .toolbar(.hidden, for: .navigationBar)
     }
+}
+
+
+private enum Constants {
+    static var modalFrameMaxSmallDimension: CGFloat { 752 }
 }
 
 // MARK: - Localization
@@ -139,7 +150,7 @@ private enum Localization {
     )
     static let socketS720Subtitle = NSLocalizedString(
         "pos.barcodeScannerSetup.socketS720.subtitle",
-        value: "Recommended scanner",
+        value: "Small handheld scanner with a charging dock or stand",
         comment: "Subtitle for Socket S720 scanner option in barcode scanner setup"
     )
     static let starBSH20BTitle = NSLocalizedString(
@@ -149,7 +160,7 @@ private enum Localization {
     )
     static let starBSH20BSubtitle = NSLocalizedString(
         "pos.barcodeScannerSetup.starBSH20B.subtitle",
-        value: "Recommended scanner",
+        value: "Ergonomic scanner with a stand",
         comment: "Subtitle for Star BSH-20B scanner option in barcode scanner setup"
     )
     static let tbcScannerTitle = NSLocalizedString(
@@ -169,7 +180,7 @@ private enum Localization {
     )
     static let otherSubtitle = NSLocalizedString(
         "pos.barcodeScannerSetup.other.subtitle",
-        value: "General setup instructions",
+        value: "General scanner setup instructions",
         comment: "Subtitle for other scanner option in barcode scanner setup"
     )
     static let backButtonTitle = NSLocalizedString(
@@ -179,6 +190,7 @@ private enum Localization {
     )
 }
 
+@available(iOS 17.0, *)
 #Preview {
     PointOfSaleBarcodeScannerSetUpFlow(isPresented: .constant(true))
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerSetUpFlow.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerSetUpFlow.swift
@@ -1,5 +1,20 @@
 import SwiftUI
 
+// MARK: - Data Models
+struct ScannerOption: Identifiable {
+    let id = UUID()
+    let title: String
+    let subtitle: String
+    let destination: SetupDestination
+}
+
+enum SetupDestination {
+    case socketS720
+    case starBSH20B
+    case tbcScanner
+    case other
+}
+
 @available(iOS 17.0, *)
 struct PointOfSaleBarcodeScannerSetUpFlow: View {
     @Binding var isPresented: Bool
@@ -15,14 +30,14 @@ struct PointOfSaleBarcodeScannerSetUpFlow: View {
                                        title: .constant(AttributedString(Localization.setupHeading)))
 
                 VStack {
-                    ScannerSelectionView(isPresented: $isPresented)
+                    ScannerSelectionView(options: scannerOptions, isPresented: $isPresented)
                     Spacer()
                 }
                 .scrollVerticallyIfNeeded()
             }
             .toolbar(.hidden, for: .navigationBar)
+            .padding(POSPadding.xxLarge)
         }
-        .padding(POSPadding.xxLarge)
         .background(Color.posSurfaceBright)
         .containerRelativeFrame([.horizontal, .vertical]) { length, _ in
             max(length * 0.75, Constants.modalFrameMaxSmallDimension)
@@ -31,12 +46,39 @@ struct PointOfSaleBarcodeScannerSetUpFlow: View {
             ServiceLocator.analytics.track(.pointOfSaleBarcodeScannerSetupFlowShown)
         }
     }
+
+    private var scannerOptions: [ScannerOption] {
+        [
+            ScannerOption(
+                title: Localization.socketS720Title,
+                subtitle: Localization.socketS720Subtitle,
+                destination: .socketS720
+            ),
+            ScannerOption(
+                title: Localization.starBSH20BTitle,
+                subtitle: Localization.starBSH20BSubtitle,
+                destination: .starBSH20B
+            ),
+            ScannerOption(
+                title: Localization.tbcScannerTitle,
+                subtitle: Localization.tbcScannerSubtitle,
+                destination: .tbcScanner
+            ),
+            ScannerOption(
+                title: Localization.otherTitle,
+                subtitle: Localization.otherSubtitle,
+                destination: .other
+            )
+        ]
+    }
 }
 
 struct ScannerSelectionView: View {
+    let options: [ScannerOption]
     @Binding var isPresented: Bool
+
     var body: some View {
-        VStack(spacing: POSSpacing.medium) {
+        VStack(alignment: .leading, spacing: POSSpacing.medium) {
             Text(Localization.setupIntroMessage)
                 .font(.posBodyLargeRegular())
                 .foregroundStyle(Color.posOnSurface)
@@ -44,42 +86,31 @@ struct ScannerSelectionView: View {
                 .fixedSize(horizontal: false, vertical: true)
 
             VStack(spacing: POSSpacing.small) {
-                // Socket S720
-                NavigationLink(destination: EmptyView()) {
-                    ScannerOptionView(
-                        title: Localization.socketS720Title,
-                        subtitle: Localization.socketS720Subtitle
-                    )
+                ForEach(options) { option in
+                    NavigationLink(destination: destinationView(for: option.destination)) {
+                        ScannerOptionView(
+                            title: option.title,
+                            subtitle: option.subtitle
+                        )
+                    }
+                    .buttonStyle(PlainButtonStyle())
                 }
-                .buttonStyle(PlainButtonStyle())
-
-                // Star BSH-20B
-                NavigationLink(destination: EmptyView()) {
-                    ScannerOptionView(
-                        title: Localization.starBSH20BTitle,
-                        subtitle: Localization.starBSH20BSubtitle
-                    )
-                }
-                .buttonStyle(PlainButtonStyle())
-
-                // TBC Scanner
-                NavigationLink(destination: EmptyView()) {
-                    ScannerOptionView(
-                        title: Localization.tbcScannerTitle,
-                        subtitle: Localization.tbcScannerSubtitle
-                    )
-                }
-                .buttonStyle(PlainButtonStyle())
-
-                // Other
-                NavigationLink(destination: BarcodeScannerInformationView(isPresented: $isPresented)) {
-                    ScannerOptionView(
-                        title: Localization.otherTitle,
-                        subtitle: Localization.otherSubtitle
-                    )
-                }
-                .buttonStyle(PlainButtonStyle())
             }
+        }
+    }
+
+    @ViewBuilder
+    private func destinationView(for destination: SetupDestination) -> some View {
+        switch destination {
+        case .socketS720:
+            EmptyView() // TODO: Implement Socket S720 setup flow WOOMOB-698
+        case .starBSH20B:
+            EmptyView() // TODO: Implement Star BSH-20B setup flow WOOMOB-696
+        case .tbcScanner:
+            EmptyView() // TODO: Implement TBC scanner setup flow WOOMOB-699
+        case .other:
+            BarcodeScannerInformationView(isPresented: $isPresented)
+                .padding(POSPadding.xxLarge)
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerSetUpFlow.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerSetUpFlow.swift
@@ -1,11 +1,185 @@
 import SwiftUI
 
 struct PointOfSaleBarcodeScannerSetUpFlow: View {
+    @Binding var isPresented: Bool
+    @State private var showingInformationModal = false
+
+    init(isPresented: Binding<Bool>) {
+        self._isPresented = isPresented
+    }
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        PointOfSaleInformationModal(isPresented: $isPresented, title: AttributedString(Localization.setupHeading)) {
+            VStack(spacing: POSSpacing.medium) {
+                Text(AttributedString(Localization.setupIntroMessage))
+                    .font(.posBodyLargeRegular())
+                    .foregroundStyle(Color.posOnSurface)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                VStack(spacing: POSSpacing.small) {
+                    // Socket S720
+                    Button(action: {
+                        // TODO: Navigate to Socket S720 setup flow
+                    }) {
+                        HStack {
+                            VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
+                                Text(Localization.socketS720Title)
+                                    .font(.posBodyLargeBold)
+                                    .foregroundColor(.posOnSurface)
+                                Text(Localization.socketS720Subtitle)
+                                    .font(.posBodyMediumRegular())
+                                    .foregroundColor(.posOnSurfaceVariantHighest)
+                            }
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.posBodyMediumBold)
+                                .foregroundColor(.posOnSurfaceVariantHighest)
+                        }
+                        .padding(POSPadding.medium)
+                        .background(Color.posSurfaceDim)
+                        .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.medium.value))
+                    }
+                    .buttonStyle(PlainButtonStyle())
+
+                    // Star BSH-20B
+                    Button(action: {
+                        // TODO: Navigate to Star BSH-20B setup flow
+                    }) {
+                        HStack {
+                            VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
+                                Text(Localization.starBSH20BTitle)
+                                    .font(.posBodyLargeBold)
+                                    .foregroundColor(.posOnSurface)
+                                Text(Localization.starBSH20BSubtitle)
+                                    .font(.posBodyMediumRegular())
+                                    .foregroundColor(.posOnSurfaceVariantHighest)
+                            }
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.posBodyMediumBold)
+                                .foregroundColor(.posOnSurfaceVariantHighest)
+                        }
+                        .padding(POSPadding.medium)
+                        .background(Color.posSurfaceDim)
+                        .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.medium.value))
+                    }
+                    .buttonStyle(PlainButtonStyle())
+
+                    // TBC Scanner
+                    Button(action: {
+                        // TODO: Navigate to TBC scanner setup flow
+                    }) {
+                        HStack {
+                            VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
+                                Text(Localization.tbcScannerTitle)
+                                    .font(.posBodyLargeBold)
+                                    .foregroundColor(.posOnSurface)
+                                Text(Localization.tbcScannerSubtitle)
+                                    .font(.posBodyMediumRegular())
+                                    .foregroundColor(.posOnSurfaceVariantHighest)
+                            }
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.posBodyMediumBold)
+                                .foregroundColor(.posOnSurfaceVariantHighest)
+                        }
+                        .padding(POSPadding.medium)
+                        .background(Color.posSurfaceDim)
+                        .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.medium.value))
+                    }
+                    .buttonStyle(PlainButtonStyle())
+
+                    // Other
+                    Button(action: {
+                        showingInformationModal = true
+                    }) {
+                        HStack {
+                            VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
+                                Text(Localization.otherTitle)
+                                    .font(.posBodyLargeBold)
+                                    .foregroundColor(.posOnSurface)
+                                Text(Localization.otherSubtitle)
+                                    .font(.posBodyMediumRegular())
+                                    .foregroundColor(.posOnSurfaceVariantHighest)
+                            }
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.posBodyMediumBold)
+                                .foregroundColor(.posOnSurfaceVariantHighest)
+                        }
+                        .padding(POSPadding.medium)
+                        .background(Color.posSurfaceDim)
+                        .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.medium.value))
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                }
+            }
+        }
+        .sheet(isPresented: $showingInformationModal) {
+            PointOfSaleBarcodeScannerInformationModal(isPresented: $showingInformationModal)
+        }
+        .onAppear(perform: {
+            ServiceLocator.analytics.track(.pointOfSaleBarcodeScannerSetupFlowShown)
+        })
+    }
+}
+
+private extension PointOfSaleBarcodeScannerSetUpFlow {
+    enum Localization {
+        static let setupHeading = NSLocalizedString(
+            "pos.barcodeScannerSetup.heading",
+            value: "Barcode Scanner Setup",
+            comment: "Heading for the barcode scanner setup flow in POS"
+        )
+        static let setupIntroMessage = NSLocalizedString(
+            "pos.barcodeScannerSetup.introMessage",
+            value: "Choose your barcode scanner to get started with the setup process.",
+            comment: "Introductory message in the barcode scanner setup flow in POS"
+        )
+        static let socketS720Title = NSLocalizedString(
+            "pos.barcodeScannerSetup.socketS720.title",
+            value: "Socket S720",
+            comment: "Title for Socket S720 scanner option in barcode scanner setup"
+        )
+        static let socketS720Subtitle = NSLocalizedString(
+            "pos.barcodeScannerSetup.socketS720.subtitle",
+            value: "Recommended scanner",
+            comment: "Subtitle for Socket S720 scanner option in barcode scanner setup"
+        )
+        static let starBSH20BTitle = NSLocalizedString(
+            "pos.barcodeScannerSetup.starBSH20B.title",
+            value: "Star BSH-20B",
+            comment: "Title for Star BSH-20B scanner option in barcode scanner setup"
+        )
+        static let starBSH20BSubtitle = NSLocalizedString(
+            "pos.barcodeScannerSetup.starBSH20B.subtitle",
+            value: "Recommended scanner",
+            comment: "Subtitle for Star BSH-20B scanner option in barcode scanner setup"
+        )
+        static let tbcScannerTitle = NSLocalizedString(
+            "pos.barcodeScannerSetup.tbcScanner.title",
+            value: "Scanner TBC",
+            comment: "Title for TBC scanner option in barcode scanner setup"
+        )
+        static let tbcScannerSubtitle = NSLocalizedString(
+            "pos.barcodeScannerSetup.tbcScanner.subtitle",
+            value: "Recommended scanner",
+            comment: "Subtitle for TBC scanner option in barcode scanner setup"
+        )
+        static let otherTitle = NSLocalizedString(
+            "pos.barcodeScannerSetup.other.title",
+            value: "Other",
+            comment: "Title for other scanner option in barcode scanner setup"
+        )
+        static let otherSubtitle = NSLocalizedString(
+            "pos.barcodeScannerSetup.other.subtitle",
+            value: "General setup instructions",
+            comment: "Subtitle for other scanner option in barcode scanner setup"
+        )
     }
 }
 
 #Preview {
-    PointOfSaleBarcodeScannerSetUpFlow()
+    PointOfSaleBarcodeScannerSetUpFlow(isPresented: .constant(true))
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerSetUpFlow.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerSetUpFlow.swift
@@ -2,11 +2,23 @@ import SwiftUI
 
 struct PointOfSaleBarcodeScannerSetUpFlow: View {
     @Binding var isPresented: Bool
-    @State private var showingInformationModal = false
 
     init(isPresented: Binding<Bool>) {
         self._isPresented = isPresented
     }
+
+    var body: some View {
+        NavigationStack {
+            ScannerSelectionView(isPresented: $isPresented)
+        }
+        .onAppear {
+            ServiceLocator.analytics.track(.pointOfSaleBarcodeScannerSetupFlowShown)
+        }
+    }
+}
+
+struct ScannerSelectionView: View {
+    @Binding var isPresented: Bool
 
     var body: some View {
         PointOfSaleInformationModal(isPresented: $isPresented, title: AttributedString(Localization.setupHeading)) {
@@ -19,9 +31,7 @@ struct PointOfSaleBarcodeScannerSetUpFlow: View {
 
                 VStack(spacing: POSSpacing.small) {
                     // Socket S720
-                    Button(action: {
-                        // TODO: Navigate to Socket S720 setup flow
-                    }) {
+                    NavigationLink(destination: EmptyView()) {
                         HStack {
                             VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
                                 Text(Localization.socketS720Title)
@@ -43,9 +53,7 @@ struct PointOfSaleBarcodeScannerSetUpFlow: View {
                     .buttonStyle(PlainButtonStyle())
 
                     // Star BSH-20B
-                    Button(action: {
-                        // TODO: Navigate to Star BSH-20B setup flow
-                    }) {
+                    NavigationLink(destination: EmptyView()) {
                         HStack {
                             VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
                                 Text(Localization.starBSH20BTitle)
@@ -67,9 +75,7 @@ struct PointOfSaleBarcodeScannerSetUpFlow: View {
                     .buttonStyle(PlainButtonStyle())
 
                     // TBC Scanner
-                    Button(action: {
-                        // TODO: Navigate to TBC scanner setup flow
-                    }) {
+                    NavigationLink(destination: EmptyView()) {
                         HStack {
                             VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
                                 Text(Localization.tbcScannerTitle)
@@ -91,9 +97,7 @@ struct PointOfSaleBarcodeScannerSetUpFlow: View {
                     .buttonStyle(PlainButtonStyle())
 
                     // Other
-                    Button(action: {
-                        showingInformationModal = true
-                    }) {
+                    NavigationLink(destination: BarcodeScannerInformationView()) {
                         HStack {
                             VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
                                 Text(Localization.otherTitle)
@@ -116,69 +120,205 @@ struct PointOfSaleBarcodeScannerSetUpFlow: View {
                 }
             }
         }
-        .sheet(isPresented: $showingInformationModal) {
-            PointOfSaleBarcodeScannerInformationModal(isPresented: $showingInformationModal)
-        }
-        .onAppear(perform: {
-            ServiceLocator.analytics.track(.pointOfSaleBarcodeScannerSetupFlowShown)
-        })
     }
 }
 
-private extension PointOfSaleBarcodeScannerSetUpFlow {
-    enum Localization {
-        static let setupHeading = NSLocalizedString(
-            "pos.barcodeScannerSetup.heading",
-            value: "Barcode Scanner Setup",
-            comment: "Heading for the barcode scanner setup flow in POS"
-        )
-        static let setupIntroMessage = NSLocalizedString(
-            "pos.barcodeScannerSetup.introMessage",
-            value: "Choose your barcode scanner to get started with the setup process.",
-            comment: "Introductory message in the barcode scanner setup flow in POS"
-        )
-        static let socketS720Title = NSLocalizedString(
-            "pos.barcodeScannerSetup.socketS720.title",
-            value: "Socket S720",
-            comment: "Title for Socket S720 scanner option in barcode scanner setup"
-        )
-        static let socketS720Subtitle = NSLocalizedString(
-            "pos.barcodeScannerSetup.socketS720.subtitle",
-            value: "Recommended scanner",
-            comment: "Subtitle for Socket S720 scanner option in barcode scanner setup"
-        )
-        static let starBSH20BTitle = NSLocalizedString(
-            "pos.barcodeScannerSetup.starBSH20B.title",
-            value: "Star BSH-20B",
-            comment: "Title for Star BSH-20B scanner option in barcode scanner setup"
-        )
-        static let starBSH20BSubtitle = NSLocalizedString(
-            "pos.barcodeScannerSetup.starBSH20B.subtitle",
-            value: "Recommended scanner",
-            comment: "Subtitle for Star BSH-20B scanner option in barcode scanner setup"
-        )
-        static let tbcScannerTitle = NSLocalizedString(
-            "pos.barcodeScannerSetup.tbcScanner.title",
-            value: "Scanner TBC",
-            comment: "Title for TBC scanner option in barcode scanner setup"
-        )
-        static let tbcScannerSubtitle = NSLocalizedString(
-            "pos.barcodeScannerSetup.tbcScanner.subtitle",
-            value: "Recommended scanner",
-            comment: "Subtitle for TBC scanner option in barcode scanner setup"
-        )
-        static let otherTitle = NSLocalizedString(
-            "pos.barcodeScannerSetup.other.title",
-            value: "Other",
-            comment: "Title for other scanner option in barcode scanner setup"
-        )
-        static let otherSubtitle = NSLocalizedString(
-            "pos.barcodeScannerSetup.other.subtitle",
-            value: "General setup instructions",
-            comment: "Subtitle for other scanner option in barcode scanner setup"
-        )
+struct BarcodeScannerInformationView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        PointOfSaleInformationModal(isPresented: .constant(true), title: AttributedString(Localization.barcodeInfoHeading)) {
+            PointOfSaleInformationModalParagraphView {
+                Text(AttributedString(Localization.barcodeInfoIntroMessage))
+            }
+
+            PointOfSaleInformationModalParagraphView {
+                Text(bulletPointWithLink)
+                    .accessibilityLabel(bulletPointWithLinkAccessibilityLabel)
+                Text(AttributedString(Localization.barcodeInfoSecondaryMessage))
+                    .accessibilityLabel(Localization.barcodeInfoSecondaryMessageAccessible)
+                Text(AttributedString(Localization.barcodeInfoTertiaryMessage))
+                    .accessibilityLabel(Localization.barcodeInfoTertiaryMessageAccessible)
+                Text(AttributedString(Localization.barcodeInfoQuaternaryMessage))
+                    .accessibilityLabel(Localization.barcodeInfoQuaternaryMessageAccessible)
+            }
+            .padding(.leading, POSSpacing.medium)
+
+            PointOfSaleInformationModalParagraphView(style: .outlined) {
+                Text(AttributedString(Localization.barcodeInfoQuinaryMessage))
+            }
+        }
+        .onAppear(perform: {
+            ServiceLocator.analytics.track(.pointOfSaleBarcodeScanningExplanationDialogShown)
+        })
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(action: {
+                    dismiss()
+                }) {
+                    HStack(spacing: POSSpacing.xSmall) {
+                        Image(systemName: "chevron.left")
+                            .font(.posBodyMediumBold)
+                        Text(Localization.backButtonTitle)
+                            .font(.posBodyMediumBold)
+                    }
+                    .foregroundColor(.posOnSurface)
+                }
+            }
+        }
+    }
+
+    private var bulletPointWithLink: AttributedString {
+        var secondary = AttributedString(Localization.barcodeInfoPrimaryMessage + " ")
+        var moreDetails = AttributedString(Localization.barcodeInfoMoreDetailsLink)
+        moreDetails.link = Constants.detailsLink
+        moreDetails.foregroundColor = .posPrimary
+        moreDetails.underlineStyle = .single
+        secondary.append(moreDetails)
+        return secondary
+    }
+
+    private var bulletPointWithLinkAccessibilityLabel: String {
+        return Localization.barcodeInfoPrimaryMessageAccessible + " " + Localization.barcodeInfoMoreDetailsLinkAccessible
     }
 }
+
+// MARK: - Localization
+private enum Localization {
+    static let setupHeading = NSLocalizedString(
+        "pos.barcodeScannerSetup.heading",
+        value: "Barcode Scanner Setup",
+        comment: "Heading for the barcode scanner setup flow in POS"
+    )
+    static let setupIntroMessage = NSLocalizedString(
+        "pos.barcodeScannerSetup.introMessage",
+        value: "Choose your barcode scanner to get started with the setup process.",
+        comment: "Introductory message in the barcode scanner setup flow in POS"
+    )
+    static let socketS720Title = NSLocalizedString(
+        "pos.barcodeScannerSetup.socketS720.title",
+        value: "Socket S720",
+        comment: "Title for Socket S720 scanner option in barcode scanner setup"
+    )
+    static let socketS720Subtitle = NSLocalizedString(
+        "pos.barcodeScannerSetup.socketS720.subtitle",
+        value: "Recommended scanner",
+        comment: "Subtitle for Socket S720 scanner option in barcode scanner setup"
+    )
+    static let starBSH20BTitle = NSLocalizedString(
+        "pos.barcodeScannerSetup.starBSH20B.title",
+        value: "Star BSH-20B",
+        comment: "Title for Star BSH-20B scanner option in barcode scanner setup"
+    )
+    static let starBSH20BSubtitle = NSLocalizedString(
+        "pos.barcodeScannerSetup.starBSH20B.subtitle",
+        value: "Recommended scanner",
+        comment: "Subtitle for Star BSH-20B scanner option in barcode scanner setup"
+    )
+    static let tbcScannerTitle = NSLocalizedString(
+        "pos.barcodeScannerSetup.tbcScanner.title",
+        value: "Scanner TBC",
+        comment: "Title for TBC scanner option in barcode scanner setup"
+    )
+    static let tbcScannerSubtitle = NSLocalizedString(
+        "pos.barcodeScannerSetup.tbcScanner.subtitle",
+        value: "Recommended scanner",
+        comment: "Subtitle for TBC scanner option in barcode scanner setup"
+    )
+    static let otherTitle = NSLocalizedString(
+        "pos.barcodeScannerSetup.other.title",
+        value: "Other",
+        comment: "Title for other scanner option in barcode scanner setup"
+    )
+    static let otherSubtitle = NSLocalizedString(
+        "pos.barcodeScannerSetup.other.subtitle",
+        value: "General setup instructions",
+        comment: "Subtitle for other scanner option in barcode scanner setup"
+    )
+    static let backButtonTitle = NSLocalizedString(
+        "pos.barcodeScannerSetup.back.button.title",
+        value: "Back",
+        comment: "Title for the back button in barcode scanner setup navigation"
+    )
+
+    // Barcode info localization (reused from existing modal)
+    static let barcodeInfoHeading = NSLocalizedString(
+        "pos.barcodeInfoModal.heading",
+        value: "Barcode scanning",
+        comment: "Heading for the barcode info modal in POS, introducing barcode scanning feature"
+    )
+    static let barcodeInfoIntroMessage = NSLocalizedString(
+        "pos.barcodeInfoModal.introMessage",
+        value: "You can scan barcodes using an external scanner to quickly build a cart.",
+        comment: "Introductory message in the barcode info modal in POS, explaining the use of external barcode scanners"
+    )
+    static let barcodeInfoPrimaryMessage = NSLocalizedString(
+        "pos.barcodeInfoModal.primaryMessage",
+        value: "• Set up barcodes in the \"GTIN, UPC, EAN, ISBN\" field in Products > Product Details > Inventory. ",
+        comment: "Primary bullet point in the barcode info modal in POS, instructing where to set up barcodes in product details"
+    )
+    static let barcodeInfoMoreDetailsLink = NSLocalizedString(
+        "pos.barcodeInfoModal.moreDetailsLink",
+        value: "More details.",
+        comment: "Link text in the barcode info modal in POS, leading to more details about barcode setup"
+    )
+    static let barcodeInfoMoreDetailsLinkAccessible = NSLocalizedString(
+        "pos.barcodeInfoModal.moreDetailsLink.accessible",
+        value: "More details, link.",
+        comment: "Accessible version of more details link in barcode info modal, announcing it as a link for screen readers"
+    )
+    static let barcodeInfoSecondaryMessage = NSLocalizedString(
+        "pos.barcodeInfoModal.secondaryMessage.2",
+        value: "• Refer to your Bluetooth barcode scanner's instructions to set HID mode. This usually " +
+        "requires scanning a special barcode in the manual.",
+        comment: "Secondary bullet point in the barcode info modal in POS, instructing to set scanner to HID mode"
+    )
+    static let barcodeInfoTertiaryMessage = NSLocalizedString(
+        "pos.barcodeInfoModal.tertiaryMessage",
+        value: "• Connect your barcode scanner in iOS Bluetooth settings.",
+        comment: "Tertiary bullet point in the barcode info modal in POS, instructing to connect scanner via Bluetooth settings"
+    )
+    static let barcodeInfoQuaternaryMessage = NSLocalizedString(
+        "pos.barcodeInfoModal.quaternaryMessage",
+        value: "• Scan barcodes while on the item list to add products to the cart.",
+        comment: "Quaternary bullet point in the barcode info modal in POS, instructing to scan barcodes on item list to add to cart"
+    )
+    static let barcodeInfoQuinaryMessage = NSLocalizedString(
+        "pos.barcodeInfoModal.quinaryMessage",
+        value: "The scanner emulates a keyboard, so sometimes it will prevent the software keyboard from showing, e.g. in search. " +
+            "Tap on the keyboard icon to show it again.",
+        comment: "Quinary message in the barcode info modal in POS, explaining scanner keyboard emulation and how to show software keyboard again"
+    )
+
+    // Accessibility-friendly versions without bullet points
+    static let barcodeInfoPrimaryMessageAccessible = NSLocalizedString(
+        "pos.barcodeInfoModal.primaryMessage.accessible",
+        value: "First: Set up barcodes in the \"G-T-I-N, U-P-C, E-A-N, I-S-B-N\" field by navigating to Products, then Product Details, then Inventory.",
+        comment: "Accessible version of primary bullet point in barcode info modal, without bullet character for screen readers"
+    )
+    static let barcodeInfoSecondaryMessageAccessible = NSLocalizedString(
+        "pos.barcodeInfoModal.secondaryMessage.accessible.2",
+        value: "Second: Refer to your Bluetooth barcode scanner's instructions to set H-I-D mode. This usually " +
+        "requires scanning a special barcode in the manual.",
+        comment: "Accessible version of secondary bullet point in barcode info modal, without bullet character for screen readers"
+    )
+    static let barcodeInfoTertiaryMessageAccessible = NSLocalizedString(
+        "pos.barcodeInfoModal.tertiaryMessage.accessible",
+        value: "Third: Connect your barcode scanner in iOS Bluetooth settings.",
+        comment: "Accessible version of tertiary bullet point in barcode info modal, without bullet character for screen readers"
+    )
+    static let barcodeInfoQuaternaryMessageAccessible = NSLocalizedString(
+        "pos.barcodeInfoModal.quaternaryMessage.accessible",
+        value: "Fourth: Scan barcodes while on the item list to add products to the cart.",
+        comment: "Accessible version of quaternary bullet point in barcode info modal, without bullet character for screen readers"
+    )
+}
+
+private enum Constants {
+    static let detailsLink = URL(string: "https://woocommerce.com/document/barcode-and-qr-code-scanner/")
+}
+
 
 #Preview {
     PointOfSaleBarcodeScannerSetUpFlow(isPresented: .constant(true))

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerSetUpFlow.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerSetUpFlow.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct PointOfSaleBarcodeScannerSetUpFlow: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    PointOfSaleBarcodeScannerSetUpFlow()
+}

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleInformationModal.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleInformationModal.swift
@@ -22,18 +22,7 @@ struct PointOfSaleInformationModal<Content: View>: View {
 
     var body: some View {
         VStack(spacing: POSSpacing.xxLarge) {
-            HStack {
-                Text(title)
-                    .font(.posHeadingBold)
-                Spacer()
-                Button {
-                    isPresented = false
-                } label: {
-                    Text(Image(systemName: "xmark"))
-                        .font(.posButtonSymbolLarge)
-                }
-            }
-            .foregroundColor(Color.posOnSurface)
+            PointOfSaleModalHeader(isPresented: $isPresented, title: .constant(title))
 
             ScrollView {
                 VStack {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleModalHeader.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleModalHeader.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct PointOfSaleModalHeader: View {
+    @Binding var isPresented: Bool
+    @Binding var title: AttributedString
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .font(.posHeadingBold)
+                .lineLimit(1)
+            Spacer()
+            Button {
+                isPresented = false
+            } label: {
+                Text(Image(systemName: "xmark"))
+                    .font(.posButtonSymbolLarge)
+            }
+        }
+        .foregroundColor(Color.posOnSurface)
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -913,6 +913,7 @@
 		20BCF6F02B0E48CC00954840 /* WooPaymentsPayoutsOverviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6EF2B0E48CC00954840 /* WooPaymentsPayoutsOverviewViewModelTests.swift */; };
 		20BCF6F72B0E5AF000954840 /* MockSystemStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6F62B0E5AEF00954840 /* MockSystemStatusService.swift */; };
 		20C3C8822E1D11F500CF7D3B /* PointOfSaleBarcodeScannerSetUpFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C3C8812E1D11F500CF7D3B /* PointOfSaleBarcodeScannerSetUpFlow.swift */; };
+		20C3CC3C2E1D31B100CF7D3B /* PointOfSaleModalHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C3CC3B2E1D31B100CF7D3B /* PointOfSaleModalHeader.swift */; };
 		20C6E7512CDE4AEA00CD124C /* ItemListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C6E7502CDE4AEA00CD124C /* ItemListState.swift */; };
 		20C909962D3151FA0013BCCF /* ItemListBaseItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C909952D3151FA0013BCCF /* ItemListBaseItem.swift */; };
 		20CC1EDB2AFA8381006BD429 /* InPersonPaymentsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */; };
@@ -4077,6 +4078,7 @@
 		20BCF6EF2B0E48CC00954840 /* WooPaymentsPayoutsOverviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsOverviewViewModelTests.swift; sourceTree = "<group>"; };
 		20BCF6F62B0E5AEF00954840 /* MockSystemStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSystemStatusService.swift; sourceTree = "<group>"; };
 		20C3C8812E1D11F500CF7D3B /* PointOfSaleBarcodeScannerSetUpFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleBarcodeScannerSetUpFlow.swift; sourceTree = "<group>"; };
+		20C3CC3B2E1D31B100CF7D3B /* PointOfSaleModalHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleModalHeader.swift; sourceTree = "<group>"; };
 		20C6E7502CDE4AEA00CD124C /* ItemListState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListState.swift; sourceTree = "<group>"; };
 		20C909952D3151FA0013BCCF /* ItemListBaseItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListBaseItem.swift; sourceTree = "<group>"; };
 		20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenu.swift; sourceTree = "<group>"; };
@@ -7108,6 +7110,7 @@
 				DA0DBE2E2C4FC61D00DF14C0 /* POSFloatingControlView.swift */,
 				20D3D42A2C64D7CC004CE6E3 /* SimpleProductsOnlyInformation.swift */,
 				01435CF72DFC2CE800C0279B /* PointOfSaleInformationModal.swift */,
+				20C3CC3B2E1D31B100CF7D3B /* PointOfSaleModalHeader.swift */,
 				014371262DFC8E2100C0279B /* PointOfSaleBarcodeScannerInformationModal.swift */,
 				20C3C8812E1D11F500CF7D3B /* PointOfSaleBarcodeScannerSetUpFlow.swift */,
 				68C53CBD2C1FE59B00C6D80B /* ItemListView.swift */,
@@ -16655,6 +16658,7 @@
 				8625C5132BF20CC6007F1901 /* ReviewsDashboardCardViewModel.swift in Sources */,
 				0225091D2A5DAEA0000AEBD2 /* WooAnalyticsEvent+ProductCreation.swift in Sources */,
 				D843D5D722485B19001BFA55 /* ShippingProvidersViewModel.swift in Sources */,
+				20C3CC3C2E1D31B100CF7D3B /* PointOfSaleModalHeader.swift in Sources */,
 				B649BC7E2A1C295B007AB988 /* View+HighlightModifier.swift in Sources */,
 				4572641927F1EB27004E1F95 /* AddEditCouponViewModel.swift in Sources */,
 				CE13681729FBD94300EBF43C /* QuantityRulesViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -912,6 +912,7 @@
 		20BCF6EE2B0E478B00954840 /* WooPaymentsPayoutsOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6ED2B0E478B00954840 /* WooPaymentsPayoutsOverviewViewModel.swift */; };
 		20BCF6F02B0E48CC00954840 /* WooPaymentsPayoutsOverviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6EF2B0E48CC00954840 /* WooPaymentsPayoutsOverviewViewModelTests.swift */; };
 		20BCF6F72B0E5AF000954840 /* MockSystemStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6F62B0E5AEF00954840 /* MockSystemStatusService.swift */; };
+		20C3C8822E1D11F500CF7D3B /* PointOfSaleBarcodeScannerSetUpFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C3C8812E1D11F500CF7D3B /* PointOfSaleBarcodeScannerSetUpFlow.swift */; };
 		20C6E7512CDE4AEA00CD124C /* ItemListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C6E7502CDE4AEA00CD124C /* ItemListState.swift */; };
 		20C909962D3151FA0013BCCF /* ItemListBaseItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C909952D3151FA0013BCCF /* ItemListBaseItem.swift */; };
 		20CC1EDB2AFA8381006BD429 /* InPersonPaymentsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */; };
@@ -4075,6 +4076,7 @@
 		20BCF6ED2B0E478B00954840 /* WooPaymentsPayoutsOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsOverviewViewModel.swift; sourceTree = "<group>"; };
 		20BCF6EF2B0E48CC00954840 /* WooPaymentsPayoutsOverviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsOverviewViewModelTests.swift; sourceTree = "<group>"; };
 		20BCF6F62B0E5AEF00954840 /* MockSystemStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSystemStatusService.swift; sourceTree = "<group>"; };
+		20C3C8812E1D11F500CF7D3B /* PointOfSaleBarcodeScannerSetUpFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleBarcodeScannerSetUpFlow.swift; sourceTree = "<group>"; };
 		20C6E7502CDE4AEA00CD124C /* ItemListState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListState.swift; sourceTree = "<group>"; };
 		20C909952D3151FA0013BCCF /* ItemListBaseItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListBaseItem.swift; sourceTree = "<group>"; };
 		20CC1EDA2AFA8381006BD429 /* InPersonPaymentsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenu.swift; sourceTree = "<group>"; };
@@ -7107,6 +7109,7 @@
 				20D3D42A2C64D7CC004CE6E3 /* SimpleProductsOnlyInformation.swift */,
 				01435CF72DFC2CE800C0279B /* PointOfSaleInformationModal.swift */,
 				014371262DFC8E2100C0279B /* PointOfSaleBarcodeScannerInformationModal.swift */,
+				20C3C8812E1D11F500CF7D3B /* PointOfSaleBarcodeScannerSetUpFlow.swift */,
 				68C53CBD2C1FE59B00C6D80B /* ItemListView.swift */,
 				026826A32BF59DF60036F959 /* CartView.swift */,
 				026826A22BF59DF60036F959 /* ItemRowView.swift */,
@@ -16073,6 +16076,7 @@
 				CEE006082077D14C0079161F /* OrderDetailsViewController.swift in Sources */,
 				01B744E22D2FCA1400AEB3F4 /* PushNotificationBackgroundSynchronizerFactory.swift in Sources */,
 				CE4ECA582BC5B66A005F9386 /* WCAnalyticsStatsTotals+UI.swift in Sources */,
+				20C3C8822E1D11F500CF7D3B /* PointOfSaleBarcodeScannerSetUpFlow.swift in Sources */,
 				01FB19582C6E901800A44FF0 /* DynamicHStack.swift in Sources */,
 				AEB73C0C25CD734200A8454A /* AttributePickerViewModel.swift in Sources */,
 				2005D3F32DC13D6900E12021 /* PointOfSaleItemListAnalyticsTracker.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
Part of WOOMOB-695

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a screen to choose a scanner for the set up flow.

It's early work, and uses a navigation stack right now, but I don't think we'll keep that approach for the flows, perhaps just for getting to the flows, but probably not because it animates too much of the content – we are likely to want the title and buttons to have a more subtle transition, with the main thing being the content that's changing.

The designs aren't done yet, so I'm just wireframing this out. I'll go back for a full design pass when we have them, for now some of the fonts/styles probably aren't right.

All this is feature flagged.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Enable the `pointOfSaleBarcodeScanningi2` feature flag
1. Open POS
2. Tap `... > Barcode scanning`
3. Observe that the new select a scanner screen is shown
4. Tap `Other` – observe that the existing scanning info screen is shown.

Disable the feature flag, and repeat, observe that the select a scanner screen is not shown.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/a2b836af-5e6e-4a97-95c0-8c8409d9740e


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
