### PR TITLE
[POS Settings] Feature flag and present settings view

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -103,6 +103,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .pointOfSaleBarcodeScanningi2:
             return true
+        case .pointOfSaleSettingsi1:
+            return false
         case .orderAddressMapSearch:
             return true
         default:

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -211,6 +211,10 @@ public enum FeatureFlag: Int {
     ///
     case pointOfSaleBarcodeScanningi2
 
+    /// Enables the entry point for Point of Sale Settings
+    ///
+    case pointOfSaleSettingsi1
+
     /// Enables the CTA to search for an address in the map in order details > shipping address.
     ///
     case orderAddressMapSearch

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -8,15 +8,18 @@ struct POSFloatingControlView: View {
     @Binding private var showExitPOSModal: Bool
     @Binding private var showSupport: Bool
     @Binding private var showDocumentation: Bool
+    @Binding private var showSettings: Bool
     @State private var showProductRestrictionsModal: Bool = false
     @State private var showBarcodeScanningModal: Bool = false
 
     init(showExitPOSModal: Binding<Bool>,
          showSupport: Binding<Bool>,
-         showDocumentation: Binding<Bool>) {
+         showDocumentation: Binding<Bool>,
+         showSettings: Binding<Bool>) {
         self._showExitPOSModal = showExitPOSModal
         self._showSupport = showSupport
         self._showDocumentation = showDocumentation
+        self._showSettings = showSettings
     }
 
     var body: some View {
@@ -71,6 +74,16 @@ struct POSFloatingControlView: View {
                                 }
                             },
                             icon: { Image(systemName: "barcode.viewfinder") })
+                    }
+                }
+                if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleSettingsi1) {
+                    Button {
+                        showSettings = true
+                    } label: {
+                        Label(
+                            title: { Text(Localization.settings) },
+                            icon: { Image(systemName: "gearshape") }
+                        )
                     }
                 }
             } label: {
@@ -185,6 +198,12 @@ private extension POSFloatingControlView {
             value: "Initial barcode scanner setup",
             comment: "The title of the menu button to start a barcode scanner setup flow."
         )
+
+        static let settings = NSLocalizedString(
+            "pointOfSale.floatingButtons.settings.button.title",
+            value: "Settings",
+            comment: "The title of the menu button to access Point of Sale settings."
+        )
     }
 }
 
@@ -192,7 +211,10 @@ private extension POSFloatingControlView {
 
 @available(iOS 17.0, *)
 #Preview("Reader Disconnected") {
-    POSFloatingControlView(showExitPOSModal: .constant(false), showSupport: .constant(false), showDocumentation: .constant(false))
+    POSFloatingControlView(showExitPOSModal: .constant(false),
+                           showSupport: .constant(false),
+                           showDocumentation: .constant(false),
+                           showSettings: .constant(false))
         .environment(\.posBackgroundAppearance, .primary)
         .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }
@@ -204,14 +226,20 @@ private extension POSFloatingControlView {
     let posModel = POSPreviewHelpers.makePreviewAggregateModel(
         cardPresentPaymentService: paymentService
     )
-    return POSFloatingControlView(showExitPOSModal: .constant(false), showSupport: .constant(false), showDocumentation: .constant(false))
+    return POSFloatingControlView(showExitPOSModal: .constant(false),
+                                  showSupport: .constant(false),
+                                  showDocumentation: .constant(false),
+                                  showSettings: .constant(false))
         .environment(\.posBackgroundAppearance, .primary)
         .environment(posModel)
 }
 
 @available(iOS 17.0, *)
 #Preview("Secondary/disabled Background") {
-    POSFloatingControlView(showExitPOSModal: .constant(false), showSupport: .constant(false), showDocumentation: .constant(false))
+    POSFloatingControlView(showExitPOSModal: .constant(false),
+                           showSupport: .constant(false),
+                           showDocumentation: .constant(false),
+                           showSettings: .constant(false))
         .environment(\.posBackgroundAppearance, .secondary)
         .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -8,6 +8,7 @@ struct PointOfSaleDashboardView: View {
     @State private var showExitPOSModal: Bool = false
     @State private var showSupport: Bool = false
     @State private var showDocumentation: Bool = false
+    @State private var showSettings: Bool = false
     @State private var waitingTimeTracker: WaitingTimeTracker?
 
     @State private var floatingSize: CGSize = .zero
@@ -90,7 +91,8 @@ struct PointOfSaleDashboardView: View {
 
             POSFloatingControlView(showExitPOSModal: $showExitPOSModal,
                                    showSupport: $showSupport,
-                                   showDocumentation: $showDocumentation)
+                                   showDocumentation: $showDocumentation,
+                                   showSettings: $showSettings)
             .offset(x: Constants.floatingControlHorizontalOffset, y: -Constants.floatingControlVerticalOffset)
             .padding(.bottom, Constants.floatingControlBottomPadding)
             .trackSize(size: $floatingSize)
@@ -129,6 +131,9 @@ struct PointOfSaleDashboardView: View {
         }
         .posSheet(isPresented: $showDocumentation) {
             documentationView
+        }
+        .posFullScreenCover(isPresented: $showSettings) {
+            PointOfSaleSettingsView()
         }
         .onChange(of: posModel.entryPointController.eligibilityState) { oldValue, newValue in
             guard newValue == .eligible else { return }
@@ -290,3 +295,19 @@ private extension PointOfSaleDashboardView {
 }
 
 #endif
+
+struct PointOfSaleSettingsView: View {
+    @Environment(\.dismiss) private var dismiss
+    var body: some View {
+        NavigationView {
+            Text("Settings")
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button("Done") {
+                            dismiss()
+                        }
+                    }
+                }
+        }
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -295,19 +295,3 @@ private extension PointOfSaleDashboardView {
 }
 
 #endif
-
-struct PointOfSaleSettingsView: View {
-    @Environment(\.dismiss) private var dismiss
-    var body: some View {
-        NavigationView {
-            Text("Settings")
-                .toolbar {
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        Button("Done") {
-                            dismiss()
-                        }
-                    }
-                }
-        }
-    }
-}

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleSettingsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleSettingsView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct PointOfSaleSettingsView: View {
+    @Environment(\.dismiss) private var dismiss
+    var body: some View {
+        NavigationView {
+            Text("Settings")
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button("Done") {
+                            dismiss()
+                        }
+                    }
+                }
+        }
+    }
+}
+
+#Preview {
+    PointOfSaleSettingsView()
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1579,6 +1579,7 @@
 		683988A72C7D82E70084B85A /* POSHeaderLayoutConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683988A62C7D82E60084B85A /* POSHeaderLayoutConstants.swift */; };
 		683AA9D62A303CB70099F7BA /* UpgradesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683AA9D52A303CB70099F7BA /* UpgradesViewModelTests.swift */; };
 		683AC4AC2CEF019A00FF0A5E /* POSSendReceiptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683AC4AB2CEF019700FF0A5E /* POSSendReceiptView.swift */; };
