### PR TITLE
[POS Orders] Add analytics for point of sale order filtering

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+OrdersListFilter.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+OrdersListFilter.swift
@@ -23,3 +23,14 @@ extension WooAnalyticsEvent {
         }
     }
 }
+
+fileprivate extension FilterOrderListViewModel.SalesChannelFilter {
+    var analyticsDescription: String? {
+        switch self {
+        case .pointOfSale:
+            return "pos"
+        case .any:
+            return nil
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+OrdersListFilter.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+OrdersListFilter.swift
@@ -8,6 +8,7 @@ extension WooAnalyticsEvent {
             static let dateRange = "date_range"
             static let product = "product"
             static let customer = "customer"
+            static let salesChannel = "sales_channel"
         }
 
         /// Tracked upon filtering orders
@@ -15,7 +16,8 @@ extension WooAnalyticsEvent {
             let properties: [String: WooAnalyticsEventPropertyType?] = [Key.status: filters.orderStatus?.analyticsDescription,
                                                                         Key.dateRange: filters.dateRange?.analyticsDescription,
                                                                         Key.product: filters.product?.analyticsDescription,
-                                                                        Key.customer: filters.customer?.analyticsDescription]
+                                                                        Key.customer: filters.customer?.analyticsDescription,
+                                                                        Key.salesChannel: filters.salesChannel?.analyticsDescription]
             return WooAnalyticsEvent(statName: .ordersListFilter,
                                      properties: properties.compactMapValues { $0 })
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
@@ -405,14 +405,5 @@ extension FilterOrderListViewModel {
                 return false
             }
         }
-
-        var analyticsDescription: String? {
-            switch self {
-            case .pointOfSale:
-                return "pos"
-            case .any:
-                return nil
-            }
-        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
@@ -405,5 +405,14 @@ extension FilterOrderListViewModel {
                 return false
             }
         }
+
+        var analyticsDescription: String? {
+            switch self {
+            case .pointOfSale:
+                return "pos"
+            case .any:
+                return nil
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes WOOMOB-705

## Description
This PR adds analytics when filtering orders by POS. We add `sales_channel: pos` to the existing `orders_list_filter` event if POS as sales channel has been selected for filtering orders.

https://github.com/user-attachments/assets/eaf6b963-95d6-4362-9cd0-d33136b85dcf

## Testing information
- In order filters, Sales Channel > Point of sale, tap `Show Orders`. Observe the property `sales_channel: pos` is tracked
```
🔵 Tracked orders_list_filter, properties: [sales_channel: pos, blog_id: -1, store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f, is_wpcom_store: false, site_url: https://indiemelon.mystagingwebsite.com, plan: , was_ecommerce_trial: false]
```

- Now select `Any`, tap `Show Orders`. Observe the property `sales_channel` is not tracked
```
🔵 Tracked orders_list_filter, properties: [blog_id: -1, is_wpcom_store: false, was_ecommerce_trial: false, plan: , store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f, site_url: https://indiemelon.mystagingwebsite.com]
```

- Try some combiation with other filters, as long as `Point of sale` is an active filter, it should be tracked.
```
🔵 Tracked orders_list_filter, properties: [was_ecommerce_trial: false, is_wpcom_store: false, date_range: last_7_days, sales_channel: pos, site_url: https://indiemelon.mystagingwebsite.com, status: completed, plan: , blog_id: -1, store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f]
```

---
- [x] TODO: Update event in tracks: https://github.com/Automattic/tracks-events-registration/pull/3014