### PR TITLE
[Woo POS][Barcodes] Handle transitions for set up flow states

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetup.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetup.swift
@@ -19,7 +19,11 @@ struct PointOfSaleBarcodeScannerSetup: View {
         ) {
             VStack(spacing: POSSpacing.xxLarge) {
                 ScrollView(showsIndicators: false) {
-                    currentContent
+                    HStack {
+                        Spacer()
+                        currentContent
+                        Spacer()
+                    }
                 }
                 .scrollBounceBehavior(.basedOnSize, axes: [.vertical])
 

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetup.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetup.swift
@@ -12,26 +12,28 @@ struct PointOfSaleBarcodeScannerSetup: View {
     }
 
     var body: some View {
-        VStack(spacing: POSSpacing.xxLarge) {
-            ScrollView(showsIndicators: false) {
-                VStack {
+        AnimatedTransitionContainer(
+            maxWidth: parentSize.width * Constants.parentWidthRatio,
+            maxHeight: parentSize.height * Constants.maxParentHeightRatio,
+            id: flowManager.currentStepKey
+        ) {
+            VStack(spacing: POSSpacing.xxLarge) {
+                ScrollView(showsIndicators: false) {
                     currentContent
                 }
-            }
+                .scrollBounceBehavior(.basedOnSize, axes: [.vertical])
 
-            // Bottom buttons
-            if flowManager.buttonConfiguration.primaryButton != nil || flowManager.buttonConfiguration.secondaryButton != nil {
-                PointOfSaleFlowButtonsView(configuration: flowManager.buttonConfiguration)
+                // Bottom buttons
+                if flowManager.buttonConfiguration.primaryButton != nil || flowManager.buttonConfiguration.secondaryButton != nil {
+                    PointOfSaleFlowButtonsView(configuration: flowManager.buttonConfiguration)
+                }
             }
+            .posModalCloseButton(action: {
+                isPresented = false
+            })
+            .padding(POSPadding.xxLarge)
+            .background(Color.posSurfaceBright)
         }
-        .posModalCloseButton(action: {
-            isPresented = false
-        })
-        .padding(POSPadding.xxLarge)
-        .background(Color.posSurfaceBright)
-        .frame(maxHeight: parentSize.height * Constants.maxParentHeightRatio)
-        .frame(width: parentSize.width * Constants.parentWidthRatio)
-        .fixedSize(horizontal: false, vertical: true)
         .onAppear {
             ServiceLocator.analytics.track(.pointOfSaleBarcodeScannerSetupFlowShown)
         }
@@ -114,4 +116,101 @@ private extension PointOfSaleBarcodeScannerSetup {
 @available(iOS 17.0, *)
 #Preview {
     PointOfSaleBarcodeScannerSetup(isPresented: .constant(true))
+}
+
+/// A container view that animates changes in its child content with a fade-out and fade-in transition,
+/// while also smoothly animating changes in height.
+///
+/// - On first appear: content shows instantly (no fade).
+/// - On content change: fades out old content, replaces it, then fades in new content.
+/// - Handles height changes with a spring animation.
+///
+@available(iOS 17.0, *)
+private struct AnimatedTransitionContainer<Content: View, ID: Equatable>: View {
+    let maxWidth: CGFloat
+    let maxHeight: CGFloat
+    let contentID: ID
+    let contentBuilder: () -> Content
+
+    @State private var visibleContent: Content
+    @State private var previousID: ID
+    @State private var animatedHeight: CGFloat = 0
+    @State private var isVisible: Bool = true
+    @State private var hasAppeared: Bool = false
+
+    private let animationDuration: CGFloat = 0.3
+
+    init(
+        maxWidth: CGFloat,
+        maxHeight: CGFloat,
+        id: ID,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.maxWidth = maxWidth
+        self.maxHeight = maxHeight
+        self.contentID = id
+        self.contentBuilder = content
+        self._visibleContent = State(initialValue: content())
+        self._previousID = State(initialValue: id)
+    }
+
+    var body: some View {
+        visibleContent
+            .opacity(isVisible ? 1 : 0)
+            .animation(.easeInOut(duration: animationDuration), value: isVisible)
+            // First layout pass: constrain content to let scrollView in content to configure itself
+            .frame(width: maxWidth)
+            .frame(maxHeight: maxHeight)
+            .fixedSize(horizontal: false, vertical: true)
+            // Measure the actual height after ScrollView has decided if it needs to scroll
+            .background(
+                GeometryReader { proxy in
+                    Color.clear
+                        .onAppear {
+                            updateSize(to: proxy.size.height)
+                        }
+                        .onChange(of: proxy.size) { newSize in
+                            updateSize(to: newSize.height)
+                        }
+                }
+            )
+            // Second layout pass: create animated viewport using measured height
+            .frame(width: maxWidth)
+            .frame(height: animatedHeight)
+            .clipped()
+            .onAppear {
+                hasAppeared = true
+            }
+            .onChange(of: contentID) { newID in
+                guard newID != previousID else { return }
+
+                if hasAppeared {
+                    withAnimation {
+                        isVisible = false
+                    }
+
+                    DispatchQueue.main.asyncAfter(deadline: .now() + animationDuration) {
+                        visibleContent = contentBuilder()
+                        previousID = newID
+
+                        withAnimation {
+                            isVisible = true
+                        }
+                    }
+                } else {
+                    // First load, no animation
+                    visibleContent = contentBuilder()
+                    previousID = newID
+                    isVisible = true
+                }
+            }
+    }
+
+    private func updateSize(to newHeight: CGFloat) {
+        guard newHeight > 0 else { return }
+
+        withAnimation(.spring(duration: hasAppeared ? animationDuration : 0)) {
+            animatedHeight = min(newHeight, maxHeight)
+        }
+    }
 }

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetup.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetup.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct PointOfSaleBarcodeScannerSetup: View {
     @Binding var isPresented: Bool
     @State private var flowManager: PointOfSaleBarcodeScannerSetupFlowManager
+    @Environment(\.posModalParentSize) var parentSize
 
     init(isPresented: Binding<Bool>) {
         self._isPresented = isPresented
@@ -12,12 +13,11 @@ struct PointOfSaleBarcodeScannerSetup: View {
 
     var body: some View {
         VStack(spacing: POSSpacing.xxLarge) {
-            VStack {
-                currentContent
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                Spacer()
+            ScrollView(showsIndicators: false) {
+                VStack {
+                    currentContent
+                }
             }
-            .scrollVerticallyIfNeeded()
 
             // Bottom buttons
             if flowManager.buttonConfiguration.primaryButton != nil || flowManager.buttonConfiguration.secondaryButton != nil {
@@ -29,9 +29,9 @@ struct PointOfSaleBarcodeScannerSetup: View {
         })
         .padding(POSPadding.xxLarge)
         .background(Color.posSurfaceBright)
-        .containerRelativeFrame([.horizontal, .vertical]) { length, _ in
-            max(length * 0.75, Constants.modalFrameMaxSmallDimension)
-        }
+        .frame(maxHeight: parentSize.height * Constants.maxParentHeightRatio)
+        .frame(width: parentSize.width * Constants.parentWidthRatio)
+        .fixedSize(horizontal: false, vertical: true)
         .onAppear {
             ServiceLocator.analytics.track(.pointOfSaleBarcodeScannerSetupFlowShown)
         }
@@ -79,7 +79,8 @@ struct PointOfSaleBarcodeScannerSetup: View {
 
 // MARK: - Constants
 private enum Constants {
-    static var modalFrameMaxSmallDimension: CGFloat { 616 }
+    static var maxParentHeightRatio: CGFloat { 0.9 }
+    static var parentWidthRatio: CGFloat { 0.75 }
 }
 
 // MARK: - Private Localization Extension

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetup.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetup.swift
@@ -161,7 +161,6 @@ private struct AnimatedTransitionContainer<Content: View, ID: Equatable>: View {
     var body: some View {
         visibleContent
             .opacity(isVisible ? 1 : 0)
-            .animation(.easeInOut(duration: animationDuration), value: isVisible)
             // First layout pass: constrain content to let scrollView in content to configure itself
             .frame(width: maxWidth)
             .frame(maxHeight: maxHeight)
@@ -189,15 +188,15 @@ private struct AnimatedTransitionContainer<Content: View, ID: Equatable>: View {
                 guard newID != previousID else { return }
 
                 if hasAppeared {
-                    withAnimation {
+                    withAnimation(.easeInOut(duration: animationDuration / 2)) {
                         isVisible = false
                     }
 
-                    DispatchQueue.main.asyncAfter(deadline: .now() + animationDuration) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + animationDuration / 2) {
                         visibleContent = contentBuilder()
                         previousID = newID
 
-                        withAnimation {
+                        withAnimation(.easeInOut(duration: animationDuration)) {
                             isVisible = true
                         }
                     }

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlow.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlow.swift
@@ -9,7 +9,7 @@ class PointOfSaleBarcodeScannerSetupFlow {
     private let onBackToSelection: () -> Void
     fileprivate let onDismiss: () -> Void
     private var flowSteps: [PointOfSaleBarcodeScannerStepID: PointOfSaleBarcodeScannerSetupStep] = [:]
-    private var currentStepKey: PointOfSaleBarcodeScannerStepID = .setupBarcodeHID
+    private(set) var currentStepKey: PointOfSaleBarcodeScannerStepID = .setupBarcodeHID
     private let analytics: Analytics
 
     init(scannerType: PointOfSaleBarcodeScannerType,

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlowManager.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlowManager.swift
@@ -12,6 +12,10 @@ class PointOfSaleBarcodeScannerSetupFlowManager {
     private let analytics: Analytics
     private var keyboardObserver: NSObjectProtocol?
 
+    var currentStepKey: String? {
+        currentFlow?.currentStepKey.rawValue
+    }
+
     init(isPresented: Binding<Bool>, analytics: Analytics = ServiceLocator.analytics) {
         self._isPresented = isPresented
         self.analytics = analytics

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleFlowButtonsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleFlowButtonsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@available(iOS 17.0, *)
 struct PointOfSaleFlowButtonsView: View {
     let configuration: PointOfSaleFlowButtonConfiguration
 
@@ -21,6 +22,7 @@ struct PointOfSaleFlowButtonsView: View {
                 .disabled(!primaryButton.isEnabled)
             }
         }
+        .geometryGroup()
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -2,43 +2,60 @@ import SwiftUI
 
 struct POSRootModalViewModifier: ViewModifier {
     @EnvironmentObject var modalManager: POSModalManager
+    @State private var modalParentSize: CGSize = UIScreen.main.bounds.size
 
     private let animationDuration = Constants.animationDuration
     private let scaleTransitionAmount = Constants.scaleTransitionAmount
 
     func body(content: Content) -> some View {
-        ZStack {
-            content
-                .blur(radius: modalManager.isPresented ? 8 : 0)
-                .disabled(modalManager.isPresented)
-                .accessibilityElement(children: modalManager.isPresented ? .ignore : .contain)
+        GeometryReader { geometry in
+            ZStack {
+                content
+                    .blur(radius: modalManager.isPresented ? 8 : 0)
+                    .disabled(modalManager.isPresented)
+                    .accessibilityElement(children: modalManager.isPresented ? .ignore : .contain)
 
-            if modalManager.isPresented {
-                Color.posSurfaceDim.opacity(0.8)
-                    .edgesIgnoringSafeArea(.all)
-                    .onTapGesture {
-                        if modalManager.allowsInteractiveDismissal {
-                            modalManager.dismiss()
+                if modalManager.isPresented {
+                    Color.posSurfaceDim.opacity(0.8)
+                        .edgesIgnoringSafeArea(.all)
+                        .onTapGesture {
+                            if modalManager.allowsInteractiveDismissal {
+                                modalManager.dismiss()
+                            }
                         }
+                        // Don't scale/fade in the backdrop
+                        .animation(nil, value: modalManager.isPresented)
+                    ZStack {
+                        modalManager.getContent()
+                            .environment(\.posModalParentSize, modalParentSize)
+                            .background(Color.posSurfaceBright)
+                            .cornerRadius(POSCornerRadiusStyle.extraLarge.value)
+                            .posShadow(.large, cornerRadius: POSCornerRadiusStyle.extraLarge.value)
+                            .padding()
                     }
-                    // Don't scale/fade in the backdrop
-                    .animation(nil, value: modalManager.isPresented)
-                ZStack {
-                    modalManager.getContent()
-                        .background(Color.posSurfaceBright)
-                        .cornerRadius(POSCornerRadiusStyle.extraLarge.value)
-                        .posShadow(.large, cornerRadius: POSCornerRadiusStyle.extraLarge.value)
-                        .padding()
+                    .zIndex(1)
+                    // Scale the modal container in and out, fading appropriately.
+                    // Unfortunately combined doesn't work on removal.
+                    // The extra ZStack prevents changing modalContent from scaling and fading, but the ZIndex needs to be
+                    // consistent even when animating out, which it wouldn't be if unspecified.
+                    .transition(.scale(scale: scaleTransitionAmount).combined(with: .opacity))
                 }
-                .zIndex(1)
-                // Scale the modal container in and out, fading appropriately.
-                // Unfortunately combined doesn't work on removal.
-                // The extra ZStack prevents changing modalContent from scaling and fading, but the ZIndex needs to be
-                // consistent even when animating out, which it wouldn't be if unspecified.
-                .transition(.scale(scale: scaleTransitionAmount).combined(with: .opacity))
+            }
+            .onAppear {
+                updateModalParentSize(from: geometry)
+            }
+            .onChange(of: geometry.size) { _ in
+                updateModalParentSize(from: geometry)
             }
         }
         .animation(.easeInOut(duration: animationDuration), value: modalManager.isPresented)
+    }
+
+    private func updateModalParentSize(from geometry: GeometryProxy) {
+        let newSize = geometry.size
+        if newSize != modalParentSize && newSize != .zero {
+            modalParentSize = newSize
+        }
     }
 }
 
@@ -176,5 +193,20 @@ extension View {
     /// Prevents a POS Modal from being dismissed by tapping on the background.
     func posInteractiveDismissDisabled(_ disabled: Bool = true) -> some View {
         self.modifier(POSInteractiveDismissModifier(disabled: disabled))
+    }
+}
+
+// MARK: - POS Modal Parent Size Environment
+
+/// Environment key for tracking the current screen size in POS modals
+struct POSModalParentSizeKey: EnvironmentKey {
+    static let defaultValue: CGSize = UIScreen.main.bounds.size
+}
+
+extension EnvironmentValues {
+    /// The current screen size available to the POS modal
+    var posModalParentSize: CGSize {
+        get { self[POSModalParentSizeKey.self] }
+        set { self[POSModalParentSizeKey.self] = newValue }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -8,53 +8,47 @@ struct POSRootModalViewModifier: ViewModifier {
     private let scaleTransitionAmount = Constants.scaleTransitionAmount
 
     func body(content: Content) -> some View {
-        GeometryReader { geometry in
-            ZStack {
-                content
-                    .blur(radius: modalManager.isPresented ? 8 : 0)
-                    .disabled(modalManager.isPresented)
-                    .accessibilityElement(children: modalManager.isPresented ? .ignore : .contain)
+        ZStack {
+            content
+                .blur(radius: modalManager.isPresented ? 8 : 0)
+                .disabled(modalManager.isPresented)
+                .accessibilityElement(children: modalManager.isPresented ? .ignore : .contain)
 
-                if modalManager.isPresented {
-                    Color.posSurfaceDim.opacity(0.8)
-                        .edgesIgnoringSafeArea(.all)
-                        .onTapGesture {
-                            if modalManager.allowsInteractiveDismissal {
-                                modalManager.dismiss()
-                            }
+            if modalManager.isPresented {
+                Color.posSurfaceDim.opacity(0.8)
+                    .edgesIgnoringSafeArea(.all)
+                    .onTapGesture {
+                        if modalManager.allowsInteractiveDismissal {
+                            modalManager.dismiss()
                         }
-                        // Don't scale/fade in the backdrop
-                        .animation(nil, value: modalManager.isPresented)
-                    ZStack {
-                        modalManager.getContent()
-                            .environment(\.posModalParentSize, modalParentSize)
-                            .background(Color.posSurfaceBright)
-                            .cornerRadius(POSCornerRadiusStyle.extraLarge.value)
-                            .posShadow(.large, cornerRadius: POSCornerRadiusStyle.extraLarge.value)
-                            .padding()
                     }
-                    .zIndex(1)
-                    // Scale the modal container in and out, fading appropriately.
-                    // Unfortunately combined doesn't work on removal.
-                    // The extra ZStack prevents changing modalContent from scaling and fading, but the ZIndex needs to be
-                    // consistent even when animating out, which it wouldn't be if unspecified.
-                    .transition(.scale(scale: scaleTransitionAmount).combined(with: .opacity))
+                // Don't scale/fade in the backdrop
+                    .animation(nil, value: modalManager.isPresented)
+                ZStack {
+                    modalManager.getContent()
+                        .environment(\.posModalParentSize, modalParentSize)
+                        .background(Color.posSurfaceBright)
+                        .cornerRadius(POSCornerRadiusStyle.extraLarge.value)
+                        .posShadow(.large, cornerRadius: POSCornerRadiusStyle.extraLarge.value)
+                        .padding()
                 }
+                .zIndex(1)
+                // Scale the modal container in and out, fading appropriately.
+                // Unfortunately combined doesn't work on removal.
+                // The extra ZStack prevents changing modalContent from scaling and fading, but the ZIndex needs to be
+                // consistent even when animating out, which it wouldn't be if unspecified.
+                .transition(.scale(scale: scaleTransitionAmount).combined(with: .opacity))
             }
-            .onAppear {
-                updateModalParentSize(from: geometry)
-            }
-            .onChange(of: geometry.size) { _ in
-                updateModalParentSize(from: geometry)
-            }
+        }
+        .measureFrame { frame in
+            updateModalParentSize(with: frame.size)
         }
         .animation(.easeInOut(duration: animationDuration), value: modalManager.isPresented)
     }
 
-    private func updateModalParentSize(from geometry: GeometryProxy) {
-        let newSize = geometry.size
-        if newSize != modalParentSize && newSize != .zero {
-            modalParentSize = newSize
+    private func updateModalParentSize(with size: CGSize) {
+        if size != modalParentSize && size != .zero {
+            modalParentSize = size
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

WOOMOB-791

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Add transitions to barcode scanning flow. I aimed to do the same behavior as Android, coupling self-sizing modal animations with fade out/in transitions.

The largest challenge was coming up with a solution that supported not some but all of these points:
- Self-sizing modals
- Animating modal height during transitions
- Modal growing up to the point, then scrolling kicking-in for the content
- Fading out and fading in

Eventually, I managed to squeeze this behavior within the private `AnimatedTransitionContainer` view. I was hoping for something simpler, but I had to put more and more little pieces on logic to get the behavior that I wanted.

Additionally, I started passing `parentModalSize` environment variable from `POSModalViewModifier` to properly control self-sizing logic. Using `containerRelativeFrame` wasn't enough, since I wanted to have a flexible relative frame up to the max which is not possible to define with `containerRelativeFrame`.

There are a few more details in the UI that needs improvement to look like on designs, I will make them with WOOMOB-867

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad OS 17.6, 18.5 and 20.6.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Happy Path

https://github.com/user-attachments/assets/7cfb4aeb-58be-4e2f-8f5e-c79dd945fba6

### Large Dynamic Type Size

https://github.com/user-attachments/assets/3427fd24-64cc-41de-b655-9eca94d16545

### Android

https://github.com/user-attachments/assets/9c5dd943-a170-4c4e-abcd-6db3a5024c9d

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.