### PR TITLE
[HACK week] TipKit in Order Creation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/AddOrderComponentsSection/AddOrderComponentsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/AddOrderComponentsSection/AddOrderComponentsSection.swift
@@ -82,6 +82,7 @@ private extension AddOrderComponentsSection {
         .renderedIf(couponLineViewModel.couponLineRows.isEmpty)
         .padding()
         .accessibilityIdentifier("add-coupon-button")
+        // Usage #2
         .tooltip(isPresented: $shouldShowCouponsInfoTooltip,
                  toolTipTitle: Localization.couponsTooltipTitle,
                  toolTipDescription: Localization.couponsTooltipDescription,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -418,13 +418,15 @@ extension CollapsibleProductRowCard {
                 }
                 // Overlay the TipView and a mostly opaque black background if tooltip is visible
                 if shouldShowInfoTooltip {
-                    Color.black.opacity(0.85)
+                    Color(.systemBackground).opacity(0.01)
                         .ignoresSafeArea()
+                        .contentShape(Rectangle())
                         .transition(.opacity)
                         .onTapGesture {
                             shouldShowInfoTooltip = false
                         }
                     TipView(ProductDiscountTip(), arrowEdge: .top)
+                        .tipBackground(Color.black)
                         .padding()
                         .onTapGesture {
                             shouldShowInfoTooltip = false

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -368,56 +368,118 @@ extension CollapsibleProductRowCard {
     }
 
     @ViewBuilder var discountRow: some View {
-        HStack {
-            if !viewModel.hasDiscount || shouldDisallowDiscounts {
-                Button(Localization.addDiscountLabel) {
-                    trackAddDiscountTapped()
-                    onAddDiscount(viewModel.id)
-                }
-                .buttonStyle(PlusButtonStyle())
-                .disabled(shouldDisallowDiscounts || isLoading)
-            } else {
+        // Always render the row, overlay the tip if needed (iOS 17+), else fallback to .tooltip (iOS 16-)
+        if #available(iOS 17.0, *) {
+            ZStack {
+                // The row content
                 HStack {
-                    Button(action: {
-                        trackEditDiscountTapped()
-                        onAddDiscount(viewModel.id)
-                    }, label: {
-                        HStack {
-                            Text(Localization.discountLabel)
-                            Image(uiImage: .pencilImage)
-                                .resizable()
-                                .frame(width: Layout.iconSize, height: Layout.iconSize)
+                    if !viewModel.hasDiscount || shouldDisallowDiscounts {
+                        Button(Localization.addDiscountLabel) {
+                            trackAddDiscountTapped()
+                            onAddDiscount(viewModel.id)
                         }
-                    })
-                    .disabled(isLoading)
+                        .buttonStyle(PlusButtonStyle())
+                        .disabled(shouldDisallowDiscounts || isLoading)
+                    } else {
+                        HStack {
+                            Button(action: {
+                                trackEditDiscountTapped()
+                                onAddDiscount(viewModel.id)
+                            }, label: {
+                                HStack {
+                                    Text(Localization.discountLabel)
+                                    Image(uiImage: .pencilImage)
+                                        .resizable()
+                                        .frame(width: Layout.iconSize, height: Layout.iconSize)
+                                }
+                            })
+                            .disabled(isLoading)
+                            Spacer()
+                            if let discountLabel = viewModel.discountLabel {
+                                Text(minusSign + discountLabel)
+                                    .foregroundColor(.green)
+                                    .shimmering(active: isLoading)
+                            }
+                        }
+                        .redacted(reason: shouldDisableDiscountEditing ? .placeholder : [] )
+                    }
+                    Group {
+                        Spacer()
+                        Button {
+                            configureTips()
+                            shouldShowInfoTooltip.toggle()
+                            debugPrint("🍍 toggle tapped - shouldShowInfoTooltip: \(shouldShowInfoTooltip)")
+                        } label: {
+                            Image(systemName: "questionmark.circle")
+                                .foregroundColor(Color(.wooCommercePurple(.shade60)))
+                        }
+                    }
+                    .renderedIf(shouldDisallowDiscounts)
+                }
+                // Overlay the TipView and a mostly opaque black background if tooltip is visible
+                if shouldShowInfoTooltip {
+                    Color.black.opacity(0.85)
+                        .ignoresSafeArea()
+                        .transition(.opacity)
+                        .onTapGesture {
+                            shouldShowInfoTooltip = false
+                        }
+                    TipView(ProductDiscountTip(), arrowEdge: .top)
+                        .padding()
+                        .onTapGesture {
+                            shouldShowInfoTooltip = false
+                        }
+                }
+            }
+        } else {
+            // iOS 16 and below: use .tooltip as before
+            HStack {
+                if !viewModel.hasDiscount || shouldDisallowDiscounts {
+                    Button(Localization.addDiscountLabel) {
+                        trackAddDiscountTapped()
+                        onAddDiscount(viewModel.id)
+                    }
+                    .buttonStyle(PlusButtonStyle())
+                    .disabled(shouldDisallowDiscounts || isLoading)
+                } else {
+                    HStack {
+                        Button(action: {
+                            trackEditDiscountTapped()
+                            onAddDiscount(viewModel.id)
+                        }, label: {
+                            HStack {
+                                Text(Localization.discountLabel)
+                                Image(uiImage: .pencilImage)
+                                    .resizable()
+                                    .frame(width: Layout.iconSize, height: Layout.iconSize)
+                            }
+                        })
+                        .disabled(isLoading)
+                        Spacer()
+                        if let discountLabel = viewModel.discountLabel {
+                            Text(minusSign + discountLabel)
+                                .foregroundColor(.green)
+                                .shimmering(active: isLoading)
+                        }
+                    }
+                    .redacted(reason: shouldDisableDiscountEditing ? .placeholder : [] )
+                }
+                Group {
                     Spacer()
-                    if let discountLabel = viewModel.discountLabel {
-                        Text(minusSign + discountLabel)
-                            .foregroundColor(.green)
-                            .shimmering(active: isLoading)
+                    Button {
+                        shouldShowInfoTooltip.toggle()
+                        debugPrint("🍍 toggle tapped - shouldShowInfoTooltip: \(shouldShowInfoTooltip)")
+                    } label: {
+                        Image(systemName: "questionmark.circle")
+                            .foregroundColor(Color(.wooCommercePurple(.shade60)))
                     }
                 }
-                // Redacts the discount editing row while product data is reloaded during remote sync.
-                // This avoids showing an out-of-date discount while hasn't synched
-                .redacted(reason: shouldDisableDiscountEditing ? .placeholder : [] )
+                .renderedIf(shouldDisallowDiscounts)
             }
-            Group {
-                Spacer()
-                Button {
-                    if #available(iOS 17.0, *) {
-                        configureTips()
-                    }
-                    shouldShowInfoTooltip.toggle()
-                    debugPrint("🍍 toggle tapped - shouldShowInfoTooltip: \(shouldShowInfoTooltip)")
-                } label: {
-                    Image(systemName: "questionmark.circle")
-                        .foregroundColor(Color(.wooCommercePurple(.shade60)))
-                }
-            }
-            .renderedIf(shouldDisallowDiscounts)
+            .tooltip(isPresented: $shouldShowInfoTooltip,
+                     toolTipTitle: Localization.discountTooltipTitle,
+                     toolTipDescription: Localization.discountTooltipDescription)
         }
-        // Usage #1
-        .modifier(CustomTooltipModifier(shouldShowInfoTooltip: $shouldShowInfoTooltip))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -1,6 +1,23 @@
 import Yosemite
 import SwiftUI
+import TipKit
 
+/// TipKit tip for explaining when product discounts are unavailable due to coupons
+@available(iOS 17.0, *)
+struct ProductDiscountTip: Tip {
+    
+    var title: Text {
+        Text("Tipkit: Discounts unavailable")
+    }
+
+    var message: Text? {
+        Text("To add a Product Discount, please remove all Coupons from your order")
+    }
+
+    var image: Image? {
+        Image(systemName: "questionmark.circle")
+    }
+}
 /// Displays a single collapsible product row or grouped parent and child product rows
 struct CollapsibleProductCard: View {
     private let viewModel: CollapsibleProductCardViewModel
@@ -126,6 +143,17 @@ private struct CollapsibleProductRowCard: View {
 
     private var shouldShowBadgeCounter: Bool {
         ServiceLocator.featureFlagService.isFeatureFlagEnabled(.subscriptionsInOrderCreationUI)
+    }
+    
+    @available(iOS 17.0, *)
+    private func configureTips() {
+        do {
+            // Passing a configuration is necessary, despite not enforced on compile-time
+            // If no config is passed, the tip will not render, and show no feedback of why
+            try Tips.configure([.displayFrequency(.immediate)])
+        } catch {
+            debugPrint("🍍 Configure TipKit failed")
+        }
     }
 
     init(viewModel: CollapsibleProductRowCardViewModel,
@@ -292,7 +320,7 @@ private extension CollapsibleProductRowCard {
     }
 }
 
-private extension CollapsibleProductRowCard {
+extension CollapsibleProductRowCard {
     // Subscription details section. Renders all elements for a Subscription-type product
     @ViewBuilder var subscriptionDetailsSection: some View {
         VStack(spacing: Layout.subscriptionDetailsPadding) {
@@ -372,7 +400,11 @@ private extension CollapsibleProductRowCard {
             Group {
                 Spacer()
                 Button {
+                    if #available(iOS 17.0, *) {
+                        configureTips()
+                    }
                     shouldShowInfoTooltip.toggle()
+                    debugPrint("🍍 toggle tapped - shouldShowInfoTooltip: \(shouldShowInfoTooltip)")
                 } label: {
                     Image(systemName: "questionmark.circle")
                         .foregroundColor(Color(.wooCommercePurple(.shade60)))
@@ -380,9 +412,35 @@ private extension CollapsibleProductRowCard {
             }
             .renderedIf(shouldDisallowDiscounts)
         }
-        .tooltip(isPresented: $shouldShowInfoTooltip,
-                 toolTipTitle: Localization.discountTooltipTitle,
-                 toolTipDescription: Localization.discountTooltipDescription)
+        // Usage #1
+        .modifier(CustomTooltipModifier(shouldShowInfoTooltip: $shouldShowInfoTooltip))
+    }
+}
+
+/// ViewModifier that handles both TipKit (iOS 17+) and custom tooltip (iOS 16-)
+private struct CustomTooltipModifier: ViewModifier {
+    @Binding var shouldShowInfoTooltip: Bool
+
+    func body(content: Content) -> some View {
+        if #available(iOS 17.0, *) {
+            // TipKit
+            content
+                .overlay(alignment: .topTrailing) {
+                    if shouldShowInfoTooltip {
+                        TipView(ProductDiscountTip(), arrowEdge: .leading)
+                            .tipBackground(.regularMaterial)
+                            .onTapGesture {
+                                shouldShowInfoTooltip = false
+                            }
+                    }
+                }
+        } else {
+            // iOS 16 and below continues using the custom tooltip
+            content
+                .tooltip(isPresented: $shouldShowInfoTooltip,
+                         toolTipTitle: "Custom: Discounts unavailable",
+                         toolTipDescription: "To add a Product Discount, please remove all Coupons from your order.")
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -425,7 +425,7 @@ extension CollapsibleProductRowCard {
                         .onTapGesture {
                             shouldShowInfoTooltip = false
                         }
-                    TipView(ProductDiscountTip(), arrowEdge: .top)
+                    TipView(ProductDiscountTip(), arrowEdge: .trailing)
                         .tipBackground(Color.black)
                         .padding()
                         .onTapGesture {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -5,17 +5,21 @@ import TipKit
 /// TipKit tip for explaining when product discounts are unavailable due to coupons
 @available(iOS 17.0, *)
 struct ProductDiscountTip: Tip {
-    
+    // Forcing a new ID recreates invalidates the existing tip marked as `seen` by the system,
+    // since we're creating a new instance each time is toggled
+    var id: String = UUID().uuidString
+
     var title: Text {
         Text("Tipkit: Discounts unavailable")
+            .font(.body)
+            .foregroundColor(.white)
+            .fontWeight(.bold)
     }
 
     var message: Text? {
         Text("To add a Product Discount, please remove all Coupons from your order")
-    }
-
-    var image: Image? {
-        Image(systemName: "questionmark.circle")
+            .font(.body)
+            .foregroundColor(.gray)
     }
 }
 /// Displays a single collapsible product row or grouped parent and child product rows
@@ -144,7 +148,7 @@ private struct CollapsibleProductRowCard: View {
     private var shouldShowBadgeCounter: Bool {
         ServiceLocator.featureFlagService.isFeatureFlagEnabled(.subscriptionsInOrderCreationUI)
     }
-    
+
     @available(iOS 17.0, *)
     private func configureTips() {
         do {
@@ -427,8 +431,8 @@ private struct CustomTooltipModifier: ViewModifier {
             content
                 .overlay(alignment: .topTrailing) {
                     if shouldShowInfoTooltip {
-                        TipView(ProductDiscountTip(), arrowEdge: .leading)
-                            .tipBackground(.regularMaterial)
+                        TipView(ProductDiscountTip(), arrowEdge: .top)
+                            .tipBackground(Color.black)
                             .onTapGesture {
                                 shouldShowInfoTooltip = false
                             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
This PR explores the usage of TipKit for iOS17+ in order creation.

| Before | After |
|--------|--------|
| <img width="730" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-07-29 at 10 03 19" src="https://github.com/user-attachments/assets/405a533b-66dc-4be2-a413-cc0962c509f8" /> | <img width="731" height="502" alt="Screenshot 2025-07-29 at 16 11 12" src="https://github.com/user-attachments/assets/00b0d9c9-f370-48e4-b0d8-d74989f42fde" /> | 



## Testing information
- Add product to order
- Add a coupon to order
- Expand product card to see its details, tap on the `?` icon by the `discount` button
- See the new tip accommodating in the view.

## Recording

https://github.com/user-attachments/assets/27e48ad3-eff6-4e71-a4dd-68a9c0d70c4b



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
