### PR TITLE
[POS Orders] Enable `pointOfSaleOrdersi2`

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -100,7 +100,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .pointOfSaleOrdersi1:
             return true
         case .pointOfSaleOrdersi2:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .pointOfSaleBarcodeScanningi2:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 22.9
 -----
-
+- [*] Order List: New orders made through Point of Sale are now filterable via the Order List filters menu [https://github.com/woocommerce/woocommerce-ios/pull/15910]
 
 22.8
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
This PR sets `pointOfSaleOrdersi2` to true, enabling Sales Channel as a filter option in production builds.

## Testing information
- Run the app in release build configuration
- Go to the orders tab, tap on `Filters`, observe that the new `Sales Channel` filter appears as an option 

<img width="640" height="402" alt="Screenshot 2025-07-15 at 15 19 23" src="https://github.com/user-attachments/assets/2e8d0083-6053-41d1-a000-af0e7c90de9e" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
