### PR TITLE
[WCiOS17] Address non-behavioral compiler warnings

### DIFF
--- a/Modules/Sources/NetworkingCore/Remote/Remote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/Remote.swift
@@ -370,7 +370,7 @@ public extension Remote {
         public static let firstPageNumber: Int = 1
     }
 
-    public enum PaginationHeaderKey {
+    enum PaginationHeaderKey {
         public static let totalPagesCount = "x-wp-totalpages"
         public static let totalCount = "x-wp-total"
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift
@@ -43,8 +43,9 @@ struct PointOfSaleCardPresentPaymentBluetoothRequiredAlertView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentBluetoothRequiredAlertView(
         viewModel: .init(error: NSError(domain: "", code: 1),
                          endSearch: {}),

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift
@@ -38,8 +38,9 @@ struct PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView(
         viewModel: PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel(
             retryButtonAction: {},

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift
@@ -38,8 +38,9 @@ struct PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView: V
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView(
         viewModel: PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertViewModel(cancelSearchAction: {}),
         animation: .init(namespace: namespace)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView.swift
@@ -29,8 +29,9 @@ struct PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView(
         viewModel: PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel(
             error: NSError(domain: "payments error", code: 1),

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
@@ -35,8 +35,9 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView(
         viewModel: PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel(
             settingsAdminUrl: URL(string: "http://example.com")!,

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
@@ -38,8 +38,9 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView(
         viewModel: PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel(
             retryButtonAction: { },

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedView.swift
@@ -45,8 +45,9 @@ struct PointOfSaleCardPresentPaymentConnectingFailedView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentConnectingFailedView(
         viewModel: PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel(
             error: NSError(domain: "preview.error", code: 1),

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingLocationPreAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingLocationPreAlertView.swift
@@ -42,8 +42,9 @@ struct PointOfSaleCardPresentPaymentConnectingLocationPreAlertView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     PointOfSaleCardPresentPaymentConnectingLocationPreAlertView(
         viewModel: PointOfSaleCardPresentPaymentConnectingLocationPreAlertViewModel(requestPermissionAction: {}),
         animation: .init(namespace: namespace)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingToReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingToReaderView.swift
@@ -33,8 +33,9 @@ struct PointOfSaleCardPresentPaymentConnectingToReaderView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentConnectingToReaderView(
         viewModel: PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel(),
         animation: .init(namespace: namespace)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift
@@ -27,8 +27,9 @@ struct PointOfSaleCardPresentPaymentConnectionSuccessAlertView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentConnectionSuccessAlertView(
         viewModel: PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel(doneAction: {}),
         animation: .init(namespace: namespace)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderView.swift
@@ -44,8 +44,9 @@ struct PointOfSaleCardPresentPaymentFoundReaderView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentFoundReaderView(
         viewModel: PointOfSaleCardPresentPaymentFoundReaderAlertViewModel(
             readerName: "READER NAME",

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView.swift
@@ -49,8 +49,9 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView(
         viewModel: .init(batteryLevel: nil, retrySearchAction: {}, cancelUpdateAction: {}),
         animation: .init(namespace: namespace)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView.swift
@@ -33,8 +33,9 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView(
         viewModel: .init(cancelUpdateAction: {}),
         animation: .init(namespace: namespace)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedView.swift
@@ -37,8 +37,9 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentReaderUpdateFailedView(
         viewModel: .init(retryAction: {}, cancelUpdateAction: {}),
         animation: .init(namespace: namespace)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersFailedView.swift
@@ -35,8 +35,9 @@ struct PointOfSaleCardPresentPaymentScanningForReadersFailedView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentScanningForReadersFailedView(
         viewModel: PointOfSaleCardPresentPaymentScanningFailedAlertViewModel(
             error: NSError(domain: "", code: 1, userInfo: nil),

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersView.swift
@@ -35,8 +35,9 @@ struct PointOfSaleCardPresentPaymentScanningForReadersView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentScanningForReadersView(
         viewModel: PointOfSaleCardPresentPaymentScanningForReadersAlertViewModel(
             endSearchAction: {}),

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentActivityIndicatingMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentActivityIndicatingMessageView.swift
@@ -38,8 +38,9 @@ private extension PointOfSaleCardPresentPaymentActivityIndicatingMessageView {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentActivityIndicatingMessageView(
         title: "Checking order",
         message: "Getting ready",

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCancelledOnReaderMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCancelledOnReaderMessageView.swift
@@ -44,8 +44,9 @@ struct PointOfSaleCardPresentPaymentCancelledOnReaderMessageView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentCancelledOnReaderMessageView(
         viewModel: PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel(tryPaymentAgainButtonAction: {}),
         animation: .init(namespace: namespace)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift
@@ -62,8 +62,9 @@ struct PointOfSaleCardPresentPaymentCaptureErrorMessageView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentCaptureErrorMessageView(
         viewModel: PointOfSaleCardPresentPaymentCaptureErrorMessageViewModel(
             tryAgainButtonAction: {},

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageView.swift
@@ -56,8 +56,9 @@ struct PointOfSaleCardPresentPaymentErrorMessageView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview("Generic retry") {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
 
     return PointOfSaleCardPresentPaymentErrorMessageView(
         viewModel: PointOfSaleCardPresentPaymentErrorMessageViewModel(
@@ -69,8 +70,9 @@ struct PointOfSaleCardPresentPaymentErrorMessageView: View {
     )
 }
 
+@available(iOS 17.0, *)
 #Preview("Retry with another payment method") {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
 
     return PointOfSaleCardPresentPaymentErrorMessageView(
         viewModel: PointOfSaleCardPresentPaymentErrorMessageViewModel(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift
@@ -52,8 +52,9 @@ struct PointOfSaleCardPresentPaymentIntentCreationErrorMessageView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
 
     return PointOfSaleCardPresentPaymentIntentCreationErrorMessageView(
         viewModel: PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift
@@ -51,8 +51,9 @@ struct PointOfSaleCardPresentPaymentNonRetryableErrorMessageView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentNonRetryableErrorMessageView(
         viewModel: PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel(
             error: CardReaderServiceError.paymentCapture(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView.swift
@@ -45,8 +45,9 @@ struct PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    @Namespace var namespace
+    @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView(
         viewModel: PointOfSaleCardPresentPaymentValidatingOrderErrorMessageViewModel(
             error: CardReaderServiceError.paymentCapture(


### PR DESCRIPTION
Closes WOOMOB-1004

## Description

This PR addresses ~20 of the non-behavioral compiler warnings as part of pre-work for the the app's iOS17 bump: 

1. `'public' modifier is redundant for enum declared in a public extension`

Removed `public` access control for an already public extension: 45fea39f7e91c927d2a74fd2870e90adaf7cf7eb

2. `'@Namespace' used inline will not work unless tagged with '@Previewable' (from macro 'Preview')`

Marked previews that use the Namespace tag as `@previewable`: a3d14400327289cae031ed8743939a63b666e86d . This adds an additional iOS17 check for each preview, but all of them will be removed in one go as soon as we bump the minimum target on a separate issue.

## Testing information
- App should compile normally
- Run the app in a simulator and physical device, should init normally. Free free to navigate around, but nothing should have changed behavior-wise. 
- CI should pass

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
