### PR TITLE
iPad: Fix split view not working after the initial launch #2

### DIFF
--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -190,14 +190,14 @@ final class MainTabBarController: UITabBarController {
 
         delegate = self
 
-        fixTabBarTraitCollectionOnIpadForiOS18()
-
         // POS tab is hidden by default.
         updateTabViewControllers(isPOSTabVisible: false)
         observeSiteIDForViewControllers()
         observeProductImageUploadStatusUpdates()
 
         startListeningToHubMenuTabBadgeUpdates()
+
+        fixTabBarTraitCollectionOnIpadForiOS18()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -294,7 +294,7 @@ final class MainTabBarController: UITabBarController {
     private func fixTabBarTraitCollectionOnIpadForiOS18() {
         if #available(iOS 18.0, *), UIDevice.current.userInterfaceIdiom == .pad {
             traitOverrides.horizontalSizeClass = .compact
-            if let rootHorizontalSizeClass = view.window?.traitCollection.horizontalSizeClass {
+            if let rootHorizontalSizeClass = AppDelegate.shared.window?.traitCollection.horizontalSizeClass {
                 tabBar.traitOverrides.horizontalSizeClass = rootHorizontalSizeClass
                 if let viewControllers {
                     for vc in viewControllers {


### PR DESCRIPTION
WOOMOB-1009

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When the Woo app is initially launched and user logs in, Orders and Products tab are not displayed in a split view. The app needs to be killed and relaunched for a split view to appeared.

[The iPadOS 18 + Xcode 16 hack](https://github.com/woocommerce/woocommerce-ios/pull/14136) was not working properly on first launch after login because it requires view.window to be available to access the window's trait collection. It turns all the views into `.compact`, not just the tab bar itself.

During initial login flow:
  1. viewDidLoad() is called before tab controller is added to window hierarchy
  2. AppCoordinator.displayLoggedInUI() sets tab controller as window root
  3. view.window becomes available, but fixTabBarTraitCollectionOnIpadForiOS18 was already called when window was nil

## Wrong solution

Calling `fixTabBarTraitCollectionOnIpadForiOS18` on `viewDidAppear` was a bad choice (implemented in https://github.com/woocommerce/woocommerce-ios/pull/15985 and reverted in https://github.com/woocommerce/woocommerce-ios/pull/15988). The fix worked with the first login, but would make tabs appear correctly after a delay during the subsequent launch, also sometimes causing crashes when opening Order and Product tabs.

## Better solution

There are two issues that need to be fixed with the original `fixTabBarTraitCollectionOnIpadForiOS18` solution:

- `window` is not yet accessible to get an overall `traitCollection` collection if the viewController is not added in the view hierarchy
- tabs are not yet loaded

To solve those issues we can do two things:
- `window` is not yet accessible on a view but can be accessed through `AppDelegate.shared.window`, since the window it self is loaded.
- Call  `fixTabBarTraitCollectionOnIpadForiOS18` after tabs are loaded (`fixTabBarTraitCollectionOnIpadForiOS18`)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### First Launch
1. Remove the app
2. Install the app on the iPad
3. Login
4. Open Orders or Products tab
5. Confirm they appear in the split view

### Subsequent Launches
1. Kill and relaunch the app
2. Open Orders or Products tab
3. Confirm they appear in the split view

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

On iPad Air 18.5 simulator and iPad Air M2 26. device:
- Tested first and subsequent launches
- Tested logging out and logging in
- Tested self-hosted and Dotcom login paths
- Tested system split views, tested changing window sizes with iPadOS 26, tested changing orientations

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.