### PR TITLE
Fix iPhone UI test failure in trunk from customer details address form

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -104,7 +104,7 @@ steps:
     command: .buildkite/commands/run-ui-tests.sh UITests "iPhone 16"
     depends_on: build
     # Only run on `trunk` and `release/*` -- See p91TBi-cBM-p2#comment-13736
-    if: build.branch == "trunk" || build.branch =~ /^release\// || build.branch == "fix/WOOMOB-957-ui-test-failure-address-form"
+    if: build.branch == "trunk" || build.branch =~ /^release\//
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - fastlane/test_output/*
@@ -116,7 +116,7 @@ steps:
     command: .buildkite/commands/run-ui-tests.sh UITests "iPad Pro 13-inch (M4)"
     depends_on: build
     # Only run on `trunk` and `release/*` -- See p91TBi-cBM-p2#comment-13736
-    if: build.branch == "trunk" || build.branch =~ /^release\// || build.branch == "fix/WOOMOB-957-ui-test-failure-address-form"
+    if: build.branch == "trunk" || build.branch =~ /^release\//
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - fastlane/test_output/*

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -104,7 +104,7 @@ steps:
     command: .buildkite/commands/run-ui-tests.sh UITests "iPhone 16"
     depends_on: build
     # Only run on `trunk` and `release/*` -- See p91TBi-cBM-p2#comment-13736
-    if: build.branch == "trunk" || build.branch =~ /^release\//
+    if: build.branch == "trunk" || build.branch =~ /^release\// || build.branch == "fix/WOOMOB-957-ui-test-failure-address-form"
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - fastlane/test_output/*
@@ -116,7 +116,7 @@ steps:
     command: .buildkite/commands/run-ui-tests.sh UITests "iPad Pro 13-inch (M4)"
     depends_on: build
     # Only run on `trunk` and `release/*` -- See p91TBi-cBM-p2#comment-13736
-    if: build.branch == "trunk" || build.branch =~ /^release\//
+    if: build.branch == "trunk" || build.branch =~ /^release\// || build.branch == "fix/WOOMOB-957-ui-test-failure-address-form"
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - fastlane/test_output/*

--- a/Modules/Sources/UITestsFoundation/Screens/Orders/CustomerDetailsScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Orders/CustomerDetailsScreen.swift
@@ -40,6 +40,7 @@ public final class CustomerDetailsScreen: ScreenObject {
     @discardableResult
     public func enterCustomerDetails(name: String) throws -> UnifiedOrderScreen {
         billingFirstNameField.tap()
+        // `\n` was added after the first name input in order to dismiss the keyboard so that the address toggle is interactive in shorter screens.
         billingFirstNameField.typeText("\(name)\n")
         let tableView = app.tables.firstMatch
         tableView.swipeUp()

--- a/Modules/Sources/UITestsFoundation/Screens/Orders/CustomerDetailsScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Orders/CustomerDetailsScreen.swift
@@ -40,8 +40,11 @@ public final class CustomerDetailsScreen: ScreenObject {
     @discardableResult
     public func enterCustomerDetails(name: String) throws -> UnifiedOrderScreen {
         billingFirstNameField.tap()
-        billingFirstNameField.typeText(name)
+        billingFirstNameField.typeText("\(name)\n")
+        let tableView = app.tables.firstMatch
+        tableView.swipeUp()
         addressToggleSet(to: "1")
+        tableView.swipeUp()
         shippingFirstNameField.tap()
         shippingFirstNameField.typeText(name)
         doneButton.tap()


### PR DESCRIPTION
For WOOMOB-957

Just one review is required.

## Description

Fixes iPhone UI test failure `test_create_new_order` in the customer details address form, where the shipping first name field tap was failing. The issue occurred because:

1. After introducing a CTA in the address form above the address fields in https://github.com/woocommerce/woocommerce-ios/pull/15958, the CTA pushes down the address switch to edit shipping address. On iPhone's smaller screen, this results in the address switch not being toggled
2. Therefore, the shipping address fields aren't shown and the shipping first name cannot be tapped

<img width="422" height="720" alt="Screenshot 2025-08-01 at 3 29 49 PM" src="https://github.com/user-attachments/assets/c986e829-2d8d-48d9-a48a-771d3504801d" />

I can reproduce the failure locally. The same test case passes on iPad consistently in trunk. The UI test is not able to interact with elements covered by the keyboard.

## Fix

After trying a few different ways to wait for the element and swipe up the view before toggling the switch, what worked is to add a `\n` to the billing address first name input so that the keyboard is dismissed. This allows the switch to be tappable.

## Steps to reproduce

1. Run the order creation UI test `test_create_new_order` on iPhone 16 iOS 18.5 simulator following the [README](https://github.com/woocommerce/woocommerce-ios/blob/2d54605796be93594b7f616d8b79e6f13444e9ff/WooCommerce/WooCommerceUITests/README.md) -> the test should not fail when trying to tap the shipping first name field after enabling the address toggle. Locally, it failed on a separate screen when editing the order shipping amount but this is unrelated to the address picker change.

## Testing information

UI tests passed [on CI](https://buildkite.com/automattic/woocommerce-ios/builds/31448#0198649d-bd7d-4152-9ad8-3aa11570aa4f) for both iPhone and iPad. The first run of the iPhone UI tests hung after the last test completed, I canceled and retried and it passed.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.