### PR TITLE
Decouple `OrderListCellViewModel` dependencies between app and watch

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -342,7 +342,7 @@ enum XcodeSupport {
             .xcodeTarget(
                 XcodeTargetNames.notificationExtension,
                 dependencies: [
-                    "Networking",
+                    "NetworkingCore",
                     "WooFoundation",
                     .product(name: "KeychainAccess", package: "KeychainAccess"),
                 ]

--- a/WooCommerce/Classes/Model/Address+Shared.swift
+++ b/WooCommerce/Classes/Model/Address+Shared.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Contacts
+import NetworkingCore
+
+extension Address {
+    /// Returns the First + LastName combined according to language rules and Locale.
+    ///
+    var fullName: String {
+        var components = PersonNameComponents()
+        components.givenName = firstName
+        components.familyName = lastName
+
+        return PersonNameComponentsFormatter.localizedString(from: components, style: .medium, options: [])
+    }
+
+    /// Returns the Postal Address, formatted and ready for display.
+    ///
+    var formattedPostalAddress: String? {
+        return postalAddress.formatted(as: .mailingAddress)
+    }
+}
+
+// MARK: - Private Methods
+//
+private extension Address {
+    /// Returns a CNPostalAddress with the receiver's properties
+    ///
+    var postalAddress: CNPostalAddress {
+        let refinedAddress = refineAddressState()
+        let address = CNMutablePostalAddress()
+
+        address.street = refinedAddress.combinedAddress
+        address.city = refinedAddress.city
+        address.state = refinedAddress.state
+        address.postalCode = refinedAddress.postcode
+        address.country = refinedAddress.country
+        address.isoCountryCode = refinedAddress.country
+
+        return address
+    }
+
+    func refineAddressState() -> Address {
+        #if !os(watchOS)
+        // https://github.com/woocommerce/woocommerce-ios/issues/5851
+        // The backend gives us the state code in the state field.
+        // For these countries we should show the state name instead, as the code is not identifiable (e.g. JP01 -> Hokkaido)
+        guard ["JP", "TR"].contains(country),
+              let stateName = LocallyStoredStateNameRetriever().retrieveLocallyStoredStateName(of: self) else {
+            return self
+        }
+
+        return copy(state: stateName)
+        #else
+        // Watch app does not have a local storage of countries.
+        // In this case we don't apply any special treatment
+        return self
+        #endif
+    }
+
+    /// Returns the two Address Lines combined (if there are, effectively, two lines).
+    /// Per US Post Office standardized rules for address lines. Ref. https://pe.usps.com/text/pub28/28c2_001.htm
+    ///
+    var combinedAddress: String {
+        guard let address2 = address2, address2.isEmpty == false else {
+            return address1
+        }
+
+        return address1 + "\n" + address2
+    }
+}

--- a/WooCommerce/Classes/Model/Address+Woo.swift
+++ b/WooCommerce/Classes/Model/Address+Woo.swift
@@ -1,27 +1,10 @@
 import Foundation
 import Contacts
-
-#if canImport(Yosemite)
 import Yosemite
-#elseif canImport(NetworkingCore)
-import NetworkingCore
-#endif
-
 
 // Yosemite.Address Helper Methods
 //
 extension Address {
-
-    /// Returns the First + LastName combined according to language rules and Locale.
-    ///
-    var fullName: String {
-        var components = PersonNameComponents()
-        components.givenName = firstName
-        components.familyName = lastName
-
-        return PersonNameComponentsFormatter.localizedString(from: components, style: .medium, options: [])
-    }
-
     /// Returns the `fullName` and `company` (on a new line). If either the `fullname` or `company` is empty,
     /// then a single line is returned containing the other value.
     ///
@@ -36,13 +19,6 @@ extension Address {
         }
 
         return output.joined(separator: "\n")
-    }
-
-
-    /// Returns the Postal Address, formatted and ready for display.
-    ///
-    var formattedPostalAddress: String? {
-        return postalAddress.formatted(as: .mailingAddress)
     }
 
     /// Returns the `fullName`, `company`, and `address`. Basically this var combines the
@@ -123,57 +99,4 @@ extension Address {
                            country: taxRate.country)
     }
 #endif
-}
-
-
-// MARK: - Private Methods
-//
-private extension Address {
-
-    /// Returns the two Address Lines combined (if there are, effectively, two lines).
-    /// Per US Post Office standardized rules for address lines. Ref. https://pe.usps.com/text/pub28/28c2_001.htm
-    ///
-    var combinedAddress: String {
-        guard let address2 = address2, address2.isEmpty == false else {
-            return address1
-        }
-
-        return address1 + "\n" + address2
-    }
-
-
-    /// Returns a CNPostalAddress with the receiver's properties
-    ///
-    var postalAddress: CNPostalAddress {
-        let refinedAddress = refineAddressState()
-        let address = CNMutablePostalAddress()
-
-        address.street = refinedAddress.combinedAddress
-        address.city = refinedAddress.city
-        address.state = refinedAddress.state
-        address.postalCode = refinedAddress.postcode
-        address.country = refinedAddress.country
-        address.isoCountryCode = refinedAddress.country
-
-        return address
-    }
-
-
-    func refineAddressState() -> Address {
-#if !os(watchOS)
-        // https://github.com/woocommerce/woocommerce-ios/issues/5851
-        // The backend gives us the state code in the state field.
-        // For these countries we should show the state name instead, as the code is not identifiable (e.g. JP01 -> Hokkaido)
-        guard ["JP", "TR"].contains(country),
-              let stateName = LocallyStoredStateNameRetriever().retrieveLocallyStoredStateName(of: self) else {
-            return self
-        }
-
-        return copy(state: stateName)
-#else
-        // Watch app does not have a local storage of countries.
-        // In this case we don't apply any special treatment
-        return self
-#endif
-    }
 }

