### PR TITLE
[Woo POS][Local Catalog] Add Better Analytics to Background Task Refresh System

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+BackgroudUpdates.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+BackgroudUpdates.swift
@@ -1,14 +1,56 @@
 import Foundation
+import WooFoundation
 
 extension WooAnalyticsEvent {
     enum BackgroundUpdates {
 
         private enum Keys {
             static let timeTaken = "time_taken"
+            static let backgroundTimeGranted = "background_time_granted"
+            static let networkType = "network_type"
+            static let isExpensiveConnection = "is_expensive_connection"
+            static let isLowDataMode = "is_low_data_mode"
+            static let isPowered = "is_powered"
+            static let batteryLevel = "battery_level"
+            static let isLowPowerMode = "is_low_power_mode"
+            static let timeSinceLastRun = "time_since_last_run"
+            static let completionStatus = "completion_status"
         }
 
         static func dataSynced(timeTaken: TimeInterval) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .backgroundDataSynced, properties: [Keys.timeTaken: timeTaken])
+        }
+
+        static func dataSyncedDetailed(
+            timeTaken: TimeInterval,
+            backgroundTimeGranted: TimeInterval?,
+            networkType: String,
+            isExpensiveConnection: Bool,
+            isLowDataMode: Bool,
+            isPowered: Bool,
+            batteryLevel: Float,
+            isLowPowerMode: Bool,
+            timeSinceLastRun: TimeInterval?
+        ) -> WooAnalyticsEvent {
+            var properties: [String: WooAnalyticsEventPropertyType] = [
+                Keys.timeTaken: Int64(timeTaken),
+                Keys.networkType: networkType,
+                Keys.isExpensiveConnection: isExpensiveConnection,
+                Keys.isLowDataMode: isLowDataMode,
+                Keys.isPowered: isPowered,
+                Keys.batteryLevel: Float64(batteryLevel),
+                Keys.isLowPowerMode: isLowPowerMode
+            ]
+
+            if let backgroundTimeGranted = backgroundTimeGranted {
+                properties[Keys.backgroundTimeGranted] = Int64(backgroundTimeGranted)
+            }
+
+            if let timeSinceLastRun = timeSinceLastRun {
+                properties[Keys.timeSinceLastRun] = Int64(timeSinceLastRun)
+            }
+
+            return WooAnalyticsEvent(statName: .backgroundDataSynced, properties: properties)
         }
 
         static func dataSyncError(_ error: Error) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+BackgroudUpdates.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+BackgroudUpdates.swift
@@ -14,14 +14,9 @@ extension WooAnalyticsEvent {
             static let batteryLevel = "battery_level"
             static let isLowPowerMode = "is_low_power_mode"
             static let timeSinceLastRun = "time_since_last_run"
-            static let completionStatus = "completion_status"
         }
 
