### PR TITLE
[POS Settings] Hardware section navigation

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -1,7 +1,9 @@
 import SwiftUI
+import enum Yosemite.AppSettingsAction
 
 struct PointOfSaleSettingsHardwareDetailView: View {
     @State private var navigationPath: [NavigationDestination] = []
+    @State private var lastKnownLoadedCardReader: String?
     @State private var showBarcodeScanningSetupModal: Bool = false
     @State private var showBarcodeScanningDocumentationModal: Bool = false
     @State private var showCardReaderDocumentationModal: Bool = false
@@ -76,6 +78,15 @@ struct PointOfSaleSettingsHardwareDetailView: View {
             }
             .padding()
 
+            if let lastKnownLoadedCardReader {
+                HStack {
+                    Text("Model: \(lastKnownLoadedCardReader)")
+                        .font(.posBodyMediumRegular())
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+            }
+
             List {
                 Button {
                     showCardReaderDocumentationModal = true
@@ -98,6 +109,17 @@ struct PointOfSaleSettingsHardwareDetailView: View {
         .navigationTitle(Localization.cardReadersTitle)
         .posSheet(isPresented: $showCardReaderDocumentationModal) {
             SafariView(url: WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL())
+        }
+        .task { @MainActor in
+            let action = AppSettingsAction.loadCardReader { reader in
+                switch reader {
+                case let .success(foundReader):
+                    lastKnownLoadedCardReader = foundReader
+                case let .failure(error):
+                    debugPrint(error)
+                }
+            }
+            ServiceLocator.stores.dispatch(action)
         }
     }
 

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -31,10 +31,6 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                     cardReadersView
                 case .hardware(.scanners):
                     scannersView
-                case .scanner:
-                    // This case in the navigation stack is not reached,
-                    // as we present the destination modally instead of further navigation through the stack.
-                    EmptyView()
                 }
             }
             .posModal(isPresented: $showBarcodeScanningSetupModal) {
@@ -151,7 +147,6 @@ struct PointOfSaleSettingsHardwareDetailView: View {
 extension PointOfSaleSettingsHardwareDetailView {
     enum NavigationDestination: Hashable {
         case hardware(PointOfSaleSettingsView.HardwareDestination)
-        case scanner(ScannerDestination)
     }
 
     enum ScannerDestination: Identifiable, CaseIterable {

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -40,7 +40,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
             .posModal(isPresented: $showBarcodeScanningSetupModal) {
                 PointOfSaleBarcodeScannerSetup(isPresented: $showBarcodeScanningSetupModal)
             }
-            .posSheet(isPresented: $showBarcodeScanningDocumentationModal) {
+            .posFullScreenCover(isPresented: $showBarcodeScanningDocumentationModal) {
                 SafariView(url: WooConstants.URLs.pointOfSaleDocumentation.asURL())
             }
         }
@@ -107,10 +107,11 @@ struct PointOfSaleSettingsHardwareDetailView: View {
             }
         }
         .navigationTitle(Localization.cardReadersTitle)
-        .posSheet(isPresented: $showCardReaderDocumentationModal) {
+        .posFullScreenCover(isPresented: $showCardReaderDocumentationModal) {
             SafariView(url: WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL())
         }
         .task { @MainActor in
+            // TODO: WOOMOB-1172
             let action = AppSettingsAction.loadCardReader { reader in
                 switch reader {
                 case let .success(foundReader):

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -10,7 +10,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
 
     var body: some View {
         NavigationStack(path: $navigationPath) {
-            List(PointOfSaleSettingsView.HardwareDestination.allCases) { destination in
+            List(HardwareDestination.allCases) { destination in
                 NavigationLink(value: NavigationDestination.hardware(destination)) {
                     HStack(alignment: .firstTextBaseline) {
                         Image(systemName: destination.icon)
@@ -145,8 +145,42 @@ struct PointOfSaleSettingsHardwareDetailView: View {
 }
 
 extension PointOfSaleSettingsHardwareDetailView {
+    enum HardwareDestination: Identifiable, CaseIterable {
+        case cardReaders
+        case scanners
+
+        var id: Self { self }
+
+        var title: String {
+            switch self {
+            case .cardReaders:
+                return Localization.hardwareNavigationCardReaderTitle
+            case .scanners:
+                return Localization.hardwareNavigationBarcodeTitle
+            }
+        }
+
+        var subtitle: String {
+            switch self {
+            case .cardReaders:
+                return Localization.hardwareNavigationCardReaderSubtitle
+            case .scanners:
+                return Localization.hardwareNavigationBarcodeSubtitle
+            }
+        }
+
+        var icon: String {
+            switch self {
+            case .cardReaders:
+                return "creditcard"
+            case .scanners:
+                return "qrcode.viewfinder"
+            }
+        }
+    }
+
     enum NavigationDestination: Hashable {
-        case hardware(PointOfSaleSettingsView.HardwareDestination)
+        case hardware(HardwareDestination)
     }
 
     enum ScannerDestination: Identifiable, CaseIterable {
@@ -256,6 +290,30 @@ private extension PointOfSaleSettingsHardwareDetailView {
             "pointOfSaleSettingsHardwareDetailView.cardReaderDocumentationSubtitle",
             value: "Learn more about accepting mobile payments",
             comment: "Subtitle describing card reader documentation in Point of Sale settings."
+        )
+
+        static let hardwareNavigationBarcodeTitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.hardwareNavigationBarcodeTitle",
+            value: "Barcode scanners",
+            comment: "Navigation title of Barcode scanner settings."
+        )
+
+        static let hardwareNavigationCardReaderTitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.hardwareNavigationCardReaderTitle",
+            value: "Card readers",
+            comment: "Navigation title of Card reader settings."
+        )
+
+        static let hardwareNavigationCardReaderSubtitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.hardwareNavigationCardReaderSubtitle",
+            value: "Manage card reader connections",
+            comment: "Description of Card reader settings for connections."
+        )
+
+        static let hardwareNavigationBarcodeSubtitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.hardwareNavigationBarcodeSubtitle",
+            value: "Configure barcode scanner settings",
+            comment: "Description of Barcode scanner settings configuration."
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct PointOfSaleSettingsHardwareDetailView: View {
     @State private var navigationPath: [NavigationDestination] = []
+    @State private var showBarcodeScanningSetupModal: Bool = false
+    @State private var showBarcodeScanningDocumentationModal: Bool = false
 
     var body: some View {
         NavigationStack(path: $navigationPath) {
@@ -26,10 +28,27 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                     cardReadersView
                 case .hardware(.scanners):
                     scannersView
-                case .scanner(let scannerDestination):
-                    scannerDetailView(for: scannerDestination)
+                case .scanner:
+                    // This case in the navigation stack is not reached,
+                    // as we present the destination modally instead of further navigation through the stack.
+                    EmptyView()
                 }
             }
+            .posModal(isPresented: $showBarcodeScanningSetupModal) {
+                PointOfSaleBarcodeScannerSetup(isPresented: $showBarcodeScanningSetupModal)
+            }
+            .posSheet(isPresented: $showBarcodeScanningDocumentationModal) {
+                SafariView(url: WooConstants.URLs.pointOfSaleDocumentation.asURL())
+            }
+        }
+    }
+
+    private func handleScannerDestination(_ destination: ScannerDestination) {
+        switch destination {
+        case .setup:
+            showBarcodeScanningSetupModal = true
+        case .documentation:
+            showBarcodeScanningDocumentationModal = true
         }
     }
 
@@ -48,7 +67,9 @@ struct PointOfSaleSettingsHardwareDetailView: View {
 
     private var scannersView: some View {
         List(ScannerDestination.allCases) { destination in
-            NavigationLink(value: NavigationDestination.scanner(destination)) {
+            Button {
+                handleScannerDestination(destination)
+            } label: {
                 HStack(alignment: .firstTextBaseline) {
                     Image(systemName: destination.icon)
                         .font(.posBodyLargeRegular())
@@ -59,24 +80,17 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                             .font(.posBodyMediumRegular())
                             .foregroundStyle(.secondary)
                     }
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.posBodyMediumRegular())
+                        .foregroundStyle(.secondary)
                 }
             }
+            .buttonStyle(.plain)
         }
         .navigationTitle(Localization.scannersTitle)
     }
 
-    private func scannerDetailView(for destination: ScannerDestination) -> some View {
-        VStack(spacing: POSSpacing.medium) {
-            Image(systemName: destination.icon).font(.largeTitle)
-            Text(destination.title)
-                .font(.posBodyLargeRegular())
-            Text("WIP")
-                .font(.posBodyMediumRegular())
-                .foregroundStyle(.secondary)
-        }
-        .padding()
-        .navigationTitle(destination.title)
-    }
 }
 
 extension PointOfSaleSettingsHardwareDetailView {

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -1,12 +1,12 @@
 import SwiftUI
 
 struct PointOfSaleSettingsHardwareDetailView: View {
-    @State private var navigationPath: [PointOfSaleSettingsView.HardwareDestination] = []
+    @State private var navigationPath: [NavigationDestination] = []
 
     var body: some View {
         NavigationStack(path: $navigationPath) {
             List(PointOfSaleSettingsView.HardwareDestination.allCases) { destination in
-                NavigationLink(value: destination) {
+                NavigationLink(value: NavigationDestination.hardware(destination)) {
                     HStack(alignment: .firstTextBaseline) {
                         Image(systemName: destination.icon)
                             .font(.posBodyLargeRegular())
@@ -20,19 +20,142 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                     }
                 }
             }
-            .navigationDestination(for: PointOfSaleSettingsView.HardwareDestination.self) { destination in
-                VStack(spacing: POSSpacing.medium) {
-                    Image(systemName: destination.icon).font(.largeTitle)
-                        .font(.posBodyLargeRegular())
-                    Text("\(destination.title) settings")
-                        .font(.posBodyMediumRegular())
-                    Text("Some placeholder")
-                        .font(.posBodyMediumRegular())
-                        .foregroundStyle(.secondary)
+            .navigationDestination(for: NavigationDestination.self) { destination in
+                switch destination {
+                case .hardware(.cardReaders):
+                    cardReadersView
+                case .hardware(.scanners):
+                    scannersView
+                case .scanner(let scannerDestination):
+                    scannerDetailView(for: scannerDestination)
                 }
-                .padding()
-                .navigationTitle(destination.title)
             }
         }
+    }
+
+    private var cardReadersView: some View {
+        VStack(spacing: POSSpacing.medium) {
+            Image(systemName: "creditcard").font(.largeTitle)
+            Text("Card readers settings")
+                .font(.posBodyLargeRegular())
+            Text("Manage your card reader connections")
+                .font(.posBodyMediumRegular())
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .navigationTitle(Localization.cardReadersTitle)
+    }
+
+    private var scannersView: some View {
+        List(ScannerDestination.allCases) { destination in
+            NavigationLink(value: NavigationDestination.scanner(destination)) {
+                HStack(alignment: .firstTextBaseline) {
+                    Image(systemName: destination.icon)
+                        .font(.posBodyLargeRegular())
+                    VStack(alignment: .leading, spacing: POSPadding.xSmall) {
+                        Text(destination.title)
+                            .font(.posBodyLargeRegular())
+                        Text(destination.subtitle)
+                            .font(.posBodyMediumRegular())
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .navigationTitle(Localization.scannersTitle)
+    }
+
+    private func scannerDetailView(for destination: ScannerDestination) -> some View {
+        VStack(spacing: POSSpacing.medium) {
+            Image(systemName: destination.icon).font(.largeTitle)
+            Text(destination.title)
+                .font(.posBodyLargeRegular())
+            Text("WIP")
+                .font(.posBodyMediumRegular())
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .navigationTitle(destination.title)
+    }
+}
+
+extension PointOfSaleSettingsHardwareDetailView {
+    enum NavigationDestination: Hashable {
+        case hardware(PointOfSaleSettingsView.HardwareDestination)
+        case scanner(ScannerDestination)
+    }
+
+    enum ScannerDestination: Identifiable, CaseIterable {
+        case setup
+        case documentation
+
+        var id: Self { self }
+
+        var title: String {
+            switch self {
+            case .setup:
+                return Localization.scannerSetupTitle
+            case .documentation:
+                return Localization.scannerDocumentationTitle
+            }
+        }
+
+        var subtitle: String {
+            switch self {
+            case .setup:
+                return Localization.scannerSetupSubtitle
+            case .documentation:
+                return Localization.scannerDocumentationSubtitle
+            }
+        }
+
+        var icon: String {
+            switch self {
+            case .setup:
+                return "gearshape"
+            case .documentation:
+                return "doc.text"
+            }
+        }
+    }
+}
+
+private extension PointOfSaleSettingsHardwareDetailView {
+    enum Localization {
+        static let cardReadersTitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.cardReadersTitle",
+            value: "Card readers",
+            comment: "Navigation title for card readers settings in Point of Sale."
+        )
+
+        static let scannersTitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.scannersTitle",
+            value: "Barcode scanners",
+            comment: "Navigation title for barcode scanners settings in Point of Sale."
+        )
+
+        static let scannerSetupTitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.scannerSetupTitle",
+            value: "Scanner Setup",
+            comment: "Title for scanner setup option in barcode scanners settings in Point of Sale."
+        )
+
+        static let scannerSetupSubtitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.scannerSetupSubtitle",
+            value: "Configure and test your barcode scanner",
+            comment: "Subtitle describing scanner setup in Point of Sale settings."
+        )
+
+        static let scannerDocumentationTitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.scannerDocumentationTitle",
+            value: "Documentation",
+            comment: "Title for barcode scanner documentation option in Point of Sale settings."
+        )
+
+        static let scannerDocumentationSubtitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.scannerDocumentationSubtitle",
+            value: "Learn more about barcode scanning in POS",
+            comment: "Subtitle describing barcode scanner documentation in Point of Sale settings."
+        )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -4,6 +4,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
     @State private var navigationPath: [NavigationDestination] = []
     @State private var showBarcodeScanningSetupModal: Bool = false
     @State private var showBarcodeScanningDocumentationModal: Bool = false
+    @State private var showCardReaderDocumentationModal: Bool = false
 
     var body: some View {
         NavigationStack(path: $navigationPath) {
@@ -53,16 +54,51 @@ struct PointOfSaleSettingsHardwareDetailView: View {
     }
 
     private var cardReadersView: some View {
-        VStack(spacing: POSSpacing.medium) {
-            Image(systemName: "creditcard").font(.largeTitle)
-            Text("Card readers settings")
-                .font(.posBodyLargeRegular())
-            Text("Manage your card reader connections")
-                .font(.posBodyMediumRegular())
-                .foregroundStyle(.secondary)
+        VStack(spacing: POSSpacing.large) {
+            VStack(spacing: POSSpacing.medium) {
+                VStack(spacing: POSPadding.small) {
+                    Text(Localization.cardReadersDescription)
+                        .font(.posBodyLargeRegular())
+                        .multilineTextAlignment(.center)
+                    Text(Localization.cardReadersSubtitle1)
+                        .font(.posBodyMediumRegular())
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                    Text(Localization.cardReadersSubtitle2)
+                        .font(.posBodyMediumRegular())
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                    Text(Localization.cardReadersSubtitle3)
+                        .font(.posBodyMediumRegular())
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .padding()
+
+            List {
+                Button {
+                    showCardReaderDocumentationModal = true
+                } label: {
+                    HStack(alignment: .firstTextBaseline) {
+                        Image(systemName: "doc.text")
+                            .font(.posBodyLargeRegular())
+                        VStack(alignment: .leading, spacing: POSPadding.xSmall) {
+                            Text(Localization.cardReaderDocumentationTitle)
+                                .font(.posBodyLargeRegular())
+                            Text(Localization.cardReaderDocumentationSubtitle)
+                                .font(.posBodyMediumRegular())
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+            }
         }
-        .padding()
         .navigationTitle(Localization.cardReadersTitle)
+        .posSheet(isPresented: $showCardReaderDocumentationModal) {
+            SafariView(url: WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL())
+        }
     }
 
     private var scannersView: some View {
@@ -80,10 +116,6 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                             .font(.posBodyMediumRegular())
                             .foregroundStyle(.secondary)
                     }
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.posBodyMediumRegular())
-                        .foregroundStyle(.secondary)
                 }
             }
             .buttonStyle(.plain)
@@ -170,6 +202,42 @@ private extension PointOfSaleSettingsHardwareDetailView {
             "pointOfSaleSettingsHardwareDetailView.scannerDocumentationSubtitle",
             value: "Learn more about barcode scanning in POS",
             comment: "Subtitle describing barcode scanner documentation in Point of Sale settings."
+        )
+
+        static let cardReadersDescription = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.cardReadersDescription",
+            value: "Accept secure and fast payments in person",
+            comment: "Main description for card readers functionality in Point of Sale settings."
+        )
+
+        static let cardReadersSubtitle1 = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.cardReadersSubtitle.1",
+            value: "Make sure the card reader is charged",
+            comment: "Subtitle describing card reader connection in Point of Sale settings."
+        )
+
+        static let cardReadersSubtitle2 = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.cardReadersSubtitle.2",
+            value: "Turn the card reader on, and place it next to the mobile device",
+            comment: "Subtitle describing card reader connection in Point of Sale settings."
+        )
+
+        static let cardReadersSubtitle3 = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.cardReadersSubtitle.3",
+            value: "Turn the mobile device bluetooth on",
+            comment: "Subtitle describing card reader connection in Point of Sale settings."
+        )
+
+        static let cardReaderDocumentationTitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.cardReaderDocumentationTitle",
+            value: "Documentation",
+            comment: "Title for card reader documentation option in Point of Sale settings."
+        )
+
+        static let cardReaderDocumentationSubtitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.cardReaderDocumentationSubtitle",
+            value: "Learn more about accepting mobile payments",
+            comment: "Subtitle describing card reader documentation in Point of Sale settings."
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
@@ -93,39 +93,6 @@ extension PointOfSaleSettingsView {
     enum Constants {
         static let sidebarWidthFraction: CGFloat = 0.35
     }
-    enum HardwareDestination: Identifiable, CaseIterable {
-        case cardReaders
-        case scanners
-
-        var id: Self { self }
-
-        var title: String {
-            switch self {
-            case .cardReaders:
-                return Localization.hardwareNavigationCardReaderTitle
-            case .scanners:
-                return Localization.hardwareNavigationBarcodeTitle
-            }
-        }
-
-        var subtitle: String {
-            switch self {
-            case .cardReaders:
-                return Localization.hardwareNavigationCardReaderSubtitle
-            case .scanners:
-                return Localization.hardwareNavigationBarcodeSubtitle
-            }
-        }
-
-        var icon: String {
-            switch self {
-            case .cardReaders:
-                return "creditcard"
-            case .scanners:
-                return "qrcode.viewfinder"
-            }
-        }
-    }
 }
 
 private extension PointOfSaleSettingsView {
@@ -202,30 +169,6 @@ private extension PointOfSaleSettingsView {
             "pointOfSaleSettingsView.sidebarNavigationHelpSubtitle",
             value: "Get help and support",
             comment: "Description of the Help section in Point of Sale settings."
-        )
-
-        static let hardwareNavigationBarcodeTitle = NSLocalizedString(
-            "pointOfSaleSettingsView.hardwareNavigationBarcodeTitle",
-            value: "Barcode scanners",
-            comment: "Navigation title of Barcode scanner settings."
-        )
-
-        static let hardwareNavigationCardReaderTitle = NSLocalizedString(
-            "pointOfSaleSettingsView.hardwareNavigationCardReaderTitle",
-            value: "Card readers",
-            comment: "Navigation title of Card reader settings."
-        )
-
-        static let hardwareNavigationCardReaderSubtitle = NSLocalizedString(
-            "pointOfSaleSettingsView.hardwareNavigationCardReaderSubtitle",
-            value: "Manage card reader connections",
-            comment: "Description of Card reader settings for connections."
-        )
-
-        static let hardwareNavigationBarcodeSubtitle = NSLocalizedString(
-            "pointOfSaleSettingsView.hardwareNavigationBarcodeSubtitle",
-            value: "Configure barcode scanner settings",
-            comment: "Description of Barcode scanner settings configuration."
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
@@ -14,73 +14,79 @@ struct PointOfSaleSettingsView: View {
                 }
                 .foregroundColor(.posOnSurface)
             })
-        HStack(spacing: POSSpacing.none) {
-            VStack(alignment: .leading, spacing: POSSpacing.none) {
-                List(selection: $selection) {
-                    Section {
-                        ForEach([SidebarNavigation.store, SidebarNavigation.hardware], id: \.self) { item in
-                            HStack {
-                                Image(systemName: item.icon)
-                                    .font(.posBodyLargeRegular())
-                                VStack(alignment: .leading) {
-                                    Text(item.title)
+        GeometryReader { geometry in
+            HStack(spacing: POSSpacing.none) {
+                VStack(alignment: .leading, spacing: POSSpacing.none) {
+                    List(selection: $selection) {
+                        Section {
+                            ForEach([SidebarNavigation.store, SidebarNavigation.hardware], id: \.self) { item in
+                                HStack {
+                                    Image(systemName: item.icon)
                                         .font(.posBodyLargeRegular())
-                                    Text(item.subtitle)
-                                        .font(.posBodyMediumRegular())
-                                        .foregroundStyle(.secondary)
+                                    VStack(alignment: .leading) {
+                                        Text(item.title)
+                                            .font(.posBodyLargeRegular())
+                                        Text(item.subtitle)
+                                            .font(.posBodyMediumRegular())
+                                            .foregroundStyle(.secondary)
+                                    }
                                 }
+                                .tag(item)
                             }
-                            .tag(item)
                         }
                     }
-                }
-                .safeAreaInset(edge: .bottom) {
-                    Button {
-                        selection = .help
-                    } label: {
-                        HStack {
-                            Image(systemName: SidebarNavigation.help.icon)
-                                .font(.posBodyLargeRegular())
-                                .foregroundStyle(selection == .help ? .white : .primary)
-                            VStack(alignment: .leading) {
-                                Text(SidebarNavigation.help.title)
+                    .safeAreaInset(edge: .bottom) {
+                        Button {
+                            selection = .help
+                        } label: {
+                            HStack {
+                                Image(systemName: SidebarNavigation.help.icon)
                                     .font(.posBodyLargeRegular())
                                     .foregroundStyle(selection == .help ? .white : .primary)
-                                Text(SidebarNavigation.help.subtitle)
-                                    .font(.posBodyMediumRegular())
-                                    .foregroundStyle(selection == .help ? .secondary : .secondary)
+                                VStack(alignment: .leading) {
+                                    Text(SidebarNavigation.help.title)
+                                        .font(.posBodyLargeRegular())
+                                        .foregroundStyle(selection == .help ? .white : .primary)
+                                    Text(SidebarNavigation.help.subtitle)
+                                        .font(.posBodyMediumRegular())
+                                        .foregroundStyle(selection == .help ? .secondary : .secondary)
+                                }
+                                Spacer()
                             }
-                            Spacer()
+                            .padding(.vertical, POSPadding.small)
+                            .padding(.horizontal, POSPadding.medium)
+                            .contentShape(Rectangle())
                         }
-                        .padding(.vertical, POSPadding.small)
-                        .padding(.horizontal, POSPadding.medium)
-                        .contentShape(Rectangle())
+                        .buttonStyle(.plain)
+                        .background(
+                            RoundedRectangle(cornerRadius: POSCornerRadiusStyle.large.value, style: .continuous)
+                                .fill(selection == .help ? Color.accentColor : Color.clear)
+                        )
                     }
-                    .buttonStyle(.plain)
-                    .background(
-                        RoundedRectangle(cornerRadius: POSCornerRadiusStyle.large.value, style: .continuous)
-                            .fill(selection == .help ? Color.accentColor : Color.clear)
-                    )
                 }
-            }
-            Group {
-                switch selection {
-                case .store:
-                    PointOfSaleSettingsStoreDetailView()
-                case .hardware:
-                    PointOfSaleSettingsHardwareDetailView()
-                case .help:
-                    PointOfSaleSettingsHelpDetailView()
-                default:
-                    EmptyView()
+                .frame(width: geometry.size.width * Constants.sidebarWidthFraction)
+                Group {
+                    switch selection {
+                    case .store:
+                        PointOfSaleSettingsStoreDetailView()
+                    case .hardware:
+                        PointOfSaleSettingsHardwareDetailView()
+                    case .help:
+                        PointOfSaleSettingsHelpDetailView()
+                    default:
+                        EmptyView()
+                    }
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 }
 
 extension PointOfSaleSettingsView {
+    enum Constants {
+        static let sidebarWidthFraction: CGFloat = 0.35
+    }
     enum HardwareDestination: Identifiable, CaseIterable {
         case cardReaders
         case scanners

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
@@ -65,20 +65,26 @@ struct PointOfSaleSettingsView: View {
                     }
                 }
                 .frame(width: geometry.size.width * Constants.sidebarWidthFraction)
-                Group {
-                    switch selection {
-                    case .store:
-                        PointOfSaleSettingsStoreDetailView()
-                    case .hardware:
-                        PointOfSaleSettingsHardwareDetailView()
-                    case .help:
-                        PointOfSaleSettingsHelpDetailView()
-                    default:
-                        EmptyView()
-                    }
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                detailView
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
+        }
+    }
+}
+
+extension PointOfSaleSettingsView {
+    @ViewBuilder
+    private var detailView: some View {
+        switch selection {
+        case .store:
+            PointOfSaleSettingsStoreDetailView()
+        case .hardware:
+            PointOfSaleSettingsHardwareDetailView()
+        case .help:
+            PointOfSaleSettingsHelpDetailView()
+        default:
+            EmptyView()
         }
     }
 }


### PR DESCRIPTION
Closes WOOMOB-1039

## Description

This PR adds the basic scaffolding and navigation for the Hardware section of POS settings, by allowing the merchant to navigate through card reader and barcode scanner setup in a detail view to the right, as well as see documentation full screen (for now) presented on top of the view.

Final UI is not handled yet, this will be done separately.

https://github.com/user-attachments/assets/78343ca6-14d6-4bbb-86d8-a6784bf90773

## Testing information
- In POS, tap on the `...` CTA, and go to `Settings`
- Tap `Hardware` > `Card Readers`. Observe that you can open documentation full screen, and the last known reader model will appear if any.
- Tap `Hardware` > `Barcode scanner` . Observe you can trigger the barcode scanner setup, as well as see the documentation.