--- a/WooCommerce/Classes/Model/MarkOrderAsReadUseCase+Woo.swift
+++ b/WooCommerce/Classes/Model/MarkOrderAsReadUseCase+Woo.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Yosemite
+
+extension MarkOrderAsReadUseCase {
+    /// Async method that marks the order note as read if it is the notification for the last order.
+    /// We do it in a way that first we syncronize notification to get the remote `Note`
+    /// and then we compare local `orderID` with the one from remote `Note`.
+    /// If they match we mark it as read.
+    /// Returns syncronized note if marking was successful and error if some error happened
+    @MainActor
+    static func markOrderNoteAsReadIfNeeded(stores: StoresManager, noteID: Int64, orderID: Int) async -> Result<Note, Error> {
+        let syncronizedNoteResult: Result<Note, Error> = await withCheckedContinuation { continuation in
+            let action = NotificationAction.synchronizeNotification(noteID: noteID) { syncronizedNote, error in
+                guard let syncronizedNote = syncronizedNote else {
+                    continuation.resume(returning: .failure(MarkOrderAsReadUseCase.Error.unavailableNote))
+                    return
+                }
+                continuation.resume(returning: .success(syncronizedNote))
+            }
+            stores.dispatch(action)
+        }
+
+        switch syncronizedNoteResult {
+        case .success(let syncronizedNote):
+            guard let syncronizedNoteOrderID = syncronizedNote.meta.identifier(forKey: .order),
+                  syncronizedNoteOrderID == orderID,
+                  syncronizedNote.read == false else {
+                return .failure(MarkOrderAsReadUseCase.Error.noNeedToMarkAsRead)
+            }
+
+            let updateNoteStatusResult: Result<Note, Error> = await withCheckedContinuation { continuation in
+                let syncAction = NotificationAction.updateReadStatus(noteID: noteID, read: true) { error in
+                    if let error {
+                        continuation.resume(returning: .failure(MarkOrderAsReadUseCase.Error.failure(error)))
+                    } else {
+                        continuation.resume(returning: .success(syncronizedNote))
+                    }
+                }
+                stores.dispatch(syncAction)
+            }
+
+            switch updateNoteStatusResult {
+            case .success(let note):
+                return .success(note)
+            case .failure(let error):
+                return .failure(error)
+            }
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+}

--- a/WooCommerce/Classes/Model/MarkOrderAsReadUseCase.swift
+++ b/WooCommerce/Classes/Model/MarkOrderAsReadUseCase.swift
@@ -6,10 +6,6 @@ import Networking
 import NetworkingCore
 #endif
 
-#if canImport(Yosemite) && !NOTIFICATION_EXTENSION
-import Yosemite
-#endif
-
 struct MarkOrderAsReadUseCase {
     /// Possible error states.
     ///
@@ -18,56 +14,6 @@ struct MarkOrderAsReadUseCase {
         case unavailableNote
         case noNeedToMarkAsRead
     }
-
-#if canImport(Yosemite) && !NOTIFICATION_EXTENSION
-    /// Async method that marks the order note as read if it is the notification for the last order.
-    /// We do it in a way that first we syncronize notification to get the remote `Note`
-    /// and then we compare local `orderID` with the one from remote `Note`.
-    /// If they match we mark it as read.
-    /// Returns syncronized note if marking was successful and error if some error happened
-    @MainActor
-    static func markOrderNoteAsReadIfNeeded(stores: StoresManager, noteID: Int64, orderID: Int) async -> Result<Note, Error> {
-        let syncronizedNoteResult: Result<Note, Error> = await withCheckedContinuation { continuation in
-            let action = NotificationAction.synchronizeNotification(noteID: noteID) { syncronizedNote, error in
-                guard let syncronizedNote = syncronizedNote else {
-                    continuation.resume(returning: .failure(MarkOrderAsReadUseCase.Error.unavailableNote))
-                    return
-                }
-                continuation.resume(returning: .success(syncronizedNote))
-            }
-            stores.dispatch(action)
-        }
-
-        switch syncronizedNoteResult {
-        case .success(let syncronizedNote):
-            guard let syncronizedNoteOrderID = syncronizedNote.meta.identifier(forKey: .order),
-                  syncronizedNoteOrderID == orderID,
-                  syncronizedNote.read == false else {
-                return .failure(MarkOrderAsReadUseCase.Error.noNeedToMarkAsRead)
-            }
-
-            let updateNoteStatusResult: Result<Note, Error> = await withCheckedContinuation { continuation in
-                let syncAction = NotificationAction.updateReadStatus(noteID: noteID, read: true) { error in
-                    if let error {
-                        continuation.resume(returning: .failure(MarkOrderAsReadUseCase.Error.failure(error)))
-                    } else {
-                        continuation.resume(returning: .success(syncronizedNote))
-                    }
-                }
-                stores.dispatch(syncAction)
-            }
-
-            switch updateNoteStatusResult {
-            case .success(let note):
-                return .success(note)
-            case .failure(let error):
-                return .failure(error)
-            }
-        case .failure(let error):
-            return .failure(error)
-        }
-    }
-#endif
 
     /// Async method that marks the order note as read if it is the notification for the last order.
     /// We do it in a way that first we syncronize notification to get the remote `Note`

--- a/WooCommerce/Classes/Model/MarkOrderAsReadUseCase.swift
+++ b/WooCommerce/Classes/Model/MarkOrderAsReadUseCase.swift
@@ -1,10 +1,5 @@
 import Foundation
-
-#if canImport(Networking)
-import Networking
-#elseif canImport(NetworkingCore)
 import NetworkingCore
-#endif
 
 struct MarkOrderAsReadUseCase {
     /// Possible error states.

--- a/WooCommerce/Classes/ServiceLocator/PushNotification.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotification.swift
@@ -1,10 +1,6 @@
 import Foundation
-
-#if canImport(Networking)
-import struct Networking.Note
-#elseif canImport(NetworkingCore)
 import struct NetworkingCore.Note
-#endif
+
 #if DEBUG
 import UserNotifications
 #endif

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel+Localizations.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel+Localizations.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Shared localization for `OrderListCellViewModel` between `WooCommerce` and `Woo Watch App` targets
+enum OrderListCellViewModelLocalization {
+    static func title(orderNumber: String, customerName: String) -> String {
+        let format = NSLocalizedString(
+            "orderlistcellviewmodel.cell.title",
+            value: "#%@ %@",
+            comment: "In Order List,"
+            + " the pattern to show the order number. For example, “#123456”."
+            + " The %@ placeholder is the order number.")
+        return String.localizedStringWithFormat(format, orderNumber, customerName)
+    }
+    static let guestName = NSLocalizedString(
+        "orderlistcellviewmodel.customerName.guestName",
+        value: "Guest",
+        comment: "In Order List, the name of the billed person when there are no first and last name.")
+}

--- a/WooCommerce/NotificationExtension/OrderNotificationDataService.swift
+++ b/WooCommerce/NotificationExtension/OrderNotificationDataService.swift
@@ -1,10 +1,5 @@
 import Foundation
-
-#if canImport(Networking)
-import Networking
-#elseif canImport(NetworkingCore)
 import NetworkingCore
-#endif
 
 /// This wrapper to fetch orders from a notification.
 ///

--- a/WooCommerce/NotificationExtension/OrderNotificationViewModel.swift
+++ b/WooCommerce/NotificationExtension/OrderNotificationViewModel.swift
@@ -1,6 +1,6 @@
 import Foundation
 import KeychainAccess
-import Networking
+import NetworkingCore
 import UserNotifications
 
 /// View Model for the `OrderNotificationViewController`type.

--- a/WooCommerce/Woo Watch App/Orders/OrderListCellViewModel.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderListCellViewModel.swift
@@ -1,6 +1,5 @@
 import Foundation
-import Yosemite
-import UIKit
+import NetworkingCore
 import WooFoundationCore
 
 // MARK: - View Model for individual cells on the Order List screen
@@ -78,16 +77,5 @@ struct OrderListCellViewModel {
     ///
     func total(for orderItem: OrderItem) -> String {
         currencyFormatter.formatAmount(orderItem.total, with: order.currency) ?? "$\(orderItem.total)"
-    }
-
-    /// Accessory view that renders the cell's disclosure indicator
-    ///
-    var accessoryView: UIImageView? {
-        guard let image = UIImage(systemName: "chevron.forward") else {
-            return nil
-        }
-        let accessoryView = UIImageView(image: image, highlightedImage: nil)
-        accessoryView.tintColor = .tertiaryLabel
-        return accessoryView
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1218,6 +1218,7 @@
 		2DB891692E27F6200001B175 /* OrderListCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB891682E27F61C0001B175 /* OrderListCellViewModel.swift */; };
 		2DB8916B2E27F6D90001B175 /* OrderListCellViewModel+Localizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB8916A2E27F6CE0001B175 /* OrderListCellViewModel+Localizations.swift */; };
 		2DB8916E2E27F7840001B175 /* OrderListCellViewModel+Localizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB8916A2E27F6CE0001B175 /* OrderListCellViewModel+Localizations.swift */; };
+		2DF0D1BC2E2907C100F8995C /* MarkOrderAsReadUseCase+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB88DA32E27DD790001B175 /* MarkOrderAsReadUseCase+Woo.swift */; };
 		310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */; };
 		311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */; };
 		311D21E8264AEDB900102316 /* CardPresentModalScanningForReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */; };
