### PR TITLE
[POS as a tab i2] Refactor plugins upsert so that plugins are matched by plugin path instead of name, and the first active WC plugin is returned for POS

### DIFF
--- a/Modules/Sources/Storage/Tools/StorageType+Deletions.swift
+++ b/Modules/Sources/Storage/Tools/StorageType+Deletions.swift
@@ -206,6 +206,17 @@ public extension StorageType {
         }
     }
 
+    /// Deletes stored system plugins for the provided siteID that are not in the currentSystemPluginPaths list.
+    ///
+    func deleteStaleSystemPlugins(siteID: Int64, currentSystemPluginPaths: [String]) {
+        let systemPlugins = loadSystemPlugins(siteID: siteID).filter {
+            !currentSystemPluginPaths.contains($0.plugin)
+        }
+        systemPlugins.forEach {
+            deleteObject($0)
+        }
+    }
+
     // MARK: - InboxNotes
 
     /// Deletes all of the stored Inbox Notes for the provided siteID.

--- a/Modules/Sources/Storage/Tools/StorageType+Deletions.swift
+++ b/Modules/Sources/Storage/Tools/StorageType+Deletions.swift
@@ -195,17 +195,6 @@ public extension StorageType {
         }
     }
 
-    /// Deletes all of the stored SystemPlugins for the provided siteID whose name is not included in `currentSystemPlugins` array
-    ///
-    func deleteStaleSystemPlugins(siteID: Int64, currentSystemPlugins: [String]) {
-        let systemPlugins = loadSystemPlugins(siteID: siteID).filter {
-            !currentSystemPlugins.contains($0.name)
-        }
-        systemPlugins.forEach {
-            deleteObject($0)
-        }
-    }
-
     /// Deletes stored system plugins for the provided siteID that are not in the currentSystemPluginPaths list.
     ///
     func deleteStaleSystemPlugins(siteID: Int64, currentSystemPluginPaths: [String]) {

--- a/Modules/Sources/Storage/Tools/StorageType+Extensions.swift
+++ b/Modules/Sources/Storage/Tools/StorageType+Extensions.swift
@@ -841,12 +841,21 @@ public extension StorageType {
 
     /// Returns a system plugin with a specified `siteID` and `path`.
     ///
-    func loadSystemPlugin(siteID: Int64, path: String) -> SystemPlugin? {
-        let predicate = \SystemPlugin.siteID == siteID && \SystemPlugin.plugin == path
+    /// - Parameters:
+    ///   - siteID: The site ID to filter by.
+    ///   - path: The plugin path to match (e.g., "woocommerce/woocommerce.php").
+    ///   - active: Optional active state filter. If provided, only plugins with matching active state are returned. If nil, active state is ignored.
+    /// - Returns: The matching system plugin, or nil if not found.
+    func loadSystemPlugin(siteID: Int64, path: String, active: Bool? = nil) -> SystemPlugin? {
+        let predicate = if let active {
+            \SystemPlugin.siteID == siteID && \SystemPlugin.plugin == path && \SystemPlugin.active == active
+        } else {
+            \SystemPlugin.siteID == siteID && \SystemPlugin.plugin == path
+        }
         return firstObject(ofType: SystemPlugin.self, matching: predicate)
     }
 
-    /// Returns stored system plugins for a provided `siteID` matching the given plugin `paths`
+    /// Returns stored system plugins for a provided `siteID` matching the given plugin `paths`.
     ///
     func loadSystemPlugins(siteID: Int64, matchingPaths paths: [String]) -> [SystemPlugin] {
         let predicate = NSPredicate(format: "siteID == %lld && plugin in %@", siteID, paths)

--- a/Modules/Sources/Storage/Tools/StorageType+Extensions.swift
+++ b/Modules/Sources/Storage/Tools/StorageType+Extensions.swift
@@ -846,6 +846,14 @@ public extension StorageType {
         return firstObject(ofType: SystemPlugin.self, matching: predicate)
     }
 
+    /// Returns stored system plugins for a provided `siteID` matching the given plugin `paths`
+    ///
+    func loadSystemPlugins(siteID: Int64, matchingPaths paths: [String]) -> [SystemPlugin] {
+        let predicate = NSPredicate(format: "siteID == %lld && plugin in %@", siteID, paths)
+        let descriptor = NSSortDescriptor(keyPath: \SystemPlugin.plugin, ascending: true)
+        return allObjects(ofType: SystemPlugin.self, matching: predicate, sortedBy: [descriptor])
+    }
+
     // MARK: - Inbox Notes
 
     /// Returns a single Inbox Note given a `siteID` and `id`

--- a/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSSystemStatusService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSSystemStatusService.swift
@@ -48,8 +48,9 @@ public final class POSSystemStatusService: POSSystemStatusServiceProtocol {
         )
 
         // Upserts all plugins in storage.
-        await storageManager.performAndSaveAsync({ [weak self] storage in
-            self?.upsertSystemPlugins(siteID: siteID, systemStatus: systemStatus, in: storage)
+        await storageManager.performAndSaveAsync({ storage in
+            let useCase = SystemPluginsUpsertUseCase(storage: storage)
+            useCase.upsert(siteID: siteID, activePlugins: systemStatus.activePlugins, inactivePlugins: systemStatus.inactivePlugins)
         })
 
         // Loads WooCommerce plugin from storage.
@@ -60,42 +61,6 @@ public final class POSSystemStatusService: POSSystemStatusServiceProtocol {
         // Extracts POS feature value from settings response.
         let featureValue = systemStatus.settings.enabledFeatures?.contains(SiteSettingsFeature.pointOfSale.rawValue) == true ? true : nil
         return POSPluginAndFeatureInfo(wcPlugin: wcPlugin, featureValue: featureValue)
-    }
-}
-
-private extension POSSystemStatusService {
-    /// Updates or inserts system plugins in storage.
-    func upsertSystemPlugins(siteID: Int64, systemStatus: POSPluginEligibilitySystemStatus, in storage: StorageType) {
-        // Active and inactive plugins share identical structure, but are stored in separate parts of the remote response
-        // (and without an active attribute in the response). So we apply the correct value for active (or not)
-        let readonlySystemPlugins: [SystemPlugin] = {
-            let activePlugins = systemStatus.activePlugins.map {
-                $0.copy(active: true)
-            }
-
-            let inactivePlugins = systemStatus.inactivePlugins.map {
-                $0.copy(active: false)
-            }
-
-            return activePlugins + inactivePlugins
-        }()
-
-        let storedPlugins = storage.loadSystemPlugins(siteID: siteID, matching: readonlySystemPlugins.map { $0.name })
-        readonlySystemPlugins.forEach { readonlySystemPlugin in
-            // Loads or creates new StorageSystemPlugin matching the readonly one.
-            let storageSystemPlugin: StorageSystemPlugin = {
-                if let systemPlugin = storedPlugins.first(where: { $0.name == readonlySystemPlugin.name }) {
-                    return systemPlugin
-                }
-                return storage.insertNewObject(ofType: StorageSystemPlugin.self)
-            }()
-
-            storageSystemPlugin.update(with: readonlySystemPlugin)
-        }
-
-        // Removes stale system plugins.
-        let currentSystemPlugins = readonlySystemPlugins.map(\.name)
-        storage.deleteStaleSystemPlugins(siteID: siteID, currentSystemPlugins: currentSystemPlugins)
     }
 }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSSystemStatusService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSSystemStatusService.swift
@@ -54,7 +54,7 @@ public final class POSSystemStatusService: POSSystemStatusServiceProtocol {
         })
 
         // Loads WooCommerce plugin from storage.
-        guard let wcPlugin = storageManager.viewStorage.loadSystemPlugin(siteID: siteID, path: Constants.wcPluginPath)?.toReadOnly() else {
+        guard let wcPlugin = storageManager.viewStorage.loadSystemPlugin(siteID: siteID, path: Constants.wcPluginPath, active: true)?.toReadOnly() else {
             return POSPluginAndFeatureInfo(wcPlugin: nil, featureValue: nil)
         }
 

--- a/Modules/Sources/Yosemite/Stores/SystemPlugin/SystemPluginsUpsertUseCase.swift
+++ b/Modules/Sources/Yosemite/Stores/SystemPlugin/SystemPluginsUpsertUseCase.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Storage
+import Networking
+
+/// Upserts `Networking.SystemPlugin` objects into Storage.
+///
+/// This UseCase encapsulates the business logic for inserting or updating system plugins,
+/// including handling active/inactive state and removing stale plugins.
+struct SystemPluginsUpsertUseCase {
+    private let storage: StorageType
+
+    /// Initializes a new UseCase.
+    ///
+    /// - Parameter storage: A derived `StorageType`.
+    init(storage: StorageType) {
+        self.storage = storage
+    }
+
+    /// Updates or inserts the given system plugins for a site.
+    ///
+    /// - Parameters:
+    ///   - siteID: The site ID these plugins belong to.
+    ///   - activePlugins: Array of active system plugins.
+    ///   - inactivePlugins: Array of inactive system plugins.
+    ///
+    func upsert(siteID: Int64, activePlugins: [SystemPlugin], inactivePlugins: [SystemPlugin]) {
+        // Active and inactive plugins share identical structure, but are stored in separate parts of the remote response
+        // (and without an active attribute in the response). So we apply the correct value for active (or not).
+        let readonlySystemPlugins: [SystemPlugin] = {
+            let activePluginsWithState = activePlugins.map {
+                $0.copy(active: true)
+            }
+
+            let inactivePluginsWithState = inactivePlugins.map {
+                $0.copy(active: false)
+            }
+
+            return activePluginsWithState + inactivePluginsWithState
+        }()
+
+        let storedPlugins = storage.loadSystemPlugins(siteID: siteID, matching: readonlySystemPlugins.map { $0.name })
+        readonlySystemPlugins.forEach { readonlySystemPlugin in
+            // Loads or creates new StorageSystemPlugin matching the readonly one.
+            let storageSystemPlugin: StorageSystemPlugin = {
+                if let systemPlugin = storedPlugins.first(where: { $0.name == readonlySystemPlugin.name }) {
+                    return systemPlugin
+                }
+                return storage.insertNewObject(ofType: StorageSystemPlugin.self)
+            }()
+
+            storageSystemPlugin.update(with: readonlySystemPlugin)
+        }
+
+        // Removes stale system plugins.
+        let currentSystemPlugins = readonlySystemPlugins.map(\.name)
+        storage.deleteStaleSystemPlugins(siteID: siteID, currentSystemPlugins: currentSystemPlugins)
+    }
+}

--- a/Modules/Sources/Yosemite/Stores/SystemPlugin/SystemPluginsUpsertUseCase.swift
+++ b/Modules/Sources/Yosemite/Stores/SystemPlugin/SystemPluginsUpsertUseCase.swift
@@ -38,11 +38,11 @@ struct SystemPluginsUpsertUseCase {
             return activePluginsWithState + inactivePluginsWithState
         }()
 
-        let storedPlugins = storage.loadSystemPlugins(siteID: siteID, matching: readonlySystemPlugins.map { $0.name })
+        let storedPlugins = storage.loadSystemPlugins(siteID: siteID, matchingPaths: readonlySystemPlugins.map { $0.plugin })
         readonlySystemPlugins.forEach { readonlySystemPlugin in
             // Loads or creates new StorageSystemPlugin matching the readonly one.
             let storageSystemPlugin: StorageSystemPlugin = {
-                if let systemPlugin = storedPlugins.first(where: { $0.name == readonlySystemPlugin.name }) {
+                if let systemPlugin = storedPlugins.first(where: { $0.plugin == readonlySystemPlugin.plugin }) {
                     return systemPlugin
                 }
                 return storage.insertNewObject(ofType: StorageSystemPlugin.self)
@@ -52,7 +52,7 @@ struct SystemPluginsUpsertUseCase {
         }
 
         // Removes stale system plugins.
-        let currentSystemPlugins = readonlySystemPlugins.map(\.name)
-        storage.deleteStaleSystemPlugins(siteID: siteID, currentSystemPlugins: currentSystemPlugins)
+        let currentSystemPluginPaths = readonlySystemPlugins.map(\.plugin)
+        storage.deleteStaleSystemPlugins(siteID: siteID, currentSystemPluginPaths: currentSystemPluginPaths)
     }
 }

--- a/Modules/Sources/Yosemite/Stores/SystemStatusStore.swift
+++ b/Modules/Sources/Yosemite/Stores/SystemStatusStore.swift
@@ -78,8 +78,9 @@ private extension SystemStatusStore {
     func upsertSystemPluginsInBackground(siteID: Int64,
                                          readonlySystemInformation: SystemStatus,
                                          completionHandler: @escaping () -> Void) {
-        storageManager.performAndSave({ [weak self] storage in
-            self?.upsertSystemPlugins(siteID: siteID, readonlySystemInformation: readonlySystemInformation, in: storage)
+        storageManager.performAndSave({ storage in
+            let useCase = SystemPluginsUpsertUseCase(storage: storage)
+            useCase.upsert(siteID: siteID, activePlugins: readonlySystemInformation.activePlugins, inactivePlugins: readonlySystemInformation.inactivePlugins)
         }, completion: completionHandler, on: .main)
     }
 
@@ -90,43 +91,6 @@ private extension SystemStatusStore {
         dispatcher.dispatch(action)
     }
 
-    /// Updates or inserts Readonly sistem plugins from the read only system information in specified storage.
-    /// Also removes stale plugins that no longer exist in remote plugin list.
-    ///
-    func upsertSystemPlugins(siteID: Int64, readonlySystemInformation: SystemStatus, in storage: StorageType) {
-        /// Active and in-active plugins share identical structure, but are stored in separate parts of the remote response
-        /// (and without an active attribute in the response). So... we use the same decoder for active and in-active plugins
-        /// and here we apply the correct value for active (or not)
-        ///
-        let readonlySystemPlugins: [SystemPlugin] = {
-            let activePlugins = readonlySystemInformation.activePlugins.map {
-                $0.copy(active: true)
-            }
-
-            let inactivePlugins = readonlySystemInformation.inactivePlugins.map {
-                $0.copy(active: false)
-            }
-
-            return activePlugins + inactivePlugins
-        }()
-
-        let storedPlugins = storage.loadSystemPlugins(siteID: siteID, matching: readonlySystemPlugins.map { $0.name })
-        readonlySystemPlugins.forEach { readonlySystemPlugin in
-            // load or create new StorageSystemPlugin matching the readonly one
-            let storageSystemPlugin: StorageSystemPlugin = {
-                if let systemPlugin = storedPlugins.first(where: { $0.name == readonlySystemPlugin.name }) {
-                    return systemPlugin
-                }
-                return storage.insertNewObject(ofType: StorageSystemPlugin.self)
-            }()
-
-            storageSystemPlugin.update(with: readonlySystemPlugin)
-        }
-
-        // remove stale system plugins
-        let currentSystemPlugins = readonlySystemPlugins.map(\.name)
-        storage.deleteStaleSystemPlugins(siteID: siteID, currentSystemPlugins: currentSystemPlugins)
-    }
 
     /// Retrieve a `SystemPlugin` entity from storage whose name matches any name from the provided name list.
     /// Useful when a plugin has had multiple names.

--- a/Modules/Tests/StorageTests/Tools/StorageTypeDeletionsTests.swift
+++ b/Modules/Tests/StorageTests/Tools/StorageTypeDeletionsTests.swift
@@ -129,6 +129,20 @@ final class StorageTypeDeletionsTests: XCTestCase {
         XCTAssertEqual(currrentSystemPlugin, [systemPlugin3])
     }
 
+    func test_deleteStaleSystemPlugins_by_plugin_paths_deletes_systemPlugins_not_included_in_currentSystemPluginPaths() throws {
+        // Given
+        _ = createSystemPlugin(name: "WooCommerce", path: "woocommerce/woocommerce.php")
+        _ = createSystemPlugin(name: "Jetpack", path: "jetpack/jetpack.php")
+        let systemPlugin3 = createSystemPlugin(name: "WooCommerce", path: "wordpress-seo/wp-seo.php")
+
+        // When
+        storage.deleteStaleSystemPlugins(siteID: sampleSiteID, currentSystemPluginPaths: ["wordpress-seo/wp-seo.php"])
+
+        // Then
+        let currentSystemPlugins = storage.loadSystemPlugins(siteID: sampleSiteID)
+        XCTAssertEqual(currentSystemPlugins, [systemPlugin3])
+    }
+
     func test_deleteBlazeTargetDevices_with_locale() throws {
         // Given
         let device1 = storage.insertNewObject(ofType: BlazeTargetDevice.self)
@@ -242,12 +256,15 @@ private extension StorageTypeDeletionsTests {
         return plugin
     }
 
-    /// Creates and inserts a `SystemPlugin` entity with a given name
+    /// Creates and inserts a `SystemPlugin` entity with a given name and optional path.
     ///
-    func createSystemPlugin(name: String) -> SystemPlugin {
+    func createSystemPlugin(name: String, path: String? = nil) -> SystemPlugin {
         let systemPlugin = storage.insertNewObject(ofType: SystemPlugin.self)
         systemPlugin.siteID = sampleSiteID
         systemPlugin.name = name
+        if let path {
+            systemPlugin.plugin = path
+        }
         return systemPlugin
     }
 }

--- a/Modules/Tests/StorageTests/Tools/StorageTypeDeletionsTests.swift
+++ b/Modules/Tests/StorageTests/Tools/StorageTypeDeletionsTests.swift
@@ -115,20 +115,6 @@ final class StorageTypeDeletionsTests: XCTestCase {
 
     // MARK: - System plugins
 
-    func test_deleteStaleSystemPlugins_deletes_systemPlugins_not_included_in_currentSystemPlugins() throws {
-        // Given
-        _ = createSystemPlugin(name: "Plugin 1")
-        _ = createSystemPlugin(name: "Plugin 2")
-        let systemPlugin3 = createSystemPlugin(name: "Plugin 3")
-
-        // When
-        storage.deleteStaleSystemPlugins(siteID: sampleSiteID, currentSystemPlugins: ["Plugin 3"])
-
-        // Then
-        let currrentSystemPlugin = storage.loadSystemPlugins(siteID: sampleSiteID)
-        XCTAssertEqual(currrentSystemPlugin, [systemPlugin3])
-    }
-
     func test_deleteStaleSystemPlugins_by_plugin_paths_deletes_systemPlugins_not_included_in_currentSystemPluginPaths() throws {
         // Given
         _ = createSystemPlugin(name: "WooCommerce", path: "woocommerce/woocommerce.php")

--- a/Modules/Tests/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Modules/Tests/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -1466,6 +1466,35 @@ final class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(foundSystemPlugin, systemPlugin2)
     }
 
+    func test_loadSystemPlugins_by_siteID_matching_paths() {
+        // Given
+        let systemPlugin1 = storage.insertNewObject(ofType: SystemPlugin.self)
+        systemPlugin1.plugin = "woocommerce/woocommerce.php"
+        systemPlugin1.siteID = sampleSiteID
+
+        let systemPlugin2 = storage.insertNewObject(ofType: SystemPlugin.self)
+        systemPlugin2.plugin = "woocommerce/woocommerce.php"
+        systemPlugin2.siteID = sampleSiteID + 1
+
+        let systemPlugin3 = storage.insertNewObject(ofType: SystemPlugin.self)
+        systemPlugin3.plugin = "wordpress-seo/wp-seo.php"
+        systemPlugin3.siteID = sampleSiteID
+
+        let systemPlugin4 = storage.insertNewObject(ofType: SystemPlugin.self)
+        systemPlugin4.plugin = "akismet/akismet.php"
+        systemPlugin4.siteID = sampleSiteID
+
+        // When
+        let storedSystemPlugins = storage.loadSystemPlugins(siteID: sampleSiteID, matchingPaths: ["woocommerce/woocommerce.php", "akismet/akismet.php"])
+
+        // Then
+        XCTAssertEqual(storedSystemPlugins.count, 2)
+        XCTAssertTrue(storedSystemPlugins.contains(systemPlugin1))
+        XCTAssertTrue(storedSystemPlugins.contains(systemPlugin4))
+        XCTAssertFalse(storedSystemPlugins.contains(systemPlugin2)) // Different siteID
+        XCTAssertFalse(storedSystemPlugins.contains(systemPlugin3)) // Not in matching paths
+    }
+
     func test_load_WCPayCharge_by_siteID_and_chargeID() throws {
         // Given
         let charge1 = storage.insertNewObject(ofType: WCPayCharge.self)

--- a/Modules/Tests/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Modules/Tests/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -1466,6 +1466,78 @@ final class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(foundSystemPlugin, systemPlugin2)
     }
 
+    func test_loadSystemPlugin_by_siteID_path_and_active_state() throws {
+        // Given
+        let inactivePlugin = storage.insertNewObject(ofType: SystemPlugin.self)
+        inactivePlugin.plugin = "woocommerce/woocommerce.php"
+        inactivePlugin.siteID = sampleSiteID
+        inactivePlugin.active = false
+
+        let activePlugin = storage.insertNewObject(ofType: SystemPlugin.self)
+        activePlugin.plugin = "woocommerce/woocommerce.php"
+        activePlugin.siteID = sampleSiteID
+        activePlugin.active = true
+
+        // When
+        let foundActivePlugin = try XCTUnwrap(storage.loadSystemPlugin(siteID: sampleSiteID, path: "woocommerce/woocommerce.php", active: true))
+
+        // Then
+        XCTAssertEqual(foundActivePlugin, activePlugin)
+    }
+
+    func test_loadSystemPlugin_by_siteID_path_and_inactive_state() throws {
+        // Given
+        let activePlugin = storage.insertNewObject(ofType: SystemPlugin.self)
+        activePlugin.plugin = "woocommerce/woocommerce.php"
+        activePlugin.siteID = sampleSiteID
+        activePlugin.active = true
+
+        let inactivePlugin = storage.insertNewObject(ofType: SystemPlugin.self)
+        inactivePlugin.plugin = "woocommerce/woocommerce.php"
+        inactivePlugin.siteID = sampleSiteID
+        inactivePlugin.active = false
+
+        // When
+        let foundInactivePlugin = try XCTUnwrap(storage.loadSystemPlugin(siteID: sampleSiteID, path: "woocommerce/woocommerce.php", active: false))
+
+        // Then
+        XCTAssertEqual(foundInactivePlugin, inactivePlugin)
+    }
+
+    func test_loadSystemPlugin_by_siteID_and_path_ignoring_active_state() throws {
+        // Given
+        let activePlugin = storage.insertNewObject(ofType: SystemPlugin.self)
+        activePlugin.plugin = "woocommerce/woocommerce.php"
+        activePlugin.siteID = sampleSiteID
+        activePlugin.active = true
+
+        let inactivePlugin = storage.insertNewObject(ofType: SystemPlugin.self)
+        inactivePlugin.plugin = "jetpack/jetpack.php"
+        inactivePlugin.siteID = sampleSiteID
+        inactivePlugin.active = false
+
+        // When
+        let foundPlugin = storage.loadSystemPlugin(siteID: sampleSiteID, path: "woocommerce/woocommerce.php", active: nil)
+
+        // Then
+        XCTAssertNotNil(foundPlugin)
+        XCTAssertEqual(foundPlugin, activePlugin)
+    }
+
+    func test_loadSystemPlugin_returns_nil_when_no_match_for_active_state() {
+        // Given
+        let activePlugin = storage.insertNewObject(ofType: SystemPlugin.self)
+        activePlugin.plugin = "woocommerce/woocommerce.php"
+        activePlugin.siteID = sampleSiteID
+        activePlugin.active = true
+
+        // When
+        let foundPlugin = storage.loadSystemPlugin(siteID: sampleSiteID, path: "woocommerce/woocommerce.php", active: false)
+
+        // Then
+        XCTAssertNil(foundPlugin)
+    }
+
     func test_loadSystemPlugins_by_siteID_matching_paths() {
         // Given
         let systemPlugin1 = storage.insertNewObject(ofType: SystemPlugin.self)

--- a/Modules/Tests/YosemiteTests/Stores/SystemPlugin/SystemPluginsUpsertUseCaseTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SystemPlugin/SystemPluginsUpsertUseCaseTests.swift
@@ -165,7 +165,8 @@ struct SystemPluginsUpsertUseCaseTests {
         #expect(site2Plugins.first?.active == false)
     }
 
-    /// It is possible to have more than one installation of the same plugin, like from using Jetpack Beta (ref p1732109416765569/1732014675.214429-slack-C025A8VV728).
+    /// It is possible to have more than one installation of the same plugin, like from using Jetpack Beta
+    /// (example p1732109416765569/1732014675.214429-slack-C025A8VV728).
     /// This test and `upsert_stores_all_plugins_per_active_state_when_two_plugins_have_the_same_plugin_path_and_name` ensures that the upsert logic correctly handles
     /// multiple installations of the same plugin.
     @Test func upsert_stores_2_plugins_when_plugin_with_same_name_and_plugin_path_in_both_active_and_inactive() async throws {

--- a/Modules/Tests/YosemiteTests/Stores/SystemPlugin/SystemPluginsUpsertUseCaseTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SystemPlugin/SystemPluginsUpsertUseCaseTests.swift
@@ -1,0 +1,213 @@
+import Foundation
+import Testing
+
+import Fakes
+import Storage
+@testable import Networking
+@testable import Yosemite
+
+@MainActor
+struct SystemPluginsUpsertUseCaseTests {
+    private let defaultSiteID: Int64 = 10
+    private var storageManager: MockStorageManager!
+    private var viewStorage: StorageType {
+        storageManager.viewStorage
+    }
+
+    init() async throws {
+        storageManager = MockStorageManager()
+        storageManager.reset()
+    }
+
+    @Test func upsert_inserts_plugins_in_storage() async throws {
+        // Given
+        let activePlugin = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "woocommerce")
+        let inactivePlugin = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "jetpack")
+
+        // When
+        await storageManager.performAndSaveAsync { storage in
+            let useCase = SystemPluginsUpsertUseCase(storage: storage)
+            useCase.upsert(siteID: defaultSiteID, activePlugins: [activePlugin], inactivePlugins: [inactivePlugin])
+        }
+
+        // Then
+        let storedPlugins = viewStorage.loadSystemPlugins(siteID: defaultSiteID)
+        #expect(storedPlugins.count == 2)
+
+        let storedActivePlugin = storedPlugins.first { $0.name == "woocommerce" }
+        #expect(storedActivePlugin?.active == true)
+
+        let storedInactivePlugin = storedPlugins.first { $0.name == "jetpack" }
+        #expect(storedInactivePlugin?.active == false)
+    }
+
+    @Test func upsert_sets_active_state_correctly() async throws {
+        // Given
+        let activePlugin = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "woocommerce", active: false) // Initially false
+        let inactivePlugin = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "jetpack", active: true) // Initially true
+
+        // When - pass activePlugin in activePlugins and inactivePlugin in inactivePlugins
+        await storageManager.performAndSaveAsync { storage in
+            let useCase = SystemPluginsUpsertUseCase(storage: storage)
+            useCase.upsert(siteID: defaultSiteID, activePlugins: [activePlugin], inactivePlugins: [inactivePlugin])
+        }
+
+        // Then - active state should be corrected based on the array they're in
+        let storedPlugins = viewStorage.loadSystemPlugins(siteID: defaultSiteID)
+
+        let storedActivePlugin = storedPlugins.first { $0.name == "woocommerce" }
+        #expect(storedActivePlugin?.active == true) // Should be true because it was in activePlugins
+
+        let storedInactivePlugin = storedPlugins.first { $0.name == "jetpack" }
+        #expect(storedInactivePlugin?.active == false) // Should be false because it was in inactivePlugins
+    }
+
+    @Test func upsert_updates_existing_plugins() async throws {
+        // Given
+        let originalPlugin = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "woocommerce", version: "1.0.0", active: false)
+
+        // Insert original plugin
+        await storageManager.performAndSaveAsync { storage in
+            let useCase = SystemPluginsUpsertUseCase(storage: storage)
+            useCase.upsert(siteID: defaultSiteID, activePlugins: [], inactivePlugins: [originalPlugin])
+        }
+
+        // When - update plugin with new version and active state
+        let updatedPlugin = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "woocommerce", version: "2.0.0", active: true)
+        await storageManager.performAndSaveAsync { storage in
+            let useCase = SystemPluginsUpsertUseCase(storage: storage)
+            useCase.upsert(siteID: defaultSiteID, activePlugins: [updatedPlugin], inactivePlugins: [])
+        }
+
+        // Then
+        let storedPlugins = viewStorage.loadSystemPlugins(siteID: defaultSiteID)
+        #expect(storedPlugins.count == 1)
+
+        let storedPlugin = storedPlugins.first { $0.name == "woocommerce" }
+        #expect(storedPlugin?.version == "2.0.0")
+        #expect(storedPlugin?.active == true)
+    }
+
+    @Test func upsert_removes_stale_plugins() async throws {
+        // Given
+        let plugin1 = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "woocommerce", active: true)
+        let plugin2 = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "jetpack", active: false)
+        let plugin3 = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "yoast", active: true)
+
+        // Insert all three plugins
+        await storageManager.performAndSaveAsync { storage in
+            let useCase = SystemPluginsUpsertUseCase(storage: storage)
+            useCase.upsert(siteID: defaultSiteID, activePlugins: [plugin1, plugin3], inactivePlugins: [plugin2])
+        }
+
+        // When - only keep plugin1 and plugin2, plugin3 should be removed
+        await storageManager.performAndSaveAsync { storage in
+            let useCase = SystemPluginsUpsertUseCase(storage: storage)
+            useCase.upsert(siteID: defaultSiteID, activePlugins: [plugin1], inactivePlugins: [plugin2])
+        }
+
+        // Then
+        let storedPlugins = viewStorage.loadSystemPlugins(siteID: defaultSiteID)
+        #expect(storedPlugins.count == 2)
+
+        let pluginNames = storedPlugins.map { $0.name }
+        #expect(pluginNames.contains("woocommerce"))
+        #expect(pluginNames.contains("jetpack"))
+        #expect(!pluginNames.contains("yoast"))
+    }
+
+    @Test func upsert_handles_empty_plugin_lists() async throws {
+        // Given
+        let plugin = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "woocommerce", active: true)
+
+        // Insert a plugin first
+        await storageManager.performAndSaveAsync { storage in
+            let useCase = SystemPluginsUpsertUseCase(storage: storage)
+            useCase.upsert(siteID: defaultSiteID, activePlugins: [plugin], inactivePlugins: [])
+        }
+
+        // When - pass empty lists
+        await storageManager.performAndSaveAsync { storage in
+            let useCase = SystemPluginsUpsertUseCase(storage: storage)
+            useCase.upsert(siteID: defaultSiteID, activePlugins: [], inactivePlugins: [])
+        }
+
+        // Then - all plugins should be removed
+        let storedPlugins = viewStorage.loadSystemPlugins(siteID: defaultSiteID)
+        #expect(storedPlugins.count == 0)
+    }
+
+    @Test func upsert_handles_site_isolation() async throws {
+        // Given
+        let plugin1 = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "woocommerce", active: true)
+        let plugin2 = SystemPlugin.fake().copy(siteID: 20, name: "jetpack", active: false)
+
+        let siteID1: Int64 = 10
+        let siteID2: Int64 = 20
+
+        // When - insert plugins for different sites
+        await storageManager.performAndSaveAsync { storage in
+            let useCase = SystemPluginsUpsertUseCase(storage: storage)
+            useCase.upsert(siteID: siteID1, activePlugins: [plugin1], inactivePlugins: [])
+            useCase.upsert(siteID: siteID2, activePlugins: [], inactivePlugins: [plugin2])
+        }
+
+        // Then - plugins should be isolated by site
+        let site1Plugins = viewStorage.loadSystemPlugins(siteID: siteID1)
+        let site2Plugins = viewStorage.loadSystemPlugins(siteID: siteID2)
+
+        #expect(site1Plugins.count == 1)
+        #expect(site1Plugins.first?.name == "woocommerce")
+        #expect(site1Plugins.first?.active == true)
+
+        #expect(site2Plugins.count == 1)
+        #expect(site2Plugins.first?.name == "jetpack")
+        #expect(site2Plugins.first?.active == false)
+    }
+
+    @Test func upsert_stores_2_plugins_when_plugin_with_same_name_in_both_active_and_inactive() async throws {
+        // Given
+        let activePlugin = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "woocommerce", version: "1.0.0", active: true)
+        let inactivePlugin = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "woocommerce", version: "2.0.0", active: false)
+
+        // When - pass the same plugin name in both active and inactive lists
+        await storageManager.performAndSaveAsync { storage in
+            let useCase = SystemPluginsUpsertUseCase(storage: storage)
+            useCase.upsert(siteID: defaultSiteID, activePlugins: [activePlugin], inactivePlugins: [inactivePlugin])
+        }
+
+        // Then - the last one processed should win (inactive in this case)
+        let storedPlugins = viewStorage.loadSystemPlugins(siteID: defaultSiteID)
+        #expect(storedPlugins.count == 2)
+
+        let storedActivePlugin = storedPlugins.first { $0.name == "woocommerce" && $0.active == true }
+        #expect(storedActivePlugin?.active == true)
+        #expect(storedActivePlugin?.version == "1.0.0")
+
+        let storedInactivePlugin = storedPlugins.first { $0.name == "woocommerce" && $0.active == false }
+        #expect(storedInactivePlugin?.active == false)
+        #expect(storedInactivePlugin?.version == "2.0.0")
+    }
+
+    @Test func upsert_handles_large_number_of_plugins() async throws {
+        // Given
+        let activePlugins = (1...500).map { SystemPlugin.fake().copy(siteID: defaultSiteID, name: "active-plugin-\($0)", active: true) }
+        let inactivePlugins = (1...500).map { SystemPlugin.fake().copy(siteID: defaultSiteID, name: "inactive-plugin-\($0)", active: false) }
+
+        // When
+        await storageManager.performAndSaveAsync { storage in
+            let useCase = SystemPluginsUpsertUseCase(storage: storage)
+            useCase.upsert(siteID: defaultSiteID, activePlugins: activePlugins, inactivePlugins: inactivePlugins)
+        }
+
+        // Then
+        let storedPlugins = viewStorage.loadSystemPlugins(siteID: defaultSiteID)
+        #expect(storedPlugins.count == 1000)
+
+        let activeCount = storedPlugins.filter { $0.active }.count
+        let inactiveCount = storedPlugins.filter { !$0.active }.count
+
+        #expect(activeCount == 500)
+        #expect(inactiveCount == 500)
+    }
+}

