### PR TITLE
[POS as a tab i2] Refresh POS eligibility in ineligible UI: site settings and feature switch disabled cases

### DIFF
--- a/WooCommerce/Classes/POS/Controllers/POSEntryPointController.swift
+++ b/WooCommerce/Classes/POS/Controllers/POSEntryPointController.swift
@@ -22,7 +22,7 @@ import protocol Experiments.FeatureFlagService
     }
 
     @MainActor
-    func refreshEligibility() async throws {
-        // TODO: WOOMOB-720 - refresh eligibility
+    func refreshEligibility(reason: POSIneligibleReason) async throws {
+        eligibilityState = try await posEligibilityChecker.refreshEligibility(ineligibleReason: reason)
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -62,7 +62,7 @@ struct PointOfSaleEntryPointView: View {
                 }
             case let .ineligible(reason):
                 POSIneligibleView(reason: reason, onRefresh: {
-                    try await posEntryPointController.refreshEligibility()
+                    try await posEntryPointController.refreshEligibility(reason: reason)
                 })
             }
         }

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -99,8 +99,8 @@ struct POSIneligibleView: View {
                                      comment: "Suggestion for disabled feature switch: enable feature in WooCommerce settings")
         case .featureSwitchSyncFailure:
             return NSLocalizedString("pos.ineligible.suggestion.featureSwitchSyncFailure",
-                                     value: "Try relaunching the app or check your internet connection and try again.",
-                                     comment: "Suggestion for feature switch sync failure: relaunch or check connection")
+                                     value: "Please check your internet connection and try again.",
+                                     comment: "Suggestion for feature switch sync failure: check connection and retry")
         case let .unsupportedCurrency(supportedCurrencies):
             let currencyList = supportedCurrencies.map { $0.rawValue }
             let formattedCurrencyList = ListFormatter.localizedString(byJoining: currencyList)
@@ -114,7 +114,7 @@ struct POSIneligibleView: View {
             return String.localizedStringWithFormat(format, formattedCurrencyList)
         case .siteSettingsNotAvailable:
             return NSLocalizedString("pos.ineligible.suggestion.siteSettingsNotAvailable",
-                                     value: "Check your internet connection and try relaunching the app. If the issue persists, please contact support.",
+                                     value: "Check your internet connection and try again. If the issue persists, please contact support.",
                                      comment: "Suggestion for site settings unavailable: check connection or contact support")
         case .selfDeallocated:
             return NSLocalizedString("pos.ineligible.suggestion.selfDeallocated",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/LegacyPOSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/LegacyPOSTabEligibilityChecker.swift
@@ -113,6 +113,11 @@ final class LegacyPOSTabEligibilityChecker: POSEntryPointEligibilityCheckerProto
         let eligibility = await checkI1Eligibility()
         return eligibility == .eligible
     }
+
+    func refreshEligibility(ineligibleReason: POSIneligibleReason) async throws -> POSEligibilityState {
+        assertionFailure("POS as a tab i1 implementation should not refresh eligibility as the eligibility check is performed in the visibility check.")
+        return .eligible
+    }
 }
 
 private extension LegacyPOSTabEligibilityChecker {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -39,6 +39,8 @@ protocol POSEntryPointEligibilityCheckerProtocol {
     func checkVisibility() async -> Bool
     /// Determines whether the site is eligible for POS.
     func checkEligibility() async -> POSEligibilityState
+    /// Refreshes the eligibility state based on the provided ineligible reason.
+    func refreshEligibility(ineligibleReason: POSIneligibleReason) async throws -> POSEligibilityState
 }
 
 final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
@@ -113,11 +115,56 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
 
         return await featureFlagEligibility == .eligible
     }