@@ -17534,6 +17535,7 @@
 				261AA30E275506DE009530FE /* PaymentMethodsViewModelTests.swift in Sources */,
 				4524CDA1242D045C00B2F20A /* ProductStatusSettingListSelectorCommandTests.swift in Sources */,
 				26A280D72B46027A00ACEE87 /* OrderNotificationView.swift in Sources */,
+				2DF0D1BC2E2907C100F8995C /* MarkOrderAsReadUseCase+Woo.swift in Sources */,
 				02077F72253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift in Sources */,
 				D8C11A6222E24C4A00D4A88D /* LedgerTableViewCellTests.swift in Sources */,
 				027111422913B9FC00F5269A /* AccountCreationFormViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1214,6 +1214,7 @@
 		26FFC50D2BED7C5B0067B3A4 /* WatchDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B249702BEC801400730730 /* WatchDependencies.swift */; };
 		2D880B492DFB2F3F00A6FB2C /* OptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D880B482DFB2F3D00A6FB2C /* OptionalBinding.swift */; };
 		2D88C1112DF883C300A6FB2C /* AttributedString+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D88C1102DF883BD00A6FB2C /* AttributedString+Helpers.swift */; };
+		2DB88DA42E27DD8D0001B175 /* MarkOrderAsReadUseCase+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB88DA32E27DD790001B175 /* MarkOrderAsReadUseCase+Woo.swift */; };
 		310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */; };
 		311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */; };
 		311D21E8264AEDB900102316 /* CardPresentModalScanningForReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */; };
