### PR TITLE
[Woo POS] Include more information in `pos_card_present_collect_payment_success` event

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2414,7 +2414,7 @@ extension WooAnalyticsEvent {
     }
 }
 
-private extension PaymentMethod {
+extension PaymentMethod {
     var analyticsValue: String {
         switch self {
         case .card, .cardPresent:

--- a/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
@@ -3,8 +3,6 @@ import protocol WooFoundation.Analytics
 import Yosemite
 
 final class POSCollectOrderPaymentAnalytics: POSCollectOrderPaymentAnalyticsTracking {
-    var connectedReaderModel: String?
-
     private var customerInteractionStarted: Double = 0
     private var orderSync: Double = 0
     private var cardReaderReady: Double = 0
@@ -14,11 +12,35 @@ final class POSCollectOrderPaymentAnalytics: POSCollectOrderPaymentAnalyticsTrac
 
     private let analytics: Analytics
 
-    init(analytics: Analytics = ServiceLocator.analytics) {
-        self.analytics = analytics
+    private let siteID: Int64
+    private var paymentGatewayAccount: PaymentGatewayAccount?
+    private let configuration: CardPresentPaymentsConfiguration
+    private var connectedReader: CardReader?
+    var connectedReaderModel: String? {
+        connectedReader?.readerType.model
     }
 
-    func preflightResultReceived(_ result: CardReaderPreflightResult?) { }
+    init(siteID: Int64,
+         analytics: Analytics = ServiceLocator.analytics,
+         configuration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration) {
+        self.siteID = siteID
+        self.analytics = analytics
+        self.configuration = configuration
+    }
+
+    func preflightResultReceived(_ result: CardReaderPreflightResult?) {
+        switch result {
+        case .completed(let connectedReader, let paymentGatewayAccount):
+            self.connectedReader = connectedReader
+            self.paymentGatewayAccount = paymentGatewayAccount
+        case .canceled(_, let paymentGatewayAccount):
+            self.connectedReader = nil
+            self.paymentGatewayAccount = paymentGatewayAccount
+        case .none:
+            break
+        }
+    }
+
     func trackProcessingCompletion(intent: Yosemite.PaymentIntent) { }
 
     func trackSuccessfulCardPayment(capturedPaymentData: CardPresentCapturedPaymentData) {
@@ -35,6 +57,11 @@ final class POSCollectOrderPaymentAnalytics: POSCollectOrderPaymentAnalyticsTrac
         let elapsedTimeSinceCardTapped = calculateElapsedTimeInMilliseconds(since: cardReaderTapped)
 
         analytics.track(event: .PointOfSale.cardPresentCollectPaymentSuccess(
+            forGatewayID: paymentGatewayAccount?.gatewayID,
+            countryCode: configuration.countryCode,
+            paymentMethod: capturedPaymentData.paymentMethod,
+            cardReaderModel: connectedReaderModel,
+            siteID: siteID,
             millisecondsSinceCustomerIteractionStarted: elapsedTimeSinceCustomerInteraction,
             millisecondsSinceOrderSyncSuccess: elapsedTimeSinceOrderSync,
             millisecondsSinceReaderReadyToCollect: elapsedTimeSinceCardReaderReady,

--- a/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -3,6 +3,8 @@ import enum Yosemite.POSItemType
 import enum Yosemite.POSItem
 import struct Yosemite.POSSimpleProduct
 import struct Yosemite.POSVariation
+import enum WooFoundation.CountryCode
+import enum Yosemite.PaymentMethod
 
 extension WooAnalyticsEvent {
     enum PointOfSale {
@@ -25,6 +27,11 @@ extension WooAnalyticsEvent {
             static let resultsCount = "results_count"
             static let millisecondsSinceRequestSent = "milliseconds_since_request_sent"
             static let totalItems = "total_items"
+            static let cardReaderModel = "card_reader_model"
+            static let countryCode = "country"
+            static let paymentMethodType = "payment_method_type"
+            static let siteID = "site_id"
+            static let gatewayID = "plugin_slug"
         }
 
         static func paymentsOnboardingShown() -> WooAnalyticsEvent {
@@ -100,12 +107,22 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .pointOfSaleReaderReadyForCardPayment, properties: [Key.waitingTime: "\(waitingTime)"])
         }
 
-        static func cardPresentCollectPaymentSuccess(millisecondsSinceCustomerIteractionStarted: Double,
+        static func cardPresentCollectPaymentSuccess(forGatewayID: String?,
+                                                     countryCode: CountryCode,
+                                                     paymentMethod: PaymentMethod,
+                                                     cardReaderModel: String?,
+                                                     siteID: Int64,
+                                                     millisecondsSinceCustomerIteractionStarted: Double,
                                                      millisecondsSinceOrderSyncSuccess: Double,
                                                      millisecondsSinceReaderReadyToCollect: Double,
                                                      millisecondsSinceCardTapped: Double,
                                                      checkoutTapCount: Int) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentSuccess, properties: [
+                Key.cardReaderModel: readerModel(for: cardReaderModel),
+                Key.countryCode: countryCode.rawValue,
+                Key.gatewayID: safeGatewayID(for: forGatewayID),
+                Key.paymentMethodType: paymentMethod.analyticsValue,
+                Key.siteID: siteID,
                 Key.millisecondsSinceCustomerInteractionStarted: "\(millisecondsSinceCustomerIteractionStarted)",
                 Key.millisecondsSinceOrderSyncSuccess: "\(millisecondsSinceOrderSyncSuccess)",
                 Key.millisecondsSinceReaderReadyToCollect: "\(millisecondsSinceReaderReadyToCollect)",
@@ -180,6 +197,16 @@ extension WooAnalyticsEvent {
                                 Key.totalItems: "\(totalItems)"
                               ])
         }
+    }
+}
+
+private extension WooAnalyticsEvent.PointOfSale {
+    static func readerModel(for connectedReaderModel: String?) -> String {
+        connectedReaderModel ?? "none_connected"
+    }
+
+    static func safeGatewayID(for gatewayID: String?) -> String {
+        gatewayID ?? "unknown"
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -105,7 +105,7 @@ struct PointOfSaleEntryPointView: View {
                               onPointOfSaleModeActiveStateChange: { _ in },
                               cardPresentPaymentService: CardPresentPaymentPreviewService(),
                               orderController: PointOfSalePreviewOrderController(),
-                              collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics(),
+                              collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentPreviewAnalytics(),
                               searchHistoryService: PointOfSalePreviewHistoryService(),
                               popularPurchasableItemsController: PointOfSalePreviewItemsController(),
                               barcodeScanService: PointOfSalePreviewBarcodeScanService(),

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -88,7 +88,7 @@ private extension POSTabCoordinator {
     func presentPOSView() {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            let collectOrderPaymentAnalyticsTracker = POSCollectOrderPaymentAnalytics()
+            let collectOrderPaymentAnalyticsTracker = POSCollectOrderPaymentAnalytics(siteID: siteID)
             let cardPresentPaymentService = await CardPresentPaymentService(siteID: siteID,
                                                                             stores: storesManager,
                                                                             collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker)

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -21,6 +21,7 @@ import enum Yosemite.POSItemType
 import protocol Yosemite.PointOfSaleBarcodeScanServiceProtocol
 import enum Yosemite.PointOfSaleBarcodeScanError
 import Combine
+import struct Yosemite.PaymentIntent
 
 // MARK: - PreviewProvider helpers
 //
@@ -212,7 +213,7 @@ struct POSPreviewHelpers {
         couponsSearchController: PointOfSaleCouponsControllerProtocol = PointOfSalePreviewCouponsController(),
         cardPresentPaymentService: CardPresentPaymentFacade = CardPresentPaymentPreviewService(),
         orderController: PointOfSaleOrderControllerProtocol = PointOfSalePreviewOrderController(),
-        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking = POSCollectOrderPaymentAnalytics(),
+        collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking = POSCollectOrderPaymentPreviewAnalytics(),
         searchHistoryService: POSSearchHistoryProviding = PointOfSalePreviewHistoryService(),
         popularItemsController: PointOfSaleItemsControllerProtocol = PointOfSalePreviewItemsController(),
         barcodeScanService: PointOfSaleBarcodeScanServiceProtocol = PointOfSalePreviewBarcodeScanService()
@@ -237,6 +238,44 @@ final class PointOfSalePreviewBarcodeScanService: PointOfSaleBarcodeScanServiceP
     func getItem(barcode: String) async throws(PointOfSaleBarcodeScanError) -> POSItem {
         return mockSimpleProductItem(id: 5, price: "35.50")
     }
+}
+
+final class POSCollectOrderPaymentPreviewAnalytics: POSCollectOrderPaymentAnalyticsTracking {
+    func trackCustomerInteractionStarted() {}
+
+    func trackOrderSyncSuccess() {}
+
+    func trackCardReaderReady() {}
+
+    func trackCardReaderTapped() {}
+
+    func trackCheckoutTapped() {}
+
+    func resetCheckoutTapCountTracker() {}
+
+    func trackSuccessfulCashPayment() {}
+
+    var connectedReaderModel: String?
+
+    func preflightResultReceived(_ result: CardReaderPreflightResult?) {}
+
+    func trackProcessingCompletion(intent: PaymentIntent) {}
+
+    func trackSuccessfulCardPayment(capturedPaymentData: CardPresentCapturedPaymentData) {}
+
+    func trackPaymentFailure(with error: any Error) {}
+
+    func trackPaymentCancelation(cancelationSource: WooAnalyticsEvent.InPersonPayments.CancellationSource) {}
+
+    func trackEmailTapped() {}
+
+    func trackReceiptPrintTapped() {}
+
+    func trackReceiptPrintSuccess() {}
+
+    func trackReceiptPrintCanceled() {}
+
+    func trackReceiptPrintFailed(error: any Error) {}
 }
 
 #endif

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -154,7 +154,7 @@ final class HubMenuViewModel: ObservableObject {
     }()
 
     private(set) var cardPresentPaymentService: CardPresentPaymentFacade?
-    private(set) var collectOrderPaymentAnalyticsTracker = POSCollectOrderPaymentAnalytics()
+    private(set) var collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics
     private let analytics: Analytics
 
     init(siteID: Int64,
@@ -181,6 +181,7 @@ final class HubMenuViewModel: ObservableObject {
                                                            currencySettings: ServiceLocator.currencySettings,
                                                            featureFlagService: featureFlagService)
         self.analytics = analytics
+        self.collectOrderPaymentAnalyticsTracker = POSCollectOrderPaymentAnalytics(siteID: siteID)
         observeSiteForUIUpdates()
         observePlanName()
         observeGoogleAdsEntryPointAvailability()

--- a/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
@@ -13,7 +13,7 @@ struct POSCollectOrderPaymentAnalyticsTests {
         analytics = WooAnalytics(analyticsProvider: analyticsProvider)
     }
 
-    @Test func POSCollectOrderPaymentAnalyticsTests_when_successful_payment_then_tracks_event_and_properties() {
+    @Test func analytics_when_successful_payment_then_tracks_event_and_properties() {
         // Given
         let siteID: Int64 = 123
         let configuration = CardPresentPaymentsConfiguration(country: .US)

--- a/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
@@ -1,5 +1,7 @@
 @testable import WooCommerce
 import protocol WooFoundation.Analytics
+import struct Yosemite.CardPresentPaymentsConfiguration
+import enum WooFoundation.CountryCode
 import Testing
 
 struct POSCollectOrderPaymentAnalyticsTests {
@@ -13,7 +15,9 @@ struct POSCollectOrderPaymentAnalyticsTests {
 
     @Test func POSCollectOrderPaymentAnalyticsTests_when_successful_payment_then_tracks_event_and_properties() {
         // Given
-        let sut = POSCollectOrderPaymentAnalytics(analytics: analytics)
+        let siteID: Int64 = 123
+        let configuration = CardPresentPaymentsConfiguration(country: .US)
+        let sut = POSCollectOrderPaymentAnalytics(siteID: siteID, analytics: analytics, configuration: configuration)
         let capturedPaymentData = CardPresentCapturedPaymentData(paymentMethod: .cardPresent(details: .fake()), receiptParameters: nil)
         let expectedEvent = "card_present_collect_payment_success"
         let expectedProperties = [
@@ -21,7 +25,12 @@ struct POSCollectOrderPaymentAnalyticsTests {
             "milliseconds_since_reader_ready_to_collect_payment",
             "milliseconds_since_card_tapped",
             "milliseconds_since_customer_interaction_started",
-            "checkout_tap_count"
+            "checkout_tap_count",
+            "card_reader_model",
+            "country",
+            "payment_method_type",
+            "site_id",
+            "plugin_slug"
         ]
 
         // When


### PR DESCRIPTION
Track gatewayID, countryCode, paymentMethod, cardReaderModel, and siteID to match IPP and Android implementation

<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

WOOMOB-776

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Track more details with POS card present, collect payment success event
Track gatewayID, countryCode, paymentMethod, cardReaderModel, and siteID to match IPP and Android implementation

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Connect a card reader
3. Make a card payment payment
4. Confirm `pos_card_present_collect_payment_success` is tracked with `gatewayID`, `countryCode`, p`aymentMetho`, `cardReaderModel`, and `siteID`

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air M2 26.0

```
Tracked pos_card_present_collect_payment_success, properties: [is_wpcom_store: false, milliseconds_since_reader_ready_to_collect_payment: 11134.0, milliseconds_since_order_sync_success: 21793.0, was_ecommerce_trial: false, store_id: 5f1b17dc-90f9-4db8-a1e8-8f3301fbb2c3, milliseconds_since_customer_interaction_started: 25562.0, checkout_tap_count: 1, card_reader_model: STRIPE_M2, milliseconds_since_card_tapped: 9757.0, plugin_slug: woocommerce-payments, site_url: https://testpovilasstore.mystagingwebsite.com, country: US, payment_method_type: card, blog_id: 234565615, site_id: 234565615, plan: jetpack_security_t1_yearly]
```

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.