### PR TITLE
Shipping Labels: Add check for dimensions when confirming custom package

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Order List: New orders made through Point of Sale are now filterable via the Order List filters menu [https://github.com/woocommerce/woocommerce-ios/pull/15910]
 - [*] Shipping Labels: Display base rate on selected shipping service cards [https://github.com/woocommerce/woocommerce-ios/pull/15916]
 - [*] Shipping Labels: Update mark order completed toggle on purchase form [https://github.com/woocommerce/woocommerce-ios/pull/15917]
+- [*] Shipping Labels: Validate custom package dimensions [https://github.com/woocommerce/woocommerce-ios/pull/15925]
 - [internal] Optimized assets for app size reduction [https://github.com/woocommerce/woocommerce-ios/pull/15881]
 
 22.8

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooAddCustomPackageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooAddCustomPackageView.swift
@@ -14,6 +14,7 @@ struct WooAddCustomPackageView: View {
 
     @State private var isSavingPackage = false
     @State private var showingSavingError = false
+    @State private var foundInvalidDimensions = false
 
     @Environment(\.shippingDimensionsUnit) private var dimensionsUnit
     @Environment(\.shippingWeightUnit) private var weightUnit
@@ -68,6 +69,14 @@ struct WooAddCustomPackageView: View {
                                     unitInputView(for: dimensionUnit, unit: dimensionsUnit)
                                 }
                             }
+
+                            if foundInvalidDimensions {
+                                Text(Localization.invalidDimensions)
+                                    .font(.footnote)
+                                    .foregroundColor(Color(.error))
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+
                             // showing weight input only if we are saving the template
                             if viewModel.showSaveTemplate {
                                 unitInputView(for: WooShippingPackageUnitType.weight, unit: weightUnit)
@@ -172,19 +181,21 @@ struct WooAddCustomPackageView: View {
             }
         }
     }
+}
 
-    private var selectionButtonDisabled: Bool {
+private extension WooAddCustomPackageView {
+    var selectionButtonDisabled: Bool {
         !viewModel.validateCustomPackageInputFields()
     }
 
-    private var selectionButtonText: String {
+    var selectionButtonText: String {
         if selectionButtonDisabled {
             return WooShippingAddPackageView.Localization.addPackageDetails
         }
         return WooShippingAddPackageView.Localization.addPackage
     }
 
-    private func unitInputView(for unitType: WooShippingPackageUnitType, unit: String) -> some View {
+    func unitInputView(for unitType: WooShippingPackageUnitType, unit: String) -> some View {
         WooShippingAddPackageUnitInputView(unitType: unitType,
                                            unit: unit,
                                            fieldValue: Binding(get: {
@@ -196,15 +207,20 @@ struct WooAddCustomPackageView: View {
 
     // MARK: - actions
 
-    private func confirmPackage() {
-        guard let packageData = viewModel.packageData else {
+    func confirmPackage() {
+        foundInvalidDimensions = !viewModel.allDimensionsValid
+        guard !foundInvalidDimensions, let packageData = viewModel.packageData else {
             return
         }
         addPackageAction(packageData)
     }
 
     @MainActor
-    private func savePackageAsTemplateButtonTapped() async {
+    func savePackageAsTemplateButtonTapped() async {
+        foundInvalidDimensions = !viewModel.allDimensionsValid
+        guard !foundInvalidDimensions else {
+            return
+        }
         let packageDataResult = await viewModel.savePackageAsTemplateAction()
         // call addPackageAction with data
         switch packageDataResult {
@@ -216,7 +232,7 @@ struct WooAddCustomPackageView: View {
         }
     }
 
-    private func onBackwardButtonTapped() {
+    func onBackwardButtonTapped() {
         switch focusedField {
         case .length:
             return
@@ -231,7 +247,7 @@ struct WooAddCustomPackageView: View {
         }
     }
 
-    private func onForwardButtonTapped() {
+    func onForwardButtonTapped() {
         switch focusedField {
         case .length:
             focusedField = .width
@@ -246,7 +262,7 @@ struct WooAddCustomPackageView: View {
         }
     }
 
-    private func dismissKeyboard() {
+    func dismissKeyboard() {
         focusedField = nil
         packageTemplateNameFieldFocused = false
     }
@@ -269,6 +285,11 @@ extension WooAddCustomPackageView {
         static let savePackageTemplatePlaceholder = NSLocalizedString("wooShipping.createLabel.addPackage.savePackageTemplatePlaceholder",
                                                            value: "Enter a unique package name",
                                                            comment: "Placeholder text for package name field")
+        static let invalidDimensions = NSLocalizedString(
+            "wooShipping.createLabel.addPackage.invalidDimensions",
+            value: "Package dimensions should all be larger than 0",
+            comment: "Message when user attempts to confirm a package with invalid dimension in the shipping label creation flow"
+        )
         enum SavingPackageError {
             static let title = NSLocalizedString(
                 "wooShipping.createLabel.addPackage.savingPackageError.title",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
@@ -67,7 +67,7 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
         for (key, value) in fieldValues {
             guard keysToCheck.contains(key) else { continue }
             let doubleValue = Double(value)
-            if doubleValue == nil || doubleValue == 0 {
+            guard let doubleValue, doubleValue > 0 else {
                 return false
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
@@ -46,7 +46,7 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
     // Field values are invalid if one of them is empty
     // - if we are saving template we check all field values
     // - if we are not saving template we check only dimensions
-    var areFieldValuesInvalid: Bool {
+    var areFieldValuesEmpty: Bool {
         let keysToCheck: [WooShippingPackageUnitType] = showSaveTemplate ? WooShippingPackageUnitType.allCases : WooShippingPackageUnitType.dimensionUnits
 
         var validFieldsCount: Int = 0
@@ -59,6 +59,19 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
             validFieldsCount += 1
         }
         return validFieldsCount != keysToCheck.count
+    }
+
+    /// Ensure that all dimensions are larger than 0
+    var allDimensionsValid: Bool {
+        let keysToCheck = WooShippingPackageUnitType.dimensionUnits
+        for (key, value) in fieldValues {
+            guard keysToCheck.contains(key) else { continue }
+            let doubleValue = Double(value)
+            if doubleValue == nil || doubleValue == 0 {
+                return false
+            }
+        }
+        return true
     }
 
     private var packageDataFromCurrentData: WooShippingPackageDataRepresentable {
@@ -117,7 +130,7 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
                     continuation.resume(returning: .success(packageData))
                 case let .failure(error):
                     DDLogError("⛔️ Error saving custom package with WCShip: \(error)")
-                    continuation.resume(returning: .failure(WooShippingAddCustomPackageViewModel.Error.failedSavingTemplate))
+                    continuation.resume(returning: .failure(WooShippingAddCustomPackageViewModel.Error.failure(error)))
                 }
             }
             stores.dispatch(action)
@@ -134,7 +147,7 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
     }
 
     func validateCustomPackageInputFields() -> Bool {
-        guard !areFieldValuesInvalid else {
+        guard !areFieldValuesEmpty else {
             return false
         }
         if showSaveTemplate {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddCustomPackageViewModel.swift
@@ -43,10 +43,10 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
         }
     }
 
-    // Field values are invalid if one of them is empty
+    // Field values are invalid if one of them is incomplete
     // - if we are saving template we check all field values
     // - if we are not saving template we check only dimensions
-    var areFieldValuesEmpty: Bool {
+    var areFieldValuesIncomplete: Bool {
         let keysToCheck: [WooShippingPackageUnitType] = showSaveTemplate ? WooShippingPackageUnitType.allCases : WooShippingPackageUnitType.dimensionUnits
 
         var validFieldsCount: Int = 0
@@ -147,7 +147,7 @@ final class WooShippingAddCustomPackageViewModel: ObservableObject {
     }
 
     func validateCustomPackageInputFields() -> Bool {
-        guard !areFieldValuesEmpty else {
+        if areFieldValuesIncomplete {
             return false
         }
         if showSaveTemplate {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
@@ -281,31 +281,6 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
 
     // MARK: - allDimensionsValid tests
 
-    func test_allDimensionsValid_returns_false_when_no_dimensions_set() {
-        // Given
-        let siteID: Int64 = 1234
-        let mockStores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID, stores: mockStores)
-
-        // Then
-        XCTAssertFalse(viewModel.allDimensionsValid)
-    }
-
-    func test_allDimensionsValid_returns_false_when_some_dimensions_missing() {
-        // Given
-        let siteID: Int64 = 1234
-        let mockStores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID, stores: mockStores)
-
-        // When
-        viewModel.fieldValues[.length] = "10"
-        viewModel.fieldValues[.width] = "5"
-        // height is missing
-
-        // Then
-        XCTAssertFalse(viewModel.allDimensionsValid)
-    }
-
     func test_allDimensionsValid_returns_false_when_dimension_is_zero() {
         // Given
         let siteID: Int64 = 1234

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
@@ -29,7 +29,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.fieldValues.isEmpty, false)
-        XCTAssertEqual(viewModel.areFieldValuesEmpty, true)
+        XCTAssertEqual(viewModel.areFieldValuesIncomplete, true)
     }
 
     @MainActor
@@ -45,7 +45,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.fieldValues.isEmpty, false)
-        XCTAssertEqual(viewModel.areFieldValuesEmpty, false)
+        XCTAssertEqual(viewModel.areFieldValuesIncomplete, false)
     }
 
     @MainActor
@@ -62,7 +62,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.fieldValues.isEmpty, false)
-        XCTAssertEqual(viewModel.areFieldValuesEmpty, false)
+        XCTAssertEqual(viewModel.areFieldValuesIncomplete, false)
     }
 
     @MainActor
@@ -79,7 +79,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.fieldValues.isEmpty, false)
-        XCTAssertEqual(viewModel.areFieldValuesEmpty, true)
+        XCTAssertEqual(viewModel.areFieldValuesIncomplete, true)
     }
 
     @MainActor
@@ -96,7 +96,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         viewModel.fieldValues[.weight] = "1"
         // Then
         XCTAssertEqual(viewModel.fieldValues.isEmpty, false)
-        XCTAssertEqual(viewModel.areFieldValuesEmpty, false)
+        XCTAssertEqual(viewModel.areFieldValuesIncomplete, false)
     }
 
     @MainActor
@@ -390,6 +390,6 @@ extension WooShippingAddCustomPackageViewModel {
         XCTAssertEqual(packageType, WooShippingPackageType.box)
         XCTAssertEqual(showSaveTemplate, false)
         XCTAssertEqual(packageTemplateName, "")
-        XCTAssertEqual(areFieldValuesEmpty, true)
+        XCTAssertEqual(areFieldValuesIncomplete, true)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddCustomPackageViewModelTests.swift
@@ -29,7 +29,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.fieldValues.isEmpty, false)
-        XCTAssertEqual(viewModel.areFieldValuesInvalid, true)
+        XCTAssertEqual(viewModel.areFieldValuesEmpty, true)
     }
 
     @MainActor
@@ -45,7 +45,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.fieldValues.isEmpty, false)
-        XCTAssertEqual(viewModel.areFieldValuesInvalid, false)
+        XCTAssertEqual(viewModel.areFieldValuesEmpty, false)
     }
 
     @MainActor
@@ -62,7 +62,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.fieldValues.isEmpty, false)
-        XCTAssertEqual(viewModel.areFieldValuesInvalid, false)
+        XCTAssertEqual(viewModel.areFieldValuesEmpty, false)
     }
 
     @MainActor
@@ -79,7 +79,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.fieldValues.isEmpty, false)
-        XCTAssertEqual(viewModel.areFieldValuesInvalid, true)
+        XCTAssertEqual(viewModel.areFieldValuesEmpty, true)
     }
 
     @MainActor
@@ -96,7 +96,7 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         viewModel.fieldValues[.weight] = "1"
         // Then
         XCTAssertEqual(viewModel.fieldValues.isEmpty, false)
-        XCTAssertEqual(viewModel.areFieldValuesInvalid, false)
+        XCTAssertEqual(viewModel.areFieldValuesEmpty, false)
     }
 
     @MainActor
@@ -278,6 +278,123 @@ final class WooShippingAddCustomPackageViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.fieldValues[.height], "1.27")
         XCTAssertEqual(viewModel.packageType, .envelope)
     }
+
+    // MARK: - allDimensionsValid tests
+
+    func test_allDimensionsValid_returns_false_when_no_dimensions_set() {
+        // Given
+        let siteID: Int64 = 1234
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID, stores: mockStores)
+
+        // Then
+        XCTAssertFalse(viewModel.allDimensionsValid)
+    }
+
+    func test_allDimensionsValid_returns_false_when_some_dimensions_missing() {
+        // Given
+        let siteID: Int64 = 1234
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID, stores: mockStores)
+
+        // When
+        viewModel.fieldValues[.length] = "10"
+        viewModel.fieldValues[.width] = "5"
+        // height is missing
+
+        // Then
+        XCTAssertFalse(viewModel.allDimensionsValid)
+    }
+
+    func test_allDimensionsValid_returns_false_when_dimension_is_zero() {
+        // Given
+        let siteID: Int64 = 1234
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID, stores: mockStores)
+
+        // When
+        viewModel.fieldValues[.length] = "10"
+        viewModel.fieldValues[.width] = "0"
+        viewModel.fieldValues[.height] = "5"
+
+        // Then
+        XCTAssertFalse(viewModel.allDimensionsValid)
+    }
+
+    func test_allDimensionsValid_returns_false_when_dimension_is_empty_string() {
+        // Given
+        let siteID: Int64 = 1234
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID, stores: mockStores)
+
+        // When
+        viewModel.fieldValues[.length] = "10"
+        viewModel.fieldValues[.width] = ""
+        viewModel.fieldValues[.height] = "5"
+
+        // Then
+        XCTAssertFalse(viewModel.allDimensionsValid)
+    }
+
+    func test_allDimensionsValid_returns_false_when_dimension_is_invalid_string() {
+        // Given
+        let siteID: Int64 = 1234
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID, stores: mockStores)
+
+        // When
+        viewModel.fieldValues[.length] = "10"
+        viewModel.fieldValues[.width] = "abc"
+        viewModel.fieldValues[.height] = "5"
+
+        // Then
+        XCTAssertFalse(viewModel.allDimensionsValid)
+    }
+
+    func test_allDimensionsValid_returns_false_when_dimension_is_negative() {
+        // Given
+        let siteID: Int64 = 1234
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID, stores: mockStores)
+
+        // When
+        viewModel.fieldValues[.length] = "10"
+        viewModel.fieldValues[.width] = "-5"
+        viewModel.fieldValues[.height] = "5"
+
+        // Then
+        XCTAssertFalse(viewModel.allDimensionsValid)
+    }
+
+    func test_allDimensionsValid_returns_true_when_all_dimensions_are_valid_positive_numbers() {
+        // Given
+        let siteID: Int64 = 1234
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID, stores: mockStores)
+
+        // When
+        viewModel.fieldValues[.length] = "10"
+        viewModel.fieldValues[.width] = "5"
+        viewModel.fieldValues[.height] = "3"
+
+        // Then
+        XCTAssertTrue(viewModel.allDimensionsValid)
+    }
+
+    func test_allDimensionsValid_returns_true_when_all_dimensions_are_valid_decimals() {
+        // Given
+        let siteID: Int64 = 1234
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = WooShippingAddCustomPackageViewModel(siteID: siteID, stores: mockStores)
+
+        // When
+        viewModel.fieldValues[.length] = "10.5"
+        viewModel.fieldValues[.width] = "5.25"
+        viewModel.fieldValues[.height] = "3.75"
+
+        // Then
+        XCTAssertTrue(viewModel.allDimensionsValid)
+    }
 }
 
 extension WooShippingAddCustomPackageViewModel {
@@ -298,6 +415,6 @@ extension WooShippingAddCustomPackageViewModel {
         XCTAssertEqual(packageType, WooShippingPackageType.box)
         XCTAssertEqual(showSaveTemplate, false)
         XCTAssertEqual(packageTemplateName, "")
-        XCTAssertEqual(areFieldValuesInvalid, true)
+        XCTAssertEqual(areFieldValuesEmpty, true)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-870

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds validation for dimensions of custom packages to ensure all are larger than 0 to avoid failure loading shipping rates and purchasing labels.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with Woo Shipping extension.
2. Navigate to the Orders tab and select an order eligible for label purchase.
3. Select Create shipping labels > Add a package.
4. On the Custom tab, enter any dimensions for your package as 0 > Add package details.
5. Confirm that an error message is displayed under the dimensions field.
6. Update any zero dimension to be larger than 0 > Add package details.
7. Confirm that adding package succeeds and shipping rates can be loaded.
8. Repeat the steps with saving package and confirm that saving works only when all dimensions are larger than 0.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested and confirmed with simulator iPhone 16 iOS 18.4.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/4546e102-5261-47ee-9acf-0b63f8cd1678



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.