--- a/Modules/Tests/YosemiteTests/Stores/SystemPlugin/SystemPluginsUpsertUseCaseTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SystemPlugin/SystemPluginsUpsertUseCaseTests.swift
@@ -165,6 +165,9 @@ struct SystemPluginsUpsertUseCaseTests {
         #expect(site2Plugins.first?.active == false)
     }
 
+    /// It is possible to have more than one installation of the same plugin, like from using Jetpack Beta (ref p1732109416765569/1732014675.214429-slack-C025A8VV728).
+    /// This test and `upsert_stores_all_plugins_per_active_state_when_two_plugins_have_the_same_plugin_path_and_name` ensures that the upsert logic correctly handles
+    /// multiple installations of the same plugin.
     @Test func upsert_stores_2_plugins_when_plugin_with_same_name_and_plugin_path_in_both_active_and_inactive() async throws {
         // Given
         let activePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", version: "1.0.0", active: true)

--- a/Modules/Tests/YosemiteTests/Stores/SystemPlugin/SystemPluginsUpsertUseCaseTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SystemPlugin/SystemPluginsUpsertUseCaseTests.swift
@@ -8,7 +8,7 @@ import Storage
 
 @MainActor
 struct SystemPluginsUpsertUseCaseTests {
-    private let defaultSiteID: Int64 = 10
+    private let siteID: Int64 = 10
     private var storageManager: MockStorageManager!
     private var viewStorage: StorageType {
         storageManager.viewStorage
@@ -21,126 +21,126 @@ struct SystemPluginsUpsertUseCaseTests {
 
     @Test func upsert_inserts_plugins_in_storage() async throws {
         // Given
-        let activePlugin = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "woocommerce")
-        let inactivePlugin = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "jetpack")
+        let activePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce")
+        let inactivePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "jetpack/jetpack.php", name: "Jetpack")
 
         // When
         await storageManager.performAndSaveAsync { storage in
             let useCase = SystemPluginsUpsertUseCase(storage: storage)
-            useCase.upsert(siteID: defaultSiteID, activePlugins: [activePlugin], inactivePlugins: [inactivePlugin])
+            useCase.upsert(siteID: siteID, activePlugins: [activePlugin], inactivePlugins: [inactivePlugin])
         }
 
         // Then
-        let storedPlugins = viewStorage.loadSystemPlugins(siteID: defaultSiteID)
+        let storedPlugins = viewStorage.loadSystemPlugins(siteID: siteID)
         #expect(storedPlugins.count == 2)
 
-        let storedActivePlugin = storedPlugins.first { $0.name == "woocommerce" }
+        let storedActivePlugin = storedPlugins.first { $0.plugin == "woocommerce/woocommerce.php" }
         #expect(storedActivePlugin?.active == true)
 
-        let storedInactivePlugin = storedPlugins.first { $0.name == "jetpack" }
+        let storedInactivePlugin = storedPlugins.first { $0.plugin == "jetpack/jetpack.php" }
         #expect(storedInactivePlugin?.active == false)
     }
 
     @Test func upsert_sets_active_state_correctly() async throws {
         // Given
-        let activePlugin = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "woocommerce", active: false) // Initially false
-        let inactivePlugin = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "jetpack", active: true) // Initially true
+        let activePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", active: false)
+        let inactivePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "jetpack/jetpack.php", name: "Jetpack", active: true)
 
         // When - pass activePlugin in activePlugins and inactivePlugin in inactivePlugins
         await storageManager.performAndSaveAsync { storage in
             let useCase = SystemPluginsUpsertUseCase(storage: storage)
-            useCase.upsert(siteID: defaultSiteID, activePlugins: [activePlugin], inactivePlugins: [inactivePlugin])
+            useCase.upsert(siteID: siteID, activePlugins: [activePlugin], inactivePlugins: [inactivePlugin])
         }
 
         // Then - active state should be corrected based on the array they're in
