### PR TITLE
[WCiOS17] Update `languageCode` and `regionCode` deprecation 

### DIFF
--- a/Modules/Sources/Yosemite/Stores/JustInTimeMessageStore.swift
+++ b/Modules/Sources/Yosemite/Stores/JustInTimeMessageStore.swift
@@ -104,10 +104,10 @@ private extension JustInTimeMessageStore {
     }
 
     func localeLanguageRegionIdentifier() -> String? {
-        guard let languageCode = Locale.current.languageCode else {
+        guard let languageCode = Locale.current.language.languageCode?.identifier else {
             return nil
         }
-        guard let regionCode = Locale.current.regionCode else {
+        guard let regionCode = Locale.current.region?.identifier else {
             return languageCode
         }
         return "\(languageCode)_\(regionCode)"


### PR DESCRIPTION
Part of WOOMOB-103

## Description
Similarly to https://github.com/woocommerce/woocommerce-ios/pull/15992, we update the usage of `languageCode` and `regionCode` in  `Locale.current` to use the new `identifier` property instead.

## Testing information
- Put a breakpoint in `JustInTimeMessageStore.localeLanguageRegionIdentifier` and run the app
- In the console confirm that the output of before and after is the same, in my case:
```
(lldb) po Locale.current.language.languageCode?.identifier
▿ Optional<String>
  - some : "en"
(lldb) po Locale.current.region?.identifier
▿ Optional<String>
  - some : "TH"
(lldb) po "\(languageCode)_\(regionCode)"
"en_TH"
```
