### PR TITLE
Shipping Labels: Load settings and origin addresses synchronously only when data is not cached

### DIFF
--- a/Modules/Sources/Storage/Model/MIGRATIONS.md
+++ b/Modules/Sources/Storage/Model/MIGRATIONS.md
@@ -10,6 +10,7 @@ This file documents changes in the WCiOS Storage data model. Please explain any 
   - Added `shipments` relationship to `Order` entity.
 - @itsmeichigo 2025-07-22
   - Added `WooShippingOriginAddress` entity.
+  - Added attributes `lastOrderCompleted` and `addPaymentMethodURL` to `ShippingLabelAccountSettings` entity.
 
 ## Model 123 (Release 22.8.0.0)
 - @iamgabrielma 2025-06-30

--- a/Modules/Sources/Storage/Model/ShippingLabelAccountSettings+CoreDataProperties.swift
+++ b/Modules/Sources/Storage/Model/ShippingLabelAccountSettings+CoreDataProperties.swift
@@ -12,6 +12,7 @@ extension ShippingLabelAccountSettings {
     @NSManaged public var canManagePayments: Bool
     @NSManaged public var isEmailReceiptsEnabled: Bool
     @NSManaged public var lastSelectedPackageID: String?
+    @NSManaged public var lastOrderCompleted: Bool
     @NSManaged public var paperSize: String?
     @NSManaged public var selectedPaymentMethodID: Int64
     @NSManaged public var siteID: Int64
@@ -19,6 +20,7 @@ extension ShippingLabelAccountSettings {
     @NSManaged public var storeOwnerUsername: String?
     @NSManaged public var storeOwnerWpcomEmail: String?
     @NSManaged public var storeOwnerWpcomUsername: String?
+    @NSManaged public var addPaymentMethodURL: String?
     @NSManaged public var paymentMethods: Set<ShippingLabelPaymentMethod>?
 
 }

--- a/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 124.xcdatamodel/contents
+++ b/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 124.xcdatamodel/contents
@@ -778,9 +778,11 @@
         <relationship name="shipment" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingShipment" inverseName="shippingLabel" inverseEntity="WooShippingShipment"/>
     </entity>
     <entity name="ShippingLabelAccountSettings" representedClassName="ShippingLabelAccountSettings" syncable="YES">
+        <attribute name="addPaymentMethodURL" optional="YES" attributeType="String"/>
         <attribute name="canEditSettings" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="canManagePayments" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="isEmailReceiptsEnabled" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="lastOrderCompleted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="lastSelectedPackageID" attributeType="String" defaultValueString=""/>
         <attribute name="paperSize" attributeType="String"/>
         <attribute name="selectedPaymentMethodID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Modules/Sources/Yosemite/Model/Storage/ShippingLabelAccountSettings+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Storage/ShippingLabelAccountSettings+ReadOnlyConvertible.swift
@@ -18,6 +18,8 @@ extension Storage.ShippingLabelAccountSettings: ReadOnlyConvertible {
         isEmailReceiptsEnabled = settings.isEmailReceiptsEnabled
         paperSize = settings.paperSize.rawValue
         lastSelectedPackageID = settings.lastSelectedPackageID
+        lastOrderCompleted = settings.lastOrderCompleted
+        addPaymentMethodURL = settings.addPaymentMethodURL?.absoluteString
     }
 
     /// Returns a ReadOnly version of the receiver.
@@ -26,7 +28,6 @@ extension Storage.ShippingLabelAccountSettings: ReadOnlyConvertible {
         let paymentMethodItems = paymentMethods?.map { $0.toReadOnly() } ?? []
 
         /// Since account settings are not persisted for the new shipping label flow,
-        /// the conversion for the new properties `addPaymentMethodURL` & `lastOrderCompleted` is ignored.
         /// This avoids the complication of unnecessary Core Data migration for the new properties.
         return ShippingLabelAccountSettings(siteID: siteID,
                                             canManagePayments: canManagePayments,
@@ -40,7 +41,7 @@ extension Storage.ShippingLabelAccountSettings: ReadOnlyConvertible {
                                             isEmailReceiptsEnabled: isEmailReceiptsEnabled,
                                             paperSize: .init(rawValue: paperSize ?? ""),
                                             lastSelectedPackageID: lastSelectedPackageID ?? "",
-                                            lastOrderCompleted: false,
-                                            addPaymentMethodURL: nil)
+                                            lastOrderCompleted: lastOrderCompleted,
+                                            addPaymentMethodURL: URL(string: addPaymentMethodURL ?? ""))
     }
 }

