### PR TITLE
[POS Settings] Help section navigation

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -10,6 +10,7 @@ struct ItemListView: View {
     @Environment(\.keyboardObserver) private var keyboardObserver
     @EnvironmentObject var modalManager: POSModalManager
     @EnvironmentObject var sheetManager: POSSheetManager
+    @EnvironmentObject var coverManager: POSFullScreenCoverManager
 
     @Binding var selectedItemListType: ItemListType
     @Binding var searchTerm: String
@@ -43,7 +44,7 @@ struct ItemListView: View {
 
     private var isBarcodeScanningEnabled: Binding<Bool> {
         Binding(
-            get: { !isSearching && !modalManager.isPresented && !sheetManager.isPresented },
+            get: { !isSearching && !modalManager.isPresented && !sheetManager.isPresented && !coverManager.isPresented },
             set: { _ in }
         )
     }

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
@@ -8,8 +8,6 @@ struct PointOfSaleSettingsHelpDetailView: View {
     var body: some View {
         NavigationStack {
             VStack(alignment: .leading) {
-                Text("Help Settings")
-                    .font(.posBodyMediumRegular())
                 List {
                     Button {
                         showProductRestrictions = true
@@ -18,9 +16,9 @@ struct PointOfSaleSettingsHelpDetailView: View {
                             Image(systemName: "magnifyingglass")
                                 .font(.posBodyLargeRegular())
                             VStack(alignment: .leading, spacing: POSPadding.xSmall) {
-                                Text("Where are my products?")
+                                Text(Localization.productRestrictionsInfo)
                                     .font(.posBodyLargeRegular())
-                                Text("Where are my products subtitle")
+                                Text(Localization.productRestrictionsInfoSubtitle)
                                     .font(.posBodyMediumRegular())
                                     .foregroundStyle(.secondary)
                             }
@@ -34,9 +32,9 @@ struct PointOfSaleSettingsHelpDetailView: View {
                             Image(systemName: "doc.text")
                                 .font(.posBodyLargeRegular())
                             VStack(alignment: .leading, spacing: POSPadding.xSmall) {
-                                Text("Documentation")
+                                Text(Localization.documentationTitle)
                                     .font(.posBodyLargeRegular())
-                                Text("Documentation subtitle")
+                                Text(Localization.documentationSubtitle)
                                     .font(.posBodyMediumRegular())
                                     .foregroundStyle(.secondary)
                             }
@@ -51,9 +49,9 @@ struct PointOfSaleSettingsHelpDetailView: View {
                             Image(systemName: "questionmark")
                                 .font(.posBodyLargeRegular())
                             VStack(alignment: .leading, spacing: POSPadding.xSmall) {
-                                Text("Get Support")
+                                Text(Localization.getSupportTitle)
                                     .font(.posBodyLargeRegular())
-                                Text("Support subtitle")
+                                Text(Localization.getSupportSubtitle)
                                     .font(.posBodyMediumRegular())
                                     .foregroundStyle(.secondary)
                             }
@@ -90,8 +88,46 @@ private extension PointOfSaleSettingsHelpDetailView {
     }
 
     enum Localization {
+        static let productRestrictionsInfo = NSLocalizedString(
+            "PointOfSaleSettingsHelpDetailView.help.productRestrictionsInfo.button.title",
+            value: "Where are my products?",
+            comment: "The title of the menu button to view product restrictions info, shown in settings. " +
+            "We only show simple and variable products in POS, this shows a modal to help explain that limitation."
+        )
+
+        static let productRestrictionsInfoSubtitle = NSLocalizedString(
+            "PointOfSaleSettingsHelpDetailView.help.productRestrictionsInfo.button.subtitle",
+            value: "Learn about which products are supported in POS",
+            comment: "The subtitle of the menu button to view product restrictions info, shown in settings. " +
+            "We only show simple and variable products in POS, this shows a modal to help explain that limitation."
+        )
+
+        static let documentationTitle = NSLocalizedString(
+            "PointOfSaleSettingsHelpDetailView.help.documentation.button.subtitle",
+            value: "Documentation",
+            comment: "The title of the menu button to view documentation, shown in settings."
+        )
+
+        static let documentationSubtitle = NSLocalizedString(
+            "PointOfSaleSettingsHelpDetailView.help.documentation.button.subtitle",
+            value: "View guides and tutorials",
+            comment: "The subtitle of the menu button to view documentation, shown in settings."
+        )
+
+        static let getSupportTitle = NSLocalizedString(
+            "PointOfSaleSettingsHelpDetailView.help.getSupport.button.subtitle",
+            value: "Get Support",
+            comment: "The title of the menu button to contact support, shown in settings."
+        )
+
+        static let getSupportSubtitle = NSLocalizedString(
+            "PointOfSaleSettingsHelpDetailView.help.getSupport.button.subtitle",
+            value: "Contact our support team",
+            comment: "The subtitle of the menu button to contact support, shown in settings."
+        )
+
         static let supportCancel = NSLocalizedString(
-            "PointOfSaleSettingsHelpDetailView.support.cancel",
+            "PointOfSaleSettingsHelpDetailView.help.support.cancel",
             value: "Cancel",
             comment: "Button to dismiss the support form from the POS settings."
         )

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
@@ -1,16 +1,85 @@
 import SwiftUI
 
 struct PointOfSaleSettingsHelpDetailView: View {
+    @State private var showProductRestrictions = false
+    @State private var showDocumentation = false
+    @State private var showSupport = false
+
     var body: some View {
         NavigationStack {
             VStack(alignment: .leading) {
                 Text("Help Settings")
                     .font(.title2)
-                Text("Help-related configuration")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                List {
+                    Button {
+                        showProductRestrictions = true
+                    } label: {
+                        HStack(alignment: .firstTextBaseline) {
+                            Image(systemName: "magnifyingglass")
+                                .font(.posBodyLargeRegular())
+                            VStack(alignment: .leading, spacing: POSPadding.xSmall) {
+                                Text("Where are my products?")
+                                    .font(.posBodyLargeRegular())
+                                Text("Where are my products subtitle")
+                                    .font(.posBodyMediumRegular())
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    Button {
+                        showDocumentation = true
+                    } label: {
+                        HStack(alignment: .firstTextBaseline) {
+                            Image(systemName: "doc.text")
+                                .font(.posBodyLargeRegular())
+                            VStack(alignment: .leading, spacing: POSPadding.xSmall) {
+                                Text("Documentation")
+                                    .font(.posBodyLargeRegular())
+                                Text("Documentation subtitle")
+                                    .font(.posBodyMediumRegular())
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+
+                    Button {
+                        showSupport = true
+                    } label: {
+                        HStack(alignment: .firstTextBaseline) {
+                            Image(systemName: "questionmark")
+                                .font(.posBodyLargeRegular())
+                            VStack(alignment: .leading, spacing: POSPadding.xSmall) {
+                                Text("Get Support")
+                                    .font(.posBodyLargeRegular())
+                                Text("Support subtitle")
+                                    .font(.posBodyMediumRegular())
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
             }
             .padding()
+        }
+        .posModal(isPresented: $showProductRestrictions) {
+            // TODO: Remove copy on POSFloatingControlView.documentationView
+            // WOOMOB-1168
+            SimpleProductsOnlyInformation(isPresented: $showProductRestrictions)
+        }
+        .posSheet(isPresented: $showDocumentation) {
+            // TODO: Remove copy on PointOfSaleDashboardView.documentationView
+            // WOOMOB-1168
+            SafariView(url: WooConstants.URLs.pointOfSaleDocumentation.asURL())
+
+        }
+        .posSheet(isPresented: $showSupport) {
+            // TODO: Remove copy on PointOfSaleDashboardView.supportForm
+            // WOOMOB-1168
+            Text("Support form")
+                .interactiveDismissDisabled(true)
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
@@ -69,13 +69,13 @@ struct PointOfSaleSettingsHelpDetailView: View {
             // WOOMOB-1168
             SimpleProductsOnlyInformation(isPresented: $showProductRestrictions)
         }
-        .posSheet(isPresented: $showDocumentation) {
+        .posFullScreenCover(isPresented: $showDocumentation) {
             // TODO: Remove copy on PointOfSaleDashboardView.documentationView
             // WOOMOB-1168
             SafariView(url: WooConstants.URLs.pointOfSaleDocumentation.asURL())
 
         }
-        .posSheet(isPresented: $showSupport) {
+        .posFullScreenCover(isPresented: $showSupport) {
             // TODO: Remove copy on PointOfSaleDashboardView.supportForm
             // WOOMOB-1168
             supportForm

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
@@ -9,7 +9,7 @@ struct PointOfSaleSettingsHelpDetailView: View {
         NavigationStack {
             VStack(alignment: .leading) {
                 Text("Help Settings")
-                    .font(.title2)
+                    .font(.posBodyMediumRegular())
                 List {
                     Button {
                         showProductRestrictions = true
@@ -78,8 +78,38 @@ struct PointOfSaleSettingsHelpDetailView: View {
         .posSheet(isPresented: $showSupport) {
             // TODO: Remove copy on PointOfSaleDashboardView.supportForm
             // WOOMOB-1168
-            Text("Support form")
+            supportForm
                 .interactiveDismissDisabled(true)
         }
+    }
+}
+
+private extension PointOfSaleSettingsHelpDetailView {
+    enum Constants {
+        static let supportTag = "origin:point-of-sale"
+    }
+
+    enum Localization {
+        static let supportCancel = NSLocalizedString(
+            "PointOfSaleSettingsHelpDetailView.support.cancel",
+            value: "Cancel",
+            comment: "Button to dismiss the support form from the POS settings."
+        )
+    }
+
+    var supportForm: some View {
+        NavigationView {
+            SupportForm(isPresented: $showSupport,
+                        viewModel: SupportFormViewModel(sourceTag: Constants.supportTag,
+                                                        defaultSite: ServiceLocator.stores.sessionManager.defaultSite))
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.supportCancel) {
+                        showSupport = false
+                    }
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
     }
 }


### PR DESCRIPTION
Closes WOOMOB-1036

## Description
This PR adds the basic scaffolding and navigation for the Help section of POS settings, by allowing the merchant to navigate through help options and documentation in a detail view to the right, documentation and support are currently presented full screen (for now) on top of the view.

Final UI is not handled yet, this will be done separately.

https://indiemelon.mystagingwebsite.com/screen-recording-2025-08-26-at-11-17-01/

## Testing information
- In POS, tap on the `...` CTA, and go to Settings
- Tap Help
  - `Where are my products` will show the modal, and can redirect the merchant to order management if they wish to
  - `Documentation` will open a web view with the docs, full-screen
  - `Get support` opens the support form, once filled it's dismissed automatically and we're back to settings.
