### PR TITLE
[Woo POS] Settings: Add endpoint to load POS setting group

### DIFF
--- a/Modules/Sources/Networking/Model/SiteSettingGroup.swift
+++ b/Modules/Sources/Networking/Model/SiteSettingGroup.swift
@@ -7,6 +7,7 @@ public enum SiteSettingGroup: Decodable, Hashable, GeneratedFakeable {
     case general
     case product
     case advanced
+    case pointOfSale
     case custom(String) // catch-all
 }
 
@@ -25,6 +26,8 @@ extension SiteSettingGroup: RawRepresentable {
             self = .product
         case Keys.advanged:
             self = .advanced
+        case Keys.pointOfSale:
+            self = .pointOfSale
         default:
             self = .custom(rawValue)
         }
@@ -37,6 +40,7 @@ extension SiteSettingGroup: RawRepresentable {
         case .general: return Keys.general
         case .product: return Keys.product
         case .advanced: return Keys.advanged
+        case .pointOfSale: return Keys.pointOfSale
         case .custom(let payload):  return payload
         }
     }
@@ -49,4 +53,5 @@ private enum Keys {
     static let general = "general"
     static let product = "product"
     static let advanged = "advanced"
+    static let pointOfSale = "point-of-sale"
 }

--- a/Modules/Sources/Networking/Remote/SiteSettingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/SiteSettingsRemote.swift
@@ -56,9 +56,10 @@ public class SiteSettingsRemote: Remote {
     ///
     /// - Parameters:
     ///   - siteID: Site for which we'll fetch the point of sale settings.
-    ///   - completion: Closure to be executed upon completion.
+    /// - Returns: An array of SiteSettings, specific to point of sale.
+    /// - Throws: Error if the request fails.
     ///
-    public func loadPointOfSaleSettings(for siteID: Int64, completion: @escaping ([SiteSetting]?, Error?) -> Void) {
+    public func loadPointOfSaleSettings(for siteID: Int64) async throws -> [SiteSetting] {
         let path = Constants.siteSettingsPath + Constants.pointOfSaleSettingsGroup
         let request = JetpackRequest(wooApiVersion: .mark3,
                                      method: .get,
@@ -68,7 +69,7 @@ public class SiteSettingsRemote: Remote {
                                      availableAsRESTRequest: true)
         let mapper = SiteSettingsMapper(siteID: siteID, settingsGroup: SiteSettingGroup.pointOfSale)
 
-        enqueue(request, mapper: mapper, completion: completion)
+        return try await enqueue(request, mapper: mapper)
     }
 
     /// Retrieve detail for a single setting for a given site

--- a/Modules/Sources/Networking/Remote/SiteSettingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/SiteSettingsRemote.swift
@@ -52,6 +52,25 @@ public class SiteSettingsRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
+    /// Retrieves all of the point of sale `SiteSetting`s for a given site.
+    ///
+    /// - Parameters:
+    ///   - siteID: Site for which we'll fetch the point of sale settings.
+    ///   - completion: Closure to be executed upon completion.
+    ///
+    public func loadPointOfSaleSettings(for siteID: Int64, completion: @escaping ([SiteSetting]?, Error?) -> Void) {
+        let path = Constants.siteSettingsPath + Constants.pointOfSaleSettingsGroup
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: nil,
+                                     availableAsRESTRequest: true)
+        let mapper = SiteSettingsMapper(siteID: siteID, settingsGroup: SiteSettingGroup.pointOfSale)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
     /// Retrieve detail for a single setting for a given site
     ///
     /// - Parameters:
@@ -179,6 +198,7 @@ private extension SiteSettingsRemote {
         static let generalSettingsGroup: String   = "general"
         static let productSettingsGroup: String   = "products"
         static let advancedSettingsGroup: String   = "advanced"
+        static let pointOfSaleSettingsGroup: String = "point-of-sale"
         static let valueParameter: String = "value"
         static let featureEnabledValue: String = "yes"
         static let featureDisabledValue: String = "no"

--- a/Modules/Sources/Yosemite/Actions/SettingAction.swift
+++ b/Modules/Sources/Yosemite/Actions/SettingAction.swift
@@ -23,7 +23,7 @@ public enum SettingAction: Action {
 
     /// Retrieves the site settings specific of Point of Sale
     ///
-    case retrievePointOfSaleSettings(siteID: Int64, onCompletion: (Result<[SiteSetting]?, Error>) -> Void)
+    case retrievePointOfSaleSettings(siteID: Int64, onCompletion: (Result<[SiteSetting], Error>) -> Void)
 
     /// Retrieves the setting for whether coupons are enabled for the specified store
     ///

--- a/Modules/Sources/Yosemite/Actions/SettingAction.swift
+++ b/Modules/Sources/Yosemite/Actions/SettingAction.swift
@@ -21,6 +21,10 @@ public enum SettingAction: Action {
     ///
     case retrieveSiteAPI(siteID: Int64, onCompletion: (Result<SiteAPI, Error>) -> Void)
 
+    /// Retrieves the site settings specific of Point of Sale
+    ///
+    case retrievePointOfSaleSettings(siteID: Int64, onCompletion: (Result<[SiteSetting]?, Error>) -> Void)
+
     /// Retrieves the setting for whether coupons are enabled for the specified store
     ///
     case retrieveCouponSetting(siteID: Int64, onCompletion: (Result<Bool, Error>) -> Void)

--- a/Modules/Sources/Yosemite/Stores/Helpers/SettingStoreMethods.swift
+++ b/Modules/Sources/Yosemite/Stores/Helpers/SettingStoreMethods.swift
@@ -9,6 +9,7 @@ internal protocol SettingStoreMethodsProtocol {
     func synchronizeGeneralSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void)
     func synchronizeProductSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void)
     func retrieveSiteAPI(siteID: Int64, onCompletion: @escaping (Result<SiteAPI, Error>) -> Void)
+    func retrievePointOfSaleSettings(siteID: Int64, onCompletion: @escaping (Result<[SiteSetting]?, Error>) -> Void)
     func retrieveCouponSetting(siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void)
     func enableCouponSetting(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void)
     func retrieveAnalyticsSetting(siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void)
@@ -65,6 +66,18 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
     ///
     func retrieveSiteAPI(siteID: Int64, onCompletion: @escaping (Result<SiteAPI, Error>) -> Void) {
         siteAPIRemote.loadAPIInformation(for: siteID, completion: onCompletion)
+    }
+
+    /// Retrieves Point of Sale settings
+    ///
+    func retrievePointOfSaleSettings(siteID: Int64, onCompletion: @escaping (Result<[SiteSetting]?, Error>) -> Void) {
+        siteSettingsRemote.loadPointOfSaleSettings(for: siteID) { settings, error in
+            if let error = error {
+                onCompletion(.failure(error))
+                return
+            }
+            onCompletion(.success(settings))
+        }
     }
 
     /// Retrieves the setting for whether coupons are enabled for the specified store

--- a/Modules/Sources/Yosemite/Stores/Helpers/SettingStoreMethods.swift
+++ b/Modules/Sources/Yosemite/Stores/Helpers/SettingStoreMethods.swift
@@ -10,7 +10,7 @@ internal protocol SettingStoreMethodsProtocol {
     func synchronizeProductSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void)
     func retrieveSiteAPI(siteID: Int64, onCompletion: @escaping (Result<SiteAPI, Error>) -> Void)
     // periphery:ignore
-    func retrievePointOfSaleSettings(siteID: Int64, onCompletion: @escaping (Result<[SiteSetting]?, Error>) -> Void)
+    func retrievePointOfSaleSettings(siteID: Int64) async throws -> [SiteSetting]
     func retrieveCouponSetting(siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void)
     func enableCouponSetting(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void)
     func retrieveAnalyticsSetting(siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void)
@@ -72,14 +72,8 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
     /// Retrieves Point of Sale settings
     ///
     // periphery:ignore
-    func retrievePointOfSaleSettings(siteID: Int64, onCompletion: @escaping (Result<[SiteSetting]?, Error>) -> Void) {
-        siteSettingsRemote.loadPointOfSaleSettings(for: siteID) { settings, error in
-            if let error = error {
-                onCompletion(.failure(error))
-                return
-            }
-            onCompletion(.success(settings))
-        }
+    func retrievePointOfSaleSettings(siteID: Int64) async throws -> [SiteSetting] {
+        return try await siteSettingsRemote.loadPointOfSaleSettings(for: siteID)
     }
 
     /// Retrieves the setting for whether coupons are enabled for the specified store

--- a/Modules/Sources/Yosemite/Stores/Helpers/SettingStoreMethods.swift
+++ b/Modules/Sources/Yosemite/Stores/Helpers/SettingStoreMethods.swift
@@ -9,6 +9,7 @@ internal protocol SettingStoreMethodsProtocol {
     func synchronizeGeneralSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void)
     func synchronizeProductSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void)
     func retrieveSiteAPI(siteID: Int64, onCompletion: @escaping (Result<SiteAPI, Error>) -> Void)
+    // periphery:ignore
     func retrievePointOfSaleSettings(siteID: Int64, onCompletion: @escaping (Result<[SiteSetting]?, Error>) -> Void)
     func retrieveCouponSetting(siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void)
     func enableCouponSetting(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void)
@@ -70,6 +71,7 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
 
     /// Retrieves Point of Sale settings
     ///
+    // periphery:ignore
     func retrievePointOfSaleSettings(siteID: Int64, onCompletion: @escaping (Result<[SiteSetting]?, Error>) -> Void) {
         siteSettingsRemote.loadPointOfSaleSettings(for: siteID) { settings, error in
             if let error = error {

--- a/Modules/Sources/Yosemite/Stores/SettingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/SettingStore.swift
@@ -38,6 +38,8 @@ public class SettingStore: Store {
             methods.synchronizeProductSiteSettings(siteID: siteID, onCompletion: onCompletion)
         case .retrieveSiteAPI(let siteID, let onCompletion):
             methods.retrieveSiteAPI(siteID: siteID, onCompletion: onCompletion)
+        case let .retrievePointOfSaleSettings(siteID, onCompletion):
+            methods.retrievePointOfSaleSettings(siteID: siteID, onCompletion: onCompletion)
         case let .retrieveCouponSetting(siteID, onCompletion):
             methods.retrieveCouponSetting(siteID: siteID, onCompletion: onCompletion)
         case let .enableCouponSetting(siteID, onCompletion):

--- a/Modules/Sources/Yosemite/Stores/SettingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/SettingStore.swift
@@ -39,7 +39,14 @@ public class SettingStore: Store {
         case .retrieveSiteAPI(let siteID, let onCompletion):
             methods.retrieveSiteAPI(siteID: siteID, onCompletion: onCompletion)
         case let .retrievePointOfSaleSettings(siteID, onCompletion):
-            methods.retrievePointOfSaleSettings(siteID: siteID, onCompletion: onCompletion)
+            Task { @MainActor in
+                do {
+                    let settings = try await methods.retrievePointOfSaleSettings(siteID: siteID)
+                    onCompletion(.success(settings))
+                } catch {
+                    onCompletion(.failure(error))
+                }
+            }
         case let .retrieveCouponSetting(siteID, onCompletion):
             methods.retrieveCouponSetting(siteID: siteID, onCompletion: onCompletion)
         case let .enableCouponSetting(siteID, onCompletion):

--- a/Modules/Tests/NetworkingTests/Responses/settings-point-of-sale.json
+++ b/Modules/Tests/NetworkingTests/Responses/settings-point-of-sale.json
@@ -1,0 +1,144 @@
+[
+    {
+        "id": "woocommerce_pos_store_name",
+        "label": "Store name",
+        "description": "The name of your physical store.",
+        "type": "text",
+        "default": "Best store",
+        "value": "Best store",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://mystagingwebsite.com/wp-json/wc/v3/settings/point-of-sale/woocommerce_pos_store_name",
+                    "targetHints": {
+                        "allow": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH"
+                        ]
+                    }
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://mystagingwebsite.com/wp-json/wc/v3/settings/point-of-sale"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_pos_store_address",
+        "label": "Physical address",
+        "description": "",
+        "type": "textarea",
+        "default": "60 29th Street #3434\nSan Francisco, CA 94110",
+        "tip": "",
+        "value": "60 29th Street #343\r\nCalifornia, CA 94110",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://mystagingwebsite.com/wp-json/wc/v3/settings/point-of-sale/woocommerce_pos_store_address",
+                    "targetHints": {
+                        "allow": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH"
+                        ]
+                    }
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://mystagingwebsite.com/wp-json/wc/v3/settings/point-of-sale"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_pos_store_phone",
+        "label": "Phone number",
+        "description": "",
+        "type": "text",
+        "default": "",
+        "value": "650-000-0000",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://mystagingwebsite.com/wp-json/wc/v3/settings/point-of-sale/woocommerce_pos_store_phone",
+                    "targetHints": {
+                        "allow": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH"
+                        ]
+                    }
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://mystagingwebsite.com/wp-json/wc/v3/settings/point-of-sale"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_pos_store_email",
+        "label": "Email",
+        "description": "Your store contact email.",
+        "type": "email",
+        "default": "some@email.com",
+        "value": "some@email.com",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://mystagingwebsite.com/wp-json/wc/v3/settings/point-of-sale/woocommerce_pos_store_email",
+                    "targetHints": {
+                        "allow": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH"
+                        ]
+                    }
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://mystagingwebsite.com/wp-json/wc/v3/settings/point-of-sale"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_pos_refund_returns_policy",
+        "label": "Refund & Returns Policy",
+        "description": "Brief statement that will appear on the receipts.",
+        "type": "textarea",
+        "default": "",
+        "tip": "Brief statement that will appear on the receipts.",
+        "value": "This is a brief refunds and return policy",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://mystagingwebsite.com/wp-json/wc/v3/settings/point-of-sale/woocommerce_pos_refund_returns_policy",
+                    "targetHints": {
+                        "allow": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH"
+                        ]
+                    }
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://mystagingwebsite.com/wp-json/wc/v3/settings/point-of-sale"
+                }
+            ]
+        }
+    }
+]

--- a/Modules/Tests/YosemiteTests/Mocks/MockSettingStoreMethods.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockSettingStoreMethods.swift
@@ -73,7 +73,7 @@ final class MockSettingStoreMethods: SettingStoreMethodsProtocol {
         }
     }
 
-    func retrievePointOfSaleSettings(siteID: Int64, onCompletion: @escaping (Result<[Yosemite.SiteSetting]?, any Error>) -> Void) {
-        // no-op
+    func retrievePointOfSaleSettings(siteID: Int64) async throws -> [SiteSetting] {
+        []
     }
 }

--- a/Modules/Tests/YosemiteTests/Mocks/MockSettingStoreMethods.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockSettingStoreMethods.swift
@@ -72,4 +72,8 @@ final class MockSettingStoreMethods: SettingStoreMethodsProtocol {
             throw error
         }
     }
