### PR TITLE
[Woo POS][Historical Orders] Order List and Details Split view layout

### DIFF
--- a/Modules/Tests/YosemiteTests/PointOfSale/POSSearchHistoryServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/POSSearchHistoryServiceTests.swift
@@ -43,7 +43,6 @@ struct POSSearchHistoryServiceTests {
         #expect(history[2] == "first")
     }
 
-    @available(iOS 17.0, *)
     @Test func saveSuccessfulSearch_removes_duplicates() throws {
         // Given
         let itemType: POSItemType = .product

--- a/WooCommerce/Classes/POS/Controllers/POSEntryPointController.swift
+++ b/WooCommerce/Classes/POS/Controllers/POSEntryPointController.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import protocol Experiments.FeatureFlagService
 
-@available(iOS 17.0, *)
 @Observable final class POSEntryPointController {
     private(set) var eligibilityState: POSEligibilityState?
     private let posEligibilityChecker: POSEntryPointEligibilityCheckerProtocol

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleCouponsController.swift
@@ -6,14 +6,12 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
 import struct Yosemite.PointOfSaleCouponFetchStrategyFactory
 import protocol Yosemite.PointOfSaleCouponFetchStrategy
 
-@available(iOS 17.0, *)
 protocol PointOfSaleCouponsControllerProtocol: PointOfSaleSearchingItemsControllerProtocol {
     /// Enables coupons in store settings
     /// Returns true if coupons enabled
     func enableCoupons() async
 }
 
-@available(iOS 17.0, *)
 @Observable final class PointOfSaleCouponsController: PointOfSaleCouponsControllerProtocol {
     var itemsViewState: ItemsViewState = ItemsViewState(containerState: .content,
                                                         itemsStack: ItemsStackState(root: .loading([]),
@@ -94,7 +92,6 @@ protocol PointOfSaleCouponsControllerProtocol: PointOfSaleSearchingItemsControll
     }
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSaleCouponsController {
     /// Loads the first page by attempting to load the first page from local storage
     /// then syncs from the remote regardless the result
@@ -140,7 +137,6 @@ private extension PointOfSaleCouponsController {
 
 // MARK: - View state helpers
 //
-@available(iOS 17.0, *)
 private extension PointOfSaleCouponsController {
     func setSearchingState() {
         itemsViewState.itemsStack.root = .loading([])

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleItemsController.swift
@@ -11,7 +11,6 @@ import class Yosemite.Store
 import enum Yosemite.POSItemType
 
 
-@available(iOS 17.0, *)
 protocol PointOfSaleItemsControllerProtocol {
     ///
     var itemsViewState: ItemsViewState { get }
@@ -23,7 +22,6 @@ protocol PointOfSaleItemsControllerProtocol {
     func loadNextItems(base: ItemListBaseItem) async
 }
 
-@available(iOS 17.0, *)
 protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsControllerProtocol {
     /// Searches for items
     func searchItems(searchTerm: String, baseItem: ItemListBaseItem) async
@@ -31,7 +29,6 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
 }
 
 
-@available(iOS 17.0, *)
 @Observable final class PointOfSaleItemsController: PointOfSaleSearchingItemsControllerProtocol {
     var itemsViewState: ItemsViewState
     private let paginationTracker: AsyncPaginationTracker
@@ -198,7 +195,6 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
     }
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSaleItemsController {
     func setLoadingState(base: ItemListBaseItem) {
         switch base {
@@ -241,7 +237,6 @@ private extension PointOfSaleItemsController {
     }
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSaleItemsController {
     /// Fetches items given a page number and appends new unique items to the `allItems` array.
     /// - Parameter pageNumber: Page number to fetch items from.
@@ -309,7 +304,6 @@ private extension PointOfSaleItemsController {
 }
 
 // MARK: - ItemsViewState Updates
-@available(iOS 17.0, *)
 private extension PointOfSaleItemsController {
     func updateState(for parent: POSItem, to state: ItemListState) {
         let viewState = itemsViewState

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderController.swift
@@ -39,7 +39,6 @@ protocol PointOfSaleOrderControllerProtocol {
     func collectCashPayment(changeDueAmount: String?) async throws
 }
 
-@available(iOS 17.0, *)
 @Observable final class PointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
     init(orderService: POSOrderServiceProtocol,
          receiptService: POSReceiptServiceProtocol,
@@ -168,7 +167,6 @@ protocol PointOfSaleOrderControllerProtocol {
     }
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSaleOrderController {
     func totals(for order: Order) -> PointOfSaleOrderTotals {
         let totalsCalculator = OrderTotalsCalculator(for: order,
@@ -210,7 +208,6 @@ private extension PointOfSaleOrderController {
     }
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSaleOrderController {
     @MainActor
     func isPluginSupported(_ plugin: Plugin, minimumVersion: String, siteID: Int64) -> Bool {
@@ -231,7 +228,6 @@ private extension PointOfSaleOrderController {
 
 // MARK: - Error Handling
 
-@available(iOS 17.0, *)
 private extension PointOfSaleOrderController {
     func orderStateError(from error: Error) -> PointOfSaleOrderState.OrderStateError {
         if let couponsError = CouponsError(underlyingError: error) {
@@ -244,7 +240,6 @@ private extension PointOfSaleOrderController {
     }
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSaleOrderController {
     enum POSReceiptEligibilityConstants {
         static let wcPluginMinimumVersion = "10.0.0"
@@ -300,7 +295,6 @@ extension PointOfSaleInternalOrderState: Equatable {
     }
 }
 
-@available(iOS 17.0, *)
 extension PointOfSaleOrderController {
     enum PointOfSaleOrderControllerError: Error {
         case noSiteID
@@ -309,7 +303,6 @@ extension PointOfSaleOrderController {
 }
 
 
-@available(iOS 17.0, *)
 private extension PointOfSaleOrderController {
     func trackOrderCreationFailed(error: Error) {
         var errorType: WooAnalyticsEvent.Orders.OrderCreationErrorType?

--- a/WooCommerce/Classes/POS/Models/ItemsStackState.swift
+++ b/WooCommerce/Classes/POS/Models/ItemsStackState.swift
@@ -2,7 +2,6 @@ import Foundation
 import enum Yosemite.POSItem
 import Observation
 
-@available(iOS 17.0, *)
 @Observable final class ItemsStackState {
     var root: ItemListState
     var itemStates: [POSItem: ItemListState]
@@ -13,7 +12,6 @@ import Observation
     }
 }
 
-@available(iOS 17.0, *)
 extension ItemsStackState: Equatable {
     static func == (lhs: ItemsStackState, rhs: ItemsStackState) -> Bool {
         return lhs.root == rhs.root

--- a/WooCommerce/Classes/POS/Models/ItemsViewState.swift
+++ b/WooCommerce/Classes/POS/Models/ItemsViewState.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Observation
 
-@available(iOS 17.0, *)
 @Observable class ItemsViewState {
     var containerState: ItemsContainerState
     var itemsStack: ItemsStackState
@@ -12,7 +11,6 @@ import Observation
     }
 }
 
-@available(iOS 17.0, *)
 extension ItemsViewState: Equatable {
     static func == (lhs: ItemsViewState, rhs: ItemsViewState) -> Bool {
         return lhs.containerState == rhs.containerState

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -14,7 +14,6 @@ import enum Yosemite.POSItemType
 import protocol Yosemite.PointOfSaleBarcodeScanServiceProtocol
 import enum Yosemite.PointOfSaleBarcodeScanError
 
-@available(iOS 17.0, *)
 protocol PointOfSaleAggregateModelProtocol {
     var orderStage: PointOfSaleOrderStage { get }
 
@@ -50,7 +49,6 @@ protocol PointOfSaleAggregateModelProtocol {
     func pointOfSaleClosed()
 }
 
-@available(iOS 17.0, *)
 @Observable final class PointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
     private(set) var orderStage: PointOfSaleOrderStage = .building
 
@@ -136,7 +134,6 @@ protocol PointOfSaleAggregateModelProtocol {
 }
 
 // MARK: - Cart
-@available(iOS 17.0, *)
 extension PointOfSaleAggregateModel {
     func addToCart(_ item: POSItem) {
         trackCustomerInteractionStarted()
@@ -186,7 +183,6 @@ extension PointOfSaleAggregateModel {
 }
 
 // MARK: - Barcode Scanning
-@available(iOS 17.0, *)
 extension PointOfSaleAggregateModel {
     func barcodeScanned(_ result: Result<String, HIDBarcodeParserError>) {
         Task { @MainActor [weak self] in
@@ -263,7 +259,6 @@ extension PointOfSaleAggregateModel {
 }
 
 // MARK: - Search
-@available(iOS 17.0, *)
 extension PointOfSaleAggregateModel {
     func saveSearchTerm(_ term: String, for itemType: POSItemType) {
         searchHistoryService.saveSuccessfulSearch(term: term, for: itemType)
@@ -275,7 +270,6 @@ extension PointOfSaleAggregateModel {
 }
 
 // MARK: - Track events
-@available(iOS 17.0, *)
 private extension PointOfSaleAggregateModel {
     func trackCustomerInteractionStarted() {
         // At the moment we're assumming that an interaction starts simply when the cart is zero
@@ -303,7 +297,6 @@ private extension PointOfSaleAggregateModel {
 }
 
 // MARK: - Card payments
-@available(iOS 17.0, *)
 extension PointOfSaleAggregateModel {
     private func publishCardReaderConnectionStatus() {
         cardPresentPaymentService.readerConnectionStatusPublisher
@@ -476,7 +469,6 @@ extension PointOfSaleAggregateModel {
     }
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSaleAggregateModel {
     func publishPaymentMessages() {
         cardPresentPaymentService.paymentEventPublisher
@@ -594,7 +586,6 @@ private extension PointOfSaleAggregateModel {
 }
 
 // MARK: - Order syncing
-@available(iOS 17.0, *)
 extension PointOfSaleAggregateModel {
     @MainActor
     func checkOut() async {
@@ -609,7 +600,6 @@ extension PointOfSaleAggregateModel {
 }
 
 // MARK: - Lifecycle
-@available(iOS 17.0, *)
 extension PointOfSaleAggregateModel {
     func pointOfSaleClosed() {
         // We cancel any payment to prevent the reader from remaining live and awaiting a card tap. Otherwise, it would
@@ -630,7 +620,6 @@ extension PointOfSaleAggregateModel {
     }
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSaleAggregateModel {
     enum Constants {
         static let initialPage: Int = 1

--- a/WooCommerce/Classes/POS/Models/PointOfSaleViewStateCoordinator.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleViewStateCoordinator.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-@available(iOS 17.0, *)
 protocol PointOfSaleViewStateResettable {
     /// Resets all view state to its default values.
     /// This should be called when starting a new cart to ensure the UI returns to its initial state.
@@ -10,7 +9,6 @@ protocol PointOfSaleViewStateResettable {
 /// Coordinates view-specific state for the Point of Sale interface.
 /// This coordinator manages UI state that needs to persist across the POS experience
 /// but should be reset when starting a new cart/order.
-@available(iOS 17.0, *)
 @Observable final class PointOfSaleViewStateCoordinator: PointOfSaleViewStateResettable {
     /// The currently selected item list type, shown when building the cart.
     /// When we reset, the non-searched products list is shown for the new cart.

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetup.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetup.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct PointOfSaleBarcodeScannerSetup: View {
     @Binding var isPresented: Bool
     @State private var flowManager: PointOfSaleBarcodeScannerSetupFlowManager
@@ -91,7 +90,6 @@ private enum Constants {
 }
 
 // MARK: - Private Localization Extension
-@available(iOS 17.0, *)
 private extension PointOfSaleBarcodeScannerSetup {
     enum Localization {
         static let starBSH20BTitle = NSLocalizedString(
@@ -119,7 +117,6 @@ private extension PointOfSaleBarcodeScannerSetup {
 
 // MARK: - Previews
 
-@available(iOS 17.0, *)
 #Preview {
     PointOfSaleBarcodeScannerSetup(isPresented: .constant(true))
 }
@@ -131,7 +128,6 @@ private extension PointOfSaleBarcodeScannerSetup {
 /// - On content change: fades out old content, replaces it, then fades in new content.
 /// - Handles height changes with a spring animation.
 ///
-@available(iOS 17.0, *)
 private struct AnimatedTransitionContainer<Content: View, ID: Equatable>: View {
     let maxWidth: CGFloat
     let maxHeight: CGFloat

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlow.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlow.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import WooFoundation
 
 // MARK: - Point of Sale Barcode Scanner Setup Flow
-@available(iOS 17.0, *)
 @Observable
 class PointOfSaleBarcodeScannerSetupFlow {
     private let scannerType: PointOfSaleBarcodeScannerType
@@ -314,7 +313,6 @@ class PointOfSaleBarcodeScannerSetupFlow {
     }
 }
 
-@available(iOS 17.0, *)
 struct PointOfSaleBarcodeScannerBackOnlyButtonCustomization: PointOfSaleBarcodeScannerButtonCustomization {
     func customizeButtons(for flow: PointOfSaleBarcodeScannerSetupFlow) -> PointOfSaleFlowButtonConfiguration {
         return PointOfSaleFlowButtonConfiguration(
@@ -335,7 +333,6 @@ struct PointOfSaleBarcodeScannerBackOnlyButtonCustomization: PointOfSaleBarcodeS
     }
 }
 
-@available(iOS 17.0, *)
 struct PointOfSaleBarcodeScannerErrorButtonCustomization: PointOfSaleBarcodeScannerButtonCustomization {
     func customizeButtons(for flow: PointOfSaleBarcodeScannerSetupFlow) -> PointOfSaleFlowButtonConfiguration {
         return PointOfSaleFlowButtonConfiguration(
@@ -364,7 +361,6 @@ struct PointOfSaleBarcodeScannerErrorButtonCustomization: PointOfSaleBarcodeScan
     }
 }
 
-@available(iOS 17.0, *)
 struct PointOfSaleBarcodeScannerOptionalScannerInformationButtonCustomization: PointOfSaleBarcodeScannerButtonCustomization {
     func customizeButtons(for flow: PointOfSaleBarcodeScannerSetupFlow) -> PointOfSaleFlowButtonConfiguration {
         return PointOfSaleFlowButtonConfiguration(
@@ -385,7 +381,6 @@ struct PointOfSaleBarcodeScannerOptionalScannerInformationButtonCustomization: P
     }
 }
 
-@available(iOS 17.0, *)
 struct PointOfSaleBarcodeScannerProductBarcodeSetupInformationButtonCustomization: PointOfSaleBarcodeScannerButtonCustomization {
     func customizeButtons(for flow: PointOfSaleBarcodeScannerSetupFlow) -> PointOfSaleFlowButtonConfiguration {
         return PointOfSaleFlowButtonConfiguration(
@@ -403,7 +398,6 @@ struct PointOfSaleBarcodeScannerProductBarcodeSetupInformationButtonCustomizatio
 
 // MARK: - Analytics
 
-@available(iOS 17.0, *)
 private extension PointOfSaleBarcodeScannerSetupFlow {
     private func trackTestScanSuccess() {
         analytics.track(event: WooAnalyticsEvent.PointOfSale.barcodeScannerSetupTestScanSuccess(scanner: scannerType))
@@ -435,7 +429,6 @@ private extension PointOfSaleBarcodeScannerSetupFlow {
 }
 
 // MARK: - Private Localization Extension
-@available(iOS 17.0, *)
 private extension PointOfSaleBarcodeScannerSetupFlow {
     enum Localization {
         static let nextButtonTitle = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlowManager.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlowManager.swift
@@ -3,7 +3,6 @@ import GameController
 import WooFoundation
 
 // MARK: - Point of Sale Barcode Scanner Setup Flow Manager
-@available(iOS 17.0, *)
 @Observable
 class PointOfSaleBarcodeScannerSetupFlowManager {
     var currentState: PointOfSaleBarcodeScannerSetupFlowState = .scannerSelection

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupModels.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupModels.swift
@@ -108,7 +108,6 @@ enum PointOfSaleBarcodeScannerStepID: String, CaseIterable {
 }
 
 // MARK: - Button Customization Protocol
-@available(iOS 17.0, *)
 protocol PointOfSaleBarcodeScannerButtonCustomization {
     func customizeButtons(for flow: PointOfSaleBarcodeScannerSetupFlow) -> PointOfSaleFlowButtonConfiguration
 }
@@ -121,7 +120,6 @@ enum PointOfSaleBarcodeScannerTransitionType: Hashable {
 }
 
 // MARK: - Setup Step
-@available(iOS 17.0, *)
 struct PointOfSaleBarcodeScannerSetupStep {
     let title: String
     let content: any View

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupScanTester.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupScanTester.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-@available(iOS 17.0, *)
 @Observable
 class PointOfSaleBarcodeScannerSetupScanTester {
     private let onTestPass: () -> Void

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupStepViews.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupStepViews.swift
@@ -112,7 +112,6 @@ private extension PointOfSaleBarcodeScannerPairingView {
     }
 }
 
-@available(iOS 17.0, *)
 struct PointOfSaleBarcodeScannerTestBarcodeView: View {
     let scanTester: PointOfSaleBarcodeScannerSetupScanTester
     let timerCompleted: Bool
@@ -136,7 +135,6 @@ struct PointOfSaleBarcodeScannerTestBarcodeView: View {
 
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSaleBarcodeScannerTestBarcodeView {
     enum Localization {
         static let title = NSLocalizedString(
@@ -248,7 +246,6 @@ struct PointOfSaleBarcodeScannerErrorView: View {
 
 // MARK: - Previews
 
-@available(iOS 17.0, *)
 #Preview("Barcode View - HID Setup") {
     PointOfSaleBarcodeScannerBarcodeView(
         title: "Star BSH-20B setup",
@@ -257,7 +254,6 @@ struct PointOfSaleBarcodeScannerErrorView: View {
     )
 }
 
-@available(iOS 17.0, *)
 #Preview("Barcode View - Barcode Setup") {
     PointOfSaleBarcodeScannerBarcodeView(
         title: "Scanner setup",
@@ -266,12 +262,10 @@ struct PointOfSaleBarcodeScannerErrorView: View {
     )
 }
 
-@available(iOS 17.0, *)
 #Preview("Pairing View - Netum 1228BC") {
     PointOfSaleBarcodeScannerPairingView(scanner: .netum1228BC)
 }
 
-@available(iOS 17.0, *)
 #Preview("Test View - Normal") {
     PointOfSaleBarcodeScannerTestBarcodeView(
         scanTester: PointOfSaleBarcodeScannerSetupScanTester(
@@ -284,7 +278,6 @@ struct PointOfSaleBarcodeScannerErrorView: View {
     )
 }
 
-@available(iOS 17.0, *)
 #Preview("Test View - Timeout") {
     PointOfSaleBarcodeScannerTestBarcodeView(
         scanTester: PointOfSaleBarcodeScannerSetupScanTester(
@@ -297,12 +290,10 @@ struct PointOfSaleBarcodeScannerErrorView: View {
     )
 }
 
-@available(iOS 17.0, *)
 #Preview("Setup Complete View") {
     PointOfSaleBarcodeScannerSetupCompleteView()
 }
 
-@available(iOS 17.0, *)
 #Preview("Error View") {
     PointOfSaleBarcodeScannerErrorView()
 }

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleFlowButtonsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanner Setup/PointOfSaleFlowButtonsView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct PointOfSaleFlowButtonsView: View {
     let configuration: PointOfSaleFlowButtonConfiguration
 

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/BarcodeScannerContainer.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/BarcodeScannerContainer.swift
@@ -6,7 +6,6 @@ import SwiftUI
 ///
 /// The container works by capturing keyboard input events and interpreting them as barcode scans
 /// when a terminating character is detected.
-@available(iOS 17.0, *)
 struct BarcodeScannerContainer: View {
     /// Configuration for the barcode scanner
     let configuration: HIDBarcodeParserConfiguration

--- a/WooCommerce/Classes/POS/Presentation/Barcode Scanning/BarcodeScanningModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Barcode Scanning/BarcodeScanningModifier.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 /// A view modifier that adds barcode scanning capability to a view.
 /// The barcode scanner is added in a ZStack below the content view.
-@available(iOS 17.0, *)
 struct BarcodeScanningModifier: ViewModifier {
     /// Whether barcode scanning is enabled
     @Binding var enabled: Bool
@@ -20,7 +19,6 @@ struct BarcodeScanningModifier: ViewModifier {
     }
 }
 
-@available(iOS 17.0, *)
 extension View {
     /// Adds barcode scanning capability to a view.
     /// - Parameters:

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateProgressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateProgressView.swift
@@ -32,7 +32,6 @@ private enum Constants {
     static let borderInset: CGFloat = POSSpacing.xSmall
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @State var progress: CGFloat = 0.5
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct CardReaderConnectionStatusView: View {
     @Environment(\.posBackgroundAppearance) var backgroundAppearance
     @Environment(PointOfSaleAggregateModel.self) private var posModel
@@ -64,7 +63,6 @@ struct CardReaderConnectionStatusView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private extension CardReaderConnectionStatusView {
     @ViewBuilder
     func progressIndicatingCardReaderStatus(title: String) -> some View {
@@ -82,7 +80,6 @@ private extension CardReaderConnectionStatusView {
     }
 }
 
-@available(iOS 17.0, *)
 private extension CardReaderConnectionStatusView {
     var connectedFontColor: Color {
         switch backgroundAppearance {
@@ -112,7 +109,6 @@ private extension CardReaderConnectionStatusView {
     }
 }
 
-@available(iOS 17.0, *)
 private extension CardReaderConnectionStatusView {
     enum Constants {
         static let buttonImageAndTextSpacing: CGFloat = POSSpacing.medium
@@ -128,7 +124,6 @@ private extension CardReaderConnectionStatusView {
     }
 }
 
-@available(iOS 17.0, *)
 private extension CardReaderConnectionStatusView {
     enum Localization {
         static let readerConnected = NSLocalizedString(
@@ -167,7 +162,6 @@ private extension CardReaderConnectionStatusView {
 
 #if DEBUG
 
-@available(iOS 17.0, *)
 #Preview {
     VStack {
         CardReaderConnectionStatusView()

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift
@@ -43,7 +43,6 @@ struct PointOfSaleCardPresentPaymentBluetoothRequiredAlertView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentBluetoothRequiredAlertView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift
@@ -38,7 +38,6 @@ struct PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift
@@ -38,7 +38,6 @@ struct PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView: V
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView.swift
@@ -29,7 +29,6 @@ struct PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
@@ -35,7 +35,6 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
@@ -38,7 +38,6 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedView.swift
@@ -45,7 +45,6 @@ struct PointOfSaleCardPresentPaymentConnectingFailedView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentConnectingFailedView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingLocationPreAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingLocationPreAlertView.swift
@@ -42,7 +42,6 @@ struct PointOfSaleCardPresentPaymentConnectingLocationPreAlertView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     PointOfSaleCardPresentPaymentConnectingLocationPreAlertView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingToReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingToReaderView.swift
@@ -33,7 +33,6 @@ struct PointOfSaleCardPresentPaymentConnectingToReaderView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentConnectingToReaderView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift
@@ -27,7 +27,6 @@ struct PointOfSaleCardPresentPaymentConnectionSuccessAlertView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentConnectionSuccessAlertView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderView.swift
@@ -44,7 +44,6 @@ struct PointOfSaleCardPresentPaymentFoundReaderView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentFoundReaderView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView.swift
@@ -49,7 +49,6 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView.swift
@@ -33,7 +33,6 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedView.swift
@@ -37,7 +37,6 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentReaderUpdateFailedView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersFailedView.swift
@@ -35,7 +35,6 @@ struct PointOfSaleCardPresentPaymentScanningForReadersFailedView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentScanningForReadersFailedView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersView.swift
@@ -35,7 +35,6 @@ struct PointOfSaleCardPresentPaymentScanningForReadersView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentScanningForReadersView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentInLineMessage.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentInLineMessage.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct PointOfSaleCardPresentPaymentInLineMessage: View {
     private let messageType: PointOfSaleCardPresentPaymentMessageType
 
@@ -48,7 +47,6 @@ struct PointOfSaleCardPresentPaymentInLineMessage: View {
     private var animation: POSCardPresentPaymentInLineMessageAnimation { .init(namespace: namespace) }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     PointOfSaleCardPresentPaymentInLineMessage(messageType: .processing(
         viewModel: PointOfSaleCardPresentPaymentProcessingMessageViewModel()))

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct PointOfSaleItemListEmptyView: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
@@ -85,7 +84,6 @@ struct PointOfSaleItemListEmptyView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSaleItemListEmptyView {
     enum Constants {
         static let iconSize: CGFloat = 88
@@ -244,7 +242,6 @@ struct PointOfSaleItemListEmptyViewModel {
 
 // MARK: - Preview
 
-@available(iOS 17.0, *)
 #Preview {
     PointOfSaleItemListEmptyView(
         viewModel: PointOfSaleItemListEmptyViewModel(
@@ -254,7 +251,6 @@ struct PointOfSaleItemListEmptyViewModel {
     ) {}
 }
 
-@available(iOS 17.0, *)
 #Preview {
     PointOfSaleItemListEmptyView(
         viewModel: PointOfSaleItemListEmptyViewModel(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 /// A view that displays an error message with a retry CTA when the list of POS items fails to load.
-@available(iOS 17.0, *)
 struct PointOfSaleItemListErrorView: View {
     @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
     private let viewModel: PointOfSaleItemListErrorViewModel
@@ -87,12 +86,10 @@ struct PointOfSaleItemListErrorViewModel {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     PointOfSaleItemListErrorView(error: .errorCouponsDisabled, onAction: {})
 }
 
-@available(iOS 17.0, *)
 #Preview {
     PointOfSaleItemListErrorView(error: .errorOnLoadingCoupons(), onAction: {})
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListFullscreenErrorView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListFullscreenErrorView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 /// A view that displays an error message with a retry CTA when the list of products fails to load.
-@available(iOS 17.0, *)
 struct PointOfSaleItemListFullscreenErrorView: View {
     private let error: PointOfSaleErrorState
     private let onAction: (() -> Void)?
@@ -18,7 +17,6 @@ struct PointOfSaleItemListFullscreenErrorView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     PointOfSaleItemListFullscreenErrorView(error: .errorOnLoadingProducts(), onAction: nil)
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListFullscreenView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListFullscreenView.swift
@@ -27,7 +27,6 @@ private enum Localization {
     )
 }
 
-@available(iOS 17.0, *)
 #Preview {
     PointOfSaleItemListFullscreenView(
         content: {

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentActivityIndicatingMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentActivityIndicatingMessageView.swift
@@ -38,7 +38,6 @@ private extension PointOfSaleCardPresentPaymentActivityIndicatingMessageView {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentActivityIndicatingMessageView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCancelledOnReaderMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCancelledOnReaderMessageView.swift
@@ -44,7 +44,6 @@ struct PointOfSaleCardPresentPaymentCancelledOnReaderMessageView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentCancelledOnReaderMessageView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift
@@ -62,7 +62,6 @@ struct PointOfSaleCardPresentPaymentCaptureErrorMessageView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentCaptureErrorMessageView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageView.swift
@@ -56,7 +56,6 @@ struct PointOfSaleCardPresentPaymentErrorMessageView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview("Generic retry") {
     @Previewable @Namespace var namespace
 
@@ -70,7 +69,6 @@ struct PointOfSaleCardPresentPaymentErrorMessageView: View {
     )
 }
 
-@available(iOS 17.0, *)
 #Preview("Retry with another payment method") {
     @Previewable @Namespace var namespace
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift
@@ -52,7 +52,6 @@ struct PointOfSaleCardPresentPaymentIntentCreationErrorMessageView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift
@@ -51,7 +51,6 @@ struct PointOfSaleCardPresentPaymentNonRetryableErrorMessageView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentNonRetryableErrorMessageView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView.swift
@@ -45,7 +45,6 @@ struct PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView: View {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @Namespace var namespace
     return PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct PointOfSalePaymentSuccessView: View {
     let viewModel: PointOfSalePaymentSuccessViewModel
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
@@ -111,7 +110,6 @@ struct PointOfSalePaymentSuccessView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSalePaymentSuccessView {
     enum Constants {
         static let imageName: String = "checkmark"
@@ -126,7 +124,6 @@ private extension PointOfSalePaymentSuccessView {
 }
 
 #if DEBUG
-@available(iOS 17.0, *)
 #Preview {
     PointOfSalePaymentSuccessView(
         viewModel: PointOfSalePaymentSuccessViewModel(formattedOrderTotal: "$3.00",

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct CartView: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     private let viewHelper = CartViewHelper()
@@ -107,7 +106,6 @@ private struct ScrollViewHeightPreferenceKey: PreferenceKey {
     }
 }
 
-@available(iOS 17.0, *)
 private extension CartView {
     var backgroundColor: Color {
         .posSurfaceBright
@@ -126,7 +124,6 @@ private extension CartView {
     }
 }
 
-@available(iOS 17.0, *)
 private extension CartView {
     enum Localization {
         static let cartTitle = NSLocalizedString(
@@ -160,7 +157,6 @@ private enum Constants {
 
 /// View sub-components
 ///
-@available(iOS 17.0, *)
 private extension CartView {
     var checkoutButton: some View {
         Button {
@@ -213,7 +209,6 @@ private extension CartView {
 
 }
 
-@available(iOS 17.0, *)
 private struct CartClearMenuButton: View {
     let removeAllItemsFromCart: () -> Void
 
@@ -244,7 +239,6 @@ private struct CartClearMenuButton: View {
     }
 }
 
-@available(iOS 17.0, *)
 private struct CartScrollViewContent: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
@@ -351,7 +345,6 @@ private struct CartScrollViewContent: View {
     }
 }
 
-@available(iOS 17.0, *)
 private struct CouponsCartSection: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Binding var shouldShowItemImages: Bool
@@ -386,7 +379,6 @@ private struct CouponsCartSection: View {
     }
 }
 
-@available(iOS 17.0, *)
 private struct PurchasableItemsCartSection: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Binding var shouldShowItemImages: Bool
@@ -443,7 +435,6 @@ private struct PurchasableItemsCartSection: View {
     }
 }
 
-@available(iOS 17.0, *)
 private extension CartView {
     func trackCheckoutTapped() {
         let purchasableItems = posModel.cart.purchasableItems.count
@@ -458,13 +449,11 @@ private extension CartView {
 }
 
 #if DEBUG
-@available(iOS 17.0, *)
 #Preview {
     CartView()
         .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }
 
-@available(iOS 17.0, *)
 #Preview("Cart with one item") {
     let posModel = POSPreviewHelpers.makePreviewAggregateModel()
     posModel.addToCart(.simpleProduct(.init(id: UUID(),

--- a/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CouponRowView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct CouponRowView: View {
     private let couponItem: Cart.CouponItem
     private let couponRowState: CouponRowState?
@@ -86,7 +85,6 @@ struct CouponRowView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private extension CouponRowView {
     enum Constants {
         static let couponCardSize: CGFloat = 96
@@ -100,7 +98,6 @@ private extension CouponRowView {
     }
 }
 
-@available(iOS 17.0, *)
 private extension CouponRowView {
     private enum Localization {
         static let invalidCoupon = NSLocalizedString(
@@ -111,7 +108,6 @@ private extension CouponRowView {
 }
 
 #if DEBUG
-@available(iOS 17.0, *)
 #Preview(traits: .sizeThatFitsLayout) {
     CouponRowView(couponItem: Cart.CouponItem(id: UUID(), code: "10-Discount", summary: "$10 Off · All products"), couponRowState: .idle) {}
 }

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSPreSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSPreSearchView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import enum Yosemite.POSItem
 
-@available(iOS 17.0, *)
 struct POSPreSearchView: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @ScaledMetric private var chipHeight: CGFloat = 56.0
@@ -104,7 +103,6 @@ struct POSPreSearchView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private extension POSPreSearchView {
     enum Localization {
         static let recentSearchesTitle = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSProductSearchable.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSProductSearchable.swift
@@ -3,7 +3,6 @@ import enum Yosemite.POSItemType
 import protocol Yosemite.POSSearchHistoryProviding
 import enum Yosemite.POSItem
 
-@available(iOS 17.0, *)
 final class POSProductSearchable: POSSearchable {
     let itemListType: ItemListType
     private let itemsController: PointOfSaleSearchingItemsControllerProtocol

--- a/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Search/POSSearchView.swift
@@ -3,7 +3,6 @@ import enum Yosemite.POSItemType
 import enum Yosemite.POSItem
 
 /// Protocol defining search capabilities for POS items
-@available(iOS 17.0, *)
 protocol POSSearchable {
     /// The type of item lists being searched
     var itemListType: ItemListType { get }
@@ -19,7 +18,6 @@ protocol POSSearchable {
 }
 
 /// A reusable search field view for POS items
-@available(iOS 17.0, *)
 struct POSSearchField: View {
     @Environment(\.keyboardObserver) private var keyboardObserver
 
@@ -105,7 +103,6 @@ struct POSSearchField: View {
 }
 
 /// A reusable search content view for POS items
-@available(iOS 17.0, *)
 struct POSSearchContentView<Content: View>: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ChildItemList.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import Yosemite
 
 /// Displays a scrollable list of child items in POS.
-@available(iOS 17.0, *)
 struct ChildItemList: View {
     private let parentItem: POSItem
     private let title: String
@@ -56,7 +55,6 @@ struct ChildItemList: View {
     }
 }
 
-@available(iOS 17.0, *)
 private extension ChildItemList {
     @ViewBuilder var headerView: some View {
         POSPageHeaderView(title: title,
@@ -118,7 +116,6 @@ private extension ChildItemList {
     }
 }
 
-@available(iOS 17.0, *)
 private extension ChildItemList {
     enum Localization {
         static let back = NSLocalizedString(
@@ -131,7 +128,6 @@ private extension ChildItemList {
 
 #if DEBUG
 
-@available(iOS 17.0, *)
 #Preview("Variable product child items") {
     let parentProduct = POSVariableParentProduct(
         id: .init(),
@@ -181,7 +177,6 @@ private extension ChildItemList {
                          ))
 }
 
-@available(iOS 17.0, *)
 #Preview("Variable items load error") {
     let parentProduct = POSVariableParentProduct(
         id: .init(),

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/GhostItemCardView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct GhostItemCardView: View {
     @ScaledMetric private var scale: CGFloat = 1.0
     @State private var viewWidth: CGFloat = 0.0
@@ -103,7 +102,6 @@ struct GhostItemCardViewConfiguration {
     )
 }
 
-@available(iOS 17.0, *)
 #Preview {
     VStack(spacing: 20) {
         GhostItemCardView(configuration: .itemList) {

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/ItemList.swift
@@ -3,7 +3,6 @@ import enum Yosemite.POSItem
 import struct Yosemite.POSVariableParentProduct
 
 /// Displays a list of POS items or placeholder card based on the given state.
-@available(iOS 17.0, *)
 struct ItemList<HeaderView: View>: View {
     @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
     @Environment(PointOfSaleAggregateModel.self) private var posModel
@@ -145,7 +144,6 @@ private enum Constants {
     static let itemSpacing: CGFloat = POSSpacing.medium
 }
 
-@available(iOS 17.0, *)
 struct ItemListRow: View {
     let item: POSItem
     let itemActionHandler: POSItemActionHandler
@@ -203,7 +201,6 @@ struct ItemListRow: View {
     }
 }
 
-@available(iOS 17.0, *)
 private extension ItemListRow {
     enum Localization {
         static let variationsAvailable = NSLocalizedString(
@@ -215,7 +212,6 @@ private extension ItemListRow {
 }
 
 #if DEBUG
-@available(iOS 17.0, *)
 #Preview("Loaded with items") {
     let itemList: ItemListState = .loaded(
         [
@@ -249,7 +245,6 @@ private extension ItemListRow {
     )
 }
 
-@available(iOS 17.0, *)
 #Preview("Loading") {
     ItemList(itemsController: PointOfSalePreviewItemsController(),
              node: .root,

--- a/WooCommerce/Classes/POS/Presentation/Item Selector/POSItemActionHandler.swift
+++ b/WooCommerce/Classes/POS/Presentation/Item Selector/POSItemActionHandler.swift
@@ -4,14 +4,12 @@ import enum Yosemite.POSItemType
 import protocol WooFoundation.Analytics
 
 /// Protocol for handling actions on POS items
-@available(iOS 17.0, *)
 protocol POSItemActionHandler {
     /// Handles a tap on an item
     /// - Parameter item: The item that was tapped
     func handleTap(_ item: POSItem)
 }
 
-@available(iOS 17.0, *)
 extension POSItemActionHandler {
     /// Default implementation for analytics tracking
     /// - Parameter item: The item that was tapped
@@ -67,7 +65,6 @@ extension POSItemActionHandler {
 }
 
 /// Standard handler for handling item taps without any special context
-@available(iOS 17.0, *)
 final class StandardPOSItemActionHandler: POSItemActionHandler {
     private let posModel: PointOfSaleAggregateModelProtocol
     private let sourceView: WooAnalyticsEvent.PointOfSale.SourceView
@@ -101,7 +98,6 @@ final class StandardPOSItemActionHandler: POSItemActionHandler {
 }
 
 /// Handler for handling taps on search result items, saving the search term
-@available(iOS 17.0, *)
 final class SearchResultItemActionHandler: POSItemActionHandler {
     private let posModel: PointOfSaleAggregateModelProtocol
     private let searchTerm: String
@@ -141,7 +137,6 @@ final class SearchResultItemActionHandler: POSItemActionHandler {
     }
 }
 
-@available(iOS 17.0, *)
 struct POSItemActionHandlerFactory {
     static func itemActionHandler(
         itemListType: ItemListType,

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import enum Yosemite.POSItem
 import protocol Yosemite.POSOrderableItem
 
-@available(iOS 17.0, *)
 struct ItemListView: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
@@ -212,7 +211,6 @@ struct ItemListView: View {
 
 /// Header view
 ///
-@available(iOS 17.0, *)
 private extension ItemListView {
     @ViewBuilder
     var headerView: some View {
@@ -278,7 +276,6 @@ private extension ItemListView {
 
 /// View Helpers
 ///
-@available(iOS 17.0, *)
 private extension ItemListView {
     @ViewBuilder
     private var createCouponButton: some View {
@@ -332,7 +329,6 @@ private extension ItemListView {
     }
 }
 
-@available(iOS 17.0, *)
 private extension ItemListView {
     func displayItemListType(_ itemListType: ItemListType) {
         // Clear search term when switching tabs
@@ -348,7 +344,6 @@ private extension ItemListView {
     }
 }
 
-@available(iOS 17.0, *)
 private extension ItemListView {
     func itemsController(_ itemType: ItemListType) -> PointOfSaleItemsControllerProtocol {
         switch itemType {
@@ -379,7 +374,6 @@ private extension ItemListView {
 
 /// Constants
 ///
-@available(iOS 17.0, *)
 private extension ItemListView {
     enum Constants {
         static let animationDuration: CGFloat = 0.2
@@ -406,7 +400,6 @@ private extension ItemListView {
 
 #if DEBUG
 
-@available(iOS 17.0, *)
 #Preview("Loaded with all product types") {
     let itemsController = PointOfSalePreviewItemsController()
     Task { @MainActor in
@@ -420,7 +413,6 @@ private extension ItemListView {
         .environmentObject(POSSheetManager())
 }
 
-@available(iOS 17.0, *)
 #Preview("Loading") {
     ItemListView(selectedItemListType: .constant(.products(search: false)),
                  searchTerm: .constant(""))

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct ItemRowView: View {
     private let cartItem: Cart.PurchasableItem
     private let onItemRemoveTapped: (() -> Void)?
@@ -124,7 +123,6 @@ struct ItemRowView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private extension ItemRowView {
     enum Constants {
         static let productCardSize: CGFloat = 96
@@ -151,7 +149,6 @@ private extension ItemRowView {
 }
 
 #if DEBUG
-@available(iOS 17.0, *)
 #Preview {
     ScrollView {
         ItemRowView(

--- a/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct PointOfSaleOrderSyncCouponsErrorMessageView: View {
     let message: String
     let retryHandler: () -> Void
@@ -71,7 +70,6 @@ struct PointOfSaleOrderSyncCouponsErrorMessageView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSaleOrderSyncCouponsErrorMessageView {
     enum Constants {
         static let headerSpacing: CGFloat = POSSpacing.large
@@ -81,7 +79,6 @@ private extension PointOfSaleOrderSyncCouponsErrorMessageView {
     }
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSaleOrderSyncCouponsErrorMessageView {
     enum Localization {
         static let title = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrderDetailsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrderDetailsView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct PointOfSaleOrderDetailsView: View {
     let orderID: String
     let onBack: () -> Void
@@ -46,14 +45,12 @@ struct PointOfSaleOrderDetailsView: View {
 }
 
 #if DEBUG
-@available(iOS 17.0, *)
 #Preview("Details - Order 1") {
     NavigationStack {
         PointOfSaleOrderDetailsView(orderID: "order1", onBack: {})
     }
 }
 
-@available(iOS 17.0, *)
 #Preview("Details - Order 2") {
     NavigationStack {
         PointOfSaleOrderDetailsView(orderID: "order2", onBack: {})

--- a/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrderDetailsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrderDetailsView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+@available(iOS 17.0, *)
+struct PointOfSaleOrderDetailsView: View {
+    let orderID: String
+    let onBack: () -> Void
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    private var orderTitle: String {
+        switch orderID {
+        case "order1":
+            return "Order 1"
+        case "order2":
+            return "Order 2"
+        default:
+            return "Unknown Order"
+        }
+    }
+
+    // Show back button when in compact mode (phone) where the detail view
+    // is presented as a pushed view, not when in regular mode (tablet split view)
+    private var shouldShowBackButton: Bool {
+        horizontalSizeClass == .compact
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            POSPageHeaderView(
+                title: orderTitle,
+                backButtonConfiguration: shouldShowBackButton ?
+                    .init(state: .enabled, action: onBack) : nil
+            )
+
+            VStack(alignment: .leading, spacing: 20) {
+                Text("Order details will be displayed here")
+                    .foregroundColor(.secondary)
+
+                Spacer()
+            }
+            .padding()
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+        .background(Color.posSurface)
+        .navigationTitle(orderTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarHidden(true)
+    }
+}
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview("Details - Order 1") {
+    NavigationStack {
+        PointOfSaleOrderDetailsView(orderID: "order1", onBack: {})
+    }
+}
+
+@available(iOS 17.0, *)
+#Preview("Details - Order 2") {
+    NavigationStack {
+        PointOfSaleOrderDetailsView(orderID: "order2", onBack: {})
+    }
+}
+#endif

--- a/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrderDetailsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrderDetailsView.swift
@@ -41,8 +41,6 @@ struct PointOfSaleOrderDetailsView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .background(Color.posSurface)
-        .navigationTitle(orderTitle)
-        .navigationBarTitleDisplayMode(.inline)
         .navigationBarHidden(true)
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrdersListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrdersListView.swift
@@ -23,6 +23,7 @@ struct PointOfSaleOrdersListView: View {
                         .padding(.vertical, 8)
                 }
             }
+            .listStyle(.plain)
         }
         .background(Color.posSurfaceBright)
         .navigationBarHidden(true)

--- a/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrdersListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrdersListView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct PointOfSaleOrdersListView: View {
     @Binding var selectedOrderID: String?
     let onClose: () -> Void
@@ -36,7 +35,6 @@ private struct Order {
 }
 
 #if DEBUG
-@available(iOS 17.0, *)
 #Preview("List") {
     NavigationSplitView {
         PointOfSaleOrdersListView(selectedOrderID: .constant("order1"), onClose: {})

--- a/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrdersListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrdersListView.swift
@@ -6,8 +6,8 @@ struct PointOfSaleOrdersListView: View {
     let onClose: () -> Void
 
     private let orders = [
-        OrderItem(id: "order1", title: "Order 1"),
-        OrderItem(id: "order2", title: "Order 2")
+        Order(id: "order1", title: "Order 1"),
+        Order(id: "order2", title: "Order 2")
     ]
 
     var body: some View {
@@ -23,14 +23,13 @@ struct PointOfSaleOrdersListView: View {
                         .padding(.vertical, 8)
                 }
             }
-            .listStyle(.plain)
         }
         .background(Color.posSurfaceBright)
         .navigationBarHidden(true)
     }
 }
 
-private struct OrderItem {
+private struct Order {
     let id: String
     let title: String
 }

--- a/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrdersListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrdersListView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+@available(iOS 17.0, *)
+struct PointOfSaleOrdersListView: View {
+    @Binding var selectedOrderID: String?
+    let onClose: () -> Void
+
+    private let orders = [
+        OrderItem(id: "order1", title: "Order 1"),
+        OrderItem(id: "order2", title: "Order 2")
+    ]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            POSPageHeaderView(
+                title: "Orders",
+                backButtonConfiguration: .init(state: .enabled, action: onClose, buttonIcon: "xmark")
+            )
+
+            List(orders, id: \.id, selection: $selectedOrderID) { order in
+                NavigationLink(value: order.id) {
+                    Text(order.title)
+                        .padding(.vertical, 8)
+                }
+            }
+            .listStyle(.plain)
+        }
+        .background(Color.posSurfaceBright)
+        .navigationBarHidden(true)
+    }
+}
+
+private struct OrderItem {
+    let id: String
+    let title: String
+}
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview("List") {
+    NavigationSplitView {
+        PointOfSaleOrdersListView(selectedOrderID: .constant("order1"), onClose: {})
+    } detail: {
+        Text("Detail View")
+    }
+}
+#endif

--- a/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrdersView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrdersView.swift
@@ -24,7 +24,7 @@ struct PointOfSaleOrdersView: View {
 }
 
 // MARK: - Split View
-/// An alternative split view implementation that gives more control of the splti view design, including the sidebar and content arrangement and separator colors
+/// An alternative split view implementation that gives more control of the split view design, including the sidebar and content arrangement and separator colors
 /// Just as NavigationSplitView, it adapts to a list -> details navigation on smaller screens
 /// It may be used as a common component in the future
 ///

--- a/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrdersView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrdersView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import UIKit
+
+@available(iOS 17.0, *)
+struct PointOfSaleOrdersView: View {
+    @Binding var isPresented: Bool
+    @State private var selectedOrderID: String? = "order1"
+    @State private var listWidth: CGFloat = Constants.defaultListWidth
+
+    var body: some View {
+        NavigationSplitView(columnVisibility: .constant(.all)) {
+            PointOfSaleOrdersListView(selectedOrderID: $selectedOrderID) {
+                isPresented = false
+            }
+            .navigationSplitViewColumnWidth(ideal: listWidth)
+        } detail: {
+            if let selectedOrderID = selectedOrderID {
+                PointOfSaleOrderDetailsView(
+                    orderID: selectedOrderID,
+                    onBack: {
+                        $selectedOrderID.wrappedValue = nil
+                    }
+                )
+            } else {
+                VStack {
+                    Text("Select an order to view details")
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color.posSurface)
+            }
+        }
+        .navigationSplitViewStyle(.balanced)
+        .background(Color.posSurface)
+        .navigationBarBackButtonHidden(true)
+        .measureWidth { totalWidth in
+            // Calculate list width as 35% of total width (matching CartView proportion)
+            listWidth = totalWidth * Constants.listWidthRatio
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+private extension PointOfSaleOrdersView {
+    enum Constants {
+        // List width ratio - list takes 35% (matching CartView), detail takes 65% (matching ItemListView)
+        static let listWidthRatio: CGFloat = 0.35
+        static let defaultListWidth: CGFloat = 400
+    }
+}
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview("Orders View") {
+    PointOfSaleOrdersView(isPresented: .constant(true))
+}
+#endif

--- a/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrdersView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrdersView.swift
@@ -4,49 +4,91 @@ import UIKit
 @available(iOS 17.0, *)
 struct PointOfSaleOrdersView: View {
     @Binding var isPresented: Bool
-    @State private var selectedOrderID: String? = "order1"
-    @State private var listWidth: CGFloat = Constants.defaultListWidth
+    @State private var selectedOrderID: String?
 
     var body: some View {
-        NavigationSplitView(columnVisibility: .constant(.all)) {
+        CustomNavigationSplitView(selection: $selectedOrderID) { _ in
             PointOfSaleOrdersListView(selectedOrderID: $selectedOrderID) {
                 isPresented = false
             }
-            .navigationSplitViewColumnWidth(ideal: listWidth)
-        } detail: {
-            if let selectedOrderID = selectedOrderID {
-                PointOfSaleOrderDetailsView(
-                    orderID: selectedOrderID,
-                    onBack: {
-                        $selectedOrderID.wrappedValue = nil
-                    }
-                )
-            } else {
-                VStack {
-                    Text("Select an order to view details")
-                        .foregroundColor(.secondary)
+        } detail: { selection in
+            PointOfSaleOrderDetailsView(
+                orderID: selection,
+                onBack: {
+                    $selectedOrderID.wrappedValue = nil
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color.posSurface)
-            }
-        }
-        .navigationSplitViewStyle(.balanced)
-        .background(Color.posSurface)
-        .navigationBarBackButtonHidden(true)
-        .measureWidth { totalWidth in
-            // Calculate list width as 35% of total width (matching CartView proportion)
-            listWidth = totalWidth * Constants.listWidthRatio
+            )
+        } setDefaultValue: {
+            selectedOrderID = "order1"
         }
     }
 }
 
+// MARK: - Split View
+/// An alternative split view implementation that gives more control of the splti view design, including the sidebar and content arrangement and separator colors
+/// Just as NavigationSplitView, it adapts to a list -> details navigation on smaller screens
+/// It may be used as a common component in the future
+///
 @available(iOS 17.0, *)
-private extension PointOfSaleOrdersView {
-    enum Constants {
-        // List width ratio - list takes 35% (matching CartView), detail takes 65% (matching ItemListView)
-        static let listWidthRatio: CGFloat = 0.35
-        static let defaultListWidth: CGFloat = 400
+private struct CustomNavigationSplitView<Sidebar: View, Detail: View, SelectionValue: Hashable>: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Binding private var selection: SelectionValue?
+
+    private let sidebar: (Binding<SelectionValue?>) -> Sidebar
+    private let detail: (SelectionValue) -> Detail
+    private let setDefaultValue: (() -> Void)?
+
+    init(
+        selection: Binding<SelectionValue?> = .constant(nil),
+        @ViewBuilder sidebar: @escaping (Binding<SelectionValue?>) -> Sidebar,
+        @ViewBuilder detail: @escaping (SelectionValue) -> Detail,
+        setDefaultValue: (() -> Void)? = nil
+    ) {
+        self._selection = selection
+        self.sidebar = sidebar
+        self.detail = detail
+        self.setDefaultValue = setDefaultValue
     }
+
+    var body: some View {
+        switch horizontalSizeClass {
+        case .regular:
+            GeometryReader { geometry in
+                HStack(spacing: 0) {
+                    sidebar($selection)
+                        .frame(width: geometry.size.width * Constants.sidebarWidthFraction)
+
+                    if let selection = selection {
+                        detail(selection)
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        EmptyView()
+                    }
+                }
+            }
+            .onAppear {
+                if selection == nil {
+                    setDefaultValue?()
+                }
+            }
+        default:
+            NavigationStack {
+                sidebar($selection)
+                    .navigationDestination(isPresented: Binding(
+                        get: { selection != nil },
+                        set: { if !$0 { selection = nil } }
+                    )) {
+                        if let selection = selection {
+                            detail(selection)
+                        }
+                    }
+            }
+        }
+    }
+}
+
+private enum Constants {
+    static let sidebarWidthFraction: CGFloat = 0.35
 }
 
 #if DEBUG

--- a/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrdersView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrdersView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import UIKit
 
-@available(iOS 17.0, *)
 struct PointOfSaleOrdersView: View {
     @Binding var isPresented: Bool
     @State private var selectedOrderID: String?
@@ -29,7 +28,6 @@ struct PointOfSaleOrdersView: View {
 /// Just as NavigationSplitView, it adapts to a list -> details navigation on smaller screens
 /// It may be used as a common component in the future
 ///
-@available(iOS 17.0, *)
 private struct CustomNavigationSplitView<Sidebar: View, Detail: View, SelectionValue: Hashable>: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Binding private var selection: SelectionValue?
@@ -92,7 +90,6 @@ private enum Constants {
 }
 
 #if DEBUG
-@available(iOS 17.0, *)
 #Preview("Orders View") {
     PointOfSaleOrdersView(isPresented: .constant(true))
 }

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -11,6 +11,7 @@ struct POSFloatingControlView: View {
     @Binding private var showSettings: Bool
     @State private var showProductRestrictionsModal: Bool = false
     @State private var showBarcodeScanningModal: Bool = false
+    @State private var showOrders: Bool = false
 
     init(showExitPOSModal: Binding<Bool>,
          showSupport: Binding<Bool>,
@@ -83,7 +84,7 @@ struct POSFloatingControlView: View {
 
                 if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleHistoricalOrdersi1) {
                     Button {
-                        // TODO: WOOMOB-1133
+                        showOrders = true
                     } label: {
                         Label(
                             title: { Text(Localization.orders) },
@@ -118,6 +119,9 @@ struct POSFloatingControlView: View {
         }
         .posModal(isPresented: $showBarcodeScanningModal) {
             PointOfSaleBarcodeScannerSetup(isPresented: $showBarcodeScanningModal)
+        }
+        .fullScreenCover(isPresented: $showOrders) {
+            PointOfSaleOrdersView(isPresented: $showOrders)
         }
         .frame(height: Constants.size)
         .background(Color.clear)

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -120,7 +120,7 @@ struct POSFloatingControlView: View {
         .posModal(isPresented: $showBarcodeScanningModal) {
             PointOfSaleBarcodeScannerSetup(isPresented: $showBarcodeScanningModal)
         }
-        .fullScreenCover(isPresented: $showOrders) {
+        .posFullScreenCover(isPresented: $showOrders) {
             PointOfSaleOrdersView(isPresented: $showOrders)
         }
         .frame(height: Constants.size)

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct POSFloatingControlView: View {
     @Environment(\.posBackgroundAppearance) var backgroundAppearance
     @Environment(PointOfSaleAggregateModel.self) private var posModel
@@ -130,7 +129,6 @@ struct POSFloatingControlView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private extension POSFloatingControlView {
     var backgroundColor: Color {
         switch backgroundAppearance {
@@ -151,14 +149,12 @@ private extension POSFloatingControlView {
     }
 }
 
-@available(iOS 17.0, *)
 extension POSFloatingControlView {
     static var secondaryFontColor: Color {
         .posOnDisabledContainer
     }
 }
 
-@available(iOS 17.0, *)
 private extension POSFloatingControlView {
     enum Constants {
         static let size: CGFloat = 80
@@ -214,7 +210,6 @@ private extension POSFloatingControlView {
 
 #if DEBUG
 
-@available(iOS 17.0, *)
 #Preview("Reader Disconnected") {
     POSFloatingControlView(showExitPOSModal: .constant(false),
                            showSupport: .constant(false),
@@ -224,7 +219,6 @@ private extension POSFloatingControlView {
         .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }
 
-@available(iOS 17.0, *)
 #Preview("Reader Connected") {
     let paymentService = CardPresentPaymentPreviewService()
     paymentService.readerConnectionStatus = .connected(.init(name: "", batteryLevel: 0.6))
@@ -239,7 +233,6 @@ private extension POSFloatingControlView {
         .environment(posModel)
 }
 
-@available(iOS 17.0, *)
 #Preview("Secondary/disabled Background") {
     POSFloatingControlView(showExitPOSModal: .constant(false),
                            showSupport: .constant(false),

--- a/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
+++ b/WooCommerce/Classes/POS/Presentation/PaymentButtons.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct PaymentsActionButtons: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Binding var isShowingSendReceiptView: Bool
@@ -18,7 +17,6 @@ struct PaymentsActionButtons: View {
     }
 }
 
-@available(iOS 17.0, *)
 private extension PaymentsActionButtons {
     var sendReceiptButton: some View {
         Button(action: {
@@ -47,7 +45,6 @@ private extension PaymentsActionButtons {
     }
 }
 
-@available(iOS 17.0, *)
 private extension PaymentsActionButtons {
     func handleSendReceiptAction() async {
         let isEligible = await checkReceiptEligibility()
@@ -67,7 +64,6 @@ private extension PaymentsActionButtons {
     }
 }
 
-@available(iOS 17.0, *)
 private extension PaymentsActionButtons {
     enum Constants {
         static let buttonSpacing: CGFloat = POSSpacing.medium
@@ -86,7 +82,6 @@ private extension PaymentsActionButtons {
 }
 
 #if DEBUG
-@available(iOS 17.0, *)
 #Preview {
     PaymentsActionButtons(isShowingSendReceiptView: .constant(false), isShowingReceiptNotEligibleBanner: .constant(true))
         .environment(POSPreviewHelpers.makePreviewAggregateModel())

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerInformationModal.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerInformationModal.swift
@@ -91,7 +91,6 @@ struct BarcodeScannerInformation: View {
     }
 }
 
-@available(iOS 17.0, *)
 struct ProductBarcodeSetupInformation: View {
     var body: some View {
         VStack(spacing: POSSpacing.xLarge) {
@@ -281,7 +280,6 @@ private enum Localization {
     )
 }
 
-@available(iOS 17.0, *)
 #Preview {
     PointOfSaleBarcodeScannerInformationModal(isPresented: .constant(true))
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import Combine
 import WooFoundation
 
-@available(iOS 17.0, *)
 struct PointOfSaleCollectCashView: View {
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
     @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
@@ -120,7 +119,6 @@ struct PointOfSaleCollectCashView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSaleCollectCashView {
     private func submitCashAmount() async {
         guard validateAmountOnSubmit() else {
@@ -152,7 +150,6 @@ private extension PointOfSaleCollectCashView {
         }
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSaleCollectCashView {
     enum Constants {
         static let minimumPadding: CGFloat = POSSpacing.xSmall
@@ -197,7 +194,6 @@ private extension PointOfSaleCollectCashView {
 }
 
 #if DEBUG
-@available(iOS 17.0, *)
 #Preview {
     PointOfSaleCollectCashView(orderTotal: "$1.23")
         .environment(POSPreviewHelpers.makePreviewAggregateModel())

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct PointOfSaleDashboardView: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -187,7 +186,6 @@ struct PointOfSaleDashboardView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSaleDashboardView {
     var supportForm: some View {
         NavigationView {
@@ -224,7 +222,6 @@ private extension PointOfSaleDashboardView {
     }
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSaleDashboardView {
     func trackTimeForInitialLoadingState() {
         waitingTimeTracker = WaitingTimeTracker(trackScenario: .pointOfSaleLoaded)
@@ -249,7 +246,6 @@ extension EnvironmentValues {
     }
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSaleDashboardView {
     enum Constants {
         // For the moment we're just considering landscape for the POS mode
@@ -273,7 +269,6 @@ private extension PointOfSaleDashboardView {
 
 #if DEBUG
 
-@available(iOS 17.0, *)
 #Preview("Container loading state") {
     return NavigationStack {
         PointOfSaleDashboardView()
@@ -282,7 +277,6 @@ private extension PointOfSaleDashboardView {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview("Content loading state") {
     let itemsController = PointOfSalePreviewItemsController()
     itemsController.itemsViewState = .init(containerState: .content, itemsStack: .init(root: .loading([]), itemStates: [:]))

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import protocol Yosemite.POSSearchHistoryProviding
 import protocol Yosemite.PointOfSaleBarcodeScanServiceProtocol
 
-@available(iOS 17.0, *)
 struct PointOfSaleEntryPointView: View {
     @State private var posModel: PointOfSaleAggregateModel?
     @StateObject private var posModalManager = POSModalManager()
@@ -92,7 +91,6 @@ struct PointOfSaleEntryPointView: View {
 }
 
 #if DEBUG
-@available(iOS 17.0, *)
 #Preview {
     PointOfSaleEntryPointView(itemsController: PointOfSalePreviewItemsController(),
                               purchasableItemsSearchController: PointOfSalePreviewItemsController(),

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleExitPosAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleExitPosAlertView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct PointOfSaleExitPosAlertView: View {
     @Environment(\.dismiss) private var dismiss
     @Binding private var isPresented: Bool
@@ -39,7 +38,6 @@ struct PointOfSaleExitPosAlertView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private extension PointOfSaleExitPosAlertView {
     enum Constants {
         static let verticalSpacing: CGFloat = POSSpacing.xLarge
@@ -66,7 +64,6 @@ private extension PointOfSaleExitPosAlertView {
 }
 
 #if DEBUG
-@available(iOS 17.0, *)
 #Preview {
     PointOfSaleExitPosAlertView(isPresented: .constant(true))
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderBackButton.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderBackButton.swift
@@ -6,7 +6,7 @@ struct POSPageHeaderBackButton: View {
     init(configuration: POSPageHeaderBackButtonConfiguration) {
         self.configuration = configuration
     }
-    
+
     private var buttonIcon: String {
         configuration.buttonIcon ?? Constants.defaultBackButtonIcon
     }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderBackButton.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderBackButton.swift
@@ -6,10 +6,14 @@ struct POSPageHeaderBackButton: View {
     init(configuration: POSPageHeaderBackButtonConfiguration) {
         self.configuration = configuration
     }
+    
+    private var buttonIcon: String {
+        configuration.buttonIcon ?? Constants.defaultBackButtonIcon
+    }
 
     var body: some View {
         Button(action: configuration.action) {
-            Text(Image(systemName: Constants.backButtonIcon))
+            Text(Image(systemName: buttonIcon))
                 .font(.posButtonSymbolLarge)
                 .dynamicTypeSize(...POSHeaderLayoutConstants.maximumDynamicTypeSize)
                 .foregroundColor(configuration.state == .disabled ? .posOnSurfaceVariantLowest : .posOnSurface)
@@ -24,7 +28,7 @@ struct POSPageHeaderBackButton: View {
 
 private extension POSPageHeaderBackButton {
     enum Constants {
-        static let backButtonIcon = "chevron.backward"
+        static let defaultBackButtonIcon = "chevron.backward"
         /// Icon container is 48x48, chevron icon width is 24px. Therefore, adding a horizontal padding (48-24)/2 = 12.
         static let backButtonHorizontalPadding: CGFloat = 12
     }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderView.swift
@@ -11,7 +11,7 @@ struct POSPageHeaderBackButtonConfiguration {
     let state: State
     let action: () -> Void
     let buttonIcon: String?
-    
+
     init(state: State, action: @escaping () -> Void, buttonIcon: String? = nil) {
         self.state = state
         self.action = action

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderView.swift
@@ -36,7 +36,6 @@ struct POSPageHeaderItem: Identifiable {
 
 /// A header view for POS pages.
 /// Design ref: 1qcjzXitBHU7xPnpCOWnNM-fi-450_24951
-@available(iOS 17.0, *)
 struct POSPageHeaderView<TrailingContent: View>: View {
     private let items: [POSPageHeaderItem]
     private let backButtonConfiguration: POSPageHeaderBackButtonConfiguration?
@@ -140,7 +139,6 @@ private enum Constants {
 
 
 
-@available(iOS 17.0, *)
 #Preview {
     @Previewable @State var isProductsSelected: Bool = true
 

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPageHeaderView.swift
@@ -10,6 +10,13 @@ struct POSPageHeaderBackButtonConfiguration {
 
     let state: State
     let action: () -> Void
+    let buttonIcon: String?
+    
+    init(state: State, action: @escaping () -> Void, buttonIcon: String? = nil) {
+        self.state = state
+        self.action = action
+        self.buttonIcon = buttonIcon
+    }
 }
 
 struct POSPageHeaderItem: Identifiable {

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -3,7 +3,6 @@ import Combine
 import WooFoundation
 import class WordPressShared.EmailFormatValidator
 
-@available(iOS 17.0, *)
 struct POSSendReceiptView: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
@@ -115,7 +114,6 @@ struct POSSendReceiptView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private extension POSSendReceiptView {
     enum Constants {
         static let minimumPadding: CGFloat = POSSpacing.xSmall
@@ -129,7 +127,6 @@ private extension POSSendReceiptView {
     }
 }
 
-@available(iOS 17.0, *)
 private extension POSSendReceiptView {
     struct Localization {
         static let buttonTitle = NSLocalizedString(
@@ -156,7 +153,6 @@ private extension POSSendReceiptView {
 }
 
 #if DEBUG
-@available(iOS 17.0, *)
 #Preview {
     POSSendReceiptView(isShowingSendReceiptView: .constant(true))
         .environment(POSPreviewHelpers.makePreviewAggregateModel())

--- a/WooCommerce/Classes/POS/Presentation/SimpleProductsOnlyInformation.swift
+++ b/WooCommerce/Classes/POS/Presentation/SimpleProductsOnlyInformation.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct SimpleProductsOnlyInformation: View {
     @Binding var isPresented: Bool
     let deepLinkNavigator: DeepLinkNavigator?
@@ -48,7 +47,6 @@ struct SimpleProductsOnlyInformation: View {
 }
 
 // Constants and Localization enums
-@available(iOS 17.0, *)
 private extension SimpleProductsOnlyInformation {
     enum Localization {
         static let modalTitle = NSLocalizedString(
@@ -85,7 +83,6 @@ private extension SimpleProductsOnlyInformation {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview {
     SimpleProductsOnlyInformation(isPresented: .constant(true),
                                   deepLinkNavigator: nil)

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct TotalsView: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     private let viewHelper = TotalsViewHelper()
@@ -103,7 +102,6 @@ struct TotalsView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private extension TotalsView {
     private func hideTotalsFieldsWithDelay(_ isShowing: Bool) {
         guard !isShowing && posModel.paymentState.card == .processingPayment else {
@@ -118,7 +116,6 @@ private extension TotalsView {
 }
 
 
-@available(iOS 17.0, *)
 private extension TotalsView {
     struct PaymentViewLayout {
         let backgroundColor: Color
@@ -212,7 +209,6 @@ private extension TotalsView {
     }
 }
 
-@available(iOS 17.0, *)
 extension TotalsView {
     fileprivate struct PaymentViewPaddingModifier: ViewModifier {
         @Environment(\.dynamicTypeSize) var dynamicTypeSize
@@ -229,14 +225,12 @@ extension TotalsView {
     }
 }
 
-@available(iOS 17.0, *)
 fileprivate extension View {
     func paymentViewPadding(layout: TotalsView.PaymentViewLayout) -> some View {
         modifier(TotalsView.PaymentViewPaddingModifier(layout: layout))
     }
 }
 
-@available(iOS 17.0, *)
 private extension TotalsView {
     enum Constants {
         static let pricesIdealWidth: CGFloat = 382
@@ -290,7 +284,6 @@ private extension TotalsView {
     }
 }
 
-@available(iOS 17.0, *)
 private struct TotalsFieldsContent: View {
     let orderState: PointOfSaleOrderState
     let paymentState: PointOfSalePaymentState
@@ -360,7 +353,6 @@ private struct TotalsFieldsContent: View {
     }
 }
 
-@available(iOS 17.0, *)
 private struct SubtotalFieldView: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
@@ -395,7 +387,6 @@ private struct SubtotalFieldView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private struct TotalFieldView: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
@@ -431,7 +422,6 @@ private struct TotalFieldView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private struct ShimmeringLineView: View {
     let width: CGFloat
     let height: CGFloat
@@ -445,7 +435,6 @@ private struct ShimmeringLineView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private struct PaymentViewContent: View {
     let paymentState: PointOfSalePaymentState
     let cardReaderViewLayout: TotalsView.PaymentViewLayout
@@ -490,7 +479,6 @@ private struct PaymentViewContent: View {
     }
 }
 
-@available(iOS 17.0, *)
 private struct CashPaymentView: View {
     let cashPaymentState: PointOfSaleCashPaymentState
     let orderState: PointOfSaleOrderState
@@ -515,7 +503,6 @@ private struct CashPaymentView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private struct CardPaymentView: View {
     let cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus
     let paymentState: PointOfSalePaymentState
@@ -545,7 +532,6 @@ private struct CardPaymentView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private struct CashPaymentButton: View {
     let orderState: PointOfSaleOrderState
     let paymentState: PointOfSalePaymentState
@@ -577,7 +563,6 @@ private struct CashPaymentButton: View {
 }
 
 #if DEBUG
-@available(iOS 17.0, *)
 #Preview {
     TotalsView()
         .environment(POSPreviewHelpers.makePreviewAggregateModel())

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 /// A view that displays when the Point of Sale (POS) feature is not available for the current store.
 /// Shows the specific reason why POS is ineligible and provides a button to re-check eligibility.
-@available(iOS 17.0, *)
 struct POSIneligibleView: View {
     let reason: POSIneligibleReason
     let onRefresh: () async throws -> Void
@@ -158,7 +157,6 @@ struct POSIneligibleView: View {
     }
 }
 
-@available(iOS 17.0, *)
 private extension POSIneligibleView {
     enum Localization {
         static let title = NSLocalizedString(
@@ -175,7 +173,6 @@ private extension POSIneligibleView {
     }
 }
 
-@available(iOS 17.0, *)
 private extension POSIneligibleReason {
     var shouldShowRetryButton: Bool {
         switch self {

--- a/WooCommerce/Classes/POS/Utils/POSBrightnessControl.swift
+++ b/WooCommerce/Classes/POS/Utils/POSBrightnessControl.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import UIKit
 
-@available(iOS 17.0, *)
 @Observable
 final class POSBrightnessControl {
     private var originalBrightness: CGFloat = 0.0
@@ -34,7 +33,6 @@ final class POSBrightnessControl {
 }
 
 /// SwiftUI View Modifier for automatic brightness control
-@available(iOS 17.0, *)
 struct POSBrightnessControlModifier: ViewModifier {
     @State private var brightnessControl = POSBrightnessControl()
 
@@ -49,7 +47,6 @@ struct POSBrightnessControlModifier: ViewModifier {
     }
 }
 
-@available(iOS 17.0, *)
 extension View {
     /// Applies brightness control to the view, increasing brightness to maximum when the view appears
     func maximumScreenBrightness() -> some View {

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -82,7 +82,6 @@ struct PointOfSalePreviewPurchasableItemFetchStrategy: PointOfSalePurchasableIte
     }
 }
 
-@available(iOS 17.0, *)
 final class PointOfSalePreviewCouponsController: PointOfSaleCouponsControllerProtocol {
     @Published var itemsViewState: ItemsViewState = ItemsViewState(containerState: .loading,
                                                                    itemsStack: ItemsStackState(root: .loading([]),
@@ -95,7 +94,6 @@ final class PointOfSalePreviewCouponsController: PointOfSaleCouponsControllerPro
     func clearSearchItems(baseItem: ItemListBaseItem) { }
 }
 
-@available(iOS 17.0, *)
 final class PointOfSalePreviewItemsController: PointOfSaleSearchingItemsControllerProtocol {
     @Published var itemsViewState: ItemsViewState = ItemsViewState(containerState: .loading,
                                                                    itemsStack: ItemsStackState(root: .loading([]),
@@ -130,7 +128,6 @@ final class PointOfSalePreviewItemsController: PointOfSaleSearchingItemsControll
     }
 }
 
-@available(iOS 17.0, *)
 final class PointOfSalePreviewItemActionHandler: POSItemActionHandler {
     func handleTap(_ item: Yosemite.POSItem) { }
 }
@@ -204,7 +201,6 @@ final class POSConnectivityObserverPreview: ConnectivityObserver {
     func stopObserving() {}
 }
 
-@available(iOS 17.0, *)
 struct POSPreviewHelpers {
     static func makePreviewAggregateModel(
         itemsController: PointOfSaleItemsControllerProtocol = PointOfSalePreviewItemsController(),

--- a/WooCommerce/Classes/POS/ViewHelpers/PointOfSaleDashboardViewHelper.swift
+++ b/WooCommerce/Classes/POS/ViewHelpers/PointOfSaleDashboardViewHelper.swift
@@ -1,7 +1,6 @@
 import Foundation
 import SwiftUI
 
-@available(iOS 17.0, *)
 struct PointOfSaleDashboardViewHelper {
     static func determineViewState(
         eligibilityState: POSEligibilityState?,
@@ -32,7 +31,6 @@ struct PointOfSaleDashboardViewHelper {
     }
 }
 
-@available(iOS 17.0, *)
 extension PointOfSaleDashboardView.ViewState {
     var showsFloatingControl: Bool {
         switch self {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -572,7 +572,6 @@ struct EditAddressForm_Previews: PreviewProvider {
     }
 }
 
-@available(iOS 17.0, *)
 #Preview("Single address form") {
     @Previewable @State var viewModel = EditOrderAddressFormViewModel(order: sampleOrder, type: .shipping)
     ScrollView {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/KeyboardObserver.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/KeyboardObserver.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import Combine
 
-@available(iOS 17.0, *)
 @Observable
 final class KeyboardObserver {
     private(set) var isKeyboardVisible: Bool = false
@@ -48,7 +47,6 @@ final class KeyboardObserver {
     }
 }
 
-@available(iOS 17.0, *)
 private extension KeyboardObserver {
     enum Constants {
         static let hardwareKeyboardHelperBarHeightThreshold: CGFloat = 90
@@ -56,14 +54,12 @@ private extension KeyboardObserver {
 }
 
 
-@available(iOS 17.0, *)
 private struct KeyboardObserverKey: EnvironmentKey {
     static var defaultValue: KeyboardObserver {
         KeyboardObserver()
     }
 }
 
-@available(iOS 17.0, *)
 extension EnvironmentValues {
     var keyboardObserver: KeyboardObserver {
         get { self[KeyboardObserverKey.self] }
@@ -71,7 +67,6 @@ extension EnvironmentValues {
     }
 }
 
-@available(iOS 17.0, *)
 struct KeyboardObserverProvider: ViewModifier {
     @State private var observer = KeyboardObserver()
 
@@ -80,7 +75,6 @@ struct KeyboardObserverProvider: ViewModifier {
     }
 }
 
-@available(iOS 17.0, *)
 extension View {
     func injectKeyboardObserver() -> some View {
         modifier(KeyboardObserverProvider())

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -81,6 +81,9 @@
 		01AB2D122DDC7AD300AA67FD /* PointOfSaleItemListAnalyticsTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AB2D112DDC7AD100AA67FD /* PointOfSaleItemListAnalyticsTrackerTests.swift */; };
 		01AB2D142DDC7CD200AA67FD /* POSItemActionHandlerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AB2D132DDC7CD000AA67FD /* POSItemActionHandlerFactoryTests.swift */; };
 		01AB2D162DDC8CDA00AA67FD /* MockAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AB2D152DDC8CD600AA67FD /* MockAnalytics.swift */; };
+		01ABA0282E57579300829DC0 /* PointOfSaleOrdersListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ABA0252E57579300829DC0 /* PointOfSaleOrdersListView.swift */; };
+		01ABA0292E57579300829DC0 /* PointOfSaleOrderDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ABA0242E57579300829DC0 /* PointOfSaleOrderDetailsView.swift */; };
+		01ABA02A2E57579300829DC0 /* PointOfSaleOrdersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ABA0262E57579300829DC0 /* PointOfSaleOrdersView.swift */; };
 		01ADC1362C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ADC1352C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift */; };
 		01ADC1382C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ADC1372C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift */; };
 		01B3A1F22DB6D48800286B7F /* ItemListType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B3A1F12DB6D48800286B7F /* ItemListType.swift */; };
@@ -3272,6 +3275,9 @@
 		01AB2D112DDC7AD100AA67FD /* PointOfSaleItemListAnalyticsTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleItemListAnalyticsTrackerTests.swift; sourceTree = "<group>"; };
 		01AB2D132DDC7CD000AA67FD /* POSItemActionHandlerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSItemActionHandlerFactoryTests.swift; sourceTree = "<group>"; };
 		01AB2D152DDC8CD600AA67FD /* MockAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAnalytics.swift; sourceTree = "<group>"; };
+		01ABA0242E57579300829DC0 /* PointOfSaleOrderDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleOrderDetailsView.swift; sourceTree = "<group>"; };
+		01ABA0252E57579300829DC0 /* PointOfSaleOrdersListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleOrdersListView.swift; sourceTree = "<group>"; };
+		01ABA0262E57579300829DC0 /* PointOfSaleOrdersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleOrdersView.swift; sourceTree = "<group>"; };
 		01ADC1352C9AB4810036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentIntentCreationErrorMessageViewModel.swift; sourceTree = "<group>"; };
 		01ADC1372C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift; sourceTree = "<group>"; };
 		01B3A1F12DB6D48800286B7F /* ItemListType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListType.swift; sourceTree = "<group>"; };
@@ -6507,6 +6513,16 @@
 			path = "Tap to Pay Education";
 			sourceTree = "<group>";
 		};
+		01ABA0272E57579300829DC0 /* Orders */ = {
+			isa = PBXGroup;
+			children = (
+				01ABA0242E57579300829DC0 /* PointOfSaleOrderDetailsView.swift */,
+				01ABA0252E57579300829DC0 /* PointOfSaleOrdersListView.swift */,
+				01ABA0262E57579300829DC0 /* PointOfSaleOrdersView.swift */,
+			);
+			path = Orders;
+			sourceTree = "<group>";
+		};
 		01BB6C082D09E9200094D55B /* Location */ = {
 			isa = PBXGroup;
 			children = (
@@ -7169,6 +7185,7 @@
 				02E71DB42C118C470036C2FD /* Card Present Payments */,
 				026826B02BF59E170036F959 /* CardReaderConnection */,
 				014BD4B62C64E26B0011A66E /* Order Messages */,
+				01ABA0272E57579300829DC0 /* Orders */,
 				02B1914A2CCF278100CF38C9 /* Payments Onboarding */,
 				026826A72BF59DF70036F959 /* PointOfSaleEntryPointView.swift */,
 				68A345632D029E09002EE324 /* PaymentButtons.swift */,
@@ -15186,6 +15203,9 @@
 				016910982E1D019500B731DA /* GameControllerBarcodeObserver.swift in Sources */,
 				EE9D031B2B89E4470077CED1 /* FilterOrdersByProduct+Analytics.swift in Sources */,
 				20C6E7512CDE4AEA00CD124C /* ItemListState.swift in Sources */,
+				01ABA0282E57579300829DC0 /* PointOfSaleOrdersListView.swift in Sources */,
+				01ABA0292E57579300829DC0 /* PointOfSaleOrderDetailsView.swift in Sources */,
+				01ABA02A2E57579300829DC0 /* PointOfSaleOrdersView.swift in Sources */,
 				2DB891662E27F0830001B175 /* Address+Shared.swift in Sources */,
 				DEC17AE02D82C513005A6E6D /* WooShippingHazmatDetailView.swift in Sources */,
 				86967D812B4E21C600C20CA8 /* BlazeAddParameterViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Controllers/POSEntryPointControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/POSEntryPointControllerTests.swift
@@ -2,7 +2,6 @@ import Testing
 @testable import WooCommerce
 
 struct POSEntryPointControllerTests {
-    @available(iOS 17.0, *)
     @Test func eligibilityState_is_always_eligible_when_i2_feature_is_disabled_regardless_of_eligibility_checker() async throws {
         // Given
         let mockEligibilityChecker = MockPOSEligibilityChecker()
@@ -19,7 +18,6 @@ struct POSEntryPointControllerTests {
         #expect(controller.eligibilityState == .eligible)
     }
 
-    @available(iOS 17.0, *)
     @Test func eligibilityState_is_set_to_ineligible_when_i2_feature_is_enabled_and_checker_returns_ineligible() async throws {
         // Given
         let mockEligibilityChecker = MockPOSEligibilityChecker()
@@ -40,7 +38,6 @@ struct POSEntryPointControllerTests {
         #expect(controller.eligibilityState == expectedState)
     }
 
-    @available(iOS 17.0, *)
     @Test func eligibilityState_is_set_to_eligible_when_i2_feature_is_enabled_and_checker_returns_eligible() async throws {
         // Given
         let mockEligibilityChecker = MockPOSEligibilityChecker()

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleCouponsControllerTests.swift
@@ -14,7 +14,6 @@ struct PointOfSaleCouponsControllerTests {
                                                                      storage: MockStorageManager())
     }
 
-    @available(iOS 17.0, *)
     @Test func loadItems_when_empty_coupons_then_results_in_empty_state() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
@@ -31,7 +30,6 @@ struct PointOfSaleCouponsControllerTests {
         #expect(sut.itemsViewState == expectedViewState)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadItems_when_some_coupons_then_results_in_coupons_loaded_state() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
@@ -48,7 +46,6 @@ struct PointOfSaleCouponsControllerTests {
         #expect(sut.itemsViewState == expectedViewState)
     }
 
-    @available(iOS 17.0, *)
     @Test func refreshItems_when_empty_coupons_then_results_in_empty_state() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
@@ -65,7 +62,6 @@ struct PointOfSaleCouponsControllerTests {
         #expect(sut.itemsViewState == expectedViewState)
     }
 
-    @available(iOS 17.0, *)
     @Test func refreshItems_when_some_coupons_then_results_in_coupons_loaded_state() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
@@ -83,7 +79,6 @@ struct PointOfSaleCouponsControllerTests {
         #expect(sut.itemsViewState == expectedViewState)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadNextItems_when_empty_coupons_then_results_in_empty_state() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
@@ -100,7 +95,6 @@ struct PointOfSaleCouponsControllerTests {
         #expect(sut.itemsViewState == expectedViewState)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadNextItems_when_some_coupons_then_results_in_coupons_loaded_state() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
@@ -117,7 +111,6 @@ struct PointOfSaleCouponsControllerTests {
         #expect(sut.itemsViewState == expectedViewState)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadItems_when_retrieving_settings_fails_then_results_in_error_state() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
@@ -135,7 +128,6 @@ struct PointOfSaleCouponsControllerTests {
         #expect(sut.itemsViewState == expectedViewState)
     }
 
-    @available(iOS 17.0, *)
     @Test func enableCoupons_sets_error_state_when_fails() async throws {
         // Given
         struct MockError: Error {}
@@ -153,7 +145,6 @@ struct PointOfSaleCouponsControllerTests {
         }
     }
 
-    @available(iOS 17.0, *)
     @Test func enableCoupons_loads_items_when_successful() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
@@ -169,7 +160,6 @@ struct PointOfSaleCouponsControllerTests {
         #expect(sut.itemsViewState == expectedViewState)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadItems_when_fails_then_sets_inlineError_state_and_preserves_items() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
@@ -188,7 +178,6 @@ struct PointOfSaleCouponsControllerTests {
         #expect(sut.itemsViewState == expectedViewState)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadNextItems_when_loadNextItems_fails_then_sets_inlineError_state_and_preserves_items() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
@@ -211,7 +200,6 @@ struct PointOfSaleCouponsControllerTests {
         #expect(sut.itemsViewState == expectedViewState)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadNextItems_when_loadNextItems_then_loads_second_page() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
@@ -229,7 +217,6 @@ struct PointOfSaleCouponsControllerTests {
         #expect(sut.itemsViewState == expectedViewState)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadNextItems_when_loadNextItems_with_more_items_then_sets_hasMoreItems() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
@@ -248,7 +235,6 @@ struct PointOfSaleCouponsControllerTests {
         #expect(sut.itemsViewState == expectedViewState)
     }
 
-    @available(iOS 17.0, *)
     @Test func searchItems_when_empty_coupons_then_results_in_empty_state() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
@@ -265,7 +251,6 @@ struct PointOfSaleCouponsControllerTests {
         #expect(sut.itemsViewState == expectedViewState)
     }
 
-    @available(iOS 17.0, *)
     @Test func searchItems_when_some_coupons_then_results_in_coupons_loaded_state() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
@@ -282,7 +267,6 @@ struct PointOfSaleCouponsControllerTests {
         #expect(sut.itemsViewState == expectedViewState)
     }
 
-    @available(iOS 17.0, *)
     @Test func searchItems_when_fails_then_sets_error_state() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()
@@ -300,7 +284,6 @@ struct PointOfSaleCouponsControllerTests {
         #expect(sut.itemsViewState == expectedViewState)
     }
 
-    @available(iOS 17.0, *)
     @Test func searchItems_when_requestCancelled_then_state_unchanged() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleItemsControllerTests.swift
@@ -9,7 +9,6 @@ import class Yosemite.PointOfSaleItemFetchStrategyFactory
 import Observation
 
 final class PointOfSaleItemsControllerTests {
-    @available(iOS 17.0, *)
     @Test func loadItems_requests_first_page_after_loading_two_pages() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -32,7 +31,6 @@ final class PointOfSaleItemsControllerTests {
         #expect(itemProvider.spyLastRequestedPageNumber == 1)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadItems_results_in_loaded_state() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -54,7 +52,6 @@ final class PointOfSaleItemsControllerTests {
                                                                                  itemStates: [:])))
     }
 
-    @available(iOS 17.0, *)
     @Test func loadItems_with_more_pages_sets_hasMoreItems() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -76,7 +73,6 @@ final class PointOfSaleItemsControllerTests {
                                                                                  itemStates: [:])))
     }
 
-    @available(iOS 17.0, *)
     @Test func loadItems_when_called_multiple_times_then_items_are_not_duplicated() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -102,7 +98,6 @@ final class PointOfSaleItemsControllerTests {
         #expect(items.count == expectedItems.count)
     }
 
-    @available(iOS 17.0, *)
     @Test func container_state_starts_as_loading() {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -115,7 +110,6 @@ final class PointOfSaleItemsControllerTests {
         #expect(sut.itemsViewState.containerState == .loading)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadNextItems_when_initial_items_empty_then_container_state_is_content_and_root_state_is_empty() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -136,7 +130,6 @@ final class PointOfSaleItemsControllerTests {
         #expect(sut.itemsViewState.itemsStack.root == .empty)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadItems_when_initial_items_has_items_but_no_more_pages_then_state_is_loaded_with_initial_items() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -159,7 +152,6 @@ final class PointOfSaleItemsControllerTests {
                                                                                  itemStates: [:])))
     }
 
-    @available(iOS 17.0, *)
     @Test func loadNextItems_when_simulateFetchNextPage_then_state_is_loaded_with_expected_items() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -182,7 +174,6 @@ final class PointOfSaleItemsControllerTests {
         #expect(items.count == 4)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadNextItems_requests_second_page() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -202,7 +193,6 @@ final class PointOfSaleItemsControllerTests {
         #expect(itemProvider.spyLastRequestedPageNumber == 2)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadNextItems_when_simulateFetchNextPage_then_state_is_loaded_with_hasMoreItems() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -227,7 +217,6 @@ final class PointOfSaleItemsControllerTests {
         #expect(items.count == 4)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadNextItems_child_when_simulateFetchNextPage_then_state_is_loaded_with_hasMoreItems() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -259,7 +248,6 @@ final class PointOfSaleItemsControllerTests {
         #expect(items.count == 4)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadNextItems_child_when_service_throws_then_state_is_inlineError() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -293,7 +281,6 @@ final class PointOfSaleItemsControllerTests {
         #expect(context == .pagination)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadItems_when_no_items_then_container_state_is_content_and_root_state_is_empty() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -314,7 +301,6 @@ final class PointOfSaleItemsControllerTests {
         #expect(sut.itemsViewState.itemsStack.root == .empty)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadItems_when_itemProvider_throws_error_then_state_is_error() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -334,7 +320,6 @@ final class PointOfSaleItemsControllerTests {
         #expect(sut.itemsViewState.itemsStack.root == .error(.errorOnLoadingProducts()))
     }
 
-    @available(iOS 17.0, *)
     @Test func loadNextItems_when_itemProvider_throws_error_then_state_is_inlineError() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -365,7 +350,6 @@ final class PointOfSaleItemsControllerTests {
         #expect(context == .pagination)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadNextItems_after_itemProvider_throws_error_then_the_same_page_is_requested_next() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -389,7 +373,6 @@ final class PointOfSaleItemsControllerTests {
         #expect(itemProvider.spyLastRequestedPageNumber == 2)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadItems_results_in_state_loaded_with_expected_items() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -411,7 +394,6 @@ final class PointOfSaleItemsControllerTests {
                                                                                  itemStates: [:])))
     }
 
-    @available(iOS 17.0, *)
     @Test func loadNextItems_when_next_page_is_empty_then_state_is_loaded() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -436,7 +418,6 @@ final class PointOfSaleItemsControllerTests {
                                                                                  itemStates: [:])))
     }
 
-    @available(iOS 17.0, *)
     @Test func loadNextItems_when_next_page_is_empty_then_the_same_page_is_requested_next() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -456,7 +437,6 @@ final class PointOfSaleItemsControllerTests {
         try #require(itemProvider.spyLastRequestedPageNumber == 1)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadItems_sets_root_items_to_loading_state_while_preserving_existing_items() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -487,7 +467,6 @@ final class PointOfSaleItemsControllerTests {
         }
     }
 
-    @available(iOS 17.0, *)
     @Test func loadItems_preserves_itemStates() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -497,9 +476,9 @@ final class PointOfSaleItemsControllerTests {
         )
 
         let parentItem = POSItem.variableParentProduct(POSVariableParentProduct(id: UUID(),
-                                                                              name: "Parent product",
-                                                                              productImageSource: nil,
-                                                                              productID: 125))
+                                                                                name: "Parent product",
+                                                                                productImageSource: nil,
+                                                                                productID: 125))
         itemProvider.itemPages = [[parentItem]]
         await sut.loadItems(base: .root)
         await sut.loadItems(base: .parent(parentItem))
@@ -513,7 +492,6 @@ final class PointOfSaleItemsControllerTests {
         try #require(sut.itemsViewState.itemsStack.itemStates == itemStates)
     }
 
-    @available(iOS 17.0, *)
     @Test func loadItems_sets_child_items_to_loading_state_while_preserving_existing_items() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -523,9 +501,9 @@ final class PointOfSaleItemsControllerTests {
         )
 
         let parentItem = POSItem.variableParentProduct(POSVariableParentProduct(id: UUID(),
-                                                                              name: "Parent product",
-                                                                              productImageSource: nil,
-                                                                              productID: 125))
+                                                                                name: "Parent product",
+                                                                                productImageSource: nil,
+                                                                                productID: 125))
         let baseItem = ItemListBaseItem.parent(parentItem)
         itemProvider.itemPages = [[parentItem]]
 
@@ -552,7 +530,6 @@ final class PointOfSaleItemsControllerTests {
         }
     }
 
-    @available(iOS 17.0, *)
     @Test func search_sets_a_fetch_strategy_with_search_term_on_the_service() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()
@@ -569,7 +546,6 @@ final class PointOfSaleItemsControllerTests {
         #expect(fetchStrategy.searchTerm == "green mug")
     }
 
-    @available(iOS 17.0, *)
     @Test func setRootLoadingState_when_not_initial_state_then_sets_loading_state() async throws {
         // Given
         let itemProvider = MockPointOfSaleItemService()

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderControllerTests.swift
@@ -18,7 +18,6 @@ struct PointOfSaleOrderControllerTests {
     let mockOrderService = MockPOSOrderService()
     let mockReceiptService = MockReceiptService()
 
-    @available(iOS 17.0, *)
     @Test func syncOrder_without_items_doesnt_call_orderService() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
@@ -31,7 +30,6 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockOrderService.syncOrderWasCalled == false)
     }
 
-    @available(iOS 17.0, *)
     @Test func syncOrder_with_cart_matching_order_doesnt_call_orderService() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
@@ -51,7 +49,6 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockOrderService.syncOrderWasCalled == false)
     }
 
-    @available(iOS 17.0, *)
     @Test func syncOrder_when_already_syncing_doesnt_call_orderService() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
@@ -72,7 +69,6 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockOrderService.syncOrderWasCalled == false)
     }
 
-    @available(iOS 17.0, *)
     @Test func syncOrder_with_no_previous_order_calls_orderService() async throws {
         // Given
         let currencySettings = CurrencySettings(currencyCode: .AUD,
@@ -91,7 +87,6 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockOrderService.spySyncOrderCurrency == .AUD)
     }
 
-    @available(iOS 17.0, *)
     @Test func syncOrder_with_changes_from_previous_order_calls_orderService() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
@@ -112,7 +107,6 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockOrderService.syncOrderWasCalled)
     }
 
-    @available(iOS 17.0, *)
     @Test func syncOrder_with_no_previous_order_sets_orderState_syncing_then_loaded() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
@@ -150,7 +144,6 @@ struct PointOfSaleOrderControllerTests {
         ])
     }
 
-    @available(iOS 17.0, *)
     @Test func syncOrder_with_order_sync_failure_sets_orderState_syncing_then_error() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
@@ -187,7 +180,6 @@ struct PointOfSaleOrderControllerTests {
         ])
     }
 
-    @available(iOS 17.0, *)
     @Test func sendReceipt_when_there_is_no_order_then_will_not_trigger() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
@@ -205,7 +197,6 @@ struct PointOfSaleOrderControllerTests {
         }
     }
 
-    @available(iOS 17.0, *)
     @Test func sendReceipt_calls_both_updateOrder_and_sendReceipt() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
@@ -225,7 +216,6 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockOrderService.orderToReturn?.billingAddress?.email == recipientEmail)
     }
 
-    @available(iOS 17.0, *)
     @Test func collectCashPayment_when_no_order_then_fails_with_noOrder_error() async throws {
         do {
             // Given/When
@@ -239,7 +229,6 @@ struct PointOfSaleOrderControllerTests {
     }
 
     @MainActor
-    @available(iOS 17.0, *)
     @Test func collectCashPayment_when_successful_calls_celebrate() async throws {
         // Given
         let mockPaymentCelebration = MockPaymentCaptureCelebration()
@@ -261,7 +250,6 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockPaymentCelebration.celebrationWasCalled == true)
     }
 
-    @available(iOS 17.0, *)
     @Test func collectCashPayment_passes_changeDueAmount_to_order_service() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
@@ -281,7 +269,6 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockOrderService.spyCashPaymentChangeDueAmount == "$6.0")
     }
 
-    @available(iOS 17.0, *)
     @Test func syncOrder_when_successful_returns_newOrder_result() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
@@ -302,7 +289,6 @@ struct PointOfSaleOrderControllerTests {
         }
     }
 
-    @available(iOS 17.0, *)
     @Test func syncOrder_when_updating_existing_order_returns_newOrder_result() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
@@ -325,7 +311,6 @@ struct PointOfSaleOrderControllerTests {
         }
     }
 
-    @available(iOS 17.0, *)
     @Test func syncOrder_when_cart_matching_order_then_returns_orderNotChanged_result() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
@@ -350,7 +335,6 @@ struct PointOfSaleOrderControllerTests {
         }
     }
 
-    @available(iOS 17.0, *)
     @Test func syncOrder_when_orderService_fails_then_returns_syncOrderState_failure() async throws {
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
                                              receiptService: mockReceiptService)
@@ -368,7 +352,6 @@ struct PointOfSaleOrderControllerTests {
         }
     }
 
-    @available(iOS 17.0, *)
     @Test func syncOrder_with_cart_matching_order_and_coupons_doesnt_call_orderService() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
@@ -392,7 +375,6 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockOrderService.syncOrderWasCalled == false)
     }
 
-    @available(iOS 17.0, *)
     @Test func syncOrder_with_matching_items_but_different_coupons_calls_orderService() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
@@ -416,7 +398,6 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockOrderService.syncOrderWasCalled == true)
     }
 
-    @available(iOS 17.0, *)
     @Test func syncOrder_with_matching_items_but_removed_coupon_calls_orderService() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
@@ -440,7 +421,6 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockOrderService.syncOrderWasCalled == true)
     }
 
-    @available(iOS 17.0, *)
     @Test func syncOrder_when_orderService_fails_with_couponsError_then_sets_invalidCoupon_error() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
@@ -480,7 +460,6 @@ struct PointOfSaleOrderControllerTests {
         ])
     }
 
-    @available(iOS 17.0, *)
     @Test func syncOrder_when_orderService_fails_with_networkError_containing_couponsError_then_sets_invalidCoupon_error() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
@@ -527,7 +506,6 @@ struct PointOfSaleOrderControllerTests {
         ])
     }
 
-    @available(iOS 17.0, *)
     @Test func syncOrder_when_fails_sets_order_to_nil() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
@@ -583,7 +561,6 @@ struct PointOfSaleOrderControllerTests {
             analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         }
 
-        @available(iOS 17.0, *)
         @Test func syncOrder_when_create_order_then_tracks_order_creation_success_event() async throws {
             // Given
             let sut = PointOfSaleOrderController(orderService: orderService,
@@ -601,7 +578,6 @@ struct PointOfSaleOrderControllerTests {
             #expect(analyticsProvider.receivedEvents.first(where: { $0 == "order_creation_success" }) != nil)
         }
 
-        @available(iOS 17.0, *)
         @Test func syncOrder_when_create_order_fails_with_order_service_error_then_tracks_order_creation_failure_event() async throws {
             // Given
             let sut = PointOfSaleOrderController(orderService: orderService,
@@ -617,7 +593,6 @@ struct PointOfSaleOrderControllerTests {
         }
 
         @MainActor
-        @available(iOS 17.0, *)
         @Test func collectCashPayment_when_failure_tracks_correct_event() async throws {
             // Given
             let mockAnalyticsProvider = MockAnalyticsProvider()
@@ -646,7 +621,6 @@ struct PointOfSaleOrderControllerTests {
             #expect(mockAnalyticsProvider.receivedEvents.first(where: { $0 == "cash_payment_failed" }) != nil)
         }
 
-        @available(iOS 17.0, *)
         @Test func sendReceipt_tracks_success_with_eligible_for_pos_receipt() async throws {
             // Given
             let mockPluginsService = MockPluginsService()
@@ -673,7 +647,6 @@ struct PointOfSaleOrderControllerTests {
             #expect(analyticsProvider.receivedProperties[indexOfEvent]["eligible_for_pos_receipt"] as? Bool == true)
         }
 
-        @available(iOS 17.0, *)
         @Test func sendReceipt_without_order_tracks_failure_without_eligible_for_pos_receipt() async throws {
             // Given
             let sut = PointOfSaleOrderController(orderService: orderService,
@@ -690,7 +663,6 @@ struct PointOfSaleOrderControllerTests {
             }
         }
 
-        @available(iOS 17.0, *)
         @Test func sendReceipt_tracks_failure_with_eligible_for_pos_receipt() async throws {
             // Given
             let mockPluginsService = MockPluginsService()
@@ -728,7 +700,6 @@ struct PointOfSaleOrderControllerTests {
     struct ReceiptTests {
         private let mockOrderService = MockPOSOrderService()
 
-        @available(iOS 17.0, *)
         @Test("Eligible core plugin versions with feature flag enabled", arguments: Constants.eligibleWCPluginVersions)
         func sendReceipt_when_feature_flag_enabled_and_eligible_plugin_version_sets_isEligibleForPOSReceipt_true(wcPluginVersion: String) async throws {
             // Given
@@ -759,7 +730,6 @@ struct PointOfSaleOrderControllerTests {
             #expect(mockReceiptService.spyIsEligibleForPOSReceipt == true)
         }
 
-        @available(iOS 17.0, *)
         @Test(
             "All core plugin versions with feature flag disabled",
             arguments: Constants.eligibleWCPluginVersions + Constants.ineligibleWCPluginVersions
@@ -794,7 +764,6 @@ struct PointOfSaleOrderControllerTests {
             #expect(mockReceiptService.spyIsEligibleForPOSReceipt == false)
         }
 
-        @available(iOS 17.0, *)
         @Test("Ineligible core plugin versions with feature flag enabled", arguments: Constants.ineligibleWCPluginVersions)
         func sendReceipt_when_feature_flag_enabled_and_ineligible_plugin_version_sets_isEligibleForPOSReceipt_false(wcPluginVersion: String) async throws {
             // Given
@@ -825,7 +794,6 @@ struct PointOfSaleOrderControllerTests {
             #expect(mockReceiptService.spyIsEligibleForPOSReceipt == false)
         }
 
-        @available(iOS 17.0, *)
         @Test("Unavailable core plugin with feature flag enabled",
               arguments: [
                 SystemPlugin.fake().copy(plugin: "woocommerce/woocommerce.php", active: false),

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleAggregateModel.swift
@@ -4,7 +4,6 @@ import enum Yosemite.POSItem
 import protocol Yosemite.POSOrderableItem
 import enum Yosemite.POSItemType
 
-@available(iOS 17.0, *)
 final class MockPointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
     var cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus
 

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleCouponsController.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleCouponsController.swift
@@ -1,6 +1,5 @@
 @testable import WooCommerce
 
-@available(iOS 17.0, *)
 final class MockPointOfSaleCouponsController: PointOfSaleCouponsControllerProtocol {
     var loadItemsCalled = false
     var loadItemsBase: ItemListBaseItem?

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleItemsService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleItemsService.swift
@@ -3,7 +3,6 @@ import Combine
 @testable import WooCommerce
 import enum Yosemite.POSItem
 
-@available(iOS 17.0, *)
 final class MockPointOfSaleItemsController: PointOfSaleItemsControllerProtocol {
     var itemsViewState: ItemsViewState = .init(containerState: .content,
                                                itemsStack: .init(root: .empty, itemStates: [:]))

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSalePurchasableItemsSearchController.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSalePurchasableItemsSearchController.swift
@@ -3,7 +3,6 @@ import Combine
 @testable import WooCommerce
 import enum Yosemite.POSItem
 
-@available(iOS 17.0, *)
 final class MockPointOfSalePurchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol {
     var itemsViewState: ItemsViewState = .init(containerState: .content,
                                                itemsStack: .init(root: .empty, itemStates: [:]))

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleAggregateModelTests.swift
@@ -13,7 +13,6 @@ import Combine
 
 struct PointOfSaleAggregateModelTests {
     struct OrderStageTests {
-        @available(iOS 17.0, *)
         @Test func inits_with_building_order_stage() async throws {
             // Given
             let sut = makePointOfSaleAggregateModel()
@@ -21,7 +20,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.orderStage == .building)
         }
 
-        @available(iOS 17.0, *)
         @Test func startNewCart_removes_all_items_from_cart_and_moves_back_to_building() async throws {
             // Given
             let sut = makePointOfSaleAggregateModel()
@@ -38,7 +36,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.cart.isEmpty)
         }
 
-        @available(iOS 17.0, *)
         @Test func checkOut_moves_to_finalizing_order_stage() async throws {
             // Given
             let sut = makePointOfSaleAggregateModel()
@@ -51,7 +48,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.orderStage == .finalizing)
         }
 
-        @available(iOS 17.0, *)
         @Test func addMoreToCart_moves_to_building_order_stage() async throws {
             // Given
             let sut = makePointOfSaleAggregateModel()
@@ -76,7 +72,6 @@ struct PointOfSaleAggregateModelTests {
             analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         }
 
-        @available(iOS 17.0, *)
         @Test func addLoadingItem_adds_loading_item_to_cart() async throws {
             // Given
             var cart = Cart()
@@ -94,7 +89,6 @@ struct PointOfSaleAggregateModelTests {
             }
         }
 
-        @available(iOS 17.0, *)
         @Test func updateLoadingItem_updates_loading_item_with_simple_product() async throws {
             // Given
             var cart = Cart()
@@ -113,7 +107,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(loadedItem.name == "Test Product")
         }
 
-        @available(iOS 17.0, *)
         @Test func addItem_results_in_a_non_empty_cart() async throws {
             // Given
             let sut = makePointOfSaleAggregateModel(analytics: analytics)
@@ -127,7 +120,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(!sut.cart.isEmpty)
         }
 
-        @available(iOS 17.0, *)
         @Test func addItem_puts_new_items_first_in_the_cart() async throws {
             // Given
             let sut = makePointOfSaleAggregateModel(analytics: analytics)
@@ -146,7 +138,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(cartItemIDs == items.reversed().map(\.id))
         }
 
-        @available(iOS 17.0, *)
         @Test func removeItem_after_adding_two_items_removes_item_correctly() async throws {
             // Given
             let sut = makePointOfSaleAggregateModel(analytics: analytics)
@@ -166,7 +157,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.cart.purchasableItems.first?.title == "Item 1")
         }
 
-        @available(iOS 17.0, *)
         @Test func removeAllItemsFromCart_removes_everything() async throws {
             // Given
             let sut = makePointOfSaleAggregateModel(analytics: analytics)
@@ -184,7 +174,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.cart.isEmpty)
         }
 
-        @available(iOS 17.0, *)
         @Test func removeAllItemsFromCartOfCouponType_removes_coupons() async throws {
             // Given
             let sut = makePointOfSaleAggregateModel(analytics: analytics)
@@ -218,7 +207,6 @@ struct PointOfSaleAggregateModelTests {
             orderController.orderStateToReturn = makeLoadedOrderState(cartTotal: "$0.00")
         }
 
-        @available(iOS 17.0, *)
         @Test func startNewCart_calls_clearOrder() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -237,7 +225,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(orderController.clearOrderWasCalled == true)
         }
 
-        @available(iOS 17.0, *)
         @Test func checkout_with_items_calls_sync_order() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -259,7 +246,6 @@ struct PointOfSaleAggregateModelTests {
         }
 
         // The UI prevents no-item checkouts, but it's the controller's responsibility to handle this.
-        @available(iOS 17.0, *)
         @Test func checkOut_without_items_calls_sync_order() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -280,7 +266,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(orderController.spyCartProducts?.isEmpty == true)
         }
 
-        @available(iOS 17.0, *)
         @Test func when_collectPayment_is_called_channel_is_set_to_pos() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -301,7 +286,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(cardPresentPaymentService.collectPaymentChannel == .pos)
         }
 
-        @available(iOS 17.0, *)
         @Test func sendReceipt_when_invoked_then_calls_controller() async throws {
             // Given
             let orderController = MockPointOfSaleOrderController()
@@ -314,7 +298,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(orderController.sendReceiptWasCalled == true)
         }
 
-        @available(iOS 17.0, *)
         @Test func sendReceipt_when_invoked_with_error_then_returns_error() async throws {
             // Given
             let orderController = MockPointOfSaleOrderController()
@@ -334,7 +317,6 @@ struct PointOfSaleAggregateModelTests {
             }
         }
 
-        @available(iOS 17.0, *)
         @Test func when_pointOfSaleClosed_then_order_is_cleared_up() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -358,7 +340,6 @@ struct PointOfSaleAggregateModelTests {
         private let cardPresentPaymentService = MockCardPresentPaymentService()
         private let orderController = MockPointOfSaleOrderController()
 
-        @available(iOS 17.0, *)
         @Test func init_sets_card_paymentState_to_idle() async throws {
             // Given that we don't specify a payment state
             // When we init
@@ -373,7 +354,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.paymentState.activePaymentMethod == .card)
         }
 
-        @available(iOS 17.0, *)
         @Test func activePaymentMethod_returns_card_when_cash_is_idle() async throws {
             // Given
             let paymentState = PointOfSalePaymentState(card: .acceptingCard, cash: .idle)
@@ -382,7 +362,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(paymentState.activePaymentMethod == .card)
         }
 
-        @available(iOS 17.0, *)
         @Test func activePaymentMethod_returns_cash_when_cash_is_not_idle() async throws {
             // Given
             let paymentState = PointOfSalePaymentState(card: .acceptingCard, cash: .collectingCash)
@@ -391,7 +370,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(paymentState.activePaymentMethod == .cash)
         }
 
-        @available(iOS 17.0, *)
         @Test func activePaymentMethod_returns_cash_when_cash_is_paymentSuccess() async throws {
             // Given
             let paymentState = PointOfSalePaymentState(card: .idle, cash: .paymentSuccess)
@@ -400,7 +378,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(paymentState.activePaymentMethod == .cash)
         }
 
-        @available(iOS 17.0, *)
         @Test func startNewCart_sets_card_payment_state_to_idle() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -417,7 +394,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.paymentState == PointOfSalePaymentState(card: .idle, cash: .idle))
         }
 
-        @available(iOS 17.0, *)
         @Test func startNewCart_sets_payment_message_to_nil() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -436,7 +412,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.cardPresentPaymentInlineMessage == nil)
         }
 
-        @available(iOS 17.0, *)
         @Test func addMoreToCart_sets_card_payment_state_to_idle() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -453,7 +428,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.paymentState == PointOfSalePaymentState(card: .idle, cash: .idle))
         }
 
-        @available(iOS 17.0, *)
         @Test func addMoreToCart_sets_payment_message_to_nil() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -476,7 +450,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.cardPresentPaymentInlineMessage == nil)
         }
 
-        @available(iOS 17.0, *)
         @Test func startCashPayment_calls_for_ongoing_card_payment_cancellation() async {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -493,7 +466,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.paymentState == PointOfSalePaymentState(card: .idle, cash: .collectingCash))
         }
 
-        @available(iOS 17.0, *)
         @Test func startCashPayment_sets_payment_state_to_collectingCash() async {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -509,7 +481,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.paymentState == PointOfSalePaymentState(card: .idle, cash: .collectingCash))
         }
 
-        @available(iOS 17.0, *)
         @Test func cancelCashPayment_resets_payment_state_to_idle() async {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -527,7 +498,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.paymentState == PointOfSalePaymentState(card: .idle, cash: .idle))
         }
 
-        @available(iOS 17.0, *)
         @Test func cancelCashPayment_maintains_order_stage_as_finalizing() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -550,7 +520,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.orderStage == .finalizing)
         }
 
-        @available(iOS 17.0, *)
         @Test func cardPresentPaymentInlineMessage_when_paymentSuccess_then_total_set() async throws {
             // Given order totals:
             // Note that orderTotal is used, but the Order values are given for test robustness.
@@ -575,7 +544,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(viewModel.message == "A card payment of $52.30 was successfully made.")
         }
 
-        @available(iOS 17.0, *)
         @Test func paymentIntentCreationErrorMessage_when_paymentIntentCreationError_tryAgain_cancels_payment() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -601,7 +569,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(cardPresentPaymentService.cancelPaymentCalled == true)
         }
 
-        @available(iOS 17.0, *)
         @Test func paymentIntentCreationErrorMessage_when_paymentIntentCreationError_editOrder_moves_back_to_building() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -630,7 +597,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.orderStage == .building)
         }
 
-        @available(iOS 17.0, *)
         @Test func checkOut_when_reader_connects_collectPayment_called() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -658,7 +624,6 @@ struct PointOfSaleAggregateModelTests {
             }
         }
 
-        @available(iOS 17.0, *)
         @Test func checkOut_when_reader_is_already_connected_and_order_more_than_zero_collectPayment_called() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -676,7 +641,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(cardPresentPaymentService.collectPaymentWasCalled)
         }
 
-        @available(iOS 17.0, *)
         @Test func checkOut_when_reader_is_already_connected_and_order_is_free_collectPayment_is_not_called() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -694,7 +658,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(!cardPresentPaymentService.collectPaymentWasCalled)
         }
 
-        @available(iOS 17.0, *)
         @Test func after_disconnection_when_reader_reconnects_collectPayment_called() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -723,7 +686,6 @@ struct PointOfSaleAggregateModelTests {
             }
         }
 
-        @available(iOS 17.0, *)
         @Test(.disabled()) func cancelThenCollectPayment_still_collects_payment_when_cancellation_fails() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -747,7 +709,6 @@ struct PointOfSaleAggregateModelTests {
         }
 
         // MARK: Onboarding
-        @available(iOS 17.0, *)
         @Test func cardPresentPaymentOnboardingViewModel_is_non_nil_when_onboarding_is_required() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -769,7 +730,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.cardPresentPaymentOnboardingViewModel?.state == .pluginNotActivated(plugin: .stripe))
         }
 
-        @available(iOS 17.0, *)
         @Test func connectionSuccessAlert_is_filtered_when_waiting_to_start_payment_on_card_reader_connection() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -795,7 +755,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(sut.cardPresentPaymentAlertViewModel == nil)
         }
 
-        @available(iOS 17.0, *)
         @Test func connectionSuccessAlert_is_shown_when_not_waiting_to_start_payment() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -832,7 +791,6 @@ struct PointOfSaleAggregateModelTests {
             orderController.orderState = makeLoadedOrderState()
         }
 
-        @available(iOS 17.0, *)
         @Test func paymentsOnboardingDismissed_event_is_tracked_with_state_when_cancelOnboarding_is_invoked() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -860,7 +818,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(eventProperties["onboarding_state"] as? String == "no_connection_error")
         }
 
-        @available(iOS 17.0, *)
         @Test func pointOfSalePaymentsOnboardingShown_event_is_tracked_when_trackOnboardingShown_is_invoked() async throws {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -879,7 +836,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(analyticsProvider.receivedEvents.first(where: { $0 == "payments_onboarding_shown" }) != nil)
         }
 
-        @available(iOS 17.0, *)
         @Test func connectCardReader_when_tapped_then_tracks_event() {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -896,7 +852,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(analyticsProvider.receivedEvents.first(where: { $0 == "card_reader_connection_tapped" }) != nil)
         }
 
-        @available(iOS 17.0, *)
         @Test func disconnectCardReader_when_tapped_then_tracks_event() {
             // Given
             let itemsController = MockPointOfSaleItemsController()
@@ -913,7 +868,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(analyticsProvider.receivedEvents.first(where: { $0 == "card_reader_disconnect_tapped" }) != nil)
         }
 
-        @available(iOS 17.0, *)
         @Test func checkout_when_invoked_then_tracks_trackCheckoutTapped() async throws {
             // Given
             let analyticsTracker = MockPOSCollectOrderPaymentAnalyticsTracker()
@@ -929,7 +883,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(analyticsTracker.didCallTrackCheckoutTapped == true)
         }
 
-        @available(iOS 17.0, *)
         @Test func cancelCashPayment_when_invoked_then_tracks_expected_event() async throws {
             // Given
             let analyticsTracker = MockPOSCollectOrderPaymentAnalyticsTracker()
@@ -943,7 +896,6 @@ struct PointOfSaleAggregateModelTests {
             #expect(analyticsProvider.receivedEvents.first(where: { $0 == "back_to_checkout_from_cash" }) != nil)
         }
 
-        @available(iOS 17.0, *)
         @Test func startCashPayment_when_invoked_tracks_expected_event() async throws {
             // Given
             let mockAnalyticsProvider = MockAnalyticsProvider()
@@ -959,7 +911,6 @@ struct PointOfSaleAggregateModelTests {
     }
 
     struct BarcodeTests {
-        @available(iOS 17.0, *)
         @Test func barcodeScanned_when_fails_then_plays_sound() async {
             // Given
             let soundPlayer = MockPointOfSaleSoundPlayer()
@@ -1008,7 +959,6 @@ private func makeLoadedOrderState(cartTotal: String = "",
     )
 }
 
-@available(iOS 17.0, *)
 private func makePointOfSaleAggregateModel(
     entryPointController: POSEntryPointController = POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
     itemsController: PointOfSaleItemsControllerProtocol = MockPointOfSaleItemsController(),

--- a/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlowManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlowManagerTests.swift
@@ -5,7 +5,6 @@ import GameController
 
 struct PointOfSaleBarcodeScannerSetupFlowManagerTests {
 
-    @available(iOS 17.0, *)
     @Test func test_flowManager_tracks_scanner_selected_when_selectScanner_called() {
         // Given a flow manager
         let mockAnalytics = MockAnalytics()
@@ -23,7 +22,6 @@ struct PointOfSaleBarcodeScannerSetupFlowManagerTests {
         #expect(event?.properties["scanner"] as? String == PointOfSaleBarcodeScannerType.starBSH20B.analyticsName)
     }
 
-    @available(iOS 17.0, *)
     @Test func test_flowManager_tracks_dismissal_when_onDisappear_called_on_non_completion_step() {
         // Given a flow manager with a setup flow in progress
         let mockAnalytics = MockAnalytics()
@@ -46,7 +44,6 @@ struct PointOfSaleBarcodeScannerSetupFlowManagerTests {
         #expect(event?.properties["step"] as? String == "setup_barcode_hid")
     }
 
-    @available(iOS 17.0, *)
     @Test func test_flowManager_tracks_dismissal_when_onDisappear_called_on_scanner_selection() {
         // Given a flow manager on scanner selection screen
         let mockAnalytics = MockAnalytics()
@@ -65,7 +62,6 @@ struct PointOfSaleBarcodeScannerSetupFlowManagerTests {
         #expect(event?.properties["step"] == nil)
     }
 
-    @available(iOS 17.0, *)
     @Test func test_flowManager_tracks_keyboard_connected_when_in_setup_flow() {
         // Given a flow manager with a setup flow
         let mockAnalytics = MockAnalytics()
@@ -87,7 +83,6 @@ struct PointOfSaleBarcodeScannerSetupFlowManagerTests {
         #expect(event?.properties["scanner"] as? String == PointOfSaleBarcodeScannerType.netum1228BC.analyticsName)
     }
 
-    @available(iOS 17.0, *)
     @Test func test_flowManager_does_not_track_keyboard_connected_when_on_scanner_selection() {
         // Given a flow manager on scanner selection
         let mockAnalytics = MockAnalytics()
@@ -103,7 +98,6 @@ struct PointOfSaleBarcodeScannerSetupFlowManagerTests {
         #expect(mockAnalytics.events.isEmpty)
     }
 
-    @available(iOS 17.0, *)
     @Test func test_flowManager_returns_correct_state_after_scanner_selection() {
         // Given a flow manager
         let mockAnalytics = MockAnalytics()
@@ -129,7 +123,6 @@ struct PointOfSaleBarcodeScannerSetupFlowManagerTests {
         }
     }
 
-    @available(iOS 17.0, *)
     @Test func test_flowManager_returns_to_scanner_selection_when_goBackToSelection_called() {
         // Given a flow manager in setup flow
         let mockAnalytics = MockAnalytics()

--- a/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupScanTesterTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupScanTesterTests.swift
@@ -3,7 +3,6 @@ import Testing
 
 struct PointOfSaleBarcodeScannerSetupScanTesterTests {
 
-    @available(iOS 17.0, *)
     @Test func test_scanTester_calls_onTestPass_when_scan_received_for_expected_barcode() {
         // Given a test EAN13 barcode
         let expectedBarcode = PointOfSaleBarcodeScannerTestBarcode.ean13
@@ -26,7 +25,6 @@ struct PointOfSaleBarcodeScannerSetupScanTesterTests {
         #expect(onTestTimeoutCalled == false)
     }
 
-    @available(iOS 17.0, *)
     @Test func test_scanTester_calls_onTestFailure_when_scan_received_for_unexpected_barcode() {
         // Given a test EAN13 barcode
         let expectedBarcode = PointOfSaleBarcodeScannerTestBarcode.ean13
@@ -55,7 +53,6 @@ struct PointOfSaleBarcodeScannerSetupScanTesterTests {
         #expect(receivedScanValue == unexpectedBarcode)
     }
 
-    @available(iOS 17.0, *)
     @Test func test_scanTester_calls_onTestFailure_when_scan_fails() {
         // Given a test EAN13 barcode
         let expectedBarcode = PointOfSaleBarcodeScannerTestBarcode.ean13
@@ -83,7 +80,6 @@ struct PointOfSaleBarcodeScannerSetupScanTesterTests {
         #expect(receivedScanValue == "short")
     }
 
-    @available(iOS 17.0, *)
     @Test func test_scanTester_provides_correct_barcode_asset() {
         // Given a test EAN13 barcode
         let expectedBarcode = PointOfSaleBarcodeScannerTestBarcode.ean13

--- a/WooCommerce/WooCommerceTests/POS/Presentation/POSItemActionHandlerFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/POSItemActionHandlerFactoryTests.swift
@@ -12,7 +12,6 @@ private enum AnalyticsKeys {
 }
 
 struct POSItemActionHandlerFactoryTests {
-    @available(iOS 17.0, *)
     @Test func products_list_tracks_correct_analytics() async throws {
         // Given
         let posModel = MockPointOfSaleAggregateModel()
@@ -37,7 +36,6 @@ struct POSItemActionHandlerFactoryTests {
         #expect(event.properties[AnalyticsKeys.productType] as? String == "simple")
     }
 
-    @available(iOS 17.0, *)
     @Test func coupons_list_tracks_correct_analytics() async throws {
         // Given
         let posModel = MockPointOfSaleAggregateModel()
@@ -62,7 +60,6 @@ struct POSItemActionHandlerFactoryTests {
         #expect(event.properties[AnalyticsKeys.productType] == nil)
     }
 
-    @available(iOS 17.0, *)
     @Test func products_search_tracks_correct_analytics() async throws {
         // Given
         let posModel = MockPointOfSaleAggregateModel()
@@ -87,7 +84,6 @@ struct POSItemActionHandlerFactoryTests {
         #expect(event.properties[AnalyticsKeys.productType] as? String == "simple")
     }
 
-    @available(iOS 17.0, *)
     @Test func coupons_search_tracks_correct_analytics() async throws {
         // Given
         let posModel = MockPointOfSaleAggregateModel()
@@ -112,7 +108,6 @@ struct POSItemActionHandlerFactoryTests {
         #expect(event.properties[AnalyticsKeys.productType] == nil)
     }
 
-    @available(iOS 17.0, *)
     @Test func variation_list_tracks_correct_analytics() async throws {
         // Given
         let posModel = MockPointOfSaleAggregateModel()
@@ -137,7 +132,6 @@ struct POSItemActionHandlerFactoryTests {
         #expect(event.properties[AnalyticsKeys.productType] as? String == "variation")
     }
 
-    @available(iOS 17.0, *)
     @Test func variation_search_tracks_correct_analytics() async throws {
         // Given
         let posModel = MockPointOfSaleAggregateModel()

--- a/WooCommerce/WooCommerceTests/POS/Presentation/POSItemActionHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/POSItemActionHandlerTests.swift
@@ -7,7 +7,6 @@ import protocol Yosemite.POSSearchHistoryProviding
 @testable import WooCommerce
 
 struct POSItemActionHandlerTests {
-    @available(iOS 17.0, *)
     @Test func handleTap_when_attempt_to_add_duplicated_coupons_in_list_then_does_not_add_it_to_cart() async throws {
         let aggregateModel = makePointOfSaleAggregateModel()
         let sut = StandardPOSItemActionHandler(
@@ -25,7 +24,6 @@ struct POSItemActionHandlerTests {
         #expect(aggregateModel.cart.coupons.count == 1)
     }
 
-    @available(iOS 17.0, *)
     @Test func handleTap_when_attempt_to_add_duplicated_coupons_in_search_then_does_not_add_it_to_cart() async throws {
         let aggregateModel = makePointOfSaleAggregateModel()
         let sut = SearchResultItemActionHandler(
@@ -44,7 +42,6 @@ struct POSItemActionHandlerTests {
         #expect(aggregateModel.cart.coupons.count == 1)
     }
 
-    @available(iOS 17.0, *)
     @Test func handleTap_when_attempt_to_add_duplicated_products_in_list_then_adds_them_to_cart() async throws {
         let aggregateModel = makePointOfSaleAggregateModel()
         let sut = StandardPOSItemActionHandler(
@@ -62,7 +59,6 @@ struct POSItemActionHandlerTests {
         #expect(aggregateModel.cart.purchasableItems.count == 3)
     }
 
-    @available(iOS 17.0, *)
     @Test func handleTap_when_attempt_to_add_duplicated_products_in_search_then_adds_them_to_cart() async throws {
         let aggregateModel = makePointOfSaleAggregateModel()
         let sut = SearchResultItemActionHandler(
@@ -97,7 +93,6 @@ private func makeProductItem() -> POSItem {
                                 stockStatusKey: ""))
 }
 
-@available(iOS 17.0, *)
 private func makePointOfSaleAggregateModel(
     entryPointController: POSEntryPointController = POSEntryPointController(eligibilityChecker: MockPOSEligibilityChecker()),
     itemsController: PointOfSaleItemsControllerProtocol = MockPointOfSaleItemsController(),

--- a/WooCommerce/WooCommerceTests/POS/Presentation/PointOfSaleItemListAnalyticsTrackerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Presentation/PointOfSaleItemListAnalyticsTrackerTests.swift
@@ -9,7 +9,6 @@ private enum AnalyticsKeys {
 }
 
 struct PointOfSaleItemListAnalyticsTrackerTests {
-    @available(iOS 17.0, *)
     @Test func trackItemListSelected_tracks_correct_event_products_list() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -24,7 +23,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
         #expect(event.properties[AnalyticsKeys.type] as? String == "product")
     }
 
-    @available(iOS 17.0, *)
     @Test func trackItemListSelected_tracks_correct_event_products_search() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -39,7 +37,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
         #expect(event.properties[AnalyticsKeys.type] as? String == "product")
     }
 
-    @available(iOS 17.0, *)
     @Test func trackItemListSelected_tracks_correct_event_coupons_list() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -54,7 +51,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
         #expect(event.properties[AnalyticsKeys.type] as? String == "coupon")
     }
 
-    @available(iOS 17.0, *)
     @Test func trackItemListSelected_tracks_correct_event_coupons_search() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -69,7 +65,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
         #expect(event.properties[AnalyticsKeys.type] as? String == "coupon")
     }
 
-    @available(iOS 17.0, *)
     @Test func trackNextPageWillLoad_tracks_correct_event_products_list() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -86,7 +81,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
     }
 
 
-    @available(iOS 17.0, *)
     @Test func trackNextPageWillLoad_tracks_correct_event_products_preSearch() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -102,7 +96,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
         #expect(event.properties[AnalyticsKeys.sourceType] as? String == "pre_search")
     }
 
-    @available(iOS 17.0, *)
     @Test func trackNextPageWillLoad_tracks_correct_event_products_search() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -118,7 +111,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
         #expect(event.properties[AnalyticsKeys.sourceType] as? String == "search")
     }
 
-    @available(iOS 17.0, *)
     @Test func trackNextPageWillLoad_tracks_correct_event_coupons_list() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -134,7 +126,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
         #expect(event.properties[AnalyticsKeys.sourceType] as? String == "list")
     }
 
-    @available(iOS 17.0, *)
     @Test func trackNextPageWillLoad_tracks_correct_event_coupons_preSearch() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -150,7 +141,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
         #expect(event.properties[AnalyticsKeys.sourceType] as? String == "pre_search")
     }
 
-    @available(iOS 17.0, *)
     @Test func trackNextPageWillLoad_tracks_correct_event_coupons_search() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -166,7 +156,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
         #expect(event.properties[AnalyticsKeys.sourceType] as? String == "search")
     }
 
-    @available(iOS 17.0, *)
     @Test func trackRefresh_tracks_correct_event_products_list() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -182,7 +171,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
         #expect(event.properties[AnalyticsKeys.sourceType] as? String == "list")
     }
 
-    @available(iOS 17.0, *)
     @Test func trackRefresh_tracks_correct_event_products_preSearch() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -198,7 +186,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
         #expect(event.properties[AnalyticsKeys.sourceType] as? String == "pre_search")
     }
 
-    @available(iOS 17.0, *)
     @Test func trackRefresh_tracks_correct_event_products_search() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -214,7 +201,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
         #expect(event.properties[AnalyticsKeys.sourceType] as? String == "search")
     }
 
-    @available(iOS 17.0, *)
     @Test func trackRefresh_tracks_correct_event_coupons_list() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -230,7 +216,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
         #expect(event.properties[AnalyticsKeys.sourceType] as? String == "list")
     }
 
-    @available(iOS 17.0, *)
     @Test func trackRefresh_tracks_correct_event_coupons_preSearch() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -246,7 +231,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
         #expect(event.properties[AnalyticsKeys.sourceType] as? String == "pre_search")
     }
 
-    @available(iOS 17.0, *)
     @Test func trackRefresh_tracks_correct_event_coupons_search() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -262,7 +246,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
         #expect(event.properties[AnalyticsKeys.sourceType] as? String == "search")
     }
 
-    @available(iOS 17.0, *)
     @Test func trackSearchTapped_tracks_correct_event_products_list() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -277,7 +260,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
         #expect(event.properties[AnalyticsKeys.source] as? String == "product")
     }
 
-    @available(iOS 17.0, *)
     @Test func trackSearchTapped_tracks_correct_event_products_search() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -292,7 +274,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
         #expect(event.properties[AnalyticsKeys.source] as? String == "product")
     }
 
-    @available(iOS 17.0, *)
     @Test func trackSearchTapped_tracks_correct_event_coupons_list() async throws {
         // Given
         let mockAnalytics = MockAnalytics()
@@ -307,7 +288,6 @@ struct PointOfSaleItemListAnalyticsTrackerTests {
         #expect(event.properties[AnalyticsKeys.source] as? String == "coupon")
     }
 
-    @available(iOS 17.0, *)
     @Test func trackSearchTapped_tracks_correct_event_coupons_search() async throws {
         // Given
         let mockAnalytics = MockAnalytics()

--- a/WooCommerce/WooCommerceTests/POS/ViewHelpers/PointOfSaleDashboardViewHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewHelpers/PointOfSaleDashboardViewHelperTests.swift
@@ -7,7 +7,6 @@ import enum WooFoundationCore.CurrencyCode
 struct PointOfSaleDashboardViewHelperTests {
     // MARK: - Horizontal Size Class Tests
 
-    @available(iOS 17.0, *)
     @Test func determineViewState_when_horizontalSizeClass_is_compact_returns_unsupportedWidth() async throws {
         // Given
         let eligibilityState: POSEligibilityState = .eligible
@@ -25,7 +24,6 @@ struct PointOfSaleDashboardViewHelperTests {
         #expect(result == .unsupportedWidth)
     }
 
-    @available(iOS 17.0, *)
     @Test func determineViewState_when_horizontalSizeClass_is_nil_returns_unsupportedWidth() async throws {
         // Given
         let eligibilityState: POSEligibilityState = .eligible
@@ -45,7 +43,6 @@ struct PointOfSaleDashboardViewHelperTests {
 
     // MARK: - Eligibility State Tests
 
-    @available(iOS 17.0, *)
     @Test func determineViewState_when_eligibilityState_is_nil_returns_loading() async throws {
         // Given
         let eligibilityState: POSEligibilityState? = nil
@@ -63,7 +60,6 @@ struct PointOfSaleDashboardViewHelperTests {
         #expect(result == .loading)
     }
 
-    @available(iOS 17.0, *)
     @Test(arguments: [
         POSIneligibleReason.unsupportedIOSVersion,
         POSIneligibleReason.unsupportedWooCommerceVersion(minimumVersion: "9.6.0"),
@@ -92,7 +88,6 @@ struct PointOfSaleDashboardViewHelperTests {
 
     // MARK: - Eligible State Tests
 
-    @available(iOS 17.0, *)
     @Test func determineViewState_when_eligible_and_loading_returns_loading() async throws {
         // Given
         let eligibilityState: POSEligibilityState = .eligible
@@ -110,7 +105,6 @@ struct PointOfSaleDashboardViewHelperTests {
         #expect(result == .loading)
     }
 
-    @available(iOS 17.0, *)
     @Test func determineViewState_when_eligible_and_content_returns_content() async throws {
         // Given
         let eligibilityState: POSEligibilityState = .eligible
@@ -130,7 +124,6 @@ struct PointOfSaleDashboardViewHelperTests {
 
     // MARK: - Error State Tests
 
-    @available(iOS 17.0, *)
     @Test(arguments: [
         PointOfSaleErrorState.errorOnLoadingProducts(),
         PointOfSaleErrorState.errorOnLoadingVariations(),
@@ -161,7 +154,6 @@ struct PointOfSaleDashboardViewHelperTests {
 
     // MARK: - Priority Tests
 
-    @available(iOS 17.0, *)
     @Test func determineViewState_horizontalSizeClass_takes_priority_over_eligibility_state() async throws {
         // Given - compact size class should return unsupportedWidth regardless of eligibility
         let eligibilityState: POSEligibilityState = .ineligible(reason: .unsupportedIOSVersion)
@@ -179,7 +171,6 @@ struct PointOfSaleDashboardViewHelperTests {
         #expect(result == .unsupportedWidth)
     }
 
-    @available(iOS 17.0, *)
     @Test func determineViewState_nil_eligibilityState_takes_priority_over_containerState() async throws {
         // Given - nil eligibility should return loading regardless of container state
         let eligibilityState: POSEligibilityState? = nil
@@ -197,7 +188,6 @@ struct PointOfSaleDashboardViewHelperTests {
         #expect(result == .loading)
     }
 
-    @available(iOS 17.0, *)
     @Test func determineViewState_ineligible_state_takes_priority_over_containerState() async throws {
         // Given - ineligible state should return ineligible regardless of container state
         let eligibilityState: POSEligibilityState = .ineligible(reason: .unsupportedIOSVersion)
@@ -217,7 +207,6 @@ struct PointOfSaleDashboardViewHelperTests {
 
     // MARK: - Floating Control Tests
 
-    @available(iOS 17.0, *)
     @Test(arguments: [
         (PointOfSaleDashboardView.ViewState.content, true),
         (PointOfSaleDashboardView.ViewState.error(PointOfSaleErrorState.errorOnLoadingProducts()), true),
@@ -228,7 +217,6 @@ struct PointOfSaleDashboardViewHelperTests {
         #expect(viewState.showsFloatingControl == expected)
     }
 
-    @available(iOS 17.0, *)
     @Test(arguments: [
         (PointOfSaleDashboardView.ViewState.loading, false),
         (PointOfSaleDashboardView.ViewState.ineligible(reason: .unsupportedIOSVersion), false)

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -337,7 +337,7 @@ final class MainTabBarControllerTests: XCTestCase {
         notice.actionHandler?()
 
         let productsNavigationController = try XCTUnwrap(tabBarController
-                    .tabContainerController(tab: .products, isPOSTabVisible: false))
+            .tabContainerController(tab: .products, isPOSTabVisible: false))
         waitUntil {
             productsNavigationController.presentedViewController != nil
         }
@@ -452,7 +452,6 @@ final class MainTabBarControllerTests: XCTestCase {
         TestingAppDelegate.mockTabBarController = nil
     }
 
-    @available(iOS 17.0, *)
     func test_pos_tab_becomes_invisible_after_being_selected_when_initially_visible_then_eligibility_changes() throws {
         // Given
         let featureFlagService = MockFeatureFlagService()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

WOOMOB-1133

Create a split view layout for order list and details.

I initially started with a native `NavigationSplitView` but it didn't have enough customizability for POS. Instead, I choose to use:
- A simple `HStack` for `.regular` size class to display a sidebar and details, just like product list and cart
- A `NavigationStack` for `.compact` size class, to display sidebar and details in separate view

As a result, I added private `CustomNavigationSplitView` that I expect to evolve while the development happens. We'll see later with POS Settings whether we can extract something reusable that works for both these and other future features.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Select Menu ... -> Orders
3. Confirm the view appears in a split view
4. Confirm selection changes details view
5. Confirm making the view smaller switches to a phone 2 view layout

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air 18.5 simulator and iPad Air 20.6 device

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/f12af8a7-ab5b-4d2d-a2f4-f4fdc5fe8c33

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.