### PR TITLE
Fix initialization of authenticator

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 23.0
 -----
+- [*] Fix initialization of authenticator to avoid crashes during login [https://github.com/woocommerce/woocommerce-ios/pull/15953]
 
 
 22.9

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -369,7 +369,6 @@ private extension StorePickerViewController {
     }
 
     func presentSiteDiscovery() {
-        ServiceLocator.authenticationManager.initialize()
         guard let viewController = WordPressAuthenticator.siteDiscoveryUI() else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -89,7 +89,6 @@ final class AppCoordinator {
                     self.displayLoggedInStateWithoutDefaultStore()
                 case (true, false):
                     self.validateRoleEligibility {
-                        self.configureAuthenticator()
                         self.displayLoggedInUI()
                         self.synchronizeAndShowWhatsNew()
                     }
@@ -200,17 +199,11 @@ private extension AppCoordinator {
             presentLoginOnboarding { [weak self] in
                 guard let self = self else { return }
                 // Only displays the authenticator when dismissing onboarding to allow time for A/B test setup.
-                self.configureAndDisplayAuthenticator()
+                self.displayAuthenticator()
             }
         } else {
-            configureAndDisplayAuthenticator()
+            displayAuthenticator()
         }
-    }
-
-    /// Configures the WPAuthenticator and sets the authenticator UI as the window's root view.
-    func configureAndDisplayAuthenticator() {
-        configureAuthenticator()
-        displayAuthenticator()
     }
 
     /// Configures the WPAuthenticator for usage in both logged-in and logged-out states.

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -289,7 +289,6 @@ private extension AppCoordinator {
         guard stores.isAuthenticatedWithoutWPCom == false else {
             return displayAuthenticatorWithOnboardingIfNeeded()
         }
-        configureAuthenticator()
 
         let matcher = ULAccountMatcher(storageManager: storageManager)
         matcher.refreshStoredSites()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -70,11 +70,8 @@ struct DashboardView: View {
     private let connectivityObserver = ServiceLocator.connectivityObserver
 
     private var shouldShowJetpackBenefitsBanner: Bool {
-        guard let currentSite, currentSite.isSimpleSite == false else {
-            return false
-        }
-        let isJetpackCPSite = currentSite.isJetpackCPConnected
-        let isNonJetpackSite = currentSite.isNonJetpackSite
+        let isJetpackCPSite = currentSite?.isJetpackCPConnected == true
+        let isNonJetpackSite = currentSite?.isNonJetpackSite == true
         return (isJetpackCPSite || isNonJetpackSite) &&
             viewModel.isSiteEligibleToInstallJetpack &&
             viewModel.jetpackBannerVisibleFromAppSettings &&

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -70,8 +70,11 @@ struct DashboardView: View {
     private let connectivityObserver = ServiceLocator.connectivityObserver
 
     private var shouldShowJetpackBenefitsBanner: Bool {
-        let isJetpackCPSite = currentSite?.isJetpackCPConnected == true
-        let isNonJetpackSite = currentSite?.isNonJetpackSite == true
+        guard let currentSite, currentSite.isSimpleSite == false else {
+            return false
+        }
+        let isJetpackCPSite = currentSite.isJetpackCPConnected
+        let isNonJetpackSite = currentSite.isNonJetpackSite
         return (isJetpackCPSite || isNonJetpackSite) &&
             viewModel.isSiteEligibleToInstallJetpack &&
             viewModel.jetpackBannerVisibleFromAppSettings &&

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -65,8 +65,8 @@ final class JetpackSetupCoordinator {
         rootViewController.present(benefitsController, animated: true, completion: nil)
     }
 
-    func handleAuthenticationUrl(_ url: URL) -> Bool {
-        let expectedPrefix = ApiCredentials.dotcomAuthScheme + "://" + Constants.magicLinkUrlHostname
+    func handleAuthenticationUrl(_ url: URL, dotcomAuthScheme: String = ApiCredentials.dotcomAuthScheme) -> Bool {
+        let expectedPrefix = dotcomAuthScheme + "://" + Constants.magicLinkUrlHostname
         guard url.absoluteString.hasPrefix(expectedPrefix) else {
             return false
         }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -19,7 +19,6 @@ final class JetpackSetupCoordinator {
     private let stores: StoresManager
     private let analytics: Analytics
     private let featureFlagService: FeatureFlagService
-    private let dotcomAuthScheme: String
 
     private var loginNavigationController: LoginNavigationController?
     private var setupStepsNavigationController: UINavigationController?
@@ -43,14 +42,12 @@ final class JetpackSetupCoordinator {
     }
 
     init(site: Site,
-         dotcomAuthScheme: String = ApiCredentials.dotcomAuthScheme,
          rootViewController: UIViewController,
          accountService: WordPressComAccountServiceProtocol = WordPressComAccountService(),
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.site = site
-        self.dotcomAuthScheme = dotcomAuthScheme
         self.requiresConnectionOnly = false // to be updated later after fetching Jetpack status
         self.rootViewController = rootViewController
         self.accountService = accountService
@@ -69,7 +66,7 @@ final class JetpackSetupCoordinator {
     }
 
     func handleAuthenticationUrl(_ url: URL) -> Bool {
-        let expectedPrefix = dotcomAuthScheme + "://" + Constants.magicLinkUrlHostname
+        let expectedPrefix = ApiCredentials.dotcomAuthScheme + "://" + Constants.magicLinkUrlHostname
         guard url.absoluteString.hasPrefix(expectedPrefix) else {
             return false
         }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -60,7 +60,7 @@ final class JetpackSetupCoordinator {
 
         /// the authenticator needs to be initialized with configs
         /// to be used for requesting authentication link and handle login later.
-        WordPressAuthenticator.initializeWithCustomConfigs(dotcomAuthScheme: dotcomAuthScheme)
+        ServiceLocator.authenticationManager.initialize()
     }
 
     func showBenefitModal() {

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -57,10 +57,6 @@ final class JetpackSetupCoordinator {
         self.stores = stores
         self.analytics = analytics
         self.featureFlagService = featureFlagService
-
-        /// the authenticator needs to be initialized with configs
-        /// to be used for requesting authentication link and handle login later.
-        ServiceLocator.authenticationManager.initialize()
     }
 
     func showBenefitModal() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
@@ -14,6 +14,9 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         window.rootViewController = UIViewController()
         window.makeKeyAndVisible()
         window.rootViewController = navigationController
+
+        AuthenticationManager().initialize()
+
         super.setUp()
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
@@ -6,6 +6,7 @@ import WordPressAuthenticator
 final class JetpackSetupCoordinatorTests: XCTestCase {
 
     private var navigationController: UINavigationController!
+    private let dotcomAuthScheme = "scheme"
 
     override func setUp() {
         navigationController = UINavigationController()
@@ -47,7 +48,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         let url = try XCTUnwrap(URL(string: "example://handle-authentication"))
 
         // When
-        let result = coordinator.handleAuthenticationUrl(url)
+        let result = coordinator.handleAuthenticationUrl(url, dotcomAuthScheme: dotcomAuthScheme)
 
         // Then
         XCTAssertFalse(result)
@@ -57,10 +58,10 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         // Given
         let testSite = Site.fake().copy(siteID: -1)
         let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController)
-        let url = try XCTUnwrap(URL(string: "\(ApiCredentials.dotcomAuthScheme)://magic-login"))
+        let url = try XCTUnwrap(URL(string: "\(dotcomAuthScheme)://magic-login"))
 
         // When
-        let result = coordinator.handleAuthenticationUrl(url)
+        let result = coordinator.handleAuthenticationUrl(url, dotcomAuthScheme: dotcomAuthScheme)
 
         // Then
         XCTAssertFalse(result)
@@ -70,10 +71,10 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         // Given
         let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID)
         let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController)
-        let url = try XCTUnwrap(URL(string: "\(ApiCredentials.dotcomAuthScheme)://handle-authentication?token=test"))
+        let url = try XCTUnwrap(URL(string: "\(dotcomAuthScheme)://handle-authentication?token=test"))
 
         // When
-        let result = coordinator.handleAuthenticationUrl(url)
+        let result = coordinator.handleAuthenticationUrl(url, dotcomAuthScheme: dotcomAuthScheme)
 
         // Then
         XCTAssertFalse(result)
@@ -83,10 +84,10 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         // Given
         let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID)
         let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController)
-        let url = try XCTUnwrap(URL(string: "\(ApiCredentials.dotcomAuthScheme)://magic-login?token=test"))
+        let url = try XCTUnwrap(URL(string: "\(dotcomAuthScheme)://magic-login?token=test"))
 
         // When
-        let result = coordinator.handleAuthenticationUrl(url)
+        let result = coordinator.handleAuthenticationUrl(url, dotcomAuthScheme: dotcomAuthScheme)
 
         // Then
         XCTAssertTrue(result)
@@ -97,7 +98,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false, defaultRoles: [.shopManager]))
         let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID)
         let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController, stores: stores)
-        let url = try XCTUnwrap(URL(string: "\(ApiCredentials.dotcomAuthScheme)://magic-login?token=test"))
+        let url = try XCTUnwrap(URL(string: "\(dotcomAuthScheme)://magic-login?token=test"))
 
         let expectedAccount = Account(userID: 123, displayName: "Test", email: "test@example.com", username: "test", gravatarUrl: nil)
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -113,7 +114,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         stores.mockJetpackCheck()
 
         // When
-        let result = coordinator.handleAuthenticationUrl(url)
+        let result = coordinator.handleAuthenticationUrl(url, dotcomAuthScheme: dotcomAuthScheme)
 
         // Then
         XCTAssertTrue(result)
@@ -127,7 +128,8 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
         let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID)
         let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController, stores: stores)
-        let url = try XCTUnwrap(URL(string: "\(ApiCredentials.dotcomAuthScheme)://magic-login?token=test"))
+        let expectedScheme = "scheme"
+        let url = try XCTUnwrap(URL(string: "\(dotcomAuthScheme)://magic-login?token=test"))
 
         let expectedAccount = Account(userID: 123, displayName: "Test", email: "test@example.com", username: "test", gravatarUrl: nil)
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -143,7 +145,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         stores.mockJetpackCheck()
 
         // When
-        let result = coordinator.handleAuthenticationUrl(url)
+        let result = coordinator.handleAuthenticationUrl(url, dotcomAuthScheme: dotcomAuthScheme)
 
         // Then
         XCTAssertTrue(result)
@@ -158,7 +160,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         let siteURL = "https://example.com"
         let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID, url: siteURL)
         let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController, stores: stores)
-        let url = try XCTUnwrap(URL(string: "\(ApiCredentials.dotcomAuthScheme)://magic-login?token=test"))
+        let url = try XCTUnwrap(URL(string: "\(dotcomAuthScheme)://magic-login?token=test"))
 
         let expectedAccount = Account(userID: 123, displayName: "Test", email: "test@example.com", username: "test", gravatarUrl: nil)
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -198,7 +200,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         stores.mockJetpackCheck()
 
         // When
-        let result = coordinator.handleAuthenticationUrl(url)
+        let result = coordinator.handleAuthenticationUrl(url, dotcomAuthScheme: dotcomAuthScheme)
 
         // Then
         XCTAssertTrue(result)

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
@@ -57,7 +57,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         // Given
         let testSite = Site.fake().copy(siteID: -1)
         let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController)
-        let url = try XCTUnwrap(URL(string: "woocommerce://magic-login"))
+        let url = try XCTUnwrap(URL(string: "\(ApiCredentials.dotcomAuthScheme)://magic-login"))
 
         // When
         let result = coordinator.handleAuthenticationUrl(url)
@@ -70,7 +70,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         // Given
         let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID)
         let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController)
