### PR TITLE
Shipping Labels: Fix the UI glitch on the shipment detail bottom sheet

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,6 +15,7 @@
 - [*] Shipping Labels: Show UPS TOS modal in full length for better accessibility. [https://github.com/woocommerce/woocommerce-ios/pull/15926]
 - [*] Shipping Labels: Optimize data loading on purchase form [https://github.com/woocommerce/woocommerce-ios/pull/15919]
 - [*] Shipping Labels: Cache settings and origin addresses to improve loading experience for purchase form [https://github.com/woocommerce/woocommerce-ios/pull/15935]
+- [*] Shipping Labels: Fixed UI glitch on the bottom sheet of the purchase form. [https://github.com/woocommerce/woocommerce-ios/pull/15940]
 - [internal] Optimized assets for app size reduction [https://github.com/woocommerce/woocommerce-ios/pull/15881]
 - [*] Shipping Labels: Allow dots in HS tariff number input field for customs settings [https://github.com/woocommerce/woocommerce-ios/pull/15933]
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ExpandableBottomSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ExpandableBottomSheet.swift
@@ -158,6 +158,9 @@ struct ExpandableBottomSheet<AlwaysVisibleContent, ExpandableContent>: View wher
                 }
         )
         .background(Color(.listForeground(modal: false)))
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
+            revealContentDuringDrag = false
+        }
     }
 
     private func calculateHeight(offsetBy dragAmount: CGFloat = 0) -> CGFloat {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ExpandableBottomSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ExpandableBottomSheet.swift
@@ -159,6 +159,9 @@ struct ExpandableBottomSheet<AlwaysVisibleContent, ExpandableContent>: View wher
         )
         .background(Color(.listForeground(modal: false)))
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
+            /// When user swipes to move the app to the background, the drag gesture is started but never finishes.
+            /// This workaround cancels the dragging when the app re-enters the foreground
+            /// and fixes the glitch caused by the divider at the bottom of the scroll view.
             revealContentDuringDrag = false
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-648

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

There is a UI glitch on the shipment detail bottom sheet when swiping the app to the background while the purchase form is displayed.

When swiping the app, the drag gesture on the bottom sheet is triggered but never ends due to the app resigning from the active state.

This PR fixes the glitch by resetting the `revealContentDuringDrag` state to false when the app re-enters the foreground. This makes sure that the bottom sheet is reset to its pre-dragged state.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with the Woo Shipping extension set up.
2. Navigate to the Orders tab and select an order eligible for creating shipping labels.
3. Select Create shipping label to open the purchase form.
4. Quickly swipe to send the app to the background.
5. Reopen the app and confirm that the bottom sheet UI doesn't have any glitch.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested and confirmed with iPhone 16 Pro iOS 18.3.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before:

https://github.com/user-attachments/assets/501f1219-a3d4-47d1-bf81-6a153675bc2f



After:

https://github.com/user-attachments/assets/af1ca10d-c91e-4de1-a52f-e9db3c6053ae



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.