### PR TITLE
Update application password enabled upon selecting default store

### DIFF
--- a/Modules/Sources/Fakes/Networking.generated.swift
+++ b/Modules/Sources/Fakes/Networking.generated.swift
@@ -1776,7 +1776,8 @@ extension Networking.Site {
             canBlaze: .fake(),
             isAdmin: .fake(),
             wasEcommerceTrial: .fake(),
-            hasSSOEnabled: .fake()
+            hasSSOEnabled: .fake(),
+            applicationPasswordAvailable: .fake()
         )
     }
 }
@@ -2012,22 +2013,6 @@ extension Networking.UploadableMedia {
             filename: .fake(),
             mimeType: .fake(),
             altText: .fake()
-        )
-    }
-}
-extension Networking.User {
-    /// Returns a "ready to use" type filled with fake values.
-    ///
-    public static func fake() -> Networking.User {
-        .init(
-            localID: .fake(),
-            siteID: .fake(),
-            email: .fake(),
-            username: .fake(),
-            firstName: .fake(),
-            lastName: .fake(),
-            nickname: .fake(),
-            roles: .fake()
         )
     }
 }

--- a/Modules/Sources/Fakes/NetworkingCore.generated.swift
+++ b/Modules/Sources/Fakes/NetworkingCore.generated.swift
@@ -575,3 +575,19 @@ extension NetworkingCore.StatsGranularityV4 {
         .hourly
     }
 }
+extension NetworkingCore.User {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> NetworkingCore.User {
+        .init(
+            localID: .fake(),
+            siteID: .fake(),
+            email: .fake(),
+            username: .fake(),
+            firstName: .fake(),
+            lastName: .fake(),
+            nickname: .fake(),
+            roles: .fake()
+        )
+    }
+}

--- a/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -2754,7 +2754,8 @@ extension Networking.Site {
         canBlaze: CopiableProp<Bool> = .copy,
         isAdmin: CopiableProp<Bool> = .copy,
         wasEcommerceTrial: CopiableProp<Bool> = .copy,
-        hasSSOEnabled: CopiableProp<Bool> = .copy
+        hasSSOEnabled: CopiableProp<Bool> = .copy,
+        applicationPasswordAvailable: CopiableProp<Bool> = .copy
     ) -> Networking.Site {
         let siteID = siteID ?? self.siteID
         let name = name ?? self.name
@@ -2778,6 +2779,7 @@ extension Networking.Site {
         let isAdmin = isAdmin ?? self.isAdmin
         let wasEcommerceTrial = wasEcommerceTrial ?? self.wasEcommerceTrial
         let hasSSOEnabled = hasSSOEnabled ?? self.hasSSOEnabled
+        let applicationPasswordAvailable = applicationPasswordAvailable ?? self.applicationPasswordAvailable
 
         return Networking.Site(
             siteID: siteID,
@@ -2801,7 +2803,8 @@ extension Networking.Site {
             canBlaze: canBlaze,
             isAdmin: isAdmin,
             wasEcommerceTrial: wasEcommerceTrial,
-            hasSSOEnabled: hasSSOEnabled
+            hasSSOEnabled: hasSSOEnabled,
+            applicationPasswordAvailable: applicationPasswordAvailable
         )
     }
 }
@@ -3093,39 +3096,6 @@ extension Networking.TopEarnerStatsItem {
             total: total,
             currency: currency,
             imageUrl: imageUrl
-        )
-    }
-}
-
-extension Networking.User {
-    public func copy(
-        localID: CopiableProp<Int64> = .copy,
-        siteID: CopiableProp<Int64> = .copy,
-        email: CopiableProp<String> = .copy,
-        username: CopiableProp<String> = .copy,
-        firstName: CopiableProp<String> = .copy,
-        lastName: CopiableProp<String> = .copy,
-        nickname: CopiableProp<String> = .copy,
-        roles: CopiableProp<[String]> = .copy
-    ) -> Networking.User {
-        let localID = localID ?? self.localID
-        let siteID = siteID ?? self.siteID
-        let email = email ?? self.email
-        let username = username ?? self.username
-        let firstName = firstName ?? self.firstName
-        let lastName = lastName ?? self.lastName
-        let nickname = nickname ?? self.nickname
-        let roles = roles ?? self.roles
-
-        return Networking.User(
-            localID: localID,
-            siteID: siteID,
-            email: email,
-            username: username,
-            firstName: firstName,
-            lastName: lastName,
-            nickname: nickname,
-            roles: roles
         )
     }
 }

