### PR TITLE
[POS Orders] Enable `pointOfSaleOrdersi1`

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -98,7 +98,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .pointOfSaleAsATabi2:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .pointOfSaleOrdersi1:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .pointOfSaleOrdersi2:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .pointOfSaleBarcodeScanningi2:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 - [*] Shipping Labels: Improve UI of Split shipments screen. [https://github.com/woocommerce/woocommerce-ios/pull/15838]
 - [*] POS: icon button with confirmation step used for clearing the cart [https://github.com/woocommerce/woocommerce-ios/pull/15829]
+- [*] POS: Orders from Point of Sale now show a badge in order list and order details [https://github.com/woocommerce/woocommerce-ios/pull/15887]
 - [*] Shipping Labels: Fixed a portion of layout issues caused by bigger accessibility content size categories. [https://github.com/woocommerce/woocommerce-ios/pull/15844]
 - [*] Shipping Labels: Enable the confirm button on the payment method sheet even when there are no changes. [https://github.com/woocommerce/woocommerce-ios/pull/15856]
 - [*] POS: start a new cart by scanning a barcode on the payment success screen [https://github.com/woocommerce/woocommerce-ios/pull/15870]

--- a/WooCommerce/Classes/Extensions/UILabel+SalesChannel.swift
+++ b/WooCommerce/Classes/Extensions/UILabel+SalesChannel.swift
@@ -23,7 +23,7 @@ private extension UILabel {
     enum Layout {
         static let borderWidth = CGFloat(0.0)
         static let cornerRadius = CGFloat(4.0)
-        static let salesChannelLabelTextColor = UIColor(color: .wooCommercePurple(.shade80))
-        static let salesChannelLabelBackgroundColor = UIColor(color: .wooCommercePurple(.shade10))
+        static let salesChannelLabelTextColor = UIColor.wooCommercePurple(.shade80)
+        static let salesChannelLabelBackgroundColor = UIColor.wooCommercePurple(.shade10)
     }
 }

--- a/WooCommerce/Classes/Extensions/UILabel+SalesChannel.swift
+++ b/WooCommerce/Classes/Extensions/UILabel+SalesChannel.swift
@@ -23,7 +23,7 @@ private extension UILabel {
     enum Layout {
         static let borderWidth = CGFloat(0.0)
         static let cornerRadius = CGFloat(4.0)
-        static let salesChannelLabelTextColor = UIColor.wooCommercePurple(.shade80)
-        static let salesChannelLabelBackgroundColor = UIColor.wooCommercePurple(.shade10)
+        static let salesChannelLabelTextColor = UIColor.withColorStudio(.wooCommercePurple, shade: .shade80)
+        static let salesChannelLabelBackgroundColor = UIColor.withColorStudio(.wooCommercePurple, shade: .shade10)
     }
 }


### PR DESCRIPTION
## Description
This PR enables the feature flag `pointOfSaleOrdersi1`, launching POS Orders i1

## Testing information
- On a store with POS and WooCommerce 9.9+, process an order through POS. 
- Upon navigating to the orders tab, observe the `POS` badge appears both in order list and order details for those orders.

| Tablet | Order list | Order details |
|--------|--------|--------|
| ![Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-07-09 at 15 28 19](https://github.com/user-attachments/assets/dce7ea0f-54fb-4b26-b6f4-45efa0e8c42d) | ![Simulator Screenshot - iPhone 16 Plus - US store - 2025-07-09 at 15 29 56](https://github.com/user-attachments/assets/eaa43f72-5f93-466d-8d6c-adbe17ec8e74) | ![Simulator Screenshot - iPhone 16 Plus - US store - 2025-07-09 at 15 30 00](https://github.com/user-attachments/assets/fb04e224-8cf1-45ee-942c-87d18cd86a1f) | 

There are some accessibility improvements to be done as part of WOOMOB-751, but these are non-blocking for feature release and will be handled as part of backlog.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
