### PR TITLE
[POS as a tab i2] Support loading WC plugin and POS feature switch from system status endpoint

### DIFF
--- a/Modules/Sources/Networking/Mapper/SingleItemMapper.swift
+++ b/Modules/Sources/Networking/Mapper/SingleItemMapper.swift
@@ -2,16 +2,20 @@ import Foundation
 
 /// SingleItemMapper: Maps generic REST API requests for a single item
 ///
-struct SingleItemMapper<Output: Decodable>: Mapper {
+public struct SingleItemMapper<Output: Decodable>: Mapper {
     /// Site Identifier associated to the items that will be parsed.
     ///
     /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned by our endpoints.
     ///
     let siteID: Int64
 
+    public init(siteID: Int64) {
+        self.siteID = siteID
+    }
+
     /// (Attempts) to convert a dictionary into Output.
     ///
-    func map(response: Data) throws -> Output {
+    public func map(response: Data) throws -> Output {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [

--- a/Modules/Sources/Networking/Remote/SystemStatusRemote.swift
+++ b/Modules/Sources/Networking/Remote/SystemStatusRemote.swift
@@ -5,12 +5,11 @@ import Foundation
 public class SystemStatusRemote: Remote {
     /// Fields that can be requested in the app from the system status endpoint.
     /// Reference of all supported fields: https://woocommerce.github.io/woocommerce-rest-api-docs/#system-status-properties
-    /// TODO: move raw value to private extension
-    public enum Field: String {
-        case activePlugins = "active_plugins"
-        case inactivePlugins = "inactive_plugins"
-        case environment = "environment"
-        case settings = "settings"
+    public enum Field {
+        case activePlugins
+        case inactivePlugins
+        case environment
+        case settings
     }
 
     /// Retrieves information from the system status that belongs to the current site.
@@ -100,5 +99,22 @@ private extension SystemStatusRemote {
 
     enum ParameterKeys {
         static let fields: String = "_fields"
+    }
+}
+
+// MARK: - Field Raw Values
+//
+private extension SystemStatusRemote.Field {
+    var rawValue: String {
+        switch self {
+        case .activePlugins:
+            return "active_plugins"
+        case .inactivePlugins:
+            return "inactive_plugins"
+        case .environment:
+            return "environment"
+        case .settings:
+            return "settings"
+        }
     }
 }

--- a/Modules/Sources/Networking/Remote/SystemStatusRemote.swift
+++ b/Modules/Sources/Networking/Remote/SystemStatusRemote.swift
@@ -3,6 +3,15 @@ import Foundation
 /// System Status: Remote Endpoint
 ///
 public class SystemStatusRemote: Remote {
+    /// Fields that can be requested in the app from the system status endpoint.
+    /// Reference of all supported fields: https://woocommerce.github.io/woocommerce-rest-api-docs/#system-status-properties
+    /// TODO: move raw value to private extension
+    public enum Field: String {
+        case activePlugins = "active_plugins"
+        case inactivePlugins = "inactive_plugins"
+        case environment = "environment"
+        case settings = "settings"
+    }
 
     /// Retrieves information from the system status that belongs to the current site.
     /// Currently fetching:
@@ -16,19 +25,17 @@ public class SystemStatusRemote: Remote {
     ///
     public func loadSystemInformation(for siteID: Int64,
                                       completion: @escaping (Result<SystemStatus, Error>) -> Void) {
-        let path = Constants.systemStatusPath
-        let parameters = [
-            ParameterKeys.fields: [ParameterValues.environment, ParameterValues.activePlugins, ParameterValues.inactivePlugins]
-        ]
-        let request = JetpackRequest(wooApiVersion: .mark3,
-                                     method: .get,
-                                     siteID: siteID,
-                                     path: path,
-                                     parameters: parameters,
-                                     availableAsRESTRequest: true)
-        let mapper = SystemStatusMapper(siteID: siteID)
-
-        enqueue(request, mapper: mapper, completion: completion)
+        Task { @MainActor in
+            do {
+                let mapper = SystemStatusMapper(siteID: siteID)
+                let systemStatus = try await loadSystemStatus(for: siteID,
+                                                              fields: [Field.environment, Field.activePlugins, Field.inactivePlugins],
+                                                              mapper: mapper)
+                completion(.success(systemStatus))
+            } catch {
+                completion(.failure(error))
+            }
+        }
     }
 
     /// Fetch details about system status for a given site.
@@ -39,15 +46,48 @@ public class SystemStatusRemote: Remote {
     ///
     public func fetchSystemStatusReport(for siteID: Int64,
                                         completion: @escaping (Result<SystemStatusReport, Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let mapper = SystemStatusReportMapper(siteID: siteID)
+                let systemStatus = try await loadSystemStatus(for: siteID,
+                                                              fields: nil,
+                                                              mapper: mapper)
+                completion(.success(systemStatus))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Loads system status information with configurable fields for a given site.
+    ///
+    /// - Parameters:
+    ///   - siteID: Site for which the system status is fetched from.
+    ///   - fields: Optional array of fields to fetch. If nil or empty, it fetches all available fields.
+    ///   - mapper: Mapper to transform the response data.
+    /// - Returns: Mapped object based on the mapper output type.
+    /// - Throws: Network or parsing errors.
+    ///
+    public func loadSystemStatus<T, M: Mapper>(for siteID: Int64,
+                                               fields: [Field]? = nil,
+                                               mapper: M) async throws -> T where M.Output == T {
         let path = Constants.systemStatusPath
+        let parameters: [String: Any]? = {
+            if let fields, !fields.isEmpty {
+                return [
+                    ParameterKeys.fields: fields.map(\.rawValue)
+                ]
+            } else {
+                return nil
+            }
+        }()
         let request = JetpackRequest(wooApiVersion: .mark3,
                                      method: .get,
                                      siteID: siteID,
                                      path: path,
-                                     parameters: nil,
+                                     parameters: parameters,
                                      availableAsRESTRequest: true)
-        let mapper = SystemStatusReportMapper(siteID: siteID)
-        enqueue(request, mapper: mapper, completion: completion)
+        return try await enqueue(request, mapper: mapper)
     }
 }
 
@@ -56,12 +96,6 @@ public class SystemStatusRemote: Remote {
 private extension SystemStatusRemote {
     enum Constants {
         static let systemStatusPath: String = "system_status"
-    }
-
-    enum ParameterValues {
-        static let activePlugins: String = "active_plugins"
-        static let inactivePlugins: String = "inactive_plugins"
-        static let environment: String = "environment"
     }
 
     enum ParameterKeys {

--- a/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSSystemStatusService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSSystemStatusService.swift
@@ -29,6 +29,11 @@ public final class POSSystemStatusService: POSSystemStatusServiceProtocol {
         remote = SystemStatusRemote(network: network)
     }
 
+    /// Test-friendly initializer that accepts a network implementation.
+    init(network: Network) {
+        remote = SystemStatusRemote(network: network)
+    }
+
     public func loadWooCommercePluginAndPOSFeatureSwitch(siteID: Int64) async throws -> POSPluginAndFeatureInfo {
         let mapper = SingleItemMapper<POSPluginEligibilitySystemStatus>(siteID: siteID)
         let systemStatus: POSPluginEligibilitySystemStatus = try await remote.loadSystemStatus(
@@ -43,7 +48,7 @@ public final class POSSystemStatusService: POSSystemStatusServiceProtocol {
         }
 
         // Extracts POS feature value from settings response.
-        let featureValue = systemStatus.settings.enabledFeatures.contains(SiteSettingsFeature.pointOfSale.rawValue) ? true : nil
+        let featureValue = systemStatus.settings.enabledFeatures?.contains(SiteSettingsFeature.pointOfSale.rawValue) == true ? true : nil
         return POSPluginAndFeatureInfo(wcPlugin: wcPlugin, featureValue: featureValue)
     }
 }
@@ -73,7 +78,9 @@ private struct POSPluginEligibilitySystemStatus: Decodable {
 }
 
 private struct POSEligibilitySystemStatusSettings: Decodable {
-    let enabledFeatures: [String]
+    // As `settings.enable_features` was introduced in WC version 9.9.0, this field is optional.
+    // Ref: https://github.com/woocommerce/woocommerce/pull/57168
+    let enabledFeatures: [String]?
 
     enum CodingKeys: String, CodingKey {
         case enabledFeatures = "enabled_features"

--- a/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSSystemStatusService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSSystemStatusService.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Networking
+
+public protocol POSSystemStatusServiceProtocol {
+    /// Loads WooCommerce plugin and POS feature switch value remotely for eligibility checks.
+    /// - Parameter siteID: The site ID to fetch information for.
+    /// - Returns: POSPluginAndFeatureInfo containing plugin and feature data.
+    /// - Throws: Network or parsing errors.
+    func loadWooCommercePluginAndPOSFeatureSwitch(siteID: Int64) async throws -> POSPluginAndFeatureInfo
+}
+
+/// Contains WooCommerce plugin information and POS feature switch value.
+public struct POSPluginAndFeatureInfo {
+    public let wcPlugin: SystemPlugin?
+    public let featureValue: Bool?
+
+    public init(wcPlugin: SystemPlugin?, featureValue: Bool?) {
+        self.wcPlugin = wcPlugin
+        self.featureValue = featureValue
+    }
+}
+
+/// Service for fetching POS-related system status information.
+public final class POSSystemStatusService: POSSystemStatusServiceProtocol {
+    private let remote: SystemStatusRemote
+
+    public init(credentials: Credentials?) {
+        let network = AlamofireNetwork(credentials: credentials)
+        remote = SystemStatusRemote(network: network)
+    }
+
+    public func loadWooCommercePluginAndPOSFeatureSwitch(siteID: Int64) async throws -> POSPluginAndFeatureInfo {
+        let mapper = SingleItemMapper<POSPluginEligibilitySystemStatus>(siteID: siteID)
+        let systemStatus: POSPluginEligibilitySystemStatus = try await remote.loadSystemStatus(
+            for: siteID,
+            fields: [.activePlugins, .settings],
+            mapper: mapper
+        )
+
+        // Finds WooCommerce plugin from active plugins response.
+        guard let wcPlugin = systemStatus.activePlugins.first(where: { $0.plugin == Constants.wcPluginPath }) else {
+            return POSPluginAndFeatureInfo(wcPlugin: nil, featureValue: nil)
+        }
+
+        // Extracts POS feature value from settings response.
+        let featureValue = systemStatus.settings.enabledFeatures.contains(SiteSettingsFeature.pointOfSale.rawValue) ? true : nil
+        return POSPluginAndFeatureInfo(wcPlugin: wcPlugin, featureValue: featureValue)
+    }
+}
+
+private extension POSSystemStatusService {
+    enum Constants {
+        static let wcPluginPath = "woocommerce/woocommerce.php"
+    }
+}
+
+// MARK: - Errors
+
+public enum POSSystemStatusServiceError: Error {
+    case wooCommercePluginNotFound
+}
+
+// MARK: - Network Response Structs
+
+private struct POSPluginEligibilitySystemStatus: Decodable {
+    let activePlugins: [SystemPlugin]
+    let settings: POSEligibilitySystemStatusSettings
+
+    enum CodingKeys: String, CodingKey {
+        case activePlugins = "active_plugins"
+        case settings
+    }
+}
+
+private struct POSEligibilitySystemStatusSettings: Decodable {
+    let enabledFeatures: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case enabledFeatures = "enabled_features"
+    }
+}

--- a/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSSystemStatusService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSSystemStatusService.swift
@@ -59,12 +59,6 @@ private extension POSSystemStatusService {
     }
 }
 
-// MARK: - Errors
-
-public enum POSSystemStatusServiceError: Error {
-    case wooCommercePluginNotFound
-}
-
 // MARK: - Network Response Structs
 
 private struct POSPluginEligibilitySystemStatus: Decodable {

--- a/Modules/Tests/NetworkingTests/Responses/system-status-wc-plugin-and-pos-feature-disabled.json
+++ b/Modules/Tests/NetworkingTests/Responses/system-status-wc-plugin-and-pos-feature-disabled.json
@@ -1,0 +1,58 @@
+{
+  "data": {
+    "active_plugins":[
+      {
+        "plugin": "woocommerce/woocommerce.php",
+        "name": "WooCommerce",
+        "version": "10.0.0-dev",
+        "version_latest": "10.0.0-dev",
+        "url": "https://woocommerce.com/",
+        "author_name": "Automattic",
+        "author_url": "https://woocommerce.com",
+        "network_activated": false
+      }
+    ],
+    "settings": {
+      "api_enabled": false,
+      "force_ssl": false,
+      "currency": "USD",
+      "currency_symbol": "&#36;",
+      "currency_position": "left",
+      "thousand_separator": ",",
+      "decimal_separator": ".",
+      "number_of_decimals": 2,
+      "geolocation_enabled": false,
+      "taxonomies": {
+        "external": "external",
+        "grouped": "grouped",
+        "simple": "simple",
+        "variable": "variable"
+      },
+      "product_visibility_terms": {
+        "exclude-from-catalog": "exclude-from-catalog",
+        "exclude-from-search": "exclude-from-search",
+        "featured": "featured",
+        "outofstock": "outofstock",
+        "rated-1": "rated-1",
+        "rated-2": "rated-2",
+        "rated-3": "rated-3",
+        "rated-4": "rated-4",
+        "rated-5": "rated-5"
+      },
+      "woocommerce_com_connected": "no",
+      "enforce_approved_download_dirs": true,
+      "order_datastore": "Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\OrdersTableDataStore",
+      "HPOS_enabled": true,
+      "HPOS_sync_enabled": false,
+      "enabled_features": [
+        "analytics",
+        "marketplace",
+        "order_attribution",
+        "site_visibility_badge",
+        "remote_logging",
+        "email_improvements",
+        "custom_order_tables"
+      ]
+    }
+  }
+}

--- a/Modules/Tests/NetworkingTests/Responses/system-status-wc-plugin-and-pos-feature-enabled.json
+++ b/Modules/Tests/NetworkingTests/Responses/system-status-wc-plugin-and-pos-feature-enabled.json
@@ -1,0 +1,59 @@
+{
+  "data": {
+    "active_plugins":[
+      {
+        "plugin": "woocommerce/woocommerce.php",
+        "name": "WooCommerce",
+        "version": "10.0.0-dev",
+        "version_latest": "10.0.0-dev",
+        "url": "https://woocommerce.com/",
+        "author_name": "Automattic",
+        "author_url": "https://woocommerce.com",
+        "network_activated": false
+      }
+    ],
+    "settings": {
+      "api_enabled": false,
+      "force_ssl": false,
+      "currency": "USD",
+      "currency_symbol": "&#36;",
+      "currency_position": "left",
+      "thousand_separator": ",",
+      "decimal_separator": ".",
+      "number_of_decimals": 2,
+      "geolocation_enabled": false,
+      "taxonomies": {
+        "external": "external",
+        "grouped": "grouped",
+        "simple": "simple",
+        "variable": "variable"
+      },
+      "product_visibility_terms": {
+        "exclude-from-catalog": "exclude-from-catalog",
+        "exclude-from-search": "exclude-from-search",
+        "featured": "featured",
+        "outofstock": "outofstock",
+        "rated-1": "rated-1",
+        "rated-2": "rated-2",
+        "rated-3": "rated-3",
+        "rated-4": "rated-4",
+        "rated-5": "rated-5"
+      },
+      "woocommerce_com_connected": "no",
+      "enforce_approved_download_dirs": true,
+      "order_datastore": "Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\OrdersTableDataStore",
+      "HPOS_enabled": true,
+      "HPOS_sync_enabled": false,
+      "enabled_features": [
+        "analytics",
+        "marketplace",
+        "order_attribution",
+        "site_visibility_badge",
+        "remote_logging",
+        "email_improvements",
+        "point_of_sale",
+        "custom_order_tables"
+      ]
+    }
+  }
+}

--- a/Modules/Tests/NetworkingTests/Responses/system-status-wc-plugin-missing.json
+++ b/Modules/Tests/NetworkingTests/Responses/system-status-wc-plugin-missing.json
@@ -1,0 +1,49 @@
+{
+  "data": {
+    "active_plugins":[
+    ],
+    "settings": {
+      "api_enabled": false,
+      "force_ssl": false,
+      "currency": "USD",
+      "currency_symbol": "&#36;",
+      "currency_position": "left",
+      "thousand_separator": ",",
+      "decimal_separator": ".",
+      "number_of_decimals": 2,
+      "geolocation_enabled": false,
+      "taxonomies": {
+        "external": "external",
+        "grouped": "grouped",
+        "simple": "simple",
+        "variable": "variable"
+      },
+      "product_visibility_terms": {
+        "exclude-from-catalog": "exclude-from-catalog",
+        "exclude-from-search": "exclude-from-search",
+        "featured": "featured",
+        "outofstock": "outofstock",
+        "rated-1": "rated-1",
+        "rated-2": "rated-2",
+        "rated-3": "rated-3",
+        "rated-4": "rated-4",
+        "rated-5": "rated-5"
+      },
+      "woocommerce_com_connected": "no",
+      "enforce_approved_download_dirs": true,
+      "order_datastore": "Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\OrdersTableDataStore",
+      "HPOS_enabled": true,
+      "HPOS_sync_enabled": false,
+      "enabled_features": [
+        "analytics",
+        "marketplace",
+        "order_attribution",
+        "site_visibility_badge",
+        "remote_logging",
+        "email_improvements",
+        "point_of_sale",
+        "custom_order_tables"
+      ]
+    }
+  }
+}

--- a/Modules/Tests/YosemiteTests/PointOfSale/POSSystemStatusServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/POSSystemStatusServiceTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+import TestKit
+@testable import Networking
+@testable import Yosemite
+
+@MainActor
+struct POSSystemStatusServiceTests {
+    private let network = MockNetwork()
+    private let sampleSiteID: Int64 = 134
+    private let sut: POSSystemStatusService
+
+    init() async throws {
+        network.removeAllSimulatedResponses()
+        sut = POSSystemStatusService(network: network)
+    }
+
+    // MARK: - loadWooCommercePluginAndPOSFeatureSwitch Tests
+
+    @Test func loadWooCommercePluginAndPOSFeatureSwitch_returns_plugin_and_nil_feature_when_settings_response_does_not_include_enabled_featuers() async throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "system_status", filename: "systemStatus")
+
+        // When
+        let result = try await sut.loadWooCommercePluginAndPOSFeatureSwitch(siteID: sampleSiteID)
+
+        // Then
+        let plugin = try #require(result.wcPlugin)
+        #expect(plugin.plugin == "woocommerce/woocommerce.php")
+        #expect(plugin.name == "WooCommerce")
+        #expect(plugin.version == "5.8.0")
+        #expect(plugin.active == true)
+        #expect(result.featureValue == nil)
+    }
+
+    @Test func loadWooCommercePluginAndPOSFeatureSwitch_returns_plugin_and_enabled_feature_when_feature_is_enabled() async throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "system_status", filename: "system-status-wc-plugin-and-pos-feature-enabled")
+
+        // When
+        let result = try await sut.loadWooCommercePluginAndPOSFeatureSwitch(siteID: sampleSiteID)
+
+        // Then
+        let plugin = try #require(result.wcPlugin)
+        #expect(plugin.plugin == "woocommerce/woocommerce.php")
+        #expect(plugin.name == "WooCommerce")
+        #expect(plugin.version == "10.0.0-dev")
+        #expect(plugin.active == true)
+        #expect(result.featureValue == true)
+    }
+
+    @Test func loadWooCommercePluginAndPOSFeatureSwitch_returns_plugin_and_nil_feature_when_feature_is_disabled() async throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "system_status", filename: "system-status-wc-plugin-and-pos-feature-disabled")
+
+        // When
+        let result = try await sut.loadWooCommercePluginAndPOSFeatureSwitch(siteID: sampleSiteID)
+
+        // Then
+        let plugin = try #require(result.wcPlugin)
+        #expect(plugin.plugin == "woocommerce/woocommerce.php")
+        #expect(plugin.name == "WooCommerce")
+        #expect(plugin.version == "10.0.0-dev")
+        #expect(plugin.active == true)
+        #expect(result.featureValue == nil)
+    }
+
+    @Test func loadWooCommercePluginAndPOSFeatureSwitch_returns_nil_plugin_and_nil_feature_when_woocommerce_plugin_not_found() async throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "system_status", filename: "system-status-wc-plugin-missing")
+
+        // When
+        let result = try await sut.loadWooCommercePluginAndPOSFeatureSwitch(siteID: sampleSiteID)
+
+        // Then
+        #expect(result.wcPlugin == nil)
+        #expect(result.featureValue == nil)
+    }
+
+    @Test func loadWooCommercePluginAndPOSFeatureSwitch_throws_error_on_network_failure() async throws {
+        // Given
+        network.simulateError(requestUrlSuffix: "system_status", error: NetworkError.notFound())
+
+        // When & Then
+        await #expect(throws: NetworkError.self) {
+            try await sut.loadWooCommercePluginAndPOSFeatureSwitch(siteID: sampleSiteID)
+        }
+    }
+}


### PR DESCRIPTION
For WOOMOB-835  
Just one review is required.

## Why

This PR adds Yosemite level support for retrying plugin related checks in the POS eligibility check WOOMOB-799. The integration with the eligibility checker will be in a separate PR because this PR is already close to 500 diffs.

## Description

This PR introduces `POSSystemStatusService` in Yosemite to efficiently load both WooCommerce plugin information and POS feature switch value from a single system status API request. This improves performance by reducing API calls when refreshing POS eligibility.

The implementation includes:
- New `POSSystemStatusServiceProtocol` with `loadWooCommercePluginAndPOSFeatureSwitch` method with `POSSystemStatusService` implementation
- Generic `loadSystemStatus` method in `SystemStatusRemote` for reusable system status requests
- Test coverage for `POSSystemStatusService`

## Steps to reproduce

The new `POSSystemStatusService` isn't used in the app yet. Some confidence testing on the refactored `SystemStatusRemote` methods would be helpful:

### `SystemStatusRemote.loadSystemInformation` usage

This method is called throughout the app via `SystemStatusAction.synchronizeSystemInformation`. Example testing steps:

- Launch the app
- Go to Menu > Settings --> the WC plugin version should be shown correctly as before
- Tap on Plugins --> plugins should be shown correctly as before

### `SystemStatusRemote.fetchSystemStatusReport` usage

This method is called throughout the app via `SystemStatusAction.fetchSystemStatusReport`.

- Launch the app
- Go to Menu > Settings > Help & Support -> System Status Report --> the SSR should be shown correctly as before

## Testing information

I tested the steps above in iPad A16 iOS 18.4 simulator.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.