### PR TITLE
Update Application Password use case to support Jetpack requests

### DIFF
--- a/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -72,6 +72,7 @@ final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
     }
 
     /// Internal initializer
+    /// periphery: ignore - used in future PR for WOOMOB-1121
     init(type: AuthenticationType,
          network: Network,
          keychain: Keychain = Keychain(service: WooConstants.keychainServiceName)) {

--- a/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -1,5 +1,6 @@
 import Foundation
 import enum Alamofire.AFError
+import struct Alamofire.HTTPMethod
 import KeychainAccess
 
 #if canImport(UIKit)
@@ -34,13 +35,20 @@ public protocol ApplicationPasswordUseCase {
 }
 
 final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase {
-    /// Site Address
+    /// Authentication type
     ///
-    private let siteAddress: String
+    private let authenticationType: AuthenticationType
 
     /// WPOrg username
     ///
-    private let username: String
+    private var username: String {
+        switch authenticationType {
+        case .wporg(let username, _, _):
+            return username
+        case .wpcom(let emailAddress, _):
+            return emailAddress
+        }
+    }
 
     /// To generate and delete application password
     ///
@@ -63,13 +71,22 @@ final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
 #endif
     }
 
+    /// Internal initializer
+    init(type: AuthenticationType,
+         network: Network,
+         keychain: Keychain = Keychain(service: WooConstants.keychainServiceName)) {
+        self.authenticationType = type
+        self.storage = ApplicationPasswordStorage(keychain: keychain)
+        self.network = network
+    }
+
+    /// Public initializer for wporg authentication
     public init(username: String,
                 password: String,
                 siteAddress: String,
                 network: Network? = nil,
                 keychain: Keychain = Keychain(service: WooConstants.keychainServiceName)) throws {
-        self.siteAddress = siteAddress
-        self.username = username
+        self.authenticationType = .wporg(username: username, password: password, siteAddress: siteAddress)
         self.storage = ApplicationPasswordStorage(keychain: keychain)
 
         if let network {
@@ -143,6 +160,24 @@ final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
 }
 
 private extension DefaultApplicationPasswordUseCase {
+    /// Helper method to construct network requests either directly with the remote site
+    /// or through Jetpack proxy.
+    func constructRequest(method: HTTPMethod, path: String, parameters: [String: Any]? = nil) -> Request {
+        switch authenticationType {
+        case .wpcom(_, let siteID):
+            JetpackRequest(wooApiVersion: .none,
+                           method: method,
+                           siteID: siteID,
+                           path: path,
+                           parameters: parameters)
+        case .wporg(_, _, let siteAddress):
+            RESTRequest(siteURL: siteAddress,
+                        method: method,
+                        path: path,
+                        parameters: parameters)
+        }
+    }
+
     /// Creates application password using WordPress.com authentication token
     ///
     /// - Returns: Generated `ApplicationPassword`
@@ -151,7 +186,9 @@ private extension DefaultApplicationPasswordUseCase {
         let passwordName = applicationPasswordName
 
         let parameters = [ParameterKey.name: passwordName]
-        let request = RESTRequest(siteURL: siteAddress, method: .post, path: Path.applicationPasswords, parameters: parameters)
+        let request = constructRequest(method: .post,
+                                       path: Path.applicationPasswords,
+                                       parameters: parameters)
         return try await withCheckedThrowingContinuation { continuation in
             network.responseData(for: request) { [weak self] result in
                 guard let self else { return }
@@ -190,7 +227,7 @@ private extension DefaultApplicationPasswordUseCase {
     /// Get the UUID of the application password
     ///
     func fetchUUIDForApplicationPassword(_ passwordName: String) async throws -> String {
-        let request = RESTRequest(siteURL: siteAddress, method: .get, path: Path.applicationPasswords)
+        let request = constructRequest(method: .get, path: Path.applicationPasswords)
 
         return try await withCheckedThrowingContinuation { continuation in
             network.responseData(for: request) { result in
@@ -217,7 +254,7 @@ private extension DefaultApplicationPasswordUseCase {
     /// Deletes application password using UUID
     ///
     func deleteApplicationPassword(_ uuid: String) async throws {
-        let request = RESTRequest(siteURL: siteAddress, method: .delete, path: Path.applicationPasswords + "/" + uuid)
+        let request = constructRequest(method: .delete, path: Path.applicationPasswords + "/" + uuid)
 
         try await withCheckedThrowingContinuation { continuation in
             network.responseData(for: request) { result in
@@ -229,6 +266,13 @@ private extension DefaultApplicationPasswordUseCase {
                 }
             }
         }
+    }
+}
+
+extension DefaultApplicationPasswordUseCase {
+    enum AuthenticationType {
+        case wporg(username: String, password: String, siteAddress: String)
+        case wpcom(emailAddress: String, siteID: Int64)
     }
 }
 

--- a/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -45,8 +45,8 @@ final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
         switch authenticationType {
         case .wporg(let username, _, _):
             return username
-        case .wpcom(let emailAddress, _):
-            return emailAddress
+        case .wpcom(let wporgUsername, _):
+            return wporgUsername
         }
     }
 
@@ -273,7 +273,7 @@ private extension DefaultApplicationPasswordUseCase {
 extension DefaultApplicationPasswordUseCase {
     enum AuthenticationType {
         case wporg(username: String, password: String, siteAddress: String)
-        case wpcom(emailAddress: String, siteID: Int64)
+        case wpcom(wporgUsername: String, siteID: Int64)
     }
 }
 

--- a/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -72,7 +72,7 @@ final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
     }
 
     /// Internal initializer
-    /// periphery: ignore - used in future PR for WOOMOB-1121
+    /// periphery: ignore - used in future PR for WOOMOB-1123
     init(type: AuthenticationType,
          network: Network,
          keychain: Keychain = Keychain(service: WooConstants.keychainServiceName)) {

--- a/Modules/Sources/NetworkingCore/ApplicationPassword/RequestProcessor.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/RequestProcessor.swift
@@ -43,6 +43,7 @@ extension RequestProcessor: RequestRetrier {
 
         requestsToRetry.append(completion)
         if !isAuthenticating {
+            isAuthenticating = true
             generateApplicationPassword()
         }
     }
@@ -53,8 +54,6 @@ extension RequestProcessor: RequestRetrier {
 private extension RequestProcessor {
     func generateApplicationPassword() {
         Task(priority: .medium) {
-            isAuthenticating = true
-
             do {
                 let _ = try await requestAuthenticator.generateApplicationPassword()
                 isAuthenticating = false
@@ -75,17 +74,14 @@ private extension RequestProcessor {
     }
 
     func shouldRetry(_ error: Error) -> Bool {
-        // Need to generate application password
-        if .applicationPasswordNotAvailable == error as? RequestAuthenticatorError {
+        switch error {
+        case RequestAuthenticatorError.applicationPasswordNotAvailable,
+            AFError.requestAdaptationFailed(RequestAuthenticatorError.applicationPasswordNotAvailable),
+            AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 401)): // Failed authorization
             return true
+        default:
+            return false
         }
-
-        // Failed authorization
-        if case .responseValidationFailed(reason: .unacceptableStatusCode(code: 401)) = error as? AFError {
-            return true
-        }
-
-        return false
     }
 
     func completeRequests(_ shouldRetry: Bool) {

--- a/Modules/Sources/NetworkingCore/Mapper/ApplicationPassword/ApplicationPasswordMapper.swift
+++ b/Modules/Sources/NetworkingCore/Mapper/ApplicationPassword/ApplicationPasswordMapper.swift
@@ -12,7 +12,22 @@ struct ApplicationPasswordMapper: Mapper {
         decoder.userInfo = [
             .wpOrgUsername: wpOrgUsername
         ]
-        let password = try decoder.decode(ApplicationPassword.self, from: response)
-        return password
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(ApplicationPasswordEnvelope.self, from: response).applicationPassword
+        } else {
+            return try decoder.decode(ApplicationPassword.self, from: response)
+        }
+    }
+}
+
+/// ApplicationPassword Disposable Entity:
+/// When generating application password with Jetpack proxy, the result is returned within the `data` key.
+/// This entity allows us to do parse data with JSONDecoder.
+///
+private struct ApplicationPasswordEnvelope: Decodable {
+    let applicationPassword: ApplicationPassword
+
+    private enum CodingKeys: String, CodingKey {
+        case applicationPassword = "data"
     }
 }

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/DefaultApplicationPasswordUseCaseTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/DefaultApplicationPasswordUseCaseTests.swift
@@ -90,4 +90,57 @@ final class DefaultApplicationPasswordUseCaseTests: XCTestCase {
         // Then
         XCTAssertTrue(failure == .unauthorizedRequest)
     }
+
+    func test_password_is_generated_with_correct_values_upon_success_response_when_authenticated_with_wpcom() async throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: URLSuffix.generateApplicationPassword,
+                                 filename: "generate-application-password-using-wporg-creds-success")
+        let email = "test@example.com"
+        let sut = DefaultApplicationPasswordUseCase(type: .wpcom(emailAddress: email, siteID: 123), network: network)
+
+        // When
+        let password = try await sut.generateNewPassword()
+
+        // Then
+        XCTAssertEqual(password.password.secretValue, "passwordvalue")
+        XCTAssertEqual(password.wpOrgUsername, email)
+    }
+
+    func test_applicationPasswordsDisabled_error_is_thrown_if_generating_password_fails_with_501_error_when_authenticated_with_wpcom() async throws {
+        // Given
+        let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 501))
+        network.simulateError(requestUrlSuffix: URLSuffix.generateApplicationPassword, error: error)
+        let email = "test@example.com"
+        let sut = DefaultApplicationPasswordUseCase(type: .wpcom(emailAddress: email, siteID: 123), network: network)
+
+        // When
+        var failure: ApplicationPasswordUseCaseError?
+        do {
+            let _ = try await sut.generateNewPassword()
+        } catch {
+            failure = error as? ApplicationPasswordUseCaseError
+        }
+
+        // Then
+        XCTAssertTrue(failure == .applicationPasswordsDisabled)
+    }
+
+    func test_unauthorizedRequest_error_is_thrown_if_generating_password_fails_with_401_error_when_authenticated_with_wpcom() async throws {
+        // Given
+        let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 401))
+        network.simulateError(requestUrlSuffix: URLSuffix.generateApplicationPassword, error: error)
+        let email = "test@example.com"
+        let sut = DefaultApplicationPasswordUseCase(type: .wpcom(emailAddress: email, siteID: 123), network: network)
+
+        // When
+        var failure: ApplicationPasswordUseCaseError?
+        do {
+            let _ = try await sut.generateNewPassword()
+        } catch {
+            failure = error as? ApplicationPasswordUseCaseError
+        }
+
+        // Then
+        XCTAssertTrue(failure == .unauthorizedRequest)
+    }
 }

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/DefaultApplicationPasswordUseCaseTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/DefaultApplicationPasswordUseCaseTests.swift
@@ -95,23 +95,23 @@ final class DefaultApplicationPasswordUseCaseTests: XCTestCase {
         // Given
         network.simulateResponse(requestUrlSuffix: URLSuffix.generateApplicationPassword,
                                  filename: "generate-application-password-using-wporg-creds-success")
-        let email = "test@example.com"
-        let sut = DefaultApplicationPasswordUseCase(type: .wpcom(emailAddress: email, siteID: 123), network: network)
+        let wporgUsername = "username"
+        let sut = DefaultApplicationPasswordUseCase(type: .wpcom(wporgUsername: wporgUsername, siteID: 123), network: network)
 
         // When
         let password = try await sut.generateNewPassword()
 
         // Then
         XCTAssertEqual(password.password.secretValue, "passwordvalue")
-        XCTAssertEqual(password.wpOrgUsername, email)
+        XCTAssertEqual(password.wpOrgUsername, wporgUsername)
     }
 
     func test_applicationPasswordsDisabled_error_is_thrown_if_generating_password_fails_with_501_error_when_authenticated_with_wpcom() async throws {
         // Given
         let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 501))
         network.simulateError(requestUrlSuffix: URLSuffix.generateApplicationPassword, error: error)
-        let email = "test@example.com"
-        let sut = DefaultApplicationPasswordUseCase(type: .wpcom(emailAddress: email, siteID: 123), network: network)
+        let wporgUsername = "username"
+        let sut = DefaultApplicationPasswordUseCase(type: .wpcom(wporgUsername: wporgUsername, siteID: 123), network: network)
 
         // When
         var failure: ApplicationPasswordUseCaseError?
@@ -129,8 +129,8 @@ final class DefaultApplicationPasswordUseCaseTests: XCTestCase {
         // Given
         let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 401))
         network.simulateError(requestUrlSuffix: URLSuffix.generateApplicationPassword, error: error)
-        let email = "test@example.com"
-        let sut = DefaultApplicationPasswordUseCase(type: .wpcom(emailAddress: email, siteID: 123), network: network)
+        let wporgUsername = "username"
+        let sut = DefaultApplicationPasswordUseCase(type: .wpcom(wporgUsername: wporgUsername, siteID: 123), network: network)
 
         // When
         var failure: ApplicationPasswordUseCaseError?

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
@@ -144,6 +144,23 @@ final class RequestProcessorTests: XCTestCase {
         XCTAssertTrue(shouldRetry.retryRequired)
     }
 
+    func test_request_is_scheduled_for_retry_when_requestAdaptationFailed_error_occurs() throws {
+        // Given
+        let session = Alamofire.Session(configuration: URLSessionConfiguration.default)
+        let request = try mockRequest()
+
+        // When
+        let error = AFError.requestAdaptationFailed(error: RequestAuthenticatorError.applicationPasswordNotAvailable)
+        let shouldRetry = waitFor { promise in
+            self.sut.retry(request, for: session, dueTo: error) { shouldRetry in
+                promise(shouldRetry)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(shouldRetry.retryRequired)
+    }
+
     func test_request_is_scheduled_for_retry_when_401_error_occurs() throws {
         // Given
         let session = Alamofire.Session(configuration: URLSessionConfiguration.default)
@@ -321,7 +338,7 @@ private class MockRequestAuthenticator: RequestAuthenticator {
     }
 }
 
-private class MockNotificationCenter: NotificationCenter {
+private class MockNotificationCenter: NotificationCenter, @unchecked Sendable {
     private(set) var notificationName: NSNotification.Name?
     private(set) var notificationObject: Any?
 
@@ -331,7 +348,7 @@ private class MockNotificationCenter: NotificationCenter {
     }
 }
 
-private class MockRequest: Alamofire.DataRequest {
+private class MockRequest: Alamofire.DataRequest, @unchecked Sendable {
     var fakeRetryCount: Int = 0
 
     override var retryCount: Int {

--- a/Modules/Tests/NetworkingTests/Mapper/ApplicationPasswordMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/ApplicationPasswordMapperTests.swift
@@ -9,10 +9,23 @@ final class ApplicationPasswordMapperTests: XCTestCase {
 
     private let wpOrgUsername = "username"
 
+    /// Verifies that generate password using WPOrg credentials response is parsed properly
+    ///
+    func test_response_is_properly_parsed_while_generating_password_using_WPOrg_credentials() {
+        guard let password = mapGenerateUsingWPOrgResponse() else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(password.password.secretValue, "passwordvalue")
+        XCTAssertEqual(password.uuid, "8ef68e6b-4670-4cfd-8ca0-456e616bcd5e")
+        XCTAssertEqual(password.wpOrgUsername, "username")
+    }
+
     /// Verifies that generate password using WPCOM token response is parsed properly
     ///
     func test_response_is_properly_parsed_while_generating_password_using_WPCOM_token() {
-        guard let password = mapGenerateUsingWPOrgResponse() else {
+        guard let password = mapGenerateUsingWPComResponse() else {
             XCTFail()
             return
         }
@@ -31,6 +44,16 @@ private extension ApplicationPasswordMapperTests {
     ///
     func mapGenerateUsingWPOrgResponse() -> ApplicationPassword? {
         guard let response = Loader.contentsOf("generate-application-password-using-wporg-creds-success") else {
+            return nil
+        }
+
+        return try? ApplicationPasswordMapper(wpOrgUsername: wpOrgUsername).map(response: response)
+    }
+
+    /// Returns the ApplicationPasswordMapper output upon receiving success response
+    ///
+    func mapGenerateUsingWPComResponse() -> ApplicationPassword? {
+        guard let response = Loader.contentsOf("generate-application-password-using-wpcom-success") else {
             return nil
         }
 

--- a/Modules/Tests/NetworkingTests/Responses/generate-application-password-using-wpcom-success.json
+++ b/Modules/Tests/NetworkingTests/Responses/generate-application-password-using-wpcom-success.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "uuid": "8ef68e6b-4670-4cfd-8ca0-456e616bcd5e",
+    "app_id": "",
+    "name": "com.automattic.woocommerce.ios-app-client.iPhone",
+    "created": "2022-12-15T06:39:38",
+    "last_used": null,
+    "last_ip": null,
+    "password": "passwordvalue",
+    "_links": {
+      "self": [
+        {
+          "href": "https://website.com/wp-json/wp/v2/users/1/application-passwords/8ef68e6b-4670-4cfd-8ca0-456e616bcd5e"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1121

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

To prepare for the switch from Jetpack tunneled requests to REST requests with application passwords, this PR adds a few changes:
- Updates `DefaultApplicationPasswordUseCase` to support generating and deleting passwords with Jetpack proxy.
- Updates `ApplicationPasswordMapper` to support parsing application password responses with `data` envelope from Jetpack requests.
- Updates `RequestProcessor` to catch `requestAdaptationFailed` from Alamofire.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Generating application passwords with Jetpack proxy will be handled in a subsequent PR. Here we just need to test that application passwords work fine with site credentials.
- Create a Jurassic Ninja site with WooCommerce but no Jetpack.
- Log in to the app natively with site credentials. If the app asks you to authorize application password through web view, navigate back and try again until the native login succeeds.
- Navigate to different parts of the app to confirm that network requests still succeeds.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested and confirmed with simulator iPhone 16 iOS 18.2.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

No UI changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.