### PR TITLE
Complete card payment only after alert presentation is done

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -179,9 +179,9 @@ where TapToPayAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
                                                               alertProvider: paymentAlertProvider,
                                                               onCompleted: onCompleted)
                             }
+                            onPaymentCompletion()
                         }
                     }
-                    onPaymentCompletion()
                 })
             case .canceled(let cancellationSource, _):
                 self.handlePaymentCancellation(from: cancellationSource)

--- a/WooCommerce/WooCommerceTests/Mocks/MockReceiptEligibilityUseCase.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockReceiptEligibilityUseCase.swift
@@ -7,8 +7,14 @@ final class MockReceiptEligibilityUseCase: ReceiptEligibilityUseCaseProtocol {
     var isEligibleForFailedPaymentEmailReceipts: Bool = false
     var isEligibleForReceipt: Bool = true
 
+    var mockIsEligibleForBackendReceiptsHandler: ((@escaping (Bool) -> Void) -> Void)?
+
     func isEligibleForBackendReceipts(onCompletion: @escaping (Bool) -> Void) {
-        onCompletion(isEligibleForBackendReceipts)
+        if let handler = mockIsEligibleForBackendReceiptsHandler {
+            handler(onCompletion)
+        } else {
+            onCompletion(isEligibleForBackendReceipts)
+        }
     }
 
     func isEligibleForSuccessfulPaymentEmailReceipts(onCompletion: @escaping (Bool) -> Void) {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -361,6 +361,55 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         // Then
         XCTAssertEqual(mockPaymentOrchestrator.spyChannel, .pos)
     }
+
+    func test_completion_called_after_alert_presentation() throws {
+        receiptEligibilityUseCase.isEligibleForBackendReceipts = true
+        let paymentMethod = PaymentMethod.cardPresent(details: .fake())
+        let intent = PaymentIntent.fake().copy(charges: [.fake().copy(paymentMethod: paymentMethod)])
+        let capturedPaymentData = CardPresentCapturedPaymentData(paymentMethod: paymentMethod, receiptParameters: .fake())
+        mockSuccessfulCardPresentPaymentActions(intent: intent, capturedPaymentData: capturedPaymentData)
+        enum Event {
+            case receiptEligibilityCheck
+            case alertPresented
+            case paymentCompletion
+        }
+        var eventOrder: [Event] = []
+
+        receiptEligibilityUseCase.mockIsEligibleForBackendReceiptsHandler = { completion in
+            // Force receiptEligibilityCheck completion delay
+            DispatchQueue.main.async {
+                eventOrder.append(.receiptEligibilityCheck)
+                completion(true)
+            }
+        }
+
+        // Track when receipt alert is presented
+        alertsPresenter.onPresentCalled = { viewModel in
+            if viewModel is CardPresentModalSuccessWithoutEmail ||
+               viewModel is CardPresentModalSuccessEmailSent {
+                eventOrder.append(.alertPresented)
+            }
+        }
+
+        // When payment succeeds
+        waitFor { promise in
+            self.useCase.collectPayment(
+                using: .bluetoothScan,
+                channel: .storeManagement,
+                onFailure: { _ in },
+                onCancel: {},
+                onPaymentCompletion: {
+                    eventOrder.append(.paymentCompletion)
+                    promise(())
+                },
+                onCompleted: {}
+            )
+            self.mockPreflightController.completeConnection(reader: MockCardReader.wisePad3(), gatewayID: Mocks.paymentGatewayAccount)
+        }
+
+        // Then ensure payment completion happens after alert presentation to avoid CollectOrderPaymentUseCase deinit before alert presentation
+        XCTAssertEqual(eventOrder, [.receiptEligibilityCheck, .alertPresented, .paymentCompletion])
+    }
 }
 
 private extension CollectOrderPaymentUseCaseTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

WOOMOB-953

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As @jaclync has noticed when doing PR Review for https://github.com/woocommerce/woocommerce-ios/pull/15956 the card payments would succeed, but POS was left stuck in "Processing..." screen.

### Investigation

I tested TestFlight versions and confirmed that the issue wasn't reproducible on 22.8 but was reproducible on the current beta, 22.9.

I couldn't pinpoint an issue by looking at the changes so I did a `git bisect` that pointed [to this commit](https://github.com/woocommerce/woocommerce-ios/pull/15941/commits/c6478d94e9e4a945a0510511f86062279eb34426).

What this small change did was expose a slight timing issue when `onPaymentCompletion()` was called. `onPaymentCompletion()` was relying on `isEligibleForBackendReceipts` check being synchronous, so alert presentation would be called **before** payment completion. However, after [this commit](https://github.com/woocommerce/woocommerce-ios/pull/15941/commits/c6478d94e9e4a945a0510511f86062279eb34426), `isEligibleForBackendReceipts` became asynchronous, and alert presentation was called after `onPaymentCompletion()`.

It didn't cause issues for IPP because of the different ways `CollectOrderPaymentUseCase` was used. For POS, `CardPresentPaymentCollectOrderPaymentUseCaseAdaptor` would deinitialize `CollectOrderPaymentUseCase` after a successful payment. Therefore, alert presenters were never called to notify about successful payment

### Solution

The solution is straightforward. Move `onPaymentCompletion()` into `isEligibleForBackendReceipts` to ensure alert presenters are called before completing the payment.

I also added a test to ensure the expected event order.


## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Verify card payments work on the POS and result in a "success" view

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- iPad Air 18.5 simulator and iPad 26 device + M2 reader
- Failed and successful payments
- IPP and POS

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.