@@ -4356,6 +4357,7 @@
 		26FFD32928C6A0F4002E5E5E /* UIImage+Widgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Widgets.swift"; sourceTree = "<group>"; };
 		2D880B482DFB2F3D00A6FB2C /* OptionalBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalBinding.swift; sourceTree = "<group>"; };
 		2D88C1102DF883BD00A6FB2C /* AttributedString+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Helpers.swift"; sourceTree = "<group>"; };
+		2DB88DA32E27DD790001B175 /* MarkOrderAsReadUseCase+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MarkOrderAsReadUseCase+Woo.swift"; sourceTree = "<group>"; };
 		310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLiveSiteInTestModeView.swift; sourceTree = "<group>"; };
 		311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalDisplayMessage.swift; sourceTree = "<group>"; };
 		311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReader.swift; sourceTree = "<group>"; };
@@ -10808,6 +10810,7 @@
 		B57B67882107545B00AF8905 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				2DB88DA32E27DD790001B175 /* MarkOrderAsReadUseCase+Woo.swift */,
 				DE02ABBD2B578D0E008E0AC4 /* CreditCardType.swift */,
 				B59D1EEB2190B08B009D1978 /* Age.swift */,
 				D85136B8231CED5800DD0539 /* ReviewAge.swift */,
@@ -15423,6 +15426,7 @@
 				455DC3A327393C7E00D4644C /* OrderDatesFilterViewController.swift in Sources */,
 				45B6F4EF27592A4000C18782 /* ReviewsView.swift in Sources */,
 				019A86842D89C13800ABBB71 /* TapToPayCardReaderPaymentAlertsProvider.swift in Sources */,