-        static func dataSynced(timeTaken: TimeInterval) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .backgroundDataSynced, properties: [Keys.timeTaken: timeTaken])
-        }
-
-        static func dataSyncedDetailed(
+        static func dataSynced(
             timeTaken: TimeInterval,
             backgroundTimeGranted: TimeInterval?,
             networkType: String,

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -50,7 +50,7 @@ extension UserDefaults {
 
         // Background Task Refresh
         case latestBackgroundOrderSyncDate
-        case lastBackgroundRefreshTime
+        case lastBackgroundRefreshCompletionTime
 
         // Blaze Local notification
         case blazeNoCampaignReminderOpened

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -50,6 +50,7 @@ extension UserDefaults {
 
         // Background Task Refresh
         case latestBackgroundOrderSyncDate
+        case lastBackgroundRefreshTime
 
         // Blaze Local notification
         case blazeNoCampaignReminderOpened

--- a/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
@@ -55,16 +55,14 @@ final class BackgroundTaskRefreshDispatcher {
             return
         }
 
-        // Capture system state at start
-        let systemInfo = BackgroundTaskSystemInfo()
-        let lastRunTime = UserDefaults.standard[.lastBackgroundRefreshTime] as? Date
-
         // Schedule a new refresh task.
         scheduleAppRefresh()
 
         // Launch all refresh tasks in parallel.
         let refreshTasks = Task {
             do {
+                let systemInfo = await BackgroundTaskSystemInfo()
+                let lastRunTime = UserDefaults.standard[.lastBackgroundRefreshTime] as? Date
 
                 let startTime = Date.now
 
@@ -152,13 +150,14 @@ private struct BackgroundTaskSystemInfo {
     var isExpensiveConnection: Bool { networkInfo.isExpensive }
     var isLowDataMode: Bool { networkInfo.isLowDataMode }
 
-    init() {
+    @MainActor
+    init() async {
         // Background time granted (nil if foreground/unlimited)
         let bgTime = UIApplication.shared.backgroundTimeRemaining
         self.backgroundTimeGranted = bgTime < Double.greatestFiniteMagnitude ? bgTime : nil
 
         // Network info
-        self.networkInfo = Self.getNetworkInfo()
+        self.networkInfo = await Self.getNetworkInfo()
 
         // Power and battery info
         let device = UIDevice.current
@@ -171,48 +170,43 @@ private struct BackgroundTaskSystemInfo {
         device.isBatteryMonitoringEnabled = false
     }
 
-    private static func getNetworkInfo() -> NetworkInfo {
-        // Use a semaphore to wait for the path update
-        let semaphore = DispatchSemaphore(value: 0)
-        let monitor = NWPathMonitor()
-        var networkInfo = NetworkInfo(type: "no_connection", isExpensive: false, isLowDataMode: false)
-        
-        monitor.pathUpdateHandler = { path in
-            // Check connection status first
-            guard path.status == .satisfied else {
-                networkInfo = NetworkInfo(type: "no_connection", isExpensive: false, isLowDataMode: false)
-                semaphore.signal()
-                return
+    private static func getNetworkInfo() async -> NetworkInfo {
+        return await withCheckedContinuation { continuation in
+            let monitor = NWPathMonitor()
+
+            monitor.pathUpdateHandler = { path in
+                // Check connection status first
+                guard path.status == .satisfied else {
+                    let networkInfo = NetworkInfo(type: "no_connection", isExpensive: false, isLowDataMode: false)
+                    continuation.resume(returning: networkInfo)
+                    monitor.cancel()
+                    return
+                }
+
+                let isExpensive = path.isExpensive
+                let isLowDataMode = path.isConstrained
+
+                // Determine connection type
+                let networkType: String
+                if path.usesInterfaceType(.wifi) {
+                    networkType = "wifi"
+                } else if path.usesInterfaceType(.cellular) {
+                    networkType = "cellular"
+                } else if path.usesInterfaceType(.wiredEthernet) {
+                    networkType = "ethernet"
+                } else if path.usesInterfaceType(.loopback) {
+                    networkType = "loopback"
+                } else {
+                    networkType = "other"
+                }
+
+                let networkInfo = NetworkInfo(type: networkType, isExpensive: isExpensive, isLowDataMode: isLowDataMode)
+                continuation.resume(returning: networkInfo)
+                monitor.cancel()
             }
-            
-            let isExpensive = path.isExpensive
-            let isLowDataMode = path.isConstrained
-            
-            // Determine connection type
-            let networkType: String
-            if path.usesInterfaceType(.wifi) {
-                networkType = "wifi"
-            } else if path.usesInterfaceType(.cellular) {
-                networkType = "cellular"
-            } else if path.usesInterfaceType(.wiredEthernet) {
-                networkType = "ethernet"
-            } else if path.usesInterfaceType(.loopback) {
-                networkType = "loopback"
-            } else {
-                networkType = "other"
-            }
-            
-            networkInfo = NetworkInfo(type: networkType, isExpensive: isExpensive, isLowDataMode: isLowDataMode)
-            semaphore.signal()
+
+            let queue = DispatchQueue(label: "network.monitor.queue")
+            monitor.start(queue: queue)
         }
-        
-        let queue = DispatchQueue(label: "network.monitor.queue")
-        monitor.start(queue: queue)
-        
-        // Wait up to 1 second for network info
-        _ = semaphore.wait(timeout: .now() + 1.0)
-        monitor.cancel()
-        
-        return networkInfo
     }
 }

--- a/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
@@ -61,7 +61,7 @@ final class BackgroundTaskRefreshDispatcher {
         // Launch all refresh tasks in parallel.
         let refreshTasks = Task {
             do {
-                let systemInfo = await BackgroundTaskSystemInfo()
+                async let systemInfo = BackgroundTaskSystemInfo()
 
                 let startTime = Date.now
 
@@ -86,7 +86,7 @@ final class BackgroundTaskRefreshDispatcher {
                     timeSinceLastRun = round(lastRunTime.timeIntervalSinceNow.magnitude)
                 }
 
-                ServiceLocator.analytics.track(event: .BackgroundUpdates.dataSynced(
+                await ServiceLocator.analytics.track(event: .BackgroundUpdates.dataSynced(
                     timeTaken: timeTaken,
                     backgroundTimeGranted: systemInfo.backgroundTimeGranted,
                     networkType: systemInfo.networkType,

--- a/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
@@ -83,7 +83,6 @@ final class BackgroundTaskRefreshDispatcher {
                 let timeTaken = round(Date.now.timeIntervalSince(startTime))
                 let timeSinceLastRun = lastRunTime?.timeIntervalSinceNow.magnitude
 
-                // Track detailed analytics
                 ServiceLocator.analytics.track(event: .BackgroundUpdates.dataSyncedDetailed(
                     timeTaken: timeTaken,
                     backgroundTimeGranted: systemInfo.backgroundTimeGranted,
@@ -96,8 +95,8 @@ final class BackgroundTaskRefreshDispatcher {
                     timeSinceLastRun: timeSinceLastRun
                 ))
 
-                // Update last run timestamp
-                UserDefaults.standard[.lastBackgroundRefreshTime] = Date()
+                // Save date, for use in analytics next time we refresh
+                UserDefaults.standard[.lastBackgroundRefreshTime] = Date.now
 
                 backgroundTask.setTaskCompleted(success: true)
 
@@ -153,8 +152,8 @@ private struct BackgroundTaskSystemInfo {
     @MainActor
     init() async {
         // Background time granted (nil if foreground/unlimited)
-        let bgTime = UIApplication.shared.backgroundTimeRemaining
-        self.backgroundTimeGranted = bgTime < Double.greatestFiniteMagnitude ? bgTime : nil
+        let backgroundTime = UIApplication.shared.backgroundTimeRemaining
+        self.backgroundTimeGranted = backgroundTime < Double.greatestFiniteMagnitude ? backgroundTime : nil
 
         // Network info
         self.networkInfo = await Self.getNetworkInfo()
@@ -175,38 +174,41 @@ private struct BackgroundTaskSystemInfo {
             let monitor = NWPathMonitor()
 
             monitor.pathUpdateHandler = { path in
-                // Check connection status first
-                guard path.status == .satisfied else {
-                    let networkInfo = NetworkInfo(type: "no_connection", isExpensive: false, isLowDataMode: false)
-                    continuation.resume(returning: networkInfo)
-                    monitor.cancel()
-                    return
-                }
-
-                let isExpensive = path.isExpensive
-                let isLowDataMode = path.isConstrained
-
-                // Determine connection type
-                let networkType: String
-                if path.usesInterfaceType(.wifi) {
-                    networkType = "wifi"
-                } else if path.usesInterfaceType(.cellular) {
-                    networkType = "cellular"
-                } else if path.usesInterfaceType(.wiredEthernet) {
-                    networkType = "ethernet"
-                } else if path.usesInterfaceType(.loopback) {
-                    networkType = "loopback"
-                } else {
-                    networkType = "other"
-                }
-
-                let networkInfo = NetworkInfo(type: networkType, isExpensive: isExpensive, isLowDataMode: isLowDataMode)
-                continuation.resume(returning: networkInfo)
+                continuation.resume(returning: NetworkInfo(path: path))
                 monitor.cancel()
             }
 
             let queue = DispatchQueue(label: "network.monitor.queue")
             monitor.start(queue: queue)
+        }
+    }
+}
+
+private extension NetworkInfo {
+    init(path: NWPath) {
+        guard path.status == .satisfied else {
+            self.type = "no_connection"
+            self.isExpensive = false
+            self.isLowDataMode = false
+            return
+        }
+
+        self.type = Self.networkType(from: path)
+        self.isExpensive = path.isExpensive
+        self.isLowDataMode = path.isConstrained
+    }
+
+    private static func networkType(from path: NWPath) -> String {
+        if path.usesInterfaceType(.wifi) {
+            return "wifi"
+        } else if path.usesInterfaceType(.cellular) {
+            return "cellular"
+        } else if path.usesInterfaceType(.wiredEthernet) {
+            return "ethernet"
+        } else if path.usesInterfaceType(.loopback) {
+            return "loopback"
+        } else {
+            return "other"
         }
     }
 }

--- a/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Foundation
 import BackgroundTasks
+import Network
 
 final class BackgroundTaskRefreshDispatcher {
 
@@ -54,6 +55,10 @@ final class BackgroundTaskRefreshDispatcher {
             return
         }
 
+        // Capture system state at start
+        let systemInfo = BackgroundTaskSystemInfo()
+        let lastRunTime = UserDefaults.standard[.lastBackgroundRefreshTime] as? Date
+
         // Schedule a new refresh task.
         scheduleAppRefresh()
 
@@ -78,7 +83,24 @@ final class BackgroundTaskRefreshDispatcher {
                 }
 
                 let timeTaken = round(Date.now.timeIntervalSince(startTime))
-                ServiceLocator.analytics.track(event: .BackgroundUpdates.dataSynced(timeTaken: timeTaken))
+                let timeSinceLastRun = lastRunTime?.timeIntervalSinceNow.magnitude
+
+                // Track detailed analytics
+                ServiceLocator.analytics.track(event: .BackgroundUpdates.dataSyncedDetailed(
+                    timeTaken: timeTaken,
+                    backgroundTimeGranted: systemInfo.backgroundTimeGranted,
+                    networkType: systemInfo.networkType,
+                    isExpensiveConnection: systemInfo.isExpensiveConnection,
+                    isLowDataMode: systemInfo.isLowDataMode,
+                    isPowered: systemInfo.isPowered,
+                    batteryLevel: systemInfo.batteryLevel,
+                    isLowPowerMode: systemInfo.isLowPowerMode,
+                    timeSinceLastRun: timeSinceLastRun
+                ))
+
+                // Update last run timestamp
+                UserDefaults.standard[.lastBackgroundRefreshTime] = Date()
+
                 backgroundTask.setTaskCompleted(success: true)
 
             } catch {
@@ -93,7 +115,7 @@ final class BackgroundTaskRefreshDispatcher {
             ServiceLocator.analytics.track(event: .BackgroundUpdates.dataSyncError(BackgroundError.expired))
             refreshTasks.cancel()
         }
-     }
+    }
 }
 
 private extension BackgroundTaskRefreshDispatcher {
@@ -107,5 +129,74 @@ private extension BackgroundTaskRefreshDispatcher {
 extension BackgroundTaskRefreshDispatcher {
     private enum BackgroundError: Error {
         case expired
+    }
+}
+
+// MARK: - System Information Helper
+
+private struct NetworkInfo {
+    let type: String
+    let isExpensive: Bool
+    let isLowDataMode: Bool
+}
+
+private struct BackgroundTaskSystemInfo {
+    let backgroundTimeGranted: TimeInterval?
+    let networkInfo: NetworkInfo
+    let isPowered: Bool
+    let batteryLevel: Float
+    let isLowPowerMode: Bool
+
+    // Computed properties for clean external access
+    var networkType: String { networkInfo.type }
+    var isExpensiveConnection: Bool { networkInfo.isExpensive }
+    var isLowDataMode: Bool { networkInfo.isLowDataMode }
+
+    init() {
+        // Background time granted (nil if foreground/unlimited)
+        let bgTime = UIApplication.shared.backgroundTimeRemaining
+        self.backgroundTimeGranted = bgTime < Double.greatestFiniteMagnitude ? bgTime : nil
+
+        // Network info
+        self.networkInfo = Self.getNetworkInfo()
+
+        // Power and battery info
+        let device = UIDevice.current
+        device.isBatteryMonitoringEnabled = true
+
+        self.isPowered = device.batteryState == .charging || device.batteryState == .full
+        self.batteryLevel = device.batteryLevel
+        self.isLowPowerMode = ProcessInfo.processInfo.isLowPowerModeEnabled
+
+        device.isBatteryMonitoringEnabled = false
+    }
+
+    private static func getNetworkInfo() -> NetworkInfo {
+        let monitor = NWPathMonitor()
+        let path = monitor.currentPath
+
+        // Check connection status first
+        guard path.status == .satisfied else {
+            return NetworkInfo(type: "no_connection", isExpensive: false, isLowDataMode: false)
+        }
+
+        let isExpensive = path.isExpensive
+        let isLowDataMode = path.isConstrained
+
+        // Determine connection type
+        let networkType: String
+        if path.usesInterfaceType(.wifi) {
+            networkType = "wifi"
+        } else if path.usesInterfaceType(.cellular) {
+            networkType = "cellular"
+        } else if path.usesInterfaceType(.wiredEthernet) {
+            networkType = "ethernet"
+        } else if path.usesInterfaceType(.loopback) {
+            networkType = "loopback"
+        } else {
+            networkType = "other"
+        }
+
+        return NetworkInfo(type: networkType, isExpensive: isExpensive, isLowDataMode: isLowDataMode)
     }
 }

--- a/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
@@ -172,31 +172,47 @@ private struct BackgroundTaskSystemInfo {
     }
 
     private static func getNetworkInfo() -> NetworkInfo {
+        // Use a semaphore to wait for the path update
+        let semaphore = DispatchSemaphore(value: 0)
         let monitor = NWPathMonitor()
-        let path = monitor.currentPath
-
-        // Check connection status first
-        guard path.status == .satisfied else {
-            return NetworkInfo(type: "no_connection", isExpensive: false, isLowDataMode: false)
+        var networkInfo = NetworkInfo(type: "no_connection", isExpensive: false, isLowDataMode: false)
+        
+        monitor.pathUpdateHandler = { path in
+            // Check connection status first
+            guard path.status == .satisfied else {
+                networkInfo = NetworkInfo(type: "no_connection", isExpensive: false, isLowDataMode: false)
+                semaphore.signal()
+                return
+            }
+            
+            let isExpensive = path.isExpensive
+            let isLowDataMode = path.isConstrained
+            
+            // Determine connection type
+            let networkType: String
+            if path.usesInterfaceType(.wifi) {
+                networkType = "wifi"
+            } else if path.usesInterfaceType(.cellular) {
+                networkType = "cellular"
+            } else if path.usesInterfaceType(.wiredEthernet) {
+                networkType = "ethernet"
+            } else if path.usesInterfaceType(.loopback) {
+                networkType = "loopback"
+            } else {
+                networkType = "other"
+            }
+            
+            networkInfo = NetworkInfo(type: networkType, isExpensive: isExpensive, isLowDataMode: isLowDataMode)
+            semaphore.signal()
         }
-
-        let isExpensive = path.isExpensive
-        let isLowDataMode = path.isConstrained
-
-        // Determine connection type
-        let networkType: String
-        if path.usesInterfaceType(.wifi) {
-            networkType = "wifi"
-        } else if path.usesInterfaceType(.cellular) {
-            networkType = "cellular"
-        } else if path.usesInterfaceType(.wiredEthernet) {
-            networkType = "ethernet"
-        } else if path.usesInterfaceType(.loopback) {
-            networkType = "loopback"
-        } else {
-            networkType = "other"
-        }
-
-        return NetworkInfo(type: networkType, isExpensive: isExpensive, isLowDataMode: isLowDataMode)
+        
+        let queue = DispatchQueue(label: "network.monitor.queue")
+        monitor.start(queue: queue)
+        
+        // Wait up to 1 second for network info
+        _ = semaphore.wait(timeout: .now() + 1.0)
+        monitor.cancel()
+        
+        return networkInfo
     }
 }

--- a/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
@@ -62,7 +62,6 @@ final class BackgroundTaskRefreshDispatcher {
         let refreshTasks = Task {
             do {
                 let systemInfo = await BackgroundTaskSystemInfo()
-                let lastRunTime = UserDefaults.standard[.lastBackgroundRefreshTime] as? Date
 
                 let startTime = Date.now
 
@@ -81,9 +80,13 @@ final class BackgroundTaskRefreshDispatcher {
                 }
 
                 let timeTaken = round(Date.now.timeIntervalSince(startTime))
-                let timeSinceLastRun = lastRunTime?.timeIntervalSinceNow.magnitude
 
-                ServiceLocator.analytics.track(event: .BackgroundUpdates.dataSyncedDetailed(
+                var timeSinceLastRun: TimeInterval? = nil
+                if let lastRunTime = UserDefaults.standard[.lastBackgroundRefreshCompletionTime] as? Date {
+                    timeSinceLastRun = round(lastRunTime.timeIntervalSinceNow.magnitude)
+                }
+
+                ServiceLocator.analytics.track(event: .BackgroundUpdates.dataSynced(
                     timeTaken: timeTaken,
                     backgroundTimeGranted: systemInfo.backgroundTimeGranted,
                     networkType: systemInfo.networkType,
@@ -96,7 +99,7 @@ final class BackgroundTaskRefreshDispatcher {
                 ))
 
                 // Save date, for use in analytics next time we refresh
-                UserDefaults.standard[.lastBackgroundRefreshTime] = Date.now
+                UserDefaults.standard[.lastBackgroundRefreshCompletionTime] = Date.now
 
                 backgroundTask.setTaskCompleted(success: true)
 
@@ -139,7 +142,7 @@ private struct NetworkInfo {
 
 private struct BackgroundTaskSystemInfo {
     let backgroundTimeGranted: TimeInterval?
-    let networkInfo: NetworkInfo
+    private let networkInfo: NetworkInfo
     let isPowered: Bool
     let batteryLevel: Float
     let isLowPowerMode: Bool


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds detailed analytics tracking to the existing background task refresh system to help us understand
how background syncing works in real-world conditions. This will inform our choices for POS local catalog sync, whether we can use the same App Refresh task or would need a background processing task.

@toupper @jaclync What do you think – 23.1, or put it in the 23.0 beta? I'm happy either way, but have done 23.1 for now.

Also, if you think there's anything else we should try to track, let me know.

### Changes

#### Analytics Updates

  - Updated WooAnalyticsEvent.BackgroundUpdates to track more system info
  - Added dataSyncedDetailed() event that captures:
    - How long the task took and how much time iOS gave us
    - Network type (wifi, cellular, ethernet) and connection flags
    - Device power status, battery level, and power-saving modes
    - Time since the last background refresh

#### System Info Collection

  - New BackgroundTaskSystemInfo struct to gather device/network info
  - Network detection using NWPathMonitor
  - Battery monitoring

### Analytics Properties

  | Property                | Type    | What it tracks                                   |
  |-------------------------|---------|--------------------------------------------------|
  | time_taken              | Int64   | How long the background task took (seconds)      |
  | background_time_granted | Int64   | How much time iOS gave us (optional)             |
  | network_type            | String  | "wifi", "cellular", "ethernet", "no_connection"  |
  | is_expensive_connection | Bool    | Roaming, hotspots, limited data plans            |
  | is_low_data_mode        | Bool    | iOS Data Saver feature enabled                   |
  | is_powered              | Bool    | Device plugged in or charging                    |
  | battery_level           | Float64 | Battery percentage (0.0 to 1.0)                  |
  | is_low_power_mode       | Bool    | iOS Low Power Mode enabled                       |
  | time_since_last_run     | Int64   | Seconds since last background refresh (optional) |

## Steps to reproduce

  1. Build and install the app on a real device (background tasks don't work in Simulator)
  2. Set up test conditions:
    - Turn Low Data Mode on/off: Settings → Cellular → Cellular Data Options → Low Data Mode
    - Turn Low Power Mode on/off: Settings → Battery → Low Power Mode
    - Try different networks: WiFi, Cellular, WiFi hotspot
  3. Test background task. Either wait half an hour or so (could be much longer) or:
    - Run from Xcode, adding a breakpoint after the task is scheduled (at the end of AppDelegate.applicationDidEnterBackground(_:))
    - In Xcode debug console, run this command:
    - `e -l objc -- (void)[[BGTaskScheduler sharedScheduler]
  _simulateLaunchForTaskWithIdentifier:@"com.automattic.woocommerce.refresh"]`
    - Allow the app to run on
  4. Check the analytics data:
    - Look for Tracked background_data_synced in the logs
    - Make sure all the properties show up and look correct:
        - `network_type` should show your current connection
        - `is_low_data_mode` should match what you set in Settings
        - `is_low_power_mode` should match what you set in Settings
        - `battery_level` should show current battery percentage
        - `is_powered` should show if you're charging
        - Note that if you are attached to the debugger, normal sheduled tasks won't run and the `background_time_granted` won't be logged, because the app is essentially in the foreground even when you background it.
  5. Try different cases:
    - WiFi with/without Low Data Mode
    - Cellular with/without roaming (if you can)
    - Different battery levels and charging states
    - Run while app is in background vs foreground

### Expected Results

Analytics should show detailed info like:
```
  background_data_synced: {
    time_taken: 2,
    network_type: "wifi",
    is_expensive_connection: false,
    is_low_data_mode: true,
    is_powered: false,
    battery_level: 0.65,
    is_low_power_mode: false,
    time_since_last_run: 1847
  }
```

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

I've tested this on an iPhone running iOS 18, with both simulated and real BGAppRefreshTasks. Screenshot below shows a real task's logged result.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![background task refresh analytics](https://github.com/user-attachments/assets/a29a8a32-cf87-408f-be59-341ffd48b1cf)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
