### PR TITLE
[Shipping Labels] Woomob 891 make hs tariff number mandatory for eu destination

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 23.0
 -----
-
+- [*] Shipping Labels: Made HS tariff number field required in customs form for EU destinations [https://github.com/woocommerce/woocommerce-ios/pull/15946]
 
 22.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -511,7 +511,13 @@ private extension WooShippingShipmentDetailsViewModel {
     func isHSTariffNumberRequiredPublisher() -> AnyPublisher<Bool, Never> {
         $destinationAddress
             /// HS tariff number is required for EU countries
-            .map { _ in return false }
+            .map { address in
+                guard let address else {
+                    return false
+                }
+
+                return Country.countriesFollowingEUCustoms.contains(address.country)
+            }
             .eraseToAnyPublisher()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -70,6 +70,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
             order: order,
             shipment: shipment,
             originCountryCode: originCountryCodePublisher(),
+            isHSTariffNumberRequired: isHSTariffNumberRequiredPublisher(),
             storageManager: storageManager
         ) { [weak self] form in
             self?.customsForm = form
@@ -504,6 +505,13 @@ private extension WooShippingShipmentDetailsViewModel {
     func originCountryCodePublisher() -> AnyPublisher<String?, Never> {
         $originAddress
             .map(\.?.country)
+            .eraseToAnyPublisher()
+    }
+
+    func isHSTariffNumberRequiredPublisher() -> AnyPublisher<Bool, Never> {
+        $destinationAddress
+            /// HS tariff number is required for EU countries
+            .map { _ in return false }
             .eraseToAnyPublisher()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsFormViewModel.swift
@@ -42,6 +42,7 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
     init(order: Order,
          shipment: Shipment,
          originCountryCode: AnyPublisher<String?, Never>? = nil,
+         isHSTariffNumberRequired: AnyPublisher<Bool, Never>? = nil,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          onFormReady: @escaping (ShippingLabelCustomsForm) -> ()) {
         self.onFormReady = onFormReady
@@ -54,6 +55,7 @@ final class WooShippingCustomsFormViewModel: ObservableObject {
                                             itemWeight: $0.weight,
                                             currencySymbol: currencySymbol(from: order),
                                             originCountryCode: originCountryCode,
+                                            isHSTariffNumberRequired: isHSTariffNumberRequired,
                                             storageManager: storageManager)
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -105,15 +105,29 @@ struct WooShippingCustomsItem: View {
                     .subheadlineStyle()
                     .padding(.top, Layout.collapsibleViewVerticalSpacing)
 
-                TextField(Localization.HSTariffNumberPlaceholder, text: $viewModel.hsTariffNumber)
-                    .keyboardType(.numberPad)
-                    .padding(Layout.extraPadding)
-                    .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderLineWidth)
+                /// HS tariff number
+                TextField(
+                    viewModel.isHSTariffNumberRequired ? "" : Localization.HSTariffNumberPlaceholder,
+                    text: $viewModel.hsTariffNumber
+                )
+                .keyboardType(.numberPad)
+                .padding(Layout.extraPadding)
+                .roundedBorder(
+                    cornerRadius: Layout.borderCornerRadius,
+                    lineColor: (viewModel.isHSTariffNumberRequired && viewModel.hsTariffNumber.isEmpty) ? warningRedColor : Color(.separator),
+                    lineWidth: Layout.borderLineWidth
+                )
+
+                Text(Localization.valueRequiredWarningText)
+                    .foregroundColor(warningRedColor)
+                    .footnoteStyle()
+                    .renderedIf(viewModel.isHSTariffNumberRequired && viewModel.hsTariffNumber.isEmpty)
 
                 Text(Localization.tariffNumberRulesWarningText)
                     .foregroundColor(warningRedColor)
                     .footnoteStyle()
                     .renderedIf(!viewModel.isValidTariffNumber)
+                ///
 
                 Button {
                     isShowingHSTarrifInfoWebView = true

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItem.swift
@@ -127,7 +127,6 @@ struct WooShippingCustomsItem: View {
                     .foregroundColor(warningRedColor)
                     .footnoteStyle()
                     .renderedIf(!viewModel.isValidTariffNumber)
-                ///
 
                 Button {
                     isShowingHSTarrifInfoWebView = true

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -69,7 +69,7 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
     ///
     /// Introduced to enforce tariff validation
     /// if `true` then `hsTariffNumber` must be valid for `requiredInformationIsEntered` to be `true`
-    private let isHSTariffNumberRequired: Bool
+    @Published private var isHSTariffNumberRequired: Bool = false
 
     init(itemName: String,
          itemProductID: Int64,
@@ -77,8 +77,8 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
          itemValue: Double,
          itemWeight: Double,
          currencySymbol: String,
-         isHSTariffNumberRequired: Bool = false,
          originCountryCode: AnyPublisher<String?, Never>? = nil,
+         isHSTariffNumberRequired: AnyPublisher<Bool, Never>? = nil,
          storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.title = itemName
         self.description = itemName
@@ -93,10 +93,12 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
 
         self.currencySymbol = currencySymbol
         self.storageManager = storageManager
-        self.isHSTariffNumberRequired = isHSTariffNumberRequired
 
         originCountryCode?
             .assign(to: &$originCountryCode)
+
+        isHSTariffNumberRequired?
+            .assign(to: &$isHSTariffNumberRequired)
 
         fetchCountries()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -151,7 +151,7 @@ private extension WooShippingCustomsItemViewModel {
 
             let ((description, valuePerUnit, weightPerUnit, selectedCountry), hsTariffNumber, isHSTariffNumberRequired) = result
 
-            let hsTariffNumberRequirementMet = hsTariffNumber.isEmpty && !isHSTariffNumberRequired || isValidTariffNumber && hsTariffNumber.isNotEmpty
+            let hsTariffNumberRequirementMet = (hsTariffNumber.isEmpty && !isHSTariffNumberRequired) || (isValidTariffNumber && hsTariffNumber.isNotEmpty)
 
             requiredInformationIsEntered = description.isNotEmpty &&
             valuePerUnit.isNotEmpty &&

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -69,7 +69,7 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
     ///
     /// Introduced to enforce tariff validation
     /// if `true` then `hsTariffNumber` must be valid for `requiredInformationIsEntered` to be `true`
-    @Published private var isHSTariffNumberRequired: Bool = false
+    @Published private(set) var isHSTariffNumberRequired: Bool = false
 
     init(itemName: String,
          itemProductID: Int64,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -145,13 +145,13 @@ private extension WooShippingCustomsItemViewModel {
             $weightPerUnit,
             $selectedCountry
         )
-        .combineLatest($hsTariffNumber)
+        .combineLatest($hsTariffNumber, $isHSTariffNumberRequired)
         .sink { [weak self] result in
             guard let self else { return }
 
-            let ((description, valuePerUnit, weightPerUnit, selectedCountry), hsTariffNumber) = result
+            let ((description, valuePerUnit, weightPerUnit, selectedCountry), hsTariffNumber, isHSTariffNumberRequired) = result
 
-            let hsTariffNumberRequirementMet = hsTariffNumber.isEmpty && !isHSTariffNumberRequired || isValidTariffNumber
+            let hsTariffNumberRequirementMet = hsTariffNumber.isEmpty && !isHSTariffNumberRequired || isValidTariffNumber && hsTariffNumber.isNotEmpty
 
             requiredInformationIsEntered = description.isNotEmpty &&
             valuePerUnit.isNotEmpty &&

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsItemViewModel.swift
@@ -64,12 +64,20 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
 
+    /// WOOMOB-891
+    /// Shipments with a EU destination address must contain HS tariff number
+    ///
+    /// Introduced to enforce tariff validation
+    /// if `true` then `hsTariffNumber` must be valid for `requiredInformationIsEntered` to be `true`
+    private let isHSTariffNumberRequired: Bool
+
     init(itemName: String,
          itemProductID: Int64,
          itemQuantity: Decimal,
          itemValue: Double,
          itemWeight: Double,
          currencySymbol: String,
+         isHSTariffNumberRequired: Bool = false,
          originCountryCode: AnyPublisher<String?, Never>? = nil,
          storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.title = itemName
@@ -85,6 +93,7 @@ final class WooShippingCustomsItemViewModel: ObservableObject {
 
         self.currencySymbol = currencySymbol
         self.storageManager = storageManager
+        self.isHSTariffNumberRequired = isHSTariffNumberRequired
 
         originCountryCode?
             .assign(to: &$originCountryCode)
@@ -128,15 +137,27 @@ private extension WooShippingCustomsItemViewModel {
     }
 
     func combineRequiredInformationIsEntered() {
-        Publishers.CombineLatest4($description, $valuePerUnit, $weightPerUnit, $selectedCountry)
-            .sink { [weak self] description, valuePerUnit, weightPerUnit, selectedCountry in
-                guard let self else { return }
-                requiredInformationIsEntered = description.isNotEmpty &&
-                valuePerUnit.isNotEmpty &&
-                Self.isWeightValid(weightPerUnit) &&
-                selectedCountry != nil
-            }
-            .store(in: &cancellables)
+        Publishers.CombineLatest4(
+            $description,
+            $valuePerUnit,
+            $weightPerUnit,
+            $selectedCountry
+        )
+        .combineLatest($hsTariffNumber)
+        .sink { [weak self] result in
+            guard let self else { return }
+
+            let ((description, valuePerUnit, weightPerUnit, selectedCountry), hsTariffNumber) = result
+
+            let hsTariffNumberRequirementMet = hsTariffNumber.isEmpty && !isHSTariffNumberRequired || isValidTariffNumber
+
+            requiredInformationIsEntered = description.isNotEmpty &&
+            valuePerUnit.isNotEmpty &&
+            Self.isWeightValid(weightPerUnit) &&
+            selectedCountry != nil &&
+            hsTariffNumberRequirementMet
+        }
+        .store(in: &cancellables)
     }
 
     func combineHSTariffNumberTotalValue() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
@@ -836,6 +836,76 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(customsItemViewModel.selectedCountry?.code, expectedCountry)
     }
 
+    func test_customs_form_is_incomplete_when_destination_country_is_eu_and_hsTariffNumber_is_empty() throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let storageManager = MockStorageManager()
+
+        let originAddressSubject = PassthroughSubject<WooShippingAddress?, Never>()
+        let destinationAddressSubject = PassthroughSubject<WooShippingAddress?, Never>()
+
+        let usCountry = Country(code: "US", name: "United States", states: [])
+        let caCountry = Country(code: "CA", name: "Canada", states: [])
+        let euCountries = [
+            Country(code: "FR", name: "France", states: []),
+            Country(code: "DE", name: "Germany", states: []),
+            Country(code: "ES", name: "Spain", states: []),
+            Country(code: "IT", name: "Italy", states: []),
+            Country(code: "NL", name: "Netherlands", states: [])
+        ]
+        storageManager.insertSampleCountries(readOnlyCountries: [usCountry, caCountry] + euCountries)
+
+        let item = ShippingLabelPackageItem(
+            productOrVariationID: 1,
+            orderItemID: 1,
+            name: "Test Item",
+            weight: 1,
+            quantity: 1,
+            value: 10, // low value, shouldn't require HS Tariff # based on value
+            dimensions: .fake(),
+            attributes: [],
+            imageURL: nil
+        )
+        let shipment = Shipment(
+            contents: [CollapsibleShipmentItemCardViewModel(item: item, currency: "USD")],
+            currency: "USD",
+            currencySettings: ServiceLocator.currencySettings,
+            shippingSettingsService: ServiceLocator.shippingSettingsService
+        )
+
+        let viewModel = WooShippingShipmentDetailsViewModel(
+            order: Order.fake(),
+            shipment: shipment,
+            shippingLabel: nil,
+            originAddress: originAddressSubject.eraseToAnyPublisher(),
+            destinationAddress: destinationAddressSubject.eraseToAnyPublisher(),
+            stores: stores,
+            storageManager: storageManager
+        )
+
+        // When
+        let itemViewModel = viewModel.customsFormViewModel.itemsViewModels[0]
+        itemViewModel.hsTariffNumber = "" // Empty tariff number
+
+        originAddressSubject.send(sampleOriginAddress(country: usCountry.code, state: ""))
+        destinationAddressSubject.send(sampleDestinationAddress(country: caCountry.code, state: ""))
+
+        // Then: HS Tariff number should not be required for non EU destination countries regardless of value
+        XCTAssertTrue(
+            itemViewModel.requiredInformationIsEntered,
+            "HS Tariff number should not be required for \(usCountry.name)"
+        )
+
+        // And: HS Tariff number should be required for EU countries regardless of value
+        for euCountry in euCountries {
+            destinationAddressSubject.send(sampleDestinationAddress(country: euCountry.code, state: ""))
+            XCTAssertFalse(
+                itemViewModel.requiredInformationIsEntered,
+                "HS Tariff number should be required for \(euCountry.name)"
+            )
+        }
+    }
+
     func test_package_contains_complete_customs_form_when_required_data_is_prefilled() throws {
         // Setup
         let originAddressSubject = PassthroughSubject<WooShippingAddress?, Never>()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
Part of: WOOMOB-891

## Description

Makes the HS tariff number required for shipments where destination country is in EU.


- Adds explicit `isHSTariffNumberRequired` var for `WooShippingCustomsItemViewModel` that's driven by destination country being a member of `Country.countriesFollowingEUCustoms`.
- `isHSTariffNumberRequired` participates in `requiredInformationIsEntered` calculation. 
- Makes the HS tariff number field as a required field in the `WooShippingCustomsItem` view:
    - Renders "value required" warning if destination country is EU and the HS tariff number is empty
    - Renders red border if destination country is EU and the HS tariff number is empty
    - Removes "Optional" placeholder in case if the HS tariff number is required.

## Testing Steps

- Navigate to a completed order with an unfulfilled shipment
- Just in case make sure the total value for products in the shipment is below the 2500 threshold
- Set a foreign destination address - for example some public address in Canada
- Fill in missing shipment details.
- Make sure the HS tariff field for customs form product items is optional
- Switch shipment destination address to a EU country. Consider using some public address.
- Make sure the customs section becomes incomplete.
- Make sure the product HS tariff field is now a required field.
- Enter HS tariff numbers for incomplete product customs cards and save the form
- Make sure the customs section is now complete
- Make sure label purchase flow is unlocked

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.