### PR TITLE
[POS as a tab i2] Update WC plugin matching to use the file name in plugin path instead of matching by full plugin path

### DIFF
--- a/Modules/Sources/Storage/Tools/StorageType+Extensions.swift
+++ b/Modules/Sources/Storage/Tools/StorageType+Extensions.swift
@@ -863,11 +863,12 @@ public extension StorageType {
     ///   - active: Optional active state filter. If provided, only plugins with matching active state are returned. If nil, active state is ignored.
     /// - Returns: The matching system plugin, or nil if not found.
     func loadSystemPlugin(siteID: Int64, fileNameWithoutExtension: String, active: Bool? = nil) -> SystemPlugin? {
-        let pathPattern = "*/\(fileNameWithoutExtension).*"
+        let escapedFileName = NSRegularExpression.escapedPattern(for: fileNameWithoutExtension)
+        let regexPattern = "(.*/)?\(escapedFileName)\\.[^/]+$"
         let predicate = if let active {
-            NSPredicate(format: "siteID == %lld AND plugin LIKE %@ AND active == %@", siteID, pathPattern, NSNumber(value: active))
+            NSPredicate(format: "siteID == %lld AND plugin MATCHES %@ AND active == %@", siteID, regexPattern, NSNumber(value: active))
         } else {
-            NSPredicate(format: "siteID == %lld AND plugin LIKE %@", siteID, pathPattern)
+            NSPredicate(format: "siteID == %lld AND plugin MATCHES %@", siteID, regexPattern)
         }
         return firstObject(ofType: SystemPlugin.self, matching: predicate)
     }

--- a/Modules/Sources/Storage/Tools/StorageType+Extensions.swift
+++ b/Modules/Sources/Storage/Tools/StorageType+Extensions.swift
@@ -855,6 +855,23 @@ public extension StorageType {
         return firstObject(ofType: SystemPlugin.self, matching: predicate)
     }
 
+    /// Returns a system plugin with a specified `siteID` and `fileNameWithoutExtension`.
+    ///
+    /// - Parameters:
+    ///   - siteID: The site ID to filter by.
+    ///   - fileNameWithoutExtension: The plugin file name to match without extension (e.g., "woocommerce", "woocommerce-payments").
+    ///   - active: Optional active state filter. If provided, only plugins with matching active state are returned. If nil, active state is ignored.
+    /// - Returns: The matching system plugin, or nil if not found.
+    func loadSystemPlugin(siteID: Int64, fileNameWithoutExtension: String, active: Bool? = nil) -> SystemPlugin? {
+        let pathPattern = "*/\(fileNameWithoutExtension).*"
+        let predicate = if let active {
+            NSPredicate(format: "siteID == %lld AND plugin LIKE %@ AND active == %@", siteID, pathPattern, NSNumber(value: active))
+        } else {
+            NSPredicate(format: "siteID == %lld AND plugin LIKE %@", siteID, pathPattern)
+        }
+        return firstObject(ofType: SystemPlugin.self, matching: predicate)
+    }
+
     /// Returns stored system plugins for a provided `siteID` matching the given plugin `paths`.
     ///
     func loadSystemPlugins(siteID: Int64, matchingPaths paths: [String]) -> [SystemPlugin] {

--- a/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSSystemStatusService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSSystemStatusService.swift
@@ -54,7 +54,9 @@ public final class POSSystemStatusService: POSSystemStatusServiceProtocol {
         })
 
         // Loads WooCommerce plugin from storage.
-        guard let wcPlugin = storageManager.viewStorage.loadSystemPlugin(siteID: siteID, path: Constants.wcPluginPath, active: true)?.toReadOnly() else {
+        guard let wcPlugin = storageManager.viewStorage.loadSystemPlugin(siteID: siteID,
+                                                                         fileNameWithoutExtension: Constants.wcPluginFileNameWithoutExtension,
+                                                                         active: true)?.toReadOnly() else {
             return POSPluginAndFeatureInfo(wcPlugin: nil, featureValue: nil)
         }
 
@@ -66,7 +68,7 @@ public final class POSSystemStatusService: POSSystemStatusServiceProtocol {
 
 private extension POSSystemStatusService {
     enum Constants {
-        static let wcPluginPath = "woocommerce/woocommerce.php"
+        static let wcPluginFileNameWithoutExtension = "woocommerce"
     }
 }
 

--- a/Modules/Tests/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Modules/Tests/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -1561,6 +1561,8 @@ final class StorageTypeExtensionsTests: XCTestCase {
         let validPluginPaths = [
             "woocommerce.php",
             "woocommerce.swift",
+            "./woocommerce.swift",
+            ".././woocommerce.swift",
             "woocommerce/woocommerce.php",
             "woocommerce/woocommerce.swift",
             "test-plugin/test-plugin/woocommerce.php",

--- a/Modules/Tests/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Modules/Tests/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -1538,6 +1538,141 @@ final class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertNil(foundPlugin)
     }
 
+    // MARK: - `loadSystemPlugin(siteID:fileNameWithoutExtension:)`
+
+    func test_loadSystemPlugin_by_fileNameWithoutExtension_returns_matching_plugin_when_two_plugins_in_storage() throws {
+        // Given
+        let systemPlugin1 = storage.insertNewObject(ofType: SystemPlugin.self)
+        systemPlugin1.plugin = "woocommerce-payments/woocommerce-payments.php"
+        systemPlugin1.siteID = sampleSiteID
+
+        let systemPlugin2 = storage.insertNewObject(ofType: SystemPlugin.self)
+        systemPlugin2.plugin = "test-plugin/woocommerce-gift-cards.php"
+        systemPlugin2.siteID = sampleSiteID
+
+        // When
+        let foundSystemPlugin = try XCTUnwrap(storage.loadSystemPlugin(siteID: sampleSiteID, fileNameWithoutExtension: "woocommerce-gift-cards"))
+
+        // Then
+        XCTAssertEqual(foundSystemPlugin, systemPlugin2)
+    }
+
+    func test_loadSystemPlugin_by_fileNameWithoutExtension_returns_matching_plugin_when_plugin_path_is_in_different_valid_formats() throws {
+        let validPluginPaths = [
+            "woocommerce/woocommerce.php",
+            "woocommerce/woocommerce.swift",
+            "woocommerce//woocommerce.php",
+            "test-plugin/test-plugin/woocommerce.php",
+            "test-plugin/test-plugin/test-plugin/woocommerce.tmp.php",
+            "test-plugin/test-plugin/woocommerce.tmp.php",
+            "test-plugin/woocommerce.tmp.php",
+            "/woocommerce.tmp.php"
+        ]
+
+        for pluginPath in validPluginPaths {
+            // Given
+            let plugin = storage.insertNewObject(ofType: SystemPlugin.self)
+            plugin.plugin = pluginPath
+            plugin.siteID = sampleSiteID
+
+            // When
+            let foundPlugin = try XCTUnwrap(storage.loadSystemPlugin(siteID: sampleSiteID, fileNameWithoutExtension: "woocommerce"))
+
+            // Then
+            XCTAssertEqual(foundPlugin, plugin)
+
+            // Cleanup for next iteration
+            storage.deleteObject(plugin)
+        }
+    }
+
+    func test_loadSystemPlugin_by_fileNameWithoutExtension_returns_nil_when_plugin_path_is_in_different_invalid_formats() throws {
+        let invalidPluginPaths = [
+            "woocommerce/woocommerce",
+            "woocommerce/woocommerce-dev.php",
+            "test-plugin/woocommerce-dev.php",
+            "test-plugin/test-plugin/woocommerce-dev.php",
+            "woocommerce.tmp.php"
+        ]
+
+        for pluginPath in invalidPluginPaths {
+            // Given
+            let plugin = storage.insertNewObject(ofType: SystemPlugin.self)
+            plugin.plugin = pluginPath
+            plugin.siteID = sampleSiteID
+
+            // When
+            let foundPlugin = storage.loadSystemPlugin(siteID: sampleSiteID, fileNameWithoutExtension: "woocommerce")
+
+            // Then
+            XCTAssertNil(foundPlugin)
+
+            // Cleanup for next iteration
+            storage.deleteObject(plugin)
+        }
+    }
+
+    func test_loadSystemPlugin_by_fileNameWithoutExtension_returns_matching_plugin_when_active_state_is_set() throws {
+        // Given
+        let inactivePlugin = storage.insertNewObject(ofType: SystemPlugin.self)
+        inactivePlugin.plugin = "test-plugin/woocommerce.php"
+        inactivePlugin.siteID = sampleSiteID
+        inactivePlugin.active = false
+
+        let activePlugin = storage.insertNewObject(ofType: SystemPlugin.self)
+        activePlugin.plugin = "woocommerce/woocommerce.php"
+        activePlugin.siteID = sampleSiteID
+        activePlugin.active = true
+
+        // When
+        let foundActivePlugin = try XCTUnwrap(storage.loadSystemPlugin(siteID: sampleSiteID, fileNameWithoutExtension: "woocommerce", active: true))
+
+        // Then
+        XCTAssertEqual(foundActivePlugin, activePlugin)
+
+        // When
+        let foundInactivePlugin = try XCTUnwrap(storage.loadSystemPlugin(siteID: sampleSiteID, fileNameWithoutExtension: "woocommerce", active: false))
+
+        // Then
+        XCTAssertEqual(foundInactivePlugin, inactivePlugin)
+    }
+
+    func test_loadSystemPlugin_by_fileNameWithoutExtension_returns_matching_plugin_when_active_state_is_nil() throws {
+        // Given
+        let activePlugin = storage.insertNewObject(ofType: SystemPlugin.self)
+        activePlugin.plugin = "test-plugin/woocommerce.php"
+        activePlugin.siteID = sampleSiteID
+        activePlugin.active = true
+
+        let inactivePlugin = storage.insertNewObject(ofType: SystemPlugin.self)
+        inactivePlugin.plugin = "jetpack/jetpack.php"
+        inactivePlugin.siteID = sampleSiteID
+        inactivePlugin.active = false
+
+        // When
+        let foundPlugin = storage.loadSystemPlugin(siteID: sampleSiteID, fileNameWithoutExtension: "woocommerce", active: nil)
+
+        // Then
+        XCTAssertNotNil(foundPlugin)
+        XCTAssertEqual(foundPlugin, activePlugin)
+    }
+
+    func test_loadSystemPlugin_by_fileNameWithoutExtension_returns_nil_when_active_state_does_not_match() {
+        // Given
+        let activePlugin = storage.insertNewObject(ofType: SystemPlugin.self)
+        activePlugin.plugin = "woocommerce/woocommerce.php"
+        activePlugin.siteID = sampleSiteID
+        activePlugin.active = true
+
+        // When
+        let foundPlugin = storage.loadSystemPlugin(siteID: sampleSiteID, fileNameWithoutExtension: "woocommerce", active: false)
+
+        // Then
+        XCTAssertNil(foundPlugin)
+    }
+
+    // MARK: - `loadSystemPlugins(siteID:matchingPaths:)`
+
     func test_loadSystemPlugins_by_siteID_matching_paths() {
         // Given
         let systemPlugin1 = storage.insertNewObject(ofType: SystemPlugin.self)

--- a/Modules/Tests/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Modules/Tests/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -1559,14 +1559,14 @@ final class StorageTypeExtensionsTests: XCTestCase {
 
     func test_loadSystemPlugin_by_fileNameWithoutExtension_returns_matching_plugin_when_plugin_path_is_in_different_valid_formats() throws {
         let validPluginPaths = [
+            "woocommerce.php",
+            "woocommerce.swift",
             "woocommerce/woocommerce.php",
             "woocommerce/woocommerce.swift",
-            "woocommerce//woocommerce.php",
             "test-plugin/test-plugin/woocommerce.php",
             "test-plugin/test-plugin/test-plugin/woocommerce.tmp.php",
             "test-plugin/test-plugin/woocommerce.tmp.php",
-            "test-plugin/woocommerce.tmp.php",
-            "/woocommerce.tmp.php"
+            "test-plugin/woocommerce.tmp.php"
         ]
 
         for pluginPath in validPluginPaths {
@@ -1588,11 +1588,13 @@ final class StorageTypeExtensionsTests: XCTestCase {
 
     func test_loadSystemPlugin_by_fileNameWithoutExtension_returns_nil_when_plugin_path_is_in_different_invalid_formats() throws {
         let invalidPluginPaths = [
+            "woocommerce",
             "woocommerce/woocommerce",
+            "woocommerce//woocommerce",
+            "woocommerce-dev.php",
             "woocommerce/woocommerce-dev.php",
             "test-plugin/woocommerce-dev.php",
-            "test-plugin/test-plugin/woocommerce-dev.php",
-            "woocommerce.tmp.php"
+            "test-plugin/test-plugin/woocommerce-dev.php"
         ]
 
         for pluginPath in invalidPluginPaths {
@@ -1611,6 +1613,49 @@ final class StorageTypeExtensionsTests: XCTestCase {
             storage.deleteObject(plugin)
         }
     }
+
+    func test_loadSystemPlugin_by_fileNameWithoutExtension_handles_regex_special_characters() throws {
+        let specialCharacterTests = [
+            // Filename with regex special characters, plugin path, should match
+            ("plugin.name", "test-folder/plugin.name.php", true),
+            ("plugin+test", "plugin-dir/plugin+test.swift", true),
+            ("plugin*wild", "nested/plugin*wild.css", true),
+            ("plugin[bracket]", "plugin[bracket].php", true),
+            ("plugin(paren)", "folder/plugin(paren).min.js", true),
+            ("plugin^caret", "plugin^caret.tmp", true),
+            ("plugin$dollar", "deep/nested/plugin$dollar.ext", true),
+            // Filenames with spaces
+            ("test plugin", "some folder with spaces/test plugin.css", true),
+            ("plugin name", "plugin name.js", true),
+            // Should not match when filename is different
+            ("plugin.name", "test-folder/pluginXname.php", false),
+            ("plugin+test", "plugin-dir/plugin-test.js", false),
+            ("plugin*wild", "nested/pluginXwild.css", false),
+            ("my plugin", "folder/my-plugin.php", false),
+            ("plugin name", "plugin-name.js", false)
+        ]
+
+        for (searchTerm, pluginPath, shouldMatch) in specialCharacterTests {
+            // Given
+            let plugin = storage.insertNewObject(ofType: SystemPlugin.self)
+            plugin.plugin = pluginPath
+            plugin.siteID = sampleSiteID
+
+            // When
+            let foundPlugin = storage.loadSystemPlugin(siteID: sampleSiteID, fileNameWithoutExtension: searchTerm)
+
+            // Then
+            if shouldMatch {
+                XCTAssertEqual(foundPlugin, plugin, "Should find plugin for search term '\(searchTerm)' in path '\(pluginPath)'")
+            } else {
+                XCTAssertNil(foundPlugin, "Should NOT find plugin for search term '\(searchTerm)' in path '\(pluginPath)'")
+            }
+
+            // Cleanup for the next iteration
+            storage.deleteObject(plugin)
+        }
+    }
+
 
     func test_loadSystemPlugin_by_fileNameWithoutExtension_returns_matching_plugin_when_active_state_is_set() throws {
         // Given


### PR DESCRIPTION
For WOOMOB-899

Just one review is required.

## Why

A (likely edge case) scenario was brought up when the WooComemrce plugin's plugin path can be altered by certain hosts or another plugin, like WooCommerce Beta Tester plugin as in WOOMOB-896. This means that one of the common plugin matching patterns in the app using the full plugin path wouldn't work anymore, resulting in unexpected behavior like the store not being able to access POS.

## How

From a previous discussion pdfdoF-3pF-p2#comment-4655 with the web team, we concluded that **matching by just the filename without extension** (e.g. `*/woocommerce.*` in the example of WC plugin) in the plugin path is the most durable solution so far. This PR just updates the plugin matching for the POS use case, while leaving other use cases for the Backlog.

## Implementation

This PR adds a new storage extension method `loadSystemPlugin(siteID:fileNameWithoutExtension:active:)` to support POS plugin matching by file name without extension.

The implementation uses [regex pattern matching with `NSPredicate` format  `MATCHES` ](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Predicates/Articles/pUsing.html)for precise filename matching to support:
- **Supports both plugin types**:
  - Single-file plugins: `plugin-name.php`
  - Folder-based plugins: `folder/plugin-name.php`
- **Exact matching**: Prevents false positives (e.g., searching "woocommerce" won't match "woocommerce-extended.php")
- **Special character handling**: Uses `NSRegularExpression.escapedPattern(for:)` to safely handle regex metacharacters in filenames

## Steps to reproduce

Prerequisite: set up a JN store using the Woo Beta Tester plugin targeting trunk or a branch (example options screenshot in WOOMOB-896):

- Log in to the JN store --> the POS tab should become visible
- Tap on the POS tab --> it should enter POS items loaded state. before this PR, an ineligible UI is shown ("plugin not found")

## Testing information

Tested in iPad mini iOS 18.5 simulator with WP store credentials login.

## Screenshots

before | after
-- | --
<img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - 2025-07-21 at 15 07 09" src="https://github.com/user-attachments/assets/ebc485aa-2515-433a-8977-32de9773f5a4" /> | <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - 2025-07-21 at 15 08 59" src="https://github.com/user-attachments/assets/fbb79fd0-3603-4252-89e5-9c70c38298f7" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.