### PR TITLE
[Woo POS][Barcodes] Search for `global_unique_id` using a `new search_fields` parameter

### DIFF
--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -259,7 +259,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
                                                    productsPerPage: String = POSConstants.productsPerPage,
                                                    productTypes: [ProductType],
                                                    orderBy: OrderKey = .name,
-                                                   order: Order = .ascending) -> [String: String] {
+                                                   order: Order = .ascending) -> [String: any Hashable] {
         [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: productsPerPage,
@@ -276,7 +276,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
 
     private func makePagedPointOfSaleProductsRequest(for siteID: Int64,
                                                      pageNumber: Int,
-                                                     parameters: [String: String]) async throws -> PagedItems<POSProduct> {
+                                                     parameters: [String: any Hashable]) async throws -> PagedItems<POSProduct> {
         let request = JetpackRequest(wooApiVersion: .mark3,
                                      method: .get,
                                      siteID: siteID,
@@ -318,7 +318,12 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             productTypes: productTypes)
 
         parameters.updateValue(query, forKey: ParameterKey.search)
+
+        // Takes precedence over `search` from WC 9.9 to 10.1
         parameters.updateValue(query, forKey: ParameterKey.searchNameOrSKU)
+
+        // Takes precedence over `search_name_or_sku` from WC 10.1+ and is combined with `search` value
+        parameters.updateValue([SearchField.name, SearchField.sku, SearchField.globalUniqueID], forKey: ParameterKey.searchFields)
 
         return try await makePagedPointOfSaleProductsRequest(
             for: siteID,
@@ -749,6 +754,7 @@ public extension ProductsRemote {
         static let include: String    = "include"
         static let search: String     = "search"
         static let searchNameOrSKU: String = "search_name_or_sku"
+        static let searchFields: String = "search_fields"
         static let orderBy: String    = "orderby"
         static let order: String      = "order"
         static let sku: String        = "sku"
@@ -775,6 +781,14 @@ public extension ProductsRemote {
         static let skuFieldValues: String = "sku"
         static let productSegment = "product"
         static let itemsSold = "items_sold"
+    }
+
+    private enum SearchField {
+        static let name = "name"
+        static let sku = "sku"
+        static let globalUniqueID = "global_unique_id"
+        static let description = "description"
+        static let shortDescription = "short_description"
     }
 }
 

--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -787,8 +787,6 @@ public extension ProductsRemote {
         static let name = "name"
         static let sku = "sku"
         static let globalUniqueID = "global_unique_id"
-        static let description = "description"
-        static let shortDescription = "short_description"
     }
 }
 

--- a/Modules/Tests/NetworkingTests/Remote/POSProductsNetworkingTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSProductsNetworkingTests.swift
@@ -64,9 +64,9 @@ struct POSProductsNetworkingTests {
         _ = try? await remote.loadProductsForPointOfSale(for: sampleSiteID, productTypes: [.simple, .variable], pageNumber: 1)
 
         // Then
-        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: String])
-        #expect(queryParametersDictionary["downloadable"] == "false")
-        #expect(queryParametersDictionary["include_types"] == "simple,variable")
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        #expect(queryParametersDictionary["downloadable"] as? String == "false")
+        #expect(queryParametersDictionary["include_types"] as? String == "simple,variable")
     }
 
     @Test(arguments: 1...4) func loadProductsForPointOfSale_returns_hasMorePages_based_on_header_with_case_insensitive_name(pageNumber: Int) async throws {
@@ -126,13 +126,13 @@ struct POSProductsNetworkingTests {
             pageNumber: 1)
 
         // Then
-        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: String])
-        #expect(queryParametersDictionary["downloadable"] == "false")
-        #expect(queryParametersDictionary["include_types"] == "simple,variable")
-        #expect(queryParametersDictionary["search"] == "search terms")
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        #expect(queryParametersDictionary["downloadable"] as? String == "false")
+        #expect(queryParametersDictionary["include_types"] as? String == "simple,variable")
+        #expect(queryParametersDictionary["search"] as? String == "search terms")
     }
 
-    @Test func searchProductsForPointOfSale_sets_both_search_parameters() async throws {
+    @Test func searchProductsForPointOfSale_sets_all_search_parameters() async throws {
         // Given
         let remote = ProductsRemote(network: network)
         let searchQuery = "search terms"
@@ -145,9 +145,10 @@ struct POSProductsNetworkingTests {
             pageNumber: 1)
 
         // Then
-        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: String])
-        #expect(queryParametersDictionary["search"] == searchQuery)
-        #expect(queryParametersDictionary["search_name_or_sku"] == searchQuery)
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        #expect(queryParametersDictionary["search"] as? String == searchQuery)
+        #expect(queryParametersDictionary["search_name_or_sku"] as? String == searchQuery)
+        #expect(queryParametersDictionary["search_fields"] as? [String] == ["name", "sku", "global_unique_id"])
     }
 
     @Test func searchProductsForPointOfSale_returns_parsed_products() async throws {
@@ -205,8 +206,8 @@ struct POSProductsNetworkingTests {
         _ = try? await remote.loadProductsForPointOfSale(for: sampleSiteID)
 
         // Then
-        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: String])
-        #expect(queryParametersDictionary["_fields"] == POSProduct.requestFields.joined(separator: ","))
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        #expect(queryParametersDictionary["_fields"] as? String == POSProduct.requestFields.joined(separator: ","))
     }
 
     @Test func searchProductsForPointOfSale_requests_only_required_fields() async throws {
@@ -217,8 +218,8 @@ struct POSProductsNetworkingTests {
         _ = try? await remote.searchProductsForPointOfSale(for: sampleSiteID, query: "search")
 
         // Then
-        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: String])
-        #expect(queryParametersDictionary["_fields"] == POSProduct.requestFields.joined(separator: ","))
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        #expect(queryParametersDictionary["_fields"] as? String == POSProduct.requestFields.joined(separator: ","))
     }
 
     @Test func loadProductsForPointOfSale_returns_total_items_from_header() async throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

WOOMOB-850

One review is enough

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Use a new `search_fields` parameter to search for `global_unique_id` as well as `sku` and `name` in the POS product search field. See [backend PR](https://github.com/woocommerce/woocommerce/pull/59450).

Currently, we are using a rigid `search_name_or_sku` parameter, but this approach hasn't scaled well when we needed to add additional fields for each.

`search_fields` takes precedence over `search_name_or_sku` and works together with `search`. We don't need additional Woo version checks, since `search_fields` will be ignored on lower WooCommerce version and `search_name_or_sku` will continue to be used

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

###  Prerequisites 

- I recommend installing `Jetpack Beta Tester` plugin, and update the version to `Bleeding Edge` (10.1 dev).
- Create a product with `sku` and `global_unique_id` (GTIN)

### WC version >=10.1

1. Open POS
2. Select product search
3. Confirm products can be found using `name`, `sku`, or `global_unique_id`. `search_fields` uses cross-field matching; therefore, if the product has a name with `scarf` and `global_unique_id` with `123`, entering `scarf 123` will find this product.

### WC version 9.9 >= to >10.1

1. Open POS
2. Select product search
3. Confirm products can be found using `name` and `sku` but are not found using `global_unique_id`

### WC version < 9.9

1. Open POS
2. Select product search
3. For lower versions, product search uses a default `search` behavior, which applies `cross-field` matching for product `name`, `description`, and `short_description`. Confirm the search continues to work but products **cannot** be found using `sku` or `global_unique_id`

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air 18.5 simulator, plus performed test cases on the site multiple times during https://github.com/woocommerce/woocommerce/pull/59450 PR

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.