--- a/Modules/Sources/Networking/Model/Site.swift
+++ b/Modules/Sources/Networking/Model/Site.swift
@@ -93,7 +93,7 @@ public struct Site: Decodable, Equatable, Hashable, GeneratedFakeable, Generated
     public let hasSSOEnabled: Bool
 
     /// Whether application password authentication is available
-    ///
+    /// periphery: ignore - to be used as part of WOOMOB-1123
     public let applicationPasswordAvailable: Bool
 
     /// Decodable Conformance.

--- a/Modules/Sources/Networking/Model/Site.swift
+++ b/Modules/Sources/Networking/Model/Site.swift
@@ -92,6 +92,10 @@ public struct Site: Decodable, Equatable, Hashable, GeneratedFakeable, Generated
     ///
     public let hasSSOEnabled: Bool
 
+    /// Whether application password authentication is available
+    ///
+    public let applicationPasswordAvailable: Bool
+
     /// Decodable Conformance.
     ///
     public init(from decoder: Decoder) throws {
@@ -156,7 +160,8 @@ public struct Site: Decodable, Equatable, Hashable, GeneratedFakeable, Generated
                   canBlaze: canBlaze,
                   isAdmin: isAdmin,
                   wasEcommerceTrial: wasEcommerceTrial,
-                  hasSSOEnabled: hasSSOEnabled)
+                  hasSSOEnabled: hasSSOEnabled,
+                  applicationPasswordAvailable: false) // to be updated by fetching SiteAPI
     }
 
     /// Designated Initializer.
@@ -182,7 +187,8 @@ public struct Site: Decodable, Equatable, Hashable, GeneratedFakeable, Generated
                 canBlaze: Bool,
                 isAdmin: Bool,
                 wasEcommerceTrial: Bool,
-                hasSSOEnabled: Bool) {
+                hasSSOEnabled: Bool,
+                applicationPasswordAvailable: Bool) {
         self.siteID = siteID
         self.name = name
         self.description = description
@@ -205,6 +211,7 @@ public struct Site: Decodable, Equatable, Hashable, GeneratedFakeable, Generated
         self.isAdmin = isAdmin
         self.wasEcommerceTrial = wasEcommerceTrial
         self.hasSSOEnabled = hasSSOEnabled
+        self.applicationPasswordAvailable = applicationPasswordAvailable
     }
 }
 

--- a/Modules/Sources/Networking/Model/WordPressSite.swift
+++ b/Modules/Sources/Networking/Model/WordPressSite.swift
@@ -109,7 +109,8 @@ public extension WordPressSite {
               canBlaze: false,
               isAdmin: false,
               wasEcommerceTrial: false,
-              hasSSOEnabled: false)
+              hasSSOEnabled: false,
+              applicationPasswordAvailable: false)
     }
 
     struct Authentication: Decodable {

--- a/Modules/Sources/NetworkingCore/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/NetworkingCore/Model/Copiable/Models+Copiable.generated.swift
@@ -888,3 +888,36 @@ extension NetworkingCore.SiteVisitStatsItem {
         )
     }
 }
+
+extension NetworkingCore.User {
+    public func copy(
+        localID: CopiableProp<Int64> = .copy,
+        siteID: CopiableProp<Int64> = .copy,
+        email: CopiableProp<String> = .copy,
+        username: CopiableProp<String> = .copy,
+        firstName: CopiableProp<String> = .copy,
+        lastName: CopiableProp<String> = .copy,
+        nickname: CopiableProp<String> = .copy,
+        roles: CopiableProp<[String]> = .copy
+    ) -> NetworkingCore.User {
+        let localID = localID ?? self.localID
+        let siteID = siteID ?? self.siteID
+        let email = email ?? self.email
+        let username = username ?? self.username
+        let firstName = firstName ?? self.firstName
+        let lastName = lastName ?? self.lastName
+        let nickname = nickname ?? self.nickname
+        let roles = roles ?? self.roles
+
+        return NetworkingCore.User(
+            localID: localID,
+            siteID: siteID,
+            email: email,
+            username: username,
+            firstName: firstName,
+            lastName: lastName,
+            nickname: nickname,
+            roles: roles
+        )
+    }
+}

--- a/Modules/Sources/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -55,7 +55,8 @@ struct ScreenshotObjectGraph: MockObjectGraph {
         canBlaze: false,
         isAdmin: false,
         wasEcommerceTrial: false,
-        hasSSOEnabled: false
+        hasSSOEnabled: false,
+        applicationPasswordAvailable: false
     )
 
     /// May not be needed anymore if we're not mocking the API

