### PR TITLE
Check for application password when fetching site API

### DIFF
--- a/Modules/Sources/Fakes/Networking.generated.swift
+++ b/Modules/Sources/Fakes/Networking.generated.swift
@@ -1786,7 +1786,8 @@ extension Networking.SiteAPI {
     public static func fake() -> Networking.SiteAPI {
         .init(
             siteID: .fake(),
-            namespaces: .fake()
+            namespaces: .fake(),
+            applicationPasswordAvailable: .fake()
         )
     }
 }

--- a/Modules/Sources/Networking/Model/SiteAPI.swift
+++ b/Modules/Sources/Networking/Model/SiteAPI.swift
@@ -13,6 +13,10 @@ public struct SiteAPI: Decodable, Equatable, GeneratedFakeable {
     ///
     public let namespaces: [String]
 
+    /// Whether application password authentication is available
+    ///
+    public let applicationPasswordAvailable: Bool
+
     /// Highest Woo API version installed on the site
     ///
     public var highestWooVersion: WooAPIVersion {
@@ -42,15 +46,18 @@ public struct SiteAPI: Decodable, Equatable, GeneratedFakeable {
 
         let siteAPIContainer = try decoder.container(keyedBy: SiteAPIKeys.self)
         let namespaces = siteAPIContainer.failsafeDecodeIfPresent([String].self, forKey: .namespaces) ?? []
+        let authentication = try? siteAPIContainer.decode(Authentication.self, forKey: .authentication)
+        let applicationPasswordAvailable = authentication?.applicationPasswords?.endpoints?.authorization != nil
 
-        self.init(siteID: siteID, namespaces: namespaces)
+        self.init(siteID: siteID, namespaces: namespaces, applicationPasswordAvailable: applicationPasswordAvailable)
     }
 
     /// Designated Initializer.
     ///
-    public init(siteID: Int64, namespaces: [String]) {
+    public init(siteID: Int64, namespaces: [String], applicationPasswordAvailable: Bool) {
         self.siteID = siteID
         self.namespaces = namespaces
+        self.applicationPasswordAvailable = applicationPasswordAvailable
     }
 }
 
@@ -60,7 +67,23 @@ public struct SiteAPI: Decodable, Equatable, GeneratedFakeable {
 private extension SiteAPI {
 
     enum SiteAPIKeys: String, CodingKey {
-        case namespaces = "namespaces"
+        case namespaces
+        case authentication
+    }
+
+    struct Authentication: Decodable {
+        let applicationPasswords: ApplicationPasswords?
+        enum CodingKeys: String, CodingKey {
+            case applicationPasswords = "application-passwords"
+        }
+    }
+
+    struct ApplicationPasswords: Decodable {
+        let endpoints: Endpoints?
+    }
+
+    struct Endpoints: Decodable {
+        let authorization: String?
     }
 }
 

--- a/Modules/Sources/Networking/Remote/SiteAPIRemote.swift
+++ b/Modules/Sources/Networking/Remote/SiteAPIRemote.swift
@@ -20,7 +20,7 @@ public class SiteAPIRemote: Remote {
                                      siteID: siteID,
                                      path: path,
                                      parameters: parameters,
-                                     availableAsRESTRequest: true)
+                                     availableAsRESTRequest: false)
         let mapper = SiteAPIMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)

--- a/Modules/Sources/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -62,7 +62,7 @@ struct ScreenshotObjectGraph: MockObjectGraph {
     let defaultSiteAPI = SiteAPI(siteID: 1, namespaces: [
         WooAPIVersion.mark3.rawValue,
         WooAPIVersion.mark4.rawValue,
-    ])
+    ], applicationPasswordAvailable: false)
 
     var sites: [Site] {
         return [defaultSite]

--- a/Modules/Tests/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SettingStoreTests.swift
@@ -949,11 +949,13 @@ private extension SettingStoreTests {
 
     func sampleSiteAPIWithWoo() -> Networking.SiteAPI {
         return SiteAPI(siteID: sampleSiteID,
-                       namespaces: ["oembed/1.0", "akismet/v1", "jetpack/v4", "wpcom/v2", "wc/v1", "wc/v2", "wc/v3", "wc-pb/v3", "wp/v2"])
+                       namespaces: ["oembed/1.0", "akismet/v1", "jetpack/v4", "wpcom/v2", "wc/v1", "wc/v2", "wc/v3", "wc-pb/v3", "wp/v2"],
+                       applicationPasswordAvailable: false)
     }
 
     func sampleSiteAPINoWoo() -> Networking.SiteAPI {
         return SiteAPI(siteID: sampleSiteID,
-                       namespaces: ["oembed/1.0", "akismet/v1", "jetpack/v4", "wpcom/v2", "wc-pb/v3", "wp/v2"])
+                       namespaces: ["oembed/1.0", "akismet/v1", "jetpack/v4", "wpcom/v2", "wc-pb/v3", "wp/v2"],
+                       applicationPasswordAvailable: false)
     }
 }

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -13,6 +13,7 @@ extension UserDefaults {
         case defaultStoreID
         case defaultStoreName
         case defaultStoreCurrencySettings
+        case defaultStoreHasApplicationPasswordEnabled
         case defaultAnonymousID
         case defaultRoles
         case deviceID

--- a/WooCommerce/Classes/Tools/RequirementsChecker.swift
+++ b/WooCommerce/Classes/Tools/RequirementsChecker.swift
@@ -26,10 +26,13 @@ final class RequirementsChecker {
 
     private let stores: StoresManager
     private let baseViewController: UIViewController?
+    private let userDefaults: UserDefaults
 
     init(stores: StoresManager = ServiceLocator.stores,
+         userDefaults: UserDefaults = .standard,
          baseViewController: UIViewController? = nil) {
         self.stores = stores
+        self.userDefaults = userDefaults
         self.baseViewController = baseViewController
     }
 
@@ -131,6 +134,9 @@ private extension RequirementsChecker {
             case .success(let siteAPI):
                 let saveTelemetryAvailabilityAction = AppSettingsAction.setTelemetryAvailability(siteID: siteID, isAvailable: siteAPI.telemetryIsAvailable)
                 self.stores.dispatch(saveTelemetryAvailabilityAction)
+
+                let applicationPasswordAvailable = siteAPI.applicationPasswordAvailable
+                userDefaults.set(applicationPasswordAvailable, forKey: .defaultStoreHasApplicationPasswordEnabled)
 
                 if siteAPI.highestWooVersion == .mark3 {
                     onCompletion?(.success(.validWCVersion))

--- a/WooCommerce/WooCommerceTests/Tools/RequirementsCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/RequirementsCheckerTests.swift
@@ -60,7 +60,7 @@ final class RequirementsCheckerTests: XCTestCase {
         stores.whenReceivingAction(ofType: SettingAction.self) { action in
             switch action {
             case .retrieveSiteAPI(_, let onCompletion):
-                onCompletion(.success(SiteAPI(siteID: site.siteID, namespaces: ["wc/v3"])))
+                onCompletion(.success(SiteAPI(siteID: site.siteID, namespaces: ["wc/v3"], applicationPasswordAvailable: true)))
             default:
                 break
             }
@@ -93,7 +93,7 @@ final class RequirementsCheckerTests: XCTestCase {
         stores.whenReceivingAction(ofType: SettingAction.self) { action in
             switch action {
             case .retrieveSiteAPI(_, let onCompletion):
-                onCompletion(.success(SiteAPI(siteID: site.siteID, namespaces: ["wc/v2"])))
+                onCompletion(.success(SiteAPI(siteID: site.siteID, namespaces: ["wc/v2"], applicationPasswordAvailable: true)))
             default:
                 break
             }
@@ -164,7 +164,7 @@ final class RequirementsCheckerTests: XCTestCase {
         stores.whenReceivingAction(ofType: SettingAction.self) { action in
             switch action {
             case .retrieveSiteAPI(_, let onCompletion):
-                onCompletion(.success(SiteAPI(siteID: site.siteID, namespaces: [])))
+                onCompletion(.success(SiteAPI(siteID: site.siteID, namespaces: [], applicationPasswordAvailable: true)))
             default:
                 break
             }
@@ -188,7 +188,7 @@ final class RequirementsCheckerTests: XCTestCase {
         stores.whenReceivingAction(ofType: SettingAction.self) { action in
             switch action {
             case .retrieveSiteAPI(_, let completion):
-                completion(.success(SiteAPI(siteID: site.siteID, namespaces: [])))
+                completion(.success(SiteAPI(siteID: site.siteID, namespaces: [], applicationPasswordAvailable: true)))
             default:
                 break
             }
@@ -201,5 +201,39 @@ final class RequirementsCheckerTests: XCTestCase {
         waitUntil {
             self.viewController.presentedViewController is UIAlertController
         }
+    }
+
+    func test_checkSiteEligibility_updates_application_password_availability_in_userDefaults() throws {
+        // Given
+        let site = Site.fake().copy(siteID: 123)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(defaultSite: site))
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: UUID().uuidString))
+        let checker = RequirementsChecker(stores: stores, userDefaults: userDefaults)
+
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case .retrieveSiteAPI(_, let onCompletion):
+                onCompletion(.success(SiteAPI(siteID: site.siteID, namespaces: ["wc/v3"], applicationPasswordAvailable: true)))
+            default:
+                break
+            }
+        }
+
+        XCTAssertFalse(userDefaults.bool(forKey: UserDefaults.Key.defaultStoreHasApplicationPasswordEnabled.rawValue))
+
+        // When
+        waitForExpectation { expectation in
+            checker.checkSiteEligibility(for: site) { result in
+                switch result {
+                case .success(let value):
+                    expectation.fulfill()
+                case .failure:
+                    break
+                }
+            }
+        }
+
+        // Then
+        XCTAssertTrue(userDefaults.bool(forKey: UserDefaults.Key.defaultStoreHasApplicationPasswordEnabled.rawValue))
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1122

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the site API handling to check for application password. The result is saved to UserDefaults for easy access from the Networking layer.

More details: pe5sF9-4aN-p2

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

The new UserDefaults value hasn't been used yet so CI passing is sufficient. You can also try logging in to the app or switch sites in the site picker to confirm that everything still works properly.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested with simulator iPhone 16 iOS 18.2.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

No UI changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.