+		683D41182E4D9B570024CFE4 /* PointOfSaleSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683D41172E4D9B570024CFE4 /* PointOfSaleSettingsView.swift */; };
 		683DF5FF2C6AF46500A5CDC6 /* POSHeaderTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683DF5FE2C6AF46500A5CDC6 /* POSHeaderTitleView.swift */; };
 		684AB83A2870677F003DFDD1 /* CardReaderManualsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684AB8392870677F003DFDD1 /* CardReaderManualsView.swift */; };
 		684AB83C2873DF04003DFDD1 /* CardReaderManualsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684AB83B2873DF04003DFDD1 /* CardReaderManualsViewModel.swift */; };
@@ -4753,6 +4754,7 @@
 		683988A62C7D82E60084B85A /* POSHeaderLayoutConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSHeaderLayoutConstants.swift; sourceTree = "<group>"; };
 		683AA9D52A303CB70099F7BA /* UpgradesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesViewModelTests.swift; sourceTree = "<group>"; };
 		683AC4AB2CEF019700FF0A5E /* POSSendReceiptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSendReceiptView.swift; sourceTree = "<group>"; };
+		683D41172E4D9B570024CFE4 /* PointOfSaleSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleSettingsView.swift; sourceTree = "<group>"; };
 		683DF5FE2C6AF46500A5CDC6 /* POSHeaderTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSHeaderTitleView.swift; sourceTree = "<group>"; };
 		684AB8392870677F003DFDD1 /* CardReaderManualsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsView.swift; sourceTree = "<group>"; };
 		684AB83B2873DF04003DFDD1 /* CardReaderManualsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsViewModel.swift; sourceTree = "<group>"; };
@@ -7177,6 +7179,7 @@
 				68A345632D029E09002EE324 /* PaymentButtons.swift */,
 				026826A52BF59DF60036F959 /* PointOfSaleDashboardView.swift */,
 				68E141DA2D13107200A70D5B /* PointOfSaleCollectCashView.swift */,
+				683D41172E4D9B570024CFE4 /* PointOfSaleSettingsView.swift */,
 				DA013F502C65125100D9A391 /* PointOfSaleExitPosAlertView.swift */,
 				DA0DBE2E2C4FC61D00DF14C0 /* POSFloatingControlView.swift */,
 				20D3D42A2C64D7CC004CE6E3 /* SimpleProductsOnlyInformation.swift */,
@@ -15330,6 +15333,7 @@
 				01BE94042DDCC7670063541C /* PointOfSaleEmptyErrorStateViewLayout.swift in Sources */,
 				029106C02BE3349500C2248B /* OrderCustomerSectionViewModel.swift in Sources */,
 				74460D4022289B7600D7316A /* Coordinator.swift in Sources */,
+				683D41182E4D9B570024CFE4 /* PointOfSaleSettingsView.swift in Sources */,
 				205E79422C1CA6E3001BA266 /* PointOfSaleCardPresentPaymentEventPresentationStyle.swift in Sources */,
 				EE4C45842C381BAA001A3D94 /* PackagePhotoView.swift in Sources */,
 				B57C743D20F5493300EEFC87 /* AccountHeaderView.swift in Sources */,


### PR DESCRIPTION
Closes WOOMOB-1021

## Description
This PR adds a feature flag for POS Settings i1, as well as a new button to the CTA entry point that will present a full screen settings dummy view.

## Testing information
- Set `pointOfSaleSettingsi1` to `true`
- Navigate to POS, and tap the `Settings` button
- Observe the dummy view presented as full screen cover. Close it.

## Screenshots

https://github.com/user-attachments/assets/4841d981-e31a-4d7a-a92a-33c4efa2b202

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
