### PR TITLE
[POS as a tab i2] Hide retry CTA for unsupported iOS version in POS ineligible view

### DIFF
--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -57,6 +57,7 @@ struct POSIneligibleView: View {
                         Text(Localization.refreshEligibility)
                     }
                     .buttonStyle(POSFilledButtonStyle(size: .normal, isLoading: isLoading))
+                    .renderedIf(reason.shouldShowRetryButton)
 
                     Button {
                         dismiss()
@@ -140,6 +141,23 @@ private extension POSIneligibleView {
             value: "Exit POS",
             comment: "Button title to dismiss POS ineligible view"
         )
+    }
+}
+
+@available(iOS 17.0, *)
+private extension POSIneligibleReason {
+    var shouldShowRetryButton: Bool {
+        switch self {
+        case .unsupportedIOSVersion:
+            return false
+        case .unsupportedWooCommerceVersion,
+                .siteSettingsNotAvailable,
+                .wooCommercePluginNotFound,
+                .featureSwitchDisabled,
+                .unsupportedCurrency,
+                .selfDeallocated:
+            return true
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -14,10 +14,7 @@ struct POSIneligibleView: View {
             Spacer()
 
             VStack(alignment: .center, spacing: POSSpacing.none) {
-                Image(PointOfSaleAssets.exclamationMark.imageName)
-                    .resizable()
-                    .frame(width: POSErrorAndAlertIconSize.large.dimension,
-                           height: POSErrorAndAlertIconSize.large.dimension)
+                POSErrorXMark()
 
                 Spacer()
                     .frame(height: POSSpacing.medium)


### PR DESCRIPTION
For WOOMOB-768

Just one review is required.

## Why

This PR hides the retry button in the POS ineligible view when the reason is unsupported iOS version. Since iOS version cannot be changed and refreshed within the app, showing a retry button doesn't make sense for this case.

## Description

The implementation adds a computed property `shouldShowRetryButton` to `POSIneligibleReason` via a private extension, which returns `false` for `.unsupportedIOSVersion` and `true` for all other cases. The retry button is now conditionally shown using `.renderedIf(reason.shouldShowRetryButton)`.

Additionally, the image in the ineligible UI was updated to X to match the design.

## Steps to reproduce

1. If you don't have a device/simulator with iOS 16 (I personally don't), you can hardcode the ineligible reason to `.unsupportedIOSVersion` in https://github.com/woocommerce/woocommerce-ios/blob/53e3bca48661a189ebf8d447073b25a695142dbd/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift#L64
2. Navigate to POS
3. Observe the ineligible view
4. Verify that only the "Exit POS" button is shown (no retry button), and the image is an X that matches the design y0zZLi1kqybNUUUd8lmvYG-fi-4133_4689

## Testing information

I tested `unsupportedIOSVersion` (hard-coded) and `unsupportedWooCommerceVersion` cases (as shown in the screenshots) in iOS 18.4 iPad A16 simulator.

## Screenshots
The retry button will no longer appear for unsupported iOS version cases, showing only the "Exit POS" button.

other ineligible reason | unsupported iOS version reason
-- | --
<img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2025-07-15 at 10 31 07" src="https://github.com/user-attachments/assets/b8154254-47bc-4e4b-a6b4-5ea0ec0efb96" /> | <img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2025-07-15 at 10 33 24" src="https://github.com/user-attachments/assets/414f7833-fa2f-4b24-a872-56251b7db234" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.