+
+    func refreshEligibility(ineligibleReason: POSIneligibleReason) async throws -> POSEligibilityState {
+        switch ineligibleReason {
+        case .unsupportedIOSVersion:
+            // TODO: WOOMOB-768 - hide refresh CTA in this case
+            return .ineligible(reason: .unsupportedIOSVersion)
+        case .siteSettingsNotAvailable, .unsupportedCurrency:
+            do {
+                try await syncSiteSettingsRemotely()
+                return await checkEligibility()
+            } catch POSTabEligibilityCheckerError.selfDeallocated {
+                return .ineligible(reason: .selfDeallocated)
+            } catch {
+                return await checkEligibility()
+            }
+        case .unsupportedWooCommerceVersion, .wooCommercePluginNotFound:
+            // TODO: sync the WooCommerce plugin then check eligibility again.
+            return await checkEligibility()
+        case .featureSwitchDisabled:
+            // TODO: WOOMOB-759 - enable feature switch via API and check eligibility again
+            // For now, just checks eligibility again.
+            return await checkEligibility()
+        case .featureSwitchSyncFailure, .selfDeallocated:
+            return await checkEligibility()
+        }
+    }
 }
 
 // MARK: - WC Plugin Related Eligibility Check
 
 private extension POSTabEligibilityChecker {
+    @MainActor
+    func syncSiteSettingsRemotely() async throws {
+        try await withCheckedThrowingContinuation { [weak self] (continuation: CheckedContinuation<Void, Error>) in
+            guard let self else {
+                return continuation.resume(throwing: POSTabEligibilityCheckerError.selfDeallocated)
+            }
+            stores.dispatch(SettingAction.synchronizeGeneralSiteSettings(siteID: siteID) { [weak self] error in
+                guard let self else {
+                    return continuation.resume(throwing: POSTabEligibilityCheckerError.selfDeallocated)
+                }
+                if let error {
+                    return continuation.resume(throwing: error)
+                }
+                siteSettings.refresh()
+                continuation.resume(returning: ())
+            })
+        }
+    }
+
     func checkPluginEligibility() async -> POSEligibilityState {
         let wcPlugin = await fetchWooCommercePlugin(siteID: siteID)
 
@@ -275,6 +322,10 @@ private extension POSTabEligibilityChecker {
             self.stores.dispatch(action)
         }
     }
+}
+
+private enum POSTabEligibilityCheckerError: Error {
+    case selfDeallocated
 }
 
 private extension POSTabEligibilityChecker {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -128,7 +128,7 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
             } catch POSTabEligibilityCheckerError.selfDeallocated {
                 return .ineligible(reason: .selfDeallocated)
             } catch {
-                return await checkEligibility()
+                throw error
             }
         case .unsupportedWooCommerceVersion, .wooCommercePluginNotFound:
             // TODO: WOOMOB-799 - sync the WooCommerce plugin then check eligibility again.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -146,25 +146,6 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
 // MARK: - WC Plugin Related Eligibility Check
 
 private extension POSTabEligibilityChecker {
-    @MainActor
-    func syncSiteSettingsRemotely() async throws {
-        try await withCheckedThrowingContinuation { [weak self] (continuation: CheckedContinuation<Void, Error>) in
-            guard let self else {
-                return continuation.resume(throwing: POSTabEligibilityCheckerError.selfDeallocated)
-            }
-            stores.dispatch(SettingAction.synchronizeGeneralSiteSettings(siteID: siteID) { [weak self] error in
-                guard let self else {
-                    return continuation.resume(throwing: POSTabEligibilityCheckerError.selfDeallocated)
-                }
-                if let error {
-                    return continuation.resume(throwing: error)
-                }
-                siteSettings.refresh()
-                continuation.resume(returning: ())
-            })
-        }
-    }
-
     func checkPluginEligibility() async -> POSEligibilityState {
         let wcPlugin = await fetchWooCommercePlugin(siteID: siteID)
 
@@ -281,6 +262,25 @@ private extension POSTabEligibilityChecker {
             return .ineligible(reason: .unsupportedCurrency(supportedCurrencies: supportedCurrenciesForCountry))
         }
         return .eligible
+    }
+
+    @MainActor
+    func syncSiteSettingsRemotely() async throws {
+        try await withCheckedThrowingContinuation { [weak self] (continuation: CheckedContinuation<Void, Error>) in
+            guard let self else {
+                return continuation.resume(throwing: POSTabEligibilityCheckerError.selfDeallocated)
+            }
+            stores.dispatch(SettingAction.synchronizeGeneralSiteSettings(siteID: siteID) { [weak self] error in
+                guard let self else {
+                    return continuation.resume(throwing: POSTabEligibilityCheckerError.selfDeallocated)
+                }
+                if let error {
+                    return continuation.resume(throwing: error)
+                }
+                siteSettings.refresh()
+                continuation.resume(returning: ())
+            })
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -131,7 +131,8 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
                 return await checkEligibility()
             }
         case .unsupportedWooCommerceVersion, .wooCommercePluginNotFound:
-            // TODO: sync the WooCommerce plugin then check eligibility again.
+            // TODO: WOOMOB-799 - sync the WooCommerce plugin then check eligibility again.
+            // For now, it requires relaunching the app or switching stores to refresh the plugin info.
             return await checkEligibility()
         case .featureSwitchDisabled:
             // TODO: WOOMOB-759 - enable feature switch via API and check eligibility again

--- a/WooCommerce/WooCommerceTests/Mocks/MockPOSEligibilityChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPOSEligibilityChecker.swift
@@ -19,4 +19,8 @@ final class MockPOSEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
     func checkEligibility() async -> POSEligibilityState {
         eligibility
     }
+
+    func refreshEligibility(ineligibleReason: POSIneligibleReason) async throws -> POSEligibilityState {
+        .ineligible(reason: ineligibleReason)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -692,4 +692,8 @@ private final class MockAsyncPOSEligibilityChecker: POSEntryPointEligibilityChec
             }
         }
     }