-        let storedPlugins = viewStorage.loadSystemPlugins(siteID: defaultSiteID)
+        let storedPlugins = viewStorage.loadSystemPlugins(siteID: siteID)
 
-        let storedActivePlugin = storedPlugins.first { $0.name == "woocommerce" }
+        let storedActivePlugin = storedPlugins.first { $0.plugin == "woocommerce/woocommerce.php" }
         #expect(storedActivePlugin?.active == true) // Should be true because it was in activePlugins
 
-        let storedInactivePlugin = storedPlugins.first { $0.name == "jetpack" }
+        let storedInactivePlugin = storedPlugins.first { $0.plugin == "jetpack/jetpack.php" }
         #expect(storedInactivePlugin?.active == false) // Should be false because it was in inactivePlugins
     }
 
     @Test func upsert_updates_existing_plugins() async throws {
         // Given
-        let originalPlugin = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "woocommerce", version: "1.0.0", active: false)
+        let originalPlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", version: "1.0.0", active: false)
 
         // Insert original plugin
         await storageManager.performAndSaveAsync { storage in
             let useCase = SystemPluginsUpsertUseCase(storage: storage)
-            useCase.upsert(siteID: defaultSiteID, activePlugins: [], inactivePlugins: [originalPlugin])
+            useCase.upsert(siteID: siteID, activePlugins: [], inactivePlugins: [originalPlugin])
         }
 
         // When - update plugin with new version and active state
