### PR TITLE
[POS Orders] Persist sales channel filter in order settings

### DIFF
--- a/Modules/Sources/Yosemite/Actions/AppSettingsAction.swift
+++ b/Modules/Sources/Yosemite/Actions/AppSettingsAction.swift
@@ -45,6 +45,7 @@ public enum AppSettingsAction: Action {
                               dateRangeFilter: OrderDateRangeFilter?,
                               productFilter: FilterOrdersByProduct?,
                               customerFilter: CustomerFilter?,
+                              salesChannelFilter: SalesChannelFilter?,
                               onCompletion: (Error?) -> Void)
 
     /// Clears all the orders settings

--- a/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockAppSettingsActionHandler.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockAppSettingsActionHandler.swift
@@ -52,7 +52,8 @@ struct MockAppSettingsActionHandler: MockActionHandler {
                                         orderStatusesFilter: nil,
                                         dateRangeFilter: nil,
                                         productFilter: nil,
-                                        customerFilter: nil)))
+                                        customerFilter: nil,
+                                        salesChannelFilter: nil)))
         case .upsertProductsSettings(_, _, _, _, _, _, _, let onCompletion):
             onCompletion(nil)
         case .resetEligibilityErrorInfo,

--- a/Modules/Sources/Yosemite/Model/Orders/SalesChannelFilter.swift
+++ b/Modules/Sources/Yosemite/Model/Orders/SalesChannelFilter.swift
@@ -3,6 +3,6 @@ import Foundation
 /// Used to filter orders by sales channel
 ///
 public enum SalesChannelFilter: String, Codable, Hashable {
-    case pointOfSale = "pos-rest-api"
-    case any = "any"
+    case pointOfSale
+    case any
 }

--- a/Modules/Sources/Yosemite/Model/Orders/SalesChannelFilter.swift
+++ b/Modules/Sources/Yosemite/Model/Orders/SalesChannelFilter.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Used to filter orders by sales channel
+///
+public enum SalesChannelFilter: String, Codable, Hashable {
+    case pointOfSale = "pos-rest-api"
+    case any = "any"
+}

