### PR TITLE
Order Details: Remove Print buttons from shipment details

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Jetpack setup: Native experience for the connection step [https://github.com/woocommerce/woocommerce-ios/pull/15983]
 - [*] Payments: Updated the In-Person Payments `Learn More` redirection to display the correct page based on the selected payment provider [https://github.com/woocommerce/woocommerce-ios/pull/15998]
 - [*] Order details: Always show shipping labels section if order is eligible for label creation. [https://github.com/woocommerce/woocommerce-ios/pull/16010]
+- [*] Order details: Remove print buttons from shipment details [https://github.com/woocommerce/woocommerce-ios/pull/16012]
 
 23.0
 -----

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1077,12 +1077,6 @@ private extension OrderDetailsDataSource {
             onViewLabel: { [weak self] label in
                 self?.onCellAction?(.openShippingLabelForm(shippingLabel: label), indexPath)
             },
-            onPrintLabel: { [weak self] label in
-                self?.onCellAction?(.reprintShippingLabel(shippingLabel: label), indexPath)
-            },
-            onPrintCustomsForm: { [weak self] url in
-                self?.onCellAction?(.printCustomsForm(url: url), indexPath)
-            },
             onRefund: { [weak self] label in
                 self?.onCellAction?(.refundShippingLabel(shippingLabel: label), indexPath)
             }
@@ -2102,7 +2096,6 @@ extension OrderDetailsDataSource {
         case createShippingLabel(shipmentIndex: Int?)
         case openShippingLabelForm(shippingLabel: ShippingLabel)
         case refundShippingLabel(shippingLabel: ShippingLabel)
-        case printCustomsForm(url: String)
         case viewShipmentItems(shipment: WooShippingShipment)
         case shippingLabelTrackingMenu(shippingLabel: ShippingLabel, sourceView: UIView)
         case viewAddOns(addOns: [OrderItemProductAddOn])

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsShipmentDetailsView.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsShipmentDetailsView.swift
@@ -9,8 +9,6 @@ struct OrderDetailsShipmentDetailsView: View {
     let onViewItems: () -> Void
     let onCreateLabel: () -> Void
     let onViewLabel: (ShippingLabel) -> Void
-    let onPrintLabel: (ShippingLabel) -> Void
-    let onPrintCustomsForm: (String) -> Void
     let onRefund: (ShippingLabel) -> Void
 
     var body: some View {
@@ -29,12 +27,6 @@ struct OrderDetailsShipmentDetailsView: View {
                             onRefund(label)
                         }
                         .renderedIf(label.isRefundable)
-
-                        if let url = label.commercialInvoiceURL, url.isNotEmpty {
-                            Button(Localization.printCustomsForm) {
-                                onPrintCustomsForm(url)
-                            }
-                        }
                     } label: {
                         Image(systemName: "ellipsis")
                             .foregroundStyle(Color.accentColor)
@@ -117,15 +109,6 @@ struct OrderDetailsShipmentDetailsView: View {
                     }
                 }
                 .buttonStyle(.plain)
-
-                Divider()
-                    .padding(.trailing, -Layout.contentPadding)
-
-                Button(String.localizedStringWithFormat(Localization.printShippingLabel, shipmentIndex)) {
-                    onPrintLabel(shippingLabel)
-                }
-                .buttonStyle(SecondaryButtonStyle())
-                .padding(.vertical, Layout.extraSpacing)
             }
         }
     }
@@ -171,11 +154,6 @@ private extension OrderDetailsShipmentDetailsView {
             value: "Request a refund",
             comment: "Button to request a refund for a purchased shipping label."
         )
-        static let printCustomsForm = NSLocalizedString(
-            "orderDetailsShipmentDetailsView.printCustomsForm",
-            value: "Print customs form",
-            comment: "Button to print the customs form for a purchased shipping label."
-        )
         static let refundMessage = NSLocalizedString(
             "orderDetailsShipmentDetailsView.refundMessage",
             value: "You have successfully submitted a request for refund. " +
@@ -196,12 +174,6 @@ private extension OrderDetailsShipmentDetailsView {
             "orderDetailsShipmentDetailsView.createShippingLabel",
             value: "Create Shipping Label",
             comment: "Button to create a shipping label for a shipment"
-        )
-        static let printShippingLabel = NSLocalizedString(
-            "orderDetailsShipmentDetailsView.printShippingLabel",
-            value: "Print Shipping Label (%1$@)",
-            comment: "Button to print a shipping label for a shipment. Placeholder is the shipment index. " +
-            "Reads like: Print Shipping Label (1/2)"
         )
         static let trackingNumber = NSLocalizedString(
             "orderDetailsShipmentDetailsView.trackingNumber",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -411,8 +411,6 @@ private extension OrderDetailsViewController {
             showShipmentItems(shipment: shipment)
         case .refundShippingLabel(let shippingLabel):
             refundShippingLabel(shippingLabel)
-        case .printCustomsForm(let url):
-            printCustomsForm(url: url)
         case .shippingLabelTrackingMenu(let shippingLabel, let sourceView):
             shippingLabelTrackingMoreMenuTapped(shippingLabel: shippingLabel, sourceView: sourceView)
         case let .viewAddOns(addOns):


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-982

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR removes the Print shipping label and Print customs form buttons on the shipment details on the order details screen. Users can print the label by tapping on viewing the label.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store with Woo Shipping set up.
2. Navigate to Orders tab and open an order with at least one purchased label.
3. Confirm that buttons to print label and print customs form are no longer available.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested with simulator iPhone 16 iOS 18.2

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before | After
--- | ---
<img src="https://github.com/user-attachments/assets/5e54e85d-122c-4f32-8830-c21c3625fc4c" width=320 /> | <img src="https://github.com/user-attachments/assets/5a17b94c-3ca1-44b1-b361-9e3d49aff8c4" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.