### PR TITLE
[POS as a tab i2] Update suggestion text in ineligible UI

### DIFF
--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -195,8 +195,8 @@ private extension POSIneligibleReason {
         switch self {
         case .featureSwitchDisabled:
             return NSLocalizedString(
-                "pos.ineligible.enable.pos.feature.and.refresh.button.title",
-                value: "Enable POS & Retry",
+                "pos.ineligible.enable.pos.feature.and.refresh.button.title.1",
+                value: "Enable POS feature",
                 comment: "Button title to enable the POS feature switch and refresh POS eligibility check"
             )
         case .unsupportedIOSVersion,

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -132,17 +132,18 @@ struct POSIneligibleView: View {
                                      value: "Point of Sale must be enabled to proceed. " +
                                      "You can enable the POS feature below or from your WordPress admin under WooCommerce settings > Advanced > Features.",
                                      comment: "Suggestion for disabled feature switch: enable feature in WooCommerce settings")
-        case let .unsupportedCurrency(supportedCurrencies):
+        case let .unsupportedCurrency(countryCode, supportedCurrencies):
             let currencyList = supportedCurrencies.map { $0.rawValue }
             let formattedCurrencyList = ListFormatter.localizedString(byJoining: currencyList)
             let format = NSLocalizedString(
-                "pos.ineligible.suggestion.unsupportedCurrency",
-                value: "The POS system is not available for your store’s currency. It currently supports only %1$@. " +
+                "pos.ineligible.suggestion.unsupportedCurrency.1",
+                value: "The POS system is not available for your store’s currency. In %1$@, it currently supports only %2$@. " +
                 "Please check your store currency settings or contact support for assistance.",
                 comment: "Suggestion for unsupported currency with list of supported currencies. " +
-                "%1$@ is a placeholder for the localized list of supported currency codes."
+                "%1$@ is a placeholder for the localized country name, " +
+                "and %2$@ is a placeholder for the localized list of supported currency codes."
             )
-            return String.localizedStringWithFormat(format, formattedCurrencyList)
+            return String.localizedStringWithFormat(format, countryCode.readableCountry, formattedCurrencyList)
         case .siteSettingsNotAvailable:
             return NSLocalizedString("pos.ineligible.suggestion.siteSettingsNotAvailable",
                                      value: "Check your internet connection and try again. If the issue persists, please contact support.",
@@ -216,7 +217,7 @@ private extension POSIneligibleReason {
 #Preview("Unsupported currency") {
     if #available(iOS 17.0, *) {
         POSIneligibleView(
-            reason: .unsupportedCurrency(supportedCurrencies: [.USD]),
+            reason: .unsupportedCurrency(countryCode: .US, supportedCurrencies: [.USD]),
             onRefresh: {}
         )
     }

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -112,8 +112,8 @@ struct POSIneligibleView: View {
     private var suggestionText: String {
         switch reason {
         case .unsupportedIOSVersion:
-            return NSLocalizedString("pos.ineligible.suggestion.unsupportedIOSVersion",
-                                     value: "Point of Sale requires iOS 17 or later. Please update your device to iOS 17+ to use this feature.",
+            return NSLocalizedString("pos.ineligible.suggestion.unsupportedIOSVersion.1",
+                                     value: "The POS system requires iOS 17 or later. Please update your device to iOS 17+ to use this feature.",
                                      comment: "Suggestion for unsupported iOS version: update iOS")
         case let .unsupportedWooCommerceVersion(minimumVersion):
             let format = NSLocalizedString("pos.ineligible.suggestion.unsupportedWooCommerceVersion",
@@ -123,14 +123,15 @@ struct POSIneligibleView: View {
                                      "%1$@ is a placeholder for the minimum required version.")
             return String.localizedStringWithFormat(format, minimumVersion)
         case .wooCommercePluginNotFound:
-            return NSLocalizedString("pos.ineligible.suggestion.wooCommercePluginNotFound.2",
-                                     value: "Please make sure the WooCommerce plugin is installed and activated from your WordPress admin. " +
-                                     "If there is still an issue, please contact support for assistance.",
+            return NSLocalizedString("pos.ineligible.suggestion.wooCommercePluginNotFound.3",
+                                     value: "We were unable to load the WooCommerce plugin info. Please make sure the WooCommerce plugin is installed " +
+                                     "and activated from your WordPress admin. If there is still an issue, contact support for assistance.",
                                      comment: "Suggestion for missing WooCommerce plugin: install plugin")
         case .featureSwitchDisabled:
-            return NSLocalizedString("pos.ineligible.suggestion.featureSwitchDisabled.2",
+            return NSLocalizedString("pos.ineligible.suggestion.featureSwitchDisabled.3",
                                      value: "Point of Sale must be enabled to proceed. " +
-                                     "You can enable the POS feature below or from your WordPress admin under WooCommerce settings > Advanced > Features.",
+                                     "Please enable the POS feature below or from your WordPress admin under WooCommerce settings > Advanced > Features " +
+                                     "and try again.",
                                      comment: "Suggestion for disabled feature switch: enable feature in WooCommerce settings")
         case let .unsupportedCurrency(countryCode, supportedCurrencies):
             let currencyList = supportedCurrencies.map { $0.rawValue }
@@ -145,8 +146,9 @@ struct POSIneligibleView: View {
             )
             return String.localizedStringWithFormat(format, countryCode.readableCountry, formattedCurrencyList)
         case .siteSettingsNotAvailable:
-            return NSLocalizedString("pos.ineligible.suggestion.siteSettingsNotAvailable",
-                                     value: "Check your internet connection and try again. If the issue persists, please contact support.",
+            return NSLocalizedString("pos.ineligible.suggestion.siteSettingsNotAvailable.1",
+                                     value: "We were unable to load the site settings info. Please check your internet connection and try again. " +
+                                     "If the issue persists, contact support for assistance.",
                                      comment: "Suggestion for site settings unavailable: check connection or contact support")
         case .selfDeallocated:
             return NSLocalizedString("pos.ineligible.suggestion.selfDeallocated",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -24,7 +24,7 @@ enum POSIneligibleReason: Equatable {
     case siteSettingsNotAvailable
     case wooCommercePluginNotFound
     case featureSwitchDisabled
-    case unsupportedCurrency(supportedCurrencies: [CurrencyCode])
+    case unsupportedCurrency(countryCode: CountryCode, supportedCurrencies: [CurrencyCode])
     case selfDeallocated
 }
 
@@ -212,7 +212,7 @@ private extension POSTabEligibilityChecker {
     enum SiteSettingsIneligibleReason {
         case siteSettingsNotAvailable
         case unsupportedCountry(supportedCountries: [CountryCode])
-        case unsupportedCurrency(supportedCurrencies: [CurrencyCode])
+        case unsupportedCurrency(countryCode: CountryCode, supportedCurrencies: [CurrencyCode])
     }
 
     func checkSiteSettingsEligibility() async -> POSEligibilityState {
@@ -227,8 +227,8 @@ private extension POSTabEligibilityChecker {
                 // changed to an unsupported country during the session. In this case, we return an ineligible reason that prompts the merchant to
                 // relaunch the app.
                 return .ineligible(reason: .siteSettingsNotAvailable)
-            case let .unsupportedCurrency(supportedCurrencies: supportedCurrencies):
-                return .ineligible(reason: .unsupportedCurrency(supportedCurrencies: supportedCurrencies))
+            case let .unsupportedCurrency(countryCode: countryCode, supportedCurrencies: supportedCurrencies):
+                return .ineligible(reason: .unsupportedCurrency(countryCode: countryCode, supportedCurrencies: supportedCurrencies))
             }
         }
     }
@@ -270,7 +270,7 @@ private extension POSTabEligibilityChecker {
 
         let supportedCurrenciesForCountry = supportedCurrencies[countryCode] ?? []
         guard supportedCurrenciesForCountry.contains(currencyCode) else {
-            return .ineligible(reason: .unsupportedCurrency(supportedCurrencies: supportedCurrenciesForCountry))
+            return .ineligible(reason: .unsupportedCurrency(countryCode: countryCode, supportedCurrencies: supportedCurrenciesForCountry))
         }
         return .eligible
     }

--- a/WooCommerce/WooCommerceTests/POS/ViewHelpers/PointOfSaleDashboardViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewHelpers/PointOfSaleDashboardViewHelperTests.swift
@@ -67,7 +67,7 @@ struct PointOfSaleDashboardViewHelperTests {
     @Test(arguments: [
         POSIneligibleReason.unsupportedIOSVersion,
         POSIneligibleReason.unsupportedWooCommerceVersion(minimumVersion: "9.6.0"),
-        POSIneligibleReason.unsupportedCurrency(supportedCurrencies: [.USD, .GBP]),
+        POSIneligibleReason.unsupportedCurrency(countryCode: .US, supportedCurrencies: [.USD, .GBP]),
         POSIneligibleReason.siteSettingsNotAvailable,
         POSIneligibleReason.wooCommercePluginNotFound,
         POSIneligibleReason.featureSwitchDisabled,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -451,7 +451,7 @@ struct POSTabEligibilityCheckerTests {
         let result = await checker.checkEligibility()
 
         // Then
-        #expect(result == .ineligible(reason: .unsupportedCurrency(supportedCurrencies: expectedSupportedCurrencies)))
+        #expect(result == .ineligible(reason: .unsupportedCurrency(countryCode: country.countryCode, supportedCurrencies: expectedSupportedCurrencies)))
     }
 
     func is_ineligible_when_woocommerce_version_is_below_minimum() async throws {
@@ -551,7 +551,7 @@ struct POSTabEligibilityCheckerTests {
 
     @Test(arguments: [
         POSIneligibleReason.siteSettingsNotAvailable,
-        POSIneligibleReason.unsupportedCurrency(supportedCurrencies: [.USD])
+        POSIneligibleReason.unsupportedCurrency(countryCode: .US, supportedCurrencies: [.USD])
     ])
     fileprivate func refreshEligibility_syncs_site_settings_and_checks_eligibility_for_site_settings_issues(ineligibleReason: POSIneligibleReason) async throws {
         // Given
@@ -586,7 +586,7 @@ struct POSTabEligibilityCheckerTests {
 
     @Test(arguments: [
         POSIneligibleReason.siteSettingsNotAvailable,
-        POSIneligibleReason.unsupportedCurrency(supportedCurrencies: [.USD])
+        POSIneligibleReason.unsupportedCurrency(countryCode: .US, supportedCurrencies: [.USD])
     ])
     fileprivate func refreshEligibility_returns_siteSettingsNotAvailable_when_site_settings_sync_fails(ineligibleReason: POSIneligibleReason) async throws {
         // Given
@@ -828,6 +828,19 @@ private extension POSTabEligibilityCheckerTests {
         case ca = "CA:NS"
         case gb = "GB"
         case es = "ES"
+
+        var countryCode: CountryCode {
+            switch self {
+            case .us:
+                return .US
+            case .ca:
+                return .CA
+            case .gb:
+                return .GB
+            case .es:
+                return .ES
+            }
+        }
     }
 
     func mockCountrySetting(country: Country, siteID: Int64? = nil) -> SiteSetting {


### PR DESCRIPTION
For WOOMOB-919

Just one review is required.

## Description

This PR updates the suggestion text for the unsupported currency ineligible case to include the store country code, plus 4 more ineligible cases with minor copy updates from the latest design shared today y0zZLi1kqybNUUUd8lmvYG-fi-4336_3140.

The main changes include:
- Updated the `unsupportedCurrency` enum case to include a `countryCode` parameter alongside `supportedCurrencies`
- Modified the suggestion text to display the merchant's store country for better context
- Fixed unit test build failures
- Updated the suggestion text copy for 4 other cases
- Updated the CTA copy for "POS feature disabled" case

## Steps to reproduce

1. Set up a store with an unsupported currency for POS (e.g., EUR/CAD in US, USD in GB)
2. Tap on the POS tab --> the suggestion text now includes the store country information

## Testing information

I tested the ineligible cases with pure copy updates in SwiftUI previews.

## Screenshots

Unsupported currency | POS feature disabled
-- | -- 
<img width="500" alt="Simulator Screenshot - iPad (A16) - 2025-07-23 at 16 24 44" src="https://github.com/user-attachments/assets/754e71ab-7505-4664-bb8c-c5e20759707d" /> | <img width="500" alt="Simulator Screenshot - iPad (A16) - 2025-07-24 at 09 50 35" src="https://github.com/user-attachments/assets/413a3f0e-5b38-4fcc-8341-376c5f66e370" />

Other 3 cases were tested in previews:

🗒️ the retry CTA copy is still being confirmed in y0zZLi1kqybNUUUd8lmvYG-fi-4133_4679#1348241139. I will make a decision before code freeze.

unsupported iOS version | WC plugin not found | site settings unavailable
-- | -- | --
<img width="1068" height="738" alt="Screenshot 2025-07-23 at 4 32 17 PM" src="https://github.com/user-attachments/assets/58afed61-bf79-4d05-aec9-52817129f0dd" /> | <img width="1061" height="742" alt="Screenshot 2025-07-23 at 4 35 19 PM" src="https://github.com/user-attachments/assets/af872137-73e1-4912-9275-6d31a1897256" /> | <img width="1059" height="743" alt="Screenshot 2025-07-23 at 4 52 54 PM" src="https://github.com/user-attachments/assets/12e3e08d-7f72-4259-88bc-7c5f907cdb29" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.