--- a/Modules/Sources/Yosemite/Model/Orders/StoredOrderSettings.swift
+++ b/Modules/Sources/Yosemite/Model/Orders/StoredOrderSettings.swift
@@ -12,17 +12,20 @@ public struct StoredOrderSettings: Codable, Equatable {
         public let dateRangeFilter: OrderDateRangeFilter?
         public let productFilter: FilterOrdersByProduct?
         public let customerFilter: CustomerFilter?
+        public let salesChannelFilter: SalesChannelFilter?
 
         public init(siteID: Int64,
                     orderStatusesFilter: [OrderStatusEnum]?,
                     dateRangeFilter: OrderDateRangeFilter?,
                     productFilter: FilterOrdersByProduct?,
-                    customerFilter: CustomerFilter?) {
+                    customerFilter: CustomerFilter?,
+                    salesChannelFilter: SalesChannelFilter?) {
             self.siteID = siteID
             self.orderStatusesFilter = orderStatusesFilter
             self.dateRangeFilter = dateRangeFilter
             self.productFilter = productFilter
             self.customerFilter = customerFilter
+            self.salesChannelFilter = salesChannelFilter
         }
 
         public func numberOfActiveFilters() -> Int {
@@ -39,6 +42,9 @@ public struct StoredOrderSettings: Codable, Equatable {
             if customerFilter != nil {
                 total += 1
             }
+            if let salesChannelFilter = salesChannelFilter, case .pointOfSale = salesChannelFilter {
+                total += 1
+            }
 
             return total
         }
@@ -51,6 +57,7 @@ public struct StoredOrderSettings: Codable, Equatable {
             case dateRangeFilter = "date_range_filter"
             case productFilter = "product_filter"
             case customerFilter = "customer_filter"
+            case salesChannelFilter = "sales_channel_filter"
         }
     }
 

--- a/Modules/Sources/Yosemite/Stores/AppSettingsStore.swift
+++ b/Modules/Sources/Yosemite/Stores/AppSettingsStore.swift
@@ -132,12 +132,14 @@ public class AppSettingsStore: Store {
                                    let dateRangeFilter,
                                    let productFilter,
                                    let customerFilter,
+                                   let salesChannelFilter,
                                    let onCompletion):
             upsertOrdersSettings(siteID: siteID,
                                  orderStatusesFilter: orderStatusesFilter,
                                  dateRangeFilter: dateRangeFilter,
                                  productFilter: productFilter,
                                  customerFilter: customerFilter,
+                                 salesChannelFilter: salesChannelFilter,
                                  onCompletion: onCompletion)
         case .resetOrdersSettings:
             resetOrdersSettings()
@@ -716,6 +718,7 @@ private extension AppSettingsStore {
                               dateRangeFilter: OrderDateRangeFilter?,
                               productFilter: FilterOrdersByProduct?,
                               customerFilter: CustomerFilter?,
+                              salesChannelFilter: SalesChannelFilter?,
                               onCompletion: (Error?) -> Void) {
         var existingSettings: [Int64: StoredOrderSettings.Setting] = [:]
         if let storedSettings: StoredOrderSettings = try? fileStorage.data(for: ordersSettingsURL) {
@@ -726,7 +729,8 @@ private extension AppSettingsStore {
                                                       orderStatusesFilter: orderStatusesFilter,
                                                       dateRangeFilter: dateRangeFilter,
                                                       productFilter: productFilter,
-                                                      customerFilter: customerFilter)
+                                                      customerFilter: customerFilter,
+                                                      salesChannelFilter: salesChannelFilter)
         existingSettings[siteID] = newSettings
 
         let newStoredOrderSettings = StoredOrderSettings(settings: existingSettings)

--- a/Modules/Tests/YosemiteTests/Stores/AppSettingsStoreTests+OrderFilterHistory.swift
+++ b/Modules/Tests/YosemiteTests/Stores/AppSettingsStoreTests+OrderFilterHistory.swift
@@ -155,11 +155,13 @@ private extension AppSettingsStoreTests_OrderFilterHistory {
         let dateRange = OrderDateRangeFilter(filter: .custom, startDate: startDate, endDate: endDate)
         let productFilter = FilterOrdersByProduct(id: 1, name: "Sample product")
         let customerFilter = CustomerFilter(customer: Customer.fake().copy(customerID: 1))
+        let salesChannelFilter = SalesChannelFilter(filter: .pointOfSale)
         return StoredOrderSettings.Setting(siteID: siteID,
                                            orderStatusesFilter: orderStatuses,
                                            dateRangeFilter: dateRange,
                                            productFilter: productFilter,
-                                           customerFilter: customerFilter)
+                                           customerFilter: customerFilter,
+                                           salesChannelFilter: salesChannelFilter)
     }
 
     func insertMockFilter(filter: StoredOrderSettings.Setting, using store: AppSettingsStore) async throws {

--- a/Modules/Tests/YosemiteTests/Stores/AppSettingsStoreTests+OrderFilterHistory.swift
+++ b/Modules/Tests/YosemiteTests/Stores/AppSettingsStoreTests+OrderFilterHistory.swift
@@ -155,7 +155,7 @@ private extension AppSettingsStoreTests_OrderFilterHistory {
         let dateRange = OrderDateRangeFilter(filter: .custom, startDate: startDate, endDate: endDate)
         let productFilter = FilterOrdersByProduct(id: 1, name: "Sample product")
         let customerFilter = CustomerFilter(customer: Customer.fake().copy(customerID: 1))
-        let salesChannelFilter = SalesChannelFilter(filter: .pointOfSale)
+        let salesChannelFilter = SalesChannelFilter.pointOfSale
         return StoredOrderSettings.Setting(siteID: siteID,
                                            orderStatusesFilter: orderStatuses,
                                            dateRangeFilter: dateRange,

--- a/Modules/Tests/YosemiteTests/Stores/AppSettingsStoreTests+OrdersSettings.swift
+++ b/Modules/Tests/YosemiteTests/Stores/AppSettingsStoreTests+OrdersSettings.swift
@@ -51,11 +51,13 @@ final class AppSettingsStoreTests_OrdersSettings: XCTestCase {
         let dateRange = OrderDateRangeFilter(filter: .custom, startDate: startDate, endDate: endDate)
         let productFilter = FilterOrdersByProduct(id: 1, name: "Sample product")
         let customerFilter = CustomerFilter(customer: Customer.fake().copy(customerID: 1))
+        let salesChannelFilter = SalesChannelFilter.pointOfSale
         let orderSettings = StoredOrderSettings.Setting(siteID: siteID,
                                                         orderStatusesFilter: orderStatuses,
                                                         dateRangeFilter: dateRange,
                                                         productFilter: productFilter,
-                                                        customerFilter: customerFilter
+                                                        customerFilter: customerFilter,
+                                                        salesChannelFilter: salesChannelFilter
         )
 
         // When
@@ -73,7 +75,8 @@ final class AppSettingsStoreTests_OrdersSettings: XCTestCase {
                                                                  orderStatusesFilter: orderStatuses,
                                                                  dateRangeFilter: dateRange,
                                                                  productFilter: productFilter,
-                                                                 customerFilter: customerFilter) { error in
+                                                                 customerFilter: customerFilter,
+                                                                 salesChannelFilter: salesChannelFilter) { error in
             XCTAssertNil(error)
         }
         subject.onAction(writeAction)
@@ -102,6 +105,7 @@ final class AppSettingsStoreTests_OrdersSettings: XCTestCase {
         let dateRange = OrderDateRangeFilter(filter: .custom, startDate: startDate, endDate: endDate)
         let productFilter = FilterOrdersByProduct(id: 1, name: "Sample product 1")
         let customerFilter = CustomerFilter(customer: Customer.fake().copy(customerID: 1))
+        let salesChannelFilter = SalesChannelFilter.any
 
         let orderStatuses2: [OrderStatusEnum] = [.pending, .cancelled]
         let startDate2 = Date().yearStart
@@ -109,24 +113,28 @@ final class AppSettingsStoreTests_OrdersSettings: XCTestCase {
         let dateRange2 = OrderDateRangeFilter(filter: .custom, startDate: startDate2, endDate: endDate2)
         let productFilter2 = FilterOrdersByProduct(id: 2, name: "Sample product 2")
         let customerFilter2 = CustomerFilter(customer: Customer.fake().copy(customerID: 2))
+        let salesChannelFilter2 = SalesChannelFilter.pointOfSale
 
         let orderSettings1 = StoredOrderSettings.Setting(siteID: siteID1,
-                                                        orderStatusesFilter: orderStatuses,
-                                                        dateRangeFilter: dateRange,
+                                                         orderStatusesFilter: orderStatuses,
+                                                         dateRangeFilter: dateRange,
                                                          productFilter: productFilter,
-                                                         customerFilter: customerFilter)
+                                                         customerFilter: customerFilter,
+                                                         salesChannelFilter: salesChannelFilter)
         let orderSettings2 = StoredOrderSettings.Setting(siteID: siteID2,
-                                                        orderStatusesFilter: orderStatuses2,
-                                                        dateRangeFilter: dateRange2,
+                                                         orderStatusesFilter: orderStatuses2,
+                                                         dateRangeFilter: dateRange2,
                                                          productFilter: productFilter2,
-                                                         customerFilter: customerFilter2)
+                                                         customerFilter: customerFilter2,
+                                                         salesChannelFilter: salesChannelFilter2)
 
         // When
         let writeAction1 = AppSettingsAction.upsertOrdersSettings(siteID: siteID1,
                                                                   orderStatusesFilter: orderStatuses,
                                                                   dateRangeFilter: dateRange,
                                                                   productFilter: productFilter,
-                                                                  customerFilter: customerFilter) { error in
+                                                                  customerFilter: customerFilter,
+                                                                  salesChannelFilter: salesChannelFilter) { error in
             XCTAssertNil(error)
         }
         subject.onAction(writeAction1)
@@ -135,7 +143,8 @@ final class AppSettingsStoreTests_OrdersSettings: XCTestCase {
                                                                   orderStatusesFilter: orderStatuses2,
                                                                   dateRangeFilter: dateRange2,
                                                                   productFilter: productFilter2,
-                                                                  customerFilter: customerFilter2) { error in
+                                                                  customerFilter: customerFilter2,
+                                                                  salesChannelFilter: salesChannelFilter2) { error in
             XCTAssertNil(error)
         }
         subject.onAction(writeAction2)

--- a/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
@@ -73,11 +73,12 @@ private struct CurrentOrderListSyncUseCase {
             let action = AppSettingsAction.loadOrdersSettings(siteID: siteID) { (result) in
                 switch result {
                 case .success(let settings):
+                    // Cannot convert value of type 'SalesChannelFilter?' to expected argument type 'FilterOrderListViewModel.SalesChannelFilter?'
                     let filters = FilterOrderListViewModel.Filters(orderStatus: settings.orderStatusesFilter,
                                                                    dateRange: settings.dateRangeFilter,
                                                                    product: settings.productFilter,
                                                                    customer: settings.customerFilter,
-                                                                   salesChannel: nil, // TODO: Filter persistence WOOMOB-712
+                                                                   salesChannel: settings.salesChannelFilter,
                                                                    numberOfActiveFilters: settings.numberOfActiveFilters())
                     continuation.resume(returning: filters)
                 case .failure:

--- a/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
@@ -73,7 +73,6 @@ private struct CurrentOrderListSyncUseCase {
             let action = AppSettingsAction.loadOrdersSettings(siteID: siteID) { (result) in
                 switch result {
                 case .success(let settings):
-                    // Cannot convert value of type 'SalesChannelFilter?' to expected argument type 'FilterOrderListViewModel.SalesChannelFilter?'
                     let filters = FilterOrderListViewModel.Filters(orderStatus: settings.orderStatusesFilter,
                                                                    dateRange: settings.dateRangeFilter,
                                                                    product: settings.productFilter,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
@@ -142,7 +142,7 @@ final class FilterOrderListViewModel: FilterListViewModel {
                                 dateRange: item.dateRangeFilter,
                                 product: item.productFilter,
                                 customer: item.customerFilter,
-                                salesChannel: nil, // TODO: Filter persistence WOOMOB-712
+                                salesChannel: item.salesChannelFilter,
                                 numberOfActiveFilters: item.numberOfActiveFilters())
                     }
                     continuation.resume(returning: filters)
@@ -168,7 +168,8 @@ final class FilterOrderListViewModel: FilterListViewModel {
                                                    orderStatusesFilter: filter.orderStatus,
                                                    dateRangeFilter: filter.dateRange,
                                                    productFilter: filter.product,
-                                                   customerFilter: filter.customer)
+                                                   customerFilter: filter.customer,
+                                                   salesChannelFilter: filter.salesChannel)
         stores.dispatch(AppSettingsAction.upsertOrderFilterHistory(filter: settings, onCompletion: { error in
             if let error {
                 DDLogError("⛔️ Error saving filter history: \(error)")
@@ -182,7 +183,8 @@ final class FilterOrderListViewModel: FilterListViewModel {
                                                    orderStatusesFilter: filter.orderStatus,
                                                    dateRangeFilter: filter.dateRange,
                                                    productFilter: filter.product,
-                                                   customerFilter: filter.customer)
+                                                   customerFilter: filter.customer,
+                                                   salesChannelFilter: filter.salesChannel)
         stores.dispatch(AppSettingsAction.removeFromOrderFilterHistory(filter: settings, onCompletion: { error in
             if let error {
                 DDLogError("⛔️ Error removing from filter history: \(error)")
@@ -266,7 +268,7 @@ extension FilterOrderListViewModel.OrderListFilter {
                                        listSelectorConfig: .customer(siteID: siteID),
                                        selectedValue: filters.customer)
         case .salesChannel:
-            let salesChannelOptions: [FilterOrderListViewModel.SalesChannelFilter] = [.any, .pointOfSale]
+            let salesChannelOptions: [SalesChannelFilter] = [.any, .pointOfSale]
             return FilterTypeViewModel(title: title,
                                        listSelectorConfig: .staticOptions(options: salesChannelOptions),
                                        selectedValue: filters.salesChannel)
@@ -377,33 +379,28 @@ extension CustomerFilter: FilterType {
     var isActive: Bool { true }
 }
 
-extension FilterOrderListViewModel {
-    enum SalesChannelFilter: FilterType {
-        case pointOfSale
-        case any
-
-        var description: String {
-            switch self {
-            case .pointOfSale:
-                return NSLocalizedString(
-                    "salesChannelFilter.row.pos.description",
-                    value: "Point of Sale",
-                    comment: "Description for the Sales channel filter option, when selecting 'Point of Sale' orders")
-            case .any:
-                return NSLocalizedString(
-                    "salesChannelFilter.row.any.description",
-                    value: "Any",
-                    comment: "Description for the Sales channel filter option, when selecting 'Any' order")
-            }
+extension SalesChannelFilter: FilterType {
+    var description: String {
+        switch self {
+        case .pointOfSale:
+            return NSLocalizedString(
+                "salesChannelFilter.row.pos.description",
+                value: "Point of Sale",
+                comment: "Description for the Sales channel filter option, when selecting 'Point of Sale' orders")
+        case .any:
+            return NSLocalizedString(
+                "salesChannelFilter.row.any.description",
+                value: "Any",
+                comment: "Description for the Sales channel filter option, when selecting 'Any' order")
         }
+    }
 
-        var isActive: Bool {
-            switch self {
-            case .pointOfSale:
-                return true
-            case .any:
-                return false
-            }
+    var isActive: Bool {
+        switch self {
+        case .pointOfSale:
+            return true
+        case .any:
+            return false
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -447,7 +447,7 @@ private extension OrdersRootViewController {
                                                                  dateRange: settings.dateRangeFilter,
                                                                  product: settings.productFilter,
                                                                  customer: settings.customerFilter,
-                                                                 salesChannel: nil, // TODO: Filter persistence WOOMOB-712
+                                                                 salesChannel: settings.salesChannelFilter,
                                                                  numberOfActiveFilters: settings.numberOfActiveFilters())
             case .failure(let error):
                 print("It was not possible to sync local orders settings: \(String(describing: error))")
@@ -464,7 +464,8 @@ private extension OrdersRootViewController {
                                                             orderStatusesFilter: filters.orderStatus,
                                                             dateRangeFilter: filters.dateRange,
                                                             productFilter: filters.product,
-                                                            customerFilter: filters.customer) { error in
+                                                            customerFilter: filters.customer,
+                                                            salesChannelFilter: filters.salesChannel) { error in
             if error != nil {
                 assertionFailure("It was not possible to store order settings due to an error: \(String(describing: error))")
             }

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationBackgroundSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationBackgroundSynchronizerTests.swift
@@ -86,7 +86,12 @@ private extension PushNotificationBackgroundSynchronizerTests {
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
             case let .loadOrdersSettings(_, onCompletion):
-                onCompletion(.success(.init(siteID: order.siteID, orderStatusesFilter: nil, dateRangeFilter: nil, productFilter: nil, customerFilter: nil)))
+                onCompletion(.success(.init(siteID: order.siteID,
+                                            orderStatusesFilter: nil,
+                                            dateRangeFilter: nil,
+                                            productFilter: nil,
+                                            customerFilter: nil,
+                                            salesChannelFilter: nil)))
             default:
                 break
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Filters/FilterOrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Filters/FilterOrderListViewModelTests.swift
@@ -105,8 +105,8 @@ final class FilterOrderListViewModelTests: XCTestCase {
                                                        dateRange: OrderDateRangeFilter(filter: .today),
                                                        product: FilterOrdersByProduct(id: 1, name: "Sample product"),
                                                        customer: CustomerFilter(customer: Customer.fake().copy(customerID: 1)),
-                                                       salesChannel: nil,
-                                                       numberOfActiveFilters: 4)
+                                                       salesChannel: SalesChannelFilter.pointOfSale,
+                                                       numberOfActiveFilters: 5)
         let viewModel = FilterOrderListViewModel(filters: filters,
                                                  allowedStatuses: [],
                                                  siteID: siteID,
@@ -122,13 +122,13 @@ final class FilterOrderListViewModelTests: XCTestCase {
                                              dateRange: result1.dateRangeFilter,
                                              product: result1.productFilter,
                                              customer: result1.customerFilter,
-                                             salesChannel: nil,
+                                             salesChannel: result1.salesChannelFilter,
                                              numberOfActiveFilters: result1.numberOfActiveFilters()),
             FilterOrderListViewModel.Filters(orderStatus: result2.orderStatusesFilter,
                                              dateRange: result2.dateRangeFilter,
                                              product: result2.productFilter,
                                              customer: result2.customerFilter,
-                                             salesChannel: nil,
+                                             salesChannel: result2.salesChannelFilter,
                                              numberOfActiveFilters: result2.numberOfActiveFilters())
         ])
     }
@@ -215,10 +215,12 @@ private extension FilterOrderListViewModelTests {
         let dateRange = OrderDateRangeFilter(filter: .custom, startDate: startDate, endDate: endDate)
         let productFilter = FilterOrdersByProduct(id: 1, name: "Sample product")
         let customerFilter = CustomerFilter(customer: Customer.fake().copy(customerID: 1))
+        let salesChannelFilter = SalesChannelFilter.pointOfSale
         return StoredOrderSettings.Setting(siteID: siteID,
                                            orderStatusesFilter: orderStatuses,
                                            dateRangeFilter: dateRange,
                                            productFilter: productFilter,
-                                           customerFilter: customerFilter)
+                                           customerFilter: customerFilter,
+                                           salesChannelFilter: salesChannelFilter)
     }
 }


### PR DESCRIPTION
Closes WOOMOB-711

## Description
This PR adds persistence between sessions to the sales channel filter.

## Testing information
- In a POS-eligible store, with existing POS orders (make a couple of new ones if not), tap on `Filter` and select any combination of filters that include the `Point of Sale` option, then tap on `Show orders`. 
- After loading, rerun the app
- Navigate to orders, observe that the filter its persisted
- Tap the `Filter history` icon, observe that has been logged accordingly. 

https://github.com/user-attachments/assets/54b89674-6230-4d77-86fe-55aed40e56bd

<img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-07-10 at 18 04 29" src="https://github.com/user-attachments/assets/fdcb2c59-2241-4f7e-8eb2-13cb61ae3a13" />

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
