### PR TITLE
Fix orderTotalChanged error for 8dp vs 2dp amounts

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -261,15 +261,17 @@ private extension CollectOrderPaymentUseCase {
             guard let self = self else { return }
 
             switch result {
-                case .success(let order):
-                    guard order.total == self.order.total else {
-                        return onCheckCompletion(.failure(CollectOrderPaymentUseCaseError.orderTotalChanged))
-                    }
+            case .success(let order):
+                let orderTotal = currencyFormatter.convertToDecimal(order.total)
+                let originalOrderTotal = currencyFormatter.convertToDecimal(self.order.total)
+                guard orderTotal == originalOrderTotal else {
+                    return onCheckCompletion(.failure(CollectOrderPaymentUseCaseError.orderTotalChanged))
+                }
 
-                    self.order = order
-                case .failure(let error):
-                    DDLogError("⛔️ Error synchronizing Order: \(error.localizedDescription)")
-                    return onCheckCompletion(.failure(CollectOrderPaymentUseCaseError.couldNotRefreshOrder(error)))
+                self.order = order
+            case .failure(let error):
+                DDLogError("⛔️ Error synchronizing Order: \(error.localizedDescription)")
+                return onCheckCompletion(.failure(CollectOrderPaymentUseCaseError.couldNotRefreshOrder(error)))
             }
 
             guard self.isTotalAmountValid() else {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -410,6 +410,62 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         // Then ensure payment completion happens after alert presentation to avoid CollectOrderPaymentUseCase deinit before alert presentation
         XCTAssertEqual(eventOrder, [.receiptEligibilityCheck, .alertPresented, .paymentCompletion])
     }
+
+    func test_collectPayment_succeeds_when_order_total_precision_differs_between_initial_and_retrieved_order() throws {
+        // Given an order with 2 decimal place precision
+        let initialOrder = Order.fake().copy(siteID: defaultSiteID, orderID: defaultOrderID, total: "22.56")
+
+        // And the retrieved order has 8 decimal place precision (same value, different formatting)
+        let retrievedOrder = Order.fake().copy(siteID: defaultSiteID, orderID: defaultOrderID, total: "22.56000000")
+
+        setUpUseCase(order: initialOrder)
+
+        // Mock the order retrieval to return the 8dp version
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .retrieveOrderRemotely(_, _, let completion):
+                completion(.success(retrievedOrder))
+            default:
+                break
+            }
+        }
+
+        let paymentMethod = PaymentMethod.cardPresent(details: .fake())
+        let intent = PaymentIntent.fake().copy(charges: [.fake().copy(paymentMethod: paymentMethod)])
+        let capturedPaymentData = CardPresentCapturedPaymentData(paymentMethod: paymentMethod, receiptParameters: .fake())
+        mockSuccessfulCardPresentPaymentActions(intent: intent, capturedPaymentData: capturedPaymentData)
+
+        // When collecting payment
+        var paymentCompleted = false
+        var paymentFailed = false
+
+        waitFor { promise in
+            self.useCase.collectPayment(
+                using: .bluetoothScan,
+                channel: .storeManagement,
+                onFailure: { error in
+                    paymentFailed = true
+                    // This should not happen with the decimal comparison fix
+                    XCTFail("Payment should not fail due to precision mismatch. Error: \(error)")
+                    promise(())
+                },
+                onCancel: {
+                    XCTFail("Payment should not be canceled")
+                    promise(())
+                },
+                onPaymentCompletion: {
+                    paymentCompleted = true
+                    promise(())
+                },
+                onCompleted: {}
+            )
+            self.mockPreflightController.completeConnection(reader: MockCardReader.wisePad3(), gatewayID: Mocks.paymentGatewayAccount)
+        }
+
+        // Then payment should succeed (with decimal comparison, "22.56" equals "22.56000000")
+        XCTAssertTrue(paymentCompleted)
+        XCTAssertFalse(paymentFailed)
+    }
 }
 
 private extension CollectOrderPaymentUseCaseTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

A recent change #15957 means that we now get 8dp precision on numbers in the Order when we create or update an order. That change broke the card payment process, which performs a check comparing the initial order total (when the merchant taps collect payment) and the most recent total when we take the payment.

Because this was using a string comparison, after the change we started comparing values like `“22.56”` with `“22.56000000”`, and the comparison would always fail. This resulted in an error showing for card payments, stating that the order total had changed since the payment started.

Note that the API always rounds the total to 2dp and pads it to 8dp – this is different for tax values, which were the values prompting the previous change. 

To fix, we now convert the totals to a `NSDecimalNumber` for comparison, which matches our treatment elsewhere in the app.

We’ll discuss the merits of the 8dp change elsewhere, but even if we revert it, this is a beneficial improvement.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Set up a product with a price and tax rate which would result in more than 2dp of precision. For example – $6 with a 9.62% tax rate (prices entered exclusive of tax) would result in a price of $6.5772, but rounded that is $6.58

1. Launch the app and open POS or the Orders tab
2. Create the order with the product set up above
3. Collect a card payment for the order (TTP or Card Reader are both fine.)

The payment should proceed without showing an error mentioning that the "Order total has changed since the beginning of payment."

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/ccd254e7-22a3-4227-acbe-c39232c3dd5e


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
