### PR TITLE
[POS Orders] Handle filtering for POS orders

### DIFF
--- a/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
@@ -22,6 +22,7 @@ public class OrdersRemote: Remote {
     ///     This method will convert it to UTC ISO 8601 before calling the REST API.
     ///     - customerID: If given, limit response to orders placed by a customer.
     ///     - productID: If given, limit response to orders including the given product.
+    ///     - createdVia: If given, limit response to orders created via the specified source (e.g. "pos-rest-api" for Point of Sale).
     ///     - pageNumber: Number of page that should be retrieved.
     ///     - pageSize: Number of Orders to be retrieved per page.
     ///     - completion: Closure to be executed upon completion.
@@ -33,6 +34,7 @@ public class OrdersRemote: Remote {
                               modifiedAfter: Date? = nil,
                               customerID: Int64? = nil,
                               productID: Int64? = nil,
+                              createdVia: String? = nil,
                               pageNumber: Int = Defaults.pageNumber,
                               pageSize: Int = Defaults.pageSize,
                               completion: @escaping (Result<[Order], Error>) -> Void) {
@@ -64,6 +66,10 @@ public class OrdersRemote: Remote {
 
             if let productID {
                 parameters[ParameterKeys.product] = productID
+            }
+
+            if let createdVia {
+                parameters[ParameterKeys.createdVia] = createdVia
             }
 
             return parameters
@@ -470,6 +476,7 @@ public extension OrdersRemote {
         static let usesGMTDates: String     = "dates_are_gmt"
         static let customer = "customer"
         static let product = "product"
+        static let createdVia = "created_via"
     }
 
     enum ParameterValues {

--- a/Modules/Sources/Yosemite/Actions/OrderAction.swift
+++ b/Modules/Sources/Yosemite/Actions/OrderAction.swift
@@ -33,6 +33,7 @@ public enum OrderAction: Action {
     ///               doesn't matter. It will be converted to UTC later.
     ///     - customerID: Only include orders placed by the given customer.
     ///     - productID: Only include orders with `lineItems` including the given product.
+    ///     - createdVia: Only include orders created via the specified source (e.g. "pos-rest-api" for Point of Sale).
     ///
     case fetchFilteredOrders(
         siteID: Int64,
@@ -42,6 +43,7 @@ public enum OrderAction: Action {
         modifiedAfter: Date? = nil,
         customerID: Int64? = nil,
         productID: Int64? = nil,
+        createdVia: String? = nil,
         writeStrategy: OrdersStorageWriteStrategy,
         pageSize: Int,
         onCompletion: (TimeInterval, Result<[Order], Error>) -> Void
@@ -58,6 +60,7 @@ public enum OrderAction: Action {
     ///               doesn't matter. It will be converted to UTC later.
     ///     - customerID: Only include orders placed by the given customer.
     ///     - productID: Only include orders with `lineItems` including the given product.
+    ///     - createdVia: Only include orders created via the specified source (e.g. "pos-rest-api" for Point of Sale).
     ///
     case synchronizeOrders(siteID: Int64,
                            statuses: [String]?,
@@ -66,6 +69,7 @@ public enum OrderAction: Action {
                            modifiedAfter: Date? = nil,
                            customerID: Int64? = nil,
                            productID: Int64? = nil,
+                           createdVia: String? = nil,
                            pageNumber: Int,
                            pageSize: Int,
                            onCompletion: (TimeInterval, Error?) -> Void)

--- a/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockOrderActionHandler.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockOrderActionHandler.swift
@@ -10,7 +10,7 @@ struct MockOrderActionHandler: MockActionHandler {
 
     func handle(action: ActionType) {
         switch action {
-        case .fetchFilteredOrders(let siteID, _, _, _, _, _, _, let writeStrategy, let pageSize, let onCompletion):
+        case .fetchFilteredOrders(let siteID, _, _, _, _, _, _, _, let writeStrategy, let pageSize, let onCompletion):
             fetchFilteredAndAllOrders(siteID: siteID,
                                       writeStrategy: writeStrategy,
                                       pageSize: pageSize,
@@ -25,7 +25,7 @@ struct MockOrderActionHandler: MockActionHandler {
             } else {
                 onCompletion(.failure(NSError(domain: "", code: 0)))
             }
-        case .updateOrderStatus(let siteID, let orderID, let status, let onCompletion):
+        case .updateOrderStatus(_, _, _, let onCompletion):
             onCompletion(nil)
 
         default: unimplementedAction(action: action)

--- a/Modules/Sources/Yosemite/Stores/OrderStore.swift
+++ b/Modules/Sources/Yosemite/Stores/OrderStore.swift
@@ -37,7 +37,7 @@ public class OrderStore: Store {
             retrieveOrderRemotely(siteID: siteID, orderID: orderID, onCompletion: onCompletion)
         case .searchOrders(let siteID, let keyword, let pageNumber, let pageSize, let onCompletion):
             searchOrders(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
-        case let .fetchFilteredOrders(siteID, statuses, after, before, modifiedAfter, customerID, productID, writeStrategy, pageSize, onCompletion):
+        case let .fetchFilteredOrders(siteID, statuses, after, before, modifiedAfter, customerID, productID, createdVia, writeStrategy, pageSize, onCompletion):
             fetchFilteredOrders(siteID: siteID,
                                 statuses: statuses,
                                 after: after,
@@ -45,10 +45,11 @@ public class OrderStore: Store {
                                 modifiedAfter: modifiedAfter,
                                 customerID: customerID,
                                 productID: productID,
+                                createdVia: createdVia,
                                 writeStrategy: writeStrategy,
                                 pageSize: pageSize,
                                 onCompletion: onCompletion)
-        case let .synchronizeOrders(siteID, statuses, after, before, modifiedAfter, customerID, productID, pageNumber, pageSize, onCompletion):
+        case let .synchronizeOrders(siteID, statuses, after, before, modifiedAfter, customerID, productID, createdVia, pageNumber, pageSize, onCompletion):
             synchronizeOrders(siteID: siteID,
                               statuses: statuses,
                               after: after,
@@ -56,12 +57,12 @@ public class OrderStore: Store {
                               modifiedAfter: modifiedAfter,
                               customerID: customerID,
                               productID: productID,
+                              createdVia: createdVia,
                               pageNumber: pageNumber,
                               pageSize: pageSize,
                               onCompletion: onCompletion)
         case .updateOrderStatus(let siteID, let orderID, let statusKey, let onCompletion):
             updateOrder(siteID: siteID, orderID: orderID, status: statusKey, onCompletion: onCompletion)
-
         case let .updateOrder(siteID, order, giftCard, fields, onCompletion):
             updateOrder(siteID: siteID, order: order, giftCard: giftCard, fields: fields, onCompletion: onCompletion)
         case let .updateOrderOptimistically(siteID, order, fields, onCompletion):
@@ -70,7 +71,6 @@ public class OrderStore: Store {
             createSimplePaymentsOrder(siteID: siteID, status: status, amount: amount, taxable: taxable, onCompletion: onCompletion)
         case let .createOrder(siteID, order, giftCard, onCompletion):
             createOrder(siteID: siteID, order: order, giftCard: giftCard, onCompletion: onCompletion)
-
         case let .updateSimplePaymentsOrder(siteID, orderID, feeID, status, amount, amountName, taxable, orderNote, email, onCompletion):
             updateSimplePaymentsOrder(siteID: siteID,
                                       orderID: orderID,
@@ -148,6 +148,7 @@ private extension OrderStore {
                              modifiedAfter: Date?,
                              customerID: Int64?,
                              productID: Int64?,
+                             createdVia: String?,
                              writeStrategy: OrderAction.OrdersStorageWriteStrategy,
                              pageSize: Int,
                              onCompletion: @escaping (TimeInterval, Result<[Order], Error>) -> Void) {
@@ -161,6 +162,7 @@ private extension OrderStore {
                                   modifiedAfter: modifiedAfter,
                                   customerID: customerID,
                                   productID: productID,
+                                  createdVia: createdVia,
                                   pageNumber: pageNumber,
                                   pageSize: pageSize) { [weak self] result in
             switch result {
@@ -189,6 +191,7 @@ private extension OrderStore {
                            modifiedAfter: Date?,
                            customerID: Int64?,
                            productID: Int64?,
+                           createdVia: String?,
                            pageNumber: Int,
                            pageSize: Int,
                            onCompletion: @escaping (TimeInterval, Error?) -> Void) {
@@ -200,6 +203,7 @@ private extension OrderStore {
                              modifiedAfter: modifiedAfter,
                              customerID: customerID,
                              productID: productID,
+                             createdVia: createdVia,
                              pageNumber: pageNumber,
                              pageSize: pageSize) { [weak self] result in
             switch result {

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -92,8 +92,6 @@ enum FilterListValueSelectorConfig {
     case products(siteID: Int64)
     // Filter list selector for customer
     case customer(siteID: Int64)
-    // Filter list selector for sales channel
-    case salesChannel
 
 }
 
@@ -299,10 +297,6 @@ private extension FilterListViewController {
                     self.listSelector.reloadData()
                 }
                 self.listSelector.navigationController?.pushViewController(statusesFilterVC, animated: true)
-            case .salesChannel:
-                // TODO: Make OrderSalesChannelFilterViewController, and handle filtering selection WOOMOB-711
-                let emptyViewController = EmptyStateViewController(style: .list)
-                self.listSelector.navigationController?.pushViewController(emptyViewController, animated: true)
             case .ordersDateRange:
                 let selectedOrderFilter = selected.selectedValue as? OrderDateRangeFilter
                 let datesFilterVC = OrderDatesFilterViewController(selected: selectedOrderFilter) { dateRangeFilter in

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -267,9 +267,11 @@ private extension FilterListViewController {
                 guard let self = self else {
                     return
                 }
-                selected.selectedValue = selectedOption
-                self.updateUI(numberOfActiveFilters: self.viewModel.filterTypeViewModels.numberOfActiveFilters)
-                self.listSelector.reloadData()
+                if selectedOption.description != selected.selectedValue.description {
+                    selected.selectedValue = selectedOption
+                    self.updateUI(numberOfActiveFilters: self.viewModel.filterTypeViewModels.numberOfActiveFilters)
+                    self.listSelector.reloadData()
+                }
             }
 
             switch selected.listSelectorConfig {

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -267,11 +267,9 @@ private extension FilterListViewController {
                 guard let self = self else {
                     return
                 }
-                if selectedOption.description != selected.selectedValue.description {
-                    selected.selectedValue = selectedOption
-                    self.updateUI(numberOfActiveFilters: self.viewModel.filterTypeViewModels.numberOfActiveFilters)
-                    self.listSelector.reloadData()
-                }
+                selected.selectedValue = selectedOption
+                self.updateUI(numberOfActiveFilters: self.viewModel.filterTypeViewModels.numberOfActiveFilters)
+                self.listSelector.reloadData()
             }
 
             switch selected.listSelectorConfig {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
@@ -210,6 +210,9 @@ final class FilterOrderListViewModel: FilterListViewModel {
 
         let clearedCustomer: CustomerFilter? = nil
         customerFilterViewModel.selectedValue = clearedCustomer
+
+        let clearSalesChannel: SalesChannelFilter? = nil
+        salesChannelFilterViewModel.selectedValue = clearSalesChannel
     }
 }
 
@@ -262,8 +265,9 @@ extension FilterOrderListViewModel.OrderListFilter {
                                        listSelectorConfig: .customer(siteID: siteID),
                                        selectedValue: filters.customer)
         case .salesChannel:
+            let salesChannelOptions: [FilterOrderListViewModel.SalesChannelFilter] = [.any, .pointOfSale]
             return FilterTypeViewModel(title: title,
-                                       listSelectorConfig: .salesChannel,
+                                       listSelectorConfig: .staticOptions(options: salesChannelOptions),
                                        selectedValue: filters.salesChannel)
         }
     }
@@ -375,16 +379,24 @@ extension CustomerFilter: FilterType {
 extension FilterOrderListViewModel {
     enum SalesChannelFilter: FilterType {
         case pointOfSale
+        case any
 
         var description: String {
             switch self {
             case .pointOfSale:
-                return "POS"
+                return NSLocalizedString("Point of Sale", comment: "Sales channel filter option for Point of Sale orders")
+            case .any:
+                return NSLocalizedString("Any", comment: "Sales channel filter option for all orders")
             }
         }
 
         var isActive: Bool {
-            return true
+            switch self {
+            case .pointOfSale:
+                return true
+            case .any:
+                return false
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
@@ -269,7 +269,7 @@ extension FilterOrderListViewModel.OrderListFilter {
             let salesChannelOptions: [FilterOrderListViewModel.SalesChannelFilter] = [.any, .pointOfSale]
             return FilterTypeViewModel(title: title,
                                        listSelectorConfig: .staticOptions(options: salesChannelOptions),
-                                       selectedValue: filters.salesChannel ?? .any)
+                                       selectedValue: filters.salesChannel)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
@@ -385,9 +385,15 @@ extension FilterOrderListViewModel {
         var description: String {
             switch self {
             case .pointOfSale:
-                return NSLocalizedString("Point of Sale", comment: "Sales channel filter option for Point of Sale orders")
+                return NSLocalizedString(
+                    "salesChannelFilter.row.pos.description",
+                    value: "Point of Sale",
+                    comment: "Description for the Sales channel filter option, when selecting 'Point of Sale' orders")
             case .any:
-                return NSLocalizedString("Any", comment: "Sales channel filter option for all orders")
+                return NSLocalizedString(
+                    "salesChannelFilter.row.any.description",
+                    value: "Any",
+                    comment: "Description for the Sales channel filter option, when selecting 'Any' order")
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
@@ -159,6 +159,7 @@ final class FilterOrderListViewModel: FilterListViewModel {
         dateRangeFilterViewModel.selectedValue = filter.dateRange
         productFilterViewModel.selectedValue = filter.product
         customerFilterViewModel.selectedValue = filter.customer
+        salesChannelFilterViewModel.selectedValue = filter.salesChannel
         analytics.track(event: .FilterHistory.trackPastFilterApplied(source: source))
     }
 
@@ -268,7 +269,7 @@ extension FilterOrderListViewModel.OrderListFilter {
             let salesChannelOptions: [FilterOrderListViewModel.SalesChannelFilter] = [.any, .pointOfSale]
             return FilterTypeViewModel(title: title,
                                        listSelectorConfig: .staticOptions(options: salesChannelOptions),
-                                       selectedValue: filters.salesChannel)
+                                       selectedValue: filters.salesChannel ?? .any)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
@@ -63,6 +63,7 @@ struct OrderListSyncActionUseCase {
         let endDate = filters?.dateRange?.computedEndDate
         let productID = filters?.product?.id
         let customerID = filters?.customer?.id
+        let createdVia = filters?.salesChannel == .pointOfSale ? "pos-rest-api" : nil
 
         if pageNumber == Defaults.pageFirstIndex {
             let deleteAllBeforeSaving = reason == SyncReason.pullToRefresh || reason == SyncReason.newFiltersApplied
@@ -76,6 +77,7 @@ struct OrderListSyncActionUseCase {
                 modifiedAfter: modifiedAfter,
                 customerID: customerID,
                 productID: productID,
+                createdVia: createdVia,
                 writeStrategy: deleteAllBeforeSaving ? .deleteAllBeforeSaving : .save,
                 pageSize: pageSize,
                 onCompletion: { timeInterval, result in
@@ -96,6 +98,7 @@ struct OrderListSyncActionUseCase {
             before: endDate,
             customerID: customerID,
             productID: productID,
+            createdVia: createdVia,
             pageNumber: pageNumber,
             pageSize: pageSize,
             onCompletion: completionHandler

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -250,8 +250,23 @@ final class OrderListViewModel {
             return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
         }()
 
+        let predicateSalesChannel: NSPredicate? = {
+            guard let salesChannelFilter = filters?.salesChannel else {
+                return nil
+            }
+
+            switch salesChannelFilter {
+            case .pointOfSale:
+                let predicate = NSPredicate(format: "createdVia == %@", "pos-rest-api")
+                return predicate
+            case .any:
+                return nil
+            }
+        }()
+
         let siteIDPredicate = NSPredicate(format: "siteID = %lld", siteID)
-        let queryPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [siteIDPredicate, predicateStatus, predicateDateRanges])
+        let allPredicates = [siteIDPredicate, predicateStatus, predicateDateRanges, predicateSalesChannel].compactMap { $0 }
+        let queryPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: allPredicates)
 
         return FetchResultSnapshotsProvider<StorageOrder>.Query(
             sortDescriptor: NSSortDescriptor(keyPath: \StorageOrder.dateCreated, ascending: false),

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -312,7 +312,6 @@ final class OrdersRootViewController: UIViewController {
         let viewModel = FilterOrderListViewModel(filters: filters, allowedStatuses: allowedStatuses, siteID: siteID)
         let filterOrderListViewController = FilterListViewController(viewModel: viewModel, onFilterAction: { [weak self] filters in
             self?.filters = filters
-
             self?.analytics.track(event: .OrdersFilter.onFilterOrders(filters: filters))
         }, onClearAction: {
         }, onDismissAction: {

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationBackgroundSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationBackgroundSynchronizerTests.swift
@@ -95,7 +95,7 @@ private extension PushNotificationBackgroundSynchronizerTests {
         // Mock sync order list
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case let .fetchFilteredOrders(_, _, _, _, _, _, _, _, _, onCompletion):
+            case let .fetchFilteredOrders(_, _, _, _, _, _, _, _, _, _, onCompletion):
                 self.storage.insertSampleOrder(readOnlyOrder: order)
                 onCompletion(0, .success([order]))
             default:
@@ -112,7 +112,7 @@ private extension PushNotificationBackgroundSynchronizerTests {
         // Mock sync order list & single order
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case let .fetchFilteredOrders(_, _, _, _, _, _, _, _, _, onCompletion):
+            case let .fetchFilteredOrders(_, _, _, _, _, _, _, _, _, _, onCompletion):
                 onCompletion(0, .success([]))
             case let .retrieveOrderRemotely(_, _, onCompletion):
                 self.storage.insertSampleOrder(readOnlyOrder: order)
@@ -129,7 +129,7 @@ private extension PushNotificationBackgroundSynchronizerTests {
         // Mock sync order list & single order
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case let .fetchFilteredOrders(_, _, _, _, _, _, _, _, _, onCompletion):
+            case let .fetchFilteredOrders(_, _, _, _, _, _, _, _, _, _, onCompletion):
                 onCompletion(0, .success([]))
             case let .retrieveOrderRemotely(_, _, onCompletion):
                 self.storage.insertSampleOrder(readOnlyOrder: Self.sampleOrderWithNoteFullDataOrderID)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModelTests.swift
@@ -66,7 +66,7 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
         // When
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case let .fetchFilteredOrders(_, _, _, _, _, _, _, _, _, completion):
+            case let .fetchFilteredOrders(_, _, _, _, _, _, _, _, _, _, completion):
                 XCTAssertTrue(viewModel.syncingData)
                 completion(1, .success(self.sampleOrders))
             default:
@@ -93,7 +93,7 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
         // When
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case let .fetchFilteredOrders(_, _, _, _, _, _, _, _, _, completion):
+            case let .fetchFilteredOrders(_, _, _, _, _, _, _, _, _, _, completion):
                 completion(1, .failure(error))
             default:
                 break
@@ -142,7 +142,7 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
         // When
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case .fetchFilteredOrders(_, let statuses, _, _, _, _, _, _, _, let completion):
+            case .fetchFilteredOrders(_, let statuses, _, _, _, _, _, _, _, _, let completion):
                 requestedOrderStatuses = statuses
                 XCTAssertTrue(viewModel.syncingData)
                 completion(1, .success(self.sampleOrders))
@@ -169,7 +169,7 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
         // When
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case .fetchFilteredOrders(_, _, _, _, _, _, _, _, let pageSize, let completion):
+            case .fetchFilteredOrders(_, _, _, _, _, _, _, _, _, let pageSize, let completion):
                 // Then
                 XCTAssertEqual(pageSize, 3)
                 completion(1, .success(self.sampleOrders))
@@ -191,7 +191,7 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
         // When
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case .fetchFilteredOrders(_, _, _, _, _, _, _, let writeStrategy, _, let completion):
+            case .fetchFilteredOrders(_, _, _, _, _, _, _, _, let writeStrategy, _, let completion):
                 // Then
                 XCTAssertEqual(writeStrategy, .doNotSave)
                 completion(1, .success(self.sampleOrders))
@@ -215,7 +215,7 @@ private extension LastOrdersDashboardCardViewModelTests {
     func mockFetchFilteredOrders() {
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case let .fetchFilteredOrders(_, _, _, _, _, _, _, _, _, completion):
+            case let .fetchFilteredOrders(_, _, _, _, _, _, _, _, _, _, completion):
                 completion(1, .success(self.sampleOrders))
             default:
                 break

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Filters/FilterOrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Filters/FilterOrderListViewModelTests.swift
@@ -43,8 +43,8 @@ final class FilterOrderListViewModelTests: XCTestCase {
                                                        dateRange: OrderDateRangeFilter(filter: .last7Days),
                                                        product: FilterOrdersByProduct(id: 1, name: "Sample product"),
                                                        customer: CustomerFilter(customer: Customer.fake().copy(customerID: 1)),
-                                                       salesChannel: nil,
-                                                       numberOfActiveFilters: 4)
+                                                       salesChannel: .pointOfSale,
+                                                       numberOfActiveFilters: 5)
 
         // When
         let viewModel = FilterOrderListViewModel(filters: filters, allowedStatuses: [], siteID: 1)
@@ -68,8 +68,8 @@ final class FilterOrderListViewModelTests: XCTestCase {
                                                        dateRange: OrderDateRangeFilter(filter: .today),
                                                        product: FilterOrdersByProduct(id: 1, name: "Sample product"),
                                                        customer: CustomerFilter(customer: Customer.fake().copy(customerID: 1)),
-                                                       salesChannel: nil,
-                                                       numberOfActiveFilters: 4)
+                                                       salesChannel: .pointOfSale,
+                                                       numberOfActiveFilters: 5)
 
         // When
         let viewModel = FilterOrderListViewModel(filters: filters,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Filters/FilterOrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Filters/FilterOrderListViewModelTests.swift
@@ -26,7 +26,7 @@ final class FilterOrderListViewModelTests: XCTestCase {
                                                        dateRange: OrderDateRangeFilter(filter: .today),
                                                        product: FilterOrdersByProduct(id: 1, name: "Sample product"),
                                                        customer: CustomerFilter(customer: Customer.fake().copy(customerID: 1)),
-                                                       salesChannel: .any,
+                                                       salesChannel: .pointOfSale,
                                                        numberOfActiveFilters: 5)
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Filters/FilterOrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Filters/FilterOrderListViewModelTests.swift
@@ -27,7 +27,7 @@ final class FilterOrderListViewModelTests: XCTestCase {
                                                        product: FilterOrdersByProduct(id: 1, name: "Sample product"),
                                                        customer: CustomerFilter(customer: Customer.fake().copy(customerID: 1)),
                                                        salesChannel: .any,
-                                                       numberOfActiveFilters: 4)
+                                                       numberOfActiveFilters: 5)
 
         // When
         let viewModel = FilterOrderListViewModel(filters: filters, allowedStatuses: [], siteID: 1)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Filters/FilterOrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Filters/FilterOrderListViewModelTests.swift
@@ -26,7 +26,7 @@ final class FilterOrderListViewModelTests: XCTestCase {
                                                        dateRange: OrderDateRangeFilter(filter: .today),
                                                        product: FilterOrdersByProduct(id: 1, name: "Sample product"),
                                                        customer: CustomerFilter(customer: Customer.fake().copy(customerID: 1)),
-                                                       salesChannel: nil,
+                                                       salesChannel: .any,
                                                        numberOfActiveFilters: 4)
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListSyncActionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListSyncActionUseCaseTests.swift
@@ -41,7 +41,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statuses, _, _, let modifiedAfter, _, _, let writeStrategy, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, let modifiedAfter, _, _, _, let writeStrategy, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
@@ -75,7 +75,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statuses, _, _, let modifiedAfter, _, _, let writeStrategy, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, let modifiedAfter, _, _, _, let writeStrategy, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
@@ -103,7 +103,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statuses, _, _, let modifiedAfter, _, _, let writeStrategy, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, let modifiedAfter, _, _, _, let writeStrategy, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
@@ -130,7 +130,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statuses, _, _, let modifiedAfter, _, _, let writeStrategy, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, let modifiedAfter, _, _, _, let writeStrategy, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
@@ -159,7 +159,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .synchronizeOrders(_, let statuses, _, _, _, _, _, let pageNumber, let pageSize, _) = action else {
+        guard case .synchronizeOrders(_, let statuses, _, _, _, _, _, _, let pageNumber, let pageSize, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
@@ -182,7 +182,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .synchronizeOrders(_, let statuses, _, _, _, _, _, let pageNumber, let pageSize, _) = action else {
+        guard case .synchronizeOrders(_, let statuses, _, _, _, _, _, _, let pageNumber, let pageSize, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
@@ -217,7 +217,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statuses, _, _, _, _, _, let writeStrategy, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, _, _, _, _, let writeStrategy, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }


### PR DESCRIPTION
Closes WOOMOB-711

## Description
This PR adds the sales channel filter to the order list with 2 options: `Point of Sale`, and `Any`. The sales channel filter should work like any other filters in the app, examples:
- Selecting POS orders should show only POS orders
- Selecting ANY should show any order
- POS filter in combination with other filters should show the expected results (ie: with "order status cancelled + POS" = No results if you have none of the sort)

https://github.com/user-attachments/assets/691e59d8-b050-44b8-affe-74da69b7a820

## Changes
- Rather than declaring a specific view controller for sales channels, I've used the existing static design introduced on https://github.com/woocommerce/woocommerce-ios/pull/2204. This automatically handles simple lists like the one we need here, without having to customize further.
- Updated `OrdersRemote` when fetching all orders, as well as `OrderAction` to pass the `created_via` property on `synchronizeOrders` and `fetchFilteredOrders`. I've discovered _too late_ that core data query is not enough for filtering,  while the correct filter was being passed locally, we need to perform a network request when filtering, which should have the `&created_via=pos-rest-api` param along it.
- Adjusted the tests to the updated signatures (no new tests have been added yet)

## Testing information
- In a site eligible for POS, and WooCommerce 9.9+, you should see your recent orders marked with a POS badge. If you have none, please go through the POS flow and checkout a few.
- Navigate to orders tab, tap in `Filters`, observe the `Sales channel` filter is now functional.
- Select "Point of sale" as an option. Observe that POS orders are listed, while others are hidden.
- Try different filtering combinations.
- `Clear all` should clear all filters
- Filter persistence is not implemented yet, so the sales channel filter won't be saved between runs.


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