-        let updatedPlugin = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "woocommerce", version: "2.0.0", active: true)
+        let updatedPlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", version: "2.0.0", active: true)
         await storageManager.performAndSaveAsync { storage in
             let useCase = SystemPluginsUpsertUseCase(storage: storage)
-            useCase.upsert(siteID: defaultSiteID, activePlugins: [updatedPlugin], inactivePlugins: [])
+            useCase.upsert(siteID: siteID, activePlugins: [updatedPlugin], inactivePlugins: [])
         }
 
         // Then
-        let storedPlugins = viewStorage.loadSystemPlugins(siteID: defaultSiteID)
+        let storedPlugins = viewStorage.loadSystemPlugins(siteID: siteID)
         #expect(storedPlugins.count == 1)
 
-        let storedPlugin = storedPlugins.first { $0.name == "woocommerce" }
+        let storedPlugin = storedPlugins.first { $0.plugin == "woocommerce/woocommerce.php" }
         #expect(storedPlugin?.version == "2.0.0")
         #expect(storedPlugin?.active == true)
     }
 
     @Test func upsert_removes_stale_plugins() async throws {
         // Given
-        let plugin1 = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "woocommerce", active: true)
-        let plugin2 = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "jetpack", active: false)
-        let plugin3 = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "yoast", active: true)
+        let plugin1 = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", active: true)
+        let plugin2 = SystemPlugin.fake().copy(siteID: siteID, plugin: "jetpack/jetpack.php", name: "Jetpack", active: false)
+        let plugin3 = SystemPlugin.fake().copy(siteID: siteID, plugin: "wordpress-seo/wp-seo.php", name: "WP SEO", active: true)
 
         // Insert all three plugins
         await storageManager.performAndSaveAsync { storage in
             let useCase = SystemPluginsUpsertUseCase(storage: storage)
-            useCase.upsert(siteID: defaultSiteID, activePlugins: [plugin1, plugin3], inactivePlugins: [plugin2])
+            useCase.upsert(siteID: siteID, activePlugins: [plugin1, plugin3], inactivePlugins: [plugin2])
         }
 
         // When - only keep plugin1 and plugin2, plugin3 should be removed
         await storageManager.performAndSaveAsync { storage in
             let useCase = SystemPluginsUpsertUseCase(storage: storage)
-            useCase.upsert(siteID: defaultSiteID, activePlugins: [plugin1], inactivePlugins: [plugin2])
+            useCase.upsert(siteID: siteID, activePlugins: [plugin1], inactivePlugins: [plugin2])
         }
 
         // Then
