### PR TITLE
[Woo POS][Barcodes] Frame the QR code and increase brightness for better scanability

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetup.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetup.swift
@@ -38,6 +38,7 @@ struct PointOfSaleBarcodeScannerSetup: View {
         .onDisappear {
             flowManager.onDisappear()
         }
+        .maximumScreenBrightness()
     }
 
     // MARK: - Computed Properties

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupStepViews.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupStepViews.swift
@@ -41,14 +41,16 @@ struct PointOfSaleBarcodeScannerBarcodeView: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(maxHeight: Constants.maxBarcodeSize)
+                .padding(POSPadding.medium)
                 .background(Color.white)
+                .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.medium.value))
         }
     }
 }
 
 extension PointOfSaleBarcodeScannerBarcodeView {
     enum Constants {
-        static let maxBarcodeSize: CGFloat = 142
+        static let maxBarcodeSize: CGFloat = 168
     }
 }
 

--- a/WooCommerce/Classes/POS/Utils/POSBrightnessControl.swift
+++ b/WooCommerce/Classes/POS/Utils/POSBrightnessControl.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import UIKit
+
+@available(iOS 17.0, *)
+@Observable
+final class POSBrightnessControl {
+    private var originalBrightness: CGFloat = 0.0
+    private var isBrightnessIncreased: Bool = false
+
+    init() {
+        originalBrightness = UIScreen.main.brightness
+    }
+
+    func increaseBrightnessToMax() {
+        guard !isBrightnessIncreased else { return }
+
+        originalBrightness = UIScreen.main.brightness
+        UIScreen.main.brightness = 1.0
+        isBrightnessIncreased = true
+    }
+
+    func restoreOriginalBrightness() {
+        guard isBrightnessIncreased else { return }
+
+        UIScreen.main.brightness = originalBrightness
+        isBrightnessIncreased = false
+    }
+
+    deinit {
+        if isBrightnessIncreased {
+            UIScreen.main.brightness = originalBrightness
+        }
+    }
+}
+
+/// SwiftUI View Modifier for automatic brightness control
+@available(iOS 17.0, *)
+struct POSBrightnessControlModifier: ViewModifier {
+    @State private var brightnessControl = POSBrightnessControl()
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                brightnessControl.increaseBrightnessToMax()
+            }
+            .onDisappear {
+                brightnessControl.restoreOriginalBrightness()
+            }
+    }
+}
+
+@available(iOS 17.0, *)
+extension View {
+    /// Applies brightness control to the view, increasing brightness to maximum when the view appears
+    func maximumScreenBrightness() -> some View {
+        modifier(POSBrightnessControlModifier())
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		0174DDBF2CE600C5005D20CA /* ReceiptEmailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0174DDBE2CE600C0005D20CA /* ReceiptEmailViewModelTests.swift */; };
 		0177250C2E1CFF7F00016148 /* GameControllerBarcodeParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0177250B2E1CFF7F00016148 /* GameControllerBarcodeParser.swift */; };
 		0177250E2E1CFF9B00016148 /* GameControllerBarcodeParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0177250D2E1CFF9B00016148 /* GameControllerBarcodeParserTests.swift */; };
+		01806E132E2F7F400033363C /* POSBrightnessControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01806E122E2F7F400033363C /* POSBrightnessControl.swift */; };
 		0182C8BE2CE3B11300474355 /* MockReceiptEligibilityUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0182C8BD2CE3B10E00474355 /* MockReceiptEligibilityUseCase.swift */; };
 		0182C8C02CE4DDC700474355 /* CardReaderTransactionAlertReceiptState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0182C8BF2CE4DDC100474355 /* CardReaderTransactionAlertReceiptState.swift */; };
 		0182C8C22CE4F0DB00474355 /* ReceiptEmailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0182C8C12CE4F0DB00474355 /* ReceiptEmailView.swift */; };
@@ -3228,6 +3229,7 @@
 		0174DDBE2CE600C0005D20CA /* ReceiptEmailViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptEmailViewModelTests.swift; sourceTree = "<group>"; };
 		0177250B2E1CFF7F00016148 /* GameControllerBarcodeParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameControllerBarcodeParser.swift; sourceTree = "<group>"; };
 		0177250D2E1CFF9B00016148 /* GameControllerBarcodeParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameControllerBarcodeParserTests.swift; sourceTree = "<group>"; };
+		01806E122E2F7F400033363C /* POSBrightnessControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSBrightnessControl.swift; sourceTree = "<group>"; };
 		0182C8BD2CE3B10E00474355 /* MockReceiptEligibilityUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockReceiptEligibilityUseCase.swift; sourceTree = "<group>"; };
 		0182C8BF2CE4DDC100474355 /* CardReaderTransactionAlertReceiptState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderTransactionAlertReceiptState.swift; sourceTree = "<group>"; };
 		0182C8C12CE4F0DB00474355 /* ReceiptEmailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptEmailView.swift; sourceTree = "<group>"; };
@@ -7113,6 +7115,7 @@
 		026826972BF59D9E0036F959 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				01806E122E2F7F400033363C /* POSBrightnessControl.swift */,
 				689F29192DE4557D004DF52B /* POSStockFormatter.swift */,
 				681BB5FD2D676060008AF8BB /* POSPadding.swift */,
 				681BB5FB2D676043008AF8BB /* POSSpacing.swift */,
@@ -16660,6 +16663,7 @@
 				B50BB4162141828F00AF0F3C /* FooterSpinnerView.swift in Sources */,
 				867B330F2B4D39B900DCBEA6 /* BlazeAddParameterView.swift in Sources */,
 				D8610CE2257099E100A5DF27 /* FancyAlertViewController+UnifiedLogin.swift in Sources */,
+				01806E132E2F7F400033363C /* POSBrightnessControl.swift in Sources */,
 				EE289AE62C9D7B31004AB1A6 /* AIToneVoiceViewModel.swift in Sources */,
 				038BC37D29C37AA400EAF565 /* SetUpTapToPayCompleteViewModel.swift in Sources */,
 				03E471CE293F63B4001A58AD /* PaymentCaptureOrchestrator.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

WOOMOB-880
Android https://github.com/woocommerce/woocommerce-android/pull/14357

To facilitate scanning setup in the dark mode:
- Frame QR code in a white clip shape background with padding
- Increase the screen brightness to maximum while the setup is open

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS on the iPad device
2. Set the device to lower background brightness
3. Select ... -> Barcode Scanning
4. Confirm the brightness increases
5. Confirm that closing the modal decreases the brightness to a previous brightness level
6. Open and continue the flow
7. Confirm that barcodes (and QR codes) are framed

Tell me your experience scanning these codes in dark mode. Is the experience smooth or does the scanner struggle to get a scan?

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air M2 iOS 26 + Inateck Scanner

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/a98c52e8-16ab-4508-b455-3f85206ea0f2

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.