### PR TITLE
[POS Settings] Minor UI updates

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
@@ -24,7 +24,7 @@ struct PointOfSaleSettingsHelpDetailView: View {
                     }
                 }
                 .buttonStyle(.plain)
-                
+
                 Button {
                     showDocumentation = true
                 } label: {

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
@@ -7,60 +7,58 @@ struct PointOfSaleSettingsHelpDetailView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(alignment: .leading) {
-                List {
-                    Button {
-                        showProductRestrictions = true
-                    } label: {
-                        HStack(alignment: .firstTextBaseline) {
-                            Image(systemName: "magnifyingglass")
+            List {
+                Button {
+                    showProductRestrictions = true
+                } label: {
+                    HStack(alignment: .firstTextBaseline) {
+                        Image(systemName: "magnifyingglass")
+                            .font(.posBodyLargeRegular())
+                        VStack(alignment: .leading, spacing: POSPadding.xSmall) {
+                            Text(Localization.productRestrictionsInfo)
                                 .font(.posBodyLargeRegular())
-                            VStack(alignment: .leading, spacing: POSPadding.xSmall) {
-                                Text(Localization.productRestrictionsInfo)
-                                    .font(.posBodyLargeRegular())
-                                Text(Localization.productRestrictionsInfoSubtitle)
-                                    .font(.posBodyMediumRegular())
-                                    .foregroundStyle(.secondary)
-                            }
+                            Text(Localization.productRestrictionsInfoSubtitle)
+                                .font(.posBodyMediumRegular())
+                                .foregroundStyle(.secondary)
                         }
                     }
-                    .buttonStyle(.plain)
-                    Button {
-                        showDocumentation = true
-                    } label: {
-                        HStack(alignment: .firstTextBaseline) {
-                            Image(systemName: "doc.text")
-                                .font(.posBodyLargeRegular())
-                            VStack(alignment: .leading, spacing: POSPadding.xSmall) {
-                                Text(Localization.documentationTitle)
-                                    .font(.posBodyLargeRegular())
-                                Text(Localization.documentationSubtitle)
-                                    .font(.posBodyMediumRegular())
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                    }
-                    .buttonStyle(.plain)
-
-                    Button {
-                        showSupport = true
-                    } label: {
-                        HStack(alignment: .firstTextBaseline) {
-                            Image(systemName: "questionmark")
-                                .font(.posBodyLargeRegular())
-                            VStack(alignment: .leading, spacing: POSPadding.xSmall) {
-                                Text(Localization.getSupportTitle)
-                                    .font(.posBodyLargeRegular())
-                                Text(Localization.getSupportSubtitle)
-                                    .font(.posBodyMediumRegular())
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                    }
-                    .buttonStyle(.plain)
                 }
+                .buttonStyle(.plain)
+                
+                Button {
+                    showDocumentation = true
+                } label: {
+                    HStack(alignment: .firstTextBaseline) {
+                        Image(systemName: "doc.text")
+                            .font(.posBodyLargeRegular())
+                        VStack(alignment: .leading, spacing: POSPadding.xSmall) {
+                            Text(Localization.documentationTitle)
+                                .font(.posBodyLargeRegular())
+                            Text(Localization.documentationSubtitle)
+                                .font(.posBodyMediumRegular())
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    showSupport = true
+                } label: {
+                    HStack(alignment: .firstTextBaseline) {
+                        Image(systemName: "questionmark")
+                            .font(.posBodyLargeRegular())
+                        VStack(alignment: .leading, spacing: POSPadding.xSmall) {
+                            Text(Localization.getSupportTitle)
+                                .font(.posBodyLargeRegular())
+                            Text(Localization.getSupportSubtitle)
+                                .font(.posBodyMediumRegular())
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
             }
-            .padding()
         }
         .posModal(isPresented: $showProductRestrictions) {
             // TODO: Remove copy on POSFloatingControlView.documentationView

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
@@ -5,45 +5,64 @@ struct PointOfSaleSettingsStoreDetailView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(alignment: .leading) {
-                Group {
+            List {
+                Section {
+                    VStack(alignment: .leading, spacing: POSPadding.small) {
+                        Text(Localization.storeName)
+                            .font(.posBodyMediumRegular())
+                        Text(settingsController.storeName)
+                            .font(.posBodyMediumRegular())
+                            .foregroundStyle(.secondary)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: POSPadding.small) {
+                        Text(Localization.address)
+                            .font(.posBodyMediumRegular())
+                        Text(settingsController.storeAddress)
+                            .font(.posBodyMediumRegular())
+                            .foregroundStyle(.secondary)
+                    }
+                } header: {
                     Text(Localization.storeInformation)
                         .font(.posBodyLargeRegular())
-
-                    Text(Localization.storeName)
-                    Text(settingsController.storeName)
-                        .font(.posBodyMediumRegular())
-                        .foregroundStyle(.secondary)
-
-                    Text(Localization.address)
-                    Text(settingsController.storeAddress)
-                        .font(.posBodyMediumRegular())
-                        .foregroundStyle(.secondary)
                 }
-
-                Group {
-                    Spacer()
+                
+                Section {
+                    VStack(alignment: .leading, spacing: POSPadding.small) {
+                        Text(Localization.receiptStoreName)
+                            .font(.posBodyMediumRegular())
+                        settingValueView(for: settingsController.receiptStoreName)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: POSPadding.small) {
+                        Text(Localization.physicalAddress)
+                            .font(.posBodyMediumRegular())
+                        settingValueView(for: settingsController.receiptStoreAddress)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: POSPadding.small) {
+                        Text(Localization.phoneNumber)
+                            .font(.posBodyMediumRegular())
+                        settingValueView(for: settingsController.receiptStorePhone)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: POSPadding.small) {
+                        Text(Localization.email)
+                            .font(.posBodyMediumRegular())
+                        settingValueView(for: settingsController.receiptStoreEmail)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: POSPadding.small) {
+                        Text(Localization.refundReturnsPolicy)
+                            .font(.posBodyMediumRegular())
+                        settingValueView(for: settingsController.receiptRefundReturnsPolicy)
+                    }
+                } header: {
                     Text(Localization.receiptInformation)
                         .font(.posBodyLargeRegular())
-                    Text(Localization.receiptStoreName)
-                    settingValueView(for: settingsController.receiptStoreName)
-
-                    Text(Localization.physicalAddress)
-                    settingValueView(for: settingsController.receiptStoreAddress)
-
-                    Text(Localization.phoneNumber)
-                    settingValueView(for: settingsController.receiptStorePhone)
-
-                    Text(Localization.email)
-                    settingValueView(for: settingsController.receiptStoreEmail)
-
-                    Text(Localization.refundReturnsPolicy)
-                    settingValueView(for: settingsController.receiptRefundReturnsPolicy)
-
                 }
                 .renderedIf(settingsController.shouldShowReceiptInformation)
             }
-            .padding()
         }
     }
 

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
@@ -14,7 +14,7 @@ struct PointOfSaleSettingsStoreDetailView: View {
                             .font(.posBodyMediumRegular())
                             .foregroundStyle(.secondary)
                     }
-                    
+
                     VStack(alignment: .leading, spacing: POSPadding.small) {
                         Text(Localization.address)
                             .font(.posBodyMediumRegular())
@@ -26,32 +26,32 @@ struct PointOfSaleSettingsStoreDetailView: View {
                     Text(Localization.storeInformation)
                         .font(.posBodyLargeRegular())
                 }
-                
+
                 Section {
                     VStack(alignment: .leading, spacing: POSPadding.small) {
                         Text(Localization.receiptStoreName)
                             .font(.posBodyMediumRegular())
                         settingValueView(for: settingsController.receiptStoreName)
                     }
-                    
+
                     VStack(alignment: .leading, spacing: POSPadding.small) {
                         Text(Localization.physicalAddress)
                             .font(.posBodyMediumRegular())
                         settingValueView(for: settingsController.receiptStoreAddress)
                     }
-                    
+
                     VStack(alignment: .leading, spacing: POSPadding.small) {
                         Text(Localization.phoneNumber)
                             .font(.posBodyMediumRegular())
                         settingValueView(for: settingsController.receiptStorePhone)
                     }
-                    
+
                     VStack(alignment: .leading, spacing: POSPadding.small) {
                         Text(Localization.email)
                             .font(.posBodyMediumRegular())
                         settingValueView(for: settingsController.receiptStoreEmail)
                     }
-                    
+
                     VStack(alignment: .leading, spacing: POSPadding.small) {
                         Text(Localization.refundReturnsPolicy)
                             .font(.posBodyMediumRegular())

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
@@ -33,55 +33,31 @@ extension PointOfSaleSettingsView {
                                                buttonIcon: "xmark"))
             .foregroundColor(.posSurface)
 
-            List(selection: $selection) {
-                Section {
-                    ForEach([SidebarNavigation.store, SidebarNavigation.hardware], id: \.self) { item in
-                        HStack {
-                            Image(systemName: item.icon)
-                                .font(.posBodyLargeRegular())
-                            VStack(alignment: .leading) {
-                                Text(item.title)
-                                    .font(.posBodyLargeRegular())
-                                Text(item.subtitle)
-                                    .font(.posBodyMediumRegular())
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                        .tag(item)
-                    }
-                }
-            }
-            .safeAreaInset(edge: .bottom) {
-                Button {
-                    selection = .help
-                } label: {
-                    HStack {
-                        Image(systemName: SidebarNavigation.help.icon)
-                            .font(.posBodyLargeRegular())
-                            .foregroundStyle(selection == .help ? .white : .primary)
-                        VStack(alignment: .leading) {
-                            Text(SidebarNavigation.help.title)
-                                .font(.posBodyLargeRegular())
-                                .foregroundStyle(selection == .help ? .white : .primary)
-                            Text(SidebarNavigation.help.subtitle)
-                                .font(.posBodyMediumRegular())
-                                .foregroundStyle(selection == .help ? .secondary : .secondary)
-                        }
-                        Spacer()
-                    }
-                    .padding(.vertical, POSPadding.small)
-                    .padding(.horizontal, POSPadding.medium)
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .background(
-                    RoundedRectangle(cornerRadius: POSCornerRadiusStyle.large.value, style: .continuous)
-                        .fill(selection == .help ? Color.accentColor : Color.clear)
+            VStack(spacing: POSSpacing.small) {
+                PointOfSaleSettingsCard(
+                    item: .store,
+                    isSelected: selection == .store,
+                    onTap: { selection = .store }
+                )
+
+                PointOfSaleSettingsCard(
+                    item: .hardware,
+                    isSelected: selection == .hardware,
+                    onTap: { selection = .hardware }
+                )
+
+                Spacer()
+
+                PointOfSaleSettingsCard(
+                    item: .help,
+                    isSelected: selection == .help,
+                    onTap: { selection = .help }
                 )
             }
+            .padding(.horizontal, POSPadding.medium)
         }
     }
-    
+
     @ViewBuilder
     private var detailView: some View {
         switch selection {
@@ -103,7 +79,40 @@ extension PointOfSaleSettingsView {
     }
 }
 
-private extension PointOfSaleSettingsView {
+struct PointOfSaleSettingsCard: View {
+    let item: PointOfSaleSettingsView.SidebarNavigation
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack {
+                Image(systemName: item.icon)
+                    .font(.posBodyLargeRegular())
+                    .foregroundStyle(isSelected ? .white : .primary)
+                VStack(alignment: .leading) {
+                    Text(item.title)
+                        .font(.posBodyLargeRegular())
+                        .foregroundStyle(isSelected ? .white : .primary)
+                    Text(item.subtitle)
+                        .font(.posBodyMediumRegular())
+                        .foregroundStyle(isSelected ? .white.opacity(0.8) : .secondary)
+                }
+                Spacer()
+            }
+            .padding(.vertical, POSPadding.small)
+            .padding(.horizontal, POSPadding.medium)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .background(
+            RoundedRectangle(cornerRadius: POSCornerRadiusStyle.large.value, style: .continuous)
+                .fill(isSelected ? Color.accentColor : Color.clear)
+        )
+    }
+}
+
+extension PointOfSaleSettingsView {
     enum SidebarNavigation: String, CaseIterable, Identifiable {
         case store
         case hardware

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
@@ -7,65 +7,9 @@ struct PointOfSaleSettingsView: View {
     let settingsController: PointOfSaleSettingsControllerProtocol
 
     var body: some View {
-        POSPageHeaderView(
-            title: Localization.navigationTitle,
-            trailingContent: {
-                Button(action: { dismiss() }) {
-                    Text(Image(systemName: "xmark"))
-                        .font(.posButtonSymbolLarge)
-                }
-                .foregroundColor(.posOnSurface)
-            })
         GeometryReader { geometry in
             HStack(spacing: POSSpacing.none) {
-                VStack(alignment: .leading, spacing: POSSpacing.none) {
-                    List(selection: $selection) {
-                        Section {
-                            ForEach([SidebarNavigation.store, SidebarNavigation.hardware], id: \.self) { item in
-                                HStack {
-                                    Image(systemName: item.icon)
-                                        .font(.posBodyLargeRegular())
-                                    VStack(alignment: .leading) {
-                                        Text(item.title)
-                                            .font(.posBodyLargeRegular())
-                                        Text(item.subtitle)
-                                            .font(.posBodyMediumRegular())
-                                            .foregroundStyle(.secondary)
-                                    }
-                                }
-                                .tag(item)
-                            }
-                        }
-                    }
-                    .safeAreaInset(edge: .bottom) {
-                        Button {
-                            selection = .help
-                        } label: {
-                            HStack {
-                                Image(systemName: SidebarNavigation.help.icon)
-                                    .font(.posBodyLargeRegular())
-                                    .foregroundStyle(selection == .help ? .white : .primary)
-                                VStack(alignment: .leading) {
-                                    Text(SidebarNavigation.help.title)
-                                        .font(.posBodyLargeRegular())
-                                        .foregroundStyle(selection == .help ? .white : .primary)
-                                    Text(SidebarNavigation.help.subtitle)
-                                        .font(.posBodyMediumRegular())
-                                        .foregroundStyle(selection == .help ? .secondary : .secondary)
-                                }
-                                Spacer()
-                            }
-                            .padding(.vertical, POSPadding.small)
-                            .padding(.horizontal, POSPadding.medium)
-                            .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                        .background(
-                            RoundedRectangle(cornerRadius: POSCornerRadiusStyle.large.value, style: .continuous)
-                                .fill(selection == .help ? Color.accentColor : Color.clear)
-                        )
-                    }
-                }
+                listView
                 .frame(width: geometry.size.width * Constants.sidebarWidthFraction)
 
                 detailView
@@ -79,6 +23,65 @@ struct PointOfSaleSettingsView: View {
 }
 
 extension PointOfSaleSettingsView {
+    @ViewBuilder
+    private var listView: some View {
+        VStack(alignment: .leading, spacing: POSSpacing.none) {
+            POSPageHeaderView(
+                title: Localization.navigationTitle,
+                backButtonConfiguration: .init(state: .enabled,
+                                               action: { dismiss() },
+                                               buttonIcon: "xmark"))
+            .foregroundColor(.posSurface)
+
+            List(selection: $selection) {
+                Section {
+                    ForEach([SidebarNavigation.store, SidebarNavigation.hardware], id: \.self) { item in
+                        HStack {
+                            Image(systemName: item.icon)
+                                .font(.posBodyLargeRegular())
+                            VStack(alignment: .leading) {
+                                Text(item.title)
+                                    .font(.posBodyLargeRegular())
+                                Text(item.subtitle)
+                                    .font(.posBodyMediumRegular())
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .tag(item)
+                    }
+                }
+            }
+            .safeAreaInset(edge: .bottom) {
+                Button {
+                    selection = .help
+                } label: {
+                    HStack {
+                        Image(systemName: SidebarNavigation.help.icon)
+                            .font(.posBodyLargeRegular())
+                            .foregroundStyle(selection == .help ? .white : .primary)
+                        VStack(alignment: .leading) {
+                            Text(SidebarNavigation.help.title)
+                                .font(.posBodyLargeRegular())
+                                .foregroundStyle(selection == .help ? .white : .primary)
+                            Text(SidebarNavigation.help.subtitle)
+                                .font(.posBodyMediumRegular())
+                                .foregroundStyle(selection == .help ? .secondary : .secondary)
+                        }
+                        Spacer()
+                    }
+                    .padding(.vertical, POSPadding.small)
+                    .padding(.horizontal, POSPadding.medium)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .background(
+                    RoundedRectangle(cornerRadius: POSCornerRadiusStyle.large.value, style: .continuous)
+                        .fill(selection == .help ? Color.accentColor : Color.clear)
+                )
+            }
+        }
+    }
+    
     @ViewBuilder
     private var detailView: some View {
         switch selection {


### PR DESCRIPTION

## Description
This PR adds some minor UI updates to POS settings, so is not that _"scaffoldy"_ (is that a word?) in trunk and represents better the UI.

UI is still not final, this is just so they don't look that bad, and closer to what we expect will end being.

## Changes
- Removed the header across the full view, moved it to the list side instead
- Moved the close button to the utmost left
- Wrapped subviews in List component for some better consistency
- Removed list usage from the left side, as limits where we can position the different buttons, instead created dedicated cards for each view.

https://github.com/user-attachments/assets/0e579158-a7e6-4163-aa22-f662b101e65e

## Testing information
- In POS > tap on Settings
- Observe that the card for each setting (Store, Hardware, Help) is consistent, and loads the detail view upon tapping
- Detail views show content within a List, which has some consistency for background/surface colors
- Navigate around, observe that buttons/webviews/modals work
- Close button is in the top-left now, tap and see that works
