### PR TITLE
[Woo POS][Local catalog] Set up GRDB database with initial schema

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2ccbd60dcad35afba3898070444c0daa9472345bb19e37fef19d2d4bc42c708e",
+  "originHash" : "045778a877f7cfead8114a762cb8d21b0b588c50e9bc72cbe8a5c1af7c0f316d",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -115,6 +115,15 @@
       "state" : {
         "revision" : "8469f2c1b334a7c1c3566e2cb2f97826c7cca898",
         "version" : "4.1.6"
+      }
+    },
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift",
+      "state" : {
+        "revision" : "8ba1bc9a96afc731a000fd4136dd13a5a46297bd",
+        "version" : "7.6.1"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -83,6 +83,7 @@ let package = Package(
         .package(url: "https://github.com/envoy/Embassy", from: "4.1.2"),
         // FIXME: This should be available via Tracks, but Tracks does not compile for watchOS
         .package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.46.0"),
+        .package(url: "https://github.com/groue/GRDB.swift", from: "7.0.0"),
         .package(url: "https://github.com/jonreid/ViewControllerPresentationSpy", from: "7.0.0"),
         .package(url: "https://github.com/kishikawakatsumi/KeychainAccess", from: "4.2.2"),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", branch: "master"),
@@ -159,7 +160,8 @@ let package = Package(
             name: "Storage",
             dependencies: [
                 "Codegen",
-                "WooFoundation"
+                "WooFoundation",
+                .product(name: "GRDB", package: "GRDB.swift")
             ],
             exclude: ["Model/Migrations.md"],
             resources: [.process("Resources")]

--- a/Modules/Sources/Storage/GRDB/GRDBManager.swift
+++ b/Modules/Sources/Storage/GRDB/GRDBManager.swift
@@ -1,0 +1,57 @@
+import Foundation
+import GRDB
+
+public final class GRDBManager {
+
+    private let databaseQueue: DatabaseQueue
+    private let databasePath: String
+
+    public init(databasePath: String) throws {
+        self.databasePath = databasePath
+
+        let databaseURL = URL(fileURLWithPath: databasePath)
+        let directoryURL = databaseURL.deletingLastPathComponent()
+
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true, attributes: nil)
+
+        self.databaseQueue = try DatabaseQueue(path: databasePath)
+
+        try migrateIfNeeded()
+    }
+    
+}
+
+private extension GRDBManager {
+    func migrateIfNeeded() throws {
+        var migrator = DatabaseMigrator()
+
+        #if DEBUG
+        // Speed up development by nuking the database when migrations change
+        migrator.eraseDatabaseOnSchemaChange = true
+        #endif
+
+        // 1st migration
+
+        // Note that it's best to use strings for names in the database
+        // not derive them from a Swift class.
+        // https://swiftpackageindex.com/groue/grdb.swift/v7.6.1/documentation/grdb/migrations#Good-Practices-for-Defining-Migrations
+        migrator.registerMigration("Create posProduct table") { db in
+            try db.create(table: "posProduct") { t in
+                t.primaryKey("id", .text)
+                t.column("siteID", .integer)
+                t.column("productID", .integer)
+                t.column("name", .text)
+                t.column("productType", .text)
+                t.column("sku", .text)
+                t.column("globalUniqueID", .text)
+                t.column("price", .text)
+                t.column("regularPrice", .text)
+                t.column("salePrice", .text)
+                t.column("onSale", .boolean)
+                t.column("downloadable", .boolean)
+            }
+        }
+
+        try migrator.migrate(databaseQueue)
+    }
+}

--- a/Modules/Sources/Storage/GRDB/GRDBManager.swift
+++ b/Modules/Sources/Storage/GRDB/GRDBManager.swift
@@ -1,6 +1,8 @@
 import Foundation
 import GRDB
 
+// TODO: remove ignore when we start using this
+// periphery: ignore
 public final class GRDBManager {
 
     let databaseQueue: DatabaseQueue
@@ -26,6 +28,8 @@ public final class GRDBManager {
     }
 }
 
+// TODO: remove ignore when we start using this
+// periphery: ignore
 private extension GRDBManager {
     func migrateIfNeeded() throws {
         var migrator = DatabaseMigrator()

--- a/Modules/Sources/Storage/GRDB/GRDBManager.swift
+++ b/Modules/Sources/Storage/GRDB/GRDBManager.swift
@@ -37,18 +37,23 @@ private extension GRDBManager {
         // https://swiftpackageindex.com/groue/grdb.swift/v7.6.1/documentation/grdb/migrations#Good-Practices-for-Defining-Migrations
         migrator.registerMigration("Create posProduct table") { db in
             try db.create(table: "posProduct") { t in
-                t.primaryKey("id", .text)
-                t.column("siteID", .integer)
-                t.column("productID", .integer)
-                t.column("name", .text)
-                t.column("productType", .text)
+                t.primaryKey(["siteID", "productID"])
+
+                t.column("siteID", .integer).notNull()
+                t.column("productID", .integer).notNull()
+                t.column("name", .text).notNull()
+                t.column("productTypeKey", .text).notNull()
+
+                t.column("fullDescription", .text)
+                t.column("shortDescription", .text)
+
                 t.column("sku", .text)
                 t.column("globalUniqueID", .text)
-                t.column("price", .text)
-                t.column("regularPrice", .text)
-                t.column("salePrice", .text)
-                t.column("onSale", .boolean)
-                t.column("downloadable", .boolean)
+                t.column("price", .text).notNull()
+
+                t.column("downloadable", .boolean).notNull()
+
+                t.column("parentID", .integer).notNull()
             }
         }
 

--- a/Modules/Sources/Storage/GRDB/GRDBManager.swift
+++ b/Modules/Sources/Storage/GRDB/GRDBManager.swift
@@ -18,7 +18,6 @@ public final class GRDBManager {
 
         try migrateIfNeeded()
     }
-    
 }
 
 private extension GRDBManager {
@@ -26,35 +25,12 @@ private extension GRDBManager {
         var migrator = DatabaseMigrator()
 
         #if DEBUG
-        // Speed up development by nuking the database when migrations change
+        // Speed up development by dropping the database when migrations change
         migrator.eraseDatabaseOnSchemaChange = true
         #endif
 
-        // 1st migration
-
-        // Note that it's best to use strings for names in the database
-        // not derive them from a Swift class.
-        // https://swiftpackageindex.com/groue/grdb.swift/v7.6.1/documentation/grdb/migrations#Good-Practices-for-Defining-Migrations
-        migrator.registerMigration("Create posProduct table") { db in
-            try db.create(table: "posProduct") { t in
-                t.primaryKey(["siteID", "productID"])
-
-                t.column("siteID", .integer).notNull()
-                t.column("productID", .integer).notNull()
-                t.column("name", .text).notNull()
-                t.column("productTypeKey", .text).notNull()
-
-                t.column("fullDescription", .text)
-                t.column("shortDescription", .text)
-
-                t.column("sku", .text)
-                t.column("globalUniqueID", .text)
-                t.column("price", .text).notNull()
-
-                t.column("downloadable", .boolean).notNull()
-
-                t.column("parentID", .integer).notNull()
-            }
+        migrator.registerMigration("V001InitialSchema") { db in
+            try V001InitialSchema.migrate(db)
         }
 
         try migrator.migrate(databaseQueue)

--- a/Modules/Sources/Storage/GRDB/GRDBManager.swift
+++ b/Modules/Sources/Storage/GRDB/GRDBManager.swift
@@ -3,7 +3,7 @@ import GRDB
 
 public final class GRDBManager {
 
-    private let databaseQueue: DatabaseQueue
+    let databaseQueue: DatabaseQueue
     private let databasePath: String
 
     public init(databasePath: String) throws {
@@ -16,6 +16,12 @@ public final class GRDBManager {
 
         self.databaseQueue = try DatabaseQueue(path: databasePath)
 
+        try migrateIfNeeded()
+    }
+
+    init() throws {
+        self.databasePath = "in-memory"
+        self.databaseQueue = try DatabaseQueue()
         try migrateIfNeeded()
     }
 }

--- a/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
+++ b/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
@@ -1,0 +1,33 @@
+import Foundation
+import GRDB
+
+struct V001InitialSchema {
+    static func migrate(_ db: Database) throws {
+        try createProductTable(db)
+    }
+
+    static func createProductTable(_ db: Database) throws {
+        // Note that it's best to use strings for names in the database
+        // not derive them from a Swift class.
+        // https://swiftpackageindex.com/groue/grdb.swift/v7.6.1/documentation/grdb/migrations#Good-Practices-for-Defining-Migrations
+        try db.create(table: "posProduct") { productTable in
+            productTable.primaryKey(["siteID", "productID"])
+
+            productTable.column("siteID", .integer).notNull()
+            productTable.column("productID", .integer).notNull()
+            productTable.column("name", .text).notNull()
+            productTable.column("productTypeKey", .text).notNull()
+
+            productTable.column("fullDescription", .text)
+            productTable.column("shortDescription", .text)
+
+            productTable.column("sku", .text)
+            productTable.column("globalUniqueID", .text)
+            productTable.column("price", .text).notNull()
+
+            productTable.column("downloadable", .boolean).notNull()
+
+            productTable.column("parentID", .integer).notNull()
+        }
+    }
+}

--- a/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
+++ b/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
@@ -4,6 +4,7 @@ import GRDB
 struct V001InitialSchema {
     static func migrate(_ db: Database) throws {
         try createProductTable(db)
+        try createProductAttributeTable(db)
     }
 
     static func createProductTable(_ db: Database) throws {
@@ -28,6 +29,23 @@ struct V001InitialSchema {
             productTable.column("downloadable", .boolean).notNull()
 
             productTable.column("parentID", .integer).notNull()
+        }
+    }
+
+    private static func createProductAttributeTable(_ db: Database) throws {
+        try db.create(table: "posProductAttribute") { productAttributeTable in
+            productAttributeTable.primaryKey(["siteID", "attributeID"])
+
+            productAttributeTable.column("siteID", .integer).notNull()
+            productAttributeTable.column("attributeID", .integer).notNull()
+
+            productAttributeTable.column("name", .text).notNull()
+            productAttributeTable.column("position", .integer).notNull()
+            productAttributeTable.column("visible", .boolean).notNull()
+            productAttributeTable.column("variation", .boolean).notNull()
+            productAttributeTable.column("options", .jsonText).notNull()
+
+            productAttributeTable.foreignKey(["siteID", "productID"], references: "posProduct")
         }
     }
 }

--- a/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
+++ b/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
@@ -14,7 +14,7 @@ struct V001InitialSchema {
         // Note that it's best to use strings for names in the database
         // not derive them from a Swift class.
         // https://swiftpackageindex.com/groue/grdb.swift/v7.6.1/documentation/grdb/migrations#Good-Practices-for-Defining-Migrations
-        try db.create(table: "posProduct") { productTable in
+        try db.create(table: "product") { productTable in
             productTable.primaryKey(["siteID", "productID"])
 
             productTable.column("siteID", .integer).notNull()
@@ -37,7 +37,7 @@ struct V001InitialSchema {
     }
 
     private static func createProductAttributeTable(_ db: Database) throws {
-        try db.create(table: "posProductAttribute") { productAttributeTable in
+        try db.create(table: "productAttribute") { productAttributeTable in
             productAttributeTable.primaryKey(["siteID", "attributeID"])
 
             productAttributeTable.column("siteID", .integer).notNull()
@@ -50,12 +50,12 @@ struct V001InitialSchema {
             productAttributeTable.column("variation", .boolean).notNull()
             productAttributeTable.column("options", .jsonText).notNull()
 
-            productAttributeTable.foreignKey(["siteID", "productID"], references: "posProduct")
+            productAttributeTable.foreignKey(["siteID", "productID"], references: "product")
         }
     }
 
     private static func createProductImageTable(_ db: Database) throws {
-        try db.create(table: "posProductImage") { productImageTable in
+        try db.create(table: "productImage") { productImageTable in
             productImageTable.primaryKey(["siteID", "imageID"])
 
             productImageTable.column("siteID", .integer).notNull()
@@ -69,12 +69,12 @@ struct V001InitialSchema {
             productImageTable.column("name", .text)
             productImageTable.column("alt", .text)
 
-            productImageTable.foreignKey(["siteID", "productID"], references: "posProduct")
+            productImageTable.foreignKey(["siteID", "productID"], references: "product")
         }
     }
 
     private static func createProductVariationTable(_ db: Database) throws {
-        try db.create(table: "posProductVariation") { productVariationTable in
+        try db.create(table: "productVariation") { productVariationTable in
             productVariationTable.primaryKey(["siteID", "productVariationID"])
 
             productVariationTable.column("siteID", .integer).notNull()
@@ -89,13 +89,13 @@ struct V001InitialSchema {
 
             productVariationTable.column("description", .text)
 
-            productVariationTable.foreignKey(["siteID", "productID"], references: "posProduct")
+            productVariationTable.foreignKey(["siteID", "productID"], references: "product")
         }
     }
 
     private static func createProductVariationAttributeTable(_ db: Database) throws {
-        try db.create(table: "posProductVariationAttribute") { productVariationAttributeTable in
-            productVariationAttributeTable.primaryKey(["siteID", "productVariationID", "attributeID"])
+        try db.create(table: "productVariationAttribute") { productVariationAttributeTable in
+            productVariationAttributeTable.primaryKey(["siteID", "attributeID"])
 
             productVariationAttributeTable.column("siteID", .integer).notNull()
             productVariationAttributeTable.column("productVariationID", .integer).notNull()
@@ -104,7 +104,7 @@ struct V001InitialSchema {
             productVariationAttributeTable.column("name", .text).notNull()
             productVariationAttributeTable.column("option", .text).notNull()
 
-            productVariationAttributeTable.foreignKey(["siteID", "productVariationID"], references: "posProductVariation")
+            productVariationAttributeTable.foreignKey(["siteID", "productVariationID"], references: "productVariation")
         }
     }
 }

--- a/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
+++ b/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
@@ -1,6 +1,8 @@
 import Foundation
 import GRDB
 
+// TODO: remove ignore when we start using this
+// periphery: ignore
 struct V001InitialSchema {
     // This migration is under development and not released yet.
     // It's still open for modification, until we ship.

--- a/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
+++ b/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
@@ -2,6 +2,10 @@ import Foundation
 import GRDB
 
 struct V001InitialSchema {
+    // This migration is under development and not released yet.
+    // It's still open for modification, until we ship.
+    // TODO: Mark this as final when we enable the pointOfSaleLocalCatalogi1 feature flag
+
     static func migrate(_ db: Database) throws {
         try createProductTable(db)
         try createProductAttributeTable(db)

--- a/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
+++ b/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
@@ -7,6 +7,7 @@ struct V001InitialSchema {
     // TODO: Mark this as final when we enable the pointOfSaleLocalCatalogi1 feature flag
 
     static func migrate(_ db: Database) throws {
+        try createSiteTable(db)
         try createProductTable(db)
         try createProductAttributeTable(db)
         try createProductImageTable(db)
@@ -15,15 +16,19 @@ struct V001InitialSchema {
         try createProductVariationImageTable(db)
     }
 
+    static func createSiteTable(_ db: Database) throws {
+        try db.create(table: "site") { siteTable in
+            siteTable.primaryKey("id", .integer).notNull()
+        }
+    }
+
     static func createProductTable(_ db: Database) throws {
         // Note that it's best to use strings for names in the database
         // not derive them from a Swift class.
         // https://swiftpackageindex.com/groue/grdb.swift/v7.6.1/documentation/grdb/migrations#Good-Practices-for-Defining-Migrations
         try db.create(table: "product") { productTable in
-            productTable.primaryKey(["siteID", "productID"])
-
-            productTable.column("siteID", .integer).notNull()
-            productTable.column("productID", .integer).notNull()
+            productTable.primaryKey("id", .integer).notNull()
+            productTable.belongsTo("site", onDelete: .cascade).notNull()
 
             productTable.column("name", .text).notNull()
             productTable.column("productTypeKey", .text).notNull()
@@ -43,29 +48,22 @@ struct V001InitialSchema {
 
     private static func createProductAttributeTable(_ db: Database) throws {
         try db.create(table: "productAttribute") { productAttributeTable in
-            productAttributeTable.primaryKey(["siteID", "attributeID"])
-
-            productAttributeTable.column("siteID", .integer).notNull()
-            productAttributeTable.column("attributeID", .integer).notNull()
-            productAttributeTable.column("productID", .integer).notNull()
+            // This table holds local product attributes only. Global attributes belong to a site.
+            productAttributeTable.autoIncrementedPrimaryKey("id").notNull()
+            productAttributeTable.belongsTo("product", onDelete: .cascade).notNull()
 
             productAttributeTable.column("name", .text).notNull()
             productAttributeTable.column("position", .integer).notNull()
             productAttributeTable.column("visible", .boolean).notNull()
             productAttributeTable.column("variation", .boolean).notNull()
             productAttributeTable.column("options", .jsonText).notNull()
-
-            productAttributeTable.foreignKey(["siteID", "productID"], references: "product")
         }
     }
 
     private static func createProductImageTable(_ db: Database) throws {
         try db.create(table: "productImage") { productImageTable in
-            productImageTable.primaryKey(["siteID", "imageID"])
-
-            productImageTable.column("siteID", .integer).notNull()
-            productImageTable.column("imageID", .integer).notNull()
-            productImageTable.column("productID", .integer).notNull()
+            productImageTable.primaryKey("id", .integer).notNull()
+            productImageTable.belongsTo("product", onDelete: .cascade).notNull()
 
             productImageTable.column("dateCreated", .datetime).notNull()
             productImageTable.column("dateModified", .datetime)
@@ -73,18 +71,14 @@ struct V001InitialSchema {
             productImageTable.column("src", .text).notNull()
             productImageTable.column("name", .text)
             productImageTable.column("alt", .text)
-
-            productImageTable.foreignKey(["siteID", "productID"], references: "product")
         }
     }
 
     private static func createProductVariationTable(_ db: Database) throws {
         try db.create(table: "productVariation") { productVariationTable in
-            productVariationTable.primaryKey(["siteID", "productVariationID"])
-
-            productVariationTable.column("siteID", .integer).notNull()
-            productVariationTable.column("productVariationID", .integer).notNull()
-            productVariationTable.column("productID", .integer).notNull()
+            productVariationTable.primaryKey("id", .integer).notNull()
+            productVariationTable.belongsTo("site", onDelete: .cascade).notNull()
+            productVariationTable.belongsTo("product", onDelete: .cascade).notNull()
 
             productVariationTable.column("sku", .text)
             productVariationTable.column("globalUniqueID", .text)
@@ -92,34 +86,25 @@ struct V001InitialSchema {
 
             productVariationTable.column("downloadable", .boolean).notNull()
 
-            productVariationTable.column("description", .text)
-
-            productVariationTable.foreignKey(["siteID", "productID"], references: "product")
+            productVariationTable.column("fullDescription", .text)
         }
     }
 
     private static func createProductVariationAttributeTable(_ db: Database) throws {
         try db.create(table: "productVariationAttribute") { productVariationAttributeTable in
-            productVariationAttributeTable.primaryKey(["siteID", "attributeID"])
-
-            productVariationAttributeTable.column("siteID", .integer).notNull()
-            productVariationAttributeTable.column("productVariationID", .integer).notNull()
-            productVariationAttributeTable.column("attributeID", .integer).notNull()
+            // This table holds local variation attributes only. Global attributes belong to a site.
+            productVariationAttributeTable.autoIncrementedPrimaryKey("id").notNull()
+            productVariationAttributeTable.belongsTo("productVariation", onDelete: .cascade).notNull()
 
             productVariationAttributeTable.column("name", .text).notNull()
             productVariationAttributeTable.column("option", .text).notNull()
-
-            productVariationAttributeTable.foreignKey(["siteID", "productVariationID"], references: "productVariation")
         }
     }
 
     private static func createProductVariationImageTable(_ db: Database) throws {
         try db.create(table: "productVariationImage") { productVariationImageTable in
-            productVariationImageTable.primaryKey(["siteID", "imageID"])
-
-            productVariationImageTable.column("siteID", .integer).notNull()
-            productVariationImageTable.column("imageID", .integer).notNull()
-            productVariationImageTable.column("productVariationID", .integer).notNull()
+            productVariationImageTable.primaryKey("id", .integer).notNull()
+            productVariationImageTable.belongsTo("productVariation").notNull()
 
             productVariationImageTable.column("dateCreated", .datetime).notNull()
             productVariationImageTable.column("dateModified", .datetime)
@@ -127,8 +112,6 @@ struct V001InitialSchema {
             productVariationImageTable.column("src", .text).notNull()
             productVariationImageTable.column("name", .text)
             productVariationImageTable.column("alt", .text)
-
-            productVariationImageTable.foreignKey(["siteID", "productVariationID"], references: "productVariation")
         }
     }
 }

--- a/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
+++ b/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
@@ -8,6 +8,7 @@ struct V001InitialSchema {
         try createProductImageTable(db)
         try createProductVariationTable(db)
         try createProductVariationAttributeTable(db)
+        try createProductVariationImageTable(db)
     }
 
     static func createProductTable(_ db: Database) throws {
@@ -105,6 +106,25 @@ struct V001InitialSchema {
             productVariationAttributeTable.column("option", .text).notNull()
 
             productVariationAttributeTable.foreignKey(["siteID", "productVariationID"], references: "productVariation")
+        }
+    }
+
+    private static func createProductVariationImageTable(_ db: Database) throws {
+        try db.create(table: "productVariationImage") { productVariationImageTable in
+            productVariationImageTable.primaryKey(["siteID", "imageID"])
+
+            productVariationImageTable.column("siteID", .integer).notNull()
+            productVariationImageTable.column("imageID", .integer).notNull()
+            productVariationImageTable.column("productVariationID", .integer).notNull()
+
+            productVariationImageTable.column("dateCreated", .datetime).notNull()
+            productVariationImageTable.column("dateModified", .datetime)
+
+            productVariationImageTable.column("src", .text).notNull()
+            productVariationImageTable.column("name", .text)
+            productVariationImageTable.column("alt", .text)
+
+            productVariationImageTable.foreignKey(["siteID", "productVariationID"], references: "productVariation")
         }
     }
 }

--- a/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
+++ b/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
@@ -5,6 +5,7 @@ struct V001InitialSchema {
     static func migrate(_ db: Database) throws {
         try createProductTable(db)
         try createProductAttributeTable(db)
+        try createProductImageTable(db)
     }
 
     static func createProductTable(_ db: Database) throws {
@@ -46,6 +47,24 @@ struct V001InitialSchema {
             productAttributeTable.column("options", .jsonText).notNull()
 
             productAttributeTable.foreignKey(["siteID", "productID"], references: "posProduct")
+        }
+    }
+
+    private static func createProductImageTable(_ db: Database) throws {
+        try db.create(table: "posProductImage") { productImageTable in
+            productImageTable.primaryKey(["siteID", "imageID"])
+
+            productImageTable.column("siteID", .integer).notNull()
+            productImageTable.column("imageID", .integer).notNull()
+
+            productImageTable.column("dateCreated", .datetime).notNull()
+            productImageTable.column("dateModified", .datetime)
+
+            productImageTable.column("src", .text).notNull()
+            productImageTable.column("name", .text)
+            productImageTable.column("alt", .text)
+
+            productImageTable.foreignKey(["siteID", "productID"], references: "posProduct")
         }
     }
 }

--- a/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
+++ b/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
@@ -6,6 +6,8 @@ struct V001InitialSchema {
         try createProductTable(db)
         try createProductAttributeTable(db)
         try createProductImageTable(db)
+        try createProductVariationTable(db)
+        try createProductVariationAttributeTable(db)
     }
 
     static func createProductTable(_ db: Database) throws {
@@ -68,6 +70,41 @@ struct V001InitialSchema {
             productImageTable.column("alt", .text)
 
             productImageTable.foreignKey(["siteID", "productID"], references: "posProduct")
+        }
+    }
+
+    private static func createProductVariationTable(_ db: Database) throws {
+        try db.create(table: "posProductVariation") { productVariationTable in
+            productVariationTable.primaryKey(["siteID", "productVariationID"])
+
+            productVariationTable.column("siteID", .integer).notNull()
+            productVariationTable.column("productVariationID", .integer).notNull()
+            productVariationTable.column("productID", .integer).notNull()
+
+            productVariationTable.column("sku", .text)
+            productVariationTable.column("globalUniqueID", .text)
+            productVariationTable.column("price", .text).notNull()
+
+            productVariationTable.column("downloadable", .boolean).notNull()
+
+            productVariationTable.column("description", .text)
+
+            productVariationTable.foreignKey(["siteID", "productID"], references: "posProduct")
+        }
+    }
+
+    private static func createProductVariationAttributeTable(_ db: Database) throws {
+        try db.create(table: "posProductVariationAttribute") { productVariationAttributeTable in
+            productVariationAttributeTable.primaryKey(["siteID", "productVariationID", "attributeID"])
+
+            productVariationAttributeTable.column("siteID", .integer).notNull()
+            productVariationAttributeTable.column("productVariationID", .integer).notNull()
+            productVariationAttributeTable.column("attributeID", .integer).notNull()
+
+            productVariationAttributeTable.column("name", .text).notNull()
+            productVariationAttributeTable.column("option", .text).notNull()
+
+            productVariationAttributeTable.foreignKey(["siteID", "productVariationID"], references: "posProductVariation")
         }
     }
 }

--- a/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
+++ b/Modules/Sources/Storage/GRDB/Migrations/V001InitialSchema.swift
@@ -17,6 +17,7 @@ struct V001InitialSchema {
 
             productTable.column("siteID", .integer).notNull()
             productTable.column("productID", .integer).notNull()
+
             productTable.column("name", .text).notNull()
             productTable.column("productTypeKey", .text).notNull()
 
@@ -39,6 +40,7 @@ struct V001InitialSchema {
 
             productAttributeTable.column("siteID", .integer).notNull()
             productAttributeTable.column("attributeID", .integer).notNull()
+            productAttributeTable.column("productID", .integer).notNull()
 
             productAttributeTable.column("name", .text).notNull()
             productAttributeTable.column("position", .integer).notNull()
@@ -56,6 +58,7 @@ struct V001InitialSchema {
 
             productImageTable.column("siteID", .integer).notNull()
             productImageTable.column("imageID", .integer).notNull()
+            productImageTable.column("productID", .integer).notNull()
 
             productImageTable.column("dateCreated", .datetime).notNull()
             productImageTable.column("dateModified", .datetime)

--- a/Modules/Tests/StorageTests/GRDB/GRDBManagerTests.swift
+++ b/Modules/Tests/StorageTests/GRDB/GRDBManagerTests.swift
@@ -1,0 +1,340 @@
+import Testing
+import GRDB
+@testable import Storage
+
+struct GRDBManagerTests {
+
+    // MARK: - Migration Tests
+    struct MigrationTests {
+        @Test("Migration runs successfully")
+        func migrationRunsSuccessfully() throws {
+            // Should not throw – initialisation performs migrations
+            let manager = try GRDBManager()
+        }
+
+        @Test("All tables are created")
+        func allTablesAreCreated() throws {
+            // Given
+            let manager = try GRDBManager()
+
+            // When
+            let tableExists = try manager.databaseQueue.read { db in
+                return (
+                    try db.tableExists("product"),
+                    try db.tableExists("productAttribute"),
+                    try db.tableExists("productImage"),
+                    try db.tableExists("productVariation"),
+                    try db.tableExists("productVariationAttribute"),
+                    try db.tableExists("productVariationImage")
+                )
+            }
+
+            // Then
+            #expect(tableExists.0, "product table should exist")
+            #expect(tableExists.1, "productAttribute table should exist")
+            #expect(tableExists.2, "productImage table should exist")
+            #expect(tableExists.3, "productVariation table should exist")
+            #expect(tableExists.4, "productVariationAttribute table should exist")
+            #expect(tableExists.5, "productVariationImage table should exist")
+        }
+    }
+
+    // MARK: - CRUD Tests
+
+    struct CRUDTests {
+        @Test("Can insert product")
+        func canInsertProduct() throws {
+            // Given
+            let manager = try GRDBManager()
+
+            // When
+            try manager.databaseQueue.write { db in
+                var record = TestProduct(
+                    siteID: 1,
+                    productID: 100,
+                    name: "Test Product",
+                    productTypeKey: "simple",
+                    price: "10.00",
+                    downloadable: false,
+                    parentID: 0
+                )
+                try record.insert(db)
+            }
+
+            // Then
+            let productCount = try manager.databaseQueue.read { db in
+                try TestProduct.fetchCount(db)
+            }
+
+            #expect(productCount == 1)
+        }
+
+        @Test("Can insert product variation with foreign key relationship")
+        func canInsertProductVariationWithForeignKey() throws {
+            // Given
+            let manager = try GRDBManager()
+
+            // Insert parent product
+            try manager.databaseQueue.write { db in
+                var product = TestProduct(
+                    siteID: 1,
+                    productID: 100,
+                    name: "Variable Product",
+                    productTypeKey: "variable",
+                    price: "10.00",
+                    downloadable: false,
+                    parentID: 0
+                )
+                try product.insert(db)
+            }
+
+            // When - Insert variation
+            try manager.databaseQueue.write { db in
+                var variation = TestProductVariation(
+                    siteID: 1,
+                    productVariationID: 200,
+                    productID: 100,
+                    price: "12.00",
+                    downloadable: false
+                )
+                try variation.insert(db)
+            }
+
+            // Then
+            let variations = try manager.databaseQueue.read { db in
+                try TestProductVariation.fetchAll(db)
+            }
+
+            #expect(variations.count == 1)
+            #expect(variations.first?.productID == 100)
+        }
+
+        @Test("Can query variations by product ID")
+        func canQueryVariationsByProduct() throws {
+            // Given
+            let manager = try GRDBManager()
+
+            try manager.databaseQueue.write { db in
+                // Insert product
+                var product = TestProduct(
+                    siteID: 1,
+                    productID: 100,
+                    name: "Variable Product",
+                    productTypeKey: "variable",
+                    price: "10.00",
+                    downloadable: false,
+                    parentID: 0
+                )
+                try product.insert(db)
+
+                // Insert multiple variations
+                for i in 1...3 {
+                    var variation = TestProductVariation(
+                        siteID: 1,
+                        productVariationID: Int64(200 + i),
+                        productID: 100,
+                        price: "\(10 + i).00",
+                        downloadable: false
+                    )
+                    try variation.insert(db)
+                }
+            }
+
+            // When
+            let variations = try manager.databaseQueue.read { db in
+                try TestProductVariation
+                    .filter(Column("productID") == 100)
+                    .fetchAll(db)
+            }
+
+            // Then
+            #expect(variations.count == 3)
+            #expect(variations.allSatisfy { $0.productID == 100 })
+        }
+
+        @Test("Can insert product attribute with JSON options")
+        func canInsertProductAttributeWithJSONOptions() throws {
+            // Given
+            let manager = try GRDBManager()
+
+            try manager.databaseQueue.write { db in
+                // Insert product first
+                var product = TestProduct(
+                    siteID: 1,
+                    productID: 100,
+                    name: "Test Product",
+                    productTypeKey: "simple",
+                    price: "10.00",
+                    downloadable: false,
+                    parentID: 0
+                )
+                try product.insert(db)
+            }
+
+            // When
+            try manager.databaseQueue.write { db in
+                var attribute = TestProductAttribute(
+                    siteID: 1,
+                    attributeID: 1,
+                    productID: 100,
+                    name: "Color",
+                    position: 0,
+                    visible: true,
+                    variation: true,
+                    options: ["Red", "Blue", "Green"]
+                )
+                try attribute.insert(db)
+            }
+
+            // Then
+            let attribute = try manager.databaseQueue.read { db in
+                try TestProductAttribute.fetchOne(db)
+            }
+
+            #expect(attribute != nil)
+            #expect(attribute?.options == ["Red", "Blue", "Green"])
+        }
+
+        @Test("Can insert variation attributes")
+        func canInsertVariationAttributes() throws {
+            // Given
+            let manager = try GRDBManager()
+
+            try manager.databaseQueue.write { db in
+                // Insert product
+                var product = TestProduct(
+                    siteID: 1,
+                    productID: 100,
+                    name: "Variable Product",
+                    productTypeKey: "variable",
+                    price: "10.00",
+                    downloadable: false,
+                    parentID: 0
+                )
+                try product.insert(db)
+
+                // Insert variation
+                var variation = TestProductVariation(
+                    siteID: 1,
+                    productVariationID: 200,
+                    productID: 100,
+                    price: "12.00",
+                    downloadable: false
+                )
+                try variation.insert(db)
+            }
+
+            // When
+            try manager.databaseQueue.write { db in
+                var variationAttribute = TestProductVariationAttribute(
+                    siteID: 1,
+                    productVariationID: 200,
+                    attributeID: 1,
+                    name: "Color",
+                    option: "Red"
+                )
+                try variationAttribute.insert(db)
+            }
+
+            // Then
+            let attributes = try manager.databaseQueue.read { db in
+                try TestProductVariationAttribute.fetchAll(db)
+            }
+
+            #expect(attributes.count == 1)
+            #expect(attributes.first?.option == "Red")
+        }
+    }
+}
+
+// MARK: - Test Models
+
+struct TestProduct: Codable {
+    let siteID: Int64
+    let productID: Int64
+    let name: String
+    let productTypeKey: String
+    let fullDescription: String?
+    let shortDescription: String?
+    let sku: String?
+    let globalUniqueID: String?
+    let price: String
+    let downloadable: Bool
+    let parentID: Int64
+
+    init(siteID: Int64, productID: Int64, name: String, productTypeKey: String,
+         price: String, downloadable: Bool, parentID: Int64,
+         fullDescription: String? = nil, shortDescription: String? = nil,
+         sku: String? = nil, globalUniqueID: String? = nil) {
+        self.siteID = siteID
+        self.productID = productID
+        self.name = name
+        self.productTypeKey = productTypeKey
+        self.price = price
+        self.downloadable = downloadable
+        self.parentID = parentID
+        self.fullDescription = fullDescription
+        self.shortDescription = shortDescription
+        self.sku = sku
+        self.globalUniqueID = globalUniqueID
+    }
+}
+
+extension TestProduct: FetchableRecord, PersistableRecord {
+    static let databaseTableName = "product"
+}
+
+struct TestProductVariation: Codable {
+    let siteID: Int64
+    let productVariationID: Int64
+    let productID: Int64
+    let sku: String?
+    let globalUniqueID: String?
+    let price: String
+    let downloadable: Bool
+    let description: String?
+
+    init(siteID: Int64, productVariationID: Int64, productID: Int64,
+         price: String, downloadable: Bool,
+         sku: String? = nil, globalUniqueID: String? = nil, description: String? = nil) {
+        self.siteID = siteID
+        self.productVariationID = productVariationID
+        self.productID = productID
+        self.price = price
+        self.downloadable = downloadable
+        self.sku = sku
+        self.globalUniqueID = globalUniqueID
+        self.description = description
+    }
+}
+
+extension TestProductVariation: FetchableRecord, PersistableRecord {
+    static let databaseTableName = "productVariation"
+}
+
+struct TestProductAttribute: Codable {
+    let siteID: Int64
+    let attributeID: Int64
+    let productID: Int64
+    let name: String
+    let position: Int
+    let visible: Bool
+    let variation: Bool
+    let options: [String]
+}
+
+extension TestProductAttribute: FetchableRecord, PersistableRecord {
+    static let databaseTableName = "productAttribute"
+}
+
+struct TestProductVariationAttribute: Codable {
+    let siteID: Int64
+    let productVariationID: Int64
+    let attributeID: Int64
+    let name: String
+    let option: String
+}
+
+extension TestProductVariationAttribute: FetchableRecord, PersistableRecord {
+    static let databaseTableName = "productVariationAttribute"
+}

--- a/Modules/Tests/StorageTests/GRDB/GRDBManagerTests.swift
+++ b/Modules/Tests/StorageTests/GRDB/GRDBManagerTests.swift
@@ -6,14 +6,14 @@ struct GRDBManagerTests {
 
     // MARK: - Migration Tests
     struct MigrationTests {
-        @Test("Migration runs successfully")
-        func migrationRunsSuccessfully() throws {
+        @Test("Migration runs successfully on initialisation")
+        func test_init_full_migration_runs_successfully() throws {
             // Should not throw – initialisation performs migrations
-            let manager = try GRDBManager()
+            _ = try GRDBManager()
         }
 
-        @Test("All tables are created")
-        func allTablesAreCreated() throws {
+        @Test("All tables are created on initialisation")
+        func test_init_all_tables_are_created() throws {
             // Given
             let manager = try GRDBManager()
 
@@ -42,14 +42,14 @@ struct GRDBManagerTests {
     // MARK: - CRUD Tests
 
     struct CRUDTests {
-        @Test("Can insert product")
-        func canInsertProduct() throws {
+        @Test("Can insert product to a freshly initialised database")
+        func test_after_init_can_insert_a_product() throws {
             // Given
             let manager = try GRDBManager()
 
             // When
             try manager.databaseQueue.write { db in
-                var record = TestProduct(
+                let record = TestProduct(
                     siteID: 1,
                     productID: 100,
                     name: "Test Product",
@@ -69,14 +69,14 @@ struct GRDBManagerTests {
             #expect(productCount == 1)
         }
 
-        @Test("Can insert product variation with foreign key relationship")
-        func canInsertProductVariationWithForeignKey() throws {
+        @Test("Can insert product variation with a relationship to a product")
+        func test_after_init_can_insert_productVariation_with_foreign_key() throws {
             // Given
             let manager = try GRDBManager()
 
             // Insert parent product
             try manager.databaseQueue.write { db in
-                var product = TestProduct(
+                let product = TestProduct(
                     siteID: 1,
                     productID: 100,
                     name: "Variable Product",
@@ -90,7 +90,7 @@ struct GRDBManagerTests {
 
             // When - Insert variation
             try manager.databaseQueue.write { db in
-                var variation = TestProductVariation(
+                let variation = TestProductVariation(
                     siteID: 1,
                     productVariationID: 200,
                     productID: 100,
@@ -110,13 +110,13 @@ struct GRDBManagerTests {
         }
 
         @Test("Can query variations by product ID")
-        func canQueryVariationsByProduct() throws {
+        func test_after_init_and_insert_can_query_productVariation_using_foreign_key() throws {
             // Given
             let manager = try GRDBManager()
 
             try manager.databaseQueue.write { db in
                 // Insert product
-                var product = TestProduct(
+                let product = TestProduct(
                     siteID: 1,
                     productID: 100,
                     name: "Variable Product",
@@ -129,7 +129,7 @@ struct GRDBManagerTests {
 
                 // Insert multiple variations
                 for i in 1...3 {
-                    var variation = TestProductVariation(
+                    let variation = TestProductVariation(
                         siteID: 1,
                         productVariationID: Int64(200 + i),
                         productID: 100,
@@ -152,14 +152,14 @@ struct GRDBManagerTests {
             #expect(variations.allSatisfy { $0.productID == 100 })
         }
 
-        @Test("Can insert product attribute with JSON options")
-        func canInsertProductAttributeWithJSONOptions() throws {
+        @Test("Can insert product attribute with options array (JSON)")
+        func test_after_init_can_insert_productAttribute_with_options_as_JSON_array() throws {
             // Given
             let manager = try GRDBManager()
 
             try manager.databaseQueue.write { db in
                 // Insert product first
-                var product = TestProduct(
+                let product = TestProduct(
                     siteID: 1,
                     productID: 100,
                     name: "Test Product",
@@ -173,7 +173,7 @@ struct GRDBManagerTests {
 
             // When
             try manager.databaseQueue.write { db in
-                var attribute = TestProductAttribute(
+                let attribute = TestProductAttribute(
                     siteID: 1,
                     attributeID: 1,
                     productID: 100,
@@ -196,13 +196,13 @@ struct GRDBManagerTests {
         }
 
         @Test("Can insert variation attributes")
-        func canInsertVariationAttributes() throws {
+        func test_after_init_can_insert_variation_attributes() throws {
             // Given
             let manager = try GRDBManager()
 
             try manager.databaseQueue.write { db in
                 // Insert product
-                var product = TestProduct(
+                let product = TestProduct(
                     siteID: 1,
                     productID: 100,
                     name: "Variable Product",
@@ -214,7 +214,7 @@ struct GRDBManagerTests {
                 try product.insert(db)
 
                 // Insert variation
-                var variation = TestProductVariation(
+                let variation = TestProductVariation(
                     siteID: 1,
                     productVariationID: 200,
                     productID: 100,
@@ -226,7 +226,7 @@ struct GRDBManagerTests {
 
             // When
             try manager.databaseQueue.write { db in
-                var variationAttribute = TestProductVariationAttribute(
+                let variationAttribute = TestProductVariationAttribute(
                     siteID: 1,
                     productVariationID: 200,
                     attributeID: 1,

--- a/Modules/Tests/StorageTests/GRDB/GRDBManagerTests.swift
+++ b/Modules/Tests/StorageTests/GRDB/GRDBManagerTests.swift
@@ -20,6 +20,7 @@ struct GRDBManagerTests {
             // When
             let tableExists = try manager.databaseQueue.read { db in
                 return (
+                    try db.tableExists("site"),
                     try db.tableExists("product"),
                     try db.tableExists("productAttribute"),
                     try db.tableExists("productImage"),
@@ -30,28 +31,39 @@ struct GRDBManagerTests {
             }
 
             // Then
-            #expect(tableExists.0, "product table should exist")
-            #expect(tableExists.1, "productAttribute table should exist")
-            #expect(tableExists.2, "productImage table should exist")
-            #expect(tableExists.3, "productVariation table should exist")
-            #expect(tableExists.4, "productVariationAttribute table should exist")
-            #expect(tableExists.5, "productVariationImage table should exist")
+            #expect(tableExists.0, "site table should exist")
+            #expect(tableExists.1, "product table should exist")
+            #expect(tableExists.2, "productAttribute table should exist")
+            #expect(tableExists.3, "productImage table should exist")
+            #expect(tableExists.4, "productVariation table should exist")
+            #expect(tableExists.5, "productVariationAttribute table should exist")
+            #expect(tableExists.6, "productVariationImage table should exist")
         }
     }
 
     // MARK: - CRUD Tests
 
     struct CRUDTests {
+        let manager: GRDBManager
+        let sampleSiteID: Int64 = 1
+
+        init() throws {
+            self.manager = try GRDBManager()
+            try manager.databaseQueue.write { db in
+                let record = TestSite(id: sampleSiteID)
+                try record.insert(db)
+            }
+        }
+
         @Test("Can insert product to a freshly initialised database")
         func test_after_init_can_insert_a_product() throws {
             // Given
-            let manager = try GRDBManager()
 
             // When
             try manager.databaseQueue.write { db in
                 let record = TestProduct(
                     siteID: 1,
-                    productID: 100,
+                    id: 100,
                     name: "Test Product",
                     productTypeKey: "simple",
                     price: "10.00",
@@ -71,14 +83,11 @@ struct GRDBManagerTests {
 
         @Test("Can insert product variation with a relationship to a product")
         func test_after_init_can_insert_productVariation_with_foreign_key() throws {
-            // Given
-            let manager = try GRDBManager()
-
-            // Insert parent product
+            // Given – parent product
             try manager.databaseQueue.write { db in
                 let product = TestProduct(
                     siteID: 1,
-                    productID: 100,
+                    id: 100,
                     name: "Variable Product",
                     productTypeKey: "variable",
                     price: "10.00",
@@ -92,7 +101,7 @@ struct GRDBManagerTests {
             try manager.databaseQueue.write { db in
                 let variation = TestProductVariation(
                     siteID: 1,
-                    productVariationID: 200,
+                    id: 200,
                     productID: 100,
                     price: "12.00",
                     downloadable: false
@@ -111,14 +120,12 @@ struct GRDBManagerTests {
 
         @Test("Can query variations by product ID")
         func test_after_init_and_insert_can_query_productVariation_using_foreign_key() throws {
-            // Given
-            let manager = try GRDBManager()
-
+            // Given parent product and some variations
             try manager.databaseQueue.write { db in
                 // Insert product
                 let product = TestProduct(
                     siteID: 1,
-                    productID: 100,
+                    id: 100,
                     name: "Variable Product",
                     productTypeKey: "variable",
                     price: "10.00",
@@ -131,7 +138,7 @@ struct GRDBManagerTests {
                 for i in 1...3 {
                     let variation = TestProductVariation(
                         siteID: 1,
-                        productVariationID: Int64(200 + i),
+                        id: Int64(200 + i),
                         productID: 100,
                         price: "\(10 + i).00",
                         downloadable: false
@@ -154,14 +161,12 @@ struct GRDBManagerTests {
 
         @Test("Can insert product attribute with options array (JSON)")
         func test_after_init_can_insert_productAttribute_with_options_as_JSON_array() throws {
-            // Given
-            let manager = try GRDBManager()
-
+            // Given parent product
             try manager.databaseQueue.write { db in
                 // Insert product first
                 let product = TestProduct(
                     siteID: 1,
-                    productID: 100,
+                    id: 100,
                     name: "Test Product",
                     productTypeKey: "simple",
                     price: "10.00",
@@ -174,8 +179,6 @@ struct GRDBManagerTests {
             // When
             try manager.databaseQueue.write { db in
                 let attribute = TestProductAttribute(
-                    siteID: 1,
-                    attributeID: 1,
                     productID: 100,
                     name: "Color",
                     position: 0,
@@ -197,14 +200,12 @@ struct GRDBManagerTests {
 
         @Test("Can insert variation attributes")
         func test_after_init_can_insert_variation_attributes() throws {
-            // Given
-            let manager = try GRDBManager()
-
+            // Given parent product and variation
             try manager.databaseQueue.write { db in
                 // Insert product
                 let product = TestProduct(
                     siteID: 1,
-                    productID: 100,
+                    id: 100,
                     name: "Variable Product",
                     productTypeKey: "variable",
                     price: "10.00",
@@ -216,7 +217,7 @@ struct GRDBManagerTests {
                 // Insert variation
                 let variation = TestProductVariation(
                     siteID: 1,
-                    productVariationID: 200,
+                    id: 200,
                     productID: 100,
                     price: "12.00",
                     downloadable: false
@@ -227,9 +228,7 @@ struct GRDBManagerTests {
             // When
             try manager.databaseQueue.write { db in
                 let variationAttribute = TestProductVariationAttribute(
-                    siteID: 1,
                     productVariationID: 200,
-                    attributeID: 1,
                     name: "Color",
                     option: "Red"
                 )
@@ -244,14 +243,248 @@ struct GRDBManagerTests {
             #expect(attributes.count == 1)
             #expect(attributes.first?.option == "Red")
         }
+
+        @Test("Deleting site cascades to all related entities")
+        func test_deleting_site_cascades_to_all_related_entities() throws {
+            // Given - Create a separate site for this test to avoid interfering with other tests
+            let testSiteId = try manager.databaseQueue.write { db -> Int64 in
+                let site = TestSite(id: 999)
+                try site.insert(db)
+                return 999
+            }
+
+            // Insert full entity hierarchy
+            try manager.databaseQueue.write { db in
+                let product = TestProduct(
+                    siteID: testSiteId,
+                    id: 100,
+                    name: "Test Product",
+                    productTypeKey: "simple",
+                    price: "10.00",
+                    downloadable: false,
+                    parentID: 0
+                )
+                try product.insert(db)
+
+                let variation = TestProductVariation(
+                    siteID: testSiteId,
+                    id: 200,
+                    productID: 100,
+                    price: "12.00",
+                    downloadable: false
+                )
+                try variation.insert(db)
+
+                let productAttribute = TestProductAttribute(
+                    productID: 100,
+                    name: "Color",
+                    position: 0,
+                    visible: true,
+                    variation: true,
+                    options: ["Red", "Blue"]
+                )
+                try productAttribute.insert(db)
+
+                let variationAttribute = TestProductVariationAttribute(
+                    productVariationID: 200,
+                    name: "Size",
+                    option: "Large"
+                )
+                try variationAttribute.insert(db)
+            }
+
+            // Verify entities exist for test site
+            let countsBefore = try manager.databaseQueue.read { db in
+                return (
+                    products: try TestProduct.filter(Column("siteID") == testSiteId).fetchCount(db),
+                    variations: try TestProductVariation.filter(Column("siteID") == testSiteId).fetchCount(db),
+                    productAttributes: try TestProductAttribute.filter(Column("productID") == 100).fetchCount(db),
+                    variationAttributes: try TestProductVariationAttribute.filter(Column("productVariationID") == 200).fetchCount(db)
+                )
+            }
+
+            #expect(countsBefore.products == 1)
+            #expect(countsBefore.variations == 1)
+            #expect(countsBefore.productAttributes == 1)
+            #expect(countsBefore.variationAttributes == 1)
+
+            // When - Delete the site
+            _ = try manager.databaseQueue.write { db in
+                try TestSite.filter(Column("id") == testSiteId).deleteAll(db)
+            }
+
+            // Then - All related entities should be deleted
+            let countsAfter = try manager.databaseQueue.read { db in
+                return (
+                    sites: try TestSite.filter(Column("id") == testSiteId).fetchCount(db),
+                    products: try TestProduct.filter(Column("siteID") == testSiteId).fetchCount(db),
+                    variations: try TestProductVariation.filter(Column("siteID") == testSiteId).fetchCount(db),
+                    productAttributes: try TestProductAttribute.filter(Column("productID") == 100).fetchCount(db),
+                    variationAttributes: try TestProductVariationAttribute.filter(Column("productVariationID") == 200).fetchCount(db)
+                )
+            }
+
+            #expect(countsAfter.sites == 0)
+            #expect(countsAfter.products == 0)
+            #expect(countsAfter.variations == 0)
+            #expect(countsAfter.productAttributes == 0)
+            #expect(countsAfter.variationAttributes == 0)
+        }
+
+        @Test("Fetch products by site")
+        func test_can_fetch_products_by_site() throws {
+            // Given - Create second site and products for both sites
+            let site2Id = try manager.databaseQueue.write { db -> Int64 in
+                let site = TestSite(id: 2)
+                try site.insert(db)
+                return 2
+            }
+
+            try manager.databaseQueue.write { db in
+                // Site 1 products
+                for i in 1...3 {
+                    let product = TestProduct(
+                        siteID: sampleSiteID,
+                        id: Int64(i),
+                        name: "Site 1 Product \(i)",
+                        productTypeKey: "simple",
+                        price: "\(i * 10).00",
+                        downloadable: false,
+                        parentID: 0
+                    )
+                    try product.insert(db)
+                }
+
+                // Site 2 products
+                for i in 1...2 {
+                    let product = TestProduct(
+                        siteID: site2Id,
+                        id: Int64(10 + i),
+                        name: "Site 2 Product \(i)",
+                        productTypeKey: "variable",
+                        price: "\(i * 5).00",
+                        downloadable: true,
+                        parentID: 0
+                    )
+                    try product.insert(db)
+                }
+            }
+
+            // When
+            let site1Products = try manager.databaseQueue.read { db in
+                try TestProduct
+                    .filter(Column("siteID") == sampleSiteID)
+                    .fetchAll(db)
+            }
+
+            let site2Products = try manager.databaseQueue.read { db in
+                try TestProduct
+                    .filter(Column("siteID") == site2Id)
+                    .fetchAll(db)
+            }
+
+            // Then
+            #expect(site1Products.count == 3)
+            #expect(site2Products.count == 2)
+
+            #expect(site1Products.allSatisfy { $0.siteID == sampleSiteID })
+            #expect(site2Products.allSatisfy { $0.siteID == site2Id })
+
+            #expect(site1Products.allSatisfy { $0.name.contains("Site 1") })
+            #expect(site2Products.allSatisfy { $0.name.contains("Site 2") })
+        }
+
+        @Test("Fetch variations by site")
+        func test_can_fetch_variations_by_site() throws {
+            // Given - Product and variations
+            try manager.databaseQueue.write { db in
+                let product = TestProduct(
+                    siteID: sampleSiteID,
+                    id: 100,
+                    name: "Variable Product",
+                    productTypeKey: "variable",
+                    price: "10.00",
+                    downloadable: false,
+                    parentID: 0
+                )
+                try product.insert(db)
+
+                for i in 1...4 {
+                    let variation = TestProductVariation(
+                        siteID: sampleSiteID,
+                        id: Int64(200 + i),
+                        productID: 100,
+                        price: "\(10 + i).00",
+                        downloadable: false
+                    )
+                    try variation.insert(db)
+                }
+            }
+
+            // When
+            let variations = try manager.databaseQueue.read { db in
+                try TestProductVariation
+                    .filter(Column("siteID") == sampleSiteID)
+                    .fetchAll(db)
+            }
+
+            // Then
+            #expect(variations.count == 4)
+            #expect(variations.allSatisfy { $0.siteID == sampleSiteID })
+            #expect(variations.allSatisfy { $0.productID == 100 })
+        }
+
+        @Test("Cannot insert product without valid site")
+        func test_cannot_insert_product_without_valid_site() throws {
+            // When/Then
+            #expect(throws: DatabaseError.self) {
+                try manager.databaseQueue.write { db in
+                    let product = TestProduct(
+                        siteID: 999, // Non-existent site
+                        id: 100,
+                        name: "Orphaned Product",
+                        productTypeKey: "simple",
+                        price: "10.00",
+                        downloadable: false,
+                        parentID: 0
+                    )
+                    try product.insert(db)
+                }
+            }
+        }
+
+        @Test("Cannot insert variation without valid product")
+        func test_cannot_insert_variation_without_valid_product() throws {
+            // When/Then
+            #expect(throws: DatabaseError.self) {
+                try manager.databaseQueue.write { db in
+                    let variation = TestProductVariation(
+                        siteID: sampleSiteID,
+                        id: 200,
+                        productID: 999, // Non-existent product
+                        price: "12.00",
+                        downloadable: false
+                    )
+                    try variation.insert(db)
+                }
+            }
+        }
     }
 }
 
 // MARK: - Test Models
 
+struct TestSite: Codable {
+    let id: Int64
+}
+
+extension TestSite: FetchableRecord, PersistableRecord {
+    static let databaseTableName = "site"
+}
+
 struct TestProduct: Codable {
     let siteID: Int64
-    let productID: Int64
+    let id: Int64
     let name: String
     let productTypeKey: String
     let fullDescription: String?
@@ -262,12 +495,12 @@ struct TestProduct: Codable {
     let downloadable: Bool
     let parentID: Int64
 
-    init(siteID: Int64, productID: Int64, name: String, productTypeKey: String,
+    init(siteID: Int64, id: Int64, name: String, productTypeKey: String,
          price: String, downloadable: Bool, parentID: Int64,
          fullDescription: String? = nil, shortDescription: String? = nil,
          sku: String? = nil, globalUniqueID: String? = nil) {
         self.siteID = siteID
-        self.productID = productID
+        self.id = id
         self.name = name
         self.productTypeKey = productTypeKey
         self.price = price
@@ -286,25 +519,25 @@ extension TestProduct: FetchableRecord, PersistableRecord {
 
 struct TestProductVariation: Codable {
     let siteID: Int64
-    let productVariationID: Int64
+    let id: Int64
     let productID: Int64
     let sku: String?
     let globalUniqueID: String?
     let price: String
     let downloadable: Bool
-    let description: String?
+    let fullDescription: String?
 
-    init(siteID: Int64, productVariationID: Int64, productID: Int64,
+    init(siteID: Int64, id: Int64, productID: Int64,
          price: String, downloadable: Bool,
-         sku: String? = nil, globalUniqueID: String? = nil, description: String? = nil) {
+         sku: String? = nil, globalUniqueID: String? = nil, fullDescription: String? = nil) {
         self.siteID = siteID
-        self.productVariationID = productVariationID
+        self.id = id
         self.productID = productID
         self.price = price
         self.downloadable = downloadable
         self.sku = sku
         self.globalUniqueID = globalUniqueID
-        self.description = description
+        self.fullDescription = fullDescription
     }
 }
 
@@ -313,8 +546,6 @@ extension TestProductVariation: FetchableRecord, PersistableRecord {
 }
 
 struct TestProductAttribute: Codable {
-    let siteID: Int64
-    let attributeID: Int64
     let productID: Int64
     let name: String
     let position: Int
@@ -328,9 +559,7 @@ extension TestProductAttribute: FetchableRecord, PersistableRecord {
 }
 
 struct TestProductVariationAttribute: Codable {
-    let siteID: Int64
     let productVariationID: Int64
-    let attributeID: Int64
     let name: String
     let option: String
 }

--- a/Modules/Tests/StorageTests/GRDB/GRDBManagerTests.swift
+++ b/Modules/Tests/StorageTests/GRDB/GRDBManagerTests.swift
@@ -55,7 +55,7 @@ struct GRDBManagerTests {
             }
         }
 
-        @Test("Can insert product to a freshly initialised database")
+        @Test("Insert product to a freshly initialised database")
         func test_after_init_can_insert_a_product() throws {
             // Given
 
@@ -81,7 +81,7 @@ struct GRDBManagerTests {
             #expect(productCount == 1)
         }
 
-        @Test("Can insert product variation with a relationship to a product")
+        @Test("Insert product variation with a relationship to a product")
         func test_after_init_can_insert_productVariation_with_foreign_key() throws {
             // Given – parent product
             try manager.databaseQueue.write { db in
@@ -118,7 +118,7 @@ struct GRDBManagerTests {
             #expect(variations.first?.productID == 100)
         }
 
-        @Test("Can query variations by product ID")
+        @Test("Fetch variations by product ID")
         func test_after_init_and_insert_can_query_productVariation_using_foreign_key() throws {
             // Given parent product and some variations
             try manager.databaseQueue.write { db in
@@ -159,7 +159,7 @@ struct GRDBManagerTests {
             #expect(variations.allSatisfy { $0.productID == 100 })
         }
 
-        @Test("Can insert product attribute with options array (JSON)")
+        @Test("Insert product attribute with options array (JSON)")
         func test_after_init_can_insert_productAttribute_with_options_as_JSON_array() throws {
             // Given parent product
             try manager.databaseQueue.write { db in
@@ -198,7 +198,7 @@ struct GRDBManagerTests {
             #expect(attribute?.options == ["Red", "Blue", "Green"])
         }
 
-        @Test("Can insert variation attributes")
+        @Test("Insert variation attributes")
         func test_after_init_can_insert_variation_attributes() throws {
             // Given parent product and variation
             try manager.databaseQueue.write { db in

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2ccbd60dcad35afba3898070444c0daa9472345bb19e37fef19d2d4bc42c708e",
+  "originHash" : "298b0576b8fba2136af19221385c7ff56047cb08dc2f781a9e3976c3952d7918",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -115,6 +115,15 @@
       "state" : {
         "revision" : "8469f2c1b334a7c1c3566e2cb2f97826c7cca898",
         "version" : "4.1.6"
+      }
+    },
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift",
+      "state" : {
+        "revision" : "8ba1bc9a96afc731a000fd4136dd13a5a46297bd",
+        "version" : "7.6.1"
       }
     },
     {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds GRDB along with the initial schema for POS products and variations in the catalog.

The tables aren't used anywhere, except in the tests. I think we'll still be treating them as a Work in Progress!

I've not done anything with indexes yet – I want to fully understand what we need before tackling that.

### Questions
1. I've deliberately left out fields related to stock management and sales, because they're not used in POS at the moment. Should we just include them anyway, since they're in the Networking models? If not, I think we should remove them from the Networking models for now.
2. I've removed all references to POS from the table design. That's to keep this open to future use by the main app. Do you think that's the right approach? Or would it be better to "namespace" the tables that way.
3. What do you think about the migration definition approach? I'm trying to strike a balance between "don't change this once it's shipped" and encapsulating everything in one place. We could go further with building a migration registration system, but I don't think we need more complexity yet.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Run `GRDBManagerTests`
Check CI passes

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

I've not tested this in the app yet – it needs a bit more scaffolding, e.g. `Storage.POSProduct` models, or some other name that doesn't include POS and can be converted to the existing `POSProduct` in Yosemite. This is similar to our existing Core Data approach... but it's potentially one more abstraction step than we really need – we could just make the existing POSProduct a `PersistableRecord` in a Yosemite extension...

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
