### PR TITLE
Fix: Customer details are incorrect after opening customer search in order creation

### DIFF
--- a/Modules/Sources/Yosemite/Model/Storage/Customer+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Storage/Customer+ReadOnlyConvertible.swift
@@ -80,10 +80,18 @@ extension Storage.Customer: ReadOnlyConvertible {
         shippingFirstName = firstName
         shippingLastName = lastName
         shippingEmail = email
+        shippingCity = customer.city
+        shippingState = customer.region
+        shippingPostcode = customer.postcode
+        shippingCountry = customer.country
 
         billingFirstName = firstName
         billingLastName = lastName
         billingEmail = email
+        billingCity = customer.city
+        billingState = customer.region
+        billingPostcode = customer.postcode
+        billingCountry = customer.country
     }
 
     /// Returns a ReadOnly (`Networking.Customer`) version of the `Storage.Customer`


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

WOOMOB-1045

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Customer details are incorrect after opening the customer search in order creation.

This issue led me down a confusing path of figuring out how customers work in the WooCommerce iOS app. There are two main types: `WCAnalyticsCustomer` from the `wc-analytics/customer` endpoint, and `Customer` from the `/customers/{user_id}` endpoint.

`WCAnalyticsCustomer` represents customers created when placing an order, while `Customer` represents registered site users (`wp-admin` -> users). These can be linked through `WCAnalyticsCustomer.user_id` (which points to `Customer.id`), and `Customer.id` (which matches `WCAnalyticsCustomer.customerID`). The `user_id` is `0` if the analytics customer is not a registered WordPress user.

It gets more complicated on iOS. Even when calling the `wc-analytics/customer` endpoint, the app persists data in both `Storage.WCAnalyticsCustomer` and `Storage.Customer`. The name `Storage.Customer` suggests it represents a `Customer` from `/customers/`, but in practice it is a shared aggregate object combining data from both `WCAnalyticsCustomer` and `Customer`.

The problem is that `Storage.Customer` only has a single identifier, `customerID`. Sometimes this field stores the `customerID` value, and other times it stores the `userID` value. The app uses these values interchangeably, which creates inconsistencies. For example, `retrieveCustomer` asks for a `customerID` parameter by name, but actually requires the WordPress `userID` to succeed. This kind of mismatch appears throughout the `Customer` implementation in the app. Also, given that both of these types are updated from one another, some data losses in the conversion process are possible.

This made it difficult to identify the real cause of the bug. In the end, it came from the fact that we create `Storage.Customer` from `WCAnalyticsCustomer` during order creation with incomplete mapping, and later use `Storage.Customer` within `Menu -> Customers -> Details`:

1. Order Creation → Add Customer Details
2. `wc-analytics/customers` call is made
3. `Storage.Customer` entities are deleted
4. `Storage.Customer` is re-inserted and mapped with `wc-analytics/customers` data, but shipping information is not set
5. The `Menu -> Customers` list shows `WCAnalyticsCustomer` data, but when tapping on a customer, the details come from `Storage.Customer` (which had been deleted and remapped without shipping information after opening the order).

I’m applying a simpler fix first, but I also plan to introduce a larger refactor to bring more clarity to the codebase. Hopefully, this will also uncover other hidden issues in the process:

* [https://github.com/woocommerce/woocommerce-ios/pull/16056](https://github.com/woocommerce/woocommerce-ios/pull/16056)

---

Do you want me to also make it slightly **more structured for a GitHub issue/PR description** (with headings like *Background*, *Problem*, *Root Cause*, *Fix*)? That would make it easier for reviewers to parse.


## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a test store.
2. Open Menu > Customers and confirm that customers' locations are correct. Billing & shipping addresses are correct if available, otherwise, only Location is displayed.
3. Open Orders > + to add new order.
4. Select Add customer details > select any customer > dismiss the form.
5. Confirm customer shipping/billing data is shown.
6. Switch back to Menu > Customers. 
7. Confirm location information is still displayed.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

iPad Air 18.5 simulator, tested with WordPress and guest users

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/74eba386-190f-440b-9914-465337b08df4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.