### PR TITLE
[WCiOS17] Update `CurrencyCode` to use `Currency.isoCurrencies`

### DIFF
--- a/Modules/Sources/Hardware/CardReader/CurrencyCode.swift
+++ b/Modules/Sources/Hardware/CardReader/CurrencyCode.swift
@@ -16,7 +16,7 @@ public struct CurrencyCode {
 
     public var wrappedValue: String {
         get {
-            guard Locale.Currency.isoCurrencies.map({ $0.identifier }).contains(value.uppercased()) else {
+            guard Locale.Currency.isoCurrencies.map({ $0.identifier.uppercased() }).contains(value.uppercased()) else {
                 return ""
             }
             return value.lowercased()

--- a/Modules/Sources/Hardware/CardReader/CurrencyCode.swift
+++ b/Modules/Sources/Hardware/CardReader/CurrencyCode.swift
@@ -16,10 +16,9 @@ public struct CurrencyCode {
 
     public var wrappedValue: String {
         get {
-            guard Locale.isoCurrencyCodes.map({ $0.uppercased() }).contains(value.uppercased()) else {
+            guard Locale.Currency.isoCurrencies.map({ $0.identifier }).contains(value.uppercased()) else {
                 return ""
             }
-
             return value.lowercased()
         }
         set {


### PR DESCRIPTION
Part of WOOMOB-103

## Description
This PR addresses the `Locale.isoCurrencyCodes` deprecation warning, and to use `Locale.Currency.isoCurrencies` instead.

The return type of the built-in function is updated from `[String]` to `[Locale.Currency]`, so we use the `identifier` property to extract the currency value. Applying `uppercased()` to the iso currency before comparing the wrapped value is redundant, so I left it out.

## Testing information
- CI should pass
- Processing a transaction via card reader and refunding it should work normally. We only seem to use this property wrapper in these two cases, for matching the currency and returning it in lowercase when we pass it to `PaymentIntentParametersBuilder` and such. 

You can add a breakpoint to return `value.lowercased()` to observe that nothing is off when performing currency comparison and returning the lowercase version of the iso identifier.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
