### PR TITLE
Revert "iPad: Fix split view not working after the initial launch"

### DIFF
--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -190,6 +190,8 @@ final class MainTabBarController: UITabBarController {
 
         delegate = self
 
+        fixTabBarTraitCollectionOnIpadForiOS18()
+
         // POS tab is hidden by default.
         updateTabViewControllers(isPOSTabVisible: false)
         observeSiteIDForViewControllers()
@@ -213,7 +215,6 @@ final class MainTabBarController: UITabBarController {
         super.viewDidAppear(animated)
 
         viewModel.onViewDidAppear()
-        fixTabBarTraitCollectionOnIpadForiOS18()
     }
 
     override func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {


### PR DESCRIPTION
Reverts woocommerce/woocommerce-ios#15985

This was too quick a fix, it creates issues on subsequent launches. 