### PR TITLE
[POS as a tab i2] Update suggestion text when WC plugin info cannot be retrieved

### DIFF
--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -87,8 +87,9 @@ struct POSIneligibleView: View {
                                      "%1$@ is a placeholder for the minimum required version.")
             return String.localizedStringWithFormat(format, minimumVersion)
         case .wooCommercePluginNotFound:
-            return NSLocalizedString("pos.ineligible.suggestion.wooCommercePluginNotFound",
-                                     value: "Install and activate the WooCommerce plugin from your WordPress admin.",
+            return NSLocalizedString("pos.ineligible.suggestion.wooCommercePluginNotFound.2",
+                                     value: "Please make sure the WooCommerce plugin is installed and activated from your WordPress admin. " +
+                                     "If there is still an issue, please contact support for assistance.",
                                      comment: "Suggestion for missing WooCommerce plugin: install plugin")
         case .featureSwitchDisabled:
             return NSLocalizedString("pos.ineligible.suggestion.featureSwitchDisabled",


### PR DESCRIPTION
For WOOMOB-898

Just one review is required.

## Description

This PR updates the suggestion text shown to merchants when the WooCommerce plugin cannot be found during POS eligibility checks (example scenario in WOOMOB-896). The updated text provides clearer guidance and includes an option to contact support if the issue persists.

### Key changes:

- Enhanced the suggestion text to be more comprehensive and helpful for merchants
- Added guidance to contact support if the issue persists after following the initial steps

## Steps to reproduce

Prerequisite: set up a test site where the WooCommerce plugin path is altered like in the repo steps in WOOMOB-896 (JN site with just Woo Beta Tester plugin targeting a branch)

1. Log in to the site in the prerequisite
2. Tap on the POS tab --> the ineligible view should show the updated suggestion text

## Testing information

I tested the above in iPad A16 iOS 18.4 simulator.

## Example screenshots

before | after
-- | --
<img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - 2025-07-17 at 14 39 54" src="https://github.com/user-attachments/assets/b8c8dea1-5077-4ef6-b5bb-20ea22284de1" /> | <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - 2025-07-17 at 14 25 34" src="https://github.com/user-attachments/assets/272ac31e-30f4-4fa3-ab44-07fb234d0735" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.