### PR TITLE
[POS Settings] Render conditional options based on settings flag

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -24,6 +24,8 @@ struct CartView: View {
     private var shouldShowCoupons: Bool {
         posModel.cart.coupons.isNotEmpty
     }
+    
+    @State private var showBarcodeScanningModal: Bool = false
 
     var body: some View {
         ZStack {
@@ -68,6 +70,9 @@ struct CartView: View {
                         .if(shouldApplyFooterTopShadow, transform: { $0.applyEdgeShadow(backgroundColor: backgroundColor, edges: .top) })
                         .zIndex(1)
                 }
+            }
+            .posModal(isPresented: $showBarcodeScanningModal) {
+                PointOfSaleBarcodeScannerSetup(isPresented: $showBarcodeScanningModal)
             }
             .animation(Constants.cartAnimation, value: posModel.cart.isEmpty)
             .frame(maxWidth: .infinity)
@@ -126,13 +131,18 @@ private extension CartView {
 
 private extension CartView {
     enum Localization {
+        static let barcodeScanningSetup = NSLocalizedString(
+            "pos.cartView.cartTitle.barcodeScanningSetup.button",
+            value: "Scan barcode",
+            comment: "The title of the menu button to start a barcode scanner setup flow."
+        )
         static let cartTitle = NSLocalizedString(
             "pos.cartView.cartTitle",
             value: "Cart",
             comment: "Title at the header for the Cart view.")
         static let addItemsToCartHint = NSLocalizedString(
-            "pos.cartView.addItemsToCartHint",
-            value: "Tap on a product to \n add it to the cart",
+            "pos.cartView.addItemsToCartHint.1",
+            value: "Tap on a product to \n add it to the cart, or ",
             comment: "Hint to add products to the Cart when this is empty.")
         static let checkoutButtonTitle = NSLocalizedString(
             "pos.cartView.checkoutButtonTitle",
@@ -202,6 +212,18 @@ private extension CartView {
                         .offset(y: -(Constants.shoppingBagImageSize + Constants.emptyViewImageTextSpacing))
                         .aspectRatio(contentMode: .fit)
                 }
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleSettingsi1) {
+                Button(action: {
+                    showBarcodeScanningModal = true
+                }, label: {
+                    HStack {
+                        Text(Localization.barcodeScanningSetup)
+                            .font(Constants.secondaryFont)
+                            .foregroundColor(Color.posOnSurfaceVariantLowest)
+                        Image(systemName: "barcode.viewfinder")
+                    }
+                })
+            }
             Spacer()
         }
         .background(backgroundColor.ignoresSafeArea(.all))

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -24,7 +24,7 @@ struct CartView: View {
     private var shouldShowCoupons: Bool {
         posModel.cart.coupons.isNotEmpty
     }
-    
+
     @State private var showBarcodeScanningModal: Bool = false
 
     var body: some View {

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -25,6 +25,10 @@ struct CartView: View {
         posModel.cart.coupons.isNotEmpty
     }
 
+    private var isPOSSettingsEnabled: Bool {
+           ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleSettingsi1)
+       }
+
     @State private var showBarcodeScanningModal: Bool = false
 
     var body: some View {
@@ -141,7 +145,11 @@ private extension CartView {
             value: "Cart",
             comment: "Title at the header for the Cart view.")
         static let addItemsToCartHint = NSLocalizedString(
-            "pos.cartView.addItemsToCartHint.1",
+            "pos.cartView.addItemsToCartHint",
+            value: "Tap on a product to \n add it to the cart",
+            comment: "Hint to add products to the Cart when this is empty.")
+        static let addItemsToCartOrScanHint = NSLocalizedString(
+            "pos.cartView.addItemsToCartOrScanHint",
             value: "Tap on a product to \n add it to the cart, or ",
             comment: "Hint to add products to the Cart when this is empty.")
         static let checkoutButtonTitle = NSLocalizedString(
@@ -201,7 +209,7 @@ private extension CartView {
             // SwiftUI doesn't allow us to absolutely pin a view to the centre then position other views relative to it
             // Instead, we can centre the text, and then put the image in an offset overlay. Offsetting from the top
             // avoids issues when the text size is changed through dynamic type.
-            Text(Localization.addItemsToCartHint)
+            Text(isPOSSettingsEnabled ? Localization.addItemsToCartOrScanHint : Localization.addItemsToCartHint)
                 .font(Constants.secondaryFont)
                 .foregroundColor(Color.posOnSurfaceVariantLowest)
                 .multilineTextAlignment(.center)
@@ -212,7 +220,7 @@ private extension CartView {
                         .offset(y: -(Constants.shoppingBagImageSize + Constants.emptyViewImageTextSpacing))
                         .aspectRatio(contentMode: .fit)
                 }
-            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleSettingsi1) {
+            if isPOSSettingsEnabled {
                 Button(action: {
                     showBarcodeScanningModal = true
                 }, label: {

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -26,8 +26,8 @@ struct CartView: View {
     }
 
     private var isPOSSettingsEnabled: Bool {
-           ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleSettingsi1)
-       }
+        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleSettingsi1)
+    }
 
     @State private var showBarcodeScanningModal: Bool = false
 

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -22,74 +22,17 @@ struct POSFloatingControlView: View {
         self._showSettings = showSettings
     }
 
+    private var isPOSSettingsEnabled: Bool {
+        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleSettingsi1)
+    }
+
     var body: some View {
         HStack {
             Menu {
-                Button {
-                    ServiceLocator.analytics.track(.pointOfSaleExitMenuItemTapped)
-                    showExitPOSModal = true
-                } label: {
-                    Label(
-                        title: { Text(Localization.exitPointOfSale) },
-                        icon: { Image(systemName: "rectangle.portrait.and.arrow.forward") }
-                    )
-                }
-                Button {
-                    ServiceLocator.analytics.track(.pointOfSaleGetSupportTapped)
-                    showSupport = true
-                } label: {
-                    Label(
-                        title: { Text(Localization.getSupport) },
-                        icon: { Image(systemName: "questionmark.circle") }
-                    )
-                }
-                Button {
-                    showDocumentation = true
-                    ServiceLocator.analytics.track(.pointOfSaleViewDocsTapped)
-                } label: {
-                    Label(
-                        title: { Text(Localization.viewDocumentation) },
-                        icon: { Image(systemName: "info.circle") }
-                    )
-                }
-                Button {
-                    showProductRestrictionsModal = true
-                    ServiceLocator.analytics.track(.pointOfSaleSimpleProductsExplanationDialogShown)
-                } label: {
-                    Label(
-                        title: { Text(Localization.productRestrictionsInfo) },
-                        icon: { Image(systemName: "magnifyingglass") })
-                }
-                Button {
-                    showBarcodeScanningModal = true
-                    ServiceLocator.analytics.track(.pointOfSaleBarcodeScanningMenuItemTapped)
-                } label: {
-                    Label(
-                        title: {
-                            Text(Localization.barcodeScanningSetup)
-                        },
-                        icon: { Image(systemName: "barcode.viewfinder") })
-                }
-                if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleSettingsi1) {
-                    Button {
-                        showSettings = true
-                    } label: {
-                        Label(
-                            title: { Text(Localization.settings) },
-                            icon: { Image(systemName: "gearshape") }
-                        )
-                    }
-                }
-
-                if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleHistoricalOrdersi1) {
-                    Button {
-                        showOrders = true
-                    } label: {
-                        Label(
-                            title: { Text(Localization.orders) },
-                            icon: { Image(systemName: "text.document") }
-                        )
-                    }
+                if isPOSSettingsEnabled {
+                    compactOptions()
+                } else {
+                    completeOptions()
                 }
             } label: {
                 VStack {
@@ -126,6 +69,110 @@ struct POSFloatingControlView: View {
         .background(Color.clear)
         .animation(.default, value: backgroundAppearance)
         .posShadow(.large, cornerRadius: Constants.cornerRadius)
+    }
+}
+
+private extension POSFloatingControlView {
+    @ViewBuilder private func compactOptions() -> some View {
+        Button {
+            ServiceLocator.analytics.track(.pointOfSaleExitMenuItemTapped)
+            showExitPOSModal = true
+        } label: {
+            Label(
+                title: { Text(Localization.exitPointOfSale) },
+                icon: { Image(systemName: "rectangle.portrait.and.arrow.forward") }
+            )
+        }
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleSettingsi1) {
+            Button {
+                showSettings = true
+            } label: {
+                Label(
+                    title: { Text(Localization.settings) },
+                    icon: { Image(systemName: "gearshape") }
+                )
+            }
+        }
+
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleHistoricalOrdersi1) {
+            Button {
+                showOrders = true
+            } label: {
+                Label(
+                    title: { Text(Localization.orders) },
+                    icon: { Image(systemName: "text.document") }
+                )
+            }
+        }
+    }
+
+    @ViewBuilder private func completeOptions() -> some View {
+        Button {
+            ServiceLocator.analytics.track(.pointOfSaleExitMenuItemTapped)
+            showExitPOSModal = true
+        } label: {
+            Label(
+                title: { Text(Localization.exitPointOfSale) },
+                icon: { Image(systemName: "rectangle.portrait.and.arrow.forward") }
+            )
+        }
+        Button {
+            ServiceLocator.analytics.track(.pointOfSaleGetSupportTapped)
+            showSupport = true
+        } label: {
+            Label(
+                title: { Text(Localization.getSupport) },
+                icon: { Image(systemName: "questionmark.circle") }
+            )
+        }
+        Button {
+            showDocumentation = true
+            ServiceLocator.analytics.track(.pointOfSaleViewDocsTapped)
+        } label: {
+            Label(
+                title: { Text(Localization.viewDocumentation) },
+                icon: { Image(systemName: "info.circle") }
+            )
+        }
+        Button {
+            showProductRestrictionsModal = true
+            ServiceLocator.analytics.track(.pointOfSaleSimpleProductsExplanationDialogShown)
+        } label: {
+            Label(
+                title: { Text(Localization.productRestrictionsInfo) },
+                icon: { Image(systemName: "magnifyingglass") })
+        }
+        Button {
+            showBarcodeScanningModal = true
+            ServiceLocator.analytics.track(.pointOfSaleBarcodeScanningMenuItemTapped)
+        } label: {
+            Label(
+                title: {
+                    Text(Localization.barcodeScanningSetup)
+                },
+                icon: { Image(systemName: "barcode.viewfinder") })
+        }
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleSettingsi1) {
+            Button {
+                showSettings = true
+            } label: {
+                Label(
+                    title: { Text(Localization.settings) },
+                    icon: { Image(systemName: "gearshape") }
+                )
+            }
+        }
+
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleHistoricalOrdersi1) {
+            Button {
+                showOrders = true
+            } label: {
+                Label(
+                    title: { Text(Localization.orders) },
+                    icon: { Image(systemName: "text.document") }
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Closes WOOMOB-1168
Closes WOOMOB-1038

## Description
This PR updates the floating CTA menu in POS to display only Orders, Settings, and Exit buttons. As well as the empty cart view to show a button to start the barcode scanner flow.

We temporarily duplicate the view and render one or the other based on feature flag. The duplicated code will be removed a cycle after release with WOOMOB-1201

## Testing information
- Run POS, tap the floating button, observe only 3 options render (Orders, Settings, and Exit buttons). Tap on all of them, confirm that work as expected.
- Tapping on the barcode scanner setup button on empty cart brings up the barcode setup flow
- Switch the  `pointOfSaleSettingsi1` flag to `false`, Run POS, tap the floating button, observe all options render (except settings).
- Confirm the barcode scanner setup button on empty cart is not present.

| Flag off | Flag on |
|--------|--------|
| <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-08-28 at 09 30 42" src="https://github.com/user-attachments/assets/40a2b1f7-89f2-436b-94d2-9d9bf8ff00ef" /> | <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-08-28 at 09 21 06" src="https://github.com/user-attachments/assets/5df67aeb-eff4-4288-81d2-220b1747d8a6" /> | 

https://github.com/user-attachments/assets/a9cd1ad8-8c21-49e8-9baf-07f2b17d8568


