### PR TITLE
[Woo POS][Barcodes] Disable scanning when the support view is open

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
@@ -28,7 +28,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView: View {
                              accessibilityLabel: viewModel.cancelButtonViewModel.title)
         .multilineTextAlignment(.center)
         .accessibilityElement(children: .contain)
-        .sheet(isPresented: $viewModel.shouldShowSettingsWebView) {
+        .posSheet(isPresented: $viewModel.shouldShowSettingsWebView) {
             WCSettingsWebView(adminUrl: viewModel.settingsAdminUrl,
                               completion: viewModel.settingsWebViewWasDismissed)
         }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressView.swift
@@ -69,7 +69,7 @@ struct PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressPreviewView: V
                 showsSheet = true
             }
         }
-        .sheet(isPresented: $showsSheet) {
+        .posSheet(isPresented: $showsSheet) {
             PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressView(viewModel: .init(
                 progress: 0.6, cancel: nil
             ), animation: .init(namespace: namespace))

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionView.swift
@@ -49,7 +49,7 @@ struct PointOfSaleCardPresentPaymentReaderUpdateCompletionPreviewView: View {
                 showsSheet = true
             }
         }
-        .sheet(isPresented: $showsSheet) {
+        .posSheet(isPresented: $showsSheet) {
             PointOfSaleCardPresentPaymentReaderUpdateCompletionView(
                 viewModel: .init(),
                 animation: .init(namespace: namespace)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView.swift
@@ -70,7 +70,7 @@ struct CardPresentPaymentRequiredReaderUpdateInProgressPreviewView: View {
                 showsSheet = true
             }
         }
-        .sheet(isPresented: $showsSheet) {
+        .posSheet(isPresented: $showsSheet) {
             PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView(viewModel: .init(
                 progress: 0.6, cancel: nil
             ), animation: .init(namespace: namespace))

--- a/WooCommerce/Classes/POS/Presentation/Coupons/POSCouponCreationSheet.swift
+++ b/WooCommerce/Classes/POS/Presentation/Coupons/POSCouponCreationSheet.swift
@@ -22,7 +22,7 @@ private struct POSCouponCreationSheetModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .sheet(item: $selectedType) { (posDiscountType: POSCouponDiscountType) in
+            .posSheet(item: $selectedType) { (posDiscountType: POSCouponDiscountType) in
                 POSCouponCreationView(
                     discountType: posDiscountType.discountType,
                     showTypeSelection: $showCouponSelectionSheet,
@@ -89,7 +89,7 @@ private extension View {
         isPresented: Binding<Bool>,
         onSelection: @escaping (POSCouponDiscountType) -> Void
     ) -> some View {
-        sheet(isPresented: isPresented) {
+        posSheet(isPresented: isPresented) {
             let command = DiscountTypeBottomSheetListSelectorCommand(selected: nil) { type in
                 onSelection(.init(discountType: type))
             }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -458,6 +458,8 @@ private extension ItemListView {
     return ItemListView(selectedItemListType: .constant(.products(search: false)),
                         searchTerm: .constant(""))
         .environment(posModel)
+        .environmentObject(POSModalManager())
+        .environmentObject(POSSheetManager())
 }
 
 @available(iOS 17.0, *)
@@ -465,6 +467,8 @@ private extension ItemListView {
     ItemListView(selectedItemListType: .constant(.products(search: false)),
                  searchTerm: .constant(""))
         .environment(POSPreviewHelpers.makePreviewAggregateModel())
+        .environmentObject(POSModalManager())
+        .environmentObject(POSSheetManager())
 }
 
 #endif

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -9,6 +9,7 @@ struct ItemListView: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.keyboardObserver) private var keyboardObserver
     @EnvironmentObject var modalManager: POSModalManager
+    @EnvironmentObject var sheetManager: POSSheetManager
 
     @Binding var selectedItemListType: ItemListType
     @Binding var searchTerm: String
@@ -42,7 +43,7 @@ struct ItemListView: View {
 
     private var isBarcodeScanningEnabled: Binding<Bool> {
         Binding(
-            get: { !isSearching && !modalManager.isPresented },
+            get: { !isSearching && !modalManager.isPresented && !sheetManager.isPresented },
             set: { _ in }
         )
     }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -190,8 +190,8 @@ private extension PointOfSaleDashboardView {
                         viewModel: SupportFormViewModel(sourceTag: Constants.supportTag,
                                                         defaultSite: ServiceLocator.stores.sessionManager.defaultSite))
             .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button(Localization.supportDone) {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.supportCancel) {
                         showSupport = false
                     }
                 }
@@ -258,9 +258,9 @@ private extension PointOfSaleDashboardView {
     }
 
     enum Localization {
-        static let supportDone = NSLocalizedString(
-            "pointOfSaleDashboard.support.done",
-            value: "Done",
+        static let supportCancel = NSLocalizedString(
+            "pointOfSaleDashboard.support.cancel",
+            value: "Cancel",
             comment: "Button to dismiss the support form from the POS dashboard."
         )
     }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -123,11 +123,11 @@ struct PointOfSaleDashboardView: View {
             .frame(maxWidth: Constants.exitPOSSheetMaxWidth)
         }
         .posRootModal()
-        .sheet(isPresented: $showSupport) {
+        .posSheet(isPresented: $showSupport) {
             supportForm
                 .interactiveDismissDisabled(true)
         }
-        .sheet(isPresented: $showDocumentation) {
+        .posSheet(isPresented: $showDocumentation) {
             documentationView
         }
         .onChange(of: posModel.entryPointController.eligibilityState) { oldValue, newValue in

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -75,6 +75,7 @@ struct PointOfSaleEntryPointView: View {
                 barcodeScanService: barcodeScanService)
         }
         .environmentObject(posModalManager)
+        .posRootSheet()
         .injectKeyboardObserver()
         .onAppear {
             onPointOfSaleModeActiveStateChange(true)

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -6,6 +6,7 @@ import protocol Yosemite.PointOfSaleBarcodeScanServiceProtocol
 struct PointOfSaleEntryPointView: View {
     @State private var posModel: PointOfSaleAggregateModel?
     @StateObject private var posModalManager = POSModalManager()
+    @StateObject private var posSheetManager = POSSheetManager()
     @State private var posEntryPointController: POSEntryPointController
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
@@ -75,7 +76,7 @@ struct PointOfSaleEntryPointView: View {
                 barcodeScanService: barcodeScanService)
         }
         .environmentObject(posModalManager)
-        .posRootSheet()
+        .environmentObject(posSheetManager)
         .injectKeyboardObserver()
         .onAppear {
             onPointOfSaleModeActiveStateChange(true)

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSheet.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSheet.swift
@@ -81,7 +81,7 @@ extension View {
     /// This works exactly like the native .sheet() modifier but automatically tracks
     /// presentation state.
     ///
-    /// This will only work in a view hierarchy containing a `posRootSheet` modifier.
+    /// This will only work in a view hierarchy containing a `POSSheetManager` environment object.
     ///
     /// - Parameters:
     ///   - isPresented: Binding to control when the sheet is shown.
@@ -107,7 +107,7 @@ extension View {
     /// This works exactly like the native .sheet(item:) modifier but automatically tracks
     /// presentation state.
     ///
-    /// This will only work in a view hierarchy containing a `posRootSheet` modifier.
+    /// This will only work in a view hierarchy containing a `POSSheetManager` environment object.
     ///
     /// - Parameters:
     ///   - item: Binding to control when the sheet is shown. When non-nil, the item is used to build the content.

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSheet.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSheet.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+
+//
+// POSSheet - Wraps default SwiftUI .sheet() modifiers to support sheet presentation detection within POS.
+//
+// Usage: Replace .sheet() with .posSheet() and apply .posRootSheet() at the POS root.
+// Sheet presentation can be detected via POSSheetManager.isPresented.
+//
+
+// MARK: - Sheet Detection Infrastructure
+
+final class POSSheetManager: ObservableObject {
+    @Published private(set) var isPresented: Bool = false
+    private var presentedSheets: Set<String> = []
+
+    func registerSheetPresented(id: String) {
+        presentedSheets.insert(id)
+        updateState()
+    }
+
+    func registerSheetDismissed(id: String) {
+        presentedSheets.remove(id)
+        updateState()
+    }
+
+    private func updateState() {
+        isPresented = !presentedSheets.isEmpty
+    }
+}
+
+// MARK: - Root Sheet Detection Modifier
+
+private struct POSRootSheetViewModifier: ViewModifier {
+    @StateObject private var sheetManager = POSSheetManager()
+
+    func body(content: Content) -> some View {
+        content
+            .environmentObject(sheetManager)
+    }
+}
+
+// MARK: - Individual Sheet Modifiers
+
+struct POSSheetViewModifier<SheetContent: View>: ViewModifier {
+    @EnvironmentObject var sheetManager: POSSheetManager
+    @Binding var isPresented: Bool
+    let onDismiss: (() -> Void)?
+    let sheetContent: () -> SheetContent
+
+    @State private var sheetId = UUID().uuidString
+
+    func body(content: Content) -> some View {
+        content
+            .sheet(isPresented: $isPresented, onDismiss: onDismiss, content: sheetContent)
+            .onChange(of: isPresented) { newValue in
+                if newValue {
+                    sheetManager.registerSheetPresented(id: sheetId)
+                } else {
+                    sheetManager.registerSheetDismissed(id: sheetId)
+                }
+            }
+    }
+}
+
+struct POSSheetViewModifierForItem<Item: Identifiable & Equatable, SheetContent: View>: ViewModifier {
+    @EnvironmentObject var sheetManager: POSSheetManager
+    @Binding var item: Item?
+    let onDismiss: (() -> Void)?
+    let sheetContent: (Item) -> SheetContent
+
+    @State private var sheetId = UUID().uuidString
+
+    func body(content: Content) -> some View {
+        content
+            .sheet(item: $item, onDismiss: onDismiss, content: sheetContent)
+            .onChange(of: item) { newItem in
+                let newValue = newItem != nil
+                if newValue {
+                    sheetManager.registerSheetPresented(id: sheetId)
+                } else {
+                    sheetManager.registerSheetDismissed(id: sheetId)
+                }
+            }
+    }
+}
+
+// MARK: - View Modifiers
+
+extension View {
+    /// This should be applied at the root Point of Sale view only. It provides sheet detection for all posSheet modifiers.
+    /// Ensure you use posSheet modifiers in child views for automatic sheet detection.
+    ///
+    /// - Returns: a view that can detect when any posSheet is presented
+    func posRootSheet() -> some View {
+        self.modifier(POSRootSheetViewModifier())
+    }
+
+    /// Shows a sheet with automatic detection of presentation.
+    ///
+    /// This works exactly like the native .sheet() modifier but automatically tracks
+    /// presentation state.
+    ///
+    /// This will only work in a view hierarchy containing a `posRootSheet` modifier.
+    ///
+    /// - Parameters:
+    ///   - isPresented: Binding to control when the sheet is shown.
+    ///   - onDismiss: Optional closure executed when the sheet is dismissed.
+    ///   - content: Content to show in the sheet
+    /// - Returns: a modified view which can show the sheet content specified, when applicable.
+    func posSheet<SheetContent: View>(
+        isPresented: Binding<Bool>,
+        onDismiss: (() -> Void)? = nil,
+        @ViewBuilder content: @escaping () -> SheetContent
+    ) -> some View {
+        self.modifier(
+            POSSheetViewModifier(
+                isPresented: isPresented,
+                onDismiss: onDismiss,
+                sheetContent: content
+            )
+        )
+    }
+
+    /// Shows a sheet with automatic detection of presentation.
+    ///
+    /// This works exactly like the native .sheet(item:) modifier but automatically tracks
+    /// presentation state.
+    ///
+    /// This will only work in a view hierarchy containing a `posRootSheet` modifier.
+    ///
+    /// - Parameters:
+    ///   - item: Binding to control when the sheet is shown. When non-nil, the item is used to build the content.
+    ///   - onDismiss: Optional closure executed when the sheet is dismissed.
+    ///   - content: Content to show in the sheet
+    /// - Returns: a modified view which can show the sheet content specified, when applicable.
+    func posSheet<Item: Identifiable & Equatable, SheetContent: View>(
+        item: Binding<Item?>,
+        onDismiss: (() -> Void)? = nil,
+        @ViewBuilder content: @escaping (Item) -> SheetContent
+    ) -> some View {
+        self.modifier(
+            POSSheetViewModifierForItem(
+                item: item,
+                onDismiss: onDismiss,
+                sheetContent: content
+            )
+        )
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSheet.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSheet.swift
@@ -3,7 +3,7 @@ import SwiftUI
 //
 // POSSheet - Wraps default SwiftUI .sheet() modifiers to support sheet presentation detection within POS.
 //
-// Usage: Replace .sheet() with .posSheet() and apply .posRootSheet() at the POS root.
+// Usage: Replace .sheet() with .posSheet() and inject POSSheetManager at the POS root.
 // Sheet presentation can be detected via POSSheetManager.isPresented.
 //
 
@@ -25,17 +25,6 @@ final class POSSheetManager: ObservableObject {
 
     private func updateState() {
         isPresented = !presentedSheets.isEmpty
-    }
-}
-
-// MARK: - Root Sheet Detection Modifier
-
-private struct POSRootSheetViewModifier: ViewModifier {
-    @StateObject private var sheetManager = POSSheetManager()
-
-    func body(content: Content) -> some View {
-        content
-            .environmentObject(sheetManager)
     }
 }
 
@@ -87,14 +76,6 @@ struct POSSheetViewModifierForItem<Item: Identifiable & Equatable, SheetContent:
 // MARK: - View Modifiers
 
 extension View {
-    /// This should be applied at the root Point of Sale view only. It provides sheet detection for all posSheet modifiers.
-    /// Ensure you use posSheet modifiers in child views for automatic sheet detection.
-    ///
-    /// - Returns: a view that can detect when any posSheet is presented
-    func posRootSheet() -> some View {
-        self.modifier(POSRootSheetViewModifier())
-    }
-
     /// Shows a sheet with automatic detection of presentation.
     ///
     /// This works exactly like the native .sheet() modifier but automatically tracks

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		01695EB82E22600800B731DA /* PointOfSaleBarcodeScannerSetupFlowManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01695EB72E22600300B731DA /* PointOfSaleBarcodeScannerSetupFlowManagerTests.swift */; };
 		016A77692D9D24B00004FCD6 /* POSCouponCreationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016A77682D9D24A70004FCD6 /* POSCouponCreationSheet.swift */; };
 		016C6B972C74AB17000D86FD /* POSConnectivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016C6B962C74AB17000D86FD /* POSConnectivityView.swift */; };
+		016DE5332E40B03200F53DF7 /* POSSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016DE5322E40B03200F53DF7 /* POSSheet.swift */; };
 		0174DDBB2CE5FD60005D20CA /* ReceiptEmailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0174DDBA2CE5FD5D005D20CA /* ReceiptEmailViewModel.swift */; };
 		0174DDBF2CE600C5005D20CA /* ReceiptEmailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0174DDBE2CE600C0005D20CA /* ReceiptEmailViewModelTests.swift */; };
 		0177250C2E1CFF7F00016148 /* GameControllerBarcodeParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0177250B2E1CFF7F00016148 /* GameControllerBarcodeParser.swift */; };
@@ -3226,6 +3227,7 @@
 		01695EB72E22600300B731DA /* PointOfSaleBarcodeScannerSetupFlowManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleBarcodeScannerSetupFlowManagerTests.swift; sourceTree = "<group>"; };
 		016A77682D9D24A70004FCD6 /* POSCouponCreationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSCouponCreationSheet.swift; sourceTree = "<group>"; };
 		016C6B962C74AB17000D86FD /* POSConnectivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSConnectivityView.swift; sourceTree = "<group>"; };
+		016DE5322E40B03200F53DF7 /* POSSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSheet.swift; sourceTree = "<group>"; };
 		0174DDBA2CE5FD5D005D20CA /* ReceiptEmailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptEmailViewModel.swift; sourceTree = "<group>"; };
 		0174DDBE2CE600C0005D20CA /* ReceiptEmailViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptEmailViewModelTests.swift; sourceTree = "<group>"; };
 		0177250B2E1CFF7F00016148 /* GameControllerBarcodeParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameControllerBarcodeParser.swift; sourceTree = "<group>"; };
@@ -6425,6 +6427,7 @@
 		01620C4C2C5394A400D3EA2F /* Reusable Views */ = {
 			isa = PBXGroup;
 			children = (
+				016DE5322E40B03200F53DF7 /* POSSheet.swift */,
 				0210A2452D55EC140054C78D /* Buttons */,
 				01620C4D2C5394B200D3EA2F /* POSProgressViewStyle.swift */,
 				204D1D612C5A50840064A6BE /* POSModalViewModifier.swift */,
@@ -15210,6 +15213,7 @@
 				26D1E9E82949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift in Sources */,
 				CE32B11A20BF8E32006FBCF4 /* UIButton+Helpers.swift in Sources */,
 				02667A1C2AC159A000C77B56 /* GiftCardCodeScannerNavigationView.swift in Sources */,
+				016DE5332E40B03200F53DF7 /* POSSheet.swift in Sources */,
 				262562352C52A6410075A8CC /* WooAnalyticsEvent+BackgroudUpdates.swift in Sources */,
 				45BBFBC5274FDCE900213001 /* HubMenu.swift in Sources */,
 				02A9BCD62737F73C00159C79 /* JetpackBenefitItem.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

WOOMOB-945

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Scanning is still detected when the support view or any other SwiftUI `.sheet` is opened in POS. The largest issue is with coupons and support sheets, which detect text input with an external keyboard (or a `macOS` keyboard when testing on a simulator).

## Solution

We already disable scanning when posModals are opened with `modalManager.isPresented` check within `ItemListView`. However, I haven't thought about doing the same for `SwiftUI` sheets.

However, we cannot keep using a native`.sheet` modifier and cleanly detect if a sheet is presented or not. I tried looking for such solutions unsuccessfully. Therefore, I decided to introduce a `.posSheet` wrapper which uses the same system as `posModal` to enable `sheetManager.isPresented` checks when needed. 

This implementation relies on future POS development to use `posSheet` instead of `sheet` for barcode scanning prevention functionality to work. Therefore, there's always a chance some new sheet will be presented without preventing barcode scanning detection.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Confirm scanning works / macOS keyboard with simulator open are detected as scans
3. Try opening sheets: (coupon creation, support, documentation) and barcode scanning
4. Confirm barcode scanning is not registered in cart
5. Dismiss the sheets
6. Confirm barcode scanning is registered in cart again

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air 20.6 simulator

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.