### PR TITLE
[POS] Update text color of card-present payment message views

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentActivityIndicatingMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentActivityIndicatingMessageView.swift
@@ -16,7 +16,7 @@ struct PointOfSaleCardPresentPaymentActivityIndicatingMessageView: View {
                 .renderedIf(!dynamicTypeSize.isAccessibilitySize)
             VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
                 Text(title)
-                    .foregroundStyle(Color.posOnSurface)
+                    .foregroundStyle(Color.posOnSurfaceVariantHighest)
                     .font(.posBodyLargeRegular())
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift
@@ -16,7 +16,7 @@ struct PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView: View {
                 .renderedIf(!dynamicTypeSize.isAccessibilitySize)
             VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
                 Text(viewModel.title)
-                    .foregroundStyle(Color.posOnSurface)
+                    .foregroundStyle(Color.posOnSurfaceVariantHighest)
                     .font(.posBodyLargeRegular())
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
# Update of text color in card-present payment message views
<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-270

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the text color in POS -> Checkout -> Card reader status title (e.g. "Getting ready", "Ready for payment") according to the updated design (FnDpCHVQ3Zpefad04ptbd4-fi-815_13464).

💡 The original issue contains also:
> * Update the cart item removal icon from X to Trash
> * Add chevron to Variable Products

Those points, however, have already been implemented.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
N/A

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Test POS Checkout screen in both dark and light modes.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="2360" height="1640" alt="image" src="https://github.com/user-attachments/assets/61f211df-7160-4dab-8a0b-303ee5e036d1" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.