### PR TITLE
[Woo POS][Barcodes] Set up flow test failure screen

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlow.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlow.swift
@@ -140,7 +140,7 @@ class PointOfSaleBarcodeScannerSetupFlow {
                     buttonCustomization: PointOfSaleBarcodeScannerBackOnlyButtonCustomization(),
                     transitions: [
                         .next: .complete,
-                        .error: .error,
+                        .error: .testFailed,
                         .back: .pairing
                     ]
                 ),
@@ -151,8 +151,7 @@ class PointOfSaleBarcodeScannerSetupFlow {
                     transitions: [
                         .back: .test
                     ]),
-                .error: PointOfSaleBarcodeScannerSetupStep(
-                    title: "Test Failed",
+                .testFailed: PointOfSaleBarcodeScannerSetupStep(
                     content: {
                         PointOfSaleBarcodeScannerErrorView()
                     },

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlow.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlow.swift
@@ -7,9 +7,6 @@ class PointOfSaleBarcodeScannerSetupFlow {
     private let scannerType: PointOfSaleBarcodeScannerType
     private let onComplete: () -> Void
     private let onBackToSelection: () -> Void
-    private var currentStepIndex: Int = 0
-    private var steps: [PointOfSaleBarcodeScannerSetupStep] = []
-    private var stepHistory: [Int] = []
     private var flowSteps: [PointOfSaleBarcodeScannerStepID: PointOfSaleBarcodeScannerSetupStep] = [:]
     private var currentStepKey: PointOfSaleBarcodeScannerStepID = .start
 
@@ -35,31 +32,18 @@ class PointOfSaleBarcodeScannerSetupFlow {
     }
 
     func nextStep() {
-        transition(to: .next) { [weak self] in
-            // Default behavior: move to next step in array
-            if self?.currentStepIndex ?? 0 < (self?.steps.count ?? 0) - 1 {
-                self?.stepHistory.append(self?.currentStepIndex ?? 0)
-                self?.currentStepIndex = (self?.currentStepIndex ?? 0) + 1
-            } else {
-                self?.onComplete()
-            }
-        }
+        transition(to: .next)
     }
 
     func previousStep() {
         transition(to: .back) { [weak self] in
-            // Default behavior: go back to previous step in history
-            if let previousIndex = self?.stepHistory.popLast() {
-                self?.currentStepIndex = previousIndex
-            } else {
-                self?.onBackToSelection()
-            }
+            // If no back transition is defined, go back to selection
+            self?.onBackToSelection()
         }
     }
 
     func restartFlow() {
         currentStepKey = .start
-        stepHistory.removeAll()
     }
 
     // MARK: - Generic Transition Methods
@@ -108,12 +92,7 @@ class PointOfSaleBarcodeScannerSetupFlow {
             return
         }
 
-        transitionToStep(transition.to)
-    }
-
-    private func transitionToStep(_ newStepKey: PointOfSaleBarcodeScannerStepID) {
-        stepHistory.append(currentStepIndex)
-        currentStepKey = newStepKey
+        currentStepKey = transition.to
     }
 
     private func createFlowSteps(for scannerType: PointOfSaleBarcodeScannerType) -> [PointOfSaleBarcodeScannerStepID: PointOfSaleBarcodeScannerSetupStep] {
@@ -141,7 +120,8 @@ class PointOfSaleBarcodeScannerSetupFlow {
                         PointOfSaleBarcodeScannerPairingView(scanner: scannerType)
                     },
                     transitions: [
-                        .next: PointOfSaleBarcodeScannerTransition(to: .test, type: .next)
+                        .next: PointOfSaleBarcodeScannerTransition(to: .test, type: .next),
+                        .back: PointOfSaleBarcodeScannerTransition(to: .start, type: .back)
                     ]
                 ),
                 .test: PointOfSaleBarcodeScannerSetupStep(
@@ -160,7 +140,8 @@ class PointOfSaleBarcodeScannerSetupFlow {
                     buttonCustomization: PointOfSaleBarcodeScannerBackOnlyButtonCustomization(),
                     transitions: [
                         .next: PointOfSaleBarcodeScannerTransition(to: .complete, type: .next),
-                        .error: PointOfSaleBarcodeScannerTransition(to: .error, type: .error)
+                        .error: PointOfSaleBarcodeScannerTransition(to: .error, type: .error),
+                        .back: PointOfSaleBarcodeScannerTransition(to: .pairing, type: .back)
                     ]
                 ),
                 .complete: PointOfSaleBarcodeScannerSetupStep(
@@ -168,8 +149,7 @@ class PointOfSaleBarcodeScannerSetupFlow {
                         PointOfSaleBarcodeScannerSetupCompleteView()
                     },
                     transitions: [
-                        .back: PointOfSaleBarcodeScannerTransition(to: .test, type: .back),
-                        .next: PointOfSaleBarcodeScannerTransition(to: .complete, type: .next)
+                        .back: PointOfSaleBarcodeScannerTransition(to: .test, type: .back)
                     ]),
                 .error: PointOfSaleBarcodeScannerSetupStep(
                     title: "Test Failed",

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlow.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlow.swift
@@ -158,8 +158,8 @@ class PointOfSaleBarcodeScannerSetupFlow {
                     },
                     buttonCustomization: PointOfSaleBarcodeScannerErrorButtonCustomization(),
                     transitions: [
-                        .retry: .test,
-                        .back: .pairing
+                        .retry: .start,
+                        .back: .test
                     ]
                 )
                 // TODO: Add optional error step and documentation step for Star BSH-20B WOOMOB-696

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlow.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlow.swift
@@ -8,7 +8,10 @@ class PointOfSaleBarcodeScannerSetupFlow {
     private let onComplete: () -> Void
     private let onBackToSelection: () -> Void
     private var currentStepIndex: Int = 0
+    private var steps: [PointOfSaleBarcodeScannerSetupStep] = []
     private var stepHistory: [Int] = []
+    private var flowSteps: [PointOfSaleBarcodeScannerStepID: PointOfSaleBarcodeScannerSetupStep] = [:]
+    private var currentStepKey: PointOfSaleBarcodeScannerStepID = .start
 
     init(scannerType: PointOfSaleBarcodeScannerType,
          onComplete: @escaping () -> Void,
@@ -16,14 +19,15 @@ class PointOfSaleBarcodeScannerSetupFlow {
         self.scannerType = scannerType
         self.onComplete = onComplete
         self.onBackToSelection = onBackToSelection
+        self.flowSteps = createFlowSteps(for: scannerType)
     }
 
     var currentStep: PointOfSaleBarcodeScannerSetupStep? {
-        steps[safe: currentStepIndex]
+        flowSteps[currentStepKey]
     }
 
     var isComplete: Bool {
-        currentStepIndex >= steps.count - 1
+        currentStepKey == .complete
     }
 
     var nextButtonTitle: String {
@@ -54,7 +58,7 @@ class PointOfSaleBarcodeScannerSetupFlow {
     }
 
     func restartFlow() {
-        currentStepIndex = 0
+        currentStepKey = .start
         stepHistory.removeAll()
     }
 
@@ -79,7 +83,11 @@ class PointOfSaleBarcodeScannerSetupFlow {
             primaryButton: PointOfSaleFlowButtonConfiguration.ButtonConfig(
                 title: nextButtonTitle,
                 action: { [weak self] in
-                    self?.nextStep()
+                    if self?.isComplete == true {
+                        self?.onComplete()
+                    } else {
+                        self?.nextStep()
+                    }
                 }
             ),
             secondaryButton: PointOfSaleFlowButtonConfiguration.ButtonConfig(
@@ -103,26 +111,21 @@ class PointOfSaleBarcodeScannerSetupFlow {
         transitionToStep(transition.to)
     }
 
-    private func transitionToStep(_ newStepIndex: Int) {
+    private func transitionToStep(_ newStepKey: PointOfSaleBarcodeScannerStepID) {
         stepHistory.append(currentStepIndex)
-        currentStepIndex = newStepIndex
-
-        // If we're completing the flow, call the completion handler
-        if newStepIndex > steps.count - 1 {
-            onComplete()
-        }
+        currentStepKey = newStepKey
     }
 
-    private var steps: [PointOfSaleBarcodeScannerSetupStep] {
+    private func createFlowSteps(for scannerType: PointOfSaleBarcodeScannerType) -> [PointOfSaleBarcodeScannerStepID: PointOfSaleBarcodeScannerSetupStep] {
         switch scannerType {
         case .socketS720:
             return [
-                createWelcomeStep(title: "Socket S720 Setup")
+                .start: createWelcomeStep(title: "Socket S720 Setup")
                 // TODO: Add more steps for Socket S720 WOOMOB-698
             ]
         case .starBSH20B:
             return [
-                PointOfSaleBarcodeScannerSetupStep(
+                .start: PointOfSaleBarcodeScannerSetupStep(
                     content: {
                         PointOfSaleBarcodeScannerBarcodeView(
                             title: String(format: Localization.starSetUpBarcodeStepTitleFormat, scannerType.name),
@@ -130,18 +133,18 @@ class PointOfSaleBarcodeScannerSetupFlow {
                             barcode: .starBsh20SetupBarcode)
                     },
                     transitions: [
-                        .next: PointOfSaleBarcodeScannerTransition(to: 1, type: .next)
+                        .next: PointOfSaleBarcodeScannerTransition(to: .pairing, type: .next)
                     ]
                 ),
-                PointOfSaleBarcodeScannerSetupStep(
+                .pairing: PointOfSaleBarcodeScannerSetupStep(
                     content: {
                         PointOfSaleBarcodeScannerPairingView(scanner: scannerType)
                     },
                     transitions: [
-                        .next: PointOfSaleBarcodeScannerTransition(to: 2, type: .next)
+                        .next: PointOfSaleBarcodeScannerTransition(to: .test, type: .next)
                     ]
                 ),
-                PointOfSaleBarcodeScannerSetupStep(
+                .test: PointOfSaleBarcodeScannerSetupStep(
                     content: {
                         PointOfSaleBarcodeScannerTestBarcodeView(
                             scanTester: PointOfSaleBarcodeScannerSetupScanTester(
@@ -156,36 +159,39 @@ class PointOfSaleBarcodeScannerSetupFlow {
                     },
                     buttonCustomization: PointOfSaleBarcodeScannerBackOnlyButtonCustomization(),
                     transitions: [
-                        .next: PointOfSaleBarcodeScannerTransition(to: 3, type: .next),
-                        .error: PointOfSaleBarcodeScannerTransition(to: 4, type: .error)
+                        .next: PointOfSaleBarcodeScannerTransition(to: .complete, type: .next),
+                        .error: PointOfSaleBarcodeScannerTransition(to: .error, type: .error)
                     ]
                 ),
-                PointOfSaleBarcodeScannerSetupStep(
+                .complete: PointOfSaleBarcodeScannerSetupStep(
                     content: {
                         PointOfSaleBarcodeScannerSetupCompleteView()
-                    }),
-                // Error step
-                PointOfSaleBarcodeScannerSetupStep(
+                    },
+                    transitions: [
+                        .back: PointOfSaleBarcodeScannerTransition(to: .test, type: .back),
+                        .next: PointOfSaleBarcodeScannerTransition(to: .complete, type: .next)
+                    ]),
+                .error: PointOfSaleBarcodeScannerSetupStep(
                     title: "Test Failed",
                     content: {
                         PointOfSaleBarcodeScannerErrorView()
                     },
                     buttonCustomization: PointOfSaleBarcodeScannerErrorButtonCustomization(),
                     transitions: [
-                        .retry: PointOfSaleBarcodeScannerTransition(to: 2, type: .retry),
-                        .back: PointOfSaleBarcodeScannerTransition(to: 1, type: .back)
+                        .retry: PointOfSaleBarcodeScannerTransition(to: .test, type: .retry),
+                        .back: PointOfSaleBarcodeScannerTransition(to: .pairing, type: .back)
                     ]
                 )
                 // TODO: Add optional error step and documentation step for Star BSH-20B WOOMOB-696
             ]
         case .tbcScanner:
             return [
-                createWelcomeStep(title: "TBC Scanner Setup")
+                .start: createWelcomeStep(title: "TBC Scanner Setup")
                 // TODO: Add more steps for TBC Scanner WOOMOB-699
             ]
         case .other:
             return [
-                PointOfSaleBarcodeScannerSetupStep(
+                .start: PointOfSaleBarcodeScannerSetupStep(
                     title: "General Scanner Setup",
                     content: { BarcodeScannerInformationContent() }
                 )

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlow.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlow.swift
@@ -8,6 +8,7 @@ class PointOfSaleBarcodeScannerSetupFlow {
     private let onComplete: () -> Void
     private let onBackToSelection: () -> Void
     private var currentStepIndex: Int = 0
+    private var stepHistory: [Int] = []
 
     init(scannerType: PointOfSaleBarcodeScannerType,
          onComplete: @escaping () -> Void,
@@ -30,23 +31,37 @@ class PointOfSaleBarcodeScannerSetupFlow {
     }
 
     func nextStep() {
-        if currentStepIndex < steps.count - 1 {
-            currentStepIndex += 1
-        } else {
-            onComplete()
+        transition(to: .next) { [weak self] in
+            // Default behavior: move to next step in array
+            if self?.currentStepIndex ?? 0 < (self?.steps.count ?? 0) - 1 {
+                self?.stepHistory.append(self?.currentStepIndex ?? 0)
+                self?.currentStepIndex = (self?.currentStepIndex ?? 0) + 1
+            } else {
+                self?.onComplete()
+            }
         }
     }
 
     func previousStep() {
-        if currentStepIndex > 0 {
-            currentStepIndex -= 1
-        } else {
-            onBackToSelection()
+        transition(to: .back) { [weak self] in
+            // Default behavior: go back to previous step in history
+            if let previousIndex = self?.stepHistory.popLast() {
+                self?.currentStepIndex = previousIndex
+            } else {
+                self?.onBackToSelection()
+            }
         }
     }
 
     func restartFlow() {
         currentStepIndex = 0
+        stepHistory.removeAll()
+    }
+
+    // MARK: - Generic Transition Methods
+
+    func transition(to transitionType: PointOfSaleBarcodeScannerTransitionType) {
+        self.transition(to: transitionType, fallback: nil)
     }
 
     func getButtonConfiguration() -> PointOfSaleFlowButtonConfiguration {
@@ -76,6 +91,28 @@ class PointOfSaleBarcodeScannerSetupFlow {
         )
     }
 
+    // MARK: - Private Methods
+
+    private func transition(to transitionType: PointOfSaleBarcodeScannerTransitionType, fallback: (() -> Void)? = nil) {
+        guard let currentStep = currentStep,
+              let transition = currentStep.transitions[transitionType] else {
+            fallback?()
+            return
+        }
+
+        transitionToStep(transition.to)
+    }
+
+    private func transitionToStep(_ newStepIndex: Int) {
+        stepHistory.append(currentStepIndex)
+        currentStepIndex = newStepIndex
+
+        // If we're completing the flow, call the completion handler
+        if newStepIndex > steps.count - 1 {
+            onComplete()
+        }
+    }
+
     private var steps: [PointOfSaleBarcodeScannerSetupStep] {
         switch scannerType {
         case .socketS720:
@@ -85,15 +122,25 @@ class PointOfSaleBarcodeScannerSetupFlow {
             ]
         case .starBSH20B:
             return [
-                PointOfSaleBarcodeScannerSetupStep(content: {
-                    PointOfSaleBarcodeScannerBarcodeView(
-                        title: String(format: Localization.starSetUpBarcodeStepTitleFormat, scannerType.name),
-                        instruction: Localization.setUpBarcodeStepInstruction,
-                        barcode: .starBsh20SetupBarcode)
-                }),
-                PointOfSaleBarcodeScannerSetupStep(content: {
-                    PointOfSaleBarcodeScannerPairingView(scanner: scannerType)
-                }),
+                PointOfSaleBarcodeScannerSetupStep(
+                    content: {
+                        PointOfSaleBarcodeScannerBarcodeView(
+                            title: String(format: Localization.starSetUpBarcodeStepTitleFormat, scannerType.name),
+                            instruction: Localization.setUpBarcodeStepInstruction,
+                            barcode: .starBsh20SetupBarcode)
+                    },
+                    transitions: [
+                        .next: PointOfSaleBarcodeScannerTransition(to: 1, type: .next)
+                    ]
+                ),
+                PointOfSaleBarcodeScannerSetupStep(
+                    content: {
+                        PointOfSaleBarcodeScannerPairingView(scanner: scannerType)
+                    },
+                    transitions: [
+                        .next: PointOfSaleBarcodeScannerTransition(to: 2, type: .next)
+                    ]
+                ),
                 PointOfSaleBarcodeScannerSetupStep(
                     content: {
                         PointOfSaleBarcodeScannerTestBarcodeView(
@@ -101,16 +148,34 @@ class PointOfSaleBarcodeScannerSetupFlow {
                                 onTestPass: { [weak self] in
                                     self?.nextStep()
                                 },
-                                onTestFailure: {},
+                                onTestFailure: { [weak self] in
+                                    self?.transition(to: .error)
+                                },
                                 barcodeDefinition: .ean13)
                         )
                     },
-                    buttonCustomization: PointOfSaleBarcodeScannerBackOnlyButtonCustomization()
+                    buttonCustomization: PointOfSaleBarcodeScannerBackOnlyButtonCustomization(),
+                    transitions: [
+                        .next: PointOfSaleBarcodeScannerTransition(to: 3, type: .next),
+                        .error: PointOfSaleBarcodeScannerTransition(to: 4, type: .error)
+                    ]
                 ),
                 PointOfSaleBarcodeScannerSetupStep(
                     content: {
                         PointOfSaleBarcodeScannerSetupCompleteView()
-                    })
+                    }),
+                // Error step
+                PointOfSaleBarcodeScannerSetupStep(
+                    title: "Test Failed",
+                    content: {
+                        PointOfSaleBarcodeScannerErrorView()
+                    },
+                    buttonCustomization: PointOfSaleBarcodeScannerErrorButtonCustomization(),
+                    transitions: [
+                        .retry: PointOfSaleBarcodeScannerTransition(to: 2, type: .retry),
+                        .back: PointOfSaleBarcodeScannerTransition(to: 1, type: .back)
+                    ]
+                )
                 // TODO: Add optional error step and documentation step for Star BSH-20B WOOMOB-696
             ]
         case .tbcScanner:
@@ -154,6 +219,35 @@ struct PointOfSaleBarcodeScannerBackOnlyButtonCustomization: PointOfSaleBarcodeS
             "pos.barcodeScannerSetup.back.button.title",
             value: "Back",
             comment: "Title for the back button in barcode scanner setup navigation"
+        )
+    }
+}
+
+@available(iOS 17.0, *)
+struct PointOfSaleBarcodeScannerErrorButtonCustomization: PointOfSaleBarcodeScannerButtonCustomization {
+    func customizeButtons(for flow: PointOfSaleBarcodeScannerSetupFlow) -> PointOfSaleFlowButtonConfiguration {
+        return PointOfSaleFlowButtonConfiguration(
+            primaryButton: PointOfSaleFlowButtonConfiguration.ButtonConfig(
+                title: Localization.retryButtonTitle,
+                action: { flow.transition(to: .retry) }
+            ),
+            secondaryButton: PointOfSaleFlowButtonConfiguration.ButtonConfig(
+                title: Localization.backButtonTitle,
+                action: { flow.transition(to: .back) }
+            )
+        )
+    }
+
+    private enum Localization {
+        static let retryButtonTitle = NSLocalizedString(
+            "pos.barcodeScannerSetup.error.retry.button.title",
+            value: "Retry",
+            comment: "Title for the retry button in barcode scanner setup error step"
+        )
+        static let backButtonTitle = NSLocalizedString(
+            "pos.barcodeScannerSetup.error.back.button.title",
+            value: "Back",
+            comment: "Title for the back button in barcode scanner setup error step"
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlow.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlow.swift
@@ -87,12 +87,12 @@ class PointOfSaleBarcodeScannerSetupFlow {
 
     private func transition(to transitionType: PointOfSaleBarcodeScannerTransitionType, fallback: (() -> Void)? = nil) {
         guard let currentStep = currentStep,
-              let transition = currentStep.transitions[transitionType] else {
+              let targetStep = currentStep.transitions[transitionType] else {
             fallback?()
             return
         }
 
-        currentStepKey = transition.to
+        currentStepKey = targetStep
     }
 
     private func createFlowSteps(for scannerType: PointOfSaleBarcodeScannerType) -> [PointOfSaleBarcodeScannerStepID: PointOfSaleBarcodeScannerSetupStep] {
@@ -112,7 +112,7 @@ class PointOfSaleBarcodeScannerSetupFlow {
                             barcode: .starBsh20SetupBarcode)
                     },
                     transitions: [
-                        .next: PointOfSaleBarcodeScannerTransition(to: .pairing, type: .next)
+                        .next: .pairing
                     ]
                 ),
                 .pairing: PointOfSaleBarcodeScannerSetupStep(
@@ -120,8 +120,8 @@ class PointOfSaleBarcodeScannerSetupFlow {
                         PointOfSaleBarcodeScannerPairingView(scanner: scannerType)
                     },
                     transitions: [
-                        .next: PointOfSaleBarcodeScannerTransition(to: .test, type: .next),
-                        .back: PointOfSaleBarcodeScannerTransition(to: .start, type: .back)
+                        .next: .test,
+                        .back: .start
                     ]
                 ),
                 .test: PointOfSaleBarcodeScannerSetupStep(
@@ -139,9 +139,9 @@ class PointOfSaleBarcodeScannerSetupFlow {
                     },
                     buttonCustomization: PointOfSaleBarcodeScannerBackOnlyButtonCustomization(),
                     transitions: [
-                        .next: PointOfSaleBarcodeScannerTransition(to: .complete, type: .next),
-                        .error: PointOfSaleBarcodeScannerTransition(to: .error, type: .error),
-                        .back: PointOfSaleBarcodeScannerTransition(to: .pairing, type: .back)
+                        .next: .complete,
+                        .error: .error,
+                        .back: .pairing
                     ]
                 ),
                 .complete: PointOfSaleBarcodeScannerSetupStep(
@@ -149,7 +149,7 @@ class PointOfSaleBarcodeScannerSetupFlow {
                         PointOfSaleBarcodeScannerSetupCompleteView()
                     },
                     transitions: [
-                        .back: PointOfSaleBarcodeScannerTransition(to: .test, type: .back)
+                        .back: .test
                     ]),
                 .error: PointOfSaleBarcodeScannerSetupStep(
                     title: "Test Failed",
@@ -158,8 +158,8 @@ class PointOfSaleBarcodeScannerSetupFlow {
                     },
                     buttonCustomization: PointOfSaleBarcodeScannerErrorButtonCustomization(),
                     transitions: [
-                        .retry: PointOfSaleBarcodeScannerTransition(to: .test, type: .retry),
-                        .back: PointOfSaleBarcodeScannerTransition(to: .pairing, type: .back)
+                        .retry: .test,
+                        .back: .pairing
                     ]
                 )
                 // TODO: Add optional error step and documentation step for Star BSH-20B WOOMOB-696

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupModels.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupModels.swift
@@ -52,7 +52,7 @@ enum PointOfSaleBarcodeScannerStepID: String, CaseIterable {
     case pairing
     case test
     case complete
-    case error
+    case testFailed
     case information
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupModels.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupModels.swift
@@ -50,21 +50,42 @@ protocol PointOfSaleBarcodeScannerButtonCustomization {
     func customizeButtons(for flow: PointOfSaleBarcodeScannerSetupFlow) -> PointOfSaleFlowButtonConfiguration
 }
 
+// MARK: - Transition Types
+enum PointOfSaleBarcodeScannerTransitionType: Hashable {
+    case next
+    case error
+    case retry
+    case back
+}
+
+// MARK: - Transition Definition
+struct PointOfSaleBarcodeScannerTransition {
+    let to: Int // Index of the target step
+    let type: PointOfSaleBarcodeScannerTransitionType
+
+    init(to: Int, type: PointOfSaleBarcodeScannerTransitionType = .next) {
+        self.to = to
+        self.type = type
+    }
+}
+
 // MARK: - Setup Step
 @available(iOS 17.0, *)
 struct PointOfSaleBarcodeScannerSetupStep {
     let title: String
     let content: any View
     let buttonCustomization: PointOfSaleBarcodeScannerButtonCustomization?
+    let transitions: [PointOfSaleBarcodeScannerTransitionType: PointOfSaleBarcodeScannerTransition]
 
     init(
         title: String = "",
         @ViewBuilder content: () -> any View,
-        buttonCustomization: PointOfSaleBarcodeScannerButtonCustomization? = nil
-    ) {
+        buttonCustomization: PointOfSaleBarcodeScannerButtonCustomization? = nil,
+        transitions: [PointOfSaleBarcodeScannerTransitionType: PointOfSaleBarcodeScannerTransition] = [:]) {
         self.title = title
         self.content = content()
         self.buttonCustomization = buttonCustomization
+        self.transitions = transitions
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupModels.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupModels.swift
@@ -70,30 +70,18 @@ enum PointOfSaleBarcodeScannerTransitionType: Hashable {
     case back
 }
 
-// MARK: - Transition Definition
-struct PointOfSaleBarcodeScannerTransition {
-    let to: PointOfSaleBarcodeScannerStepID
-    let type: PointOfSaleBarcodeScannerTransitionType
-
-    init(to: PointOfSaleBarcodeScannerStepID, type: PointOfSaleBarcodeScannerTransitionType = .next) {
-        self.to = to
-        self.type = type
-    }
-}
-
 // MARK: - Setup Step
 @available(iOS 17.0, *)
 struct PointOfSaleBarcodeScannerSetupStep {
     let title: String
     let content: any View
     let buttonCustomization: PointOfSaleBarcodeScannerButtonCustomization?
-    let transitions: [PointOfSaleBarcodeScannerTransitionType: PointOfSaleBarcodeScannerTransition]
+    let transitions: [PointOfSaleBarcodeScannerTransitionType: PointOfSaleBarcodeScannerStepID]
 
-    init(
-        title: String = "",
-        @ViewBuilder content: () -> any View,
-        buttonCustomization: PointOfSaleBarcodeScannerButtonCustomization? = nil,
-        transitions: [PointOfSaleBarcodeScannerTransitionType: PointOfSaleBarcodeScannerTransition] = [:]) {
+    init(title: String = "",
+         @ViewBuilder content: () -> any View,
+         buttonCustomization: PointOfSaleBarcodeScannerButtonCustomization? = nil,
+         transitions: [PointOfSaleBarcodeScannerTransitionType: PointOfSaleBarcodeScannerStepID] = [:]) {
         self.title = title
         self.content = content()
         self.buttonCustomization = buttonCustomization

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupModels.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupModels.swift
@@ -44,6 +44,18 @@ enum PointOfSaleBarcodeScannerSetupFlowState {
     case setupFlow(PointOfSaleBarcodeScannerType)
 }
 
+// MARK: - Step Identifiers
+enum PointOfSaleBarcodeScannerStepID: String, CaseIterable {
+    case start
+    case setupBarcode1
+    case setupBarcode2
+    case pairing
+    case test
+    case complete
+    case error
+    case information
+}
+
 // MARK: - Button Customization Protocol
 @available(iOS 17.0, *)
 protocol PointOfSaleBarcodeScannerButtonCustomization {
@@ -60,10 +72,10 @@ enum PointOfSaleBarcodeScannerTransitionType: Hashable {
 
 // MARK: - Transition Definition
 struct PointOfSaleBarcodeScannerTransition {
-    let to: Int // Index of the target step
+    let to: PointOfSaleBarcodeScannerStepID
     let type: PointOfSaleBarcodeScannerTransitionType
 
-    init(to: Int, type: PointOfSaleBarcodeScannerTransitionType = .next) {
+    init(to: PointOfSaleBarcodeScannerStepID, type: PointOfSaleBarcodeScannerTransitionType = .next) {
         self.to = to
         self.type = type
     }

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupStepViews.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupStepViews.swift
@@ -173,6 +173,40 @@ private extension PointOfSaleBarcodeScannerSetupCompleteView {
     }
 }
 
+struct PointOfSaleBarcodeScannerErrorView: View {
+    var body: some View {
+        VStack(spacing: POSSpacing.xLarge) {
+            // Error icon
+            errorIcon
+                .accessibilityHidden(true)
+
+            VStack(alignment: .center, spacing: POSSpacing.small) {
+                Text(Localization.title)
+                    .font(.posHeadingBold)
+                    .foregroundColor(.posOnSurface)
+                    .accessibilityAddTraits(.isHeader)
+
+                Text(Localization.instruction)
+                    .font(.posBodyMediumRegular())
+                    .foregroundColor(.posOnSurfaceVariantHighest)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .padding(POSSpacing.xLarge)
+    }
+
+    private var errorIcon: some View {
+        Image(systemName: "exclamationmark.triangle.fill")
+            .font(.system(size: 60))
+            .foregroundColor(.orange)
+    }
+
+    private enum Localization {
+        static let title = "Test Failed"
+        static let instruction = "The barcode test was unsuccessful. Please check your scanner connection and try again."
+    }
+}
+
 // MARK: - Button Customizations
 @available(iOS 17.0, *)
 struct PointOfSaleBarcodeScannerWelcomeButtonCustomization: PointOfSaleBarcodeScannerButtonCustomization {

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupStepViews.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupStepViews.swift
@@ -32,7 +32,7 @@ struct PointOfSaleBarcodeScannerBarcodeView: View {
                     .accessibilityAddTraits(.isHeader)
 
                 Text(instruction)
-                    .font(.posBodyMediumRegular())
+                    .font(.posBodyLargeRegular())
                     .foregroundColor(.posOnSurfaceVariantHighest)
                     .multilineTextAlignment(.center)
             }
@@ -59,7 +59,7 @@ struct PointOfSaleBarcodeScannerPairingView: View {
                     .accessibilityAddTraits(.isHeader)
 
                 Text(instruction)
-                    .font(.posBodyMediumRegular())
+                    .font(.posBodyLargeRegular())
                     .foregroundColor(.posOnSurfaceVariantHighest)
                     .multilineTextAlignment(.center)
             }
@@ -143,7 +143,7 @@ struct PointOfSaleBarcodeScannerSetupCompleteView: View {
                     .accessibilityAddTraits(.isHeader)
 
                 Text(Localization.instruction)
-                    .font(.posBodyMediumRegular())
+                    .font(.posBodyLargeRegular())
                     .foregroundColor(.posOnSurfaceVariantHighest)
                     .multilineTextAlignment(.center)
             }
@@ -176,9 +176,7 @@ private extension PointOfSaleBarcodeScannerSetupCompleteView {
 struct PointOfSaleBarcodeScannerErrorView: View {
     var body: some View {
         VStack(spacing: POSSpacing.xLarge) {
-            // Error icon
-            errorIcon
-                .accessibilityHidden(true)
+            POSErrorXMark()
 
             VStack(alignment: .center, spacing: POSSpacing.small) {
                 Text(Localization.title)
@@ -187,7 +185,7 @@ struct PointOfSaleBarcodeScannerErrorView: View {
                     .accessibilityAddTraits(.isHeader)
 
                 Text(Localization.instruction)
-                    .font(.posBodyMediumRegular())
+                    .font(.posBodyLargeRegular())
                     .foregroundColor(.posOnSurfaceVariantHighest)
                     .multilineTextAlignment(.center)
             }
@@ -195,15 +193,10 @@ struct PointOfSaleBarcodeScannerErrorView: View {
         .padding(POSSpacing.xLarge)
     }
 
-    private var errorIcon: some View {
-        Image(systemName: "exclamationmark.triangle.fill")
-            .font(.system(size: 60))
-            .foregroundColor(.orange)
-    }
-
     private enum Localization {
-        static let title = "Test Failed"
-        static let instruction = "The barcode test was unsuccessful. Please check your scanner connection and try again."
+        static let title = "Scanning issue found"
+        static let instruction = "Please check the scanner’s manual and reset it \n" +
+        "to factory settings, then retry the set up flow."
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of: WOOMOB-696

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the error state for test scan's failing in the Star set up flow.

To do this, I've updated the flow definition to use a dictionary, rather than a linear array. Steps now define their own transitions.

In future, we may want an associated value on the error transition to pass different errors, but it might break the hashability and be a bit of a pain. We'll see if we need it, I don't want to over-complicate at the moment.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS, tap `... > Barcode scanning`
2. Follow the Star flow
3. When asked to scan the test barcode, scan a different barcode instead.
4. Observe that you're shown the error.

Retry restarts the flow
Back takes you to the test page again.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/7e02a5df-71f5-45e5-9e6a-2a01cbe43f10


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
