### PR TITLE
Shipping Labels: Always show all contents of UPS TOS modal

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [*] Shipping Labels: Display base rate on selected shipping service cards [https://github.com/woocommerce/woocommerce-ios/pull/15916]
 - [*] Shipping Labels: Update mark order completed toggle on purchase form [https://github.com/woocommerce/woocommerce-ios/pull/15917]
 - [*] Shipping Labels: Validate custom package dimensions [https://github.com/woocommerce/woocommerce-ios/pull/15925]
+- [*] Shipping Labels: Show UPS TOS modal in full length for better accessibility. [https://github.com/woocommerce/woocommerce-ios/pull/15926]
 - [internal] Optimized assets for app size reduction [https://github.com/woocommerce/woocommerce-ios/pull/15881]
 
 22.8

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -131,7 +131,7 @@ struct WooShippingCreateLabelsView: View {
                             await viewModel.purchaseLabel(shouldRefreshPackageAndRate: true)
                         }
                     }
-                    .presentationDetents([.fraction(0.8), .large])
+                    .presentationDetents([.large])
                 }
             }
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-874

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates to UPS TOS modal to always be full length to avoid clipping off content in different font sizes and device sizes.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Build and run the app on an iPad (or simulator)
2. Log in to a test store with Woo Shipping set up.
3. Navigate to the Orders tab and select an order eligible for label purchase.
4. Select Create shipping label > update the origin address to one that hasn't accepted TOS for UPS.
5. Proceed to purchase a label.
6. Confirm that the UPS TOS modal shows up in full length.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested and confirmed with simulator iPhone 16 and iPad A16.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before | After 
--- | ---
<img src="https://github.com/user-attachments/assets/39bf10d6-1b25-4173-a4c6-0d481536a050" width=320 /> | <img src="https://github.com/user-attachments/assets/86cec10b-2197-4628-b61b-2e395da1a452" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.