### PR TITLE
[POS as a tab i2] Integrate with core API to enable feature switch from ineligible UI

### DIFF
--- a/Modules/Sources/Networking/Remote/SiteSettingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/SiteSettingsRemote.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+/// Protocol for SiteSettingsRemote to enable testing.
+public protocol SiteSettingsRemoteProtocol {
+    func setFeature(for siteID: Int64, feature: SiteSettingsFeature, enabled: Bool) async throws -> Bool
+}
+
 /// Features that can be enabled/disabled in core, under WC Settings > Advanced > Features.
 public enum SiteSettingsFeature {
     case pointOfSale

--- a/Modules/Sources/Networking/Remote/SiteSettingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/SiteSettingsRemote.swift
@@ -114,15 +114,48 @@ public class SiteSettingsRemote: Remote {
         let mapper = SiteSettingMapper(siteID: siteID, settingsGroup: .advanced)
         let response = try await enqueue(request, mapper: mapper)
         switch response.value {
-        case "yes":
+        case Constants.featureEnabledValue:
             return true
-        case "no":
+        case Constants.featureDisabledValue:
+            return false
+        default:
+            throw SiteSettingsRemoteError.invalidResponse
+        }
+    }
+
+    /// Enables or disables a specific feature in the site WC settings.
+    ///
+    /// - Parameters:
+    ///   - siteID: Site for which we'll update the feature status.
+    ///   - feature: The feature to enable or disable.
+    ///   - enabled: Whether the feature should be enabled (true) or disabled (false).
+    /// - Returns: A boolean indicating the updated feature status.
+    /// - Throws: Error if the request fails.
+    ///
+    public func setFeature(for siteID: Int64, feature: SiteSettingsFeature, enabled: Bool) async throws -> Bool {
+        let value = enabled ? Constants.featureEnabledValue : Constants.featureDisabledValue
+        let parameters: [String: Any] = [Constants.valueParameter: value]
+        let path = Constants.siteSettingsPath + Constants.advancedSettingsGroup + "/woocommerce_feature_\(feature.rawValue)_enabled"
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .put,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
+        let mapper = SiteSettingMapper(siteID: siteID, settingsGroup: .advanced)
+        let response = try await enqueue(request, mapper: mapper)
+        switch response.value {
+        case Constants.featureEnabledValue:
+            return true
+        case Constants.featureDisabledValue:
             return false
         default:
             throw SiteSettingsRemoteError.invalidResponse
         }
     }
 }
+
+extension SiteSettingsRemote: SiteSettingsRemoteProtocol {}
 
 public extension SiteSettingsFeature {
     var rawValue: String {
@@ -142,6 +175,8 @@ private extension SiteSettingsRemote {
         static let productSettingsGroup: String   = "products"
         static let advancedSettingsGroup: String   = "advanced"
         static let valueParameter: String = "value"
+        static let featureEnabledValue: String = "yes"
+        static let featureDisabledValue: String = "no"
     }
 }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSSiteSettingService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSSiteSettingService.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Networking
+
+/// Protocol for POS site setting service that manages WooCommerce feature flags.
+public protocol POSSiteSettingServiceProtocol {
+    /// Enables or disables a specific feature in the site WC settings.
+    /// - Parameters:
+    ///   - siteID: The site ID for which to update the feature setting.
+    ///   - feature: The feature to enable or disable.
+    ///   - enabled: Whether the feature should be enabled (true) or disabled (false).
+    /// - Returns: A boolean indicating the updated feature status.
+    /// - Throws: Error if the request fails or the setting cannot be updated.
+    func setFeature(siteID: Int64, feature: SiteSettingsFeature, enabled: Bool) async throws -> Bool
+}
+
+/// Service for managing Point of Sale related site settings.
+public final class POSSiteSettingService: POSSiteSettingServiceProtocol {
+    private let remote: SiteSettingsRemoteProtocol
+
+    public init(credentials: Credentials?) {
+        let network = AlamofireNetwork(credentials: credentials)
+        self.remote = SiteSettingsRemote(network: network)
+    }
+
+    /// Test-friendly initializer that accepts a remote implementation.
+    /// - Parameter remote: The remote service implementation to use for network requests.
+    init(remote: SiteSettingsRemoteProtocol) {
+        self.remote = remote
+    }
+
+    public func setFeature(siteID: Int64, feature: SiteSettingsFeature, enabled: Bool) async throws -> Bool {
+        try await remote.setFeature(for: siteID, feature: feature, enabled: enabled)
+    }
+}

--- a/Modules/Tests/NetworkingTests/Remote/SiteSettingsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/SiteSettingsRemoteTests.swift
@@ -228,4 +228,48 @@ final class SiteSettingsRemoteTests: XCTestCase {
             XCTAssertEqual(error as? NetworkError, .unacceptableStatusCode(statusCode: 500))
         }
     }
