### PR TITLE
Enhance POS ineligible view accessibility and scrolling behavior

### DIFF
--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -66,7 +66,6 @@ struct POSIneligibleView: View {
                                     try await onRefresh()
                                     isLoading = false
                                 } catch {
-                                    // TODO: WOOMOB-720 - handle error if needed, e.g., show an error message
                                     DDLogError("Error refreshing eligibility: \(error)")
                                     isLoading = false
                                 }

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -7,79 +7,107 @@ struct POSIneligibleView: View {
     let reason: POSIneligibleReason
     let onRefresh: () async throws -> Void
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.sizeCategory) private var sizeCategory
     @State private var isLoading: Bool = false
+    @State private var scrollViewHeight: CGFloat = 0
+    @State private var contentHeight: CGFloat = 0
+
+    /// Returns the frame width multiplier for the content view based on accessibility size category.
+    private var frameWidthMultiplier: Double {
+        if sizeCategory >= .accessibilityMedium {
+            return 0.9  // Use more horizontal space for larger accessibility sizes
+        } else {
+            return 0.5  // Standard multiplier for regular sizes
+        }
+    }
+
+    /// Returns true if scrolling should be disabled (content fits within scroll view).
+    private var shouldDisableScrolling: Bool {
+        scrollViewHeight > 0 && contentHeight > 0 && contentHeight <= scrollViewHeight
+    }
 
     var body: some View {
-        VStack(spacing: POSSpacing.none) {
-            Spacer()
-
-            VStack(alignment: .center, spacing: POSSpacing.none) {
-                POSErrorXMark()
-
+        ScrollView {
+            VStack(spacing: POSSpacing.none) {
                 Spacer()
-                    .frame(height: POSSpacing.medium)
 
-                VStack(spacing: POSSpacing.small) {
-                    Text(Localization.title)
-                        .font(POSFontStyle.posHeadingBold.font())
-                        .multilineTextAlignment(.center)
-                        .foregroundColor(Color.posOnSurface)
+                VStack(alignment: .center, spacing: POSSpacing.none) {
+                    POSErrorXMark()
 
-                    Text(suggestionText)
-                        .font(POSFontStyle.posBodyLargeRegular().font())
-                        .multilineTextAlignment(.center)
-                        .foregroundColor(Color.posOnSurface)
-                }
-                .containerRelativeFrame(.horizontal) { length, _ in
-                    max(length * 0.5, 300)
-                }
+                    Spacer()
+                        .frame(height: POSSpacing.medium)
 
-                Spacer()
-                    .frame(height: POSSpacing.large)
+                    VStack(spacing: POSSpacing.small) {
+                        Text(Localization.title)
+                            .font(POSFontStyle.posHeadingBold.font())
+                            .multilineTextAlignment(.center)
+                            .foregroundColor(Color.posOnSurface)
 
-                VStack(spacing: POSSpacing.medium) {
-                    Button {
-                        Task { @MainActor in
-                            do {
-                                isLoading = true
-                                ServiceLocator.analytics.track(
-                                    event: .PointOfSaleIneligibleUI.ineligibleUIRetryTapped(reason: reason)
-                                )
-                                try await onRefresh()
-                                isLoading = false
-                            } catch {
-                                // TODO: WOOMOB-720 - handle error if needed, e.g., show an error message
-                                DDLogError("Error refreshing eligibility: \(error)")
-                                isLoading = false
+                        Text(suggestionText)
+                            .font(POSFontStyle.posBodyLargeRegular().font())
+                            .multilineTextAlignment(.center)
+                            .foregroundColor(Color.posOnSurface)
+                    }
+                    .containerRelativeFrame(.horizontal) { length, _ in
+                        max(length * frameWidthMultiplier, 300)
+                    }
+
+                    Spacer()
+                        .frame(height: POSSpacing.large)
+
+                    VStack(spacing: POSSpacing.medium) {
+                        Button {
+                            Task { @MainActor in
+                                do {
+                                    isLoading = true
+                                    ServiceLocator.analytics.track(
+                                        event: .PointOfSaleIneligibleUI.ineligibleUIRetryTapped(reason: reason)
+                                    )
+                                    try await onRefresh()
+                                    isLoading = false
+                                } catch {
+                                    // TODO: WOOMOB-720 - handle error if needed, e.g., show an error message
+                                    DDLogError("Error refreshing eligibility: \(error)")
+                                    isLoading = false
+                                }
                             }
+                        } label: {
+                            Text(reason.refreshEligibilityTitle)
                         }
-                    } label: {
-                        Text(reason.refreshEligibilityTitle)
-                    }
-                    .buttonStyle(POSFilledButtonStyle(size: .normal, isLoading: isLoading))
-                    .renderedIf(reason.shouldShowRetryButton)
+                        .buttonStyle(POSFilledButtonStyle(size: .normal, isLoading: isLoading))
+                        .renderedIf(reason.shouldShowRetryButton)
 
-                    Button {
-                        dismiss()
-                    } label: {
-                        Text(Localization.dismiss)
+                        Button {
+                            dismiss()
+                        } label: {
+                            Text(Localization.dismiss)
+                        }
+                        .buttonStyle(POSOutlinedButtonStyle(size: .normal))
                     }
-                    .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+                    .containerRelativeFrame(.horizontal) { length, _ in
+                        max(length * frameWidthMultiplier - 132, 300)
+                    }
                 }
-                .containerRelativeFrame(.horizontal) { length, _ in
-                    max(length * 0.5 - 132, 300)
-                }
+
+                Spacer()
             }
-
-            Spacer()
+            .padding(POSPadding.large)
+            .frame(maxWidth: .infinity, minHeight: scrollViewHeight > 0 ? scrollViewHeight : nil)
+            .measureHeight { height in
+                contentHeight = height
+            }
+            .onAppear {
+                ServiceLocator.analytics.track(event: .PointOfSaleIneligibleUI.ineligibleUIShown(reason: reason))
+            }
+            .onChange(of: reason) { newReason in
+                ServiceLocator.analytics.track(event: .PointOfSaleIneligibleUI.ineligibleUIShown(reason: newReason))
+            }
         }
-        .padding(POSPadding.large)
-        .onAppear {
-            ServiceLocator.analytics.track(event: .PointOfSaleIneligibleUI.ineligibleUIShown(reason: reason))
+        .scrollDisabled(shouldDisableScrolling)
+        .measureHeight { height in
+            scrollViewHeight = height
         }
-        .onChange(of: reason) { newReason in
-            ServiceLocator.analytics.track(event: .PointOfSaleIneligibleUI.ineligibleUIShown(reason: newReason))
-        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var suggestionText: String {


### PR DESCRIPTION
For WOOMOB-750

Just one review is required.

## Description

Enhances the POS ineligible view to improve accessibility and scrolling behavior for merchants using larger text sizes or different screen configurations. The view now dynamically adjusts its layout based on accessibility settings and provides a better user experience across all device sizes.

Key improvements include adaptive content width that increases for larger accessibility text sizes, proper vertical centering regardless of content height, and scroll behavior that only enables scrolling when necessary.

## Steps to reproduce

Prerequisite: the store is ineligible for POS

1. Log in to the store in the prerequisite if needed
2. Tap on the POS tab
3. Test with different accessibility text sizes (Settings → Accessibility → Display & Text Size → Larger Text) --> layout and scrolling behavior should have good UX in all font sizes

## Testing information

Tested in iPad A16 iOS 18.4 simulator with and without split view.

## Screenshots

before | after
-- | --
<img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2025-07-22 at 09 27 34" src="https://github.com/user-attachments/assets/12d8ed21-b479-4e73-9f47-aac2c22a1a00" /> | <img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2025-07-22 at 10 15 09" src="https://github.com/user-attachments/assets/228cc02d-2bbf-46fe-b1e1-b72eb206337e" />

for smaller font sizes, content remains vertically centered with 0.5 width:

<img width="500" alt="Simulator Screenshot - iPad (A16) - 2025-07-22 at 10 15 33" src="https://github.com/user-attachments/assets/63551dcf-6cf0-4cd3-bae3-fb17be85434c" />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.