-        let storedPlugins = viewStorage.loadSystemPlugins(siteID: defaultSiteID)
+        let storedPlugins = viewStorage.loadSystemPlugins(siteID: siteID)
         #expect(storedPlugins.count == 2)
 
-        let pluginNames = storedPlugins.map { $0.name }
-        #expect(pluginNames.contains("woocommerce"))
-        #expect(pluginNames.contains("jetpack"))
-        #expect(!pluginNames.contains("yoast"))
+        let pluginPaths = storedPlugins.map { $0.plugin }
+        #expect(pluginPaths.contains("woocommerce/woocommerce.php"))
+        #expect(pluginPaths.contains("jetpack/jetpack.php"))
+        #expect(!pluginPaths.contains("wordpress-seo/wp-seo.php"))
     }
 
     @Test func upsert_handles_empty_plugin_lists() async throws {
         // Given
-        let plugin = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "woocommerce", active: true)
+        let plugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", active: true)
 
         // Insert a plugin first
         await storageManager.performAndSaveAsync { storage in
             let useCase = SystemPluginsUpsertUseCase(storage: storage)
-            useCase.upsert(siteID: defaultSiteID, activePlugins: [plugin], inactivePlugins: [])
+            useCase.upsert(siteID: siteID, activePlugins: [plugin], inactivePlugins: [])
         }
 
         // When - pass empty lists
         await storageManager.performAndSaveAsync { storage in
             let useCase = SystemPluginsUpsertUseCase(storage: storage)
-            useCase.upsert(siteID: defaultSiteID, activePlugins: [], inactivePlugins: [])
+            useCase.upsert(siteID: siteID, activePlugins: [], inactivePlugins: [])
         }
 
         // Then - all plugins should be removed