--- a/Modules/Sources/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
@@ -57,6 +57,7 @@ extension Storage.Site: ReadOnlyConvertible {
                     canBlaze: canBlaze,
                     isAdmin: isAdmin,
                     wasEcommerceTrial: wasEcommerceTrial,
-                    hasSSOEnabled: hasSSOEnabled)
+                    hasSSOEnabled: hasSSOEnabled,
+                    applicationPasswordAvailable: false) // to be updated separately
     }
 }

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -13,7 +13,6 @@ extension UserDefaults {
         case defaultStoreID
         case defaultStoreName
         case defaultStoreCurrencySettings
-        case defaultStoreHasApplicationPasswordEnabled
         case defaultAnonymousID
         case defaultRoles
         case deviceID

--- a/WooCommerce/Classes/Tools/RequirementsChecker.swift
+++ b/WooCommerce/Classes/Tools/RequirementsChecker.swift
@@ -135,9 +135,6 @@ private extension RequirementsChecker {
                 let saveTelemetryAvailabilityAction = AppSettingsAction.setTelemetryAvailability(siteID: siteID, isAvailable: siteAPI.telemetryIsAvailable)
                 self.stores.dispatch(saveTelemetryAvailabilityAction)
 
-                let applicationPasswordAvailable = siteAPI.applicationPasswordAvailable
-                userDefaults.set(applicationPasswordAvailable, forKey: .defaultStoreHasApplicationPasswordEnabled)
-
                 if siteAPI.highestWooVersion == .mark3 {
                     onCompletion?(.success(.validWCVersion))
                 } else {

--- a/WooCommerce/Classes/Tools/RequirementsChecker.swift
+++ b/WooCommerce/Classes/Tools/RequirementsChecker.swift
@@ -26,13 +26,10 @@ final class RequirementsChecker {
 
     private let stores: StoresManager
     private let baseViewController: UIViewController?
-    private let userDefaults: UserDefaults
 
     init(stores: StoresManager = ServiceLocator.stores,
-         userDefaults: UserDefaults = .standard,
          baseViewController: UIViewController? = nil) {
         self.stores = stores
-        self.userDefaults = userDefaults
         self.baseViewController = baseViewController
     }
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -296,6 +296,8 @@ class DefaultStoresManager: StoresManager {
             return
         }
 
+        sessionManager.defaultSite = site
+
         /// Triggers root endpoint to check if application password is available
         dispatch(SettingAction.retrieveSiteAPI(siteID: site.siteID) { [weak self] result in
             guard let self else { return }
@@ -304,7 +306,7 @@ class DefaultStoresManager: StoresManager {
                 let updatedSite = site.copy(applicationPasswordAvailable: siteAPI.applicationPasswordAvailable)
                 sessionManager.defaultSite = updatedSite
             case .failure:
-                sessionManager.defaultSite = site
+                break // ignores failure
             }
         })
     }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -295,7 +295,18 @@ class DefaultStoresManager: StoresManager {
         guard site.siteID == sessionManager.defaultStoreID else {
             return
         }
-        sessionManager.defaultSite = site
+
+        /// Triggers root endpoint to check if application password is available
+        dispatch(SettingAction.retrieveSiteAPI(siteID: site.siteID) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let siteAPI):
+                let updatedSite = site.copy(applicationPasswordAvailable: siteAPI.applicationPasswordAvailable)
+                sessionManager.defaultSite = updatedSite
+            case .failure:
+                sessionManager.defaultSite = site
+            }
+        })
     }
 
     /// Updates the user roles for the default Store site.
