### PR TITLE
[Shipping Labels] Handle dots in HS tariff number

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 - [*] Shipping Labels: Update mark order completed toggle on purchase form [https://github.com/woocommerce/woocommerce-ios/pull/15917]
 - [*] Shipping Labels: Optimize data loading on purchase form [https://github.com/woocommerce/woocommerce-ios/pull/15919]
 - [internal] Optimized assets for app size reduction [https://github.com/woocommerce/woocommerce-ios/pull/15881]
+- [*] Shipping Labels: Allow dots in HS tariff number input field for customs settings [https://github.com/woocommerce/woocommerce-ios/pull/15933]
 
 22.8
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -211,7 +211,7 @@ private extension WooShippingCustomsFormViewModel {
                     quantity: $0.itemQuantity,
                     value: Double($0.valuePerUnit) ?? 0,
                     weight: Double($0.weightPerUnit) ?? 0,
-                    hsTariffNumber: $0.isValidTariffNumber ? $0.hsTariffNumber : "",
+                    hsTariffNumber: $0.isValidTariffNumber ? $0.sanitizedHSTariffNumber : "",
                     originCountry: $0.selectedCountry?.code ?? "",
                     productID: $0.itemProductID
                 )

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -52,6 +52,10 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
         return HSTariffNumberValidator.isNumberValid(hsTariffNumber)
     }
 
+    var sanitizedHSTariffNumber: String {
+        HSTariffNumberValidator.sanitize(hsTariffNumber)
+    }
+
     @Published var requiredInformationIsEntered: Bool = false
 
     private var cancellables = Set<AnyCancellable>()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -144,7 +144,7 @@ private extension WooShippingCustomsItemViewModel {
 /// Follows validation logic from `woocommerce-shipping/client/utils/customs.ts`
 enum HSTariffNumberValidator {
     static let pattern = "^(\\d{1,2}\\.?){3,6}$"
-    
+
     /// Check if the HS Tariff Number is valid.
     /// It should be a string of 6 to 12 digits, with optional dots in between every 2 digits.
     /// - Parameter tariffNumber: The tariff number string.
@@ -168,5 +168,13 @@ enum HSTariffNumberValidator {
         ).joined()
         let count = digitsOnly.count
         return count >= 6 && count <= 12
+    }
+
+    /// Sanitize the HS Tariff Number
+    /// Remove all non-digit characters
+    /// - Parameter tariffNumber: The tariff number string.
+    /// - Returns: Tariff string without non-digit characters
+    static func sanitize(_ tariffNumber: String) -> String {
+        return tariffNumber.components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -49,17 +49,7 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
     }
 
     var isValidTariffNumber: Bool {
-        guard hsTariffNumber.isNotEmpty else {
-            return true
-        }
-
-        // Check if the string contains only digits
-        let digitsOnly = CharacterSet.decimalDigits.isSuperset(of: CharacterSet(charactersIn: hsTariffNumber))
-        guard digitsOnly else { return false }
-
-        // Check the length of the string
-        let length = hsTariffNumber.count
-        return length >= 6 && length <= 12
+        return HSTariffNumberValidator.isNumberValid(hsTariffNumber)
     }
 
     @Published var requiredInformationIsEntered: Bool = false
@@ -148,5 +138,35 @@ private extension WooShippingCustomsItemViewModel {
                 self.hsTariffNumberTotalValue = (hsTariffNumber, valuePerUnitDecimal * itemQuantity)
             }
             .store(in: &cancellables)
+    }
+}
+
+/// Follows validation logic from `woocommerce-shipping/client/utils/customs.ts`
+enum HSTariffNumberValidator {
+    static let pattern = "^(\\d{1,2}\\.?){3,6}$"
+    
+    /// Check if the HS Tariff Number is valid.
+    /// It should be a string of 6 to 12 digits, with optional dots in between every 2 digits.
+    /// - Parameter tariffNumber: The tariff number string.
+    /// - Returns: `Bool` if tariff number valid or not.
+    static func isNumberValid(_ tariffNumber: String) -> Bool {
+        if tariffNumber.isEmpty {
+            return true
+        }
+
+        let patternRange = tariffNumber.range(
+            of: pattern,
+            options: .regularExpression
+        )
+
+        if patternRange == nil {
+            return false
+        }
+
+        let digitsOnly = tariffNumber.components(
+            separatedBy: CharacterSet.decimalDigits.inverted
+        ).joined()
+        let count = digitsOnly.count
+        return count >= 6 && count <= 12
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModelTests.swift
@@ -110,7 +110,7 @@ final class WooShippingCustomsItemViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.hsTariffNumberTotalValue?.1, Decimal(string: viewModel.valuePerUnit)! * 2)
     }
 
-    func test_isNumberValid_withValidNumbers() {
+    func test_isNumberValid_whenGivenValidTariffNumbers_shouldReturnTrue() {
         XCTAssertTrue(HSTariffNumberValidator.isNumberValid("123456"))
         XCTAssertTrue(HSTariffNumberValidator.isNumberValid("12.34.56"))
         XCTAssertTrue(HSTariffNumberValidator.isNumberValid("12.34.56.78"))
@@ -121,7 +121,7 @@ final class WooShippingCustomsItemViewModelTests: XCTestCase {
         XCTAssertTrue(HSTariffNumberValidator.isNumberValid("1.2.3.4.5.6"))
     }
 
-    func test_isNumberValid_withInvalidNumbers() {
+    func test_isNumberValid_whenGivenInvalidTariffNumbers_shouldReturnFalse() {
         // Less than 6 digits
         XCTAssertFalse(HSTariffNumberValidator.isNumberValid("12345"))
         XCTAssertFalse(HSTariffNumberValidator.isNumberValid("12.34.5"))
@@ -137,5 +137,13 @@ final class WooShippingCustomsItemViewModelTests: XCTestCase {
         // Invalid structure
         XCTAssertFalse(HSTariffNumberValidator.isNumberValid("12.34..56"))
         XCTAssertFalse(HSTariffNumberValidator.isNumberValid(".123456"))
+    }
+
+    func test_hsTariffNumber_sanitize_whenGivenStringWithNonDigits_shouldReturnOnlyDigits() {
+        XCTAssertEqual(HSTariffNumberValidator.sanitize("12.34.56"), "123456")
+        XCTAssertEqual(HSTariffNumberValidator.sanitize("12a34b56c"), "123456")
+        XCTAssertEqual(HSTariffNumberValidator.sanitize("...123---456..."), "123456")
+        XCTAssertEqual(HSTariffNumberValidator.sanitize("123456"), "123456")
+        XCTAssertEqual(HSTariffNumberValidator.sanitize(""), "")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModelTests.swift
@@ -109,4 +109,33 @@ final class WooShippingCustomsItemViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.hsTariffNumberTotalValue?.0, viewModel.hsTariffNumber)
         XCTAssertEqual(viewModel.hsTariffNumberTotalValue?.1, Decimal(string: viewModel.valuePerUnit)! * 2)
     }
+
+    func test_isNumberValid_withValidNumbers() {
+        XCTAssertTrue(HSTariffNumberValidator.isNumberValid("123456"))
+        XCTAssertTrue(HSTariffNumberValidator.isNumberValid("12.34.56"))
+        XCTAssertTrue(HSTariffNumberValidator.isNumberValid("12.34.56.78"))
+        XCTAssertTrue(HSTariffNumberValidator.isNumberValid("12.34.56.78.90"))
+        XCTAssertTrue(HSTariffNumberValidator.isNumberValid("12.34.56.78.90.12"))
+        XCTAssertTrue(HSTariffNumberValidator.isNumberValid("123456789012"))
+        XCTAssertTrue(HSTariffNumberValidator.isNumberValid("12.345.678.90"))
+        XCTAssertTrue(HSTariffNumberValidator.isNumberValid("1.2.3.4.5.6"))
+    }
+
+    func test_isNumberValid_withInvalidNumbers() {
+        // Less than 6 digits
+        XCTAssertFalse(HSTariffNumberValidator.isNumberValid("12345"))
+        XCTAssertFalse(HSTariffNumberValidator.isNumberValid("12.34.5"))
+
+        // More than 12 digits
+        XCTAssertFalse(HSTariffNumberValidator.isNumberValid("1234567890123"))
+        XCTAssertFalse(HSTariffNumberValidator.isNumberValid("12.34.56.78.90.123"))
+
+        // Invalid characters
+        XCTAssertFalse(HSTariffNumberValidator.isNumberValid("12345a"))
+        XCTAssertFalse(HSTariffNumberValidator.isNumberValid("12.34.5a"))
+
+        // Invalid structure
+        XCTAssertFalse(HSTariffNumberValidator.isNumberValid("12.34..56"))
+        XCTAssertFalse(HSTariffNumberValidator.isNumberValid(".123456"))
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: WOOMOB-891

## Description

Addresses the: `3. The HS tariff number can contain dots, but the app doesn't allow it`

- Allow HS tariff input to contain dots
- Validates the input similarly to the `isHSTariffNumberValid` in [woocommerce-shipping/client/utils/customs.ts](https://github.com/woocommerce/woocommerce-shipping/blob/fefdd83ee75fa5c60ee7f493b85a047e8484b9e2/client/utils/customs.ts#L4)
- Strips the HS tariff string by deleting non-digit characters before sending customs info

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Open a completed order with physical items and unfulfilled shipments
- Navigate to "Create Shipping Labels" flow
- Set a foreign destination address for a shipment to unlock "Customs" section
- Navigate to customs form settings
- Expand the product item customs card
- Enter a valid HS tariff number.
    - Try the old numeric only number (`1234567`)
    - Try number with dots (`12.34.56.78`)
- Enter an invalid HS tariff number. The red error notice message should appear below the field.
    - Try long numeric number - longer than 12 digits
    - Try incorrect dot format (`12.34..56`) 
- Enter a correct tariff number containing dots `12.34.56.78` and save customs details
- Fill in other required shipment details like package weight and select a package to start loading shipping rates.
- Use Proxyman to check out the `/wcshipping/v1/label/rate&_method=post` and make sure the request payload contains `hs_tariff_number` value with no dots, i.e. `12345678`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.