### PR TITLE
[Local Catalog] Add remote for products/variations incremental sync API

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -100,6 +100,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .pointOfSaleHistoricalOrdersi1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .pointOfSaleLocalCatalogi1:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -206,4 +206,9 @@ public enum FeatureFlag: Int {
     /// Enables the entry point for Point of Sale Orders
     ///
     case pointOfSaleHistoricalOrdersi1
+
+    /// Enables Local Catalog i1 in Point of Sale.
+    /// It syncs products and variations to local storage and display them in POS for quick access.
+    ///
+    case pointOfSaleLocalCatalogi1
 }

--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -10,17 +10,15 @@ public class POSCatalogSyncRemote: Remote {
     /// - Parameters:
     ///   - modifiedAfter: Only products modified after this date will be returned.
     ///   - siteID: Site ID to load products from.
-    ///   - productTypes: Product types to filter by.
     ///   - pageNumber: Page number for pagination.
     /// - Returns: Paginated list of POS products.
     ///
     // periphery:ignore - TODO - remove this periphery ignore comment when this endpoint is integrated with catalog sync
-    public func loadProducts(modifiedAfter: Date, siteID: Int64, productTypes: [ProductType] = [.simple, .variable], pageNumber: Int)
+    public func loadProducts(modifiedAfter: Date, siteID: Int64, pageNumber: Int)
     async throws -> PagedItems<POSProduct> {
         let path = "products"
         let parameters = [
             ParameterKey.modifiedAfter: dateFormatter.string(from: modifiedAfter),
-            ParameterKey.productTypes: productTypes.map { $0.rawValue }.joined(separator: ","),
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(Constants.defaultPageSize),
             ParameterKey.fields: POSProduct.requestFields.joined(separator: ",")
@@ -68,7 +66,6 @@ private extension POSCatalogSyncRemote {
 
     enum ParameterKey {
         static let modifiedAfter = "modified_after"
-        static let productTypes = "include_types"
         static let page = "page"
         static let perPage = "per_page"
         static let fields = "_fields"

--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -3,6 +3,8 @@ import Foundation
 /// POS Catalog Sync: Remote Endpoints
 ///
 public class POSCatalogSyncRemote: Remote {
+    private let dateFormatter = ISO8601DateFormatter()
+
     /// Loads POS products modified after the specified date.
     ///
     /// - Parameters:
@@ -16,7 +18,6 @@ public class POSCatalogSyncRemote: Remote {
     public func loadProducts(modifiedAfter: Date, siteID: Int64, productTypes: [ProductType] = [.simple, .variable], pageNumber: Int)
     async throws -> PagedItems<POSProduct> {
         let path = "products"
-        let dateFormatter = ISO8601DateFormatter()
         let parameters = [
             ParameterKey.modifiedAfter: dateFormatter.string(from: modifiedAfter),
             ParameterKey.productTypes: productTypes.map { $0.rawValue }.joined(separator: ","),
@@ -43,7 +44,6 @@ public class POSCatalogSyncRemote: Remote {
     // periphery:ignore - TODO - remove when this endpoint is integrated with catalog sync
     public func loadProductVariations(modifiedAfter: Date, siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
         let path = "variations"
-        let dateFormatter = ISO8601DateFormatter()
         let parameters = [
             ParameterKey.modifiedAfter: dateFormatter.string(from: modifiedAfter),
             ParameterKey.page: String(pageNumber),

--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Protocol for `POSCatalogSyncRemote` mainly used for mocking.
+///
+public protocol POSCatalogSyncRemoteProtocol {
+    func loadProducts(modifiedAfter: Date, siteID: Int64, productTypes: [ProductType], pageNumber: Int) async throws -> PagedItems<POSProduct>
+    func loadProductVariations(modifiedAfter: Date, siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation>
+}
+
+/// POS Catalog Sync: Remote Endpoints
+///
+public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
+    /// Loads POS products modified after the specified date.
+    ///
+    /// - Parameters:
+    ///   - modifiedAfter: Only products modified after this date will be returned.
+    ///   - siteID: Site ID to load products from.
+    ///   - productTypes: Product types to filter by.
+    ///   - pageNumber: Page number for pagination.
+    /// - Returns: Paginated list of POS products.
+    ///
+    public func loadProducts(modifiedAfter: Date, siteID: Int64, productTypes: [ProductType] = [.simple, .variable], pageNumber: Int)
+    async throws -> PagedItems<POSProduct> {
+        let path = "products"
+        let dateFormatter = ISO8601DateFormatter()
+        let parameters = [
+            ParameterKey.modifiedAfter: dateFormatter.string(from: modifiedAfter),
+            ParameterKey.productTypes: productTypes.map { $0.rawValue }.joined(separator: ","),
+            ParameterKey.page: String(pageNumber),
+            ParameterKey.perPage: String(Constants.defaultPageSize),
+            ParameterKey.fields: POSProduct.requestFields.joined(separator: ",")
+        ]
+
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let mapper = ListMapper<POSProduct>(siteID: siteID)
+        let (products, responseHeaders) = try await enqueueWithResponseHeaders(request, mapper: mapper)
+
+        return createPagedItems(items: products, responseHeaders: responseHeaders, currentPageNumber: pageNumber)
+    }
+
+    /// Loads POS product variations modified after the specified date.
+    ///
+    /// - Parameters:
+    ///   - modifiedAfter: Only variations modified after this date will be returned.
+    ///   - siteID: Site ID to load variations from.
+    ///   - pageNumber: Page number for pagination.
+    /// - Returns: Paginated list of POS product variations.
+    ///
+    public func loadProductVariations(modifiedAfter: Date, siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
+        let path = "variations"
+        let dateFormatter = ISO8601DateFormatter()
+        let parameters = [
+            ParameterKey.modifiedAfter: dateFormatter.string(from: modifiedAfter),
+            ParameterKey.page: String(pageNumber),
+            ParameterKey.perPage: String(Constants.defaultPageSize),
+            ParameterKey.fields: POSProductVariation.requestFields.joined(separator: ",")
+        ]
+
+        let request = JetpackRequest(wooApiVersion: .wcAnalytics, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let mapper = ListMapper<POSProductVariation>(siteID: siteID)
+        let (variations, responseHeaders) = try await enqueueWithResponseHeaders(request, mapper: mapper)
+
+        return createPagedItems(items: variations, responseHeaders: responseHeaders, currentPageNumber: pageNumber)
+    }
+}
+
+// MARK: - Constants
+//
+private extension POSCatalogSyncRemote {
+    enum Constants {
+        static let defaultPageSize = 100
+    }
+
+    enum ParameterKey {
+        static let modifiedAfter = "modified_after"
+        static let productTypes = "include_types"
+        static let page = "page"
+        static let perPage = "per_page"
+        static let fields = "_fields"
+    }
+}

--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -1,15 +1,8 @@
 import Foundation
 
-/// Protocol for `POSCatalogSyncRemote` mainly used for mocking.
-///
-public protocol POSCatalogSyncRemoteProtocol {
-    func loadProducts(modifiedAfter: Date, siteID: Int64, productTypes: [ProductType], pageNumber: Int) async throws -> PagedItems<POSProduct>
-    func loadProductVariations(modifiedAfter: Date, siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation>
-}
-
 /// POS Catalog Sync: Remote Endpoints
 ///
-public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
+public class POSCatalogSyncRemote: Remote {
     /// Loads POS products modified after the specified date.
     ///
     /// - Parameters:

--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -12,6 +12,7 @@ public class POSCatalogSyncRemote: Remote {
     ///   - pageNumber: Page number for pagination.
     /// - Returns: Paginated list of POS products.
     ///
+    // periphery:ignore - TODO - remove when this endpoint is integrated with catalog sync
     public func loadProducts(modifiedAfter: Date, siteID: Int64, productTypes: [ProductType] = [.simple, .variable], pageNumber: Int)
     async throws -> PagedItems<POSProduct> {
         let path = "products"
@@ -39,6 +40,7 @@ public class POSCatalogSyncRemote: Remote {
     ///   - pageNumber: Page number for pagination.
     /// - Returns: Paginated list of POS product variations.
     ///
+    // periphery:ignore - TODO - remove when this endpoint is integrated with catalog sync
     public func loadProductVariations(modifiedAfter: Date, siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
         let path = "variations"
         let dateFormatter = ISO8601DateFormatter()

--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -14,7 +14,7 @@ public class POSCatalogSyncRemote: Remote {
     ///   - pageNumber: Page number for pagination.
     /// - Returns: Paginated list of POS products.
     ///
-    // periphery:ignore - TODO - remove when this endpoint is integrated with catalog sync
+    // periphery:ignore - TODO - remove this periphery ignore comment when this endpoint is integrated with catalog sync
     public func loadProducts(modifiedAfter: Date, siteID: Int64, productTypes: [ProductType] = [.simple, .variable], pageNumber: Int)
     async throws -> PagedItems<POSProduct> {
         let path = "products"
@@ -41,7 +41,7 @@ public class POSCatalogSyncRemote: Remote {
     ///   - pageNumber: Page number for pagination.
     /// - Returns: Paginated list of POS product variations.
     ///
-    // periphery:ignore - TODO - remove when this endpoint is integrated with catalog sync
+    // periphery:ignore - TODO - remove this periphery ignore comment when this endpoint is integrated with catalog sync
     public func loadProductVariations(modifiedAfter: Date, siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
         let path = "variations"
         let parameters = [

--- a/Modules/Sources/Networking/Remote/ProductVariationsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductVariationsRemote.swift
@@ -97,18 +97,7 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
         let mapper = ListMapper<POSProductVariation>(siteID: siteID)
 
         let (variations, responseHeaders) = try await enqueueWithResponseHeaders(request, mapper: mapper)
-
-        // Extracts the total number of pages from the response headers.
-        // Response header names are case insensitive.
-        let totalPages = responseHeaders?.first(where: { $0.key.lowercased() == Remote.PaginationHeaderKey.totalPagesCount.lowercased() })
-            .flatMap { Int($0.value) }
-        let hasMorePages = totalPages.map { pageNumber < $0 } ?? true
-
-        // Extract total count from X-WP-Total header
-        let totalItems = responseHeaders?.first(where: { $0.key.lowercased() == Remote.PaginationHeaderKey.totalCount.lowercased() })
-            .flatMap { Int($0.value) }
-
-        return PagedItems(items: variations, hasMorePages: hasMorePages, totalItems: totalItems)
+        return createPagedItems(items: variations, responseHeaders: responseHeaders, currentPageNumber: pageNumber)
     }
 
     private func productVariationsRequest(for siteID: Int64,

--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -286,18 +286,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         let mapper = ListMapper<POSProduct>(siteID: siteID)
 
         let (products, responseHeaders) = try await enqueueWithResponseHeaders(request, mapper: mapper)
-
-        // Extracts the total number of pages from the response headers.
-        // Response header names are case insensitive.
-        let totalPages = responseHeaders?.first(where: { $0.key.lowercased() == Remote.PaginationHeaderKey.totalPagesCount.lowercased() })
-            .flatMap { Int($0.value) }
-        let hasMorePages = totalPages.map { pageNumber < $0 } ?? true
-
-        // Extract total count from X-WP-Total header
-        let totalItems = responseHeaders?.first(where: { $0.key.lowercased() == Remote.PaginationHeaderKey.totalCount.lowercased() })
-            .flatMap { Int($0.value) }
-
-        return .init(items: products, hasMorePages: hasMorePages, totalItems: totalItems)
+        return createPagedItems(items: products, responseHeaders: responseHeaders, currentPageNumber: pageNumber)
     }
 
     /// Remote search of products for the Point of Sale. Simple and variable products are loaded for WC version 9.6+, otherwise only simple products are loaded.

--- a/Modules/Sources/NetworkingCore/Remote/Remote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/Remote.swift
@@ -362,6 +362,35 @@ public struct PagedItems<T> {
     }
 }
 
+// MARK: - Pagination Helpers
+//
+public extension Remote {
+    /// Creates a PagedItems instance from response data and headers.
+    ///
+    /// - Parameters:
+    ///   - items: The parsed items from the response.
+    ///   - responseHeaders: HTTP response headers containing pagination info.
+    ///   - currentPageNumber: The current page number for determining if more pages exist.
+    /// - Returns: PagedItems instance with pagination metadata.
+    func createPagedItems<T>(items: [T],
+                             responseHeaders: [String: String]?,
+                             currentPageNumber: Int) -> PagedItems<T> {
+        // Extract total pages from response headers (case insensitive)
+        let totalPages = responseHeaders?.first(where: {
+            $0.key.lowercased() == PaginationHeaderKey.totalPagesCount.lowercased()
+        }).flatMap { Int($0.value) }
+
+        let hasMorePages = totalPages.map { currentPageNumber < $0 } ?? true
+
+        // Extract total count from response headers (case insensitive)
+        let totalItems = responseHeaders?.first(where: {
+            $0.key.lowercased() == PaginationHeaderKey.totalCount.lowercased()
+        }).flatMap { Int($0.value) }
+
+        return PagedItems(items: items, hasMorePages: hasMorePages, totalItems: totalItems)
+    }
+}
+
 // MARK: - Constants!
 //
 public extension Remote {

--- a/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
@@ -11,11 +11,10 @@ struct POSCatalogSyncRemoteTests {
         // Given
         let remote = POSCatalogSyncRemote(network: network)
         let modifiedAfter = Date(timeIntervalSince1970: 1692968400) // 2023-08-25 12:00:00 UTC
-        let productTypes: [ProductType] = [.simple, .variable]
         let pageNumber = 2
 
         // When
-        _ = try? await remote.loadProducts(modifiedAfter: modifiedAfter, siteID: sampleSiteID, productTypes: productTypes, pageNumber: pageNumber)
+        _ = try? await remote.loadProducts(modifiedAfter: modifiedAfter, siteID: sampleSiteID, pageNumber: pageNumber)
 
         // Then
         let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
@@ -23,7 +22,6 @@ struct POSCatalogSyncRemoteTests {
         let expectedDateString = dateFormatter.string(from: modifiedAfter)
 
         #expect(queryParametersDictionary["modified_after"] as? String == expectedDateString)
-        #expect(queryParametersDictionary["include_types"] as? String == "simple,variable")
         #expect(queryParametersDictionary["page"] as? String == String(pageNumber))
         #expect(queryParametersDictionary["per_page"] as? String == "100")
         #expect(queryParametersDictionary["_fields"] as? String == POSProduct.requestFields.joined(separator: ","))
@@ -33,12 +31,11 @@ struct POSCatalogSyncRemoteTests {
         // Given
         let remote = POSCatalogSyncRemote(network: network)
         let modifiedAfter = Date()
-        let productTypes: [ProductType] = [.simple]
         let expectedProductsCount = 2
 
         // When
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-pos")
-        let pagedProducts = try await remote.loadProducts(modifiedAfter: modifiedAfter, siteID: sampleSiteID, productTypes: productTypes, pageNumber: 1)
+        let pagedProducts = try await remote.loadProducts(modifiedAfter: modifiedAfter, siteID: sampleSiteID, pageNumber: 1)
 
         // Then
         #expect(pagedProducts.items.count == expectedProductsCount)
@@ -55,7 +52,7 @@ struct POSCatalogSyncRemoteTests {
 
         // When/Then
         await #expect(throws: NetworkError.notFound()) {
-            try await remote.loadProducts(modifiedAfter: Date(), siteID: sampleSiteID, productTypes: [.simple], pageNumber: 1)
+            try await remote.loadProducts(modifiedAfter: Date(), siteID: sampleSiteID, pageNumber: 1)
         }
     }
 
@@ -70,7 +67,6 @@ struct POSCatalogSyncRemoteTests {
         let pagedProducts = try await remote.loadProducts(
             modifiedAfter: modifiedAfter,
             siteID: sampleSiteID,
-            productTypes: [.simple],
             pageNumber: pageNumber
         )
 
@@ -89,7 +85,6 @@ struct POSCatalogSyncRemoteTests {
         let pagedProducts = try await remote.loadProducts(
             modifiedAfter: modifiedAfter,
             siteID: sampleSiteID,
-            productTypes: [.simple],
             pageNumber: pageNumber
         )
 
@@ -109,7 +104,6 @@ struct POSCatalogSyncRemoteTests {
         let pagedProducts = try await remote.loadProducts(
             modifiedAfter: modifiedAfter,
             siteID: sampleSiteID,
-            productTypes: [.simple],
             pageNumber: 1
         )
 
@@ -128,7 +122,6 @@ struct POSCatalogSyncRemoteTests {
         let pagedProducts = try await remote.loadProducts(
             modifiedAfter: modifiedAfter,
             siteID: sampleSiteID,
-            productTypes: [.simple],
             pageNumber: 1
         )
 
@@ -281,7 +274,7 @@ struct POSCatalogSyncRemoteTests {
 
         // When
         network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
-        _ = try? await remote.loadProducts(modifiedAfter: modifiedAfter, siteID: sampleSiteID, productTypes: [.simple], pageNumber: largePageNumber)
+        _ = try? await remote.loadProducts(modifiedAfter: modifiedAfter, siteID: sampleSiteID, pageNumber: largePageNumber)
 
         // Then
         let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])

--- a/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
@@ -1,0 +1,290 @@
+import Foundation
+import Testing
+@testable import Networking
+@testable import NetworkingCore
+
+struct POSCatalogSyncRemoteTests {
+    private let network = MockNetwork()
+    private let sampleSiteID: Int64 = 1234
+
+    @Test func loadProducts_sets_correct_parameters() async throws {
+        // Given
+        let remote = POSCatalogSyncRemote(network: network)
+        let modifiedAfter = Date(timeIntervalSince1970: 1692968400) // 2023-08-25 12:00:00 UTC
+        let productTypes: [ProductType] = [.simple, .variable]
+        let pageNumber = 2
+
+        // When
+        _ = try? await remote.loadProducts(modifiedAfter: modifiedAfter, siteID: sampleSiteID, productTypes: productTypes, pageNumber: pageNumber)
+
+        // Then
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        let dateFormatter = ISO8601DateFormatter()
+        let expectedDateString = dateFormatter.string(from: modifiedAfter)
+
+        #expect(queryParametersDictionary["modified_after"] as? String == expectedDateString)
+        #expect(queryParametersDictionary["include_types"] as? String == "simple,variable")
+        #expect(queryParametersDictionary["page"] as? String == String(pageNumber))
+        #expect(queryParametersDictionary["per_page"] as? String == "100")
+        #expect(queryParametersDictionary["_fields"] as? String == POSProduct.requestFields.joined(separator: ","))
+    }
+
+    @Test func loadProducts_returns_parsed_products() async throws {
+        // Given
+        let remote = POSCatalogSyncRemote(network: network)
+        let modifiedAfter = Date()
+        let productTypes: [ProductType] = [.simple]
+        let expectedProductsCount = 2
+
+        // When
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-pos")
+        let pagedProducts = try await remote.loadProducts(modifiedAfter: modifiedAfter, siteID: sampleSiteID, productTypes: productTypes, pageNumber: 1)
+
+        // Then
+        #expect(pagedProducts.items.count == expectedProductsCount)
+
+        let firstProduct = try #require(pagedProducts.items.first)
+        #expect(firstProduct.siteID == sampleSiteID)
+        #expect(firstProduct.productID == 168)
+        #expect(firstProduct.name == "Beanie")
+    }
+
+    @Test func loadProducts_relays_networking_error() async throws {
+        // Given
+        let remote = POSCatalogSyncRemote(network: network)
+
+        // When/Then
+        await #expect(throws: NetworkError.notFound()) {
+            try await remote.loadProducts(modifiedAfter: Date(), siteID: sampleSiteID, productTypes: [.simple], pageNumber: 1)
+        }
+    }
+
+    @Test(arguments: 1...4) func loadProducts_returns_hasMorePages_based_on_header(pageNumber: Int) async throws {
+        // Given a response with 5 pages
+        let remote = POSCatalogSyncRemote(network: network)
+        let modifiedAfter = Date()
+        network.responseHeaders = ["X-WP-TotalPages": "5"]
+        network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
+
+        // When loading page 1 to 4
+        let pagedProducts = try await remote.loadProducts(
+            modifiedAfter: modifiedAfter,
+            siteID: sampleSiteID,
+            productTypes: [.simple],
+            pageNumber: pageNumber
+        )
+
+        // Then there are more pages
+        #expect(pagedProducts.hasMorePages == true)
+    }
+
+    @Test(arguments: [5, 6]) func loadProducts_returns_false_for_hasMorePages_when_on_last_page(pageNumber: Int) async throws {
+        // Given a response with 5 pages
+        let remote = POSCatalogSyncRemote(network: network)
+        let modifiedAfter = Date()
+        network.responseHeaders = ["X-WP-TotalPages": "5"]
+        network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
+
+        // When loading page 5 or above
+        let pagedProducts = try await remote.loadProducts(
+            modifiedAfter: modifiedAfter,
+            siteID: sampleSiteID,
+            productTypes: [.simple],
+            pageNumber: pageNumber
+        )
+
+        // Then there are no more pages
+        #expect(pagedProducts.hasMorePages == false)
+    }
+
+    @Test func loadProducts_returns_total_items_from_header() async throws {
+        // Given
+        let remote = POSCatalogSyncRemote(network: network)
+        let modifiedAfter = Date()
+        let expectedTotalItems = 42
+        network.responseHeaders = ["X-WP-Total": "\(expectedTotalItems)"]
+        network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
+
+        // When
+        let pagedProducts = try await remote.loadProducts(
+            modifiedAfter: modifiedAfter,
+            siteID: sampleSiteID,
+            productTypes: [.simple],
+            pageNumber: 1
+        )
+
+        // Then
+        #expect(pagedProducts.totalItems == expectedTotalItems)
+    }
+
+    @Test func loadProducts_returns_nil_total_items_when_header_missing() async throws {
+        // Given
+        let remote = POSCatalogSyncRemote(network: network)
+        let modifiedAfter = Date()
+        network.responseHeaders = nil
+        network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
+
+        // When
+        let pagedProducts = try await remote.loadProducts(
+            modifiedAfter: modifiedAfter,
+            siteID: sampleSiteID,
+            productTypes: [.simple],
+            pageNumber: 1
+        )
+
+        // Then
+        #expect(pagedProducts.totalItems == nil)
+    }
+
+    // MARK: - Product Variations Tests
+
+    @Test func loadProductVariations_sets_correct_parameters() async throws {
+        // Given
+        let remote = POSCatalogSyncRemote(network: network)
+        let modifiedAfter = Date(timeIntervalSince1970: 1692968400) // 2023-08-25 12:00:00 UTC
+        let pageNumber = 3
+
+        // When
+        _ = try? await remote.loadProductVariations(modifiedAfter: modifiedAfter, siteID: sampleSiteID, pageNumber: pageNumber)
+
+        // Then
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        let dateFormatter = ISO8601DateFormatter()
+        let expectedDateString = dateFormatter.string(from: modifiedAfter)
+
+        #expect(queryParametersDictionary["modified_after"] as? String == expectedDateString)
+        #expect(queryParametersDictionary["page"] as? String == String(pageNumber))
+        #expect(queryParametersDictionary["per_page"] as? String == "100")
+        #expect(queryParametersDictionary["_fields"] as? String == POSProductVariation.requestFields.joined(separator: ","))
+    }
+
+    @Test func loadProductVariations_returns_parsed_variations() async throws {
+        // Given
+        let remote = POSCatalogSyncRemote(network: network)
+        let modifiedAfter = Date()
+
+        // When
+        network.simulateResponse(requestUrlSuffix: "variations", filename: "product-variations-load-pos")
+        let pagedVariations = try await remote.loadProductVariations(modifiedAfter: modifiedAfter, siteID: sampleSiteID, pageNumber: 1)
+
+        // Then
+        #expect(pagedVariations.items.count > 0)
+
+        let firstVariation = try #require(pagedVariations.items.first)
+        #expect(firstVariation.siteID == sampleSiteID)
+        #expect(firstVariation.productVariationID == 123)
+        #expect(firstVariation.productID == 119)
+    }
+
+    @Test func loadProductVariations_relays_networking_error() async throws {
+        // Given
+        let remote = POSCatalogSyncRemote(network: network)
+
+        // When/Then
+        await #expect(throws: NetworkError.notFound()) {
+            try await remote.loadProductVariations(modifiedAfter: Date(), siteID: sampleSiteID, pageNumber: 1)
+        }
+    }
+
+    @Test func loadProductVariations_returns_hasMorePages_based_on_header() async throws {
+        // Given a response with 3 pages
+        let remote = POSCatalogSyncRemote(network: network)
+        let modifiedAfter = Date()
+        network.responseHeaders = ["X-WP-TotalPages": "3"]
+        network.simulateResponse(requestUrlSuffix: "variations", filename: "empty-data-array")
+
+        // When loading page 1
+        let pagedVariations = try await remote.loadProductVariations(
+            modifiedAfter: modifiedAfter,
+            siteID: sampleSiteID,
+            pageNumber: 1
+        )
+
+        // Then there are more pages
+        #expect(pagedVariations.hasMorePages == true)
+    }
+
+    @Test func loadProductVariations_returns_false_for_hasMorePages_when_on_last_page() async throws {
+        // Given a response with 3 pages
+        let remote = POSCatalogSyncRemote(network: network)
+        let modifiedAfter = Date()
+        network.responseHeaders = ["X-WP-TotalPages": "3"]
+        network.simulateResponse(requestUrlSuffix: "variations", filename: "empty-data-array")
+
+        // When loading page 3
+        let pagedVariations = try await remote.loadProductVariations(
+            modifiedAfter: modifiedAfter,
+            siteID: sampleSiteID,
+            pageNumber: 3
+        )
+
+        // Then there are no more pages
+        #expect(pagedVariations.hasMorePages == false)
+    }
+
+    @Test func loadProductVariations_returns_total_items_from_header() async throws {
+        // Given
+        let remote = POSCatalogSyncRemote(network: network)
+        let modifiedAfter = Date()
+        let expectedTotalItems = 15
+        network.responseHeaders = ["X-WP-Total": "\(expectedTotalItems)"]
+        network.simulateResponse(requestUrlSuffix: "variations", filename: "empty-data-array")
+
+        // When
+        let pagedVariations = try await remote.loadProductVariations(
+            modifiedAfter: modifiedAfter,
+            siteID: sampleSiteID,
+            pageNumber: 1
+        )
+
+        // Then
+        #expect(pagedVariations.totalItems == expectedTotalItems)
+    }
+
+    // MARK: - Edge Cases
+
+    @Test func handles_very_old_date() async throws {
+        // Given
+        let remote = POSCatalogSyncRemote(network: network)
+        let veryOldDate = Date(timeIntervalSince1970: 0) // January 1, 1970
+
+        // When
+        network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
+        _ = try? await remote.loadProducts(modifiedAfter: veryOldDate, siteID: sampleSiteID, pageNumber: 1)
+
+        // Then
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        let dateString = try #require(queryParametersDictionary["modified_after"] as? String)
+        #expect(dateString == "1970-01-01T00:00:00Z")
+    }
+
+    @Test func handles_future_date() async throws {
+        // Given
+        let remote = POSCatalogSyncRemote(network: network)
+        let futureDate = Date(timeIntervalSince1970: 4102444800) // January 1, 2100
+
+        // When
+        network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
+        _ = try? await remote.loadProducts(modifiedAfter: futureDate, siteID: sampleSiteID, pageNumber: 1)
+
+        // Then
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        let dateString = try #require(queryParametersDictionary["modified_after"] as? String)
+        #expect(dateString == "2100-01-01T00:00:00Z")
+    }
+
+    @Test func handles_large_page_number() async throws {
+        // Given
+        let remote = POSCatalogSyncRemote(network: network)
+        let modifiedAfter = Date()
+        let largePageNumber = 999999
+
+        // When
+        network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
+        _ = try? await remote.loadProducts(modifiedAfter: modifiedAfter, siteID: sampleSiteID, productTypes: [.simple], pageNumber: largePageNumber)
+
+        // Then
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        #expect(queryParametersDictionary["page"] as? String == String(largePageNumber))
+    }
+}

--- a/Modules/Tests/NetworkingTests/Responses/product-variations-load-pos.json
+++ b/Modules/Tests/NetworkingTests/Responses/product-variations-load-pos.json
@@ -1,0 +1,43 @@
+{
+  "data": [
+    {
+      "id": 123,
+      "sku": "200815216",
+      "global_unique_id": "",
+      "price": "8",
+      "regular_price": "8",
+      "sale_price": "",
+      "on_sale": false,
+      "downloadable": false,
+      "manage_stock": "parent",
+      "stock_quantity": 10,
+      "stock_status": "instock",
+      "image": {
+        "id": 118,
+        "date_created": "2024-10-30T15:01:52",
+        "date_created_gmt": "2024-10-30T15:01:52",
+        "date_modified": "2025-08-25T08:04:03",
+        "date_modified_gmt": "2025-08-25T08:04:03",
+        "src": "https://example.com/wp-content/uploads/2024/10/dsc01913.jpeg",
+        "name": "dsc01913",
+        "alt": ""
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "name": "Size",
+          "slug": "pa_size",
+          "option": "Medium"
+        },
+        {
+          "id": 0,
+          "name": "Shot",
+          "slug": "shot",
+          "option": "triple"
+        }
+      ],
+      "parent_id": 119
+    }
+  ]
+}
+

--- a/Modules/Tests/NetworkingTests/Responses/products-load-pos.json
+++ b/Modules/Tests/NetworkingTests/Responses/products-load-pos.json
@@ -1,0 +1,105 @@
+{
+  "data": [
+    {
+      "id": 168,
+      "name": "Beanie",
+      "type": "simple",
+      "sku": "Woo-beanie",
+      "price": "18",
+      "regular_price": "20",
+      "sale_price": "18",
+      "on_sale": true,
+      "downloadable": false,
+      "parent_id": 0,
+      "images": [
+        {
+          "id": 192,
+          "date_created": "2024-10-31T05:19:56",
+          "date_created_gmt": "2024-10-31T05:19:56",
+          "date_modified": "2025-08-25T07:27:52",
+          "date_modified_gmt": "2025-08-25T07:27:52",
+          "src": "https://example.com/wp-content/uploads/2024/10/beanie-1.jpg",
+          "name": "beanie-1.jpg",
+          "alt": "",
+          "srcset": "",
+          "thumbnail": "https://example.com/wp-content/uploads/2024/10/beanie-300x300.jpg"
+        }
+      ],
+      "attributes": [
+        {
+          "id": 1,
+          "name": "Color",
+          "slug": "pa_color",
+          "position": 0,
+          "visible": true,
+          "variation": false,
+          "options": [
+            "Orange"
+          ]
+        }
+      ],
+      "manage_stock": false,
+      "stock_quantity": null,
+      "stock_status": "instock",
+      "global_unique_id": ""
+    },
+    {
+      "id": 119,
+      "name": "Latte",
+      "type": "variable",
+      "sku": "200815216",
+      "price": "7",
+      "regular_price": "",
+      "sale_price": "",
+      "on_sale": false,
+      "downloadable": false,
+      "parent_id": 0,
+      "images": [
+        {
+          "id": 118,
+          "date_created": "2024-10-30T15:01:52",
+          "date_created_gmt": "2024-10-30T15:01:52",
+          "date_modified": "2025-08-25T07:19:33",
+          "date_modified_gmt": "2025-08-25T07:19:33",
+          "src": "https://example.com/wp-content/uploads/2024/10/dsc01913.jpeg",
+          "name": "dsc01913",
+          "alt": "",
+          "srcset": "",
+          "sizes": "(max-width: 1616px) 100vw, 1616px",
+          "thumbnail": "https://example.com/wp-content/uploads/2024/10/dsc01913-300x300.jpeg"
+        }
+      ],
+      "attributes": [
+        {
+          "id": 2,
+          "name": "Size",
+          "slug": "pa_size",
+          "position": 0,
+          "visible": true,
+          "variation": true,
+          "options": [
+            "Large",
+            "Medium"
+          ]
+        },
+        {
+          "id": 0,
+          "name": "Espresso shot",
+          "slug": "Espresso shot",
+          "position": 0,
+          "visible": true,
+          "variation": true,
+          "options": [
+            "single",
+            "triple"
+          ]
+        }
+      ],
+      "manage_stock": true,
+      "stock_quantity": 10,
+      "stock_status": "instock",
+      "global_unique_id": ""
+    }
+  ]
+}
+


### PR DESCRIPTION
For WOOMOB-1096

## Description

Adds a new `POSCatalogSyncRemote` class to support incremental synchronization of POS catalog data. This enables merchants to efficiently sync only products and product variations that have been modified after a specific date, significantly reducing bandwidth usage and improving sync performance for large catalogs.

The implementation includes:
- `POSCatalogSyncRemote` with protocol-based design for easy mocking in the future
- `loadProducts` method with product type filtering and default values
- `loadProductVariations` method for fetching variation data
  - We are tentatively using an existing wc-analytics endpoint, and we will create a new endpoint with a WC path later
- Reusable pagination helper extracted to `Remote` base class

This PR also includes a feature flag for Local Catalog i1.

## Steps to reproduce

Just CI is sufficient as the remote isn't used in the app yet.

## Testing information

I tested with

```swift
let products = try await syncRemote.loadProducts(modifiedAfter: .init().addingTimeInterval(-90000), siteID: siteID, pageNumber: 1)
let variations = try await syncRemote.loadProductVariations(
    modifiedAfter: .init().addingTimeInterval(-90000),
    siteID: siteID,
    pageNumber: 1
)
print("Synced \(products.items.count) products and \(variations.items.count) variations for siteID \(siteID)")
```

in the app to verify that the remote methods are working as expected.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.