@@ -708,14 +719,24 @@ private extension DefaultStoresManager {
     ///
     func restoreSessionSiteAndSynchronizeIfNeeded(with siteID: Int64) {
         let action = AccountAction
-            .loadAndSynchronizeSite(siteID: siteID,
-                                    forcedUpdate: false) { [weak self] result in
-            guard let self = self else { return }
+            .loadAndSynchronizeSite(siteID: siteID, forcedUpdate: false) { [weak self] result in
+            guard let self else { return }
             guard case .success(let site) = result else {
                 return
             }
-            self.sessionManager.defaultSite = site
-            self.updateAndReloadWidgetInformation(with: siteID)
+            /// Triggers root endpoint to check if application password is available
+            dispatch(SettingAction.retrieveSiteAPI(siteID: siteID) { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case .success(let siteAPI):
+                    let updatedSite = site.copy(applicationPasswordAvailable: siteAPI.applicationPasswordAvailable)
+                    sessionManager.defaultSite = updatedSite
+                    updateAndReloadWidgetInformation(with: siteID)
+                case .failure:
+                    sessionManager.defaultSite = site
+                    updateAndReloadWidgetInformation(with: siteID)
+                }
+            })
         }
         dispatch(action)
     }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -659,9 +659,9 @@ private extension DefaultStoresManager {
 
         if siteID == WooConstants.placeholderStoreID,
            let url = sessionManager.defaultCredentials?.siteAddress {
-            restoreSessionSite(with: url)
+            restoreWordPressSite(with: url)
         } else {
-            restoreSessionSiteAndSynchronizeIfNeeded(with: siteID)
+            restoreJetpackSiteAndSynchronizeIfNeeded(with: siteID)
         }
 
         synchronizeSettings(with: siteID) {
@@ -685,7 +685,7 @@ private extension DefaultStoresManager {
 
     /// Load the site with the specified URL into the session if possible.
     ///
-    func restoreSessionSite(with url: String) {
+    func restoreWordPressSite(with url: String) {
         let action = WordPressSiteAction.fetchSiteInfo(siteURL: url) { [weak self] result in
             guard let self else { return }
             switch result {
@@ -717,7 +717,7 @@ private extension DefaultStoresManager {
     /// Loads the specified siteID into the Session, if possible.
     /// If the site does not exist in storage, it synchronizes the site asynchronously.
     ///
-    func restoreSessionSiteAndSynchronizeIfNeeded(with siteID: Int64) {
+    func restoreJetpackSiteAndSynchronizeIfNeeded(with siteID: Int64) {
         let action = AccountAction
             .loadAndSynchronizeSite(siteID: siteID, forcedUpdate: false) { [weak self] result in
             guard let self else { return }

--- a/WooCommerce/WooCommerceTests/Tools/RequirementsCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/RequirementsCheckerTests.swift
@@ -202,38 +202,4 @@ final class RequirementsCheckerTests: XCTestCase {
             self.viewController.presentedViewController is UIAlertController
         }
     }
-
-    func test_checkSiteEligibility_updates_application_password_availability_in_userDefaults() throws {
-        // Given
-        let site = Site.fake().copy(siteID: 123)
-        let stores = MockStoresManager(sessionManager: .makeForTesting(defaultSite: site))
-        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: UUID().uuidString))
-        let checker = RequirementsChecker(stores: stores, userDefaults: userDefaults)
-
-        stores.whenReceivingAction(ofType: SettingAction.self) { action in
-            switch action {
-            case .retrieveSiteAPI(_, let onCompletion):
-                onCompletion(.success(SiteAPI(siteID: site.siteID, namespaces: ["wc/v3"], applicationPasswordAvailable: true)))
-            default:
-                break
-            }
-        }
-
-        XCTAssertFalse(userDefaults.bool(forKey: UserDefaults.Key.defaultStoreHasApplicationPasswordEnabled.rawValue))
-
-        // When
-        waitForExpectation { expectation in
-            checker.checkSiteEligibility(for: site) { result in
-                switch result {
-                case .success(let value):
-                    expectation.fulfill()
-                case .failure:
-                    break
-                }
-            }
-        }
-
-        // Then
-        XCTAssertTrue(userDefaults.bool(forKey: UserDefaults.Key.defaultStoreHasApplicationPasswordEnabled.rawValue))
-    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of WOOMOB-1123

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously in #16020 I added a user default value to update application password enabled for a site when checking site API from the store picker. This is not reliable as we also select site from other places, e.g. after [setting up Jetpack](https://github.com/woocommerce/woocommerce-ios/blob/46a51258e6a6a088b96cc206a8bd2ca28fbb5f77/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift#L261) or [installing Jetpack for a JCP site](https://github.com/woocommerce/woocommerce-ios/blob/46a51258e6a6a088b96cc206a8bd2ca28fbb5f77/WooCommerce/Classes/ViewRelated/Dashboard/JCPJetpackInstall/JCPJetpackInstallStepsViewModel.swift#L176).

Changes in this PR:
- Adds a new property `applicationPasswordAvailable` for `Site` model. This is false by default and needs to be updated separately.
- Triggers site API checks in `DefaultStoresManager` at 2 places: when setting site through `updateDefaultStore` and when restoring Jetpack sites.
- Removes the redundant user default key and logic in `RequirementsChecker`.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Build and run the app - confirm that the site title is displayed correctly on the dashboard and menu screens upon app launch, after login and switching stores.

The new property `applicationPasswordAvailable` will be used in #16027.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested app launch, login, store switching on simulator iPhone 16 iOS 18.2.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

No UI changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.