+
+    // MARK: - `setFeature`
+
+    func test_setFeature_enables_feature_when_enabled_is_true() async throws {
+        // Given
+        let remote = SiteSettingsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "settings/advanced/woocommerce_feature_point_of_sale_enabled",
+                                 filename: "settings-advanced-feature-pos-enabled")
+
+        // When
+        let isEnabled = try await remote.setFeature(for: sampleSiteID, feature: .pointOfSale, enabled: true)
+
+        // Then
+        XCTAssertTrue(isEnabled)
+    }
+
+    func test_setFeature_disables_feature_when_enabled_is_false() async throws {
+        // Given
+        let remote = SiteSettingsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "settings/advanced/woocommerce_feature_point_of_sale_enabled",
+                                 filename: "settings-advanced-feature-pos-disabled")
+
+        // When
+        let isEnabled = try await remote.setFeature(for: sampleSiteID, feature: .pointOfSale, enabled: false)
+
+        // Then
+        XCTAssertFalse(isEnabled)
+    }
+
+    func test_setFeature_throws_error_when_network_fails() async {
+        // Given
+        let remote = SiteSettingsRemote(network: network)
+        let error = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: "settings/advanced/woocommerce_feature_point_of_sale_enabled",
+                              error: error)
+
+        // When/Then
+        do {
+            _ = try await remote.setFeature(for: sampleSiteID, feature: .pointOfSale, enabled: true)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual(error as? NetworkError, .unacceptableStatusCode(statusCode: 500))
+        }
+    }
 }

--- a/Modules/Tests/YosemiteTests/Mocks/MockSiteSettingsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockSiteSettingsRemote.swift
@@ -1,0 +1,23 @@
+import Networking
+
+final class MockSiteSettingsRemote: SiteSettingsRemoteProtocol {
+    var setFeatureCalled: Bool = false
+    var spySetFeatureSiteID: Int64?
+    var spySetFeatureFeature: SiteSettingsFeature?
+    var spySetFeatureEnabled: Bool?
+    var setFeatureResult: Result<Bool, Error> = .success(true)
+
+    func setFeature(for siteID: Int64, feature: SiteSettingsFeature, enabled: Bool) async throws -> Bool {
+        setFeatureCalled = true
+        spySetFeatureSiteID = siteID
+        spySetFeatureFeature = feature
+        spySetFeatureEnabled = enabled
+
+        switch setFeatureResult {
+        case .success(let result):
+            return result
+        case .failure(let error):
+            throw error
+        }
+    }
+}

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSSiteSettingServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSSiteSettingServiceTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import Yosemite
+@testable import Networking
+
+struct POSSiteSettingServiceTests {
+    private let sut: POSSiteSettingService
+    private let mockRemote: MockSiteSettingsRemote
+    private let sampleSiteID: Int64 = 123
+
+    init() {
+        let mockRemote = MockSiteSettingsRemote()
+        self.mockRemote = mockRemote
+        self.sut = POSSiteSettingService(remote: mockRemote)
+    }
+
+    @Test(arguments: [true, false])
+    func setFeature_calls_remote_with_correct_parameters(featureEnabled: Bool) async throws {
+        // Given
+        let feature = SiteSettingsFeature.pointOfSale
+        mockRemote.setFeatureResult = .success(true)
+
+        // When
+        let result = try await sut.setFeature(siteID: sampleSiteID, feature: feature, enabled: featureEnabled)
+
+        // Then
+        #expect(mockRemote.setFeatureCalled == true)
+        #expect(mockRemote.spySetFeatureSiteID == sampleSiteID)
+        #expect(mockRemote.spySetFeatureFeature == feature)
+        #expect(mockRemote.spySetFeatureEnabled == featureEnabled)
+        #expect(result == true)
+    }
+
+    @Test(arguments: [true, false])
+    func setFeature_returns_false_when_remote_returns_false(remoteFeatureEnabled: Bool) async throws {
+        // Given
+        let feature = SiteSettingsFeature.pointOfSale
+        mockRemote.setFeatureResult = .success(remoteFeatureEnabled)
+
+        // When
+        let result = try await sut.setFeature(siteID: sampleSiteID, feature: feature, enabled: true)
+
+        // Then
+        #expect(result == remoteFeatureEnabled)
+    }
+
+    @Test func setFeature_throws_error_when_remote_throws_error() async throws {
+        // Given
+        let feature = SiteSettingsFeature.pointOfSale
+        let expectedError = SiteSettingsRemoteError.invalidResponse
+        mockRemote.setFeatureResult = .failure(expectedError)
+
+        // When/Then
+        await #expect(performing: {
+            try await sut.setFeature(siteID: sampleSiteID, feature: feature, enabled: true)
+        }, throws: { error in
+            return error as? SiteSettingsRemoteError == expectedError
+        })
+    }
+}

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -51,7 +51,7 @@ struct POSIneligibleView: View {
                             }
                         }
                     } label: {
-                        Text(Localization.refreshEligibility)
+                        Text(reason.refreshEligibilityTitle)
                     }
                     .buttonStyle(POSFilledButtonStyle(size: .normal, isLoading: isLoading))
                     .renderedIf(reason.shouldShowRetryButton)