-        let storedPlugins = viewStorage.loadSystemPlugins(siteID: defaultSiteID)
+        let storedPlugins = viewStorage.loadSystemPlugins(siteID: siteID)
         #expect(storedPlugins.count == 0)
     }
 
     @Test func upsert_handles_site_isolation() async throws {
         // Given
-        let plugin1 = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "woocommerce", active: true)
-        let plugin2 = SystemPlugin.fake().copy(siteID: 20, name: "jetpack", active: false)
+        let plugin1 = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", active: true)
+        let plugin2 = SystemPlugin.fake().copy(siteID: 20, plugin: "jetpack/jetpack.php", name: "Jetpack", active: false)
 
         let siteID1: Int64 = 10
         let siteID2: Int64 = 20
@@ -157,51 +157,79 @@ struct SystemPluginsUpsertUseCaseTests {
         let site2Plugins = viewStorage.loadSystemPlugins(siteID: siteID2)
 
         #expect(site1Plugins.count == 1)
-        #expect(site1Plugins.first?.name == "woocommerce")
+        #expect(site1Plugins.first?.plugin == "woocommerce/woocommerce.php")
         #expect(site1Plugins.first?.active == true)
 
         #expect(site2Plugins.count == 1)
-        #expect(site2Plugins.first?.name == "jetpack")
+        #expect(site2Plugins.first?.plugin == "jetpack/jetpack.php")
         #expect(site2Plugins.first?.active == false)
     }
 
