### PR TITLE
[Woo POS][Barcodes] Analytics for scan performance

### DIFF
--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -151,6 +151,8 @@ private extension TracksProvider {
             WooAnalyticsStat.pointOfSaleBarcodeScanningMenuItemTapped,
             WooAnalyticsStat.pointOfSaleBarcodeScanningExplanationDialogShown,
             WooAnalyticsStat.pointOfSaleBarcodeScannerSetupFlowShown,
+            WooAnalyticsStat.pointOfSaleBarcodeScanningSuccess,
+            WooAnalyticsStat.pointOfSaleBarcodeScanningFailed,
 
             // Order
             WooAnalyticsStat.orderCreationSuccess,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1306,6 +1306,8 @@ enum WooAnalyticsStat: String {
     case pointOfSaleBarcodeScanningMenuItemTapped = "barcode_scanning_menu_item_tapped"
     case pointOfSaleBarcodeScanningExplanationDialogShown = "barcode_scanning_explanation_dialog_shown"
     case pointOfSaleBarcodeScannerSetupFlowShown = "barcode_scanner_setup_flow_shown"
+    case pointOfSaleBarcodeScanningSuccess = "barcode_scanned"
+    case pointOfSaleBarcodeScanningFailed = "barcode_scanning_failed"
 
     // MARK: Custom Fields events
     case productDetailCustomFieldsTapped = "product_detail_custom_fields_tapped"

--- a/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/WooCommerce/Classes/POS/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -32,6 +32,9 @@ extension WooAnalyticsEvent {
             static let paymentMethodType = "payment_method_type"
             static let siteID = "site_id"
             static let gatewayID = "plugin_slug"
+            static let scanDurationMs = "scan_duration_ms"
+            static let barcodeLength = "barcode_length"
+            static let failReason = "fail_reason"
         }
 
         static func paymentsOnboardingShown() -> WooAnalyticsEvent {
@@ -195,6 +198,23 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Key.sourceView: SourceView(itemType: itemType).rawValue,
                                 Key.totalItems: "\(totalItems)"
+                              ])
+        }
+
+        static func barcodeScanningSuccess(scanDurationMs: Int, barcodeLength: Int) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .pointOfSaleBarcodeScanningSuccess,
+                              properties: [
+                                Key.scanDurationMs: "\(scanDurationMs)",
+                                Key.barcodeLength: "\(barcodeLength)"
+                              ])
+        }
+
+        static func barcodeScanningFailed(scanDurationMs: Int, barcodeLength: Int, failReason: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .pointOfSaleBarcodeScanningFailed,
+                              properties: [
+                                Key.scanDurationMs: "\(scanDurationMs)",
+                                Key.barcodeLength: "\(barcodeLength)",
+                                Key.failReason: failReason
                               ])
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/GameControllerBarcodeObserver.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/GameControllerBarcodeObserver.swift
@@ -88,7 +88,12 @@ final class GameControllerBarcodeObserver {
         cleanupKeyboard()
 
         coalescedKeyboard = keyboard
-        barcodeParser = GameControllerBarcodeParser(configuration: configuration, onScan: onScan)
+        barcodeParser = GameControllerBarcodeParser(
+            configuration: configuration,
+            onScan: { [weak self] result in
+                self?.handleScanResult(result)
+            }
+        )
 
         keyboard.keyboardInput?.keyChangedHandler = { [weak self] _, _, keyCode, pressed in
             guard let self = self else { return }
@@ -111,5 +116,30 @@ final class GameControllerBarcodeObserver {
         coalescedKeyboard = nil
         barcodeParser = nil
         isShiftPressed = false
+    }
+
+    private func handleScanResult(_ result: HIDBarcodeParserResult) {
+        trackAnalyticsEvent(for: result)
+        onScan(result.asResult)
+    }
+
+    private func trackAnalyticsEvent(for result: HIDBarcodeParserResult) {
+        switch result {
+        case .success(let barcode, let scanDurationMs):
+            ServiceLocator.analytics.track(
+                event: WooAnalyticsEvent.PointOfSale.barcodeScanningSuccess(
+                    scanDurationMs: scanDurationMs,
+                    barcodeLength: barcode.count
+                )
+            )
+        case .failure(let error, let scanDurationMs):
+            ServiceLocator.analytics.track(
+                event: WooAnalyticsEvent.PointOfSale.barcodeScanningFailed(
+                    scanDurationMs: scanDurationMs,
+                    barcodeLength: error.barcode.count,
+                    failReason: error.analyticsReason
+                )
+            )
+        }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/GameControllerBarcodeParser.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/GameControllerBarcodeParser.swift
@@ -8,15 +8,16 @@ final class GameControllerBarcodeParser {
     /// Configuration for the barcode scanner
     let configuration: HIDBarcodeParserConfiguration
     /// Callback that is triggered when a barcode scan completes (success or failure)
-    let onScan: (Result<String, Error>) -> Void
+    let onScan: (HIDBarcodeParserResult) -> Void
 
     private let timeProvider: TimeProvider
 
     private var buffer = ""
     private var lastKeyPressTime: Date?
+    private var scanStartTime: Date?
 
     init(configuration: HIDBarcodeParserConfiguration,
-         onScan: @escaping (Result<String, Error>) -> Void,
+         onScan: @escaping (HIDBarcodeParserResult) -> Void,
          timeProvider: TimeProvider = DefaultTimeProvider()) {
         self.configuration = configuration
         self.onScan = onScan
@@ -41,6 +42,12 @@ final class GameControllerBarcodeParser {
         } else {
             guard !excludedKeyCodes.contains(keyCode) else { return }
             checkForTimeoutBetweenKeystrokes()
+
+            // Start timing on first character
+            if buffer.isEmpty {
+                scanStartTime = timeProvider.now()
+            }
+
             buffer.append(character)
         }
     }
@@ -69,7 +76,10 @@ final class GameControllerBarcodeParser {
 
         if let lastTime = lastKeyPressTime,
            currentTime.timeIntervalSince(lastTime) > configuration.maximumInterCharacterTime {
-            onScan(.failure(HIDBarcodeParserError.timedOut(barcode: buffer)))
+            let scanDurationMs = calculateScanDurationMs()
+            let result = HIDBarcodeParserResult.failure(error: HIDBarcodeParserError.timedOut(barcode: buffer), scanDurationMs: scanDurationMs)
+
+            onScan(result)
             resetScan()
         }
 
@@ -175,14 +185,24 @@ final class GameControllerBarcodeParser {
     private func resetScan() {
         buffer = ""
         lastKeyPressTime = nil
+        scanStartTime = nil
+    }
+
+    private func calculateScanDurationMs() -> Int {
+        guard let startTime = scanStartTime else { return 0 }
+        return Int(timeProvider.now().timeIntervalSince(startTime) * 1000)
     }
 
     private func processScan() {
         checkForTimeoutBetweenKeystrokes()
+        let scanDurationMs = calculateScanDurationMs()
+
         if buffer.count >= configuration.minimumBarcodeLength {
-            onScan(.success(buffer))
+            let result = HIDBarcodeParserResult.success(barcode: buffer, scanDurationMs: scanDurationMs)
+            onScan(result)
         } else {
-            onScan(.failure(HIDBarcodeParserError.scanTooShort(barcode: buffer)))
+            let result = HIDBarcodeParserResult.failure(error: HIDBarcodeParserError.scanTooShort(barcode: buffer), scanDurationMs: scanDurationMs)
+            onScan(result)
         }
         resetScan()
     }
@@ -211,4 +231,34 @@ struct HIDBarcodeParserConfiguration {
 enum HIDBarcodeParserError: Error {
     case scanTooShort(barcode: String)
     case timedOut(barcode: String)
+
+    var analyticsReason: String {
+        switch self {
+        case .scanTooShort:
+            return "too_short"
+        case .timedOut:
+            return "no_terminator"
+        }
+    }
+
+    var barcode: String {
+        switch self {
+        case .scanTooShort(let barcode), .timedOut(let barcode):
+            return barcode
+        }
+    }
+}
+
+enum HIDBarcodeParserResult {
+    case success(barcode: String, scanDurationMs: Int)
+    case failure(error: HIDBarcodeParserError, scanDurationMs: Int)
+
+    var asResult: Result<String, Error> {
+        switch self {
+        case .success(let barcode, _):
+            return .success(barcode)
+        case .failure(let error, _):
+            return .failure(error)
+        }
+    }
 }

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/GameControllerBarcodeParser.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/GameControllerBarcodeParser.swift
@@ -190,7 +190,7 @@ final class GameControllerBarcodeParser {
 
     private func calculateScanDurationMs() -> Int {
         guard let startTime = scanStartTime else { return 0 }
-        return Int(timeProvider.now().timeIntervalSince(startTime) * 1000)
+        return Int(round(timeProvider.now().timeIntervalSince(startTime) * 1000))
     }
 
     private func processScan() {

--- a/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/GameControllerBarcodeParserTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/GameControllerBarcodeParserTests.swift
@@ -45,7 +45,7 @@ struct GameControllerBarcodeParserTests {
         @Test("complete scan succeeds with valid barcode")
         func validBarcode_whenScannedCompletely_succeeds() {
             // Given
-            var results: [Result<String, Error>] = []
+            var results: [HIDBarcodeParserResult] = []
             let parser = GameControllerBarcodeParser(
                 configuration: Self.testConfiguration,
                 onScan: { results.append($0) }
@@ -62,7 +62,7 @@ struct GameControllerBarcodeParserTests {
 
             // Then
             #expect(results.count == 1)
-            if case .success(let barcode) = results.first {
+            if case .success(let barcode, _) = results.first {
                 #expect(barcode == "123456")
             } else {
                 Issue.record("Expected successful scan")
@@ -72,7 +72,7 @@ struct GameControllerBarcodeParserTests {
         @Test("multiple consecutive scans work correctly")
         func multipleBarcodes_whenScannedConsecutively_workCorrectly() {
             // Given
-            var results: [Result<String, Error>] = []
+            var results: [HIDBarcodeParserResult] = []
             let parser = GameControllerBarcodeParser(
                 configuration: Self.testConfiguration,
                 onScan: { results.append($0) }
@@ -92,12 +92,12 @@ struct GameControllerBarcodeParserTests {
 
             // Then
             #expect(results.count == 2)
-            if case .success(let barcode1) = results[0] {
+            if case .success(let barcode1, _) = results[0] {
                 #expect(barcode1 == "123")
             } else {
                 Issue.record("Expected first scan to succeed")
             }
-            if case .success(let barcode2) = results[1] {
+            if case .success(let barcode2, _) = results[1] {
                 #expect(barcode2 == "456")
             } else {
                 Issue.record("Expected second scan to succeed")
@@ -107,7 +107,7 @@ struct GameControllerBarcodeParserTests {
         @Test("cancelled scan clears buffer and allows new scan")
         func partialScan_whenCancelled_clearsBufferAndAllowsNewScan() {
             // Given
-            var results: [Result<String, Error>] = []
+            var results: [HIDBarcodeParserResult] = []
             let parser = GameControllerBarcodeParser(
                 configuration: Self.testConfiguration,
                 onScan: { results.append($0) }
@@ -129,7 +129,7 @@ struct GameControllerBarcodeParserTests {
 
             // Then
             #expect(results.count == 1)
-            if case .success(let barcode) = results.first {
+            if case .success(let barcode, _) = results.first {
                 #expect(barcode == "456")
             } else {
                 Issue.record("Expected successful scan after cancel")
@@ -150,7 +150,7 @@ struct GameControllerBarcodeParserTests {
         @Test("scan too short triggers error with default configuration")
         func shortBarcode_whenScannedWithDefaultConfig_triggersError() {
             // Given
-            var results: [Result<String, Error>] = []
+            var results: [HIDBarcodeParserResult] = []
             let parser = GameControllerBarcodeParser(
                 configuration: .default, // min length 6
                 onScan: { results.append($0) }
@@ -166,9 +166,10 @@ struct GameControllerBarcodeParserTests {
 
             // Then
             #expect(results.count == 1)
-            if case .failure(let error) = results.first {
-                if case HIDBarcodeParserError.scanTooShort(let barcode) = error {
+            if case .failure(let error, let duration) = results.first {
+                if case .scanTooShort(let barcode) = error {
                     #expect(barcode == "12345")
+                    #expect(duration >= 0)
                 } else {
                     Issue.record("Expected scanTooShort error")
                 }
@@ -180,7 +181,7 @@ struct GameControllerBarcodeParserTests {
         @Test("scan too short triggers error with custom configuration")
         func shortBarcode_whenScannedWithCustomConfig_triggersError() {
             // Given
-            var results: [Result<String, Error>] = []
+            var results: [HIDBarcodeParserResult] = []
             let configuration = HIDBarcodeParserConfiguration(
                 terminatingStrings: ["\r"],
                 minimumBarcodeLength: 8,
@@ -203,9 +204,10 @@ struct GameControllerBarcodeParserTests {
 
             // Then
             #expect(results.count == 1)
-            if case .failure(let error) = results.first {
-                if case HIDBarcodeParserError.scanTooShort(let barcode) = error {
+            if case .failure(let error, let duration) = results.first {
+                if case .scanTooShort(let barcode) = error {
                     #expect(barcode == "1234567")
+                    #expect(duration >= 0)
                 } else {
                     Issue.record("Expected scanTooShort error")
                 }
@@ -217,7 +219,7 @@ struct GameControllerBarcodeParserTests {
         @Test("slow typing triggers timeout error")
         func slowTyping_whenExceedsTimeout_triggersError() {
             // Given
-            var results: [Result<String, Error>] = []
+            var results: [HIDBarcodeParserResult] = []
             let configuration = HIDBarcodeParserConfiguration(
                 terminatingStrings: ["\r", "\n"],
                 minimumBarcodeLength: 3,
@@ -242,9 +244,10 @@ struct GameControllerBarcodeParserTests {
 
             // Then - Should get timeout error and successful scan
             #expect(results.count == 2)
-            if case .failure(let error) = results.first {
-                if case HIDBarcodeParserError.timedOut(let barcode) = error {
+            if case .failure(let error, let duration) = results.first {
+                if case .timedOut(let barcode) = error {
                     #expect(barcode == "123")
+                    #expect(duration >= 0)
                 } else {
                     Issue.record("Expected timedOut error")
                 }
@@ -252,8 +255,9 @@ struct GameControllerBarcodeParserTests {
                 Issue.record("Expected timeout failure")
             }
 
-            if case .success(let barcode) = results[1] {
+            if case .success(let barcode, let duration) = results[1] {
                 #expect(barcode == "456")
+                #expect(duration >= 0)
             } else {
                 Issue.record("Expected successful scan after timeout reset")
             }
@@ -262,7 +266,7 @@ struct GameControllerBarcodeParserTests {
         @Test("fast typing within timeout succeeds")
         func fastTyping_whenWithinTimeout_succeeds() {
             // Given
-            var results: [Result<String, Error>] = []
+            var results: [HIDBarcodeParserResult] = []
             let configuration = HIDBarcodeParserConfiguration.default
             let mockTimeProvider = MockTimeProvider()
             let parser = GameControllerBarcodeParser(
@@ -288,17 +292,82 @@ struct GameControllerBarcodeParserTests {
 
             // Then
             #expect(results.count == 1)
-            if case .success(let barcode) = results.first {
+            if case .success(let barcode, _) = results.first {
                 #expect(barcode == "123456")
             } else {
                 Issue.record("Expected successful scan")
             }
         }
 
+        @Test("scan duration is properly tracked for successful scan")
+        func scanDuration_whenSuccessfulScan_isProperlyTracked() {
+            // Given
+            var results: [HIDBarcodeParserResult] = []
+            let mockTimeProvider = MockTimeProvider()
+            let parser = GameControllerBarcodeParser(
+                configuration: Self.testConfiguration,
+                onScan: { results.append($0) },
+                timeProvider: mockTimeProvider
+            )
+
+            // When - Simulate a scan with known duration
+            parser.processKeyPress(GCKeyCode.one)
+            mockTimeProvider.advance(by: 0.04)
+            parser.processKeyPress(GCKeyCode.two)
+            parser.processKeyPress(GCKeyCode.three)
+            parser.processKeyPress(GCKeyCode.four)
+            mockTimeProvider.advance(by: 0.04)
+            parser.processKeyPress(GCKeyCode.five)
+            mockTimeProvider.advance(by: 0.02)
+            parser.processKeyPress(GCKeyCode.six)
+            parser.processKeyPress(GCKeyCode.returnOrEnter)
+
+            // Then
+            #expect(results.count == 1)
+            if case .success(let barcode, let duration) = results.first {
+                #expect(barcode == "123456")
+                #expect(duration == 100)
+            } else {
+                Issue.record("Expected successful scan with duration")
+            }
+        }
+
+        @Test("scan duration is properly tracked for failed scan")
+        func scanDuration_whenFailedScan_isProperlyTracked() {
+            // Given
+            var results: [HIDBarcodeParserResult] = []
+            let mockTimeProvider = MockTimeProvider()
+            let parser = GameControllerBarcodeParser(
+                configuration: .default, // min length 6
+                onScan: { results.append($0) },
+                timeProvider: mockTimeProvider
+            )
+
+            // When - Simulate a short scan with known duration
+            parser.processKeyPress(GCKeyCode.one)
+            mockTimeProvider.advance(by: 0.05)
+            parser.processKeyPress(GCKeyCode.two)
+            parser.processKeyPress(GCKeyCode.three)
+            parser.processKeyPress(GCKeyCode.returnOrEnter)
+
+            // Then
+            #expect(results.count == 1)
+            if case .failure(let error, let duration) = results.first {
+                if case .scanTooShort(let barcode) = error {
+                    #expect(barcode == "123")
+                    #expect(duration == 50)
+                } else {
+                    Issue.record("Expected scanTooShort error")
+                }
+            } else {
+                Issue.record("Expected failed scan with duration")
+            }
+        }
+
         @Test("empty scan with only terminator is ignored")
         func emptyBuffer_whenTerminatorSent_isIgnored() {
             // Given
-            var results: [Result<String, Error>] = []
+            var results: [HIDBarcodeParserResult] = []
             let parser = GameControllerBarcodeParser(
                 configuration: Self.testConfiguration,
                 onScan: { results.append($0) }
@@ -325,7 +394,7 @@ struct GameControllerBarcodeParserTests {
         @Test("modifier keys are excluded from scan input")
         func modifierKeys_whenPressed_areExcludedFromScanInput() {
             // Given
-            var results: [Result<String, Error>] = []
+            var results: [HIDBarcodeParserResult] = []
             let parser = GameControllerBarcodeParser(
                 configuration: Self.testConfiguration,
                 onScan: { results.append($0) }
@@ -343,7 +412,7 @@ struct GameControllerBarcodeParserTests {
 
             // Then
             #expect(results.count == 1)
-            if case .success(let barcode) = results.first {
+            if case .success(let barcode, _) = results.first {
                 #expect(barcode == "123")
             } else {
                 Issue.record("Expected successful scan ignoring modifier keys")
@@ -353,7 +422,7 @@ struct GameControllerBarcodeParserTests {
         @Test("arrow keys are excluded from scan input")
         func arrowKeys_whenPressed_areExcludedFromScanInput() {
             // Given
-            var results: [Result<String, Error>] = []
+            var results: [HIDBarcodeParserResult] = []
             let parser = GameControllerBarcodeParser(
                 configuration: Self.testConfiguration,
                 onScan: { results.append($0) }
@@ -370,7 +439,7 @@ struct GameControllerBarcodeParserTests {
 
             // Then
             #expect(results.count == 1)
-            if case .success(let barcode) = results.first {
+            if case .success(let barcode, _) = results.first {
                 #expect(barcode == "123")
             } else {
                 Issue.record("Expected successful scan ignoring arrow keys")
@@ -380,7 +449,7 @@ struct GameControllerBarcodeParserTests {
         @Test("function and system keys are excluded from scan input")
         func systemKeys_whenPressed_areExcludedFromScanInput() {
             // Given
-            var results: [Result<String, Error>] = []
+            var results: [HIDBarcodeParserResult] = []
             let parser = GameControllerBarcodeParser(
                 configuration: Self.testConfiguration,
                 onScan: { results.append($0) }
@@ -398,7 +467,7 @@ struct GameControllerBarcodeParserTests {
 
             // Then
             #expect(results.count == 1)
-            if case .success(let barcode) = results.first {
+            if case .success(let barcode, _) = results.first {
                 #expect(barcode == "123")
             } else {
                 Issue.record("Expected successful scan ignoring system keys")
@@ -408,7 +477,7 @@ struct GameControllerBarcodeParserTests {
         @Test("navigation keys are excluded from scan input")
         func navigationKeys_whenPressed_areExcludedFromScanInput() {
             // Given
-            var results: [Result<String, Error>] = []
+            var results: [HIDBarcodeParserResult] = []
             let parser = GameControllerBarcodeParser(
                 configuration: Self.testConfiguration,
                 onScan: { results.append($0) }
@@ -427,7 +496,7 @@ struct GameControllerBarcodeParserTests {
 
             // Then
             #expect(results.count == 1)
-            if case .success(let barcode) = results.first {
+            if case .success(let barcode, _) = results.first {
                 #expect(barcode == "123")
             } else {
                 Issue.record("Expected successful scan ignoring navigation keys")
@@ -448,7 +517,7 @@ struct GameControllerBarcodeParserTests {
         @Test("carriage return terminates scan")
         func carriageReturn_whenPressed_terminatesScan() {
             // Given
-            var results: [Result<String, Error>] = []
+            var results: [HIDBarcodeParserResult] = []
             let parser = GameControllerBarcodeParser(
                 configuration: Self.testConfiguration,
                 onScan: { results.append($0) }
@@ -462,7 +531,7 @@ struct GameControllerBarcodeParserTests {
 
             // Then
             #expect(results.count == 1)
-            if case .success(let barcode) = results.first {
+            if case .success(let barcode, _) = results.first {
                 #expect(barcode == "123")
             } else {
                 Issue.record("Expected successful scan with carriage return")
@@ -472,7 +541,7 @@ struct GameControllerBarcodeParserTests {
         @Test("multiple terminating strings work correctly")
         func multipleTerminators_whenConfigured_workCorrectly() {
             // Given
-            var results: [Result<String, Error>] = []
+            var results: [HIDBarcodeParserResult] = []
             let configuration = HIDBarcodeParserConfiguration(
                 terminatingStrings: ["\r", "\n", "\t", " "],
                 minimumBarcodeLength: 3,
@@ -504,17 +573,17 @@ struct GameControllerBarcodeParserTests {
 
             // Then
             #expect(results.count == 3)
-            if case .success(let barcode1) = results[0] {
+            if case .success(let barcode1, _) = results[0] {
                 #expect(barcode1 == "123")
             } else {
                 Issue.record("Expected first scan to succeed")
             }
-            if case .success(let barcode2) = results[1] {
+            if case .success(let barcode2, _) = results[1] {
                 #expect(barcode2 == "456")
             } else {
                 Issue.record("Expected second scan to succeed")
             }
-            if case .success(let barcode3) = results[2] {
+            if case .success(let barcode3, _) = results[2] {
                 #expect(barcode3 == "789")
             } else {
                 Issue.record("Expected third scan to succeed")
@@ -524,7 +593,7 @@ struct GameControllerBarcodeParserTests {
         @Test("terminator at start of empty buffer is ignored")
         func emptyBuffer_whenTerminatorPressed_isIgnored() {
             // Given
-            var results: [Result<String, Error>] = []
+            var results: [HIDBarcodeParserResult] = []
             let parser = GameControllerBarcodeParser(
                 configuration: Self.testConfiguration,
                 onScan: { results.append($0) }
@@ -542,7 +611,7 @@ struct GameControllerBarcodeParserTests {
         @Test("terminator in middle of scan is included in barcode")
         func nonTerminatorCharacter_whenPressed_isIncludedInBarcode() {
             // Given
-            var results: [Result<String, Error>] = []
+            var results: [HIDBarcodeParserResult] = []
             let configuration = HIDBarcodeParserConfiguration(
                 terminatingStrings: ["\n"], // Only newline terminates
                 minimumBarcodeLength: 3,
@@ -567,7 +636,7 @@ struct GameControllerBarcodeParserTests {
         @Test("parser does not start a timeout for an ignored character")
         func emptyBuffer_whenIgnoredCharacterPressed_doesNotStartTimeout() {
             // Given
-            var results: [Result<String, Error>] = []
+            var results: [HIDBarcodeParserResult] = []
             let mockTimeProvider = MockTimeProvider()
             let parser = GameControllerBarcodeParser(
                 configuration: Self.testConfiguration,
@@ -594,12 +663,12 @@ struct GameControllerBarcodeParserTests {
 
             // Then
             #expect(results.count == 2)
-            if case .success(let barcode1) = results[0] {
+            if case .success(let barcode1, _) = results[0] {
                 #expect(barcode1 == "123")
             } else {
                 Issue.record("Expected success result for first scan")
             }
-            if case .success(let barcode2) = results[1] {
+            if case .success(let barcode2, _) = results[1] {
                 #expect(barcode2 == "456")
             } else {
                 Issue.record("Expected success result for second scan")

--- a/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/MockTimeProvider.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanning/MockTimeProvider.swift
@@ -4,7 +4,7 @@ import Foundation
 final class MockTimeProvider: TimeProvider {
     private var currentTime: Date
 
-    init(startTime: Date = Date()) {
+    init(startTime: Date = Date(timeIntervalSince1970: 0)) {
         self.currentTime = startTime
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Context: pdfdoF-7wE-p2
WOOMOB-691

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing "See original issue" – clarify what the problem was and how you've fixed it. -->

Adds barcode scanning analytics events for POS to track scan performance. Implements `pos_barcode_scanning_success` and `pos_barcode_scanning_failed` events with scan duration and barcode length properties.

## Registered events

- https://github.com/Automattic/tracks-events-registration/pull/3015
- https://github.com/Automattic/tracks-events-registration/pull/3016

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and open POS
2. Connect a barcode scanner
3. Scan a valid barcode
4. Check logs and confirm `pos_barcode_scanned` is tracked with `scan_duration_ms` and `barcode_length`
5. Scan a too short barcode
6. Check logs and confirm `pos_barcode_scanning_failed` is tracked with `scan_duration_ms`, `barcode_length`, and `fail_reason` = `too_short`
7. Disable terminating character in the scanner settings
8. Scan two barcodes
9. Check logs and confirm `pos_barcode_scanning_failed` is tracked with `scan_duration_ms`, `barcode_length`, and `fail_reason` = `no_terminator`

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air M2 26 with Inateck scanner

- Test successful scans produce `pos_barcode_scanning_success` with `scan_duration_ms` and `barcode_length`
- Test failed scans produce `pos_barcode_scanning_failed` with `fail_reason` (`too_short` or `no_terminator`)
- Test scan timing accuracy with various scan speeds
- Unit tests verify timing calculations

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.