@@ -91,9 +91,9 @@ struct POSIneligibleView: View {
                                      value: "Install and activate the WooCommerce plugin from your WordPress admin.",
                                      comment: "Suggestion for missing WooCommerce plugin: install plugin")
         case .featureSwitchDisabled:
-            return NSLocalizedString("pos.ineligible.suggestion.featureSwitchDisabled",
+            return NSLocalizedString("pos.ineligible.suggestion.featureSwitchDisabled.2",
                                      value: "Point of Sale must be enabled to proceed. " +
-                                     "Please enable the POS feature from your WordPress admin under WooCommerce settings > Advanced > Features.",
+                                     "You can enable the POS feature below or from your WordPress admin under WooCommerce settings > Advanced > Features.",
                                      comment: "Suggestion for disabled feature switch: enable feature in WooCommerce settings")
         case let .unsupportedCurrency(supportedCurrencies):
             let currencyList = supportedCurrencies.map { $0.rawValue }
@@ -127,12 +127,6 @@ private extension POSIneligibleView {
             comment: "Title shown in POS ineligible view"
         )
 
-        static let refreshEligibility = NSLocalizedString(
-            "pos.ineligible.refresh.button.title",
-            value: "Retry",
-            comment: "Button title to refresh POS eligibility check"
-        )
-
         static let dismiss = NSLocalizedString(
             "pos.ineligible.dismiss.button.title",
             value: "Exit POS",
@@ -154,6 +148,28 @@ private extension POSIneligibleReason {
                 .unsupportedCurrency,
                 .selfDeallocated:
             return true
+        }
+    }
+
+    var refreshEligibilityTitle: String {
+        switch self {
+        case .featureSwitchDisabled:
+            return NSLocalizedString(
+                "pos.ineligible.enable.pos.feature.and.refresh.button.title",
+                value: "Enable POS & Retry",
+                comment: "Button title to enable the POS feature switch and refresh POS eligibility check"
+            )
+        case .unsupportedIOSVersion,
+                .unsupportedWooCommerceVersion,
+                .siteSettingsNotAvailable,
+                .wooCommercePluginNotFound,
+                .unsupportedCurrency,
+                .selfDeallocated:
+            return NSLocalizedString(
+                "pos.ineligible.refresh.button.title",
+                value: "Retry",
+                comment: "Button title to refresh POS eligibility check"
+            )
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -13,6 +13,9 @@ import enum Yosemite.FeatureFlagAction
 import enum Yosemite.SettingAction
 import protocol Yosemite.POSSystemStatusServiceProtocol
 import class Yosemite.POSSystemStatusService
+import protocol Yosemite.POSSiteSettingServiceProtocol
+import class Yosemite.POSSiteSettingService
+import enum Networking.SiteSettingsFeature
 
 /// Represents the reasons why a site may be ineligible for POS.
 enum POSIneligibleReason: Equatable {
@@ -50,6 +53,7 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
     private let systemStatusService: POSSystemStatusServiceProtocol
+    private let siteSettingService: POSSiteSettingServiceProtocol
 
     init(siteID: Int64,
          userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
@@ -58,7 +62,8 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
          stores: StoresManager = ServiceLocator.stores,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          systemStatusService: POSSystemStatusServiceProtocol = POSSystemStatusService(credentials: ServiceLocator.stores.sessionManager.defaultCredentials,
-                                                                                      storageManager: ServiceLocator.storageManager)) {
+                                                                                      storageManager: ServiceLocator.storageManager),
+         siteSettingService: POSSiteSettingServiceProtocol = POSSiteSettingService(credentials: ServiceLocator.stores.sessionManager.defaultCredentials)) {
         self.siteID = siteID
         self.userInterfaceIdiom = userInterfaceIdiom
         self.siteSettings = siteSettings
@@ -66,6 +71,7 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
         self.stores = stores
         self.featureFlagService = featureFlagService
         self.systemStatusService = systemStatusService
+        self.siteSettingService = siteSettingService
     }
 
     /// Checks the initial visibility of the POS tab without dependance on network requests.
@@ -133,8 +139,7 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
         case .unsupportedWooCommerceVersion, .wooCommercePluginNotFound:
             return await checkEligibility()
         case .featureSwitchDisabled:
-            // TODO: WOOMOB-759 - enable feature switch via API and check eligibility again
-            // For now, just checks eligibility again.
+            _ = try await siteSettingService.setFeature(siteID: siteID, feature: .pointOfSale, enabled: true)
             return await checkEligibility()
         case .selfDeallocated:
             return await checkEligibility()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -12,6 +12,7 @@ struct POSTabEligibilityCheckerTests {
     private var siteSettings: MockSelectedSiteSettings!
     private var eligibilityService: MockPOSEligibilityService!
     private var mockSystemStatusService: MockPOSSystemStatusService!
+    private var mockSiteSettingService: MockPOSSiteSettingService!
     private let siteID: Int64 = 2
 
     init() async throws {
@@ -21,6 +22,7 @@ struct POSTabEligibilityCheckerTests {
         eligibilityService = MockPOSEligibilityService()
         siteSettings = MockSelectedSiteSettings()
         mockSystemStatusService = MockPOSSystemStatusService()
+        mockSiteSettingService = MockPOSSiteSettingService()
         setupWooCommerceVersion()
     }
 
@@ -622,7 +624,8 @@ struct POSTabEligibilityCheckerTests {
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+                                               systemStatusService: mockSystemStatusService,
+                                               siteSettingService: mockSiteSettingService)
 
         // When
         let result = try await checker.refreshEligibility(ineligibleReason: .featureSwitchDisabled)
@@ -868,6 +871,19 @@ private final class MockPOSSystemStatusService: POSSystemStatusServiceProtocol {
         switch resultToReturn {
         case .success(let info):
             return info
+        case .failure(let error):
+            throw error
+        }
+    }
+}
+
+private final class MockPOSSiteSettingService: POSSiteSettingServiceProtocol {
+    var setFeatureResult: Result<Bool, Error> = .success(true)
+
+    func setFeature(siteID: Int64, feature: SiteSettingsFeature, enabled: Bool) async throws -> Bool {
+        switch setFeatureResult {
+        case .success(let result):
+            return result
         case .failure(let error):
             throw error
         }


### PR DESCRIPTION
For WOOMOB-881

Just one review is required.

## Description

This PR allows merchants to enable the POS feature switch (WC version 10.0+) directly from the ineligible UI when the feature switch is disabled. Previously, merchants would see an ineligible state without the ability to enable the feature in the app. This enhancement provides a seamless path to activate POS functionality through the settings API.

The implementation includes:
- New `POSSiteSettingService` with protocol for updating POS feature switch via API
- Enhanced `SiteSettingsRemote` with `setFeature` method for WC settings feature updates
- Updated ineligible UI to provide enable & retry functionality
- Unit tests for the new service and remote layer changes

## Steps to reproduce

Prerequisite: a store has WC version 10.0+ and eligible for POS except for the feature switch in WC settings > Advanced > Features

1. Log in to the site in the prerequisite if needed
2. Tap on the POS tab --> after loading UI, the ineligible UI should have a CTA to enable & retry
3. Tap the enable & retry CTA to activate POS feature --> shortly, it should enter POS now that the store is eligible

## Testing information

In iPad Air 13-in iOS 18.5 simuator:

- Tested the enable flow from ineligible UI
- Tested on both eligibile and other ineligible store configurations

## Screenshots

feature switch disabled | other ineligible case
-- | --
<img width="2732" height="2048" alt="Simulator Screenshot - iPad Air 13-inch (M3) - 2025-07-17 at 13 38 47" src="https://github.com/user-attachments/assets/bf94a9e4-1012-4038-8d70-93c02fbde97e" /> | <img width="2732" height="2048" alt="Simulator Screenshot - iPad Air 13-inch (M3) - 2025-07-17 at 13 52 27" src="https://github.com/user-attachments/assets/bd368c4e-ed84-446e-9a77-76e7f68015c8" />


https://github.com/user-attachments/assets/19aace88-f3fd-4c1d-bb5e-db8862a71194

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.