-    @Test func upsert_stores_2_plugins_when_plugin_with_same_name_in_both_active_and_inactive() async throws {
+    @Test func upsert_stores_2_plugins_when_plugin_with_same_name_and_plugin_path_in_both_active_and_inactive() async throws {
         // Given
-        let activePlugin = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "woocommerce", version: "1.0.0", active: true)
-        let inactivePlugin = SystemPlugin.fake().copy(siteID: defaultSiteID, name: "woocommerce", version: "2.0.0", active: false)
-
-        // When - pass the same plugin name in both active and inactive lists
-        await storageManager.performAndSaveAsync { storage in
-            let useCase = SystemPluginsUpsertUseCase(storage: storage)
-            useCase.upsert(siteID: defaultSiteID, activePlugins: [activePlugin], inactivePlugins: [inactivePlugin])
-        }
-
-        // Then - the last one processed should win (inactive in this case)
-        let storedPlugins = viewStorage.loadSystemPlugins(siteID: defaultSiteID)
-        #expect(storedPlugins.count == 2)
-
-        let storedActivePlugin = storedPlugins.first { $0.name == "woocommerce" && $0.active == true }
-        #expect(storedActivePlugin?.active == true)
-        #expect(storedActivePlugin?.version == "1.0.0")
-
-        let storedInactivePlugin = storedPlugins.first { $0.name == "woocommerce" && $0.active == false }
-        #expect(storedInactivePlugin?.active == false)
-        #expect(storedInactivePlugin?.version == "2.0.0")
-    }
-
-    @Test func upsert_handles_large_number_of_plugins() async throws {
-        // Given
-        let activePlugins = (1...500).map { SystemPlugin.fake().copy(siteID: defaultSiteID, name: "active-plugin-\($0)", active: true) }
-        let inactivePlugins = (1...500).map { SystemPlugin.fake().copy(siteID: defaultSiteID, name: "inactive-plugin-\($0)", active: false) }
+        let activePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", version: "1.0.0", active: true)
+        let inactivePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", version: "2.0.0", active: false)
 
         // When
         await storageManager.performAndSaveAsync { storage in
             let useCase = SystemPluginsUpsertUseCase(storage: storage)
-            useCase.upsert(siteID: defaultSiteID, activePlugins: activePlugins, inactivePlugins: inactivePlugins)
+            useCase.upsert(siteID: siteID, activePlugins: [activePlugin], inactivePlugins: [inactivePlugin])
         }
 
         // Then
-        let storedPlugins = viewStorage.loadSystemPlugins(siteID: defaultSiteID)
+        let storedPlugins = viewStorage.loadSystemPlugins(siteID: siteID)
+        #expect(storedPlugins.count == 2)
+
+        let storedActivePlugin = storedPlugins.first { $0.plugin == "woocommerce/woocommerce.php" && $0.active == true }
+        #expect(storedActivePlugin?.active == true)
+        #expect(storedActivePlugin?.version == "1.0.0")
+
+        let storedInactivePlugin = storedPlugins.first { $0.plugin == "woocommerce/woocommerce.php" && $0.active == false }
+        #expect(storedInactivePlugin?.active == false)
+        #expect(storedInactivePlugin?.version == "2.0.0")
+    }
+
+    @Test func upsert_stores_all_plugins_per_active_state_when_two_plugins_have_the_same_plugin_path_and_name() async throws {
+        // Given
+        let activePlugin1 = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", version: "1.0.0", active: true)
+        let activePlugin2 = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", version: "1.1.0", active: true)
+        let inactivePlugin1 = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", version: "2.0.0", active: false)
+        let inactivePlugin2 = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", version: "2.5.0", active: false)
+
+        // When
+        await storageManager.performAndSaveAsync { storage in
+            let useCase = SystemPluginsUpsertUseCase(storage: storage)
+            useCase.upsert(siteID: siteID, activePlugins: [activePlugin1, activePlugin2], inactivePlugins: [inactivePlugin1, inactivePlugin2])
+        }
+
+        // Then
+        let storedPlugins = viewStorage.loadSystemPlugins(siteID: siteID)
+        #expect(storedPlugins.count == 4)
+
+        let storedActivePlugins = storedPlugins.filter { $0.plugin == "woocommerce/woocommerce.php" && $0.active == true }
+        #expect(Set(storedActivePlugins.map { $0.version }) == ["1.0.0", "1.1.0"])
+
+        let storedInactivePlugins = storedPlugins.filter { $0.plugin == "woocommerce/woocommerce.php" && $0.active == false }
+        #expect(Set(storedInactivePlugins.map { $0.version }) == ["2.0.0", "2.5.0"])
+    }
+
+    @Test func upsert_handles_large_number_of_plugins() async throws {
+        // Given
+        let activePlugins = (1...500).map {
+            SystemPlugin.fake().copy(siteID: siteID, plugin: "active-plugin-\($0)/plugin.php", name: "Active Plugin \($0)", active: true)
+        }
+        let inactivePlugins = (1...500).map {
+            SystemPlugin.fake().copy(siteID: siteID, plugin: "inactive-plugin-\($0)/plugin.php", name: "Inactive Plugin \($0)", active: false)
+        }
+
+        // When
+        await storageManager.performAndSaveAsync { storage in
+            let useCase = SystemPluginsUpsertUseCase(storage: storage)
+            useCase.upsert(siteID: siteID, activePlugins: activePlugins, inactivePlugins: inactivePlugins)
+        }
+
+        // Then
+        let storedPlugins = viewStorage.loadSystemPlugins(siteID: siteID)
         #expect(storedPlugins.count == 1000)
 
         let activeCount = storedPlugins.filter { $0.active }.count

--- a/Modules/Tests/YosemiteTests/Stores/SystemPlugin/SystemPluginsUpsertUseCaseTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SystemPlugin/SystemPluginsUpsertUseCaseTests.swift
@@ -21,8 +21,8 @@ struct SystemPluginsUpsertUseCaseTests {
 
     @Test func upsert_inserts_plugins_in_storage() async throws {
         // Given
-        let activePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce")
-        let inactivePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "jetpack/jetpack.php", name: "Jetpack")
+        let activePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php")
+        let inactivePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "jetpack/jetpack.php")
 
         // When
         await storageManager.performAndSaveAsync { storage in
@@ -43,8 +43,8 @@ struct SystemPluginsUpsertUseCaseTests {
 
     @Test func upsert_sets_active_state_correctly() async throws {
         // Given
-        let activePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", active: false)
-        let inactivePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "jetpack/jetpack.php", name: "Jetpack", active: true)
+        let activePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", active: false)
+        let inactivePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "jetpack/jetpack.php", active: true)
 
         // When - pass activePlugin in activePlugins and inactivePlugin in inactivePlugins
         await storageManager.performAndSaveAsync { storage in
@@ -64,7 +64,7 @@ struct SystemPluginsUpsertUseCaseTests {
 
     @Test func upsert_updates_existing_plugins() async throws {
         // Given
-        let originalPlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", version: "1.0.0", active: false)
+        let originalPlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", version: "1.0.0", active: false)
 
         // Insert original plugin
         await storageManager.performAndSaveAsync { storage in
@@ -73,7 +73,7 @@ struct SystemPluginsUpsertUseCaseTests {
         }
 
         // When - update plugin with new version and active state
-        let updatedPlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", version: "2.0.0", active: true)
+        let updatedPlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", version: "2.0.0", active: true)
         await storageManager.performAndSaveAsync { storage in
             let useCase = SystemPluginsUpsertUseCase(storage: storage)
             useCase.upsert(siteID: siteID, activePlugins: [updatedPlugin], inactivePlugins: [])
@@ -90,9 +90,9 @@ struct SystemPluginsUpsertUseCaseTests {
 
     @Test func upsert_removes_stale_plugins() async throws {
         // Given
-        let plugin1 = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", active: true)
-        let plugin2 = SystemPlugin.fake().copy(siteID: siteID, plugin: "jetpack/jetpack.php", name: "Jetpack", active: false)
-        let plugin3 = SystemPlugin.fake().copy(siteID: siteID, plugin: "wordpress-seo/wp-seo.php", name: "WP SEO", active: true)
+        let plugin1 = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", active: true)
+        let plugin2 = SystemPlugin.fake().copy(siteID: siteID, plugin: "jetpack/jetpack.php", active: false)
+        let plugin3 = SystemPlugin.fake().copy(siteID: siteID, plugin: "wordpress-seo/wp-seo.php", active: true)
 
         // Insert all three plugins
         await storageManager.performAndSaveAsync { storage in
@@ -118,7 +118,7 @@ struct SystemPluginsUpsertUseCaseTests {
 
     @Test func upsert_handles_empty_plugin_lists() async throws {
         // Given
-        let plugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", active: true)
+        let plugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", active: true)
 
         // Insert a plugin first
         await storageManager.performAndSaveAsync { storage in
@@ -139,8 +139,8 @@ struct SystemPluginsUpsertUseCaseTests {
 
     @Test func upsert_handles_site_isolation() async throws {
         // Given
-        let plugin1 = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", active: true)
-        let plugin2 = SystemPlugin.fake().copy(siteID: 20, plugin: "jetpack/jetpack.php", name: "Jetpack", active: false)
+        let plugin1 = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", active: true)
+        let plugin2 = SystemPlugin.fake().copy(siteID: 20, plugin: "jetpack/jetpack.php", active: false)
 
         let siteID1: Int64 = 10
         let siteID2: Int64 = 20
@@ -167,12 +167,12 @@ struct SystemPluginsUpsertUseCaseTests {
 
     /// It is possible to have more than one installation of the same plugin, like from using Jetpack Beta
     /// (example p1732109416765569/1732014675.214429-slack-C025A8VV728).
-    /// This test and `upsert_stores_all_plugins_per_active_state_when_two_plugins_have_the_same_plugin_path_and_name` ensures that the upsert logic correctly handles
-    /// multiple installations of the same plugin.
+    /// This test and `upsert_stores_all_plugins_per_active_state_when_two_plugins_have_the_same_plugin_path_and_name` ensures that the upsert logic correctly
+    /// handles multiple installations of the same plugin.
     @Test func upsert_stores_2_plugins_when_plugin_with_same_name_and_plugin_path_in_both_active_and_inactive() async throws {
         // Given
-        let activePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", version: "1.0.0", active: true)
-        let inactivePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", version: "2.0.0", active: false)
+        let activePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", version: "1.0.0", active: true)
+        let inactivePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", version: "2.0.0", active: false)
 
         // When
         await storageManager.performAndSaveAsync { storage in
@@ -195,10 +195,10 @@ struct SystemPluginsUpsertUseCaseTests {
 
     @Test func upsert_stores_all_plugins_per_active_state_when_two_plugins_have_the_same_plugin_path_and_name() async throws {
         // Given
-        let activePlugin1 = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", version: "1.0.0", active: true)
-        let activePlugin2 = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", version: "1.1.0", active: true)
-        let inactivePlugin1 = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", version: "2.0.0", active: false)
-        let inactivePlugin2 = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", name: "WooCommerce", version: "2.5.0", active: false)
+        let activePlugin1 = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", version: "1.0.0", active: true)
+        let activePlugin2 = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", version: "1.1.0", active: true)
+        let inactivePlugin1 = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", version: "2.0.0", active: false)
+        let inactivePlugin2 = SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", version: "2.5.0", active: false)
 
         // When
         await storageManager.performAndSaveAsync { storage in
@@ -220,10 +220,10 @@ struct SystemPluginsUpsertUseCaseTests {
     @Test func upsert_handles_large_number_of_plugins() async throws {
         // Given
         let activePlugins = (1...500).map {
-            SystemPlugin.fake().copy(siteID: siteID, plugin: "active-plugin-\($0)/plugin.php", name: "Active Plugin \($0)", active: true)
+            SystemPlugin.fake().copy(siteID: siteID, plugin: "active-plugin-\($0)/plugin.php", active: true)
         }
         let inactivePlugins = (1...500).map {
-            SystemPlugin.fake().copy(siteID: siteID, plugin: "inactive-plugin-\($0)/plugin.php", name: "Inactive Plugin \($0)", active: false)
+            SystemPlugin.fake().copy(siteID: siteID, plugin: "inactive-plugin-\($0)/plugin.php", active: false)
         }
 
         // When


### PR DESCRIPTION
For WOOMOB-859

Just one review is required.

## Why

The existing `SystemPlugin` upsert logic is prone to errors when the plugin name changes, which happened at least twice throughout the app history like the recent shipping plugin rename p91TBi-diK-p2#the-cause-and-solution. This PR aims to make the plugins persistence and use cases more durable by matching plugins by plugin path instead of name. Furthermore, this PR extracts the `SystemPlugin` upsert logic from `POSSystemStatusService` and `SystemStatusStore` into a reusable use case to improve code maintainability and unit testing.

## Description

Key changes:

- Created `SystemPluginsUpsertUseCase` to encapsulate plugin upsert logic.
- Updated `POSSystemStatusService` and `SystemStatusStore` to use the new use case.
- Changed plugin matching from name-based to path-based for better reliability.
- Added test coverage for the upsert case and related storage methods.
- Enhanced storage methods with conditional active state filtering, for the POS use case to ensure the first **active** WC plugin is returned.

## Steps to reproduce

In the past, it was possible to have two WC plugins, one active and one inactive, when using Jetpack Beta plugin for testing. If you have a test site with Jetpack Beta plugin, it's a good candidate for testing this PR.

Prerequisite: the user has admin role to view plugins in the app

- Log in to a store in the prerequisite, ideally a site with Jetpack Beta plugin
- Go to Menu > Settings --> under the Plugins section, the WooCommerce row should show the correct version as in wp-admin for the active WC plugin
- Tap on `Plugins` row under the Plugins section --> the plugins and their name/version should match the active plugins in wp-admin
- Tap on the POS tab --> the plugin based eligibility checks should work as before

## Testing information

I tested the above and POS eligibility with 9.5.2 (ineligible) version, and 10.0+ version.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.