-        let url = try XCTUnwrap(URL(string: "woocommerce://handle-authentication?token=test"))
+        let url = try XCTUnwrap(URL(string: "\(ApiCredentials.dotcomAuthScheme)://handle-authentication?token=test"))
 
         // When
         let result = coordinator.handleAuthenticationUrl(url)
@@ -83,7 +83,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         // Given
         let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID)
         let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController)
-        let url = try XCTUnwrap(URL(string: "woocommerce://magic-login?token=test"))
+        let url = try XCTUnwrap(URL(string: "\(ApiCredentials.dotcomAuthScheme)://magic-login?token=test"))
 
         // When
         let result = coordinator.handleAuthenticationUrl(url)
@@ -97,7 +97,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false, defaultRoles: [.shopManager]))
         let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID)
         let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController, stores: stores)
-        let url = try XCTUnwrap(URL(string: "woocommerce://magic-login?token=test"))
+        let url = try XCTUnwrap(URL(string: "\(ApiCredentials.dotcomAuthScheme)://magic-login?token=test"))
 
         let expectedAccount = Account(userID: 123, displayName: "Test", email: "test@example.com", username: "test", gravatarUrl: nil)
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -113,9 +113,10 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         stores.mockJetpackCheck()
 
         // When
-        _ = coordinator.handleAuthenticationUrl(url)
+        let result = coordinator.handleAuthenticationUrl(url)
 
         // Then
