### PR TITLE
[Woo POS][Barcodes] Minor copy updates

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupModels.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupModels.swift
@@ -29,11 +29,11 @@ enum PointOfSaleBarcodeScannerType {
     var analyticsName: String {
         switch self {
         case .starBSH20B:
-            return "Star_BSH_20B"
+            return "star_bsh_20b"
         case .tera12002D:
-            return "Tera_1200_2D"
+            return "tera_1200_2d"
         case .netum1228BC:
-            return "Netum_1228BC"
+            return "netum_1228bc"
         case .other:
             return "other"
         }

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupStepViews.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupStepViews.swift
@@ -196,9 +196,9 @@ private extension PointOfSaleBarcodeScannerSetupCompleteView {
             comment: "Title shown when scanner setup is successfully completed"
         )
         static let instruction = NSLocalizedString(
-            "pos.barcodeScannerSetup.complete.instruction",
-            value: "You are ready to start scanning products. \nRead more about barcode and QR code scanner support.",
-            comment: "Message shown when scanner setup is complete, with additional information link"
+            "pos.barcodeScannerSetup.complete.instruction.2",
+            value: "You are ready to start scanning products. Next time you need to connect your scanner, just turn it on and it will reconnect automatically.",
+            comment: "Message shown when scanner setup is complete"
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -63,7 +63,13 @@ struct POSFloatingControlView: View {
                         ServiceLocator.analytics.track(.pointOfSaleBarcodeScanningMenuItemTapped)
                     } label: {
                         Label(
-                            title: { Text(Localization.barcodeScanning) },
+                            title: {
+                                if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleBarcodeScanningi2) {
+                                    Text(Localization.barcodeScanningSetup)
+                                } else {
+                                    Text(Localization.barcodeScanning)
+                                }
+                            },
                             icon: { Image(systemName: "barcode.viewfinder") })
                     }
                 }
@@ -172,6 +178,12 @@ private extension POSFloatingControlView {
             "pointOfSale.floatingButtons.barcodeScanning.button.title",
             value: "Barcode scanning",
             comment: "The title of the menu button to view barcode scanner documentation, shown in a popover menu."
+        )
+
+        static let barcodeScanningSetup = NSLocalizedString(
+            "pointOfSale.floatingButtons.barcodeScanningSetup.button.title",
+            value: "Initial barcode scanner setup",
+            comment: "The title of the menu button to start a barcode scanner setup flow."
         )
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlowManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlowManagerTests.swift
@@ -20,7 +20,7 @@ struct PointOfSaleBarcodeScannerSetupFlowManagerTests {
         // Then it tracks the scanner selected event
         let event = mockAnalytics.events.first
         #expect(event?.eventName == WooAnalyticsStat.pointOfSaleBarcodeScannerSetupScannerSelected.rawValue)
-        #expect(event?.properties["scanner"] as? String == "Star_BSH_20B")
+        #expect(event?.properties["scanner"] as? String == PointOfSaleBarcodeScannerType.starBSH20B.analyticsName)
     }
 
     @available(iOS 17.0, *)
@@ -42,7 +42,7 @@ struct PointOfSaleBarcodeScannerSetupFlowManagerTests {
         // Then it tracks the dismissal event
         let event = mockAnalytics.events.first
         #expect(event?.eventName == WooAnalyticsStat.pointOfSaleBarcodeScannerSetupDismissed.rawValue)
-        #expect(event?.properties["scanner"] as? String == "Star_BSH_20B")
+        #expect(event?.properties["scanner"] as? String == PointOfSaleBarcodeScannerType.starBSH20B.analyticsName)
         #expect(event?.properties["step"] as? String == "setup_barcode_hid")
     }
 
@@ -84,7 +84,7 @@ struct PointOfSaleBarcodeScannerSetupFlowManagerTests {
         // Then it tracks the scanner connected event
         let event = mockAnalytics.events.first
         #expect(event?.eventName == WooAnalyticsStat.pointOfSaleBarcodeScannerSetupScannerConnected.rawValue)
-        #expect(event?.properties["scanner"] as? String == "Netum_1228BC")
+        #expect(event?.properties["scanner"] as? String == PointOfSaleBarcodeScannerType.netum1228BC.analyticsName)
     }
 
     @available(iOS 17.0, *)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

WOOMOB-926

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Make minor copy updates to barcode scanning implementation based on changes made on Android after testing:
- Lowercase analytics scanner identifier for consistency between platforms
- Make menu option naming more explicit
- Update the success message for clarity

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Select the menu
3. Confirm "Initial barcode scanner setup" menu option
4. Start setup flow
5. Check tracking, confirm lowercase scanner identifier
6. Complete the scanning flow
7. Confirm the success message mentions that scanner will reconnect automatically next time

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

iPad 26 device + Inateck scanner

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.