--- a/Modules/Tests/StorageTests/CoreData/MigrationTests.swift
+++ b/Modules/Tests/StorageTests/CoreData/MigrationTests.swift
@@ -3518,6 +3518,57 @@ final class MigrationTests: XCTestCase {
         let insertedAddress = try XCTUnwrap(targetContext.firstObject(ofType: WooShippingOriginAddress.self))
         XCTAssertEqual(insertedAddress, address)
     }
+
+    func test_migrating_from_123_to_124_adds_new_attributes_lastOrderCompleted_and_addPaymentMethodURL_to_ShippingLabelAccountSettings() throws {
+        // Given
+        let sourceContainer = try startPersistentContainer("Model 123")
+        let sourceContext = sourceContainer.viewContext
+
+        let object = sourceContext.insert(entityName: "ShippingLabelAccountSettings", properties: [
+            "siteID": 123,
+            "canEditSettings": false,
+            "canManagePayments": false,
+            "isEmailReceiptsEnabled": false,
+            "lastSelectedPackageID": "",
+            "paperSize": "",
+            "selectedPaymentMethodID": 0,
+            "storeOwnerDisplayName": "",
+            "storeOwnerUsername": "",
+            "storeOwnerWpcomEmail": "",
+            "storeOwnerWpcomUsername": ""
+        ])
+        try sourceContext.save()
+
+        // `lastOrderCompleted` and `addPaymentMethodURL` should not be present in model 122
+        XCTAssertNil(object.entity.attributesByName["lastOrderCompleted"], "Precondition. Attribute does not exist.")
+        XCTAssertNil(object.entity.attributesByName["addPaymentMethodURL"], "Precondition. Attribute does not exist.")
+
+        // When
+        let targetContainer = try migrate(sourceContainer, to: "Model 124")
+
+        // Then
+        let targetContext = targetContainer.viewContext
+        let migratedObject = try XCTUnwrap(targetContext.first(entityName: "ShippingLabelAccountSettings"))
+
+        // `lastOrderCompleted` should be present in model 124
+        XCTAssertNotNil(migratedObject.entity.attributesByName["lastOrderCompleted"])
+
+        // `addPaymentMethodURL` value should default as nil in model 124
+        let value = migratedObject.value(forKey: "addPaymentMethodURL") as? String
+        XCTAssertNil(value)
+
+        // `lastOrderCompleted` must be settable
+        migratedObject.setValue(true, forKey: "lastOrderCompleted")
+        try targetContext.save()
+        let updatedValue = migratedObject.value(forKey: "lastOrderCompleted") as? Bool
+        XCTAssertEqual(updatedValue, true)
+
+        // `addPaymentMethodURL` must be settable
+        migratedObject.setValue("https://example.com", forKey: "addPaymentMethodURL")
+        try targetContext.save()
+        let urlValue = migratedObject.value(forKey: "addPaymentMethodURL") as? String
+        XCTAssertEqual(urlValue, "https://example.com")
+    }
 }
 
 // MARK: - Persistent Store Setup and Migrations

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 - [*] Shipping Labels: Validate custom package dimensions [https://github.com/woocommerce/woocommerce-ios/pull/15925]
 - [*] Shipping Labels: Show UPS TOS modal in full length for better accessibility. [https://github.com/woocommerce/woocommerce-ios/pull/15926]
 - [*] Shipping Labels: Optimize data loading on purchase form [https://github.com/woocommerce/woocommerce-ios/pull/15919]
+- [*] Shipping Labels: Cache settings and origin addresses to improve loading experience for purchase form [https://github.com/woocommerce/woocommerce-ios/pull/15935]
 - [internal] Optimized assets for app size reduction [https://github.com/woocommerce/woocommerce-ios/pull/15881]
 
 22.8

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -220,6 +220,15 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         return ResultsController<StorageWooShippingShipment>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
     }()
 
+    /// Origin addresses Results Controller.
+    ///
+    private lazy var originAddressResultsController: ResultsController<StorageWooShippingOriginAddress> = {
+        let predicate = NSPredicate(format: "siteID = %ld", self.order.siteID)
+        let descriptor = NSSortDescriptor(keyPath: \StorageWooShippingOriginAddress.id, ascending: true)
+
+        return ResultsController<StorageWooShippingOriginAddress>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+    }()
+
     /// Initialize the view model with or without an existing shipping label.
     init(order: Order,
          preselection: WooShippingCreateLabelSelection? = nil,
@@ -267,6 +276,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         observeViewStates()
         observePaymentMethod()
         configureShipmentResultsController()
+        configureOriginAddressResultsController()
 
         Task { @MainActor in
             await loadRequiredData()
@@ -297,10 +307,14 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
                 }
             }
 
-            if hasUnfulfilledShipments {
+            /// Only load origin addresses synchronously if no addresses have been saved in storage yet.
+            if hasUnfulfilledShipments, originAddress.isEmpty {
                 group.addTask {
                     await self.loadOriginAddresses()
                 }
+            } else if hasUnfulfilledShipments {
+                /// load asynchronously to update the local storage and unblock UI
+                stores.dispatch(WooShippingAction.loadOriginAddresses(siteID: order.siteID, completion: { _ in }))
             }
         }
 
@@ -442,12 +456,7 @@ private extension WooShippingCreateLabelsViewModel {
             }
             stores.dispatch(action)
         }
-        selectedOriginAddress = addresses.first(where: \.defaultAddress)
-        originAddresses = WooShippingOriginAddressListViewModel(addresses: addresses,
-                                                                selectedAddressID: selectedOriginAddress?.id)
-        originAddresses.onSelect = { [weak self] selectedAddress in
-            self?.selectedOriginAddress = selectedAddress
-        }
+        updateSelectedOriginAddress(addresses: addresses)
     }
 
     /// Loads destination address of the order from remote.
@@ -671,6 +680,37 @@ private extension WooShippingCreateLabelsViewModel {
             reloadShipments()
         } catch {
             DDLogError("⛔️ Unable to fetch shipments: \(error)")
+        }
+    }
+
+    func configureOriginAddressResultsController() {
+        let updateSelectedAddress = { [weak self] in
+            guard let self else { return }
+            let addresses = originAddressResultsController.fetchedObjects
+            updateSelectedOriginAddress(addresses: addresses)
+        }
+        originAddressResultsController.onDidChangeContent = {
+            updateSelectedAddress()
+        }
+
+        originAddressResultsController.onDidResetContent = {
+            updateSelectedAddress()
+        }
+
+        do {
+            try originAddressResultsController.performFetch()
+            updateSelectedAddress()
+        } catch {
+            DDLogError("⛔️ Unable to fetch origin addresses: \(error)")
+        }
+    }
+
+    func updateSelectedOriginAddress(addresses: [WooShippingOriginAddress]) {
+        selectedOriginAddress = addresses.first(where: \.defaultAddress)
+        originAddresses = WooShippingOriginAddressListViewModel(addresses: addresses,
+                                                                selectedAddressID: selectedOriginAddress?.id)
+        originAddresses.onSelect = { [weak self] selectedAddress in
+            self?.selectedOriginAddress = selectedAddress
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -229,6 +229,18 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         return ResultsController<StorageWooShippingOriginAddress>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
     }()
 
+    /// Shipping Label Account Settings ResultsController
+    ///
+    private lazy var accountSettingsResultsController: ResultsController<StorageShippingLabelAccountSettings> = {
+        let predicate = NSPredicate(format: "siteID == %lld", order.siteID)
+        return ResultsController<StorageShippingLabelAccountSettings>(
+            storageManager: storageManager,
+            matching: predicate,
+            fetchLimit: 1,
+            sortedBy: []
+        )
+    }()
+
     /// Initialize the view model with or without an existing shipping label.
     init(order: Order,
          preselection: WooShippingCreateLabelSelection? = nil,
@@ -250,6 +262,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.storageManager = storageManager
         self.analytics = analytics
         self.shippingSettingsService = shippingSettingsService
+        self.weightUnit = shippingSettingsService.weightUnit ?? ""
+        self.dimensionsUnit = shippingSettingsService.dimensionUnit ?? ""
         self.initialNoticeDelay = initialNoticeDelay
         self.isOrderCompleted = order.status == .completed
 
@@ -277,6 +291,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         observePaymentMethod()
         configureShipmentResultsController()
         configureOriginAddressResultsController()
+        configureAccountSettingsResultsController()
 
         Task { @MainActor in
             await loadRequiredData()
@@ -301,10 +316,14 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     func loadRequiredData() async {
         state = .loading
         await withTaskGroup(of: Void.self) { group in
+            /// Only load store options synchronously if no settings have been saved in storage yet.
             if isMissingStoreSettings {
                 group.addTask {
                     await self.loadStoreOptions()
                 }
+            } else {
+                /// load asynchronously to update the local storage and unblock UI
+                stores.dispatch(WooShippingAction.loadAccountSettings(siteID: order.siteID, completion: { _ in }))
             }
 
             /// Only load origin addresses synchronously if no addresses have been saved in storage yet.
@@ -432,12 +451,7 @@ private extension WooShippingCreateLabelsViewModel {
         }
         weightUnit = settings?.storeOptions.weightUnit ?? shippingSettingsService.weightUnit ?? ""
         dimensionsUnit = settings?.storeOptions.dimensionUnit ?? shippingSettingsService.dimensionUnit ?? ""
-        markOrderComplete = settings?.accountSettings.lastOrderCompleted ?? false
-
-        if let accountSettings = settings?.accountSettings {
-            paymentMethodsViewModel = ShippingLabelPaymentMethodsViewModel(accountSettings: accountSettings)
-        }
-        setupPaymentMethod(accountSettings: settings?.accountSettings)
+        updateAccountSettings(accountSettings: settings?.accountSettings)
     }
 
     /// Syncs origin addresses to use for shipping label from remote.
@@ -712,6 +726,39 @@ private extension WooShippingCreateLabelsViewModel {
         originAddresses.onSelect = { [weak self] selectedAddress in
             self?.selectedOriginAddress = selectedAddress
         }
+    }
+
+    /// Shipping Label Account Settings ResultsController monitoring
+    ///
+    func configureAccountSettingsResultsController() {
+        let updateSettings = { [weak self] in
+            guard let self else { return }
+            let settings = accountSettingsResultsController.fetchedObjects.first
+            updateAccountSettings(accountSettings: settings)
+        }
+        accountSettingsResultsController.onDidChangeContent = {
+            updateSettings()
+        }
+
+        accountSettingsResultsController.onDidResetContent = {
+            updateSettings()
+        }
+
+        do {
+            try accountSettingsResultsController.performFetch()
+            updateSettings()
+        } catch {
+            DDLogError("⛔️ Unable to fetch woo shipping account settings: \(error)")
+        }
+    }
+
+    func updateAccountSettings(accountSettings: ShippingLabelAccountSettings?) {
+        markOrderComplete = accountSettings?.lastOrderCompleted ?? false
+
+        if let accountSettings {
+            paymentMethodsViewModel = ShippingLabelPaymentMethodsViewModel(accountSettings: accountSettings)
+        }
+        setupPaymentMethod(accountSettings: accountSettings)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -778,7 +778,9 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         }
 
         // When
-        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(), stores: stores)
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(),
+                                                         shippingSettingsService: MockShippingSettingsService(dimensionUnit: "", weightUnit: ""),
+                                                         stores: stores)
 
         waitUntil {
             viewModel.state == .ready
@@ -847,6 +849,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
             case .loadOriginAddresses(_, let completion):
                 completion(.success([originAddress]))
             case .loadAccountSettings(_, let completion):
+                self.insert(accountSettings: accountSettings)
                 completion(.success(settings))
             case .loadPackages, .verifyDestinationAddress:
                 break
@@ -856,7 +859,9 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         }
 
 
-        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(), stores: stores)
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(),
+                                                         shippingSettingsService: MockShippingSettingsService(dimensionUnit: "", weightUnit: ""),
+                                                         stores: stores)
 
         waitUntil {
             viewModel.state == .ready
@@ -884,6 +889,154 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
                   title: "MASTERCARD****4444",
                   isEditable: true)
         ))
