### PR TITLE
Crash fix for network changes while fetching info

### DIFF
--- a/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
@@ -177,8 +177,8 @@ private struct BackgroundTaskSystemInfo {
             let monitor = NWPathMonitor()
 
             monitor.pathUpdateHandler = { path in
-                continuation.resume(returning: NetworkInfo(path: path))
                 monitor.cancel()
+                continuation.resume(returning: NetworkInfo(path: path))
             }
 
             let queue = DispatchQueue(label: "network.monitor.queue")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1204

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR attempts to fix a crash while fetching the network info. It most likely happens when the network path changes as we're checking the info. This happens when the app's in the background.

If the handler's called twice, the continuation would be called twice as well, meaning that we crash.

Cancelling the network monitor before we resume should give us some resillience to this (but may not be a 100% fix).

I tried using a nillableCancellation pattern, but it adds a warning that will become an error with Swift 6, so let's see if the crash can be fixed without that. Alternatively, we could use a non-async-await approach.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

I couldn't repro the crash – it's very timing dependent. Testing steps just cover that the regular code path still works.

1. Launch the app with a breakpoint in `BackgroundTaskRefreshDispatcher.scheduleAppRefresh():23`. 
2. Background the app and then you'll hit the breakpoint
3. Step over the `try BGTaskScheduler.shared.submit(request)` line.
4. When that's run, use `e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"com.automattic.woocommerce.refresh"]` in LLDB to trigger a refresh
5. Observe that the analytic `background_data_synced` is synced with expected properties

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="1500" height="298" alt="CleanShot 2025-08-28 at 10 27 55@2x" src="https://github.com/user-attachments/assets/d3f0f958-03d7-43a2-b220-c1baac69fc1b" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