+				2DB88DA42E27DD8D0001B175 /* MarkOrderAsReadUseCase+Woo.swift in Sources */,
 				86A4EBBD2B2F1306008011F5 /* ThemesPreviewViewModel.swift in Sources */,
 				B6F37970293798ED00718561 /* AnalyticsHubTodayRangeData.swift in Sources */,
 				CCFBBCF629C4B9A30081B595 /* ComponentsListViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1019,7 +1019,6 @@
 		263491D5299C923400594566 /* SupportFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263491D4299C923300594566 /* SupportFormViewModelTests.swift */; };
 		26373E2C2BFD13E0008E6735 /* OrdersDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26373E2B2BFD13E0008E6735 /* OrdersDataService.swift */; };
 		26373E2E2BFD2F46008E6735 /* OrdersListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26373E2D2BFD2F46008E6735 /* OrdersListViewModel.swift */; };
-		26373E2F2BFD7C18008E6735 /* OrderListCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6557217258B7510008AE7CA /* OrderListCellViewModel.swift */; };
 		263C4CC02963784900CA7E05 /* ProductVariationGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */; };
 		263EAF9A2A15D513008C66CB /* PrivacyBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EAF992A15D513008C66CB /* PrivacyBannerViewModel.swift */; };
 		263EAF9C2A15E1F3008C66CB /* PrivacyBannerViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EAF9B2A15E1F3008C66CB /* PrivacyBannerViewModelTest.swift */; };
@@ -1216,6 +1215,9 @@
 		2DB88DA42E27DD8D0001B175 /* MarkOrderAsReadUseCase+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB88DA32E27DD790001B175 /* MarkOrderAsReadUseCase+Woo.swift */; };
 		2DB891662E27F0830001B175 /* Address+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB891652E27F07E0001B175 /* Address+Shared.swift */; };
 		2DB891672E27F0880001B175 /* Address+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB891652E27F07E0001B175 /* Address+Shared.swift */; };
