### PR TITLE
Fix crash on iOS 26 when printing ErrorCode initialized from NSError

### DIFF
--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -1109,7 +1109,7 @@ private extension StripeCardReaderService {
             DDLogError("💳 Card Reader Config Error: \(error)")
         default:
             let errorCode = ErrorCode(_nsError: error as NSError)
-            DDLogError("💳 Stripe Error Code: \(errorCode.code)")
+            DDLogError("💳 Stripe Error Code: \(errorCode.errorCode)")
         }
         return UnderlyingError(with: error)
     }


### PR DESCRIPTION
WOOMOB-660
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description

This PR fixes a crash occurring on iOS 26 when converting certain `NSError` values into `ErrorCode` using `ErrorCode(_nsError:)`.

### Problem

On iOS 26, some `NSError` instances, especially those from the Stripe SDK, cause a fatal crash when converted to `ErrorCode` and accessed or logged (e.g., `print(errorCode.code)`).
This crash **does not** occur on iOS 18.5, including on simulators.

Example that triggers the crash:

```swift
let errorCode = ErrorCode(_nsError: NSError(domain: "com.stripe.terminal", code: 2020, userInfo: [:]))
print(errorCode.code) // Fatal error on iOS 26
```

Notably, not all error codes cause this behavior. Some values are fine, while others fail, regardless of whether the code is valid or known to the Stripe SDK.

The issue can be seen using lldb

```
(lldb) po ErrorCode(_nsError: NSError(domain: "com.stripe.terminal", code: 2020, userInfo: [:])).code

SignalCompression/SignalEncoder.swift:261: Fatal error: Unknown error
.SCPErrorCanceled
```

### Solution

For now, avoid calling `errorCode.code`, and calling `errorCode.errorCode` instead.

We will get in logs:

`💳 Stripe Error Code: 2020`

instead of

`💳 Stripe Error Code: SCPError(rawValue: 2020)`

Stripe Report: https://github.com/stripe/stripe-terminal-ios/issues/362

---


## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

I only tested on iPadOS 26 (simulator and device), and wasn't able to check iPhone TTP crashes. To reproduce a crash on iPadOS:

1. Turn on simulated card reader
2. Open POS
3. Connect to card reader
4. Check out
5. Come back to cancel the order
6. It should crash on trunk without the fix, and shouldn't fix here

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Additionally, it was[ tested on an iOS 26 device](https://linear.app/a8c/issue/WOOMOB-660/ios-26-exc-breakpoint-signalcompressionsignalencoderswift261-fatal#comment-63cbf8b9) and there's no more crash. There's only an expected  "unsupported software version" since TTP shouldn't work on the beta releases (https://docs.stripe.com/terminal/payments/setup-reader/tap-to-pay?platform=ios#supported-devices)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.