+
+    func refreshEligibility(ineligibleReason: POSIneligibleReason) async throws -> POSEligibilityState {
+        .ineligible(reason: ineligibleReason)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -570,6 +570,180 @@ struct POSTabEligibilityCheckerTests {
         // Then
         #expect(result == .eligible)
     }
+
+    // MARK: - `refreshEligibility` Tests
+
+    @Test func refreshEligibility_returns_ineligible_for_unsupportedIOSVersion() async throws {
+        // Given
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               siteSettings: siteSettings,
+                                               pluginsService: pluginsService,
+                                               stores: stores)
+
+        // When
+        let result = try await checker.refreshEligibility(ineligibleReason: .unsupportedIOSVersion)
+
+        // Then
+        #expect(result == .ineligible(reason: .unsupportedIOSVersion))
+    }
+
+    @Test(arguments: [
+        POSIneligibleReason.siteSettingsNotAvailable,
+        POSIneligibleReason.unsupportedCurrency(supportedCurrencies: [.USD])
+    ])
+    fileprivate func refreshEligibility_syncs_site_settings_and_checks_eligibility_for_site_settings_issues(ineligibleReason: POSIneligibleReason) async throws {
+        // Given
+        setupCountry(country: .us, currency: .USD)
+        setupWooCommerceVersion("9.6.0")
+        setupPOSFeatureEnabled(.success(true))
+
+        var syncCalled = false
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case .synchronizeGeneralSiteSettings(_, let completion):
+                syncCalled = true
+                completion(nil) // Success
+            case .isFeatureEnabled(_, _, let completion):
+                completion(.success(true))
+            default:
+                break
+            }
+        }
+
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               siteSettings: siteSettings,
+                                               pluginsService: pluginsService,
+                                               stores: stores)
+
+        // When
+        let result = try await checker.refreshEligibility(ineligibleReason: ineligibleReason)
+
+        // Then
+        #expect(syncCalled == true)
+        #expect(result == .eligible)
+    }
+
+    @Test(arguments: [
+        POSIneligibleReason.siteSettingsNotAvailable,
+        POSIneligibleReason.unsupportedCurrency(supportedCurrencies: [.USD])
+    ])
+    fileprivate func refreshEligibility_returns_siteSettingsNotAvailable_when_site_settings_sync_fails(ineligibleReason: POSIneligibleReason) async throws {
+        // Given
+        setupCountry(country: .us, currency: .USD)
+        setupWooCommerceVersion("9.6.0")
+
+        var syncCalled = false
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case .synchronizeGeneralSiteSettings(_, let completion):
+                syncCalled = true
+                completion(NSError(domain: "test", code: 500)) // Network error
+            default:
+                break
+            }
+        }
+
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               siteSettings: siteSettings,
+                                               pluginsService: pluginsService,
+                                               stores: stores)
+
+        // When & Then - Should throw the network error
+        #expect(syncCalled == false) // Not called yet
+        await #expect(throws: NSError.self) {
+            try await checker.refreshEligibility(ineligibleReason: ineligibleReason)
+        }
+        #expect(syncCalled == true) // Called during the attempt
+    }
+
+    @Test func refreshEligibility_checks_eligibility_for_unsupportedWooCommerceVersion() async throws {
+        // Given
+        setupCountry(country: .us, currency: .USD)
+        setupWooCommerceVersion("9.5.0") // Still below minimum
+
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               siteSettings: siteSettings,
+                                               pluginsService: pluginsService,
+                                               stores: stores)
+
+        // When
+        let result = try await checker.refreshEligibility(ineligibleReason: .unsupportedWooCommerceVersion(minimumVersion: "9.6.0-beta"))
+
+        // Then - Should check eligibility again (still ineligible due to version)
+        #expect(result == .ineligible(reason: .unsupportedWooCommerceVersion(minimumVersion: "9.6.0-beta")))
+    }
+
+    @Test func refreshEligibility_checks_eligibility_for_wooCommercePluginNotFound() async throws {
+        // Given
+        setupCountry(country: .us, currency: .USD)
+        setupWooCommerceVersion("9.6.0") // Now eligible version
+        setupPOSFeatureEnabled(.success(true))
+
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               siteSettings: siteSettings,
+                                               pluginsService: pluginsService,
+                                               stores: stores)
+
+        // When
+        let result = try await checker.refreshEligibility(ineligibleReason: .wooCommercePluginNotFound)
+
+        // Then - Should check eligibility again (now eligible)
+        #expect(result == .eligible)
+    }
+
+    @Test func refreshEligibility_checks_eligibility_for_featureSwitchDisabled() async throws {
+        // Given
+        setupCountry(country: .us, currency: .USD)
+        setupWooCommerceVersion("10.0.0") // Version that supports feature switch
+        setupPOSFeatureEnabled(.success(true)) // Now enabled
+
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               siteSettings: siteSettings,
+                                               pluginsService: pluginsService,
+                                               stores: stores)
+
+        // When
+        let result = try await checker.refreshEligibility(ineligibleReason: .featureSwitchDisabled)
+
+        // Then - Should check eligibility again (now eligible)
+        #expect(result == .eligible)
+    }
+
+    @Test func refreshEligibility_checks_eligibility_for_featureSwitchSyncFailure() async throws {
+        // Given
+        setupCountry(country: .us, currency: .USD)
+        setupWooCommerceVersion("10.0.0")
+        setupPOSFeatureEnabled(.failure(NSError(domain: "test", code: 0))) // Still failing
+
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               siteSettings: siteSettings,
+                                               pluginsService: pluginsService,
+                                               stores: stores)
+
+        // When
+        let result = try await checker.refreshEligibility(ineligibleReason: .featureSwitchSyncFailure)
+
+        // Then - Should check eligibility again (still failing)
+        #expect(result == .ineligible(reason: .featureSwitchSyncFailure))
+    }
+
+    @Test func refreshEligibility_checks_eligibility_for_selfDeallocated() async throws {
+        // Given
+        setupCountry(country: .us, currency: .USD)
+        setupWooCommerceVersion("9.6.0")
+        setupPOSFeatureEnabled(.success(true))
+
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               siteSettings: siteSettings,
+                                               pluginsService: pluginsService,
+                                               stores: stores)
+
+        // When
+        let result = try await checker.refreshEligibility(ineligibleReason: .selfDeallocated)
+
+        // Then - Should check eligibility again (now eligible)
+        #expect(result == .eligible)
+    }
 }
 
 private extension POSTabEligibilityCheckerTests {


### PR DESCRIPTION
For WOOMOB-757

Just one review is required.

## Description

This pull request introduces a new method `refreshEligibility(ineligibleReason:)` to `POSEntryPointEligibilityCheckerProtocol` with basic implementation in `POSTabEligibilityChecker` to handle eligibility state updates based on specific ineligible reasons. Site settings related cases and the POS feature switch disabled case are covered in this PR. Unsupported WC plugin version case will be supported separately in WOOMOB-799.

### Eligibility refresh logic:

* [`WooCommerce/Classes/POS/Controllers/POSEntryPointController.swift`](diffhunk://#diff-1227be6d8d2c90578d67461618576e732b891a59a7b69532fb46c098581c87efL25-R26): Updated the `refreshEligibility` method to accept an `ineligibleReason` parameter and use `posEligibilityChecker` for eligibility state updates.
* [`WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift`](diffhunk://#diff-879b19d2d74a851baa4794369063b610eae3d1fbdff47679418245fa053fbde3L65-R65): Modified the `POSIneligibleView` refresh action to pass the `reason` parameter to the `posEntryPointController.refreshEligibility` method.

### Protocol and implementation updates:

* [`WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift`](diffhunk://#diff-c17e8dbfb52562a157337395575a7e666264d27ffc3f86c06a75a4f8a6863e61R42-R43): Added the `refreshEligibility` method to the `POSEntryPointEligibilityCheckerProtocol` and implemented it in `POSTabEligibilityChecker` to handle various ineligible reasons, including syncing site settings remotely and checking eligibility again. `checkEligibility` currently just includes one API request to reload the POS feature switch value, the site settings and WC plugin values are synced outside of the eligibility checker from site initialization. [[1]](diffhunk://#diff-c17e8dbfb52562a157337395575a7e666264d27ffc3f86c06a75a4f8a6863e61R42-R43) [[2]](diffhunk://#diff-c17e8dbfb52562a157337395575a7e666264d27ffc3f86c06a75a4f8a6863e61R118-R144)

### Error handling and site settings synchronization:

* [`WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift`](diffhunk://#diff-c17e8dbfb52562a157337395575a7e666264d27ffc3f86c06a75a4f8a6863e61R267-R285): Introduced the `POSTabEligibilityCheckerError` enum for error handling, including a `selfDeallocated` case. Added the `syncSiteSettingsRemotely` method to synchronize site settings and refresh eligibility state. [[1]](diffhunk://#diff-c17e8dbfb52562a157337395575a7e666264d27ffc3f86c06a75a4f8a6863e61R267-R285) [[2]](diffhunk://#diff-c17e8dbfb52562a157337395575a7e666264d27ffc3f86c06a75a4f8a6863e61R328-R331)

### Legacy checker adjustments:

* [`WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/LegacyPOSTabEligibilityChecker.swift`](diffhunk://#diff-db91def6802195eee9510f8a16d64fd899c8047b9607672de02f7591ded57b23R116-R120): Added a `refreshEligibility` method with an assertion failure for unsupported refresh operations in the legacy POS tab implementation.

## Steps to reproduce

### Unsupported store currency

Prerequisite: for a store that is eligible for POS, change the currency in core under WC settings > General to a different value

- Launch the app with the site in the prerequisite --> the POS tab should appear shortly
- Tap on the POS tab --> after the loading state, an ineligible screen should be shown about the unsupported currency
- Tap `Retry` --> the CTA should be in loading state, then back to normal state
- In wp-admin, update the store currency to the supported value
- Back in the app, tap `Retry` --> the CTA should be in loading state, then the app enters POS

### POS feature switch disabled

Prerequisite: for a store that is eligible for POS and with WC version 10.0+, disable the POS feature in WooCommerce settings > Advanced > Features

- Launch the app with the site in the prerequisite --> the POS tab should appear shortly
- Tap on the POS tab --> after the loading state, an ineligible screen should be shown about the disabled POS feature
- Tap `Retry` --> the CTA should be in loading state, then back to normal state
- In wp-admin, enable the feature switch
- Back in the app, tap `Retry` --> the CTA should be in loading state, then the app enters POS

## Testing information

I tested the above cases, and when the device is offline.

## Screenshots

### Unsupported store currency


https://github.com/user-attachments/assets/81a53ef8-d5af-44e7-aabe-48e505cc2a43



### POS feature switch disabled


https://github.com/user-attachments/assets/e245d101-8d77-4244-a5b7-f60eeec4ba02



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.