### PR TITLE
Update WC plugin matching to use the file name in plugin path: use cases that match plugin by name - part 3

### DIFF
--- a/Modules/Sources/Yosemite/Model/Enums/CardPresentPaymentsPlugin.swift
+++ b/Modules/Sources/Yosemite/Model/Enums/CardPresentPaymentsPlugin.swift
@@ -13,12 +13,12 @@ public enum CardPresentPaymentsPlugin: Equatable, CaseIterable {
         }
     }
 
-    public var fileNameWithoutExtension: String {
+    public var plugin: Plugin {
         switch self {
         case .wcPay:
-            return "woocommerce-payments"
+            return .wooPayments
         case .stripe:
-            return "woocommerce-gateway-stripe"
+            return .stripe
         }
     }
 

--- a/Modules/Sources/Yosemite/Tools/Plugin.swift
+++ b/Modules/Sources/Yosemite/Tools/Plugin.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public enum Plugin: Equatable, CaseIterable {
+    case blaze
     case jetpack
     case googleListingsAndAds
     case stripe
@@ -38,6 +39,8 @@ public enum Plugin: Equatable, CaseIterable {
     /// Full plugin path is like `woocommerce/woocommerce.php`.
     var fileNameWithoutExtension: String {
         switch self {
+        case .blaze:
+            return "blaze-ads"
         case .jetpack:
             return "jetpack"
         case .googleListingsAndAds:

--- a/Modules/Sources/Yosemite/Tools/Plugin.swift
+++ b/Modules/Sources/Yosemite/Tools/Plugin.swift
@@ -1,23 +1,47 @@
 import Foundation
 
 public enum Plugin: Equatable, CaseIterable {
+    case googleListingsAndAds
     case stripe
     case wooCommerce
+    case wooCompositeProducts
+    case wooGiftCards
     case wooPayments
+    case wooProductBundles
     case wooSubscriptions
     case wooShipmentTracking
     case wooSquare
+
+    /// Creates a Plugin from a SystemPlugin by matching the plugin file name in the plugin path.
+    /// Returns nil if the SystemPlugin doesn't match any known Plugin case.
+    ///
+    /// - Parameter systemPlugin: The SystemPlugin to convert.
+    public init?(systemPlugin: SystemPlugin) {
+        let pluginFileNameWithoutExtension = systemPlugin.fileNameWithoutExtension
+        guard let plugin = Plugin.allCases.first(where: { $0.fileNameWithoutExtension == pluginFileNameWithoutExtension }) else {
+            return nil
+        }
+        self = plugin
+    }
 
     /// File name without extension in the plugin path.
     /// Full plugin path is like `woocommerce/woocommerce.php`.
     var fileNameWithoutExtension: String {
         switch self {
+        case .googleListingsAndAds:
+            return "google-listings-and-ads"
         case .stripe:
             return "woocommerce-gateway-stripe"
         case .wooCommerce:
             return "woocommerce"
+        case .wooCompositeProducts:
+            return "woocommerce-composite-products"
+        case .wooGiftCards:
+            return "woocommerce-gift-cards"
         case .wooPayments:
             return "woocommerce-payments"
+        case .wooProductBundles:
+            return "woocommerce-product-bundles"
         case .wooSubscriptions:
             return "woocommerce-subscriptions"
         case .wooShipmentTracking:
@@ -25,5 +49,11 @@ public enum Plugin: Equatable, CaseIterable {
         case .wooSquare:
             return "woocommerce-square"
         }
+    }
+}
+
+extension SystemPlugin {
+    var fileNameWithoutExtension: String {
+        ((plugin as NSString).lastPathComponent as NSString).deletingPathExtension
     }
 }

--- a/Modules/Sources/Yosemite/Tools/Plugin.swift
+++ b/Modules/Sources/Yosemite/Tools/Plugin.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public enum Plugin: Equatable, CaseIterable {
+    case jetpack
     case googleListingsAndAds
     case stripe
     case wooCommerce
@@ -28,6 +29,8 @@ public enum Plugin: Equatable, CaseIterable {
     /// Full plugin path is like `woocommerce/woocommerce.php`.
     var fileNameWithoutExtension: String {
         switch self {
+        case .jetpack:
+            return "jetpack"
         case .googleListingsAndAds:
             return "google-listings-and-ads"
         case .stripe:

--- a/Modules/Sources/Yosemite/Tools/Plugin.swift
+++ b/Modules/Sources/Yosemite/Tools/Plugin.swift
@@ -8,10 +8,22 @@ public enum Plugin: Equatable, CaseIterable {
     case wooCompositeProducts
     case wooGiftCards
     case wooPayments
+    case wooPayPal
     case wooProductBundles
     case wooSubscriptions
     case wooShipmentTracking
     case wooSquare
+
+    /// Creates a Plugin from a plugin file name in the plugin path.
+    /// Returns nil if the file name doesn't match any known Plugin case.
+    ///
+    /// - Parameter systemPlugin: The SystemPlugin to convert.
+    public init?(fileNameWithoutExtension: String) {
+        guard let plugin = Plugin.allCases.first(where: { $0.fileNameWithoutExtension == fileNameWithoutExtension }) else {
+            return nil
+        }
+        self = plugin
+    }
 
     /// Creates a Plugin from a SystemPlugin by matching the plugin file name in the plugin path.
     /// Returns nil if the SystemPlugin doesn't match any known Plugin case.
@@ -19,10 +31,7 @@ public enum Plugin: Equatable, CaseIterable {
     /// - Parameter systemPlugin: The SystemPlugin to convert.
     public init?(systemPlugin: SystemPlugin) {
         let pluginFileNameWithoutExtension = systemPlugin.fileNameWithoutExtension
-        guard let plugin = Plugin.allCases.first(where: { $0.fileNameWithoutExtension == pluginFileNameWithoutExtension }) else {
-            return nil
-        }
-        self = plugin
+        self.init(fileNameWithoutExtension: pluginFileNameWithoutExtension)
     }
 
     /// File name without extension in the plugin path.
@@ -43,6 +52,8 @@ public enum Plugin: Equatable, CaseIterable {
             return "woocommerce-gift-cards"
         case .wooPayments:
             return "woocommerce-payments"
+        case .wooPayPal:
+            return "woocommerce-paypal-payments"
         case .wooProductBundles:
             return "woocommerce-product-bundles"
         case .wooSubscriptions:

--- a/Modules/Sources/Yosemite/Tools/Plugin.swift
+++ b/Modules/Sources/Yosemite/Tools/Plugin.swift
@@ -69,7 +69,7 @@ public enum Plugin: Equatable, CaseIterable {
     }
 }
 
-extension SystemPlugin {
+private extension SystemPlugin {
     var fileNameWithoutExtension: String {
         ((plugin as NSString).lastPathComponent as NSString).deletingPathExtension
     }

--- a/Modules/Tests/YosemiteTests/Tools/PluginTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/PluginTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+import Networking
+
+@testable import Yosemite
+
+struct PluginTests {
+    @Test(arguments: [
+        ("blaze-ads/blaze-ads.php", Plugin.blaze),
+        ("jetpack/jetpack.php", Plugin.jetpack),
+        ("google-listings-and-ads/google-listings-and-ads.php", Plugin.googleListingsAndAds),
+        ("woocommerce-gateway-stripe/woocommerce-gateway-stripe.php", Plugin.stripe),
+        ("woocommerce/woocommerce.php", Plugin.wooCommerce),
+        ("woocommerce-composite-products/woocommerce-composite-products.php", Plugin.wooCompositeProducts),
+        ("woocommerce-gift-cards/woocommerce-gift-cards.php", Plugin.wooGiftCards),
+        ("woocommerce-payments/woocommerce-payments.php", Plugin.wooPayments),
+        ("woocommerce-paypal-payments/woocommerce-paypal-payments.php", Plugin.wooPayPal),
+        ("woocommerce-product-bundles/woocommerce-product-bundles.php", Plugin.wooProductBundles),
+        ("woocommerce-subscriptions/woocommerce-subscriptions.php", Plugin.wooSubscriptions),
+        ("woocommerce-shipment-tracking/woocommerce-shipment-tracking.php", Plugin.wooShipmentTracking),
+        ("woocommerce-square/woocommerce-square.php", Plugin.wooSquare),
+        // Altered paths
+        ("_woocommerce-subscriptions/woocommerce-subscriptions.php", .wooSubscriptions),
+        ("woocommerce-subscriptions.php", .wooSubscriptions),
+        ("test/woocommerce-dev.php", nil)
+    ])
+    func init_with_systemPlugin_returns_correct_plugin(pluginPath: String, expectedPlugin: Plugin?) {
+        // Given
+        let systemPlugin = SystemPlugin.fake().copy(
+            siteID: 134,
+            plugin: pluginPath,
+            active: true
+        )
+
+        // When
+        let plugin = Plugin(systemPlugin: systemPlugin)
+
+        // Then
+        #expect(plugin == expectedPlugin)
+    }
+
+    @Test func init_with_systemPlugin_returns_nil_for_unknown_plugin() {
+        // Given
+        let systemPlugin = SystemPlugin.fake().copy(
+            siteID: 134,
+            plugin: "unknown-plugin/unknown-plugin.php"
+        )
+
+        // When
+        let plugin = Plugin(systemPlugin: systemPlugin)
+
+        // Then
+        #expect(plugin == nil)
+    }
+
+    @Test func init_with_systemPlugin_returns_nil_for_empty_plugin_path() {
+        // Given
+        let systemPlugin = SystemPlugin.fake().copy(
+            plugin: ""
+        )
+
+        // When
+        let plugin = Plugin(systemPlugin: systemPlugin)
+
+        // Then
+        #expect(plugin == nil)
+    }
+
+    // MARK: - `init(fileNameWithoutExtension:)`
+
+    @Test(arguments: [
+        ("blaze-ads", Plugin.blaze),
+        ("jetpack", Plugin.jetpack),
+        ("google-listings-and-ads", Plugin.googleListingsAndAds),
+        ("woocommerce-gateway-stripe", Plugin.stripe),
+        ("woocommerce", Plugin.wooCommerce),
+        ("woocommerce-composite-products", Plugin.wooCompositeProducts),
+        ("woocommerce-gift-cards", Plugin.wooGiftCards),
+        ("woocommerce-payments", Plugin.wooPayments),
+        ("woocommerce-paypal-payments", Plugin.wooPayPal),
+        ("woocommerce-product-bundles", Plugin.wooProductBundles),
+        ("woocommerce-subscriptions", Plugin.wooSubscriptions),
+        ("woocommerce-shipment-tracking", Plugin.wooShipmentTracking),
+        ("woocommerce-square", Plugin.wooSquare)
+    ])
+    func init_with_fileNameWithoutExtension_returns_correct_plugin(fileName: String, expectedPlugin: Plugin) {
+        // When
+        let plugin = Plugin(fileNameWithoutExtension: fileName)
+
+        // Then
+        #expect(plugin == expectedPlugin)
+    }
+
+    @Test func init_with_fileNameWithoutExtension_returns_nil_for_unknown_filename() {
+        // When
+        let plugin = Plugin(fileNameWithoutExtension: "wooooocommerce")
+
+        // Then
+        #expect(plugin == nil)
+    }
+
+    @Test func init_with_fileNameWithoutExtension_returns_nil_for_empty_filename() {
+        // When
+        let plugin = Plugin(fileNameWithoutExtension: "")
+
+        // Then
+        #expect(plugin == nil)
+    }
+}

--- a/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
+++ b/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
@@ -71,18 +71,12 @@ private extension BlazeEligibilityChecker {
             stores.dispatch(SystemStatusAction.synchronizeSystemInformation(siteID: siteID) { result in
                 switch result {
                 case .success(let info):
-                    let plugin = info.systemPlugins.first(where: { $0.plugin == Constants.pluginSlug })
+                    let plugin = info.systemPlugins.first(where: { Plugin(systemPlugin: $0) == .blaze && $0.active })
                     continuation.resume(returning: plugin)
                 case .failure:
                     continuation.resume(returning: nil)
                 }
             })
         }
-    }
-}
-
-private extension BlazeEligibilityChecker {
-    enum Constants {
-        static let pluginSlug = "blaze-ads/blaze-ads.php"
     }
 }

--- a/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
+++ b/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
@@ -3,14 +3,6 @@ import Yosemite
 /// Defines the names of the Site Plugins officially supported by the app.
 ///
 extension SitePlugin {
-    enum SupportedPlugin {
-        public static let WCSubscriptions = ["WooCommerce Subscriptions", "Woo Subscriptions"]
-        public static let WCProductBundles = ["WooCommerce Product Bundles", "Woo Product Bundles"]
-        public static let WCCompositeProducts = "WooCommerce Composite Products"
-        public static let WCGiftCards = ["WooCommerce Gift Cards", "Woo Gift Cards"]
-        public static let GoogleForWooCommerce = ["Google Listings and Ads", "Google for WooCommerce"]
-    }
-
     enum SupportedPluginPath {
         public static let LegacyWCShip = "woocommerce-services/woocommerce-services.php"
         public static let WooShipping = "woocommerce-shipping/woocommerce-shipping.php"

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
@@ -49,7 +49,7 @@ private extension DefaultGoogleAdsEligibilityChecker {
             stores.dispatch(SystemStatusAction.synchronizeSystemInformation(siteID: siteID) { result in
                 switch result {
                 case .success(let info):
-                    let plugin = info.systemPlugins.first(where: { $0.plugin == Constants.pluginSlug })
+                    let plugin = info.systemPlugins.first(where: { Plugin(systemPlugin: $0) == .googleListingsAndAds && $0.active })
                     continuation.resume(returning: plugin)
                 case .failure:
                     continuation.resume(returning: nil)
@@ -76,8 +76,6 @@ private extension DefaultGoogleAdsEligibilityChecker {
     }
 
     enum Constants {
-        static let pluginSlug = "google-listings-and-ads/google-listings-and-ads.php"
-
         /// Version 2.7.7 is required for an optimized experience of the plugin on the mobile web.
         /// Ref: https://github.com/woocommerce/google-listings-and-ads/releases/tag/2.7.7.
         /// We can remove this limit once we support native experience.

--- a/WooCommerce/Classes/Tools/CardPresentPluginsDataProvider.swift
+++ b/WooCommerce/Classes/Tools/CardPresentPluginsDataProvider.swift
@@ -95,12 +95,6 @@ struct CardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol {
         }
         return storageManager.viewStorage
             .loadSystemPlugins(siteID: siteID).map { $0.toReadOnly() }
-            .first(where: { $0.fileNameWithoutExtension == configuration.fileNameWithoutExtension })
-    }
-}
-
-extension Yosemite.SystemPlugin {
-    var fileNameWithoutExtension: String {
-        ((plugin as NSString).lastPathComponent as NSString).deletingPathExtension
+            .first(where: { Plugin(systemPlugin: $0) == configuration.plugin })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomersListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomersListViewModel.swift
@@ -329,7 +329,6 @@ private extension CustomersListViewModel {
     }
 
     enum Constants {
-        static let wcPluginName = "WooCommerce"
         static let wcPluginMinimumVersion = "8.0.0-beta.1"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -258,7 +258,7 @@ final class AnalyticsHubViewModel: ObservableObject {
     ///
     private var timeRangeSelection: AnalyticsHubTimeRangeSelection
 
-    /// Names of the active plugins on the store.
+    /// A list of known active plugins on the store.
     ///
     private lazy var activePlugins: [Plugin] = {
         let predicate = NSPredicate(format: "siteID == %lld && active == true", siteID)
@@ -570,9 +570,9 @@ private extension AnalyticsHubViewModel {
         }
     }
 
-    /// Helper function that returns `true` in its callback if the provided plugin is active on the  store.
+    /// Helper function that returns `true` in its callback if the provided plugin is active on the store.
     ///
-    /// - Parameter plugin: A list of known plugins.
+    /// - Parameter plugin: Plugin to check.
     private func isPluginActive(_ plugin: Plugin) -> Bool {
         activePlugins.contains(plugin)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -164,11 +164,11 @@ final class AnalyticsHubViewModel: ObservableObject {
         case .sessions:
             isEligibleForSessionsCard
         case .bundles:
-            isPluginActive(SitePlugin.SupportedPlugin.WCProductBundles)
+            isPluginActive(.wooProductBundles)
         case .giftCards:
-            isPluginActive(SitePlugin.SupportedPlugin.WCGiftCards)
+            isPluginActive(.wooGiftCards)
         case .googleCampaigns:
-            isPluginActive(SitePlugin.SupportedPlugin.GoogleForWooCommerce) && googleCampaignsCard.isEligibleForGoogleAds
+            isPluginActive(.googleListingsAndAds) && googleCampaignsCard.isEligibleForGoogleAds
         default:
             true
         }
@@ -260,7 +260,7 @@ final class AnalyticsHubViewModel: ObservableObject {
 
     /// Names of the active plugins on the store.
     ///
-    private lazy var activePlugins: [String] = {
+    private lazy var activePlugins: [Plugin] = {
         let predicate = NSPredicate(format: "siteID == %lld && active == true", siteID)
         let resultsController = ResultsController<StorageSystemPlugin>(storageManager: storage, matching: predicate, sortedBy: [])
         do {
@@ -268,7 +268,7 @@ final class AnalyticsHubViewModel: ObservableObject {
         } catch {
             DDLogError("⛔️ Error fetching active plugins for Analytics Hub")
         }
-        return resultsController.fetchedObjects.map { $0.name }
+        return resultsController.fetchedObjects.compactMap { Plugin(systemPlugin: $0) }
     }()
 
     /// Request stats data from network
@@ -570,11 +570,11 @@ private extension AnalyticsHubViewModel {
         }
     }
 
-    /// Helper function that returns `true` in its callback if the provided plugin name is active on the  store.
+    /// Helper function that returns `true` in its callback if the provided plugin is active on the  store.
     ///
-    /// - Parameter plugin: A list of names for the plugin (provide all possible names for plugins that have changed names).
-    private func isPluginActive(_ plugin: [String]) -> Bool {
-        activePlugins.contains(where: plugin.contains)
+    /// - Parameter plugin: A list of known plugins.
+    private func isPluginActive(_ plugin: Plugin) -> Bool {
+        activePlugins.contains(plugin)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -346,8 +346,7 @@ private extension JetpackSetupCoordinator {
             stores.dispatch(SystemStatusAction.synchronizeSystemInformation(siteID: 0) { result in
                 switch result {
                 case let .success(systemInformation):
-                    if let plugin = systemInformation.systemPlugins.first(where: { $0.name.lowercased() == Constants.jetpackPluginName.lowercased() }),
-                       plugin.active {
+                    if let plugin = systemInformation.systemPlugins.first(where: { Plugin(systemPlugin: $0) == .jetpack && $0.active }) {
                         continuation.resume(returning: true)
                     } else {
                         continuation.resume(returning: false)
@@ -504,7 +503,6 @@ private extension JetpackSetupCoordinator {
 
     enum Constants {
         static let magicLinkUrlHostname = "magic-login"
-        static let jetpackPluginName = "Jetpack"
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/WooSubscriptions/WooSubscriptionProductsEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/WooSubscriptions/WooSubscriptionProductsEligibilityChecker.swift
@@ -40,8 +40,8 @@ final class WooSubscriptionProductsEligibilityChecker: WooSubscriptionProductsEl
 
 private extension WooSubscriptionProductsEligibilityChecker {
     func isWooSubscriptionsPluginActive() -> Bool {
-        let activePluginNames = resultsController.fetchedObjects
-            .map { $0.name }
-        return Set(activePluginNames).intersection(SitePlugin.SupportedPlugin.WCSubscriptions).count > 0
+        let activePlugins = resultsController.fetchedObjects
+            .compactMap { Plugin(systemPlugin: $0) }
+        return activePlugins.contains(.wooSubscriptions)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductPasswordEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductPasswordEligibilityUseCase.swift
@@ -43,13 +43,12 @@ final class ProductPasswordEligibilityUseCase {
     private func getSystemPlugin(siteID: Int64) -> Yosemite.SystemPlugin? {
         return storageManager.viewStorage
             .loadSystemPlugins(siteID: siteID).map { $0.toReadOnly() }
-            .first(where: { $0.fileNameWithoutExtension == Constants.wcPluginName })
+            .first(where: { Plugin(systemPlugin: $0) == .wooCommerce })
     }
 }
 
 private extension ProductPasswordEligibilityUseCase {
     enum Constants {
-        static let wcPluginName = "woocommerce"
         static let wcPluginMinimumVersion = "8.1.0"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
@@ -289,10 +289,10 @@ extension FilterProductListViewModel.ProductListFilter {
     /// Builds the products types filter array identifying which extension is available or not.
     ///
     private func buildPromotableTypes(siteID: Int64, storageManager: StorageManagerType) -> [PromotableProductType?] {
-        let activePluginNames = fetchActivePluginNames(siteID: siteID, storageManager: storageManager)
-        let isSubscriptionsAvailable = Set(activePluginNames).intersection(SitePlugin.SupportedPlugin.WCSubscriptions).count > 0
-        let isCompositeProductsAvailable = activePluginNames.contains(SitePlugin.SupportedPlugin.WCCompositeProducts)
-        let isProductBundlesAvailable = activePluginNames.contains(where: SitePlugin.SupportedPlugin.WCProductBundles.contains)
+        let activePlugins = fetchActivePlugins(siteID: siteID, storageManager: storageManager)
+        let isSubscriptionsAvailable = activePlugins.contains(.wooSubscriptions)
+        let isCompositeProductsAvailable = activePlugins.contains(.wooCompositeProducts)
+        let isProductBundlesAvailable = activePlugins.contains(.wooProductBundles)
 
         return [nil,
                 .init(productType: .simple, isAvailable: true, promoteUrl: nil),
@@ -315,12 +315,12 @@ extension FilterProductListViewModel.ProductListFilter {
 
     /// Fetches the active plugin names for the provided site IDs using a `ResultsController`
     ///
-    private func fetchActivePluginNames(siteID: Int64, storageManager: StorageManagerType) -> [String] {
+    private func fetchActivePlugins(siteID: Int64, storageManager: StorageManagerType) -> [Plugin] {
         let predicate = \StorageSystemPlugin.siteID == siteID && \StorageSystemPlugin.active == true
         let resultsController = ResultsController<StorageSystemPlugin>(storageManager: storageManager, sortedBy: [])
         resultsController.predicate = predicate
 
         try? resultsController.performFetch()
-        return resultsController.fetchedObjects.map { $0.name }
+        return resultsController.fetchedObjects.compactMap { Plugin(systemPlugin: $0) }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
@@ -313,7 +313,7 @@ extension FilterProductListViewModel.ProductListFilter {
                       promoteUrl: WooConstants.URLs.compositeProductsExtension.asURL())]
     }
 
-    /// Fetches the active plugins for the provided site IDs using a `ResultsController`
+    /// Fetches the active known plugins for the provided site IDs using a `ResultsController`
     ///
     private func fetchActivePlugins(siteID: Int64, storageManager: StorageManagerType) -> [Plugin] {
         let predicate = \StorageSystemPlugin.siteID == siteID && \StorageSystemPlugin.active == true

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
@@ -313,7 +313,7 @@ extension FilterProductListViewModel.ProductListFilter {
                       promoteUrl: WooConstants.URLs.compositeProductsExtension.asURL())]
     }
 
-    /// Fetches the active plugin names for the provided site IDs using a `ResultsController`
+    /// Fetches the active plugins for the provided site IDs using a `ResultsController`
     ///
     private func fetchActivePlugins(siteID: Int64, storageManager: StorageManagerType) -> [Plugin] {
         let predicate = \StorageSystemPlugin.siteID == siteID && \StorageSystemPlugin.active == true

--- a/WooCommerce/Classes/Yosemite/SiteSnapshotTracker.swift
+++ b/WooCommerce/Classes/Yosemite/SiteSnapshotTracker.swift
@@ -83,7 +83,9 @@ private struct PaymentGatewaySnapshot {
     }
 
     func status(of plugin: Plugin) -> Status {
-        guard let systemPlugin = plugins.first(where: { $0.fileNameWithoutExtension == plugin.rawValue }) else {
+        guard let systemPlugin = plugins.first(where: {
+            Yosemite.Plugin(systemPlugin: $0) == Yosemite.Plugin(fileNameWithoutExtension: plugin.rawValue)
+        }) else {
             return .notInstalled
         }
         return systemPlugin.active ? .active: .installed

--- a/WooCommerce/WooCommerceTests/GoogleAds/DefaultGoogleAdsEligibilityCheckTests.swift
+++ b/WooCommerce/WooCommerceTests/GoogleAds/DefaultGoogleAdsEligibilityCheckTests.swift
@@ -36,7 +36,6 @@ final class DefaultGoogleAdsEligibilityCheckerTests: XCTestCase {
         // Given
         let featureFlagService = MockFeatureFlagService(googleAdsCampaignCreationOnWebView: true)
         let checker = DefaultGoogleAdsEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
-        let connection = GoogleAdsConnection.fake().copy(rawStatus: "incomplete")
         mockRequests(adsConnection: nil)
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -1219,11 +1219,11 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
 
     func test_CardPresentPaymentsPlugin_has_expected_name_and_fileNames() {
         XCTAssertEqual(CardPresentPaymentsPlugin.wcPay.pluginName, "WooPayments")
-        XCTAssertEqual(CardPresentPaymentsPlugin.wcPay.fileNameWithoutExtension, "woocommerce-payments")
+        XCTAssertEqual(CardPresentPaymentsPlugin.wcPay.plugin, .wooPayments)
         XCTAssertEqual(CardPresentPaymentsPlugin.wcPay.fileNameWithPathExtension, "woocommerce-payments/woocommerce-payments")
 
         XCTAssertEqual(CardPresentPaymentsPlugin.stripe.pluginName, "WooCommerce Stripe Gateway")
-        XCTAssertEqual(CardPresentPaymentsPlugin.stripe.fileNameWithoutExtension, "woocommerce-gateway-stripe")
+        XCTAssertEqual(CardPresentPaymentsPlugin.stripe.plugin, .stripe)
         XCTAssertEqual(CardPresentPaymentsPlugin.stripe.fileNameWithPathExtension, "woocommerce-gateway-stripe/woocommerce-gateway-stripe")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -27,9 +27,10 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     func test_cards_viewmodels_show_correct_data_after_updating_from_network() async {
         // Given
         let storage = MockStorageManager()
-        insertActivePlugins([SitePlugin.SupportedPlugin.WCProductBundles.first,
-                             SitePlugin.SupportedPlugin.WCGiftCards.first],
-                            to: storage)
+        insertPlugins([
+            "woocommerce-product-bundles/woocommerce-product-bundles.php",
+            "woocommerce-gift-cards/woocommerce-gift-cards.php"
+        ], active: true, to: storage)
         let vm = createViewModel(storage: storage)
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
             switch action {
@@ -89,9 +90,10 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         var loadingBundlesSoldCardRedacted: Bool = false
         var loadingGiftCardsCardRedacted: Bool = false
         let storage = MockStorageManager()
-        insertActivePlugins([SitePlugin.SupportedPlugin.WCProductBundles.first,
-                             SitePlugin.SupportedPlugin.WCGiftCards.first],
-                            to: storage)
+        insertPlugins([
+            "woocommerce-product-bundles/woocommerce-product-bundles.php",
+            "woocommerce-gift-cards/woocommerce-gift-cards.php"
+        ], active: true, to: storage)
         let vm = createViewModel(storage: storage)
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
             switch action {
@@ -243,7 +245,10 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     func test_enabledCards_contains_new_cards_not_in_stored_customizations_when_extensions_are_active() async {
         // Given
         let storage = MockStorageManager()
-        insertActivePlugins([SitePlugin.SupportedPlugin.WCProductBundles.first, SitePlugin.SupportedPlugin.WCGiftCards.first], to: storage)
+        insertPlugins([
+            "woocommerce-product-bundles/woocommerce-product-bundles.php",
+            "woocommerce-gift-cards/woocommerce-gift-cards.php"
+        ], active: true, to: storage)
         let vm = createViewModel(storage: storage)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
@@ -472,9 +477,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     func test_bundles_card_is_inactive_in_customizeAnalytics_when_extension_is_inactive() throws {
         // Given
         let storage = MockStorageManager()
-        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
-                                                                            name: SitePlugin.SupportedPlugin.WCProductBundles.first,
-                                                                            active: false))
+        insertPlugin("woocommerce-product-bundles/woocommerce-product-bundles.php", active: false, to: storage)
         let vm = createViewModel(storage: storage)
 
         // When
@@ -489,9 +492,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     func test_gift_cards_card_is_inactive_in_customizeAnalytics_when_extension_is_inactive() throws {
         // Given
         let storage = MockStorageManager()
-        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
-                                                                            name: SitePlugin.SupportedPlugin.WCGiftCards.first,
-                                                                            active: false))
+        insertPlugin("woocommerce-gift-cards/woocommerce-gift-cards.php", active: false, to: storage)
         let vm = createViewModel(storage: storage)
 
         // When
@@ -514,9 +515,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     func test_product_bundles_card_displayed_when_plugin_active() {
         // Given
         let storage = MockStorageManager()
-        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
-                                                                            name: SitePlugin.SupportedPlugin.WCProductBundles.first,
-                                                                            active: true))
+        insertPlugin("woocommerce-product-bundles/woocommerce-product-bundles.php", active: true, to: storage)
         let vm = createViewModel(storage: storage)
 
         // Then
@@ -526,9 +525,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     func test_product_bundles_card_not_displayed_when_plugin_inactive() {
         // Given
         let storage = MockStorageManager()
-        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
-                                                                            name: SitePlugin.SupportedPlugin.WCProductBundles.first,
-                                                                            active: false))
+        insertPlugin("woocommerce-product-bundles/woocommerce-product-bundles.php", active: false, to: storage)
         let vm = createViewModel(storage: storage)
 
         // Then
@@ -538,9 +535,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     func test_gift_cards_card_displayed_when_plugin_active() {
         // Given
         let storage = MockStorageManager()
-        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
-                                                                            name: SitePlugin.SupportedPlugin.WCGiftCards.first,
-                                                                            active: true))
+        insertPlugin("woocommerce-gift-cards/woocommerce-gift-cards.php", active: true, to: storage)
         let vm = createViewModel(storage: storage)
 
         // Then
@@ -550,9 +545,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     func test_gift_cards_card_not_displayed_when_plugin_inactive() {
         // Given
         let storage = MockStorageManager()
-        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
-                                                                            name: SitePlugin.SupportedPlugin.WCGiftCards.first,
-                                                                            active: false))
+        insertPlugin("woocommerce-gift-cards/woocommerce-gift-cards.php", active: false, to: storage)
         let vm = createViewModel(storage: storage)
 
         // Then
@@ -563,9 +556,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     func test_google_campaigns_card_not_displayed_when_plugin_inactive() {
         // Given
         let storage = MockStorageManager()
-        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
-                                                                            name: SitePlugin.SupportedPlugin.GoogleForWooCommerce.first,
-                                                                            active: false))
+        insertPlugin("google-listings-and-ads/google-listings-and-ads.php", active: false, to: storage)
 
         // When
         let vm = createViewModel(storage: storage)
@@ -585,9 +576,13 @@ private extension AnalyticsHubViewModelTests {
                               analytics: analytics)
     }
 
-    func insertActivePlugins(_ pluginNames: [String?], to storage: MockStorageManager) {
-        pluginNames.forEach { pluginName in
-            storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID, name: pluginName, active: true))
+    func insertPlugins(_ pluginPaths: [String], active: Bool, to storage: MockStorageManager) {
+        pluginPaths.forEach { pluginPath in
+            storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID, plugin: pluginPath, active: active))
         }
+    }
+
+    func insertPlugin(_ pluginPath: String, active: Bool, to storage: MockStorageManager) {
+        insertPlugins([pluginPath], active: active, to: storage)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
@@ -283,7 +283,8 @@ private extension MockStoresManager {
         whenReceivingAction(ofType: SystemStatusAction.self) { action in
             switch action {
             case let .synchronizeSystemInformation(_, onCompletion):
-                onCompletion(.success(.init(systemPlugins: [.fake().copy(name: isJetpackInstalled ? "Jetpack" : "Plugin", active: isJetpackActive)])))
+                onCompletion(.success(.init(systemPlugins: [.fake()
+                    .copy(plugin: isJetpackInstalled ? "jetpack/jetpack.php" : "plugin/plugin.php", active: isJetpackActive)])))
             default:
                 break
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/WooSubscriptions/WooSubscriptionProductsEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/WooSubscriptions/WooSubscriptionProductsEligibilityCheckerTests.swift
@@ -29,10 +29,7 @@ final class WooSubscriptionProductsEligibilityCheckerTests: XCTestCase {
 
     func test_isSiteEligible_is_true_when_woo_subscriptions_is_installed_and_active() throws {
         // Given
-        let activePlugin = SystemPlugin.fake().copy(siteID: sampleSiteID,
-                                                    name: "Woo Subscriptions",
-                                                    active: true)
-        insert(activePlugin)
+        insertPlugin("woocommerce-subscriptions/woocommerce-subscriptions.php", active: true)
 
         let checker = WooSubscriptionProductsEligibilityChecker(siteID: sampleSiteID,
                                                                 storage: storageManager)
@@ -46,10 +43,7 @@ final class WooSubscriptionProductsEligibilityCheckerTests: XCTestCase {
 
     func test_isSiteEligible_is_false_when_woo_subscriptions_is_installed_but_not_active() throws {
         // Given
-        let activePlugin = SystemPlugin.fake().copy(siteID: sampleSiteID,
-                                                    name: "Woo Subscriptions",
-                                                    active: false)
-        insert(activePlugin)
+        insertPlugin("woocommerce-subscriptions/woocommerce-subscriptions.php", active: false)
 
         let checker = WooSubscriptionProductsEligibilityChecker(siteID: sampleSiteID,
                                                                 storage: storageManager)
@@ -73,12 +67,9 @@ final class WooSubscriptionProductsEligibilityCheckerTests: XCTestCase {
         XCTAssertFalse(isEligible)
     }
 
-    func test_isSiteEligible_is_true_for_plugin_name_woocommerce_subscriptions() throws {
+    func test_isSiteEligible_is_true_for_plugin_path_woocommerce_subscriptions() throws {
         // Given
-        let activePlugin = SystemPlugin.fake().copy(siteID: sampleSiteID,
-                                                    name: "WooCommerce Subscriptions",
-                                                    active: true)
-        insert(activePlugin)
+        insertPlugin("woocommerce-subscriptions/woocommerce-subscriptions.php", active: true)
 
         let checker = WooSubscriptionProductsEligibilityChecker(siteID: sampleSiteID,
                                                                 storage: storageManager)
@@ -93,6 +84,11 @@ final class WooSubscriptionProductsEligibilityCheckerTests: XCTestCase {
 }
 
 private extension WooSubscriptionProductsEligibilityCheckerTests {
+    func insertPlugin(_ pluginPath: String, active: Bool) {
+        let systemPlugin = SystemPlugin.fake().copy(siteID: sampleSiteID, plugin: pluginPath, active: active)
+        insert(systemPlugin)
+    }
+
     func insert(_ readOnlyPlugin: SystemPlugin) {
         let plugin = storage.insertNewObject(ofType: StorageSystemPlugin.self)
         plugin.update(with: readOnlyPlugin)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductPasswordEligibilityUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductPasswordEligibilityUseCaseTests.swift
@@ -8,8 +8,7 @@ final class ProductPasswordEligibilityUseCaseTests: XCTestCase {
     private var storageManager: MockStorageManager!
     private var stores: MockStoresManager!
 
-    private let pluginName = "WooCommerce"
-    private let pluginSlug = "woocommerce"
+    private let pluginPath = "woocommerce/woocommerce.php"
     private let siteID: Int64 = 1
 
     override func setUp() {
@@ -37,8 +36,7 @@ final class ProductPasswordEligibilityUseCaseTests: XCTestCase {
 
     func test_isEligibleForNewPasswordEndpoint_when_WooCommerce_is_not_active_return_false() {
         // Given
-        let inactivePlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: pluginSlug, name: pluginName, version: "9.0", active: false)
-        storageManager.insertSampleSystemPlugin(readOnlySystemPlugin: inactivePlugin)
+        insertWooCommercePlugin(version: "9.0", active: false)
 
         // When
         let result = sut.isEligibleForWooProductPasswordEndpoint()
@@ -49,8 +47,7 @@ final class ProductPasswordEligibilityUseCaseTests: XCTestCase {
 
     func test_isEligibleForNewPasswordEndpoint_when_WooCommerce_version_is_below_minimum_return_false() {
         // Given
-        let oldVersionPlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: pluginSlug, name: pluginName, version: "7.0", active: true)
-        storageManager.insertSampleSystemPlugin(readOnlySystemPlugin: oldVersionPlugin)
+        insertWooCommercePlugin(version: "7.0", active: true)
 
         // When
         let result = sut.isEligibleForWooProductPasswordEndpoint()
@@ -61,8 +58,7 @@ final class ProductPasswordEligibilityUseCaseTests: XCTestCase {
 
     func test_isEligibleForNewPasswordEndpoint_when_WooCommerce_version_is_equal_to_minimum_return_true() {
         // Given
-        let validPlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: pluginSlug, name: pluginName, version: "8.1.0", active: true)
-        storageManager.insertSampleSystemPlugin(readOnlySystemPlugin: validPlugin)
+        insertWooCommercePlugin(version: "8.1.0", active: true)
 
         // When
         let result = sut.isEligibleForWooProductPasswordEndpoint()
@@ -73,8 +69,7 @@ final class ProductPasswordEligibilityUseCaseTests: XCTestCase {
 
     func test_isEligibleForNewPasswordEndpoint_when_WooCommerce_version_is_above_to_minimum_return_true() {
         // Given
-        let validPlugin = SystemPlugin.fake().copy(siteID: siteID, plugin: pluginSlug, name: pluginName, version: "9.1.0", active: true)
-        storageManager.insertSampleSystemPlugin(readOnlySystemPlugin: validPlugin)
+        insertWooCommercePlugin(version: "9.1.0", active: true)
 
         // When
         let result = sut.isEligibleForWooProductPasswordEndpoint()
@@ -85,12 +80,7 @@ final class ProductPasswordEligibilityUseCaseTests: XCTestCase {
 
     func test_editing_product_and_password_when_WooCommerce_version_is_below_8_1_returns_false() {
         // Given
-        let plugin = SystemPlugin.fake().copy(siteID: siteID,
-                                              plugin: pluginSlug,
-                                              name: pluginName,
-                                              version: "8.0.0",
-                                              active: true)
-        storageManager.insertSampleSystemPlugin(readOnlySystemPlugin: plugin)
+        insertWooCommercePlugin(version: "8.0.0", active: true)
 
         let sut = ProductPasswordEligibilityUseCase(stores: stores, storageManager: storageManager)
 
@@ -103,12 +93,7 @@ final class ProductPasswordEligibilityUseCaseTests: XCTestCase {
 
     func test_isEligibleForWooProductPasswordEndpoint_when_WooCommerce_version_is_equal_to_8_1_returns_true() {
         // Given
-        let plugin = SystemPlugin.fake().copy(siteID: siteID,
-                                              plugin: pluginSlug,
-                                              name: pluginName,
-                                              version: "8.1.0",
-                                              active: true)
-        storageManager.insertSampleSystemPlugin(readOnlySystemPlugin: plugin)
+        insertWooCommercePlugin(version: "8.1.0", active: true)
 
         let sut = ProductPasswordEligibilityUseCase(stores: stores, storageManager: storageManager)
 
@@ -121,12 +106,7 @@ final class ProductPasswordEligibilityUseCaseTests: XCTestCase {
 
     func test_editing_product_and_password_when_WooCommerce_version_is_above_8_1_returns_true() {
         // Given
-        let plugin = SystemPlugin.fake().copy(siteID: siteID,
-                                              plugin: pluginSlug,
-                                              name: pluginName,
-                                              version: "8.2.0",
-                                              active: true)
-        storageManager.insertSampleSystemPlugin(readOnlySystemPlugin: plugin)
+        insertWooCommercePlugin(version: "8.2.0", active: true)
 
         let sut = ProductPasswordEligibilityUseCase(stores: stores, storageManager: storageManager)
 
@@ -135,5 +115,12 @@ final class ProductPasswordEligibilityUseCaseTests: XCTestCase {
 
         // Then
         XCTAssertTrue(isEligible)
+    }
+}
+
+private extension ProductPasswordEligibilityUseCaseTests {
+    func insertWooCommercePlugin(version: String, active: Bool) {
+        let plugin = SystemPlugin.fake().copy(siteID: siteID, plugin: pluginPath, version: version, active: active)
+        storageManager.insertSampleSystemPlugin(readOnlySystemPlugin: plugin)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelProductListFilterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelProductListFilterTests.swift
@@ -111,10 +111,10 @@ final class FilterProductListViewModelProductListFilterTests: XCTestCase {
                                                          numberOfActiveFilters: 0)
         let mockStorage = MockStorageManager()
         mockStorage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
-                                                                                name: SitePlugin.SupportedPlugin.WCSubscriptions[0],
+                                                                                plugin: "woocommerce-subscriptions/woocommerce-subscriptions.php",
                                                                                 active: true))
         mockStorage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
-                                                                                name: SitePlugin.SupportedPlugin.WCProductBundles[0],
+                                                                                plugin: "woocommerce-product-bundles/woocommerce-product-bundles.php",
                                                                                 active: true))
 
         // When


### PR DESCRIPTION
Part 3 of WOOMOB-913

Just one review is required.

## Description

This is part 3 of the effort to replace plugin matching by name with plugin file name matching. It uses the centralized `Plugin` enum hiding the file name matching implementation.

### Key Changes

1. **Enhanced Plugin enum**: Added new plugin cases (blaze, PayPal, etc.) and two new initializers with unit tests
2. **Updated plugin matching logic**: Refactored most remaining use cases to use the Plugin enum instead of string plugin name matching

This change improves the reliability of plugin detection for merchants and provides a more robust foundation for future plugin-related features.

## Testing steps

Please feel free to pick up one or more of the test cases below.

## Testing information

Testing one of the states for each case is fine.

1. Analytics Hub - Plugin-Dependent Cards

- [x] @jaclync tests this

**WooCommerce Product Bundles Plugin**

- Test Active State:
  - Install and activate WooCommerce Product Bundles plugin
  - Navigate to dashboard > View all store analytics
  - Expected: Product Bundles analytics card should be visible and functional
- Test Inactive State:
  - Deactivate (but keep installed) WooCommerce Product Bundles plugin
  - Navigate to dashboard > View all store analytics
  - Expected: Product Bundles analytics card should be hidden/disabled

**WooCommerce Gift Cards Plugin**

- Test Active State:
  - Install and activate WooCommerce Gift Cards plugin
  - Navigate to dashboard > View all store analytics
  - Expected: Gift Cards analytics card should be visible and functional
- Test Inactive State:
  - Deactivate WooCommerce Gift Cards plugin
  - Navigate to dashboard > View all store analytics
  - Expected: Gift Cards analytics card should be hidden/disabled

**Google Listings and Ads Plugin**

- Test Active State:
  - Install and activate Google Listings and Ads plugin
  - Navigate to dashboard > View all store analytics
  - Expected: Google Campaigns analytics card should be visible
- Test Inactive State:
  - Deactivate Google Listings and Ads plugin
  - Navigate to dashboard > View all store analytics
  - Expected: Google Campaigns analytics card should be hidden

3. Product Filter

- [x] @jaclync tests this

**WooCommerce Subscriptions Plugin**

- Test Active State:
  - Install and activate WooCommerce Subscriptions plugin
  - Navigate to Products → Filter > Product Type
  - Expected: "Subscription" product types should be available
- Test Inactive State:
  - Deactivate WooCommerce Subscriptions plugin
  - Navigate to Products → Filter > Product Type
  - Expected: "Subscription" product type should show as "Explore" with promote URL

**WooCommerce Product Bundles Plugin**

- Test Active State:
  - Install and activate WooCommerce Product Bundles plugin
  - Navigate to Products → Filter > Product Type
  - Expected: "Bundle" product type should be available
- Test Inactive State:
  - Deactivate WooCommerce Product Bundles plugin
  - Navigate to Products → Filter > Product Type
  - Expected: "Bundle" product type should show as "Explore"
with promote URL

**WooCommerce Composite Products Plugin**

- Test Active State:
  - Install and activate WooCommerce Composite Products plugin
  - Navigate to Products → Filter > Product Type
  - Expected: "Composite" product type should be available
- Test Inactive State:
  - Deactivate WooCommerce Composite Products plugin
  - Navigate to Products → Filter > Product Type
  - Expected: "Composite" product type should show as "Explore" with promote URL

4. Product Password Feature

- [x] @jaclync tests this

WooCommerce Version Requirements

- Test Version 8.1.0+:
  - Ensure WooCommerce plugin is active with version 8.1.0 or higher
  - Edit a product → Product Settings → Visibility
  - Expected: Password protection options should be available via mobile app
- Test Version Below 8.1.0:
  - Downgrade WooCommerce to version below 8.1.0 (if possible in test environment)
  - Edit a product → Product Settings → Visibility
  - Expected: Should fall back to legacy password handling

5. Blaze Plugin Integration

- [x] @jaclync tests this

Note: I had to comment out some checks in `BlazeEligibilityChecker.checkSiteEligibility` to reach the Blaze plugin check.

- Site with Blaze plugin & not Jetpack plugin (which already includes Blaze feature):
  - Expected: the dashboard should have a Blaze card (edit the cards to see the option)
- Site without Blaze & Jetpack plugin:
  - Expected: the dashboard should not have a Blaze card

6. Jetpack Plugin Integration

- [x] @jaclync tests this

Jetpack plugin state

- Site with Jetpack plugin:
  - Expected: no Jetpack installation banner
- Site without Jetpack plugin:
  - Expected: Jetpack installation banner in the dashboard

## Screenshots

product filter | analytics hub
-- | --
<img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2025-07-24 at 11 35 21" src="https://github.com/user-attachments/assets/908c8dfb-41fb-4cbb-9408-c49c2f911410" /> | <img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2025-07-24 at 15 19 47" src="https://github.com/user-attachments/assets/1f957817-c6e1-4073-8057-7bbe435e50b9" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.