### PR TITLE
iPad: Fix split view not working after the initial launch

### DIFF
--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -190,8 +190,6 @@ final class MainTabBarController: UITabBarController {
 
         delegate = self
 
-        fixTabBarTraitCollectionOnIpadForiOS18()
-
         // POS tab is hidden by default.
         updateTabViewControllers(isPOSTabVisible: false)
         observeSiteIDForViewControllers()
@@ -215,6 +213,7 @@ final class MainTabBarController: UITabBarController {
         super.viewDidAppear(animated)
 
         viewModel.onViewDidAppear()
+        fixTabBarTraitCollectionOnIpadForiOS18()
     }
 
     override func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

WOOMOB-1009

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When the Woo app is initially launched and user logs in, Orders and Products tab are not displayed in a split view. The app needs to be killed and relaunched for a split view to appeared.

[The iPadOS 18 + Xcode 16 hack](https://github.com/woocommerce/woocommerce-ios/pull/14136) was not working properly on first launch after login because it requires view.window to be available to access the window's trait collection. It turns all the views into `.compact`, not just the tab bar itself.

During initial login flow:
  1. viewDidLoad() is called before tab controller is added to window hierarchy
  2. AppCoordinator.displayLoggedInUI() sets tab controller as window root
  3. view.window becomes available, but fixTabBarTraitCollectionOnIpadForiOS18 was already called when window was nil

Fixed by adding fixTabBarTraitCollectionOnIpadForiOS18() call to viewDidAppear() which is guaranteed to run after the view controller is in the window hierarchy and view.window is available.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Remove the app
2. Install the app on the iPad
3. Login
4. Open Orders or Products tab
5. Confirm they appear in the split view

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air 18.5 simulator and iPadAir 26 device

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/3af139a6-7fda-4f80-91c6-55de80b3caf7

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.