### PR TITLE
[Shipping Labels] Update ITN number format 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -17,6 +17,7 @@
 - [Internal] Shipping Labels: Optimize requests for syncing countries [https://github.com/woocommerce/woocommerce-ios/pull/15875]
 - [*] Shipping Labels: Display label size from account settings as default [https://github.com/woocommerce/woocommerce-ios/pull/15873]
 - [*] Shipping Labels: Ensured customs form validation enforces non-zero product weight to fix shipping rate loading failure. [https://github.com/woocommerce/woocommerce-ios/pull/15927]
+- [*] Shipping Labels: ITN number is now required for shipments with total value more than 2500. [https://github.com/woocommerce/woocommerce-ios/pull/15937]
 
 22.7
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -146,8 +146,7 @@ private extension WooShippingCustomsFormViewModel {
             let totalItemValue = items.reduce(0, { sum, item in
                 sum + item.totalValue
             })
-            if hsTariffNumberTotalValueDictionary.isEmpty,
-                totalItemValue > Constants.minimumValueForRequiredITN {
+            if totalItemValue > Constants.minimumValueForRequiredITN {
                 return .missingForTotalShipmentValue
             }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -140,7 +140,7 @@ private extension WooShippingCustomsFormViewModel {
         .map { input -> ITNValidationError? in
             let (itn, items, hsTariffNumberTotalValueDictionary, countryCode) = input
             guard itn.isEmpty else {
-                return itn.isValidITN ? nil : .invalidFormat
+                return ITNNumberValidator.isValid(itn) ? nil : .invalidFormat
             }
 
             let totalItemValue = items.reduce(0, { sum, item in
@@ -204,7 +204,7 @@ private extension WooShippingCustomsFormViewModel {
             restrictionType: restrictionType.toFormRestrictionType(),
             restrictionComments: restrictionType == .other ? restrictionDetails : "",
             nonDeliveryOption: returnToSenderIfNotDelivered ? .return : .abandon,
-            itn: internationalTransactionNumber.isValidITN ? internationalTransactionNumber : "",
+            itn: ITNNumberValidator.isValid(internationalTransactionNumber) ? internationalTransactionNumber : "",
             items: itemsViewModels.map {
                 ShippingLabelCustomsForm.Item(
                     description: $0.description,
@@ -385,18 +385,24 @@ extension WooShippingContentType {
     }
 }
 
-private extension String {
-    var isValidITN: Bool {
-        guard self.isNotEmpty else {
+enum ITNNumberValidator {
+    /// Validates AES/ITN (International Transaction Number) or NOEEI (No EEI) exemption codes
+    /// Accepts formats like:
+    /// - AES ITN: X12345678901234, AES 12345678901234 or AES ITN: 12345678901234
+    /// - NOEEI exemptions: NOEEI 30.36 or NOEEI 30.36(a) or NOEEI 30.36(a)(1)
+    /// AES/ITN numbers which are 14 digits long, optionally prefixed with 'X', 'AES', and/or 'ITN'
+    /// NOEEI exemption codes in the format "NOEEI 30.XX" with optional subsection letters and numbers
+    static func isValid(_ itnNumber: String) -> Bool {
+        guard itnNumber.isNotEmpty else {
             return true
         }
 
-        let pattern = "^(?:(?:AES X\\d{14})|(?:NOEEI 30\\.\\d{1,2}(?:\\([a-z]\\)(?:\\(\\d\\))?)?))$"
+        let pattern = "^(?:(?:AES\\s*ITN:?\\s*)?(?:AES(?!\\S)\\s*)?X?\\d{14}|(?:NOEEI\\s+30\\.\\d{2}(?:\\([a-z]\\)(?:\\(\\d\\))?)?))$"
 
         do {
-            let regex = try NSRegularExpression(pattern: pattern)
-            let range = NSRange(self.startIndex..<self.endIndex, in: self)
-            return regex.firstMatch(in: self, options: [], range: range) != nil
+            let regex = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+            let range = NSRange(itnNumber.startIndex..<itnNumber.endIndex, in: itnNumber)
+            return regex.firstMatch(in: itnNumber, options: [], range: range) != nil
         } catch {
             return false
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -396,7 +396,7 @@ enum ITNNumberValidator {
             return true
         }
 
-        let pattern = "^(?:(?:AES\\s*ITN:?\\s*)?(?:AES(?!\\S)\\s*)?X?\\d{14}|(?:NOEEI\\s+30\\.\\d{2}(?:\\([a-z]\\)(?:\\(\\d\\))?)?))$"
+        let pattern = "^(?:(?:AES(?!\\S)\\s*(?:ITN:?\\s*)?X?\\d{14})|(?:NOEEI\\s+30\\.\\d{2}(?:\\([a-z]\\)(?:\\(\\d\\))?)?))$"
 
         do {
             let regex = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -245,9 +245,10 @@ extension WooShippingCustomsFormViewModel.ITNValidationError {
 
     private enum Localization {
         static let itnInvalidFormat = NSLocalizedString(
-            "wooShippingCustomsFormViewModel.ITNValidationError.invalidFormat",
-            value: "Please enter a valid ITN in one of these formats: X12345678901234, AES X12345678901234, or NOEEI 30.37(a).",
-            comment: "Message when the ITN field is invalid in the customs form of a shipping label"
+            "wooShippingCustomsFormViewModel.ITNValidationError.invalidFormat.mandatoryAES",
+            value: "Please enter a valid ITN in one of these formats: AES X12345678901234, or NOEEI 30.37(a).",
+            comment: "Message when the ITN field is invalid in the customs form of a shipping label. " +
+            "Doesn't contain X12345678901234 format example."
         )
         static let itnRequiredForTariffClass = NSLocalizedString(
             "wooShippingCustomsFormViewModel.ITNValidationError.missingForTariffClass",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
@@ -399,8 +399,6 @@ final class WooShippingCustomsFormViewModelTests: XCTestCase {
         // Valid ITN formats
         XCTAssertTrue(ITNNumberValidator.isValid("AES X12345678901234"))
         XCTAssertTrue(ITNNumberValidator.isValid("AES 12345678901234"))
-        XCTAssertTrue(ITNNumberValidator.isValid("X12345678901234"))
-        XCTAssertTrue(ITNNumberValidator.isValid("12345678901234"))
         XCTAssertTrue(ITNNumberValidator.isValid("AES ITN 12345678901234"))
         XCTAssertTrue(ITNNumberValidator.isValid("AES ITN:12345678901234"))
         XCTAssertTrue(ITNNumberValidator.isValid("aes itn:12345678901234"))
@@ -415,6 +413,8 @@ final class WooShippingCustomsFormViewModelTests: XCTestCase {
 
     func test_ITNNumberValidator_when_number_is_invalid_then_returns_false() {
         // Invalid formats
+        XCTAssertFalse(ITNNumberValidator.isValid("X12345678901234"))
+        XCTAssertFalse(ITNNumberValidator.isValid("12345678901234"))
         XCTAssertFalse(ITNNumberValidator.isValid("AES Y12345678901234")) // Invalid prefix
         XCTAssertFalse(ITNNumberValidator.isValid("X1234567890123")) // Too short
         XCTAssertFalse(ITNNumberValidator.isValid("X123456789012345")) // Too long

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
@@ -427,6 +427,56 @@ final class WooShippingCustomsFormViewModelTests: XCTestCase {
         XCTAssertTrue(ITNNumberValidator.isValid(""))
         XCTAssertFalse(ITNNumberValidator.isValid(" "))
     }
+
+    func test_itnValidationError_when_totalShipmentValueExceedsThreshold_andTariffClassesDont() {
+        // Given
+        let storageManager = MockStorageManager()
+        let originCountryCodeSubject = PassthroughSubject<String?, Never>()
+
+        let usCountry = Country(
+            code: "US",
+            name: "United States",
+            states: []
+        )
+        let ukCountry = Country(
+            code: "UK",
+            name: "United Kingdom",
+            states: []
+        )
+        storageManager.insertSampleCountries(readOnlyCountries: [usCountry, ukCountry])
+        let shipment = sampleShipment
+        let order = Order.fake().copy(currency: "USD")
+
+        viewModel = WooShippingCustomsFormViewModel(
+            order: order,
+            shipment: shipment,
+            originCountryCode: originCountryCodeSubject.eraseToAnyPublisher(),
+            storageManager: storageManager,
+            onFormReady: { _ in }
+        )
+
+        // Set values to have a total > $2500, but each tariff class < $2500
+        // Item 1 has quantity 2, Item 2 has quantity 1.
+        viewModel.itemsViewModels[0].valuePerUnit = "1200" // Total: 2 * 1200 = 2400
+        viewModel.itemsViewModels[1].valuePerUnit = "200"  // Total: 1 * 200 = 200
+                                                           // Shipment total: 2600
+
+        // When
+        originCountryCodeSubject.send("US")
+        viewModel.updateDestinationCountry(code: "UK") // A country that doesn't have special ITN rules
+        viewModel.internationalTransactionNumber = "" // No ITN provided
+        // Set different tariff numbers for each item
+        viewModel.itemsViewModels[0].hsTariffNumber = "111111"
+        viewModel.itemsViewModels[1].hsTariffNumber = "222222"
+        viewModel.itemsViewModels.forEach {
+            $0.description = "Test"
+            $0.weightPerUnit = "1"
+        }
+
+        // Then
+        // The shipment total value is 2600, which is > $2500, so an ITN should be required.
+        XCTAssertEqual(viewModel.itnValidationError, .missingForTotalShipmentValue)
+    }
 }
 
 private extension WooShippingCustomsFormViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModelTests.swift
@@ -394,6 +394,39 @@ final class WooShippingCustomsFormViewModelTests: XCTestCase {
         XCTAssertFalse(itemViewModel.isValidWeight)
         XCTAssertFalse(itemViewModel.requiredInformationIsEntered)
     }
+
+    func test_ITNNumberValidator_when_number_is_valid_then_returns_true() {
+        // Valid ITN formats
+        XCTAssertTrue(ITNNumberValidator.isValid("AES X12345678901234"))
+        XCTAssertTrue(ITNNumberValidator.isValid("AES 12345678901234"))
+        XCTAssertTrue(ITNNumberValidator.isValid("X12345678901234"))
+        XCTAssertTrue(ITNNumberValidator.isValid("12345678901234"))
+        XCTAssertTrue(ITNNumberValidator.isValid("AES ITN 12345678901234"))
+        XCTAssertTrue(ITNNumberValidator.isValid("AES ITN:12345678901234"))
+        XCTAssertTrue(ITNNumberValidator.isValid("aes itn:12345678901234"))
+        XCTAssertTrue(ITNNumberValidator.isValid("aes x12345678901234"))
+
+        // Valid NOEEI formats
+        XCTAssertTrue(ITNNumberValidator.isValid("NOEEI 30.36"))
+        XCTAssertTrue(ITNNumberValidator.isValid("NOEEI 30.37(a)"))
+        XCTAssertTrue(ITNNumberValidator.isValid("NOEEI 30.37(a)(1)"))
+        XCTAssertTrue(ITNNumberValidator.isValid("noeei 30.37(a)(1)"))
+    }
+
+    func test_ITNNumberValidator_when_number_is_invalid_then_returns_false() {
+        // Invalid formats
+        XCTAssertFalse(ITNNumberValidator.isValid("AES Y12345678901234")) // Invalid prefix
+        XCTAssertFalse(ITNNumberValidator.isValid("X1234567890123")) // Too short
+        XCTAssertFalse(ITNNumberValidator.isValid("X123456789012345")) // Too long
+        XCTAssertFalse(ITNNumberValidator.isValid("NOEEI 30.3")) // Incomplete NOEEI
+        XCTAssertFalse(ITNNumberValidator.isValid("NOEEI 30.37(a)(1)(i)")) // Invalid NOEEI
+        XCTAssertFalse(ITNNumberValidator.isValid("AESX12345678901234"))
+        XCTAssertFalse(ITNNumberValidator.isValid("NOEEI30.36"))
+
+        // Empty and whitespace
+        XCTAssertTrue(ITNNumberValidator.isValid(""))
+        XCTAssertFalse(ITNNumberValidator.isValid(" "))
+    }
 }
 
 private extension WooShippingCustomsFormViewModelTests {


### PR DESCRIPTION
Part of: WOOMOB-891

## Description

Addresses the `2. The ITN number is not required when the total value is more than 2500 in some cases`

More context in p1753116680786689-slack-C03L1NF1EA3

- Makes ITN number mandatory for all shipments with a total value of 2500+.
- ~~Updates ITN validator format to follow the regexp used in shipping plugin~~. We decided to keep the `AES` prefix mandatory. But other from that the regexp was updated to behave closer to web:
    - Mandatory AES Prefix for ITN Numbers: All ITN numbers are now required to start with AES. Formats like X12345678901234 without the AES prefix are no longer valid.
    - Flexible Spacing in AES Prefix: The validator now accepts variable whitespace after AES and around the optional ITN: part, such as AES ITN: 12345678901234.
    - Whole Word AES: The AES prefix must be a distinct word, separated by a space. Formats like AESX12345678901234 are now invalid.
    - Stricter NOEEI Numeric Validation: The numeric part of a NOEEI code must now have exactly two digits after the dot (e.g., NOEEI 30.36). Incomplete codes like NOEEI 30.3 are now invalid.
    - Case-Insensitive Matching: The entire validation is now case-insensitive, so aes x12345678901234 and noeei 30.36 are both valid. 
- Updates ITN field format error notice message to exclude non-AES-prefixed misleading example.
- Extracts validator to static method for testability.

## Testing steps

- Create an order with items total value of 2500+ 
- Set a foreign destination address
- Make sure the ITN number field is required
- In customs form Input valid ITN numbers an make sure the format is accepted:
    - `AES X12345678901234`
    - `AES 12345678901234`
- In customs form Input invalid ITN numbers and make sure an error notice is displayed:
    -  `AES Y12345678901234`
    - `X12345678901234` Still invalid
    - Be creative :)
- In customs form Input `AES X12345678901234`, save.
- Fill in missing details for a shipping including a package and total weight to trigger carrier rates loading.
- Make sure shipping rates are loaded successfully.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.