### PR TITLE
POS: Fix taller button height in loading state

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/Buttons/POSButtonStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/Buttons/POSButtonStyle.swift
@@ -89,14 +89,6 @@ private struct POSButton: View {
     private var progressView: some View {
         ProgressView()
             .progressViewStyle(POSButtonProgressViewStyle(size: size.progressViewDimensions.size, lineWidth: size.progressViewDimensions.lineWidth))
-            .padding(
-                .init(
-                    top: size.additionalPadding.vertical,
-                    leading: size.additionalPadding.horizontal,
-                    bottom: size.additionalPadding.vertical,
-                    trailing: size.additionalPadding.horizontal
-                )
-            )
     }
 
     private var backgroundColor: Color {
@@ -173,17 +165,6 @@ private extension POSButtonSize {
             (size: 20, lineWidth: 6)
         }
     }
-
-    /// The internal use of `IndefiniteCircularProgressViewStyle` progress style results in half of the line width drawn outside of the progress view.
-    /// This additional padding is thus adjusted by the partial line width to achieve the expected padding in design.
-    var additionalPadding: (vertical: CGFloat, horizontal: CGFloat) {
-        switch self {
-        case .normal:
-            (vertical: progressViewDimensions.lineWidth * 0.5, horizontal: progressViewDimensions.lineWidth * 0.5)
-        case .extraSmall:
-            (vertical: 2 + progressViewDimensions.lineWidth * 0.5, horizontal: 16 + progressViewDimensions.lineWidth * 0.5)
-        }
-    }
 }
 
 // MARK: - Preview
@@ -191,6 +172,7 @@ private extension POSButtonSize {
 #if DEBUG
 
 struct POSButtonStyle_Previews: View {
+    @State private var showsLoadingState: Bool = false
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: POSSpacing.xLarge) {
@@ -254,6 +236,11 @@ struct POSButtonStyle_Previews: View {
         VStack(alignment: .leading, spacing: POSSpacing.medium) {
             Text(title)
                 .font(.headline)
+
+            Button("Show loading state") {
+                showsLoadingState.toggle()
+            }
+            .buttonStyle(POSFilledButtonStyle(size: size, isLoading: showsLoadingState))
 
             Button("Enabled Loading Button") {}
                 .buttonStyle(POSFilledButtonStyle(size: size, isLoading: true))

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/Buttons/POSButtonStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/Buttons/POSButtonStyle.swift
@@ -172,7 +172,6 @@ private extension POSButtonSize {
 #if DEBUG
 
 struct POSButtonStyle_Previews: View {
-    @State private var showsLoadingState: Bool = false
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: POSSpacing.xLarge) {
@@ -188,9 +187,9 @@ struct POSButtonStyle_Previews: View {
                 previewSection(title: "Outlined Buttons - Extra Small",
                                variant: .outlined, size: .extraSmall)
 
-                loadingPreviewSection(title: "Loading Buttons - Normal", size: .normal)
+                LoadingPreviewSection(title: "Loading Buttons - Normal", size: .normal)
 
-                loadingPreviewSection(title: "Loading Buttons - Extra Small", size: .extraSmall)
+                LoadingPreviewSection(title: "Loading Buttons - Extra Small", size: .extraSmall)
 
                 // Example with long text
                 VStack(alignment: .leading, spacing: POSSpacing.medium) {
@@ -231,13 +230,24 @@ struct POSButtonStyle_Previews: View {
             }
         }
     }
+}
 
-    private func loadingPreviewSection(title: String, size: POSButtonSize) -> some View {
+private struct LoadingPreviewSection: View {
+    let title: String
+    let size: POSButtonSize
+    @State private var showsLoadingState: Bool = false
+
+    var body: some View {
         VStack(alignment: .leading, spacing: POSSpacing.medium) {
             Text(title)
                 .font(.headline)
 
             Button("Show loading state") {
+                showsLoadingState.toggle()
+            }
+            .buttonStyle(POSFilledButtonStyle(size: size, isLoading: showsLoadingState))
+
+            Button("Show loading state in\nmultiple\nlines") {
                 showsLoadingState.toggle()
             }
             .buttonStyle(POSFilledButtonStyle(size: size, isLoading: showsLoadingState))


### PR DESCRIPTION
For WOOMOB-956

Just one review is required.

## Description

Fixed an issue where POS buttons had inconsistent height when showing loading state due to redundant padding in the progress view that made it larger than the text label.

## Steps to reproduce

1. Navigate to POS screen with buttons that show loading states. Example: in cash payment, the CTA `Mark payment as complete`
2. Trigger loading state on buttons --> the button height should not change when switching between normal and loading states

## Testing information

Tested in SwiftUI previews with an additional multi-line button, and cash payment flow in POS.

## Screenshots

SwiftUI previews:

normal state | loading state
-- | --
<img width="909" height="543" alt="Screenshot 2025-08-22 at 2 46 29 PM" src="https://github.com/user-attachments/assets/ad7b49b2-86f0-48c4-b0d5-e32d4f8ade47" /> | <img width="918" height="550" alt="Screenshot 2025-08-22 at 2 46 37 PM" src="https://github.com/user-attachments/assets/e89372dd-f171-42cb-a951-e0dd250d9e11" />

Cash payment:

normal state | loading state
-- | --
<img width="1552" height="1112" alt="Screenshot 2025-08-22 at 3 12 22 PM" src="https://github.com/user-attachments/assets/aa59ae27-5edd-4f3d-abf7-f322ebff2f53" /> | <img width="1552" height="1112" alt="Screenshot 2025-08-22 at 3 12 30 PM" src="https://github.com/user-attachments/assets/c4286b96-8f67-4f75-bd51-00c3b81204e0" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.