+    }
+
+    // MARK: - loadRequiredData with stored data tests
+
+    func test_loadRequiredData_state_becomes_ready_immediately_when_origin_addresses_and_settings_are_stored() {
+        // Given
+        let originAddress = WooShippingOriginAddress(siteID: siteID,
+                                                     id: "stored_address",
+                                                     company: "Stored Company",
+                                                     address1: "123 Stored St",
+                                                     address2: "",
+                                                     city: "San Francisco",
+                                                     state: "CA",
+                                                     postcode: "94102",
+                                                     country: "US",
+                                                     phone: "555-0123",
+                                                     firstName: "John",
+                                                     lastName: "Doe",
+                                                     email: "john@stored.com",
+                                                     defaultAddress: true,
+                                                     isVerified: true)
+
+        let accountSettings = ShippingLabelAccountSettings.fake().copy(siteID: siteID)
+
+        // Pre-populate storage with data
+        insert(originAddress: originAddress)
+        insert(accountSettings: accountSettings)
+
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let shippingSettingsService = MockShippingSettingsService(dimensionUnit: "cm", weightUnit: "g")
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(siteID: siteID),
+                                                         shippingSettingsService: shippingSettingsService,
+                                                         stores: stores,
+                                                         storageManager: storageManager)
+
+        waitUntil {
+            viewModel.state == .ready
+        }
+
+        // Then
+        XCTAssertEqual(viewModel.originAddress, "123 Stored St, San Francisco CA 94102, US")
+        XCTAssertEqual(viewModel.dimensionsUnit, "cm")
+        XCTAssertEqual(viewModel.weightUnit, "g")
+    }
+
+    func test_loadRequiredData_state_becomes_ready_immediately_when_only_origin_addresses_are_stored() {
+        // Given
+        let originAddress = WooShippingOriginAddress(siteID: siteID,
+                                                     id: "stored_address",
+                                                     company: "Stored Company",
+                                                     address1: "456 Another St",
+                                                     address2: "",
+                                                     city: "Los Angeles",
+                                                     state: "CA",
+                                                     postcode: "90210",
+                                                     country: "US",
+                                                     phone: "555-0456",
+                                                     firstName: "Jane",
+                                                     lastName: "Smith",
+                                                     email: "jane@stored.com",
+                                                     defaultAddress: true,
+                                                     isVerified: false)
+
+        // Pre-populate storage with origin addresses only
+        insert(originAddress: originAddress)
+
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var accountSettingsLoaded = false
+
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .loadAccountSettings(_, let completion):
+                accountSettingsLoaded = true
+                completion(.success(self.settings))
+            case .loadPackages, .verifyDestinationAddress, .loadOriginAddresses:
+                break
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        let shippingSettingsService = MockShippingSettingsService(dimensionUnit: nil, weightUnit: nil)
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(siteID: siteID),
+                                                         shippingSettingsService: shippingSettingsService,
+                                                         stores: stores,
+                                                         storageManager: storageManager)
+
+        waitUntil {
+            viewModel.state == .ready
+        }
+
+        // Then
+        XCTAssertEqual(viewModel.originAddress, "456 Another St, Los Angeles CA 90210, US")
+        XCTAssertTrue(accountSettingsLoaded, "Account settings should be loaded from remote when missing")
+        XCTAssertEqual(viewModel.dimensionsUnit, settings.storeOptions.dimensionUnit)
+        XCTAssertEqual(viewModel.weightUnit, settings.storeOptions.weightUnit)
+    }
+
+    func test_loadRequiredData_state_becomes_ready_immediately_when_only_account_settings_are_stored() {
+        // Given
+        let accountSettings = ShippingLabelAccountSettings.fake().copy(siteID: siteID)
+
+        // Pre-populate storage with account settings only
+        insert(accountSettings: accountSettings)
+
+        let originAddress = WooShippingOriginAddress(siteID: siteID,
+                                                     id: "stored_address",
+                                                     company: "Stored Company",
+                                                     address1: "456 Another St",
+                                                     address2: "",
+                                                     city: "Los Angeles",
+                                                     state: "CA",
+                                                     postcode: "90210",
+                                                     country: "US",
+                                                     phone: "555-0456",
+                                                     firstName: "Jane",
+                                                     lastName: "Smith",
+                                                     email: "jane@stored.com",
+                                                     defaultAddress: true,
+                                                     isVerified: false)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var originAddressesLoaded = false
+
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .loadOriginAddresses(_, let completion):
+                originAddressesLoaded = true
+                completion(.success([originAddress]))
+            case .loadPackages, .verifyDestinationAddress, .loadAccountSettings:
+                break
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        let shippingSettingsService = MockShippingSettingsService(dimensionUnit: "cm", weightUnit: "g")
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake().copy(siteID: siteID),
+                                                         shippingSettingsService: shippingSettingsService,
+                                                         stores: stores,
+                                                         storageManager: storageManager)
+
+        waitUntil {
+            viewModel.state == .ready
+        }
+
+        // Then
+        XCTAssertTrue(originAddressesLoaded, "Origin addresses should be loaded from remote when missing")
+        XCTAssertFalse(viewModel.originAddress.isEmpty, "Origin address should be set from loaded data")
     }
 }
 
