### PR TITLE
[POS as a tab] Remove i1 feature flag

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -93,8 +93,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .showPointOfSaleBarcodeSimulator:
             // Enables a simulated barcode scanner in dev builds for testing. Do not ship this one!
             return false
-        case .pointOfSaleAsATabi1:
-            return true
         case .pointOfSaleAsATabi2:
             return true
         case .pointOfSaleOrdersi1:

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -191,10 +191,6 @@ public enum FeatureFlag: Int {
     ///
     case showPointOfSaleBarcodeSimulator
 
-    /// Enables displaying POS as a tab in the tab bar with the same eligibility as the previous entry point
-    ///
-    case pointOfSaleAsATabi1
-
     /// Enables displaying POS as a tab in the tab bar for stores in eligible countries
     ///
     case pointOfSaleAsATabi2

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -79,13 +79,6 @@ private extension HubMenu {
                 .disabled(!viewModel.switchStoreEnabled)
             }
 
-            // Point of Sale
-            if let menu = viewModel.posElement {
-                Section {
-                    menuItemView(menu: menu, chevron: .enteringMode)
-                }
-            }
-
             // Settings Section
             Section(Localization.settings) {
                 ForEach(viewModel.settingsElements, id: \.id) { menu in

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -57,10 +57,6 @@ final class HubMenuViewModel: ObservableObject {
 
     @Published private(set) var woocommerceAdminURL = WooConstants.URLs.blog.asURL()
 
-    /// POS Section Element
-    ///
-    @Published private(set) var posElement: HubMenuItem?
-
     /// Settings Elements
     ///
     @Published private(set) var settingsElements: [HubMenuItem] = []
@@ -89,38 +85,6 @@ final class HubMenuViewModel: ObservableObject {
     private let inboxEligibilityChecker: InboxEligibilityChecker
     private let blazeEligibilityChecker: BlazeEligibilityCheckerProtocol
     private let googleAdsEligibilityChecker: GoogleAdsEligibilityChecker
-
-    private(set) lazy var posItemFetchStrategyFactory: PointOfSaleItemFetchStrategyFactory = {
-        PointOfSaleItemFetchStrategyFactory(siteID: siteID, credentials: credentials)
-    }()
-
-    private(set) lazy var posPopularItemFetchStrategyFactory: PointOfSaleFixedItemFetchStrategyFactory = {
-        PointOfSaleFixedItemFetchStrategyFactory(fixedStrategy: posItemFetchStrategyFactory.popularStrategy())
-    }()
-
-    private(set) lazy var posCouponFetchStrategyFactory: PointOfSaleCouponFetchStrategyFactory = {
-        PointOfSaleCouponFetchStrategyFactory(siteID: siteID,
-                                              currencySettings: ServiceLocator.currencySettings,
-                                              credentials: credentials,
-                                              storage: ServiceLocator.storageManager)
-    }()
-
-    private(set) lazy var posCouponProvider: PointOfSaleCouponServiceProtocol = {
-        let storage = ServiceLocator.storageManager
-        let currencySettings = ServiceLocator.currencySettings
-
-        return PointOfSaleCouponService(siteID: siteID,
-                                        currencySettings: currencySettings,
-                                        credentials: credentials,
-                                        storage: storage)
-    }()
-
-    private(set) lazy var barcodeScanService: PointOfSaleBarcodeScanService = {
-        PointOfSaleBarcodeScanService(
-            siteID: siteID,
-            credentials: credentials,
-            currencySettings: ServiceLocator.currencySettings)
-    }()
 
     private(set) lazy var inboxViewModel = InboxViewModel(siteID: siteID)
 
@@ -236,11 +200,6 @@ final class HubMenuViewModel: ObservableObject {
         isSiteEligibleForBlaze = await blazeEligibilityChecker.isSiteEligible(site)
     }
 
-    func updateDefaultConfigurationForPointOfSale(_ isPointOfSaleActive: Bool) {
-        updateInAppNotifications(isPointOfSaleActive)
-        updateTrackEventPrefix(isPointOfSaleActive)
-    }
-
     func trackMenuItemTapEvent(menu: HubMenuItem) {
         analytics.track(.hubMenuOptionTapped, withProperties: [AnalyticsKeys.trackingOption: menu.trackingOption])
     }
@@ -264,26 +223,6 @@ final class HubMenuViewModel: ObservableObject {
 
     deinit {
         NotificationCenter.default.removeObserver(self, name: .setUpTapToPayViewDidAppear, object: nil)
-    }
-}
-
-// MARK: - Helper method for WooCommerce POS
-//
-private extension HubMenuViewModel {
-    // Disables foreground in-app notifications when Point of Sale is active
-    //
-    func updateInAppNotifications(_ isPointOfSaleActive: Bool) {
-        if isPointOfSaleActive {
-            ServiceLocator.pushNotesManager.disableInAppNotifications()
-        } else {
-            ServiceLocator.pushNotesManager.enableInAppNotifications()
-        }
-    }
-
-    // Decorates track events with a different prefix when Point of Sale is active
-    //
-    func updateTrackEventPrefix(_ isPointOfSaleActive: Bool) {
-        TracksProvider.setPOSMode(isPointOfSaleActive)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -664,7 +664,7 @@ extension MainTabBarController: DeepLinkNavigator {
 //
 private extension MainTabBarController {
     func observePOSEligibilityForPOSTabVisibility(siteID: Int64) {
-        guard let posEligibilityChecker, featureFlagService.isFeatureFlagEnabled(.pointOfSaleAsATabi1) else {
+        guard let posEligibilityChecker else {
             updateTabViewControllers(isPOSTabVisible: false)
             viewModel.loadHubMenuTabBadge()
             return

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarController+TabsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarController+TabsTests.swift
@@ -12,7 +12,6 @@ final class MainTabBarController_TabsTests: XCTestCase {
         // Arrange
         // Sets mock `FeatureFlagService` before `MainTabBarController` is initialized so that the feature flags are set correctly.
         let featureFlagService = MockFeatureFlagService()
-        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleAsATabi1] = false
 
         let storesManager = MockStoresManager(sessionManager: .makeForTesting())
 
@@ -45,7 +44,6 @@ final class MainTabBarController_TabsTests: XCTestCase {
     func test_tab_view_controllers_include_pos_tab_when_pos_tab_is_visible() throws {
         // Given
         let featureFlagService = MockFeatureFlagService()
-        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleAsATabi1] = true
 
         let mockPOSEligibilityChecker = MockPOSEligibilityChecker()
         mockPOSEligibilityChecker.visibility = true
@@ -88,7 +86,6 @@ final class MainTabBarController_TabsTests: XCTestCase {
     func test_tab_view_controllers_exclude_pos_tab_when_pos_tab_is_not_visible() throws {
         // Given
         let featureFlagService = MockFeatureFlagService()
-        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleAsATabi1] = true
 
         let mockPOSEligibilityChecker = MockPOSEligibilityChecker()
         mockPOSEligibilityChecker.visibility = false
@@ -126,49 +123,9 @@ final class MainTabBarController_TabsTests: XCTestCase {
                    isAnInstanceOf: HubMenuViewController.self)
     }
 
-    func test_tab_view_controllers_exclude_pos_tab_when_feature_flag_is_disabled() throws {
-        // Given
-        let featureFlagService = MockFeatureFlagService()
-        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleAsATabi1] = false
-
-        let mockPOSEligibilityChecker = MockPOSEligibilityChecker()
-        mockPOSEligibilityChecker.visibility = true
-
-        let storesManager = MockStoresManager(sessionManager: .makeForTesting())
-
-        guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
-            return MainTabBarController(coder: coder,
-                                        featureFlagService: featureFlagService,
-                                        stores: storesManager,
-                                        posEligibilityCheckerFactory: { _ in mockPOSEligibilityChecker })
-        }) else {
-            return
-        }
-
-        // Trigger `viewDidLoad`
-        XCTAssertNotNil(tabBarController.view)
-
-        // When
-        storesManager.updateDefaultStore(storeID: 802)
-
-        // Then
-        XCTAssertEqual(tabBarController.viewControllers?.count, 4)
-        assertThat(tabBarController.tabRootViewController(tab: .myStore, isPOSTabVisible: false),
-                   isAnInstanceOf: DashboardViewHostingController.self)
-        assertThat(tabBarController.tabRootViewController(tab: .orders, isPOSTabVisible: false),
-                   isAnInstanceOf: OrdersSplitViewWrapperController.self)
-        assertThat(tabBarController.tabRootViewController(tab: .products, isPOSTabVisible: false),
-                   isAnInstanceOf: ProductsViewController.self)
-
-        let hubMenuNavigationController = try XCTUnwrap(tabBarController.tabRootViewController(tab: .hubMenu, isPOSTabVisible: false) as? UINavigationController)
-        assertThat(hubMenuNavigationController.topViewController,
-                   isAnInstanceOf: HubMenuViewController.self)
-    }
-
     func test_tab_view_controllers_do_not_change_when_pos_visibility_changes() throws {
         // Given
         let featureFlagService = MockFeatureFlagService()
-        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleAsATabi1] = true
 
         let mockPOSEligibilityChecker = MockPOSEligibilityChecker()
         mockPOSEligibilityChecker.visibility = false

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarController+TabsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarController+TabsTests.swift
@@ -10,13 +10,10 @@ final class MainTabBarController_TabsTests: XCTestCase {
 
     func test_tab_view_controllers_are_not_empty_after_updating_default_site() throws {
         // Arrange
-        // Sets mock `FeatureFlagService` before `MainTabBarController` is initialized so that the feature flags are set correctly.
-        let featureFlagService = MockFeatureFlagService()
-
         let storesManager = MockStoresManager(sessionManager: .makeForTesting())
 
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
-            return MainTabBarController(coder: coder, featureFlagService: featureFlagService, stores: storesManager)
+            return MainTabBarController(coder: coder, featureFlagService: MockFeatureFlagService(), stores: storesManager)
         }) else {
             return
         }
@@ -43,8 +40,6 @@ final class MainTabBarController_TabsTests: XCTestCase {
 
     func test_tab_view_controllers_include_pos_tab_when_pos_tab_is_visible() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService()
-
         let mockPOSEligibilityChecker = MockPOSEligibilityChecker()
         mockPOSEligibilityChecker.visibility = true
 
@@ -52,7 +47,7 @@ final class MainTabBarController_TabsTests: XCTestCase {
 
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
             return MainTabBarController(coder: coder,
-                                        featureFlagService: featureFlagService,
+                                        featureFlagService: MockFeatureFlagService(),
                                         stores: storesManager,
                                         posEligibilityCheckerFactory: { _ in mockPOSEligibilityChecker })
         }) else {
@@ -85,8 +80,6 @@ final class MainTabBarController_TabsTests: XCTestCase {
 
     func test_tab_view_controllers_exclude_pos_tab_when_pos_tab_is_not_visible() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService()
-
         let mockPOSEligibilityChecker = MockPOSEligibilityChecker()
         mockPOSEligibilityChecker.visibility = false
 
@@ -94,7 +87,7 @@ final class MainTabBarController_TabsTests: XCTestCase {
 
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
             return MainTabBarController(coder: coder,
-                                        featureFlagService: featureFlagService,
+                                        featureFlagService: MockFeatureFlagService(),
                                         stores: storesManager,
                                         posEligibilityCheckerFactory: { _ in mockPOSEligibilityChecker })
         }) else {
@@ -125,8 +118,6 @@ final class MainTabBarController_TabsTests: XCTestCase {
 
     func test_tab_view_controllers_do_not_change_when_pos_visibility_changes() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService()
-
         let mockPOSEligibilityChecker = MockPOSEligibilityChecker()
         mockPOSEligibilityChecker.visibility = false
 
@@ -134,7 +125,7 @@ final class MainTabBarController_TabsTests: XCTestCase {
 
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
             return MainTabBarController(coder: coder,
-                                        featureFlagService: featureFlagService,
+                                        featureFlagService: MockFeatureFlagService(),
                                         stores: storesManager,
                                         posEligibilityCheckerFactory: { _ in mockPOSEligibilityChecker })
         }) else {

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -71,9 +71,6 @@ final class MainTabBarControllerTests: XCTestCase {
         let pushNotificationsManager = MockPushNotificationsManager()
         ServiceLocator.setPushNotesManager(pushNotificationsManager)
 
-        let featureFlagService = MockFeatureFlagService()
-        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleAsATabi1] = true
-
         // Hides POS tab.
         let mockPOSEligibilityChecker = MockPOSEligibilityChecker()
         mockPOSEligibilityChecker.visibility = false
@@ -85,7 +82,6 @@ final class MainTabBarControllerTests: XCTestCase {
 
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
             return MainTabBarController(coder: coder,
-                                        featureFlagService: featureFlagService,
                                         stores: storesManager,
                                         posEligibilityCheckerFactory: { _ in mockPOSEligibilityChecker })
         }) else {
@@ -455,9 +451,6 @@ final class MainTabBarControllerTests: XCTestCase {
     @available(iOS 17.0, *)
     func test_pos_tab_becomes_invisible_after_being_selected_when_initially_visible_then_eligibility_changes() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService()
-        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleAsATabi1] = true
-
         let mockPOSEligibilityChecker = MockAsyncPOSEligibilityChecker()
         mockPOSEligibilityChecker.initialVisibility = true
 
@@ -472,7 +465,6 @@ final class MainTabBarControllerTests: XCTestCase {
 
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
             return MainTabBarController(coder: coder,
-                                        featureFlagService: featureFlagService,
                                         stores: stores,
                                         posEligibilityCheckerFactory: { _ in mockPOSEligibilityChecker })
         }) else {
@@ -526,9 +518,6 @@ final class MainTabBarControllerTests: XCTestCase {
 
     func test_pos_tab_visibility_is_cached_after_eligibility_check() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService()
-        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleAsATabi1] = true
-
         let mockPOSEligibilityChecker = MockAsyncPOSEligibilityChecker()
         mockPOSEligibilityChecker.initialVisibility = false
 
@@ -538,7 +527,6 @@ final class MainTabBarControllerTests: XCTestCase {
 
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
             return MainTabBarController(coder: coder,
-                                        featureFlagService: featureFlagService,
                                         stores: stores,
                                         posEligibilityCheckerFactory: { _ in mockPOSEligibilityChecker },
                                         posEligibilityService: mockPOSEligibilityService)
@@ -563,9 +551,6 @@ final class MainTabBarControllerTests: XCTestCase {
 
     func test_event_is_tracked_after_eligibility_check() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService()
-        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleAsATabi1] = true
-
         let mockPOSEligibilityChecker = MockPOSEligibilityChecker()
         mockPOSEligibilityChecker.visibility = true
 
@@ -573,7 +558,6 @@ final class MainTabBarControllerTests: XCTestCase {
 
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
             return MainTabBarController(coder: coder,
-                                        featureFlagService: featureFlagService,
                                         analytics: self.analytics,
                                         stores: storesManager,
                                         posEligibilityCheckerFactory: { _ in mockPOSEligibilityChecker })


### PR DESCRIPTION
For WOOMOB-917

Just one review is required.

## Description

Remove the `pointOfSaleAsATabi1` feature flag and all related code. This feature flag was used for the initial POS tab implementation, replacing the Menu tab entry point. The functionality is now controlled by the `pointOfSaleAsATabi2` feature flag.

The POS tab visibility now depends solely on the availability of a `posEligibilityChecker`, which is controlled by the `pointOfSaleAsATabi2` feature flag that determines whether to use the new `POSTabEligibilityChecker` or the legacy `LegacyPOSTabEligibilityChecker`. The i2 feature flag will be removed in release 23.3 if no blocking issues.

## Changes Made

- Removed `pointOfSaleAsATabi1` feature flag
- Removed feature flag usage and unused POS code in the HubMenu classes

## Steps to reproduce

- Launch the app
- Tap on the Menu tab --> there should be no POS row like before
- The POS tab behavior should remain the same (shown for stores in eligible countries)
- Tap on the POS tab just for a confidence test

## Testing information

Tested in iPad A16 iOS 18.4 simulator, and ensured that POS events are prefixed with `pos_` within POS.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.