+		2DB891692E27F6200001B175 /* OrderListCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB891682E27F61C0001B175 /* OrderListCellViewModel.swift */; };
+		2DB8916B2E27F6D90001B175 /* OrderListCellViewModel+Localizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB8916A2E27F6CE0001B175 /* OrderListCellViewModel+Localizations.swift */; };
+		2DB8916E2E27F7840001B175 /* OrderListCellViewModel+Localizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB8916A2E27F6CE0001B175 /* OrderListCellViewModel+Localizations.swift */; };
 		310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */; };
 		311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */; };
 		311D21E8264AEDB900102316 /* CardPresentModalScanningForReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */; };
@@ -4360,6 +4362,8 @@
 		2D88C1102DF883BD00A6FB2C /* AttributedString+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Helpers.swift"; sourceTree = "<group>"; };
 		2DB88DA32E27DD790001B175 /* MarkOrderAsReadUseCase+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MarkOrderAsReadUseCase+Woo.swift"; sourceTree = "<group>"; };
 		2DB891652E27F07E0001B175 /* Address+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Address+Shared.swift"; sourceTree = "<group>"; };
+		2DB891682E27F61C0001B175 /* OrderListCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListCellViewModel.swift; sourceTree = "<group>"; };
+		2DB8916A2E27F6CE0001B175 /* OrderListCellViewModel+Localizations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderListCellViewModel+Localizations.swift"; sourceTree = "<group>"; };
 		310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLiveSiteInTestModeView.swift; sourceTree = "<group>"; };
 		311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalDisplayMessage.swift; sourceTree = "<group>"; };
 		311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReader.swift; sourceTree = "<group>"; };
@@ -8692,6 +8696,7 @@
 		26A0B2D52BFBA51D002E9620 /* Orders */ = {
 			isa = PBXGroup;
 			children = (
+				2DB891682E27F61C0001B175 /* OrderListCellViewModel.swift */,
 				26A0B2D62BFBA536002E9620 /* OrdersListView.swift */,
 				26373E2D2BFD2F46008E6735 /* OrdersListViewModel.swift */,
 				26373E2B2BFD13E0008E6735 /* OrdersDataService.swift */,
@@ -12661,6 +12666,7 @@
 				CE1CCB4A20570B1F000EE3AC /* OrderTableViewCell.swift */,
 				B5FD110D21D3CB8500560344 /* OrderTableViewCell.xib */,
 				A6557217258B7510008AE7CA /* OrderListCellViewModel.swift */,
+				2DB8916A2E27F6CE0001B175 /* OrderListCellViewModel+Localizations.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -14924,6 +14930,7 @@
 				264E9E952BF400AD009C48FD /* StoreInfoDataService.swift in Sources */,
 				26CFDEE32C029AD2005ABC31 /* Dictionary+Woo.swift in Sources */,
 				26373E2E2BFD2F46008E6735 /* OrdersListViewModel.swift in Sources */,
+				2DB891692E27F6200001B175 /* OrderListCellViewModel.swift in Sources */,
 				26A0B2D72BFBA536002E9620 /* OrdersListView.swift in Sources */,
 				2DB891672E27F0880001B175 /* Address+Shared.swift in Sources */,
 				26A52EF12C69B947000B1CFB /* ApiCredentials.swift in Sources */,
@@ -14932,13 +14939,13 @@
 				26F81B1A2BE433A2009EC58E /* MyStoreView.swift in Sources */,
 				26A52EF02C69B8F5000B1CFB /* WatchCrashLoggingStack.swift in Sources */,
 				268631CF2C07D38C00521364 /* WooAnalyticsStat.swift in Sources */,
-				26373E2F2BFD7C18008E6735 /* OrderListCellViewModel.swift in Sources */,
 				26CFDEDA2C029322005ABC31 /* AppDelegate.swift in Sources */,
 				264E9E942BF1D1DF009C48FD /* AppLocalizedString.swift in Sources */,
 				26A52EEE2C69B51D000B1CFB /* PerformanceTracking.swift in Sources */,
 				26A0B2D42BF9A78C002E9620 /* StoreInfoFormatter.swift in Sources */,
 				26DD32D42BEBCDFB00F2C69C /* WooConstants.swift in Sources */,
 				269FFA4B2BF544C9004E6B86 /* MyStoreViewModel.swift in Sources */,
+				2DB8916E2E27F7840001B175 /* OrderListCellViewModel+Localizations.swift in Sources */,
 				26A52EEA2C69AE6B000B1CFB /* CrashLogging.swift in Sources */,
 				26CA47202BFD823200E54348 /* Date+Woo.swift in Sources */,
 				26B984D62BEECF260052658C /* ConnectView.swift in Sources */,
@@ -15159,6 +15166,7 @@
 				DAB4099F2CA5A329008EE1F2 /* WooShippingAddPackageView.swift in Sources */,
 				02B21C5729C9EEF900C5623B /* WooAnalyticsEvent+StoreOnboarding.swift in Sources */,
 				0216271E2375044D000208D2 /* AztecFormatBar+Update.swift in Sources */,
+				2DB8916B2E27F6D90001B175 /* OrderListCellViewModel+Localizations.swift in Sources */,
 				CC254F3626C437AB005F3C82 /* ShippingLabelCustomPackageForm.swift in Sources */,
 				025B3C9A2C0EE5BA0013F036 /* WCSettingsWebView.swift in Sources */,
 				DE86E9292A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1153,7 +1153,6 @@
 		26CA2BC42AA92CA9003B16C2 /* AppLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F50FE4228CAEBA800C89201 /* AppLocalizedString.swift */; };
 		26CA2BC62AAA1773003B16C2 /* OrderNotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CA2BC52AAA1773003B16C2 /* OrderNotificationView.swift */; };
 		26CA2BC72AAA17A2003B16C2 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5744BEB0248FE44C000A6FE2 /* SwiftUI.framework */; };