+        XCTAssertTrue(result)
         waitUntil {
             (self.navigationController.presentedViewController as? UINavigationController)?.topViewController is AdminRoleRequiredHostingController
         }
@@ -126,7 +127,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
         let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID)
         let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController, stores: stores)
-        let url = try XCTUnwrap(URL(string: "woocommerce://magic-login?token=test"))
+        let url = try XCTUnwrap(URL(string: "\(ApiCredentials.dotcomAuthScheme)://magic-login?token=test"))
 
         let expectedAccount = Account(userID: 123, displayName: "Test", email: "test@example.com", username: "test", gravatarUrl: nil)
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -142,9 +143,10 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         stores.mockJetpackCheck()
 
         // When
-        _ = coordinator.handleAuthenticationUrl(url)
+        let result = coordinator.handleAuthenticationUrl(url)
 
         // Then
+        XCTAssertTrue(result)
         waitUntil {
             (self.navigationController.presentedViewController as? UINavigationController)?.topViewController is JetpackSetupHostingController
         }
@@ -156,7 +158,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         let siteURL = "https://example.com"
         let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID, url: siteURL)
         let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController, stores: stores)
-        let url = try XCTUnwrap(URL(string: "woocommerce://magic-login?token=test"))
+        let url = try XCTUnwrap(URL(string: "\(ApiCredentials.dotcomAuthScheme)://magic-login?token=test"))
 
         let expectedAccount = Account(userID: 123, displayName: "Test", email: "test@example.com", username: "test", gravatarUrl: nil)
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -196,9 +198,10 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         stores.mockJetpackCheck()
 
         // When
