### PR TITLE
[POS as a tab i2] Streamline loading UI animation when transitioning from eligibility check to items loading

### DIFF
--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -66,6 +66,7 @@ protocol PointOfSaleAggregateModelProtocol {
     var orderState: PointOfSaleOrderState { orderController.orderState.externalState }
     private var internalOrderState: PointOfSaleInternalOrderState { orderController.orderState }
 
+    let entryPointController: POSEntryPointController
     let purchasableItemsController: PointOfSaleItemsControllerProtocol
     let purchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol
     let popularPurchasableItemsController: PointOfSaleItemsControllerProtocol
@@ -99,7 +100,8 @@ protocol PointOfSaleAggregateModelProtocol {
         _viewStateCoordinator
     }
 
-    init(itemsController: PointOfSaleItemsControllerProtocol,
+    init(entryPointController: POSEntryPointController,
+         itemsController: PointOfSaleItemsControllerProtocol,
          purchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol,
          couponsController: PointOfSaleCouponsControllerProtocol,
          couponsSearchController: PointOfSaleSearchingItemsControllerProtocol,
@@ -112,6 +114,7 @@ protocol PointOfSaleAggregateModelProtocol {
          barcodeScanService: PointOfSaleBarcodeScanServiceProtocol,
          soundPlayer: PointOfSaleSoundPlayerProtocol = PointOfSaleSoundPlayer(),
          paymentState: PointOfSalePaymentState = .idle) {
+        self.entryPointController = entryPointController
         self.purchasableItemsController = itemsController
         self.purchasableItemsSearchController = purchasableItemsSearchController
         self.couponsController = couponsController

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleLoadingView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleLoadingView.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
 struct PointOfSaleLoadingView: View {
-    @State private var waitingTimeTracker: WaitingTimeTracker?
-
     var body: some View {
         HStack(alignment: .center) {
             Spacer()
@@ -15,25 +13,7 @@ struct PointOfSaleLoadingView: View {
             .multilineTextAlignment(.center)
             Spacer()
         }
-        .onAppear {
-            trackTimeOnAppear()
-        }
-        .onDisappear {
-            trackElapsedTimeOnDisappear()
-        }
         .background(Color.posSurface)
-    }
-}
-
-private extension PointOfSaleLoadingView {
-    func trackTimeOnAppear() {
-        waitingTimeTracker = WaitingTimeTracker(trackScenario: .pointOfSaleLoaded)
-    }
-
-    func trackElapsedTimeOnDisappear() {
-        if let waitingTimeTracker = waitingTimeTracker {
-            waitingTimeTracker.end(using: .milliseconds)
-        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleLoadingView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleLoadingView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct PointOfSaleLoadingView: View {
+    @State private var waitingTimeTracker: WaitingTimeTracker?
+
     var body: some View {
         HStack(alignment: .center) {
             Spacer()
@@ -13,7 +15,25 @@ struct PointOfSaleLoadingView: View {
             .multilineTextAlignment(.center)
             Spacer()
         }
+        .onAppear {
+            trackTimeOnAppear()
+        }
+        .onDisappear {
+            trackElapsedTimeOnDisappear()
+        }
         .background(Color.posSurface)
+    }
+}
+
+private extension PointOfSaleLoadingView {
+    func trackTimeOnAppear() {
+        waitingTimeTracker = WaitingTimeTracker(trackScenario: .pointOfSaleLoaded)
+    }
+
+    func trackElapsedTimeOnDisappear() {
+        if let waitingTimeTracker = waitingTimeTracker {
+            waitingTimeTracker.end(using: .milliseconds)
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -62,6 +62,7 @@ struct PointOfSaleDashboardView: View {
                 POSIneligibleView(reason: reason, onRefresh: {
                     try await posModel.entryPointController.refreshEligibility(reason: reason)
                 })
+                .frame(maxWidth: .infinity)
             case .error(let error):
                 PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
                     Task {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -94,7 +94,7 @@ struct PointOfSaleDashboardView: View {
             .padding(.bottom, Constants.floatingControlBottomPadding)
             .trackSize(size: $floatingSize)
             .accessibilitySortPriority(1)
-            .renderedIf(viewState != .loading)
+            .renderedIf(viewState.showsFloatingControl)
 
             POSConnectivityView()
         }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -32,35 +32,55 @@ struct PointOfSaleDashboardView: View {
         }
     }
 
+    // MARK: View State
+
+    enum ViewState: Equatable {
+        case loading
+        case ineligible(reason: POSIneligibleReason)
+        case error(PointOfSaleErrorState)
+        case content
+        case unsupportedWidth
+    }
+
+    private var viewState: ViewState {
+        PointOfSaleDashboardViewHelper.determineViewState(
+            eligibilityState: posModel.entryPointController.eligibilityState,
+            itemsContainerState: itemsViewState.containerState,
+            horizontalSizeClass: horizontalSizeClass
+        )
+    }
+
     var body: some View {
         @Bindable var posModel = posModel
         ZStack(alignment: .bottomLeading) {
-            if case .regular = horizontalSizeClass {
-                switch itemsViewState.containerState {
-                case .loading:
-                    PointOfSaleLoadingView()
-                        .transition(.opacity)
-                        .ignoresSafeArea()
-                case .error(let error):
-                    PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
-                        Task {
-                            switch viewStateCoordinator.selectedItemListType {
-                            case .products(search: false):
-                                await posModel.purchasableItemsController.loadItems(base: .root)
-                            case .products(search: true):
-                                await posModel.purchasableItemsSearchController.loadItems(base: .root)
-                            case .coupons(search: false):
-                                await posModel.couponsSearchController.loadItems(base: .root)
-                            case .coupons(search: true):
-                                await posModel.couponsSearchController.loadItems(base: .root)
-                            }
+            switch viewState {
+            case .loading:
+                PointOfSaleLoadingView()
+                    .transition(.opacity)
+                    .ignoresSafeArea()
+            case .ineligible(let reason):
+                POSIneligibleView(reason: reason, onRefresh: {
+                    try await posModel.entryPointController.refreshEligibility(reason: reason)
+                })
+            case .error(let error):
+                PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
+                    Task {
+                        switch viewStateCoordinator.selectedItemListType {
+                        case .products(search: false):
+                            await posModel.purchasableItemsController.loadItems(base: .root)
+                        case .products(search: true):
+                            await posModel.purchasableItemsSearchController.loadItems(base: .root)
+                        case .coupons(search: false):
+                            await posModel.couponsSearchController.loadItems(base: .root)
+                        case .coupons(search: true):
+                            await posModel.couponsSearchController.loadItems(base: .root)
                         }
-                    })
-                case .content:
-                    contentView
-                        .accessibilitySortPriority(2)
-                }
-            } else {
+                    }
+                })
+            case .content:
+                contentView
+                    .accessibilitySortPriority(2)
+            case .unsupportedWidth:
                 PointOfSaleUnsupportedWidthView()
                     .transition(.opacity)
                     .ignoresSafeArea()
@@ -73,7 +93,7 @@ struct PointOfSaleDashboardView: View {
             .padding(.bottom, Constants.floatingControlBottomPadding)
             .trackSize(size: $floatingSize)
             .accessibilitySortPriority(1)
-            .renderedIf(itemsViewState.containerState != .loading)
+            .renderedIf(viewState != .loading)
 
             POSConnectivityView()
         }
@@ -81,7 +101,7 @@ struct PointOfSaleDashboardView: View {
                       CGSizeMake(floatingSize.width + Constants.floatingControlHorizontalOffset,
                                  floatingSize.height + Constants.floatingControlVerticalOffset))
         .environment(\.posBackgroundAppearance, backgroundAppearance)
-        .animation(.easeInOut, value: itemsViewState.containerState == .loading)
+        .animation(.easeInOut, value: viewState == .loading)
         .background(Color.posSurface)
         .navigationBarBackButtonHidden(true)
         .posModal(item: $posModel.cardPresentPaymentOnboardingViewModel, onDismiss: {
@@ -108,10 +128,13 @@ struct PointOfSaleDashboardView: View {
         .sheet(isPresented: $showDocumentation) {
             documentationView
         }
-        .task {
-            await posModel.purchasableItemsController.loadItems(base: .root)
-            await posModel.couponsController.loadItems(base: .root)
-            await posModel.popularPurchasableItemsController.loadItems(base: .root)
+        .onChange(of: posModel.entryPointController.eligibilityState) { oldValue, newValue in
+            guard newValue == .eligible else { return }
+            Task { @MainActor in
+                await posModel.purchasableItemsController.loadItems(base: .root)
+                await posModel.couponsController.loadItems(base: .root)
+                await posModel.popularPurchasableItemsController.loadItems(base: .root)
+            }
         }
         .ignoresSafeArea(.keyboard)
     }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -50,20 +50,11 @@ struct PointOfSaleEntryPointView: View {
 
     var body: some View {
         Group {
-            switch posEntryPointController.eligibilityState {
-            case .none:
+            if let posModel {
+                PointOfSaleDashboardView()
+                    .environment(posModel)
+            } else {
                 PointOfSaleLoadingView()
-            case .eligible:
-                if let posModel = posModel {
-                    PointOfSaleDashboardView()
-                        .environment(posModel)
-                } else {
-                    PointOfSaleLoadingView()
-                }
-            case let .ineligible(reason):
-                POSIneligibleView(reason: reason, onRefresh: {
-                    try await posEntryPointController.refreshEligibility(reason: reason)
-                })
             }
         }
         .task {
@@ -71,6 +62,7 @@ struct PointOfSaleEntryPointView: View {
             // Confusingly, init can be called more than once, but `task` matches the lifecycle.
             // See https://developer.apple.com/documentation/swiftui/state#Store-observable-objects for details.
             posModel = PointOfSaleAggregateModel(
+                entryPointController: posEntryPointController,
                 itemsController: itemsController,
                 purchasableItemsSearchController: purchasableItemsSearchController,
                 couponsController: couponsController,

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -219,6 +219,7 @@ struct POSPreviewHelpers {
         barcodeScanService: PointOfSaleBarcodeScanServiceProtocol = PointOfSalePreviewBarcodeScanService()
     ) -> PointOfSaleAggregateModel {
         return PointOfSaleAggregateModel(
+            entryPointController: POSEntryPointController(eligibilityChecker: LegacyPOSTabEligibilityChecker(siteID: 0)),
             itemsController: itemsController,
             purchasableItemsSearchController: purchasableItemsSearchController,
             couponsController: couponsController,

--- a/WooCommerce/Classes/POS/ViewHelpers/PointOfSaleDashboardViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/PointOfSaleDashboardViewHelper.swift
@@ -1,0 +1,33 @@
+import Foundation
+import SwiftUI
+
+@available(iOS 17.0, *)
+struct PointOfSaleDashboardViewHelper {
+    static func determineViewState(
+        eligibilityState: POSEligibilityState?,
+        itemsContainerState: ItemsContainerState,
+        horizontalSizeClass: UserInterfaceSizeClass?
+    ) -> PointOfSaleDashboardView.ViewState {
+        guard case .regular = horizontalSizeClass else {
+            return .unsupportedWidth
+        }
+
+        guard let eligibilityState else {
+            return .loading
+        }
+
+        switch eligibilityState {
+        case .eligible:
+            switch itemsContainerState {
+            case .loading:
+                return .loading
+            case .error(let error):
+                return .error(error)
+            case .content:
+                return .content
+            }
+        case .ineligible(let reason):
+            return .ineligible(reason: reason)
+        }
+    }
+}

--- a/WooCommerce/Classes/POS/ViewHelpers/PointOfSaleDashboardViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/PointOfSaleDashboardViewHelper.swift
@@ -31,3 +31,15 @@ struct PointOfSaleDashboardViewHelper {
         }
     }
 }
+
+@available(iOS 17.0, *)
+extension PointOfSaleDashboardView.ViewState {
+    var showsFloatingControl: Bool {
+        switch self {
+        case .content, .error, .unsupportedWidth:
+            return true
+        case .loading, .ineligible:
+            return false
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -359,6 +359,8 @@
 		026826C22BF59E410036F959 /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026826B92BF59E400036F959 /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView.swift */; };
 		026826C42BF59E410036F959 /* PointOfSaleCardPresentPaymentFoundReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026826BB2BF59E410036F959 /* PointOfSaleCardPresentPaymentFoundReaderView.swift */; };
 		026826C72BF59E410036F959 /* PointOfSaleCardPresentPaymentScanningForReadersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026826BE2BF59E410036F959 /* PointOfSaleCardPresentPaymentScanningForReadersView.swift */; };
+		026878D62E293E7C00DBFD34 /* PointOfSaleDashboardViewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026878D52E293E7300DBFD34 /* PointOfSaleDashboardViewHelper.swift */; };
+		026878D82E2942E400DBFD34 /* PointOfSaleDashboardViewHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026878D72E2942E200DBFD34 /* PointOfSaleDashboardViewHelperTests.swift */; };
 		02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */; };
 		02691782232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02691781232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift */; };
 		0269576A23726304001BA0BF /* KeyboardFrameObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576923726304001BA0BF /* KeyboardFrameObserver.swift */; };
@@ -3528,6 +3530,8 @@
 		026826B92BF59E400036F959 /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView.swift; sourceTree = "<group>"; };
 		026826BB2BF59E410036F959 /* PointOfSaleCardPresentPaymentFoundReaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentFoundReaderView.swift; sourceTree = "<group>"; };
 		026826BE2BF59E410036F959 /* PointOfSaleCardPresentPaymentScanningForReadersView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentScanningForReadersView.swift; sourceTree = "<group>"; };
+		026878D52E293E7300DBFD34 /* PointOfSaleDashboardViewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleDashboardViewHelper.swift; sourceTree = "<group>"; };
+		026878D72E2942E200DBFD34 /* PointOfSaleDashboardViewHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleDashboardViewHelperTests.swift; sourceTree = "<group>"; };
 		0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductViewModelTests.swift; sourceTree = "<group>"; };
 		02691781232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListViewControllerStateCoordinatorTests.swift; sourceTree = "<group>"; };
 		0269576923726304001BA0BF /* KeyboardFrameObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardFrameObserver.swift; sourceTree = "<group>"; };
@@ -7085,6 +7089,7 @@
 		026826912BF59D7A0036F959 /* ViewHelpers */ = {
 			isa = PBXGroup;
 			children = (
+				026878D52E293E7300DBFD34 /* PointOfSaleDashboardViewHelper.swift */,
 				6891C3632D364AFB00B5B48C /* CollectCashViewHelper.swift */,
 				6885E2CB2C32B14B004C8D70 /* TotalsViewHelper.swift */,
 				6837631B2C2E847D00AD51D0 /* CartViewHelper.swift */,
@@ -13016,6 +13021,7 @@
 			children = (
 				683763192C2E6F5900AD51D0 /* CartViewHelperTests.swift */,
 				6891C3652D364C1A00B5B48C /* CollectCashViewHelperTests.swift */,
+				026878D72E2942E200DBFD34 /* PointOfSaleDashboardViewHelperTests.swift */,
 				208628732D48E4CB003F45DC /* TotalsViewHelperTests.swift */,
 			);
 			path = ViewHelpers;
@@ -16278,6 +16284,7 @@
 				68E674AD2A4DAC010034BA1E /* CurrentPlanDetailsView.swift in Sources */,
 				20134CE82D4D38E000076A80 /* CardPresentPaymentPlugin+SetUpTapToPay.swift in Sources */,
 				DE68B81F26F86B1700C86CFB /* OfflineBannerView.swift in Sources */,
+				026878D62E293E7C00DBFD34 /* PointOfSaleDashboardViewHelper.swift in Sources */,
 				B90D21802D1ED1F300ED60ED /* WooShippingCustomsItemOriginCountryInfoDialog.swift in Sources */,
 				D8610BCC256F284700A5DF27 /* ULErrorViewModel.swift in Sources */,
 				CCFC50552743BC0D001E505F /* OrderForm.swift in Sources */,
@@ -16930,6 +16937,7 @@
 				019130212CF5B0FF008C0C88 /* TapToPayEducationViewModelTests.swift in Sources */,
 				026A50302D2F80B5002C42C2 /* ThresholdInfiniteScrollTriggerDeterminerTests.swift in Sources */,
 				CC33238C29CDF67D00CA9709 /* ComponentSettingsViewModelTests.swift in Sources */,
+				026878D82E2942E400DBFD34 /* PointOfSaleDashboardViewHelperTests.swift in Sources */,
 				86F5FFE42CA30D9200C767C4 /* CustomFieldsListViewModelTests.swift in Sources */,
 				01AB2D162DDC8CDA00AA67FD /* MockAnalytics.swift in Sources */,
 				0261F5A728D454CF00B7AC72 /* ProductSearchUICommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -1,6 +1,8 @@
 import Testing
 import Foundation
 @testable import WooCommerce
+import protocol WooFoundation.Analytics
+import protocol Yosemite.PointOfSaleBarcodeScanServiceProtocol
 import protocol Yosemite.POSOrderableItem
 import enum Yosemite.POSItem
 @testable import struct Yosemite.POSSimpleProduct
@@ -14,19 +16,7 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func inits_with_building_order_stage() async throws {
             // Given
-            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                itemsController: MockPointOfSaleItemsController(),
-                                                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                couponsController: MockPointOfSaleCouponsController(),
-                                                couponsSearchController: MockPointOfSaleCouponsController(),
-                                                cardPresentPaymentService: MockCardPresentPaymentService(),
-                                                orderController: MockPointOfSaleOrderController(),
-                                                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                                                searchHistoryService: MockPOSSearchHistoryService(),
-                                                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                                                soundPlayer: MockPointOfSaleSoundPlayer())
+            let sut = makePointOfSaleAggregateModel()
             // Then
             #expect(sut.orderStage == .building)
         }
@@ -34,19 +24,7 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func startNewCart_removes_all_items_from_cart_and_moves_back_to_building() async throws {
             // Given
-            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                itemsController: MockPointOfSaleItemsController(),
-                                                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                couponsController: MockPointOfSaleCouponsController(),
-                                                couponsSearchController: MockPointOfSaleCouponsController(),
-                                                cardPresentPaymentService: MockCardPresentPaymentService(),
-                                                orderController: MockPointOfSaleOrderController(),
-                                                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                                                searchHistoryService: MockPOSSearchHistoryService(),
-                                                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                                                soundPlayer: MockPointOfSaleSoundPlayer())
+            let sut = makePointOfSaleAggregateModel()
             sut.addToCart(makePurchasableItem())
             await sut.checkOut()
             try #require(sut.orderStage == .finalizing)
@@ -63,19 +41,7 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func checkOut_moves_to_finalizing_order_stage() async throws {
             // Given
-            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                itemsController: MockPointOfSaleItemsController(),
-                                                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                couponsController: MockPointOfSaleCouponsController(),
-                                                couponsSearchController: MockPointOfSaleCouponsController(),
-                                                cardPresentPaymentService: MockCardPresentPaymentService(),
-                                                orderController: MockPointOfSaleOrderController(),
-                                                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                                                searchHistoryService: MockPOSSearchHistoryService(),
-                                                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                                                soundPlayer: MockPointOfSaleSoundPlayer())
+            let sut = makePointOfSaleAggregateModel()
             sut.addToCart(makePurchasableItem())
 
             // When
@@ -88,19 +54,7 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func addMoreToCart_moves_to_building_order_stage() async throws {
             // Given
-            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                itemsController: MockPointOfSaleItemsController(),
-                                                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                couponsController: MockPointOfSaleCouponsController(),
-                                                couponsSearchController: MockPointOfSaleCouponsController(),
-                                                cardPresentPaymentService: MockCardPresentPaymentService(),
-                                                orderController: MockPointOfSaleOrderController(),
-                                                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                                                searchHistoryService: MockPOSSearchHistoryService(),
-                                                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                                                soundPlayer: MockPointOfSaleSoundPlayer())
+            let sut = makePointOfSaleAggregateModel()
             sut.addToCart(makePurchasableItem())
             await sut.checkOut()
             try #require(sut.orderStage == .finalizing)
@@ -162,19 +116,7 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func addItem_results_in_a_non_empty_cart() async throws {
             // Given
-            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                itemsController: MockPointOfSaleItemsController(),
-                                                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                couponsController: MockPointOfSaleCouponsController(),
-                                                couponsSearchController: MockPointOfSaleCouponsController(),
-                                                cardPresentPaymentService: MockCardPresentPaymentService(),
-                                                orderController: MockPointOfSaleOrderController(),
-                                                analytics: analytics,
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                                                searchHistoryService: MockPOSSearchHistoryService(),
-                                                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                                                soundPlayer: MockPointOfSaleSoundPlayer())
+            let sut = makePointOfSaleAggregateModel(analytics: analytics)
             try #require(sut.cart.isEmpty)
             let item = makePurchasableItem()
 
@@ -188,19 +130,7 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func addItem_puts_new_items_first_in_the_cart() async throws {
             // Given
-            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                itemsController: MockPointOfSaleItemsController(),
-                                                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                couponsController: MockPointOfSaleCouponsController(),
-                                                couponsSearchController: MockPointOfSaleCouponsController(),
-                                                cardPresentPaymentService: MockCardPresentPaymentService(),
-                                                orderController: MockPointOfSaleOrderController(),
-                                                analytics: analytics,
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                                                searchHistoryService: MockPOSSearchHistoryService(),
-                                                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                                                soundPlayer: MockPointOfSaleSoundPlayer())
+            let sut = makePointOfSaleAggregateModel(analytics: analytics)
             let items = [makePurchasableItem(), makePurchasableItem(), makePurchasableItem()]
 
             // When
@@ -219,19 +149,7 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func removeItem_after_adding_two_items_removes_item_correctly() async throws {
             // Given
-            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                itemsController: MockPointOfSaleItemsController(),
-                                                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                couponsController: MockPointOfSaleCouponsController(),
-                                                couponsSearchController: MockPointOfSaleCouponsController(),
-                                                cardPresentPaymentService: MockCardPresentPaymentService(),
-                                                orderController: MockPointOfSaleOrderController(),
-                                                analytics: analytics,
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                                                searchHistoryService: MockPOSSearchHistoryService(),
-                                                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                                                soundPlayer: MockPointOfSaleSoundPlayer())
+            let sut = makePointOfSaleAggregateModel(analytics: analytics)
             let item = makePurchasableItem(name: "Item 1")
             let anotherItem = makePurchasableItem(name: "Item 2")
 
@@ -251,19 +169,7 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func removeAllItemsFromCart_removes_everything() async throws {
             // Given
-            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                itemsController: MockPointOfSaleItemsController(),
-                                                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                couponsController: MockPointOfSaleCouponsController(),
-                                                couponsSearchController: MockPointOfSaleCouponsController(),
-                                                cardPresentPaymentService: MockCardPresentPaymentService(),
-                                                orderController: MockPointOfSaleOrderController(),
-                                                analytics: analytics,
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                                                searchHistoryService: MockPOSSearchHistoryService(),
-                                                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                                                soundPlayer: MockPointOfSaleSoundPlayer())
+            let sut = makePointOfSaleAggregateModel(analytics: analytics)
             let item = makePurchasableItem(name: "Item 1")
             let anotherItem = makePurchasableItem(name: "Item 2")
 
@@ -281,19 +187,7 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func removeAllItemsFromCartOfCouponType_removes_coupons() async throws {
             // Given
-            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                itemsController: MockPointOfSaleItemsController(),
-                                                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                couponsController: MockPointOfSaleCouponsController(),
-                                                couponsSearchController: MockPointOfSaleCouponsController(),
-                                                cardPresentPaymentService: MockCardPresentPaymentService(),
-                                                orderController: MockPointOfSaleOrderController(),
-                                                analytics: analytics,
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                                                searchHistoryService: MockPOSSearchHistoryService(),
-                                                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                                                soundPlayer: MockPointOfSaleSoundPlayer())
+            let sut = makePointOfSaleAggregateModel(analytics: analytics)
             let item = makePurchasableItem(name: "Item 1")
             let anotherItem = makePurchasableItem(name: "Item 2")
             let couponItem = makeCouponItem(code: "VALID")
@@ -328,20 +222,11 @@ struct PointOfSaleAggregateModelTests {
         @Test func startNewCart_calls_clearOrder() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+            )
 
             sut.addToCart(makePurchasableItem())
 
@@ -356,20 +241,11 @@ struct PointOfSaleAggregateModelTests {
         @Test func checkout_with_items_calls_sync_order() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+            )
 
             sut.addToCart(makePurchasableItem())
             sut.addToCart(makePurchasableItem())
@@ -387,20 +263,11 @@ struct PointOfSaleAggregateModelTests {
         @Test func checkOut_without_items_calls_sync_order() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+            )
 
             sut.addToCart(makePurchasableItem())
             sut.removeAllItemsFromCart()
@@ -417,20 +284,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func when_collectPayment_is_called_channel_is_set_to_pos() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
 
             sut.addToCart(makePurchasableItem())
             cardPresentPaymentService.connectedReader = .init(name: "Test reader", batteryLevel: 0.7)
@@ -448,19 +305,7 @@ struct PointOfSaleAggregateModelTests {
         @Test func sendReceipt_when_invoked_then_calls_controller() async throws {
             // Given
             let orderController = MockPointOfSaleOrderController()
-            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                itemsController: MockPointOfSaleItemsController(),
-                                                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                couponsController: MockPointOfSaleCouponsController(),
-                                                couponsSearchController: MockPointOfSaleCouponsController(),
-                                                cardPresentPaymentService: MockCardPresentPaymentService(),
-                                                orderController: orderController,
-                                                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                                                searchHistoryService: MockPOSSearchHistoryService(),
-                                                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                                                soundPlayer: MockPointOfSaleSoundPlayer())
+            let sut = makePointOfSaleAggregateModel(orderController: orderController)
 
             // When
             try await sut.sendReceipt(to: "")
@@ -476,19 +321,7 @@ struct PointOfSaleAggregateModelTests {
             orderController.shouldThrowReceiptError = true
             let expectedError = NSError(domain: "some error", code: -1)
 
-            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                itemsController: MockPointOfSaleItemsController(),
-                                                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                couponsController: MockPointOfSaleCouponsController(),
-                                                couponsSearchController: MockPointOfSaleCouponsController(),
-                                                cardPresentPaymentService: MockCardPresentPaymentService(),
-                                                orderController: orderController,
-                                                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                                                searchHistoryService: MockPOSSearchHistoryService(),
-                                                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                                                soundPlayer: MockPointOfSaleSoundPlayer())
+            let sut = makePointOfSaleAggregateModel(orderController: orderController)
 
             do {
                 // When
@@ -505,20 +338,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func when_pointOfSaleClosed_then_order_is_cleared_up() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
 
             sut.addToCart(makePurchasableItem())
 
@@ -540,20 +363,10 @@ struct PointOfSaleAggregateModelTests {
             // Given that we don't specify a payment state
             // When we init
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
 
             // Then
             #expect(sut.paymentState == PointOfSalePaymentState(card: .idle, cash: .idle))
@@ -591,19 +404,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func startNewCart_sets_card_payment_state_to_idle() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer(),
                 paymentState: PointOfSalePaymentState(card: .cardPaymentSuccessful, cash: .idle))
 
             // When
@@ -617,20 +421,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func startNewCart_sets_payment_message_to_nil() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
 
             cardPresentPaymentService.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
             try #require(sut.cardPresentPaymentInlineMessage != nil)
@@ -646,19 +440,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func addMoreToCart_sets_card_payment_state_to_idle() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer(),
                 paymentState: PointOfSalePaymentState(card: .cardPaymentSuccessful, cash: .idle))
 
             // When
@@ -672,20 +457,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func addMoreToCart_sets_payment_message_to_nil() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
 
             cardPresentPaymentService.paymentEvent = .show(
                 eventDetails: .tapSwipeOrInsertCard(
@@ -705,20 +480,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func startCashPayment_calls_for_ongoing_card_payment_cancellation() async {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
 
             // When
             await sut.startCashPayment()
@@ -732,20 +497,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func startCashPayment_sets_payment_state_to_collectingCash() async {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
 
             // When
             await sut.startCashPayment()
@@ -758,20 +513,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func cancelCashPayment_resets_payment_state_to_idle() async {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
             await sut.startCashPayment()
             #expect(sut.paymentState == PointOfSalePaymentState(card: .idle, cash: .collectingCash))
 
@@ -786,20 +531,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func cancelCashPayment_maintains_order_stage_as_finalizing() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
             #expect(sut.orderStage == .building)
 
             await sut.checkOut()
@@ -824,20 +559,10 @@ struct PointOfSaleAggregateModelTests {
                 orderTotalDecimal: 52.3,
                 order: Order.fake().copy(currency: "$", total: "52.30"))
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
 
             // When
             cardPresentPaymentService.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
@@ -854,20 +579,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func paymentIntentCreationErrorMessage_when_paymentIntentCreationError_tryAgain_cancels_payment() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
             struct TestError: Error {}
 
             // When paymentIntentCreationError event is received
@@ -890,20 +605,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func paymentIntentCreationErrorMessage_when_paymentIntentCreationError_editOrder_moves_back_to_building() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
             struct TestError: Error {}
             await sut.checkOut()
 
@@ -929,20 +634,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func checkOut_when_reader_connects_collectPayment_called() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
             cardPresentPaymentService.connectedReader = nil
 
             orderController.orderStateToReturn = makeLoadedOrderState(orderTotal: "$1.00", orderTotalDecimal: 1)
@@ -967,20 +662,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func checkOut_when_reader_is_already_connected_and_order_more_than_zero_collectPayment_called() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
             cardPresentPaymentService.connectedReader = .init(name: "Test reader", batteryLevel: 0.7)
             orderController.orderStateToReturn = makeLoadedOrderState(orderTotal: "$0.01", orderTotalDecimal: 0.01)
 
@@ -995,20 +680,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func checkOut_when_reader_is_already_connected_and_order_is_free_collectPayment_is_not_called() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
             cardPresentPaymentService.connectedReader = .init(name: "Test reader", batteryLevel: 0.7)
             orderController.orderStateToReturn = makeLoadedOrderState(orderTotal: "$0.00", orderTotalDecimal: 0.0)
 
@@ -1023,20 +698,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func after_disconnection_when_reader_reconnects_collectPayment_called() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
             cardPresentPaymentService.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
 
             orderController.orderStateToReturn = makeLoadedOrderState(orderTotal: "$1.00", orderTotalDecimal: 1)
@@ -1062,20 +727,10 @@ struct PointOfSaleAggregateModelTests {
         @Test(.disabled()) func cancelThenCollectPayment_still_collects_payment_when_cancellation_fails() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
             orderController.orderStateToReturn = makeLoadedOrderState(cartTotal: "$1.00")
             await orderController.syncOrder(for: .init(), retryHandler: {})
 
@@ -1096,20 +751,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func cardPresentPaymentOnboardingViewModel_is_non_nil_when_onboarding_is_required() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
             let onboardingViewModel = CardPresentPaymentsOnboardingViewModel(
                 fixedState: .pluginNotActivated(plugin: .stripe),
                 useCase: MockCardPresentPaymentsOnboardingUseCase(initial: .pluginNotActivated(plugin: .stripe))
@@ -1128,20 +773,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func connectionSuccessAlert_is_filtered_when_waiting_to_start_payment_on_card_reader_connection() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
 
             // Add item to cart and checkout to trigger payment waiting state
             sut.addToCart(makePurchasableItem())
@@ -1164,20 +799,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func connectionSuccessAlert_is_shown_when_not_waiting_to_start_payment() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
-                orderController: orderController,
-                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                orderController: orderController)
 
             // Verify we're in building stage and no alert is currently shown
             try #require(sut.orderStage == .building)
@@ -1211,20 +836,11 @@ struct PointOfSaleAggregateModelTests {
         @Test func paymentsOnboardingDismissed_event_is_tracked_with_state_when_cancelOnboarding_is_invoked() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
-                analytics: analytics,
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                analytics: analytics)
 
             sut.addToCart(makePurchasableItem())
 
@@ -1248,20 +864,11 @@ struct PointOfSaleAggregateModelTests {
         @Test func pointOfSalePaymentsOnboardingShown_event_is_tracked_when_trackOnboardingShown_is_invoked() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
-                analytics: analytics,
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                analytics: analytics)
 
             sut.addToCart(makePurchasableItem())
 
@@ -1276,20 +883,11 @@ struct PointOfSaleAggregateModelTests {
         @Test func connectCardReader_when_tapped_then_tracks_event() {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
-                analytics: analytics,
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                analytics: analytics)
 
             //When
             sut.connectCardReader()
@@ -1302,20 +900,11 @@ struct PointOfSaleAggregateModelTests {
         @Test func disconnectCardReader_when_tapped_then_tracks_event() {
             // Given
             let itemsController = MockPointOfSaleItemsController()
-            let sut = PointOfSaleAggregateModel(
-                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+            let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
-                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                couponsController: MockPointOfSaleCouponsController(),
-                couponsSearchController: MockPointOfSaleCouponsController(),
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController,
-                analytics: analytics,
-                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                searchHistoryService: MockPOSSearchHistoryService(),
-                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                soundPlayer: MockPointOfSaleSoundPlayer())
+                analytics: analytics)
 
             //When
             sut.disconnectCardReader()
@@ -1328,18 +917,10 @@ struct PointOfSaleAggregateModelTests {
         @Test func checkout_when_invoked_then_tracks_trackCheckoutTapped() async throws {
             // Given
             let analyticsTracker = MockPOSCollectOrderPaymentAnalyticsTracker()
-            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                itemsController: MockPointOfSaleItemsController(),
-                                                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                couponsController: MockPointOfSaleCouponsController(),
-                                                couponsSearchController: MockPointOfSaleCouponsController(),
-                                                cardPresentPaymentService: cardPresentPaymentService,
-                                                orderController: orderController,
-                                                collectOrderPaymentAnalyticsTracker: analyticsTracker,
-                                                searchHistoryService: MockPOSSearchHistoryService(),
-                                                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                                                soundPlayer: MockPointOfSaleSoundPlayer())
+            let sut = makePointOfSaleAggregateModel(
+                cardPresentPaymentService: cardPresentPaymentService,
+                orderController: orderController,
+                collectOrderPaymentAnalyticsTracker: analyticsTracker)
 
             // When
             await sut.checkOut()
@@ -1352,19 +933,9 @@ struct PointOfSaleAggregateModelTests {
         @Test func cancelCashPayment_when_invoked_then_tracks_expected_event() async throws {
             // Given
             let analyticsTracker = MockPOSCollectOrderPaymentAnalyticsTracker()
-            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                itemsController: MockPointOfSaleItemsController(),
-                                                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                couponsController: MockPointOfSaleCouponsController(),
-                                                couponsSearchController: MockPointOfSaleCouponsController(),
-                                                cardPresentPaymentService: MockCardPresentPaymentService(),
-                                                orderController: MockPointOfSaleOrderController(),
-                                                analytics: analytics,
-                                                collectOrderPaymentAnalyticsTracker: analyticsTracker,
-                                                searchHistoryService: MockPOSSearchHistoryService(),
-                                                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                                                soundPlayer: MockPointOfSaleSoundPlayer())
+            let sut = makePointOfSaleAggregateModel(
+                analytics: analytics,
+                collectOrderPaymentAnalyticsTracker: analyticsTracker)
             // When
             await sut.cancelCashPayment()
 
@@ -1377,19 +948,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let mockAnalyticsProvider = MockAnalyticsProvider()
             let mockAnalytics = WooAnalytics(analyticsProvider: mockAnalyticsProvider)
-            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                itemsController: MockPointOfSaleItemsController(),
-                                                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                couponsController: MockPointOfSaleCouponsController(),
-                                                couponsSearchController: MockPointOfSaleCouponsController(),
-                                                cardPresentPaymentService: MockCardPresentPaymentService(),
-                                                orderController: MockPointOfSaleOrderController(),
-                                                analytics: mockAnalytics,
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                                                searchHistoryService: MockPOSSearchHistoryService(),
-                                                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                barcodeScanService: MockPointOfSaleBarcodeScanService(),
-                                                soundPlayer: MockPointOfSaleSoundPlayer())
+            let sut = makePointOfSaleAggregateModel(analytics: mockAnalytics)
 
             // When
             await sut.startCashPayment()
@@ -1405,19 +964,9 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let soundPlayer = MockPointOfSaleSoundPlayer()
             let barcodeScanService = MockPointOfSaleBarcodeScanService()
-            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                itemsController: MockPointOfSaleItemsController(),
-                                                purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                couponsController: MockPointOfSaleCouponsController(),
-                                                couponsSearchController: MockPointOfSaleCouponsController(),
-                                                cardPresentPaymentService: MockCardPresentPaymentService(),
-                                                orderController: MockPointOfSaleOrderController(),
-                                                analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-                                                collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                                                searchHistoryService: MockPOSSearchHistoryService(),
-                                                popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                barcodeScanService: barcodeScanService,
-                                                soundPlayer: soundPlayer)
+            let sut = makePointOfSaleAggregateModel(
+                barcodeScanService: barcodeScanService,
+                soundPlayer: soundPlayer)
             barcodeScanService.errorToThrow = .notFound(scannedCode: "123456")
 
             // When & Then
@@ -1456,5 +1005,40 @@ private func makeLoadedOrderState(cartTotal: String = "",
     PointOfSaleInternalOrderState.loaded(
         PointOfSaleOrderTotals(cartTotal: cartTotal, orderTotal: orderTotal, taxTotal: taxTotal, orderTotalDecimal: orderTotalDecimal),
         order
+    )
+}
+
+@available(iOS 17.0, *)
+private func makePointOfSaleAggregateModel(
+    entryPointController: POSEntryPointController = POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+    itemsController: PointOfSaleItemsControllerProtocol = MockPointOfSaleItemsController(),
+    purchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol = MockPointOfSalePurchasableItemsSearchController(),
+    couponsController: PointOfSaleCouponsControllerProtocol = MockPointOfSaleCouponsController(),
+    couponsSearchController: PointOfSaleSearchingItemsControllerProtocol = MockPointOfSaleCouponsController(),
+    cardPresentPaymentService: CardPresentPaymentFacade = MockCardPresentPaymentService(),
+    orderController: PointOfSaleOrderControllerProtocol = MockPointOfSaleOrderController(),
+    analytics: Analytics = WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
+    collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking = MockPOSCollectOrderPaymentAnalyticsTracker(),
+    searchHistoryService: POSSearchHistoryProviding = MockPOSSearchHistoryService(),
+    popularPurchasableItemsController: PointOfSaleItemsControllerProtocol = MockPointOfSaleItemsController(),
+    barcodeScanService: PointOfSaleBarcodeScanServiceProtocol = MockPointOfSaleBarcodeScanService(),
+    soundPlayer: PointOfSaleSoundPlayerProtocol = MockPointOfSaleSoundPlayer(),
+    paymentState: PointOfSalePaymentState = .idle
+) -> PointOfSaleAggregateModel {
+    PointOfSaleAggregateModel(
+        entryPointController: entryPointController,
+        itemsController: itemsController,
+        purchasableItemsSearchController: purchasableItemsSearchController,
+        couponsController: couponsController,
+        couponsSearchController: couponsSearchController,
+        cardPresentPaymentService: cardPresentPaymentService,
+        orderController: orderController,
+        analytics: analytics,
+        collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker,
+        searchHistoryService: searchHistoryService,
+        popularPurchasableItemsController: popularPurchasableItemsController,
+        barcodeScanService: barcodeScanService,
+        soundPlayer: soundPlayer,
+        paymentState: paymentState
     )
 }

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -14,7 +14,8 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func inits_with_building_order_stage() async throws {
             // Given
-            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                itemsController: MockPointOfSaleItemsController(),
                                                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                 couponsController: MockPointOfSaleCouponsController(),
                                                 couponsSearchController: MockPointOfSaleCouponsController(),
@@ -33,7 +34,8 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func startNewCart_removes_all_items_from_cart_and_moves_back_to_building() async throws {
             // Given
-            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                itemsController: MockPointOfSaleItemsController(),
                                                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                 couponsController: MockPointOfSaleCouponsController(),
                                                 couponsSearchController: MockPointOfSaleCouponsController(),
@@ -61,7 +63,8 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func checkOut_moves_to_finalizing_order_stage() async throws {
             // Given
-            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                itemsController: MockPointOfSaleItemsController(),
                                                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                 couponsController: MockPointOfSaleCouponsController(),
                                                 couponsSearchController: MockPointOfSaleCouponsController(),
@@ -85,7 +88,8 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func addMoreToCart_moves_to_building_order_stage() async throws {
             // Given
-            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                itemsController: MockPointOfSaleItemsController(),
                                                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                 couponsController: MockPointOfSaleCouponsController(),
                                                 couponsSearchController: MockPointOfSaleCouponsController(),
@@ -158,7 +162,8 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func addItem_results_in_a_non_empty_cart() async throws {
             // Given
-            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                itemsController: MockPointOfSaleItemsController(),
                                                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                 couponsController: MockPointOfSaleCouponsController(),
                                                 couponsSearchController: MockPointOfSaleCouponsController(),
@@ -183,7 +188,8 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func addItem_puts_new_items_first_in_the_cart() async throws {
             // Given
-            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                itemsController: MockPointOfSaleItemsController(),
                                                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                 couponsController: MockPointOfSaleCouponsController(),
                                                 couponsSearchController: MockPointOfSaleCouponsController(),
@@ -213,7 +219,8 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func removeItem_after_adding_two_items_removes_item_correctly() async throws {
             // Given
-            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                itemsController: MockPointOfSaleItemsController(),
                                                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                 couponsController: MockPointOfSaleCouponsController(),
                                                 couponsSearchController: MockPointOfSaleCouponsController(),
@@ -244,7 +251,8 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func removeAllItemsFromCart_removes_everything() async throws {
             // Given
-            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                itemsController: MockPointOfSaleItemsController(),
                                                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                 couponsController: MockPointOfSaleCouponsController(),
                                                 couponsSearchController: MockPointOfSaleCouponsController(),
@@ -273,7 +281,8 @@ struct PointOfSaleAggregateModelTests {
         @available(iOS 17.0, *)
         @Test func removeAllItemsFromCartOfCouponType_removes_coupons() async throws {
             // Given
-            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                itemsController: MockPointOfSaleItemsController(),
                                                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                 couponsController: MockPointOfSaleCouponsController(),
                                                 couponsSearchController: MockPointOfSaleCouponsController(),
@@ -320,6 +329,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -347,6 +357,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -377,6 +388,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -406,6 +418,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -435,7 +448,8 @@ struct PointOfSaleAggregateModelTests {
         @Test func sendReceipt_when_invoked_then_calls_controller() async throws {
             // Given
             let orderController = MockPointOfSaleOrderController()
-            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                itemsController: MockPointOfSaleItemsController(),
                                                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                 couponsController: MockPointOfSaleCouponsController(),
                                                 couponsSearchController: MockPointOfSaleCouponsController(),
@@ -462,7 +476,8 @@ struct PointOfSaleAggregateModelTests {
             orderController.shouldThrowReceiptError = true
             let expectedError = NSError(domain: "some error", code: -1)
 
-            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                itemsController: MockPointOfSaleItemsController(),
                                                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                 couponsController: MockPointOfSaleCouponsController(),
                                                 couponsSearchController: MockPointOfSaleCouponsController(),
@@ -491,6 +506,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -525,6 +541,7 @@ struct PointOfSaleAggregateModelTests {
             // When we init
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -575,6 +592,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -600,6 +618,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -628,6 +647,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -653,6 +673,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -685,6 +706,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -711,6 +733,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -736,6 +759,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -763,6 +787,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -800,6 +825,7 @@ struct PointOfSaleAggregateModelTests {
                 order: Order.fake().copy(currency: "$", total: "52.30"))
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -829,6 +855,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -864,6 +891,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -902,6 +930,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -939,6 +968,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -966,6 +996,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -993,6 +1024,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -1031,6 +1063,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -1064,6 +1097,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -1095,6 +1129,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -1130,6 +1165,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -1176,6 +1212,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -1212,6 +1249,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -1239,6 +1277,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -1264,6 +1303,7 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let itemsController = MockPointOfSaleItemsController()
             let sut = PointOfSaleAggregateModel(
+                entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
                 itemsController: itemsController,
                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                 couponsController: MockPointOfSaleCouponsController(),
@@ -1288,7 +1328,8 @@ struct PointOfSaleAggregateModelTests {
         @Test func checkout_when_invoked_then_tracks_trackCheckoutTapped() async throws {
             // Given
             let analyticsTracker = MockPOSCollectOrderPaymentAnalyticsTracker()
-            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                itemsController: MockPointOfSaleItemsController(),
                                                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                 couponsController: MockPointOfSaleCouponsController(),
                                                 couponsSearchController: MockPointOfSaleCouponsController(),
@@ -1311,7 +1352,8 @@ struct PointOfSaleAggregateModelTests {
         @Test func cancelCashPayment_when_invoked_then_tracks_expected_event() async throws {
             // Given
             let analyticsTracker = MockPOSCollectOrderPaymentAnalyticsTracker()
-            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                itemsController: MockPointOfSaleItemsController(),
                                                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                 couponsController: MockPointOfSaleCouponsController(),
                                                 couponsSearchController: MockPointOfSaleCouponsController(),
@@ -1335,7 +1377,8 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let mockAnalyticsProvider = MockAnalyticsProvider()
             let mockAnalytics = WooAnalytics(analyticsProvider: mockAnalyticsProvider)
-            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                itemsController: MockPointOfSaleItemsController(),
                                                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                 couponsController: MockPointOfSaleCouponsController(),
                                                 couponsSearchController: MockPointOfSaleCouponsController(),
@@ -1362,7 +1405,8 @@ struct PointOfSaleAggregateModelTests {
             // Given
             let soundPlayer = MockPointOfSaleSoundPlayer()
             let barcodeScanService = MockPointOfSaleBarcodeScanService()
-            let sut = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+            let sut = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                itemsController: MockPointOfSaleItemsController(),
                                                 purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                 couponsController: MockPointOfSaleCouponsController(),
                                                 couponsSearchController: MockPointOfSaleCouponsController(),

--- a/WooCommerce/WooCommerceTests/POS/Presentation/POSItemActionHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/POSItemActionHandlerTests.swift
@@ -8,7 +8,8 @@ import protocol Yosemite.POSSearchHistoryProviding
 struct POSItemActionHandlerTests {
     @available(iOS 17.0, *)
     @Test func handleTap_when_attempt_to_add_duplicated_coupons_in_list_then_does_not_add_it_to_cart() async throws {
-        let aggregateModel = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+        let aggregateModel = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                       itemsController: MockPointOfSaleItemsController(),
                                                        purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                        couponsController: MockPointOfSaleCouponsController(),
                                                        couponsSearchController: MockPointOfSaleCouponsController(),
@@ -35,7 +36,8 @@ struct POSItemActionHandlerTests {
 
     @available(iOS 17.0, *)
     @Test func handleTap_when_attempt_to_add_duplicated_coupons_in_search_then_does_not_add_it_to_cart() async throws {
-        let aggregateModel = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+        let aggregateModel = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                       itemsController: MockPointOfSaleItemsController(),
                                                        purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                        couponsController: MockPointOfSaleCouponsController(),
                                                        couponsSearchController: MockPointOfSaleCouponsController(),
@@ -63,7 +65,8 @@ struct POSItemActionHandlerTests {
 
     @available(iOS 17.0, *)
     @Test func handleTap_when_attempt_to_add_duplicated_products_in_list_then_adds_them_to_cart() async throws {
-        let aggregateModel = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+        let aggregateModel = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                       itemsController: MockPointOfSaleItemsController(),
                                                        purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                        couponsController: MockPointOfSaleCouponsController(),
                                                        couponsSearchController: MockPointOfSaleCouponsController(),
@@ -90,7 +93,8 @@ struct POSItemActionHandlerTests {
 
     @available(iOS 17.0, *)
     @Test func handleTap_when_attempt_to_add_duplicated_products_in_search_then_adds_them_to_cart() async throws {
-        let aggregateModel = PointOfSaleAggregateModel(itemsController: MockPointOfSaleItemsController(),
+        let aggregateModel = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+                                                       itemsController: MockPointOfSaleItemsController(),
                                                        purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
                                                        couponsController: MockPointOfSaleCouponsController(),
                                                        couponsSearchController: MockPointOfSaleCouponsController(),

--- a/WooCommerce/WooCommerceTests/POS/Presentation/POSItemActionHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/POSItemActionHandlerTests.swift
@@ -2,23 +2,14 @@ import Testing
 import Foundation
 import enum Yosemite.POSItem
 import enum Yosemite.POSItemType
+import protocol Yosemite.PointOfSaleBarcodeScanServiceProtocol
 import protocol Yosemite.POSSearchHistoryProviding
 @testable import WooCommerce
 
 struct POSItemActionHandlerTests {
     @available(iOS 17.0, *)
     @Test func handleTap_when_attempt_to_add_duplicated_coupons_in_list_then_does_not_add_it_to_cart() async throws {
-        let aggregateModel = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                       itemsController: MockPointOfSaleItemsController(),
-                                                       purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                       couponsController: MockPointOfSaleCouponsController(),
-                                                       couponsSearchController: MockPointOfSaleCouponsController(),
-                                                       cardPresentPaymentService: MockCardPresentPaymentService(),
-                                                       orderController: MockPointOfSaleOrderController(),
-                                                       collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                                                       searchHistoryService: MockPOSSearchHistoryService(),
-                                                       popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                       barcodeScanService: MockPointOfSaleBarcodeScanService())
+        let aggregateModel = makePointOfSaleAggregateModel()
         let sut = StandardPOSItemActionHandler(
             posModel: aggregateModel,
             sourceView: .coupon,
@@ -36,17 +27,7 @@ struct POSItemActionHandlerTests {
 
     @available(iOS 17.0, *)
     @Test func handleTap_when_attempt_to_add_duplicated_coupons_in_search_then_does_not_add_it_to_cart() async throws {
-        let aggregateModel = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                       itemsController: MockPointOfSaleItemsController(),
-                                                       purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                       couponsController: MockPointOfSaleCouponsController(),
-                                                       couponsSearchController: MockPointOfSaleCouponsController(),
-                                                       cardPresentPaymentService: MockCardPresentPaymentService(),
-                                                       orderController: MockPointOfSaleOrderController(),
-                                                       collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                                                       searchHistoryService: MockPOSSearchHistoryService(),
-                                                       popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                       barcodeScanService: MockPointOfSaleBarcodeScanService())
+        let aggregateModel = makePointOfSaleAggregateModel()
         let sut = SearchResultItemActionHandler(
             posModel: aggregateModel,
             searchTerm: "",
@@ -65,17 +46,7 @@ struct POSItemActionHandlerTests {
 
     @available(iOS 17.0, *)
     @Test func handleTap_when_attempt_to_add_duplicated_products_in_list_then_adds_them_to_cart() async throws {
-        let aggregateModel = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                       itemsController: MockPointOfSaleItemsController(),
-                                                       purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                       couponsController: MockPointOfSaleCouponsController(),
-                                                       couponsSearchController: MockPointOfSaleCouponsController(),
-                                                       cardPresentPaymentService: MockCardPresentPaymentService(),
-                                                       orderController: MockPointOfSaleOrderController(),
-                                                       collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                                                       searchHistoryService: MockPOSSearchHistoryService(),
-                                                       popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                       barcodeScanService: MockPointOfSaleBarcodeScanService())
+        let aggregateModel = makePointOfSaleAggregateModel()
         let sut = StandardPOSItemActionHandler(
             posModel: aggregateModel,
             sourceView: .product,
@@ -93,17 +64,7 @@ struct POSItemActionHandlerTests {
 
     @available(iOS 17.0, *)
     @Test func handleTap_when_attempt_to_add_duplicated_products_in_search_then_adds_them_to_cart() async throws {
-        let aggregateModel = PointOfSaleAggregateModel(entryPointController: POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
-                                                       itemsController: MockPointOfSaleItemsController(),
-                                                       purchasableItemsSearchController: MockPointOfSalePurchasableItemsSearchController(),
-                                                       couponsController: MockPointOfSaleCouponsController(),
-                                                       couponsSearchController: MockPointOfSaleCouponsController(),
-                                                       cardPresentPaymentService: MockCardPresentPaymentService(),
-                                                       orderController: MockPointOfSaleOrderController(),
-                                                       collectOrderPaymentAnalyticsTracker: MockPOSCollectOrderPaymentAnalyticsTracker(),
-                                                       searchHistoryService: MockPOSSearchHistoryService(),
-                                                       popularPurchasableItemsController: MockPointOfSaleItemsController(),
-                                                       barcodeScanService: MockPointOfSaleBarcodeScanService())
+        let aggregateModel = makePointOfSaleAggregateModel()
         let sut = SearchResultItemActionHandler(
             posModel: aggregateModel,
             searchTerm: "",
@@ -134,4 +95,33 @@ private func makeProductItem() -> POSItem {
                                 manageStock: false,
                                 stockQuantity: nil,
                                 stockStatusKey: ""))
+}
+
+@available(iOS 17.0, *)
+private func makePointOfSaleAggregateModel(
+    entryPointController: POSEntryPointController = POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
+    itemsController: PointOfSaleItemsControllerProtocol = MockPointOfSaleItemsController(),
+    purchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol = MockPointOfSalePurchasableItemsSearchController(),
+    couponsController: PointOfSaleCouponsControllerProtocol = MockPointOfSaleCouponsController(),
+    couponsSearchController: PointOfSaleSearchingItemsControllerProtocol = MockPointOfSaleCouponsController(),
+    cardPresentPaymentService: CardPresentPaymentFacade = MockCardPresentPaymentService(),
+    orderController: PointOfSaleOrderControllerProtocol = MockPointOfSaleOrderController(),
+    collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking = MockPOSCollectOrderPaymentAnalyticsTracker(),
+    searchHistoryService: POSSearchHistoryProviding = MockPOSSearchHistoryService(),
+    popularPurchasableItemsController: PointOfSaleItemsControllerProtocol = MockPointOfSaleItemsController(),
+    barcodeScanService: PointOfSaleBarcodeScanServiceProtocol = MockPointOfSaleBarcodeScanService()
+) -> PointOfSaleAggregateModel {
+    PointOfSaleAggregateModel(
+        entryPointController: entryPointController,
+        itemsController: itemsController,
+        purchasableItemsSearchController: purchasableItemsSearchController,
+        couponsController: couponsController,
+        couponsSearchController: couponsSearchController,
+        cardPresentPaymentService: cardPresentPaymentService,
+        orderController: orderController,
+        collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker,
+        searchHistoryService: searchHistoryService,
+        popularPurchasableItemsController: popularPurchasableItemsController,
+        barcodeScanService: barcodeScanService
+    )
 }

--- a/WooCommerce/WooCommerceTests/POS/ViewHelpers/PointOfSaleDashboardViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewHelpers/PointOfSaleDashboardViewHelperTests.swift
@@ -214,4 +214,27 @@ struct PointOfSaleDashboardViewHelperTests {
         // Then
         #expect(result == .ineligible(reason: .unsupportedIOSVersion))
     }
+
+    // MARK: - Floating Control Tests
+
+    @available(iOS 17.0, *)
+    @Test(arguments: [
+        (PointOfSaleDashboardView.ViewState.content, true),
+        (PointOfSaleDashboardView.ViewState.error(PointOfSaleErrorState.errorOnLoadingProducts()), true),
+        (PointOfSaleDashboardView.ViewState.unsupportedWidth, true)
+    ])
+    func showsFloatingControl_when_content_error_or_unsupportedWidth_returns_true(viewState: PointOfSaleDashboardView.ViewState, expected: Bool) async throws {
+        // When & Then
+        #expect(viewState.showsFloatingControl == expected)
+    }
+
+    @available(iOS 17.0, *)
+    @Test(arguments: [
+        (PointOfSaleDashboardView.ViewState.loading, false),
+        (PointOfSaleDashboardView.ViewState.ineligible(reason: .unsupportedIOSVersion), false)
+    ])
+    func showsFloatingControl_when_loading_or_ineligible_returns_false(viewState: PointOfSaleDashboardView.ViewState, expected: Bool) async throws {
+        // When & Then
+        #expect(viewState.showsFloatingControl == expected)
+    }
 }

--- a/WooCommerce/WooCommerceTests/POS/ViewHelpers/PointOfSaleDashboardViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewHelpers/PointOfSaleDashboardViewHelperTests.swift
@@ -1,0 +1,217 @@
+import Foundation
+import SwiftUI
+import Testing
+import enum WooFoundationCore.CurrencyCode
+@testable import WooCommerce
+
+struct PointOfSaleDashboardViewHelperTests {
+    // MARK: - Horizontal Size Class Tests
+
+    @available(iOS 17.0, *)
+    @Test func determineViewState_when_horizontalSizeClass_is_compact_returns_unsupportedWidth() async throws {
+        // Given
+        let eligibilityState: POSEligibilityState = .eligible
+        let itemsContainerState: ItemsContainerState = .content
+        let horizontalSizeClass: UserInterfaceSizeClass = .compact
+
+        // When
+        let result = PointOfSaleDashboardViewHelper.determineViewState(
+            eligibilityState: eligibilityState,
+            itemsContainerState: itemsContainerState,
+            horizontalSizeClass: horizontalSizeClass
+        )
+
+        // Then
+        #expect(result == .unsupportedWidth)
+    }
+
+    @available(iOS 17.0, *)
+    @Test func determineViewState_when_horizontalSizeClass_is_nil_returns_unsupportedWidth() async throws {
+        // Given
+        let eligibilityState: POSEligibilityState = .eligible
+        let itemsContainerState: ItemsContainerState = .content
+        let horizontalSizeClass: UserInterfaceSizeClass? = nil
+
+        // When
+        let result = PointOfSaleDashboardViewHelper.determineViewState(
+            eligibilityState: eligibilityState,
+            itemsContainerState: itemsContainerState,
+            horizontalSizeClass: horizontalSizeClass
+        )
+
+        // Then
+        #expect(result == .unsupportedWidth)
+    }
+
+    // MARK: - Eligibility State Tests
+
+    @available(iOS 17.0, *)
+    @Test func determineViewState_when_eligibilityState_is_nil_returns_loading() async throws {
+        // Given
+        let eligibilityState: POSEligibilityState? = nil
+        let itemsContainerState: ItemsContainerState = .content
+        let horizontalSizeClass: UserInterfaceSizeClass = .regular
+
+        // When
+        let result = PointOfSaleDashboardViewHelper.determineViewState(
+            eligibilityState: eligibilityState,
+            itemsContainerState: itemsContainerState,
+            horizontalSizeClass: horizontalSizeClass
+        )
+
+        // Then
+        #expect(result == .loading)
+    }
+
+    @available(iOS 17.0, *)
+    @Test(arguments: [
+        POSIneligibleReason.unsupportedIOSVersion,
+        POSIneligibleReason.unsupportedWooCommerceVersion(minimumVersion: "9.6.0"),
+        POSIneligibleReason.unsupportedCurrency(supportedCurrencies: [.USD, .GBP]),
+        POSIneligibleReason.siteSettingsNotAvailable,
+        POSIneligibleReason.wooCommercePluginNotFound,
+        POSIneligibleReason.featureSwitchDisabled,
+        POSIneligibleReason.selfDeallocated
+    ])
+    func determineViewState_when_ineligible_returns_ineligible(reason: POSIneligibleReason) async throws {
+        // Given
+        let eligibilityState: POSEligibilityState = .ineligible(reason: reason)
+        let itemsContainerState: ItemsContainerState = .content
+        let horizontalSizeClass: UserInterfaceSizeClass = .regular
+
+        // When
+        let result = PointOfSaleDashboardViewHelper.determineViewState(
+            eligibilityState: eligibilityState,
+            itemsContainerState: itemsContainerState,
+            horizontalSizeClass: horizontalSizeClass
+        )
+
+        // Then
+        #expect(result == .ineligible(reason: reason))
+    }
+
+    // MARK: - Eligible State Tests
+
+    @available(iOS 17.0, *)
+    @Test func determineViewState_when_eligible_and_loading_returns_loading() async throws {
+        // Given
+        let eligibilityState: POSEligibilityState = .eligible
+        let itemsContainerState: ItemsContainerState = .loading
+        let horizontalSizeClass: UserInterfaceSizeClass = .regular
+
+        // When
+        let result = PointOfSaleDashboardViewHelper.determineViewState(
+            eligibilityState: eligibilityState,
+            itemsContainerState: itemsContainerState,
+            horizontalSizeClass: horizontalSizeClass
+        )
+
+        // Then
+        #expect(result == .loading)
+    }
+
+    @available(iOS 17.0, *)
+    @Test func determineViewState_when_eligible_and_content_returns_content() async throws {
+        // Given
+        let eligibilityState: POSEligibilityState = .eligible
+        let itemsContainerState: ItemsContainerState = .content
+        let horizontalSizeClass: UserInterfaceSizeClass = .regular
+
+        // When
+        let result = PointOfSaleDashboardViewHelper.determineViewState(
+            eligibilityState: eligibilityState,
+            itemsContainerState: itemsContainerState,
+            horizontalSizeClass: horizontalSizeClass
+        )
+
+        // Then
+        #expect(result == .content)
+    }
+
+    // MARK: - Error State Tests
+
+    @available(iOS 17.0, *)
+    @Test(arguments: [
+        PointOfSaleErrorState.errorOnLoadingProducts(),
+        PointOfSaleErrorState.errorOnLoadingVariations(),
+        PointOfSaleErrorState.errorOnLoadingCoupons(),
+        PointOfSaleErrorState.errorCouponsDisabled,
+        PointOfSaleErrorState.errorOnLoadingProductsNextPage(),
+        PointOfSaleErrorState.errorOnLoadingVariationsNextPage(),
+        PointOfSaleErrorState.errorOnLoadingCouponsNextPage(),
+        PointOfSaleErrorState.errorOnRefreshingCoupons(),
+        PointOfSaleErrorState.errorOnEnablingCoupons()
+    ])
+    func determineViewState_when_eligible_and_error_returns_error(errorState: PointOfSaleErrorState) async throws {
+        // Given
+        let eligibilityState: POSEligibilityState = .eligible
+        let itemsContainerState: ItemsContainerState = .error(errorState)
+        let horizontalSizeClass: UserInterfaceSizeClass = .regular
+
+        // When
+        let result = PointOfSaleDashboardViewHelper.determineViewState(
+            eligibilityState: eligibilityState,
+            itemsContainerState: itemsContainerState,
+            horizontalSizeClass: horizontalSizeClass
+        )
+
+        // Then
+        #expect(result == .error(errorState))
+    }
+
+    // MARK: - Priority Tests
+
+    @available(iOS 17.0, *)
+    @Test func determineViewState_horizontalSizeClass_takes_priority_over_eligibility_state() async throws {
+        // Given - compact size class should return unsupportedWidth regardless of eligibility
+        let eligibilityState: POSEligibilityState = .ineligible(reason: .unsupportedIOSVersion)
+        let itemsContainerState: ItemsContainerState = .content
+        let horizontalSizeClass: UserInterfaceSizeClass = .compact
+
+        // When
+        let result = PointOfSaleDashboardViewHelper.determineViewState(
+            eligibilityState: eligibilityState,
+            itemsContainerState: itemsContainerState,
+            horizontalSizeClass: horizontalSizeClass
+        )
+
+        // Then
+        #expect(result == .unsupportedWidth)
+    }
+
+    @available(iOS 17.0, *)
+    @Test func determineViewState_nil_eligibilityState_takes_priority_over_containerState() async throws {
+        // Given - nil eligibility should return loading regardless of container state
+        let eligibilityState: POSEligibilityState? = nil
+        let itemsContainerState: ItemsContainerState = .content
+        let horizontalSizeClass: UserInterfaceSizeClass = .regular
+
+        // When
+        let result = PointOfSaleDashboardViewHelper.determineViewState(
+            eligibilityState: eligibilityState,
+            itemsContainerState: itemsContainerState,
+            horizontalSizeClass: horizontalSizeClass
+        )
+
+        // Then
+        #expect(result == .loading)
+    }
+
+    @available(iOS 17.0, *)
+    @Test func determineViewState_ineligible_state_takes_priority_over_containerState() async throws {
+        // Given - ineligible state should return ineligible regardless of container state
+        let eligibilityState: POSEligibilityState = .ineligible(reason: .unsupportedIOSVersion)
+        let itemsContainerState: ItemsContainerState = .content
+        let horizontalSizeClass: UserInterfaceSizeClass = .regular
+
+        // When
+        let result = PointOfSaleDashboardViewHelper.determineViewState(
+            eligibilityState: eligibilityState,
+            itemsContainerState: itemsContainerState,
+            horizontalSizeClass: horizontalSizeClass
+        )
+
+        // Then
+        #expect(result == .ineligible(reason: .unsupportedIOSVersion))
+    }
+}


### PR DESCRIPTION
For WOOMOB-767

Just one review is required.

## Why

For stores eligible for POS, when transitioning from eligibility check to items loading, both being async tasks, the spinner animation appears discontinuous during the transition.

## How

This PR streamlines the animation by moving the eligibility state based UI from a separate view (entry point view) to the dashboard view with some refactoring on the view state. Other attempts on the loading UI animation side that did not work due to having 3 sets of animations using SwiftUI `withAnimation` which is reset when the view is redrawn (triggered when entering `PointOfSaleDashboardView`):

- Updating `IndefiniteCircularProgressViewStyle` to only start the timer if there is no timer before, and disable invalidating the timer in `onDisappear`. 
- Extracting the animation states to be an ObservableObject owned by the entry point view and DI'ed to both loading use cases in the entry point view and dashboard view.
- Replacing `withAnimation` entirely using `CADisplayLink` timer - I could not get it to match the previous animation 100%.

## Description

This PR moves the eligibility state based UI from `PointOfSaleEntryPointView` to `PointOfSaleDashboardView` and refactors `PointOfSaleEntryPointView` view body to use a centralized `ViewState` approach with a view helper class, improving code maintainability and following the [POS architecture guidelines](https://github.com/woocommerce/woocommerce-ios/blob/25a203371edaf2d9a69ed23cb6c58ce9e431c5f2/WooCommerce/Classes/POS/README.md#viewmodels).

### Key Changes:

1. **Created PointOfSaleDashboardViewHelper**: A stateless helper that centralizes ViewState determination logic
2. **ViewState enum**: includes all cases in the top-level view body with associated values for the ineligible and error cases
3. **Streamlined view logic**: Replaced nested conditional checks with a clean switch statement
4. **Test coverage**: Added test cases for `PointOfSaleDashboardViewHelper`
5. Some adjustments to the ineligible UI presentation are required now that it's moved to `PointOfSaleDashboardView`, like updating the floating control visibility and adding the frame width to fit to parent width

### Architecture Benefits:

- **Single source of truth**: All view state logic centralized in the helper
- **Better separation of concerns**: Helper handles state determination, view handles rendering
- **Improved testability**: Helper is easily unit tested with comprehensive coverage
- **Cleaner code structure**: Replace nested conditionals with clear switch statements

## Steps to reproduce

Prerequisite: the store is in an eligible country (US/UK) and is one fixable reason away from being eligible for POS (e.g. unsupported currency, POS feature switch disabled for WC version 10.0+)

- Log in to the store in the prerequisite if needed
- Tap on the POS tab --> after loading UI, ineligible UI should be shown. the floating control should not be shown
- Fix the ineligible reason
- In the app, tap `Retry` --> it should enter loading UI to fetch products, and to the products loaded state
- Smoke test the items operations a bit, like searching for products/coupons to ensure that the states work as before
- Exit POS
- Tap on the POS tab --> the loading animation should be continuous before reaching the items loaded state

## Testing information

Tested on iPad Pro 11in 3rd generation device, iOS 18.5:

- Horizontal size class changes using split view (compact, regular)
- Eligibility states:
  - Ineligible -> eligible after retry
  - Eligible
- Priority ordering (size class > eligibility > container state)
- Error 

## Screenshots

Ineligible -> eligible with split screen testing:


https://github.com/user-attachments/assets/1c619053-0975-42fc-b592-1e04101d1a30


Eligible where the animation is now continuous:


https://github.com/user-attachments/assets/c29d8a67-7382-45c0-81cc-1154b38e960e

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.