+
+    func retrievePointOfSaleSettings(siteID: Int64, onCompletion: @escaping (Result<[Yosemite.SiteSetting]?, any Error>) -> Void) {
+        // no-op
+    }
 }

--- a/Modules/Tests/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SettingStoreTests.swift
@@ -823,6 +823,85 @@ final class SettingStoreTests: XCTestCase {
         XCTAssertEqual(allSettings?.count, 2)
     }
 
+    // MARK: - SettingAction.retrievePointOfSaleSettings
+
+    func test_retrievePointOfSaleSettings_returns_expected_settings() throws {
+        // Given
+        let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "settings/point-of-sale", filename: "settings-point-of-sale")
+
+        // When
+        let result: Result<[Networking.SiteSetting]?, Error> = waitFor { promise in
+            let action = SettingAction.retrievePointOfSaleSettings(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            settingStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let settings = try XCTUnwrap(result.get())
+        XCTAssertEqual(settings.count, 5)
+
+        let storeNameSetting = settings.first { $0.settingID == "woocommerce_pos_store_name" }
+        XCTAssertEqual(storeNameSetting?.value, "Best store")
+        XCTAssertEqual(storeNameSetting?.label, "Store name")
+        XCTAssertEqual(storeNameSetting?.settingGroupKey, "point-of-sale")
+
+        let storeAddressSetting = settings.first { $0.settingID == "woocommerce_pos_store_address" }
+        XCTAssertEqual(storeAddressSetting?.value, "60 29th Street #343\r\nCalifornia, CA 94110")
+        XCTAssertEqual(storeAddressSetting?.label, "Physical address")
+        XCTAssertEqual(storeAddressSetting?.settingGroupKey, "point-of-sale")
+
+        let storePhoneSetting = settings.first { $0.settingID == "woocommerce_pos_store_phone" }
+        XCTAssertEqual(storePhoneSetting?.value, "650-000-0000")
+        XCTAssertEqual(storePhoneSetting?.label, "Phone number")
+        XCTAssertEqual(storePhoneSetting?.settingGroupKey, "point-of-sale")
+
+        let storeEmailSetting = settings.first { $0.settingID == "woocommerce_pos_store_email" }
+        XCTAssertEqual(storeEmailSetting?.value, "some@email.com")
+        XCTAssertEqual(storeEmailSetting?.label, "Email")
+        XCTAssertEqual(storeEmailSetting?.settingGroupKey, "point-of-sale")
+
+        let refundPolicySetting = settings.first { $0.settingID == "woocommerce_pos_refund_returns_policy" }
+        XCTAssertEqual(refundPolicySetting?.value, "This is a brief refunds and return policy")
+        XCTAssertEqual(refundPolicySetting?.label, "Refund & Returns Policy")
+        XCTAssertEqual(refundPolicySetting?.settingGroupKey, "point-of-sale")
+    }
+
+    func test_retrievePointOfSaleSettings_returns_error_upon_response_error() {
+        // Given
+        let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "settings/point-of-sale", filename: "generic_error")
+
+        // When
+        let result: Result<[Networking.SiteSetting]?, Error> = waitFor { promise in
+            let action = SettingAction.retrievePointOfSaleSettings(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            settingStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
+
+    func test_retrievePointOfSaleSettings_returns_error_upon_empty_response() {
+        // Given
+        let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let result: Result<[Networking.SiteSetting]?, Error> = waitFor { promise in
+            let action = SettingAction.retrievePointOfSaleSettings(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            settingStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
+
     // MARK: - SettingAction.isFeatureEnabled
 
     func test_isFeatureEnabled_returns_true_when_feature_is_enabled() {

--- a/Modules/Tests/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SettingStoreTests.swift
@@ -831,7 +831,7 @@ final class SettingStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "settings/point-of-sale", filename: "settings-point-of-sale")
 
         // When
-        let result: Result<[Networking.SiteSetting]?, Error> = waitFor { promise in
+        let result: Result<[Networking.SiteSetting], Error> = waitFor { promise in
             let action = SettingAction.retrievePointOfSaleSettings(siteID: self.sampleSiteID) { result in
                 promise(result)
             }
@@ -840,7 +840,7 @@ final class SettingStoreTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        let settings = try XCTUnwrap(result.get())
+        let settings = try result.get()
         XCTAssertEqual(settings.count, 5)
 
         let storeNameSetting = settings.first { $0.settingID == "woocommerce_pos_store_name" }
@@ -875,7 +875,7 @@ final class SettingStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "settings/point-of-sale", filename: "generic_error")
 
         // When
-        let result: Result<[Networking.SiteSetting]?, Error> = waitFor { promise in
+        let result: Result<[Networking.SiteSetting], Error> = waitFor { promise in
             let action = SettingAction.retrievePointOfSaleSettings(siteID: self.sampleSiteID) { result in
                 promise(result)
             }
@@ -891,7 +891,7 @@ final class SettingStoreTests: XCTestCase {
         let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         // When
-        let result: Result<[Networking.SiteSetting]?, Error> = waitFor { promise in
+        let result: Result<[Networking.SiteSetting], Error> = waitFor { promise in
             let action = SettingAction.retrievePointOfSaleSettings(siteID: self.sampleSiteID) { result in
                 promise(result)
             }


### PR DESCRIPTION
Closes WOOMOB-1160

## Description
This PR updates the `SiteSettingsRemote` to add support for retrieving Point of Sale settings at `/v3/settings/point-of-sale/`, retrieving the following paths:

```
woocommerce_pos_store_name
woocommerce_pos_store_address
woocommerce_pos_store_phone
woocommerce_pos_store_email
woocommerce_pos_refund_returns_policy
```

This will be needed to display POS receipt details in POS Settings. 

## Changes:
- Added `pointOfSale` group to `SiteSettingGroup` enum
- Added `loadPointOfSaleSettings()` method to `SiteSettingsRemote`
- Added `retrievePointOfSaleSettings` action to `SettingStore`
- Unit tests

## Testing information
The endpoint is not used yet. Please add the following to `PointOfSaleDashboardView`:

```
.task { @MainActor in
            let siteID = ServiceLocator.stores.sessionManager.defaultSite?.siteID ?? 0
            let action = SettingAction.retrievePointOfSaleSettings(siteID: siteID) { result in
                debugPrint(result)
            }
            ServiceLocator.stores.dispatch(action)
        }
```

On a store running WooCommerce 10+, assure that you have some store details in WooCommerce > Settings > Point of Sale, and run POS:

<img width="866" height="347" alt="Screenshot 2025-08-22 at 12 34 35" src="https://github.com/user-attachments/assets/946f65f4-1c1a-464b-87b7-b6d3138c84b7" />

Observe the response in the console:

```
"success(Optional([Networking.SiteSetting(siteID: -1, settingID: \"woocommerce_pos_store_name\", label: \"Store name\", settingDescription: \"The name of your physical store.\", value: \"Indie Melon\", settingGroupKey: \"point-of-sale\"), Networking.SiteSetting(siteID: -1, settingID: \"woocommerce_pos_store_address\", label: \"Physical address\", settingDescription: \"\", value: \"60 29th Street #343\\r\\nCalifornia, CA 94110\", settingGroupKey: \"point-of-sale\"), Networking.SiteSetting(siteID: -1, settingID: \"woocommerce_pos_store_phone\", label: \"Phone number\", settingDescription: \"\", value: \"\", settingGroupKey: \"point-of-sale\"), Networking.SiteSetting(siteID: -1, settingID: \"woocommerce_pos_store_email\", label: \"Email\", settingDescription: \"Your store contact email.\", value: \"someemail@automattic.com\", settingGroupKey: \"point-of-sale\"), Networking.SiteSetting(siteID: -1, settingID: \"woocommerce_pos_refund_returns_policy\", label: \"Refund & Returns Policy\", settingDescription: \"Brief statement that will appear on the receipts.\", value: \"This is a brief refunds and return policy. Maybe you get a refund, we\\\'ll see! Testing\", settingGroupKey: \"point-of-sale\")]))"
```

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