-        _ = coordinator.handleAuthenticationUrl(url)
+        let result = coordinator.handleAuthenticationUrl(url)
 
         // Then
+        XCTAssertTrue(result)
         waitUntil {
             stores.sessionManager.defaultSite == expectedSite
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
@@ -40,8 +40,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
     func test_handleAuthenticationUrl_returns_false_for_unsupported_url_scheme() throws {
         // Given
         let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID)
-        let expectedScheme = "scheme"
-        let coordinator = JetpackSetupCoordinator(site: testSite, dotcomAuthScheme: expectedScheme, rootViewController: navigationController)
+        let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController)
         let url = try XCTUnwrap(URL(string: "example://handle-authentication"))
 
         // When
@@ -54,9 +53,8 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
     func test_handleAuthenticationUrl_returns_false_for_missing_queries() throws {
         // Given
         let testSite = Site.fake().copy(siteID: -1)
-        let expectedScheme = "scheme"
-        let coordinator = JetpackSetupCoordinator(site: testSite, dotcomAuthScheme: expectedScheme, rootViewController: navigationController)
-        let url = try XCTUnwrap(URL(string: "scheme://magic-login"))
+        let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController)
+        let url = try XCTUnwrap(URL(string: "woocommerce://magic-login"))
 
         // When
         let result = coordinator.handleAuthenticationUrl(url)