-		26CA471C2BFD7FE600E54348 /* Address+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57B67892107546E00AF8905 /* Address+Woo.swift */; };
 		26CA471D2BFD805900E54348 /* CNContact+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4296B820A5E9E400B2AFBD /* CNContact+Helpers.swift */; };
 		26CA471F2BFD81E900E54348 /* String+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D0A52F2139CF1300E2919F /* String+Helpers.swift */; };
 		26CA47202BFD823200E54348 /* Date+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5290ED8219B3FA900A6AF7F /* Date+Woo.swift */; };
@@ -1215,6 +1214,8 @@
 		2D880B492DFB2F3F00A6FB2C /* OptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D880B482DFB2F3D00A6FB2C /* OptionalBinding.swift */; };
 		2D88C1112DF883C300A6FB2C /* AttributedString+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D88C1102DF883BD00A6FB2C /* AttributedString+Helpers.swift */; };
 		2DB88DA42E27DD8D0001B175 /* MarkOrderAsReadUseCase+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB88DA32E27DD790001B175 /* MarkOrderAsReadUseCase+Woo.swift */; };
+		2DB891662E27F0830001B175 /* Address+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB891652E27F07E0001B175 /* Address+Shared.swift */; };
+		2DB891672E27F0880001B175 /* Address+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB891652E27F07E0001B175 /* Address+Shared.swift */; };
 		310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */; };
 		311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */; };
 		311D21E8264AEDB900102316 /* CardPresentModalScanningForReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */; };
@@ -4358,6 +4359,7 @@
 		2D880B482DFB2F3D00A6FB2C /* OptionalBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalBinding.swift; sourceTree = "<group>"; };
 		2D88C1102DF883BD00A6FB2C /* AttributedString+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Helpers.swift"; sourceTree = "<group>"; };
 		2DB88DA32E27DD790001B175 /* MarkOrderAsReadUseCase+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MarkOrderAsReadUseCase+Woo.swift"; sourceTree = "<group>"; };
+		2DB891652E27F07E0001B175 /* Address+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Address+Shared.swift"; sourceTree = "<group>"; };
 		310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLiveSiteInTestModeView.swift; sourceTree = "<group>"; };
 		311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalDisplayMessage.swift; sourceTree = "<group>"; };
 		311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReader.swift; sourceTree = "<group>"; };
@@ -10815,6 +10817,7 @@
 				B59D1EEB2190B08B009D1978 /* Age.swift */,
 				D85136B8231CED5800DD0539 /* ReviewAge.swift */,
 				B57B67892107546E00AF8905 /* Address+Woo.swift */,
