### PR TITLE
Disable Wormholy shake gesture trigger

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -19,9 +19,7 @@ import class Yosemite.ScreenshotStoresManager
 // In that way, Inject will be available in the entire target.
 @_exported import Inject
 
-#if DEBUG
 import WormholySwift
-#endif
 
 // MARK: - Woo's App Delegate!
 //
@@ -415,10 +413,8 @@ private extension AppDelegate {
     /// Set up Wormholy only in Debug build configuration
     ///
     func setupWormholy() {
-#if DEBUG
         // We want to activate it programmatically, not using the shake.
         Wormholy.shakeEnabled = false
-#endif
     }
 
     /// Set up `KeyboardStateProvider`


### PR DESCRIPTION
For WOOMOB-1014
Just one review is required.

## Description
Disables Wormholy shake gesture trigger to prevent accidental activation in production builds. Previously, Wormholy was only included in debug configurations with CocoaPods, but after migrating to SPM, the library is included in all configurations ([attempts to exclude the library](https://github.com/woocommerce/woocommerce-ios/pull/15813), still WIP). This change ensures merchants won't accidentally trigger the debugging tool through shake gestures.

## Steps to reproduce

1. Build the app in Release configuration (Edit Scheme > Run > Info > Build Configuration)
2. Test shake gesture on device or simulator (Device > Shake)
3. Verify Wormholy UI does not appear

## Testing information

I tested in iPad Pro 11in iOS 18.5 simulator, and was able to repro the issue before the fix when running the app in Release configuration.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.