### PR TITLE
[POS Settings] Display card reader details in hardware section

### DIFF
--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -99,13 +99,6 @@ protocol PointOfSaleAggregateModelProtocol {
         _viewStateCoordinator
     }
 
-    private var connectedCardReader: CardPresentPaymentCardReader? {
-        guard case .connected(let reader) = cardReaderConnectionStatus else {
-            return nil
-        }
-        return reader
-    }
-
     init(entryPointController: POSEntryPointController,
          itemsController: PointOfSaleItemsControllerProtocol,
          purchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol,

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -99,7 +99,7 @@ protocol PointOfSaleAggregateModelProtocol {
         _viewStateCoordinator
     }
 
-    var connectedCardReader: CardPresentPaymentCardReader? {
+    private var connectedCardReader: CardPresentPaymentCardReader? {
         guard case .connected(let reader) = cardReaderConnectionStatus else {
             return nil
         }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -133,7 +133,6 @@ protocol PointOfSaleAggregateModelProtocol {
         publishCardReaderConnectionStatus()
         publishPaymentMessages()
         setupReaderReconnectionObservation()
-        observeCardReaderForSettings()
     }
 }
 
@@ -324,21 +323,6 @@ extension PointOfSaleAggregateModel {
         }
     }
 
-    private func observeCardReaderForSettings() {
-        cardPresentPaymentService.readerConnectionStatusPublisher
-            .sink(receiveValue: { [weak self] connectionStatus in
-                guard let self else { return }
-                let cardReader: CardPresentPaymentCardReader?
-                switch connectionStatus {
-                case .connected(let reader):
-                    cardReader = reader
-                default:
-                    cardReader = nil
-                }
-                settingsController.updateCardReader(cardReader)
-            })
-            .store(in: &cancellables)
-    }
 
     /// Starts a payment immediately if a reader is connected.
     /// Otherwise, schedules a payment to start the next time a reader connects.

--- a/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleAggregateModel.swift
@@ -99,6 +99,13 @@ protocol PointOfSaleAggregateModelProtocol {
         _viewStateCoordinator
     }
 
+    var connectedCardReader: CardPresentPaymentCardReader? {
+        guard case .connected(let reader) = cardReaderConnectionStatus else {
+            return nil
+        }
+        return reader
+    }
+
     init(entryPointController: POSEntryPointController,
          itemsController: PointOfSaleItemsControllerProtocol,
          purchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol,
@@ -133,6 +140,7 @@ protocol PointOfSaleAggregateModelProtocol {
         publishCardReaderConnectionStatus()
         publishPaymentMessages()
         setupReaderReconnectionObservation()
+        observeCardReaderForSettings()
     }
 }
 
@@ -321,6 +329,22 @@ extension PointOfSaleAggregateModel {
         Task { @MainActor [weak self] in
             await self?.cardPresentPaymentService.disconnectReader()
         }
+    }
+
+    private func observeCardReaderForSettings() {
+        cardPresentPaymentService.readerConnectionStatusPublisher
+            .sink(receiveValue: { [weak self] connectionStatus in
+                guard let self else { return }
+                let cardReader: CardPresentPaymentCardReader?
+                switch connectionStatus {
+                case .connected(let reader):
+                    cardReader = reader
+                default:
+                    cardReader = nil
+                }
+                settingsController.updateCardReader(cardReader)
+            })
+            .store(in: &cancellables)
     }
 
     /// Starts a payment immediately if a reader is connected.

--- a/WooCommerce/Classes/POS/Models/PointOfSaleSettingsController.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleSettingsController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 import struct Yosemite.SiteSetting
 import enum Yosemite.Plugin
 import class Yosemite.PluginsService
@@ -22,7 +23,6 @@ protocol PointOfSaleSettingsControllerProtocol {
     var connectedCardReader: CardPresentPaymentCardReader? { get }
 
     func retrievePOSReceiptSettings() async
-    func updateCardReader(_ cardReader: CardPresentPaymentCardReader?)
 }
 
 @Observable final class PointOfSaleSettingsController: PointOfSaleSettingsControllerProtocol {
@@ -38,17 +38,32 @@ protocol PointOfSaleSettingsControllerProtocol {
     private let settingsService: PointOfSaleSettingsServiceProtocol
     private let siteSettings: [SiteSetting]
     private(set) var connectedCardReader: CardPresentPaymentCardReader?
+    private var cancellables: AnyCancellable?
 
     init(settingsService: PointOfSaleSettingsServiceProtocol,
+         cardPresentPaymentService: CardPresentPaymentFacade,
          defaultSiteName: String? = ServiceLocator.stores.sessionManager.defaultSite?.name,
          siteSettings: [SiteSetting] = ServiceLocator.selectedSiteSettings.siteSettings) {
         self.settingsService = settingsService
         self.defaultSiteName = defaultSiteName
         self.siteSettings = siteSettings
+
+        observeCardReader(from: cardPresentPaymentService)
     }
 
-    func updateCardReader(_ cardReader: CardPresentPaymentCardReader?) {
-        connectedCardReader = cardReader
+    private func observeCardReader(from service: CardPresentPaymentFacade) {
+        cancellables = service.readerConnectionStatusPublisher
+            .sink(receiveValue: { [weak self] connectionStatus in
+                guard let self else { return }
+                let cardReader: CardPresentPaymentCardReader?
+                switch connectionStatus {
+                case .connected(let reader):
+                    cardReader = reader
+                default:
+                    cardReader = nil
+                }
+                connectedCardReader = cardReader
+            })
     }
 
     var storeName: String {
@@ -149,8 +164,5 @@ final class PointOfSaleSettingsPreviewController: PointOfSaleSettingsControllerP
         // no-op
     }
 
-    func updateCardReader(_ cardReader: CardPresentPaymentCardReader?) {
-        // no-op for preview
-    }
 }
 #endif

--- a/WooCommerce/Classes/POS/Models/PointOfSaleSettingsController.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleSettingsController.swift
@@ -19,7 +19,10 @@ protocol PointOfSaleSettingsControllerProtocol {
     var storeName: String { get }
     var storeAddress: String { get }
 
+    var connectedCardReader: CardPresentPaymentCardReader? { get }
+
     func retrievePOSReceiptSettings() async
+    func updateCardReader(_ cardReader: CardPresentPaymentCardReader?)
 }
 
 @Observable final class PointOfSaleSettingsController: PointOfSaleSettingsControllerProtocol {
@@ -34,6 +37,7 @@ protocol PointOfSaleSettingsControllerProtocol {
     private let defaultSiteName: String?
     private let settingsService: PointOfSaleSettingsServiceProtocol
     private let siteSettings: [SiteSetting]
+    private(set) var connectedCardReader: CardPresentPaymentCardReader?
 
     init(settingsService: PointOfSaleSettingsServiceProtocol,
          defaultSiteName: String? = ServiceLocator.stores.sessionManager.defaultSite?.name,
@@ -41,6 +45,10 @@ protocol PointOfSaleSettingsControllerProtocol {
         self.settingsService = settingsService
         self.defaultSiteName = defaultSiteName
         self.siteSettings = siteSettings
+    }
+
+    func updateCardReader(_ cardReader: CardPresentPaymentCardReader?) {
+        connectedCardReader = cardReader
     }
 
     var storeName: String {
@@ -53,6 +61,20 @@ protocol PointOfSaleSettingsControllerProtocol {
 
     var storeAddress: String {
         SiteAddress(siteSettings: siteSettings).address
+    }
+
+    var cardReaderName: String? {
+        connectedCardReader?.name
+    }
+
+    var cardReaderBatteryLevel: Float? {
+        connectedCardReader?.batteryLevel
+    }
+
+    var formattedBatteryLevel: String? {
+        guard let batteryLevel = cardReaderBatteryLevel else { return nil }
+        let percentage = Int(batteryLevel * 100)
+        return "\(percentage)%"
     }
 
     @MainActor
@@ -128,12 +150,29 @@ final class PointOfSaleSettingsPreviewController: PointOfSaleSettingsControllerP
     var shouldShowReceiptInformation: Bool = true
     var storeName: String = "Sample Store"
 
+    var connectedCardReader: CardPresentPaymentCardReader? = CardPresentPaymentCardReader(
+        name: "WisePad 3",
+        batteryLevel: 0.75
+    )
+
+    var cardReaderName: String? { connectedCardReader?.name }
+    var cardReaderBatteryLevel: Float? { connectedCardReader?.batteryLevel }
+    var formattedBatteryLevel: String? {
+        guard let batteryLevel = cardReaderBatteryLevel else { return nil }
+        let percentage = Int(batteryLevel * 100)
+        return "\(percentage)%"
+    }
+
     var storeAddress: String {
         "123 Main Street\nAnytown, ST 12345"
     }
 
     func retrievePOSReceiptSettings() async {
         // no-op
+    }
+
+    func updateCardReader(_ cardReader: CardPresentPaymentCardReader?) {
+        // no-op for preview
     }
 }
 #endif

--- a/WooCommerce/Classes/POS/Models/PointOfSaleSettingsController.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleSettingsController.swift
@@ -63,20 +63,6 @@ protocol PointOfSaleSettingsControllerProtocol {
         SiteAddress(siteSettings: siteSettings).address
     }
 
-    var cardReaderName: String? {
-        connectedCardReader?.name
-    }
-
-    var cardReaderBatteryLevel: Float? {
-        connectedCardReader?.batteryLevel
-    }
-
-    var formattedBatteryLevel: String? {
-        guard let batteryLevel = cardReaderBatteryLevel else { return nil }
-        let percentage = Int(batteryLevel * 100)
-        return "\(percentage)%"
-    }
-
     @MainActor
     func retrievePOSReceiptSettings() async {
         isLoading = true
@@ -154,14 +140,6 @@ final class PointOfSaleSettingsPreviewController: PointOfSaleSettingsControllerP
         name: "WisePad 3",
         batteryLevel: 0.75
     )
-
-    var cardReaderName: String? { connectedCardReader?.name }
-    var cardReaderBatteryLevel: Float? { connectedCardReader?.batteryLevel }
-    var formattedBatteryLevel: String? {
-        guard let batteryLevel = cardReaderBatteryLevel else { return nil }
-        let percentage = Int(batteryLevel * 100)
-        return "\(percentage)%"
-    }
 
     var storeAddress: String {
         "123 Main Street\nAnytown, ST 12345"

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -303,6 +303,8 @@ private extension PointOfSaleSettingsHardwareDetailView {
     }
 }
 
+#if DEBUG
 #Preview {
     PointOfSaleSettingsHardwareDetailView(settingsController: PointOfSaleSettingsPreviewController())
 }
+#endif

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct PointOfSaleSettingsHardwareDetailView: View {
     let settingsController: PointOfSaleSettingsControllerProtocol
-    
+
     @State private var navigationPath: [NavigationDestination] = []
     @State private var showBarcodeScanningSetupModal: Bool = false
     @State private var showBarcodeScanningDocumentationModal: Bool = false
@@ -12,16 +12,16 @@ struct PointOfSaleSettingsHardwareDetailView: View {
         if let cardReaderName = settingsController.connectedCardReader?.name {
             return cardReaderName
         } else {
-            return "Not set"
+            return Localization.cardReaderNotSet
         }
     }
-    
+
     private var formattedBatteryLevel: String {
         if let batteryLevel = settingsController.connectedCardReader?.batteryLevel {
             let percentage = Int(batteryLevel * 100)
             return "\(percentage)%"
         } else {
-            return "Unknown"
+            return Localization.batteryLevelUnknown
         }
     }
 
@@ -70,41 +70,29 @@ struct PointOfSaleSettingsHardwareDetailView: View {
 
     private var cardReadersView: some View {
         VStack(spacing: POSSpacing.large) {
-            VStack(spacing: POSSpacing.medium) {
-                VStack(spacing: POSPadding.small) {
-                    Text(Localization.cardReadersDescription)
-                        .font(.posBodyLargeRegular())
-                        .multilineTextAlignment(.center)
-                    Text(Localization.cardReadersSubtitle1)
-                        .font(.posBodyMediumRegular())
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                    Text(Localization.cardReadersSubtitle2)
-                        .font(.posBodyMediumRegular())
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                    Text(Localization.cardReadersSubtitle3)
-                        .font(.posBodyMediumRegular())
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                }
-            }
-            .padding()
-
-            VStack(spacing: POSPadding.xSmall) {
-                HStack {
-                    Text("Model: \(cardReaderName)")
-                        .font(.posBodyMediumRegular())
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity)
-                    Text("Battery: \(formattedBatteryLevel)")
-                        .font(.posBodyMediumRegular())
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity)
-                }
-            }
-
             List {
+                VStack(spacing: POSPadding.xSmall) {
+                    HStack {
+                        Text("Model")
+                            .font(.posBodyMediumRegular())
+                            .foregroundStyle(.primary)
+                        Spacer()
+                        Text(cardReaderName)
+                            .font(.posBodyMediumRegular())
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding()
+                    HStack {
+                        Text("Battery")
+                            .font(.posBodyMediumRegular())
+                            .foregroundStyle(.primary)
+                        Spacer()
+                        Text(formattedBatteryLevel)
+                            .font(.posBodyMediumRegular())
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding()
+                }
                 Button {
                     showCardReaderDocumentationModal = true
                 } label: {
@@ -229,6 +217,18 @@ extension PointOfSaleSettingsHardwareDetailView {
 
 private extension PointOfSaleSettingsHardwareDetailView {
     enum Localization {
+        static let cardReaderNotSet = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.cardReaderNotSet",
+            value: "Not set",
+            comment: "Text displayed on Point of Sale settings when any setting has not been provided."
+        )
+
+        static let batteryLevelUnknown = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.batteryLevelUnknown",
+            value: "Unknown",
+            comment: "Text displayed on Point of Sale settings when card reader battery is unknown."
+        )
+
         static let cardReadersTitle = NSLocalizedString(
             "pointOfSaleSettingsHardwareDetailView.cardReadersTitle",
             value: "Card readers",
@@ -263,30 +263,6 @@ private extension PointOfSaleSettingsHardwareDetailView {
             "pointOfSaleSettingsHardwareDetailView.scannerDocumentationSubtitle",
             value: "Learn more about barcode scanning in POS",
             comment: "Subtitle describing barcode scanner documentation in Point of Sale settings."
-        )
-
-        static let cardReadersDescription = NSLocalizedString(
-            "pointOfSaleSettingsHardwareDetailView.cardReadersDescription",
-            value: "Accept secure and fast payments in person",
-            comment: "Main description for card readers functionality in Point of Sale settings."
-        )
-
-        static let cardReadersSubtitle1 = NSLocalizedString(
-            "pointOfSaleSettingsHardwareDetailView.cardReadersSubtitle.1",
-            value: "Make sure the card reader is charged",
-            comment: "Subtitle describing card reader connection in Point of Sale settings."
-        )
-
-        static let cardReadersSubtitle2 = NSLocalizedString(
-            "pointOfSaleSettingsHardwareDetailView.cardReadersSubtitle.2",
-            value: "Turn the card reader on, and place it next to the mobile device",
-            comment: "Subtitle describing card reader connection in Point of Sale settings."
-        )
-
-        static let cardReadersSubtitle3 = NSLocalizedString(
-            "pointOfSaleSettingsHardwareDetailView.cardReadersSubtitle.3",
-            value: "Turn the mobile device bluetooth on",
-            comment: "Subtitle describing card reader connection in Point of Sale settings."
         )
 
         static let cardReaderDocumentationTitle = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -8,6 +8,23 @@ struct PointOfSaleSettingsHardwareDetailView: View {
     @State private var showBarcodeScanningDocumentationModal: Bool = false
     @State private var showCardReaderDocumentationModal: Bool = false
 
+    private var cardReaderName: String {
+        if let cardReaderName = settingsController.connectedCardReader?.name {
+            return cardReaderName
+        } else {
+            return "Not set"
+        }
+    }
+    
+    private var formattedBatteryLevel: String {
+        if let batteryLevel = settingsController.connectedCardReader?.batteryLevel {
+            let percentage = Int(batteryLevel * 100)
+            return "\(percentage)%"
+        } else {
+            return "Unknown"
+        }
+    }
+
     var body: some View {
         NavigationStack(path: $navigationPath) {
             List(HardwareDestination.allCases) { destination in
@@ -74,20 +91,16 @@ struct PointOfSaleSettingsHardwareDetailView: View {
             }
             .padding()
 
-            if let cardReader = settingsController.connectedCardReader {
-                VStack(spacing: POSPadding.xSmall) {
-                    HStack {
-                        Text("Model: \(cardReader.name)")
-                            .font(.posBodyMediumRegular())
-                            .foregroundStyle(.secondary)
-                            .multilineTextAlignment(.center)
-                        HStack {
-                            Text("Battery: \(cardReader.batteryLevel)")
-                                .font(.posBodyMediumRegular())
-                                .foregroundStyle(.secondary)
-                                .multilineTextAlignment(.center)
-                        }
-                    }
+            VStack(spacing: POSPadding.xSmall) {
+                HStack {
+                    Text("Model: \(cardReaderName)")
+                        .font(.posBodyMediumRegular())
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity)
+                    Text("Battery: \(formattedBatteryLevel)")
+                        .font(.posBodyMediumRegular())
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity)
                 }
             }
 

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import enum Yosemite.AppSettingsAction
 
 struct PointOfSaleSettingsHardwareDetailView: View {
     let settingsController: PointOfSaleSettingsControllerProtocol
@@ -75,12 +74,20 @@ struct PointOfSaleSettingsHardwareDetailView: View {
             }
             .padding()
 
-            if let lastKnownLoadedCardReader {
-                HStack {
-                    Text("Model: \(lastKnownLoadedCardReader)")
-                        .font(.posBodyMediumRegular())
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
+            if let cardReader = settingsController.connectedCardReader {
+                VStack(spacing: POSPadding.xSmall) {
+                    HStack {
+                        Text("Model: \(cardReader.name)")
+                            .font(.posBodyMediumRegular())
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                        HStack {
+                            Text("Battery: \(cardReader.batteryLevel)")
+                                .font(.posBodyMediumRegular())
+                                .foregroundStyle(.secondary)
+                                .multilineTextAlignment(.center)
+                        }
+                    }
                 }
             }
 
@@ -106,18 +113,6 @@ struct PointOfSaleSettingsHardwareDetailView: View {
         .navigationTitle(Localization.cardReadersTitle)
         .posFullScreenCover(isPresented: $showCardReaderDocumentationModal) {
             SafariView(url: WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL())
-        }
-        .task { @MainActor in
-            // TODO: WOOMOB-1172
-            let action = AppSettingsAction.loadCardReader { reader in
-                switch reader {
-                case let .success(foundReader):
-                    lastKnownLoadedCardReader = foundReader
-                case let .failure(error):
-                    debugPrint(error)
-                }
-            }
-            ServiceLocator.stores.dispatch(action)
         }
     }
 
@@ -320,5 +315,5 @@ private extension PointOfSaleSettingsHardwareDetailView {
 }
 
 #Preview {
-    PointOfSaleSettingsHardwareDetailView()
+    PointOfSaleSettingsHardwareDetailView(settingsController: PointOfSaleSettingsPreviewController())
 }

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -12,7 +12,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
         if let cardReaderName = settingsController.connectedCardReader?.name {
             return cardReaderName
         } else {
-            return Localization.cardReaderNotSet
+            return Localization.cardReaderNotConnected
         }
     }
 
@@ -229,10 +229,10 @@ private extension PointOfSaleSettingsHardwareDetailView {
             comment: "Text displayed on Point of Sale settings pointing to the card reader battery."
         )
 
-        static let cardReaderNotSet = NSLocalizedString(
-            "pointOfSaleSettingsHardwareDetailView.cardReaderNotSet",
-            value: "Not set",
-            comment: "Text displayed on Point of Sale settings when any setting has not been provided."
+        static let cardReaderNotConnected = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.cardReaderNotConnected",
+            value: "Reader not connected",
+            comment: "Text displayed on Point of Sale settings when the card reader is not connected."
         )
 
         static let batteryLevelUnknown = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -73,7 +73,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
             List {
                 VStack(spacing: POSPadding.xSmall) {
                     HStack {
-                        Text("Model")
+                        Text(Localization.readerModelTitle)
                             .font(.posBodyMediumRegular())
                             .foregroundStyle(.primary)
                         Spacer()
@@ -83,7 +83,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                     }
                     .padding()
                     HStack {
-                        Text("Battery")
+                        Text(Localization.readerBatteryTitle)
                             .font(.posBodyMediumRegular())
                             .foregroundStyle(.primary)
                         Spacer()
@@ -217,6 +217,18 @@ extension PointOfSaleSettingsHardwareDetailView {
 
 private extension PointOfSaleSettingsHardwareDetailView {
     enum Localization {
+        static let readerModelTitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.readerModelTitle",
+            value: "Model",
+            comment: "Text displayed on Point of Sale settings pointing to the card reader model."
+        )
+
+        static let readerBatteryTitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.readerBatteryTitle",
+            value: "Battery",
+            comment: "Text displayed on Point of Sale settings pointing to the card reader battery."
+        )
+
         static let cardReaderNotSet = NSLocalizedString(
             "pointOfSaleSettingsHardwareDetailView.cardReaderNotSet",
             value: "Not set",

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -2,8 +2,9 @@ import SwiftUI
 import enum Yosemite.AppSettingsAction
 
 struct PointOfSaleSettingsHardwareDetailView: View {
+    let settingsController: PointOfSaleSettingsControllerProtocol
+    
     @State private var navigationPath: [NavigationDestination] = []
-    @State private var lastKnownLoadedCardReader: String?
     @State private var showBarcodeScanningSetupModal: Bool = false
     @State private var showBarcodeScanningDocumentationModal: Bool = false
     @State private var showCardReaderDocumentationModal: Bool = false
@@ -316,4 +317,8 @@ private extension PointOfSaleSettingsHardwareDetailView {
             comment: "Description of Barcode scanner settings configuration."
         )
     }
+}
+
+#Preview {
+    PointOfSaleSettingsHardwareDetailView()
 }

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
@@ -64,7 +64,7 @@ extension PointOfSaleSettingsView {
         case .store:
             PointOfSaleSettingsStoreDetailView(settingsController: settingsController)
         case .hardware:
-            PointOfSaleSettingsHardwareDetailView()
+            PointOfSaleSettingsHardwareDetailView(settingsController: settingsController)
         case .help:
             PointOfSaleSettingsHelpDetailView()
         default:

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -121,7 +121,8 @@ private extension POSTabCoordinator {
                     cardPresentPaymentService: cardPresentPaymentService,
                     orderController: PointOfSaleOrderController(orderService: orderService,
                                                                 receiptService: receiptService),
-                    settingsController: PointOfSaleSettingsController(settingsService: settingsService),
+                    settingsController: PointOfSaleSettingsController(settingsService: settingsService,
+                                                                      cardPresentPaymentService: cardPresentPaymentService),
                     collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker,
                     searchHistoryService: POSSearchHistoryService(siteID: siteID),
                     popularPurchasableItemsController: PointOfSaleItemsController(

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleSettingsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleSettingsControllerTests.swift
@@ -1,4 +1,3 @@
-
 import Testing
 import Foundation
 @testable import WooCommerce
@@ -9,11 +8,13 @@ import Storage
 struct PointOfSaleSettingsControllerTests {
     private let mockSettingsService = MockPointOfSaleSettingsService()
     private let mockStorageManager = MockStorageManager()
+    private let mockCardPresentPaymentService = MockCardPresentPaymentService()
 
     @Test func storeName_when_defaultSiteName_provided_then_returns_defaultSiteName() async throws {
         // Given
         let expectedStoreName = "My Test Store"
         let sut = PointOfSaleSettingsController(settingsService: mockSettingsService,
+                                                cardPresentPaymentService: mockCardPresentPaymentService,
                                                 defaultSiteName: expectedStoreName,
                                                 siteSettings: [])
 
@@ -27,6 +28,7 @@ struct PointOfSaleSettingsControllerTests {
     @Test func storeName_when_defaultSiteName_nil_then_returns_notSet() async throws {
         // Given
         let sut = PointOfSaleSettingsController(settingsService: mockSettingsService,
+                                                cardPresentPaymentService: mockCardPresentPaymentService,
                                                 defaultSiteName: nil,
                                                 siteSettings: [])
 
@@ -41,6 +43,7 @@ struct PointOfSaleSettingsControllerTests {
         // Given
         let siteSettings = makeSampleSiteSettings()
         let sut = PointOfSaleSettingsController(settingsService: mockSettingsService,
+                                                cardPresentPaymentService: mockCardPresentPaymentService,
                                                 defaultSiteName: "Test Store",
                                                 siteSettings: siteSettings)
 
@@ -54,6 +57,7 @@ struct PointOfSaleSettingsControllerTests {
     @Test func connectedCardReader_initially_nil() async throws {
         // Given
         let sut = PointOfSaleSettingsController(settingsService: mockSettingsService,
+                                                cardPresentPaymentService: mockCardPresentPaymentService,
                                                 defaultSiteName: "Test Store",
                                                 siteSettings: [])
 
@@ -64,35 +68,26 @@ struct PointOfSaleSettingsControllerTests {
         #expect(cardReader == nil)
     }
 
-    @Test func updateCardReader_sets_connectedCardReader() async throws {
+    @Test func cardReader_observation_updates_connectedCardReader() async throws {
         // Given
+        let mockService = MockCardPresentPaymentService()
         let sut = PointOfSaleSettingsController(settingsService: mockSettingsService,
+                                                cardPresentPaymentService: mockService,
                                                 defaultSiteName: "Test Store",
                                                 siteSettings: [])
-        let cardReader = CardPresentPaymentCardReader(name: "WisePad 3", batteryLevel: 0.85)
+
+        // Initially nil
+        #expect(sut.connectedCardReader == nil)
 
         // When
-        sut.updateCardReader(cardReader)
+        let cardReader = CardPresentPaymentCardReader(name: "WisePad 3", batteryLevel: 0.75)
+        mockService.connectedReader = cardReader
 
         // Then
         #expect(sut.connectedCardReader?.name == "WisePad 3")
-        #expect(sut.connectedCardReader?.batteryLevel == 0.85)
+        #expect(sut.connectedCardReader?.batteryLevel == 0.75)
     }
 
-    @Test func updateCardReader_with_nil_clears_connectedCardReader() async throws {
-        // Given
-        let sut = PointOfSaleSettingsController(settingsService: mockSettingsService,
-                                                defaultSiteName: "Test Store",
-                                                siteSettings: [])
-        let cardReader = CardPresentPaymentCardReader(name: "WisePad 3", batteryLevel: 0.85)
-        sut.updateCardReader(cardReader)
-
-        // When
-        sut.updateCardReader(nil)
-
-        // Then
-        #expect(sut.connectedCardReader == nil)
-    }
 
     private func makeSampleSiteSettings() -> [Yosemite.SiteSetting] {
         return [
@@ -154,7 +149,4 @@ final class MockPointOfSaleSettingsController: PointOfSaleSettingsControllerProt
         // no-op
     }
 
-    func updateCardReader(_ cardReader: CardPresentPaymentCardReader?) {
-        // no-op
-    }
 }

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleSettingsControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleSettingsControllerTests.swift
@@ -51,6 +51,49 @@ struct PointOfSaleSettingsControllerTests {
         #expect(!storeAddress.isEmpty)
     }
 
+    @Test func connectedCardReader_initially_nil() async throws {
+        // Given
+        let sut = PointOfSaleSettingsController(settingsService: mockSettingsService,
+                                                defaultSiteName: "Test Store",
+                                                siteSettings: [])
+
+        // When
+        let cardReader = sut.connectedCardReader
+
+        // Then
+        #expect(cardReader == nil)
+    }
+
+    @Test func updateCardReader_sets_connectedCardReader() async throws {
+        // Given
+        let sut = PointOfSaleSettingsController(settingsService: mockSettingsService,
+                                                defaultSiteName: "Test Store",
+                                                siteSettings: [])
+        let cardReader = CardPresentPaymentCardReader(name: "WisePad 3", batteryLevel: 0.85)
+
+        // When
+        sut.updateCardReader(cardReader)
+
+        // Then
+        #expect(sut.connectedCardReader?.name == "WisePad 3")
+        #expect(sut.connectedCardReader?.batteryLevel == 0.85)
+    }
+
+    @Test func updateCardReader_with_nil_clears_connectedCardReader() async throws {
+        // Given
+        let sut = PointOfSaleSettingsController(settingsService: mockSettingsService,
+                                                defaultSiteName: "Test Store",
+                                                siteSettings: [])
+        let cardReader = CardPresentPaymentCardReader(name: "WisePad 3", batteryLevel: 0.85)
+        sut.updateCardReader(cardReader)
+
+        // When
+        sut.updateCardReader(nil)
+
+        // Then
+        #expect(sut.connectedCardReader == nil)
+    }
+
     private func makeSampleSiteSettings() -> [Yosemite.SiteSetting] {
         return [
             SiteSetting(siteID: 123,
@@ -105,7 +148,13 @@ final class MockPointOfSaleSettingsController: PointOfSaleSettingsControllerProt
         "123 Main Street\nAnytown, ST 12345"
     }
 
+    var connectedCardReader: CardPresentPaymentCardReader? = nil
+
     func retrievePOSReceiptSettings() async {
+        // no-op
+    }
+
+    func updateCardReader(_ cardReader: CardPresentPaymentCardReader?) {
         // no-op
     }
 }


### PR DESCRIPTION
Closes WOOMOB-1172

## Description
This PR updates the Hardware section in POS settings to display the reader name and battery level if present. For this we observe and update the card reader details and pass it to the settings controller when is connected, or nil in other reader status.

https://github.com/user-attachments/assets/34cafe97-19be-422a-b399-62629e699a81

## Testing information
- With a disconnected reader, go to `POS` > `...` > `Settings` > `Hardware` > `Card Readers`
- Observe is set to "Not set" and "Unknown"
- Close settings, connect a reader, go back to `Card Readers`
- Observe is set to the reader name and battery levels