@@ -68,9 +66,8 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
     func test_handleAuthenticationUrl_returns_false_for_incorrect_host_name() throws {
         // Given
         let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID)
-        let expectedScheme = "scheme"
-        let coordinator = JetpackSetupCoordinator(site: testSite, dotcomAuthScheme: expectedScheme, rootViewController: navigationController)
-        let url = try XCTUnwrap(URL(string: "scheme://handle-authentication?token=test"))
+        let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController)
+        let url = try XCTUnwrap(URL(string: "woocommerce://handle-authentication?token=test"))
 
         // When
         let result = coordinator.handleAuthenticationUrl(url)
@@ -82,9 +79,8 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
     func test_handleAuthenticationUrl_returns_true_for_correct_url_and_sufficient_queries() throws {
         // Given
         let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID)
-        let expectedScheme = "scheme"
-        let coordinator = JetpackSetupCoordinator(site: testSite, dotcomAuthScheme: expectedScheme, rootViewController: navigationController)
-        let url = try XCTUnwrap(URL(string: "scheme://magic-login?token=test"))
+        let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController)
+        let url = try XCTUnwrap(URL(string: "woocommerce://magic-login?token=test"))
 
         // When
         let result = coordinator.handleAuthenticationUrl(url)
@@ -97,9 +93,8 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false, defaultRoles: [.shopManager]))
         let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID)
-        let expectedScheme = "scheme"
-        let coordinator = JetpackSetupCoordinator(site: testSite, dotcomAuthScheme: expectedScheme, rootViewController: navigationController, stores: stores)
-        let url = try XCTUnwrap(URL(string: "scheme://magic-login?token=test"))
+        let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController, stores: stores)
+        let url = try XCTUnwrap(URL(string: "woocommerce://magic-login?token=test"))
 
         let expectedAccount = Account(userID: 123, displayName: "Test", email: "test@example.com", username: "test", gravatarUrl: nil)
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -127,9 +122,8 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
         let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID)
-        let expectedScheme = "scheme"
-        let coordinator = JetpackSetupCoordinator(site: testSite, dotcomAuthScheme: expectedScheme, rootViewController: navigationController, stores: stores)
-        let url = try XCTUnwrap(URL(string: "scheme://magic-login?token=test"))
+        let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController, stores: stores)
+        let url = try XCTUnwrap(URL(string: "woocommerce://magic-login?token=test"))
 
         let expectedAccount = Account(userID: 123, displayName: "Test", email: "test@example.com", username: "test", gravatarUrl: nil)
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -158,9 +152,8 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
         let siteURL = "https://example.com"
         let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID, url: siteURL)
-        let expectedScheme = "scheme"
-        let coordinator = JetpackSetupCoordinator(site: testSite, dotcomAuthScheme: expectedScheme, rootViewController: navigationController, stores: stores)
-        let url = try XCTUnwrap(URL(string: "scheme://magic-login?token=test"))
+        let coordinator = JetpackSetupCoordinator(site: testSite, rootViewController: navigationController, stores: stores)
+        let url = try XCTUnwrap(URL(string: "woocommerce://magic-login?token=test"))
 
         let expectedAccount = Account(userID: 123, displayName: "Test", email: "test@example.com", username: "test", gravatarUrl: nil)
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in

