### PR TITLE
[Woo POS][Historical Orders] Feature flag and entry point

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -107,6 +107,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return false
         case .orderAddressMapSearch:
             return true
+        case .pointOfSaleHistoricalOrdersi1:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -88,11 +88,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .productImageOptimizedHandling:
             return true
-        case .pointOfSaleBarcodeScanningi1:
-            return true
-        case .showPointOfSaleBarcodeSimulator:
-            // Enables a simulated barcode scanner in dev builds for testing. Do not ship this one!
-            return false
         case .pointOfSaleAsATabi1:
             return true
         case .pointOfSaleAsATabi2:
@@ -100,8 +95,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .pointOfSaleOrdersi1:
             return true
         case .pointOfSaleOrdersi2:
-            return true
-        case .pointOfSaleBarcodeScanningi2:
             return true
         case .pointOfSaleSettingsi1:
             return false

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -183,14 +183,6 @@ public enum FeatureFlag: Int {
     ///
     case pointOfSaleReceipts
 
-    /// Enables barcode scanning with an external scanner in POS
-    ///
-    case pointOfSaleBarcodeScanningi1
-
-    /// Enables a simulated barcode scanner for testing in POS. Do not ship this one!
-    ///
-    case showPointOfSaleBarcodeSimulator
-
     /// Enables displaying POS as a tab in the tab bar with the same eligibility as the previous entry point
     ///
     case pointOfSaleAsATabi1
@@ -206,10 +198,6 @@ public enum FeatureFlag: Int {
     /// Enables displaying Point Of Sale as a filter in order list
     ///
     case pointOfSaleOrdersi2
-
-    /// Enables the Point of Sale Barcode Scanner set up flows, as part of i2
-    ///
-    case pointOfSaleBarcodeScanningi2
 
     /// Enables the entry point for Point of Sale Settings
     ///

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -218,4 +218,8 @@ public enum FeatureFlag: Int {
     /// Enables the CTA to search for an address in the map in order details > shipping address.
     ///
     case orderAddressMapSearch
+
+    /// Enables the entry point for Point of Sale Orders
+    ///
+    case pointOfSaleHistoricalOrdersi1
 }

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/BarcodeScanningModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/BarcodeScanningModifier.swift
@@ -9,15 +9,11 @@ struct BarcodeScanningModifier: ViewModifier {
     /// Callback that is triggered when a barcode is successfully scanned
     let onScan: (Result<String, HIDBarcodeParserError>) -> Void
 
-    private var isBarcodeScani1FeatureEnabled: Bool {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleBarcodeScanningi1)
-    }
-
     func body(content: Content) -> some View {
         ZStack {
             content
 
-            if enabled && isBarcodeScani1FeatureEnabled {
+            if enabled {
                 BarcodeScannerContainer(onScan: onScan)
             }
         }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -51,14 +51,6 @@ struct ItemListView: View {
     @State private var searchTask: Task<Void, Never>?
     @State private var didFinishSearch = true
 
-    private var isBarcodeScani1FeatureEnabled: Bool {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleBarcodeScanningi1)
-    }
-
-    private var isBarcodeScanSimulatorEnabled: Bool {
-        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.showPointOfSaleBarcodeSimulator)
-    }
-
     private var isAddingCouponAllowed: Bool {
         guard case .coupons = selectedItemListType else { return false }
         let itemListState = itemListState(selectedItemListType)
@@ -70,9 +62,6 @@ struct ItemListView: View {
     }
 
     @State private var showCouponCreationModal: Bool = false
-
-    @State private var barcodeScanSimulatorIsPresented: Bool = false
-    @State private var barcodeScanSimulatorText: String = ""
 
     var body: some View {
         if #available(iOS 18.0, *) {
@@ -244,9 +233,6 @@ private extension ItemListView {
                     } else {
                         createCouponButton
 
-                        simulatedScanButton
-                            .renderedIf(isBarcodeScanSimulatorEnabled && isBarcodeScani1FeatureEnabled)
-
                         POSPageHeaderActionButton(systemName: "magnifyingglass") {
                             analyticsTracker.trackSearchTapped(itemListType: selectedItemListType)
                             setSearch(true)
@@ -256,9 +242,6 @@ private extension ItemListView {
 
                 }
             })
-
-            barcodeScanSimulator
-                .renderedIf(barcodeScanSimulatorIsPresented)
         }
         .animation(.easeInOut(duration: Constants.animationDuration), value: isSearching)
         .animation(.easeInOut(duration: Constants.animationDuration), value: isAddingCouponAllowed)
@@ -305,31 +288,6 @@ private extension ItemListView {
         }
         .renderedIf(isAddingCouponAllowed)
         .transition(.opacity.combined(with: .scale))
-    }
-
-    @ViewBuilder
-    private var simulatedScanButton: some View {
-        POSPageHeaderActionButton(systemName: "barcode") {
-            barcodeScanSimulatorIsPresented.toggle()
-        }
-        .transition(.opacity.combined(with: .scale))
-    }
-
-    @ViewBuilder
-    private var barcodeScanSimulator: some View {
-        HStack {
-            TextField(text: $barcodeScanSimulatorText) {
-                Text("Barcode value")
-            }
-
-            Button {
-                posModel.barcodeScanned(.success(barcodeScanSimulatorText))
-            } label: {
-                Text("Scan!")
-            }
-            .buttonStyle(POSFilledButtonStyle(size: .extraSmall))
-        }
-        .padding([.bottom, .horizontal], 16)
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -86,6 +86,17 @@ struct POSFloatingControlView: View {
                         )
                     }
                 }
+
+                if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleHistoricalOrdersi1) {
+                    Button {
+                        // TODO: WOOMOB-1133
+                    } label: {
+                        Label(
+                            title: { Text(Localization.orders) },
+                            icon: { Image(systemName: "text.document") }
+                        )
+                    }
+                }
             } label: {
                 VStack {
                     Spacer()
@@ -161,6 +172,12 @@ private extension POSFloatingControlView {
     }
 
     enum Localization {
+        static let orders = NSLocalizedString(
+            "pointOfSale.floatingButtons.orders.button.title",
+            value: "Orders",
+            comment: "The title of the menu button to access Point of Sale historical orders, shown in a fullscreen view."
+        )
+
         static let exitPointOfSale = NSLocalizedString(
             "pointOfSale.floatingButtons.exit.button.title",
             value: "Exit POS",

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -60,21 +60,15 @@ struct POSFloatingControlView: View {
                         title: { Text(Localization.productRestrictionsInfo) },
                         icon: { Image(systemName: "magnifyingglass") })
                 }
-                if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleBarcodeScanningi1) {
-                    Button {
-                        showBarcodeScanningModal = true
-                        ServiceLocator.analytics.track(.pointOfSaleBarcodeScanningMenuItemTapped)
-                    } label: {
-                        Label(
-                            title: {
-                                if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleBarcodeScanningi2) {
-                                    Text(Localization.barcodeScanningSetup)
-                                } else {
-                                    Text(Localization.barcodeScanning)
-                                }
-                            },
-                            icon: { Image(systemName: "barcode.viewfinder") })
-                    }
+                Button {
+                    showBarcodeScanningModal = true
+                    ServiceLocator.analytics.track(.pointOfSaleBarcodeScanningMenuItemTapped)
+                } label: {
+                    Label(
+                        title: {
+                            Text(Localization.barcodeScanningSetup)
+                        },
+                        icon: { Image(systemName: "barcode.viewfinder") })
                 }
                 if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleSettingsi1) {
                     Button {
@@ -123,11 +117,7 @@ struct POSFloatingControlView: View {
             SimpleProductsOnlyInformation(isPresented: $showProductRestrictionsModal)
         }
         .posModal(isPresented: $showBarcodeScanningModal) {
-            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleBarcodeScanningi2) {
-                PointOfSaleBarcodeScannerSetup(isPresented: $showBarcodeScanningModal)
-            } else {
-                PointOfSaleBarcodeScannerInformationModal(isPresented: $showBarcodeScanningModal)
-            }
+            PointOfSaleBarcodeScannerSetup(isPresented: $showBarcodeScanningModal)
         }
         .frame(height: Constants.size)
         .background(Color.clear)
@@ -202,12 +192,6 @@ private extension POSFloatingControlView {
             value: "Where are my products?",
             comment: "The title of the menu button to view product restrictions info, shown in a popover menu. " +
             "We only show simple and variable products in POS, this shows a modal to help explain that limitation."
-        )
-
-        static let barcodeScanning = NSLocalizedString(
-            "pointOfSale.floatingButtons.barcodeScanning.button.title",
-            value: "Barcode scanning",
-            comment: "The title of the menu button to view barcode scanner documentation, shown in a popover menu."
         )
 
         static let barcodeScanningSetup = NSLocalizedString(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Created a feature flag for POS Historical Orders i1 project
- Show an entry point CTA in the menu

Additionally did a small clean-up:
- Removed barcode scanning feature flag code

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Open menu
3. Confirm "Orders" exists

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air M2 18.5 simulator
---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.