@@ -933,5 +1086,15 @@ private extension WooShippingCreateLabelsViewModelTests {
                 storageShippingLabel.destinationAddress = destinationAddress
             }
         }
+    }
+
+    func insert(originAddress: WooShippingOriginAddress) {
+        let storageAddress = storage.insertNewObject(ofType: StorageWooShippingOriginAddress.self)
+        storageAddress.update(with: originAddress)
+    }
+
+    func insert(accountSettings: ShippingLabelAccountSettings) {
+        let storageSettings = storage.insertNewObject(ofType: StorageShippingLabelAccountSettings.self)
+        storageSettings.update(with: accountSettings)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-627

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR continues the work in #15932 to improve the experience on the label purchase form:
- Fetches origin addresses and account settings from storage upon initialization.
- Updates weight unit and dimension units to use the injected `shippingSettingsService`.
- Fetches data from remote asynchronously when cached data are available.
- Add missing attributes for `ShippingLabelAccountSettings` to ensure that all data are stored properly.


## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log out of the app to clear any cached data.
2. Log back in to a store with Woo Shipping set up.
3. Navigate to the Orders tab and open an order eligible for creating shipping labels.
4. Disconnect the Internet and tap the Create shipping label button.
5. Confirm that the loading state is displayed and then error state is displayed after requests time out.
6. Reconnect to the Internet and tap the reload button.
7. Confirm that data is loaded successfully and the purchase form is displayed.
8. Close the form and tap the Create shipping label button again.
9. Confirm that the purchase form is displayed immediately without the loading state.
10. Edit any Woo Shipping settings on the web (paper size, selected payment method, etc.) then repeat step 8. Confirm that the correct data is displayed after loading the purchase form.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Tested and confirmed with simulator iPhone 16 iOS 18.4.
- Updated migration tests and unit tests for the purchase form.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/d73b471a-5dcd-41ec-9a70-f5fef06a1f40



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.