### PR TITLE
[Woo POS] Remove `site_id` from`pos_card_present_collect_payment_success` event

### DIFF
--- a/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/POS/Analytics/POSCollectOrderPaymentAnalytics.swift
@@ -12,7 +12,6 @@ final class POSCollectOrderPaymentAnalytics: POSCollectOrderPaymentAnalyticsTrac
 
     private let analytics: Analytics
 
-    private let siteID: Int64
     private var paymentGatewayAccount: PaymentGatewayAccount?
     private let configuration: CardPresentPaymentsConfiguration
     private var connectedReader: CardReader?
@@ -20,10 +19,8 @@ final class POSCollectOrderPaymentAnalytics: POSCollectOrderPaymentAnalyticsTrac
         connectedReader?.readerType.model
     }
 
-    init(siteID: Int64,
-         analytics: Analytics = ServiceLocator.analytics,
+    init(analytics: Analytics = ServiceLocator.analytics,
          configuration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration) {
-        self.siteID = siteID
         self.analytics = analytics
         self.configuration = configuration
     }
@@ -61,7 +58,6 @@ final class POSCollectOrderPaymentAnalytics: POSCollectOrderPaymentAnalyticsTrac
             countryCode: configuration.countryCode,
             paymentMethod: capturedPaymentData.paymentMethod,
             cardReaderModel: connectedReaderModel,
-            siteID: siteID,
             millisecondsSinceCustomerIteractionStarted: elapsedTimeSinceCustomerInteraction,
             millisecondsSinceOrderSyncSuccess: elapsedTimeSinceOrderSync,
             millisecondsSinceReaderReadyToCollect: elapsedTimeSinceCardReaderReady,

--- a/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -30,7 +30,6 @@ extension WooAnalyticsEvent {
             static let cardReaderModel = "card_reader_model"
             static let countryCode = "country"
             static let paymentMethodType = "payment_method_type"
-            static let siteID = "site_id"
             static let gatewayID = "plugin_slug"
         }
 
@@ -111,7 +110,6 @@ extension WooAnalyticsEvent {
                                                      countryCode: CountryCode,
                                                      paymentMethod: PaymentMethod,
                                                      cardReaderModel: String?,
-                                                     siteID: Int64,
                                                      millisecondsSinceCustomerIteractionStarted: Double,
                                                      millisecondsSinceOrderSyncSuccess: Double,
                                                      millisecondsSinceReaderReadyToCollect: Double,
@@ -122,7 +120,6 @@ extension WooAnalyticsEvent {
                 Key.countryCode: countryCode.rawValue,
                 Key.gatewayID: safeGatewayID(for: forGatewayID),
                 Key.paymentMethodType: paymentMethod.analyticsValue,
-                Key.siteID: siteID,
                 Key.millisecondsSinceCustomerInteractionStarted: "\(millisecondsSinceCustomerIteractionStarted)",
                 Key.millisecondsSinceOrderSyncSuccess: "\(millisecondsSinceOrderSyncSuccess)",
                 Key.millisecondsSinceReaderReadyToCollect: "\(millisecondsSinceReaderReadyToCollect)",

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -88,7 +88,7 @@ private extension POSTabCoordinator {
     func presentPOSView() {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            let collectOrderPaymentAnalyticsTracker = POSCollectOrderPaymentAnalytics(siteID: siteID)
+            let collectOrderPaymentAnalyticsTracker = POSCollectOrderPaymentAnalytics()
             let cardPresentPaymentService = await CardPresentPaymentService(siteID: siteID,
                                                                             stores: storesManager,
                                                                             collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -154,7 +154,7 @@ final class HubMenuViewModel: ObservableObject {
     }()
 
     private(set) var cardPresentPaymentService: CardPresentPaymentFacade?
-    private(set) var collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalytics
+    private(set) var collectOrderPaymentAnalyticsTracker = POSCollectOrderPaymentAnalytics()
     private let analytics: Analytics
 
     init(siteID: Int64,
@@ -181,7 +181,6 @@ final class HubMenuViewModel: ObservableObject {
                                                            currencySettings: ServiceLocator.currencySettings,
                                                            featureFlagService: featureFlagService)
         self.analytics = analytics
-        self.collectOrderPaymentAnalyticsTracker = POSCollectOrderPaymentAnalytics(siteID: siteID)
         observeSiteForUIUpdates()
         observePlanName()
         observeGoogleAdsEntryPointAvailability()

--- a/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Analytics/POSCollectOrderPaymentAnalyticsTests.swift
@@ -17,7 +17,7 @@ struct POSCollectOrderPaymentAnalyticsTests {
         // Given
         let siteID: Int64 = 123
         let configuration = CardPresentPaymentsConfiguration(country: .US)
-        let sut = POSCollectOrderPaymentAnalytics(siteID: siteID, analytics: analytics, configuration: configuration)
+        let sut = POSCollectOrderPaymentAnalytics(analytics: analytics, configuration: configuration)
         let capturedPaymentData = CardPresentCapturedPaymentData(paymentMethod: .cardPresent(details: .fake()), receiptParameters: nil)
         let expectedEvent = "card_present_collect_payment_success"
         let expectedProperties = [
@@ -29,7 +29,6 @@ struct POSCollectOrderPaymentAnalyticsTests {
             "card_reader_model",
             "country",
             "payment_method_type",
-            "site_id",
             "plugin_slug"
         ]
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Continuation of https://github.com/woocommerce/woocommerce-ios/pull/15892

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As @iamgabrielma have noticed, the event already contains blog_id, so we don't need to track site_id separately.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

CI success should be enough.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad 18.5 simulator


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.