--- a/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -84,6 +84,10 @@ import WordPressUI
                                   unifiedStyle: WordPressAuthenticatorUnifiedStyle?,
                                   displayImages: WordPressAuthenticatorDisplayImages = .defaultImages,
                                   displayStrings: WordPressAuthenticatorDisplayStrings = .defaultStrings) {
+        guard privateInstance == nil else {
+            assertionFailure("Attempting to initialize WordPressAuthenticator more than once - this would cause the delegate to be reset. Aborting... 🙅⛔️")
+            return
+        }
         privateInstance = WordPressAuthenticator(configuration: configuration,
                                                  style: style,
                                                  unifiedStyle: unifiedStyle,

--- a/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -85,7 +85,9 @@ import WordPressUI
                                   displayImages: WordPressAuthenticatorDisplayImages = .defaultImages,
                                   displayStrings: WordPressAuthenticatorDisplayStrings = .defaultStrings) {
         guard privateInstance == nil else {
-            assertionFailure("Attempting to initialize WordPressAuthenticator more than once - this would cause the delegate to be reset. Aborting... 🙅⛔️")
+            if isRunningTests() == false { // avoid crashing in tests
+                assertionFailure("Attempting to initialize WordPressAuthenticator more than once - this would cause the delegate to be reset. Aborting... 🙅⛔️")
+            }
             return
         }
         privateInstance = WordPressAuthenticator(configuration: configuration,
@@ -489,5 +491,11 @@ public extension WordPressAuthenticator {
             NotificationCenter.default.removeObserver(observer)
         }
         appleIDCredentialObserver = nil
+    }
+}
+
+private extension WordPressAuthenticator {
+    static func isRunningTests() -> Bool {
+        return NSClassFromString("XCTestCase") != nil
     }
 }

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -32,7 +32,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
 
     var authenticationDelegate: WordPressAuthenticatorDelegate {
         guard let delegate = WordPressAuthenticator.shared.delegate else {
-            fatalError()
+            fatalError("No delegate found for WordPressAuthenticator")
         }
 
         return delegate
@@ -140,7 +140,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
 
     func showLoginEpilogue(for credentials: AuthenticatorCredentials) {
         guard let navigationController = navigationController else {
-            fatalError()
+            fatalError("No navigation controller found to show login epilogue")
         }
 
         authenticationDelegate.presentLoginEpilogue(in: navigationController,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-902

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We got crash reports in the `LoginViewController.showLoginEpilogue` step of the login flow. This method can fail in two cases:
- When the `navigationController` of the view controller cannot be found.
- When the `authenticationDelegate` is nil.

This PR mitigates the issue with some enhancements:
- Updates the initialization of the authenticator to allow initializing only once [upon app start](https://github.com/woocommerce/woocommerce-ios/blob/c9c8b485b4cb3f4d80fd7e32be0d1731eeaddad3/WooCommerce/Classes/ViewRelated/AppCoordinator.swift#L69). Reasons behind this fix:
  - It's not necessary to initialize more than once.
  - The previous implementation allows the private instance to be recreated, breaking the delegate reference.
- Add messages to the `fatalError` in the login flow to better understand the issue if the above doesn't fix the crash. 

Note: I'm targeting 23.0 for this PR as the crash is likely an edge case. Let me know if you think we should target the beta build 22.9 instead.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Test login using different scenarios:
- Log out of the app and try logging back in => confirm that login succeeds.
- Test login with magic link when the app is forced closed (detailed steps [here](https://github.com/woocommerce/woocommerce-ios/pull/8570)).
- Test that connecting to existing site flow still works (detailed steps [here](https://github.com/woocommerce/woocommerce-ios/pull/13766))

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested the above test cases using simulator iPhone 16 iOS 18.4.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

No UI changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.