+				2DB891652E27F07E0001B175 /* Address+Shared.swift */,
 				B57C5C9121B80E3B00FF82B2 /* APNSDevice+Woo.swift */,
 				B59D1EE4219080B4009D1978 /* Note+Woo.swift */,
 				DA25ADDC2C86145E00AE81FE /* MarkOrderAsReadUseCase.swift */,
@@ -14919,10 +14922,10 @@
 				26CFDEE22C029A5A005ABC31 /* PushNotification.swift in Sources */,
 				26CA47222BFD82B900E54348 /* TimeZone+Woo.swift in Sources */,
 				264E9E952BF400AD009C48FD /* StoreInfoDataService.swift in Sources */,
-				26CA471C2BFD7FE600E54348 /* Address+Woo.swift in Sources */,
 				26CFDEE32C029AD2005ABC31 /* Dictionary+Woo.swift in Sources */,
 				26373E2E2BFD2F46008E6735 /* OrdersListViewModel.swift in Sources */,
 				26A0B2D72BFBA536002E9620 /* OrdersListView.swift in Sources */,
+				2DB891672E27F0880001B175 /* Address+Shared.swift in Sources */,
 				26A52EF12C69B947000B1CFB /* ApiCredentials.swift in Sources */,
 				262619F12C03AB9600BD733B /* OrderDetailLoader.swift in Sources */,
 				26B984D42BEECC610052658C /* Environment+Dependencies.swift in Sources */,
@@ -15127,6 +15130,7 @@
 				016910982E1D019500B731DA /* GameControllerBarcodeObserver.swift in Sources */,
 				EE9D031B2B89E4470077CED1 /* FilterOrdersByProduct+Analytics.swift in Sources */,
 				20C6E7512CDE4AEA00CD124C /* ItemListState.swift in Sources */,
+				2DB891662E27F0830001B175 /* Address+Shared.swift in Sources */,
 				DEC17AE02D82C513005A6E6D /* WooShippingHazmatDetailView.swift in Sources */,
 				86967D812B4E21C600C20CA8 /* BlazeAddParameterViewModel.swift in Sources */,
 				EE45E2B92A409BA40085F227 /* ProductDescriptionAITooltipUseCase.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

WOOMOB-772

## Description

Resolves the issue of conditional import of `Yosemite/Networking/NetworkingCore` between targets.

- Split `MarkOrderAsReadUseCase`. Extracted main app target implementations into `MarkOrderAsReadUseCase+Woo.swift` and linked only against main target. `MarkOrderAsReadUseCase+Woo.swift` utilizes `import Yosemite`.
- `NotificationExtension` now dependent on `NetworkingCore` instead of `Networking`. This allows to avoid embedding resources of Aztec editor into NotificationExtension -> binary size reduced.
- Separated `Address` type extension. The implementations that are shared between targets were moved to `Address+shared.swift` with `import NetworkingCore`. The remaining part contained in `Address+Woo` is no longer has to be shared and can be linked against the main target only utilizing the `import Yosemite`.
- Duplicated `OrderListCellViewModel` for main and watch target. Removed conditional imports. Moved corresponding localizations into `OrderListCellViewModelLocalization` that's shared between targets and reused in both `OrderListCellViewModel` duplicates.
- Reduced the `NotificationExtension` size by ~17,8 MBs for debug build. Something similar can be done for the StoreWidgetExtension I guess.

## Testing information
- The behaviour is not changed. The main app and watch app should compile and work ok. CI should be green.

### Before
<img width="755" height="148" alt="Снимок экрана 2025-07-17 в 13 08 48" src="https://github.com/user-attachments/assets/d4ccf559-2247-4d9e-965d-3ad0a1f0b052" />

### After
<img width="847" height="135" alt="Снимок экрана 2025-07-17 в 13 03 57" src="https://github.com/user-attachments/assets/09b4ed6b-c66c-4898-833c-9b0bc082f883" />

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.