### PR TITLE
[Order Creation - Taxes] Fix Scroll View in Tax Modal

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Taxes/TaxEducationalDialogView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Taxes/TaxEducationalDialogView.swift
@@ -16,31 +16,34 @@ struct TaxEducationalDialogView: View {
         ZStack {
             Color.black.opacity(Layout.backgroundOpacity).edgesIgnoringSafeArea(.all)
 
-                VStack {
-                    GeometryReader { geometry in
-                        ScrollView {
-                            VStack(alignment: .center, spacing: Layout.verticalSpacing) {
-                                Text(Localization.title)
-                                    .headlineStyle()
-                                Text(Localization.bodyFirstParagraph)
-                                    .bodyStyle()
-                                    .fixedSize(horizontal: false, vertical: true)
-                                Text(Localization.bodySecondParagraph)
-                                    .bodyStyle()
+            VStack {
+                GeometryReader { geometry in
+                    VStack(spacing: 0) {
+                        VStack {
+                            ScrollView {
+                                VStack(alignment: .center, spacing: Layout.verticalSpacing) {
+                                    Text(Localization.title)
+                                        .headlineStyle()
 
+                                    Text(Localization.bodyFirstParagraph)
+                                        .bodyStyle()
+                                        .fixedSize(horizontal: false, vertical: true)
 
-                                VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
-                                    Divider()
-                                        .frame(height: Layout.dividerHeight)
-                                        .foregroundColor(Color(.opaqueSeparator))
-                                    if let taxBasedOnSettingExplanatoryText = viewModel.taxBasedOnSettingExplanatoryText {
-                                        Text(taxBasedOnSettingExplanatoryText)
-                                            .bodyStyle()
-                                            .fixedSize(horizontal: false, vertical: true)
-                                    }
+                                    Text(Localization.bodySecondParagraph)
+                                        .bodyStyle()
 
-                                    ForEach(viewModel.taxLines, id: \.title) { taxLine in
-                                        HStack {
+                                    VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
+                                        Divider()
+                                            .frame(height: Layout.dividerHeight)
+                                            .foregroundColor(Color(.opaqueSeparator))
+
+                                        if let explanatoryText = viewModel.taxBasedOnSettingExplanatoryText {
+                                            Text(explanatoryText)
+                                                .bodyStyle()
+                                                .fixedSize(horizontal: false, vertical: true)
+                                        }
+
+                                        ForEach(viewModel.taxLines, id: \.title) { taxLine in
                                             AdaptiveStack(horizontalAlignment: .leading, spacing: Layout.taxLinesInnerSpacing) {
                                                 Text(taxLine.title)
                                                     .font(.body)
@@ -55,50 +58,56 @@ struct TaxEducationalDialogView: View {
                                                     .frame(width: nil, alignment: .trailing)
                                             }
                                         }
-                                    }
-                                    Divider()
-                                        .frame(height: Layout.dividerHeight)
-                                        .foregroundColor(Color(.opaqueSeparator))
-                                }.renderedIf(viewModel.taxLines.isNotEmpty)
 
-                                Button {
-                                    viewModel.onGoToWpAdminButtonTapped()
-                                    showingWPAdminWebview = true
-                                } label: {
-                                    Label {
-                                        Text(Localization.editTaxRatesInAdminButtonTitle)
-                                            .font(.body)
-                                            .fontWeight(.bold)
-                                    } icon: {
-                                        Image(systemName: "arrow.up.forward.square")
-                                            .resizable()
-                                            .frame(width: Layout.externalLinkImageSize * scale, height: Layout.externalLinkImageSize * scale)
+                                        Divider()
+                                            .frame(height: Layout.dividerHeight)
+                                            .foregroundColor(Color(.opaqueSeparator))
                                     }
-                                }
-                                .buttonStyle(PrimaryButtonStyle())
-                                .safariSheet(isPresented: $showingWPAdminWebview, url: viewModel.wpAdminTaxSettingsURL, onDismiss: {
-                                    onDismissWpAdminWebView()
-                                    showingWPAdminWebview = false
-                                })
+                                    .renderedIf(viewModel.taxLines.isNotEmpty)
 
-                                Button {
-                                    dismiss()
-                                } label: {
-                                    Text(Localization.doneButtonTitle)
+                                    Button {
+                                        viewModel.onGoToWpAdminButtonTapped()
+                                        showingWPAdminWebview = true
+                                    } label: {
+                                        Label {
+                                            Text(Localization.editTaxRatesInAdminButtonTitle)
+                                                .font(.body)
+                                                .fontWeight(.bold)
+                                        } icon: {
+                                            Image(systemName: "arrow.up.forward.square")
+                                                .resizable()
+                                                .frame(width: Layout.externalLinkImageSize * scale,
+                                                       height: Layout.externalLinkImageSize * scale)
+                                        }
+                                    }
+                                    .buttonStyle(PrimaryButtonStyle())
+                                    .safariSheet(
+                                        isPresented: $showingWPAdminWebview,
+                                        url: viewModel.wpAdminTaxSettingsURL,
+                                        onDismiss: {
+                                            onDismissWpAdminWebView()
+                                            showingWPAdminWebview = false
+                                        })
+
+                                    Button {
+                                        dismiss()
+                                    } label: {
+                                        Text(Localization.doneButtonTitle)
+                                    }
+                                    .buttonStyle(SecondaryButtonStyle())
                                 }
-                                .buttonStyle(SecondaryButtonStyle())
+                                .padding(Layout.outterPadding)
                             }
-                            .padding(Layout.outterPadding)
-                            .frame(maxWidth: .infinity, alignment: .center)
-                            .background(Color(.systemBackground))
-                            .cornerRadius(Layout.cornerRadius)
-                            .frame(width: geometry.size.width)      // Make the scroll view full-width
-                            .frame(minHeight: geometry.size.height)
                         }
+                        .background(Color(.systemBackground))
+                        .cornerRadius(Layout.cornerRadius)
+                        .padding(Layout.outterPadding)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .frame(minHeight: geometry.size.height)
+                        .frame(width: geometry.size.width)
+                    }
                 }
             }
-            .padding(Layout.outterPadding)
-            .frame(maxWidth: .infinity, alignment: .center)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Taxes/TaxEducationalDialogView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Taxes/TaxEducationalDialogView.swift
@@ -17,97 +17,89 @@ struct TaxEducationalDialogView: View {
             Color.black.opacity(Layout.backgroundOpacity).edgesIgnoringSafeArea(.all)
 
             VStack {
-                GeometryReader { geometry in
-                    VStack(spacing: 0) {
-                        VStack {
-                            ScrollView {
-                                VStack(alignment: .center, spacing: Layout.verticalSpacing) {
-                                    Text(Localization.title)
-                                        .headlineStyle()
+                ScrollView {
+                    VStack(alignment: .center, spacing: Layout.verticalSpacing) {
+                        Text(Localization.title)
+                            .headlineStyle()
 
-                                    Text(Localization.bodyFirstParagraph)
+                        Text(Localization.bodyFirstParagraph)
+                            .bodyStyle()
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        Text(Localization.bodySecondParagraph)
+                            .bodyStyle()
+
+                        if viewModel.taxLines.isNotEmpty {
+                            VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
+                                Divider()
+                                    .frame(height: Layout.dividerHeight)
+                                    .foregroundColor(Color(.opaqueSeparator))
+
+                                if let explanatoryText = viewModel.taxBasedOnSettingExplanatoryText {
+                                    Text(explanatoryText)
                                         .bodyStyle()
                                         .fixedSize(horizontal: false, vertical: true)
-
-                                    Text(Localization.bodySecondParagraph)
-                                        .bodyStyle()
-
-                                    VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
-                                        Divider()
-                                            .frame(height: Layout.dividerHeight)
-                                            .foregroundColor(Color(.opaqueSeparator))
-
-                                        if let explanatoryText = viewModel.taxBasedOnSettingExplanatoryText {
-                                            Text(explanatoryText)
-                                                .bodyStyle()
-                                                .fixedSize(horizontal: false, vertical: true)
-                                        }
-
-                                        ForEach(viewModel.taxLines, id: \.title) { taxLine in
-                                            AdaptiveStack(horizontalAlignment: .leading, spacing: Layout.taxLinesInnerSpacing) {
-                                                Text(taxLine.title)
-                                                    .font(.body)
-                                                    .fontWeight(.semibold)
-                                                    .multilineTextAlignment(.leading)
-                                                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                                                Text(taxLine.value)
-                                                    .font(.body)
-                                                    .fontWeight(.semibold)
-                                                    .multilineTextAlignment(.trailing)
-                                                    .frame(width: nil, alignment: .trailing)
-                                            }
-                                        }
-
-                                        Divider()
-                                            .frame(height: Layout.dividerHeight)
-                                            .foregroundColor(Color(.opaqueSeparator))
-                                    }
-                                    .renderedIf(viewModel.taxLines.isNotEmpty)
-
-                                    Button {
-                                        viewModel.onGoToWpAdminButtonTapped()
-                                        showingWPAdminWebview = true
-                                    } label: {
-                                        Label {
-                                            Text(Localization.editTaxRatesInAdminButtonTitle)
-                                                .font(.body)
-                                                .fontWeight(.bold)
-                                        } icon: {
-                                            Image(systemName: "arrow.up.forward.square")
-                                                .resizable()
-                                                .frame(width: Layout.externalLinkImageSize * scale,
-                                                       height: Layout.externalLinkImageSize * scale)
-                                        }
-                                    }
-                                    .buttonStyle(PrimaryButtonStyle())
-                                    .safariSheet(
-                                        isPresented: $showingWPAdminWebview,
-                                        url: viewModel.wpAdminTaxSettingsURL,
-                                        onDismiss: {
-                                            onDismissWpAdminWebView()
-                                            showingWPAdminWebview = false
-                                        })
-
-                                    Button {
-                                        dismiss()
-                                    } label: {
-                                        Text(Localization.doneButtonTitle)
-                                    }
-                                    .buttonStyle(SecondaryButtonStyle())
                                 }
-                                .padding(Layout.outterPadding)
+
+                                ForEach(viewModel.taxLines, id: \.title) { taxLine in
+                                    AdaptiveStack(horizontalAlignment: .leading, spacing: Layout.taxLinesInnerSpacing) {
+                                        Text(taxLine.title)
+                                            .font(.body)
+                                            .fontWeight(.semibold)
+                                            .multilineTextAlignment(.leading)
+                                            .frame(maxWidth: .infinity, alignment: .leading)
+
+                                        Text(taxLine.value)
+                                            .font(.body)
+                                            .fontWeight(.semibold)
+                                            .multilineTextAlignment(.trailing)
+                                            .frame(width: nil, alignment: .trailing)
+                                    }
+                                }
+
+                                Divider()
+                                    .frame(height: Layout.dividerHeight)
+                                    .foregroundColor(Color(.opaqueSeparator))
                             }
                         }
-                        .background(Color(.systemBackground))
-                        .cornerRadius(Layout.cornerRadius)
-                        .padding(Layout.outterPadding)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .frame(minHeight: geometry.size.height)
-                        .frame(width: geometry.size.width)
+
+                        Button {
+                            viewModel.onGoToWpAdminButtonTapped()
+                            showingWPAdminWebview = true
+                        } label: {
+                            Label {
+                                Text(Localization.editTaxRatesInAdminButtonTitle)
+                                    .font(.body)
+                                    .fontWeight(.bold)
+                            } icon: {
+                                Image(systemName: "arrow.up.forward.square")
+                                    .resizable()
+                                    .frame(width: Layout.externalLinkImageSize * scale,
+                                           height: Layout.externalLinkImageSize * scale)
+                            }
+                        }
+                        .buttonStyle(PrimaryButtonStyle())
+                        .safariSheet(
+                            isPresented: $showingWPAdminWebview,
+                            url: viewModel.wpAdminTaxSettingsURL,
+                            onDismiss: {
+                                onDismissWpAdminWebView()
+                                showingWPAdminWebview = false
+                            })
+
+                        Button {
+                            dismiss()
+                        } label: {
+                            Text(Localization.doneButtonTitle)
+                        }
+                        .buttonStyle(SecondaryButtonStyle())
                     }
+                    .padding(Layout.outterPadding)
                 }
             }
+            .background(Color(.systemBackground))
+            .cornerRadius(Layout.cornerRadius)
+            .padding(Layout.outterPadding)
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a visual issue in the TaxEducationalDialogView where the modal's corners were displayed incorrectly due to the ScrollView being the outermost container. This caused the background and corner radius to misbehave—specifically, the bottom corners appeared square until the content was scrolled.

The solution involves moving the styled container (VStack with background and corner radius) outside the ScrollView, ensuring the modal frame is preserved regardless of scroll interaction. The `GeometryReader` is not necessary, and this removed.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

With an increased device font size and a tax rate set in the settings of your store

1. Go to Orders
2. Tap on + to create a new order
3. Add a product
4. Tap on Set New Tax Rate
5. Tap on the ? button
6. The content should be scrollable. Before, the bottom corners appear square initially and become rounded only after scrolling. Now it is rounded.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on iPad with Largest accessibility siw

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/d6e70000-3cfa-4715-85d4-b10e7beb0d85


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
