### PR TITLE
[Shipping Labels] Handle zero weight in customs form

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,7 @@
 - [*] Watch app: Fixed connection issue upon fresh install [https://github.com/woocommerce/woocommerce-ios/pull/15867]
 - [Internal] Shipping Labels: Optimize requests for syncing countries [https://github.com/woocommerce/woocommerce-ios/pull/15875]
 - [*] Shipping Labels: Display label size from account settings as default [https://github.com/woocommerce/woocommerce-ios/pull/15873]
+- [*] Shipping Labels: Ensured customs form validation enforces non-zero product weight to fix shipping rate loading failure. [https://github.com/woocommerce/woocommerce-ios/pull/15927]
 
 22.7
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -11,7 +11,6 @@ struct WooShippingCustomsItem: View {
     @State private var isShowingDescriptionInfoDialog = false
     @State private var isShowingOriginCountryInfoDialog = false
 
-
     @Environment(\.shippingWeightUnit) var weightUnit: String
 
     var body: some View {
@@ -167,12 +166,12 @@ struct WooShippingCustomsItem: View {
                                 .padding(.trailing, Layout.unitsHorizontalSpacing)
                         }
                         .roundedBorder(cornerRadius: Layout.borderCornerRadius,
-                                       lineColor: viewModel.weightPerUnit.isEmpty ? warningRedColor : Color(.separator),
+                                       lineColor: viewModel.isValidWeight ? Color(.separator) : warningRedColor,
                                        lineWidth: Layout.borderLineWidth)
                         Text(Localization.valueRequiredWarningText)
                             .foregroundColor(warningRedColor)
                             .footnoteStyle()
-                            .renderedIf(viewModel.weightPerUnit.isEmpty)
+                            .renderedIf(!viewModel.isValidWeight)
                     }
                 }
                 .padding(.bottom, Layout.collapsibleViewVerticalSpacing)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -83,7 +83,12 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
         self.itemProductID = itemProductID
         self.itemQuantity = itemQuantity
         self.valuePerUnit = String(itemValue)
-        self.weightPerUnit = String(itemWeight)
+
+        /// Skip zero weight
+        if Self.isWeightNonZero(itemWeight) {
+            self.weightPerUnit = String(itemWeight)
+        }
+
         self.currencySymbol = currencySymbol
         self.storageManager = storageManager
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -62,6 +62,10 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
         return length >= 6 && length <= 12
     }
 
+    var isValidWeight: Bool {
+        return Self.isWeightValid(weightPerUnit)
+    }
+
     @Published var requiredInformationIsEntered: Bool = false
 
     private var cancellables = Set<AnyCancellable>()
@@ -127,7 +131,11 @@ private extension WooShippingCustomsItemViewModel {
     func combineRequiredInformationIsEntered() {
         Publishers.CombineLatest4($description, $valuePerUnit, $weightPerUnit, $selectedCountry)
             .sink { [weak self] description, valuePerUnit, weightPerUnit, selectedCountry in
-                self?.requiredInformationIsEntered = description.isNotEmpty && valuePerUnit.isNotEmpty && weightPerUnit.isNotEmpty && selectedCountry != nil
+                guard let self else { return }
+                requiredInformationIsEntered = description.isNotEmpty &&
+                valuePerUnit.isNotEmpty &&
+                Self.isWeightValid(weightPerUnit) &&
+                selectedCountry != nil
             }
             .store(in: &cancellables)
     }
@@ -148,5 +156,14 @@ private extension WooShippingCustomsItemViewModel {
                 self.hsTariffNumberTotalValue = (hsTariffNumber, valuePerUnitDecimal * itemQuantity)
             }
             .store(in: &cancellables)
+    }
+
+    /// Specifically introduced to check for a `0` value
+    static func isWeightValid(_ weightString: String) -> Bool {
+        return isWeightNonZero(Double(weightString) ?? 0)
+    }
+
+    static func isWeightNonZero(_ weightValue: Double) -> Bool {
+        return weightValue > 0
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Yosemite
+import Combine
 @testable import WooCommerce
 
 final class WooShippingCustomsFormViewModelTests: XCTestCase {
@@ -331,6 +332,67 @@ final class WooShippingCustomsFormViewModelTests: XCTestCase {
         XCTAssertEqual(firstItemViewModel?.description, firstItem?.name)
         XCTAssertEqual(firstItemViewModel?.valuePerUnit, String(firstItem?.value ?? 0))
         XCTAssertEqual(firstItemViewModel?.weightPerUnit, String(firstItem?.weight ?? 0))
+    }
+
+    func test_requiredInformationIsEntered_when_weight_is_zero_then_returns_false() {
+        // Given
+        let storageManager = MockStorageManager()
+        let originCountryCodeSubject = PassthroughSubject<String?, Never>()
+
+        let country = Country(
+            code: "US",
+            name: "United States",
+            states: []
+        )
+        storageManager.insertSampleCountries(readOnlyCountries: [country])
+
+        let itemWithZeroWeight = ShippingLabelPackageItem(
+            productOrVariationID: 1,
+            orderItemID: 123,
+            name: "Shirt",
+            weight: 0,
+            quantity: 1,
+            value: 10,
+            dimensions: .fake(),
+            attributes: [],
+            imageURL: nil
+        )
+
+        let shipment = Shipment(
+            contents: [
+                CollapsibleShipmentItemCardViewModel(
+                    item: itemWithZeroWeight,
+                    currency: "USD"
+                )
+            ],
+            currency: "USD",
+            currencySettings: ServiceLocator.currencySettings,
+            shippingSettingsService: ServiceLocator.shippingSettingsService
+        )
+
+        viewModel = WooShippingCustomsFormViewModel(
+            order: .fake(),
+            shipment: shipment,
+            originCountryCode: originCountryCodeSubject.eraseToAnyPublisher(),
+            storageManager: storageManager,
+            onFormReady: { _ in }
+        )
+
+        let itemViewModel = viewModel.itemsViewModels[0]
+        itemViewModel.description = "Test Description"
+        itemViewModel.valuePerUnit = "10.0"
+
+        // When
+        originCountryCodeSubject.send("US")
+
+        // Then
+        XCTAssertFalse(
+            viewModel.requiredInformationIsEntered,
+            "requiredInformationIsEntered should be false when an item's weight is zero"
+        )
+        XCTAssertTrue(itemViewModel.weightPerUnit.isEmpty)
+        XCTAssertFalse(itemViewModel.isValidWeight)
+        XCTAssertFalse(itemViewModel.requiredInformationIsEntered)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModelTests.swift
@@ -49,6 +49,23 @@ final class WooShippingCustomsItemViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isValidTariffNumber)
     }
 
+    func test_when_item_weight_is_zero_then_it_is_invalid() {
+        // Given
+        let viewModel = WooShippingCustomsItemViewModel(
+            itemName: "Test",
+            itemProductID: 22,
+            itemQuantity: 1,
+            itemValue: 10,
+            itemWeight: 0,
+            currencySymbol: "$",
+            storageManager: MockStorageManager()
+        )
+
+        // Then
+        XCTAssertTrue(viewModel.weightPerUnit.isEmpty, "Weight should be empty it the initial value is zero")
+        XCTAssertFalse(viewModel.isValidWeight, "isValidWeight should be false when the weight is zero")
+    }
+
     func test_hsTariffNumberTotalValue_when_currency_symbol_is_not_$_returns_nil() {
         // Given
         viewModel = WooShippingCustomsItemViewModel(itemName: "Test",


### PR DESCRIPTION
Part of: WOOMOB-891

## Description
 
The PR addresses the `4. Product weight should not be 0` in WOOMOB-891. Some more context of the issue is in the thread: p1752766904002629-slack-C03L1NF1EA3. If the customs form item weight is 0, the shipping rates fail to load. 

In this PR we make sure the customs form remains invalid if a zero weight is entered for a product.
- Keep `requiredInformationIsEntered` as `false` for `WooShippingCustomsItemViewModel` if entered item weight is 0.
- Skips `0` value passed in `itemWeight` init argument upon `WooShippingCustomsItemViewModel` initialization. The `weightPerUnit` string value will be `""` keeping `requiredInformationIsEntered` as `false` as well.

## Testing steps

- Navigate to a completed order with a physical item with an item weight of `0` and a foreign destination address.
- Go to "Create shipping Labels" flow.
- Select a shipment that contains that zero-wight product item.
- Make sure "Customs" section has "Missing info" status.
- Open customs form and check out the item card status. The card should have red border, and warning icon.
- Expand the card and make sure that the weight is not entered, has 0 placeholder and `value required` notice.
- Enter a 0 weight and make sure the customs form remains incomplete and requires a weight value.
- Enter a non-zero weight and make sure the customs form becomes complete and tap "Save Customs Details".
- On shipment screen specify a product weight to be non zero.
- On shipment screen select a package and make sure shipping rates are loaded without an error.

## Demo

https://github.com/user-attachments/assets/3458021c-4529-4a95-8d44-379f271af105

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.