### PR TITLE
Fix broken build by updating fileprivate extension access

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+OrdersListFilter.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+OrdersListFilter.swift
@@ -1,4 +1,5 @@
 import protocol WooFoundation.WooAnalyticsEventPropertyType
+import enum Yosemite.SalesChannelFilter
 
 extension WooAnalyticsEvent {
     enum OrdersFilter {
@@ -24,7 +25,7 @@ extension WooAnalyticsEvent {
     }
 }
 
-fileprivate extension FilterOrderListViewModel.SalesChannelFilter {
+fileprivate extension SalesChannelFilter {
     var analyticsDescription: String? {
         switch self {
         case .pointOfSale:


### PR DESCRIPTION
## Description
After merging https://github.com/woocommerce/woocommerce-ios/pull/15891 into trunk it seems a conflict sneaked through, making the build to not compile due to `SalesChannelFilter' is not a member type of class 'WooCommerce.FilterOrderListViewModel'` error.

This is an update that was made [here](https://github.com/woocommerce/woocommerce-ios/pull/15890) and was merged into trunk before #15891, without pulling the latests updates from trunk. 

## Changes
Updated access to `analyticsDescription` from `FilterOrderListViewModel.SalesChannelFilter` to `SalesChannelFilter`

## Testing information
- Build should compile. CI should pass.
- Feel free to skip this is you have no POS setup: If you do, you can confirm that tapping on Orders > Filters > Sales Channel > Point of Sale > Show Orders still tracks the event with the `sales_channel: pos` property, as: 

```
🔵 Tracked orders_list_filter, properties: [plan: , is_wpcom_store: false, blog_id: -1, store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f, site_url: https://indiemelon.mystagingwebsite.com, sales_channel: pos, was_ecommerce_trial: false]
```