### PR TITLE
[POS Settings] Design updates

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -111,7 +111,22 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                 .buttonStyle(.plain)
             }
         }
-        .navigationTitle(Localization.cardReadersTitle)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    navigationPath.removeLast()
+                } label: {
+                    HStack(spacing: POSSpacing.small) {
+                        Image(systemName: "chevron.left")
+                        Text(Localization.cardReadersTitle)
+                    }
+                    .font(.posBodyLargeRegular())
+                    .foregroundColor(.posOnSurface)
+                    .contentShape(Rectangle())
+                }
+            }
+        }
         .posFullScreenCover(isPresented: $showCardReaderDocumentationModal) {
             SafariView(url: WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL())
         }
@@ -136,7 +151,22 @@ struct PointOfSaleSettingsHardwareDetailView: View {
             }
             .buttonStyle(.plain)
         }
-        .navigationTitle(Localization.scannersTitle)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    navigationPath.removeLast()
+                } label: {
+                    HStack(spacing: POSSpacing.small) {
+                        Image(systemName: "chevron.left")
+                        Text(Localization.scannersTitle)
+                    }
+                    .font(.posBodyLargeRegular())
+                    .foregroundColor(.posOnSurface)
+                    .contentShape(Rectangle())
+                }
+            }
+        }
     }
 
 }

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -82,7 +82,14 @@ struct PointOfSaleSettingsHardwareDetailView: View {
     }
 
     private var cardReadersView: some View {
-        VStack(spacing: POSSpacing.large) {
+        VStack(spacing: POSSpacing.none) {
+            POSPageHeaderView(
+                title: Localization.cardReadersTitle,
+                backButtonConfiguration: .init(state: .enabled, action: {
+                    navigationPath.removeLast()
+                }, buttonIcon: "chevron.left"))
+            .foregroundColor(.posSurface)
+
             List {
                 VStack(spacing: POSPadding.xSmall) {
                     HStack {
@@ -131,71 +138,47 @@ struct PointOfSaleSettingsHardwareDetailView: View {
             .foregroundColor(.posOnSurface)
         }
         .navigationBarBackButtonHidden(true)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button {
-                    navigationPath.removeLast()
-                } label: {
-                    HStack(spacing: POSSpacing.small) {
-                        Image(systemName: "chevron.left")
-                        Text(Localization.cardReadersTitle)
-                    }
-                    .font(.posBodyLargeRegular())
-                    .foregroundColor(.posOnSurface)
-                    .contentShape(Rectangle())
-                }
-            }
-        }
-        .toolbarBackground(backgroundColor, for: .navigationBar)
         .posFullScreenCover(isPresented: $showCardReaderDocumentationModal) {
             SafariView(url: WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL())
         }
     }
 
     private var scannersView: some View {
-        List(ScannerDestination.allCases) { destination in
-            Button {
-                handleScannerDestination(destination)
-            } label: {
-                HStack(alignment: .firstTextBaseline) {
-                    Image(systemName: destination.icon)
-                        .font(.posBodyLargeRegular())
-                    VStack(alignment: .leading, spacing: POSPadding.xSmall) {
-                        Text(destination.title)
-                            .font(.posBodyLargeRegular())
-                        Text(destination.subtitle)
-                            .font(.posBodyMediumRegular())
-                            .foregroundStyle(.secondary)
-                    }
-                }
-            }
-            .buttonStyle(.plain)
-            .listRowSeparator(.hidden)
-        }
-        .listStyle(.plain)
-        .scrollContentBackground(.hidden)
-        .listRowBackground(Color.clear)
-        .background(backgroundColor)
-        .foregroundColor(.posOnSurface)
-        .navigationBarBackButtonHidden(true)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button {
+        VStack(spacing: POSSpacing.none) {
+            POSPageHeaderView(
+                title: Localization.scannersTitle,
+                backButtonConfiguration: .init(state: .enabled, action: {
                     navigationPath.removeLast()
-                } label: {
-                    HStack(spacing: POSSpacing.small) {
-                        Image(systemName: "chevron.left")
-                        Text(Localization.scannersTitle)
-                    }
-                    .font(.posBodyLargeRegular())
-                    .foregroundColor(.posOnSurface)
-                    .contentShape(Rectangle())
-                }
-            }
-        }
-        .toolbarBackground(backgroundColor, for: .navigationBar)
-    }
+                }, buttonIcon: "chevron.left"))
+            .foregroundColor(.posSurface)
 
+            List(ScannerDestination.allCases) { destination in
+                Button {
+                    handleScannerDestination(destination)
+                } label: {
+                    HStack(alignment: .firstTextBaseline) {
+                        Image(systemName: destination.icon)
+                            .font(.posBodyLargeRegular())
+                        VStack(alignment: .leading, spacing: POSPadding.xSmall) {
+                            Text(destination.title)
+                                .font(.posBodyLargeRegular())
+                            Text(destination.subtitle)
+                                .font(.posBodyMediumRegular())
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+                .listRowSeparator(.hidden)
+            }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .listRowBackground(Color.clear)
+            .background(backgroundColor)
+            .foregroundColor(.posOnSurface)
+        }
+        .navigationBarBackButtonHidden(true)
+    }
 }
 
 extension PointOfSaleSettingsHardwareDetailView {

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -118,7 +118,13 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                     }
                 }
                 .buttonStyle(.plain)
+                .listRowSeparator(.hidden)
             }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .listRowBackground(Color.clear)
+            .background(Color.posSurface)
+            .foregroundColor(.posOnSurface)
         }
         .navigationBarBackButtonHidden(true)
         .toolbar {
@@ -159,7 +165,13 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                 }
             }
             .buttonStyle(.plain)
+            .listRowSeparator(.hidden)
         }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .listRowBackground(Color.clear)
+        .background(Color.posSurface)
+        .foregroundColor(.posOnSurface)
         .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -27,6 +27,9 @@ struct PointOfSaleSettingsHardwareDetailView: View {
 
     var body: some View {
         NavigationStack(path: $navigationPath) {
+            POSPageHeaderView(title: Localization.hardwareTitle)
+            .foregroundColor(.posSurface)
+
             List(HardwareDestination.allCases) { destination in
                 NavigationLink(value: NavigationDestination.hardware(destination)) {
                     HStack(alignment: .firstTextBaseline) {
@@ -275,6 +278,12 @@ private extension PointOfSaleSettingsHardwareDetailView {
             "pointOfSaleSettingsHardwareDetailView.batteryLevelUnknown",
             value: "Unknown",
             comment: "Text displayed on Point of Sale settings when card reader battery is unknown."
+        )
+
+        static let hardwareTitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.hardwareTitle",
+            value: "Hardware",
+            comment: "Navigation title for the hardware settings list."
         )
 
         static let cardReadersTitle = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -123,7 +123,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
             .listRowBackground(Color.clear)
-            .background(Color.posSurface)
+            .background(Color.posSurfaceBright)
             .foregroundColor(.posOnSurface)
         }
         .navigationBarBackButtonHidden(true)
@@ -170,7 +170,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
         .listRowBackground(Color.clear)
-        .background(Color.posSurface)
+        .background(Color.posSurfaceBright)
         .foregroundColor(.posOnSurface)
         .navigationBarBackButtonHidden(true)
         .toolbar {

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -25,6 +25,10 @@ struct PointOfSaleSettingsHardwareDetailView: View {
         }
     }
 
+    private var backgroundColor: Color {
+        Color.posOnSecondaryContainer
+    }
+
     var body: some View {
         NavigationStack(path: $navigationPath) {
             POSPageHeaderView(title: Localization.hardwareTitle)
@@ -48,7 +52,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
-            .background(Color.posOnPrimaryContainer)
+            .background(backgroundColor)
             .listRowBackground(Color.clear)
             .listRowSeparator(.hidden)
             .navigationDestination(for: NavigationDestination.self) { destination in
@@ -123,7 +127,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
             .listRowBackground(Color.clear)
-            .background(Color.posSurfaceBright)
+            .background(backgroundColor)
             .foregroundColor(.posOnSurface)
         }
         .navigationBarBackButtonHidden(true)
@@ -142,6 +146,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                 }
             }
         }
+        .toolbarBackground(backgroundColor, for: .navigationBar)
         .posFullScreenCover(isPresented: $showCardReaderDocumentationModal) {
             SafariView(url: WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL())
         }
@@ -170,7 +175,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
         .listRowBackground(Color.clear)
-        .background(Color.posSurfaceBright)
+        .background(backgroundColor)
         .foregroundColor(.posOnSurface)
         .navigationBarBackButtonHidden(true)
         .toolbar {
@@ -188,6 +193,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                 }
             }
         }
+        .toolbarBackground(backgroundColor, for: .navigationBar)
     }
 
 }

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -41,7 +41,13 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                         }
                     }
                 }
+                .listRowSeparator(.hidden)
             }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .background(Color.posOnPrimaryContainer)
+            .listRowBackground(Color.clear)
+            .listRowSeparator(.hidden)
             .navigationDestination(for: NavigationDestination.self) { destination in
                 switch destination {
                 case .hardware(.cardReaders):

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
@@ -5,8 +5,14 @@ struct PointOfSaleSettingsHelpDetailView: View {
     @State private var showDocumentation = false
     @State private var showSupport = false
 
+    private var backgroundColor: Color {
+        Color.posOnSecondaryContainer
+    }
+
     var body: some View {
         NavigationStack {
+            POSPageHeaderView(title: Localization.helpTitle)
+            .foregroundColor(.posSurface)
             List {
                 Button {
                     showProductRestrictions = true
@@ -23,6 +29,7 @@ struct PointOfSaleSettingsHelpDetailView: View {
                         }
                     }
                 }
+                .listRowSeparator(.hidden)
                 .buttonStyle(.plain)
 
                 Button {
@@ -40,6 +47,7 @@ struct PointOfSaleSettingsHelpDetailView: View {
                         }
                     }
                 }
+                .listRowSeparator(.hidden)
                 .buttonStyle(.plain)
 
                 Button {
@@ -57,8 +65,14 @@ struct PointOfSaleSettingsHelpDetailView: View {
                         }
                     }
                 }
+                .listRowSeparator(.hidden)
                 .buttonStyle(.plain)
             }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .background(backgroundColor)
+            .listRowBackground(Color.clear)
+            .listRowSeparator(.hidden)
         }
         .posModal(isPresented: $showProductRestrictions) {
             // TODO: Remove copy on POSFloatingControlView.documentationView
@@ -86,6 +100,12 @@ private extension PointOfSaleSettingsHelpDetailView {
     }
 
     enum Localization {
+        static let helpTitle = NSLocalizedString(
+            "PointOfSaleSettingsHelpDetailView.help.title",
+            value: "Help",
+            comment: "Navigation title for the help settings list."
+        )
+
         static let productRestrictionsInfo = NSLocalizedString(
             "PointOfSaleSettingsHelpDetailView.help.productRestrictionsInfo.button.title",
             value: "Where are my products?",
@@ -147,3 +167,9 @@ private extension PointOfSaleSettingsHelpDetailView {
         .navigationViewStyle(.stack)
     }
 }
+
+#if DEBUG
+#Preview {
+    PointOfSaleSettingsHelpDetailView()
+}
+#endif

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
@@ -114,7 +114,11 @@ struct PointOfSaleSettingsStoreDetailView: View {
     @ViewBuilder
     private func settingValueView(for value: String?) -> some View {
         if isLoading {
-            GhostSettingRowView()
+            Rectangle()
+                .fill(Color.posOnSurfaceVariantLowest)
+                .frame(width: Constants.shimmeringTextWidth, height: Constants.shimmeringTextHeight)
+                .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value))
+                .shimmering()
         } else {
             Text(value ?? Localization.notSet)
                 .font(.posBodyMediumRegular())
@@ -123,46 +127,13 @@ struct PointOfSaleSettingsStoreDetailView: View {
     }
 }
 
-// Temporary: Simplified copy from PointOfSaleOrderListView.GhostOrderRowView
-private struct GhostSettingRowView: View {
-    @ScaledMetric private var scale: CGFloat = 1.0
-    @Environment(\.dynamicTypeSize) var dynamicTypeSize
-
-    private var minHeight: CGFloat {
-        min(Constants.orderCardMinHeight * scale, Constants.maximumOrderCardHeight)
-    }
-
-    var body: some View {
-        HStack(alignment: .center, spacing: POSSpacing.medium) {
-            VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
-                Rectangle()
-                    .fill(Color.posOnSurfaceVariantLowest)
-                    .frame(width: 70, height: 16)
-                    .clipShape(RoundedRectangle(cornerRadius: 4))
-                    .shimmering()
-
-                Rectangle()
-                    .fill(Color.posOnSurfaceVariantLowest)
-                    .frame(width: 160, height: 14)
-                    .clipShape(RoundedRectangle(cornerRadius: 4))
-                    .shimmering()
-            }
-        }
-        .padding(.horizontal, POSPadding.medium * (1 / scale))
-        .padding(.vertical, POSPadding.medium * (1 / scale))
-        .frame(maxWidth: .infinity, minHeight: dynamicTypeSize.isAccessibilitySize ? nil : minHeight, alignment: .leading)
-        .background(Color.posSurfaceContainerLowest)
-        .posItemCardBorderStyles()
-        .geometryGroup()
-    }
-
-    private enum Constants {
-        static let orderCardMinHeight: CGFloat = 90
-        static let maximumOrderCardHeight: CGFloat = Constants.orderCardMinHeight * 2
-    }
-}
 
 private extension PointOfSaleSettingsStoreDetailView {
+    enum Constants {
+        static let shimmeringTextWidth: CGFloat = 70
+        static let shimmeringTextHeight: CGFloat = 16
+    }
+
     enum Localization {
         static let notSet = NSLocalizedString(
             "pointOfSaleSettingsStoreDetailView.notSet",

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
@@ -31,6 +31,7 @@ struct PointOfSaleSettingsStoreDetailView: View {
                 } header: {
                     Text(Localization.storeInformation)
                         .font(.posBodyLargeRegular())
+                        .textCase(nil)
                 }
 
                 Section {
@@ -66,6 +67,7 @@ struct PointOfSaleSettingsStoreDetailView: View {
                 } header: {
                     Text(Localization.receiptInformation)
                         .font(.posBodyLargeRegular())
+                        .textCase(nil)
                 }
                 .renderedIf(viewModel.shouldShowReceiptInformation)
             }

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
@@ -20,7 +20,8 @@ struct PointOfSaleSettingsStoreDetailView: View {
                             .font(.posBodyMediumRegular())
                             .foregroundStyle(.secondary)
                     }
-
+                    .listRowSeparator(.hidden)
+                    
                     VStack(alignment: .leading, spacing: POSPadding.small) {
                         Text(Localization.address)
                             .font(.posBodyMediumRegular())
@@ -28,6 +29,7 @@ struct PointOfSaleSettingsStoreDetailView: View {
                             .font(.posBodyMediumRegular())
                             .foregroundStyle(.secondary)
                     }
+                    .listRowSeparator(.hidden)
                 } header: {
                     Text(Localization.storeInformation)
                         .font(.posBodyLargeRegular())
@@ -40,30 +42,35 @@ struct PointOfSaleSettingsStoreDetailView: View {
                             .font(.posBodyMediumRegular())
                         settingValueView(for: viewModel.receiptInformation.storeName)
                     }
+                    .listRowSeparator(.hidden)
 
                     VStack(alignment: .leading, spacing: POSPadding.small) {
                         Text(Localization.physicalAddress)
                             .font(.posBodyMediumRegular())
                         settingValueView(for: viewModel.receiptInformation.storeAddress)
                     }
+                    .listRowSeparator(.hidden)
 
                     VStack(alignment: .leading, spacing: POSPadding.small) {
                         Text(Localization.phoneNumber)
                             .font(.posBodyMediumRegular())
                         settingValueView(for: viewModel.receiptInformation.phone)
                     }
+                    .listRowSeparator(.hidden)
 
                     VStack(alignment: .leading, spacing: POSPadding.small) {
                         Text(Localization.email)
                             .font(.posBodyMediumRegular())
                         settingValueView(for: viewModel.receiptInformation.email)
                     }
-
+                    .listRowSeparator(.hidden)
+  
                     VStack(alignment: .leading, spacing: POSPadding.small) {
                         Text(Localization.refundReturnsPolicy)
                             .font(.posBodyMediumRegular())
                         settingValueView(for: viewModel.receiptInformation.refundReturnsPolicy)
                     }
+                    .listRowSeparator(.hidden)
                 } header: {
                     Text(Localization.receiptInformation)
                         .font(.posBodyLargeRegular())
@@ -71,6 +78,11 @@ struct PointOfSaleSettingsStoreDetailView: View {
                 }
                 .renderedIf(viewModel.shouldShowReceiptInformation)
             }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .background(Color.posOnPrimaryContainer)
+            .listRowSeparator(.hidden)
+            .listSectionSeparator(.hidden)
             .task {
                 isLoading = true
                 await viewModel.retrievePOSReceiptSettings()

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
@@ -9,6 +9,10 @@ struct PointOfSaleSettingsStoreDetailView: View {
         self.viewModel = viewModel
     }
 
+    private var backgroundColor: Color {
+        Color.posOnSecondaryContainer
+    }
+
     var body: some View {
         NavigationStack {
             List {
@@ -31,10 +35,17 @@ struct PointOfSaleSettingsStoreDetailView: View {
                     }
                     .listRowSeparator(.hidden)
                 } header: {
-                    Text(Localization.storeInformation)
-                        .font(.posHeadingBold)
-                        .foregroundStyle(.primary)
-                        .textCase(nil)
+                    ZStack {
+                        backgroundColor
+                        Text(Localization.storeInformation)
+                            .font(.posHeadingBold)
+                            .foregroundColor(.posOnSurface)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, POSPadding.medium)
+                            .padding(.vertical, POSPadding.small)
+                            .textCase(nil)
+                    }
+                    .listRowInsets(EdgeInsets())
                 }
 
                 Section {
@@ -73,16 +84,23 @@ struct PointOfSaleSettingsStoreDetailView: View {
                     }
                     .listRowSeparator(.hidden)
                 } header: {
-                    Text(Localization.receiptInformation)
-                        .font(.posHeadingBold)
-                        .foregroundStyle(.primary)
-                        .textCase(nil)
+                    ZStack {
+                        backgroundColor
+                        Text(Localization.receiptInformation)
+                            .font(.posHeadingBold)
+                            .foregroundColor(.posOnSurface)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, POSPadding.medium)
+                            .padding(.vertical, POSPadding.small)
+                            .textCase(nil)
+                    }
+                    .listRowInsets(EdgeInsets())
                 }
                 .renderedIf(viewModel.shouldShowReceiptInformation)
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
-            .background(Color.posOnPrimaryContainer)
+            .background(backgroundColor)
             .listRowSeparator(.hidden)
             .listSectionSeparator(.hidden)
             .task {

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
@@ -21,7 +21,7 @@ struct PointOfSaleSettingsStoreDetailView: View {
                             .foregroundStyle(.secondary)
                     }
                     .listRowSeparator(.hidden)
-                    
+
                     VStack(alignment: .leading, spacing: POSPadding.small) {
                         Text(Localization.address)
                             .font(.posBodyMediumRegular())
@@ -32,7 +32,8 @@ struct PointOfSaleSettingsStoreDetailView: View {
                     .listRowSeparator(.hidden)
                 } header: {
                     Text(Localization.storeInformation)
-                        .font(.posBodyLargeRegular())
+                        .font(.posHeadingBold)
+                        .foregroundStyle(.primary)
                         .textCase(nil)
                 }
 
@@ -64,7 +65,7 @@ struct PointOfSaleSettingsStoreDetailView: View {
                         settingValueView(for: viewModel.receiptInformation.email)
                     }
                     .listRowSeparator(.hidden)
-  
+
                     VStack(alignment: .leading, spacing: POSPadding.small) {
                         Text(Localization.refundReturnsPolicy)
                             .font(.posBodyMediumRegular())
@@ -73,7 +74,8 @@ struct PointOfSaleSettingsStoreDetailView: View {
                     .listRowSeparator(.hidden)
                 } header: {
                     Text(Localization.receiptInformation)
-                        .font(.posBodyLargeRegular())
+                        .font(.posHeadingBold)
+                        .foregroundStyle(.primary)
                         .textCase(nil)
                 }
                 .renderedIf(viewModel.shouldShowReceiptInformation)

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
@@ -65,6 +65,7 @@ extension PointOfSaleSettingsView {
             }
             .padding(.horizontal, POSPadding.medium)
         }
+        .background(Color.posSurface)
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
@@ -99,14 +99,14 @@ struct PointOfSaleSettingsCard: View {
             HStack {
                 Image(systemName: item.icon)
                     .font(.posBodyLargeRegular())
-                    .foregroundStyle(isSelected ? .white : .primary)
+                    .foregroundStyle(Color.posOnSurface)
                 VStack(alignment: .leading) {
                     Text(item.title)
                         .font(.posBodyLargeRegular())
-                        .foregroundStyle(isSelected ? .white : .primary)
+                        .foregroundStyle(Color.posOnSurface)
                     Text(item.subtitle)
                         .font(.posBodyMediumRegular())
-                        .foregroundStyle(isSelected ? .white.opacity(0.8) : .secondary)
+                        .foregroundStyle(Color.posOnSurface)
                 }
                 Spacer()
             }
@@ -116,8 +116,8 @@ struct PointOfSaleSettingsCard: View {
         }
         .buttonStyle(.plain)
         .background(
-            RoundedRectangle(cornerRadius: POSCornerRadiusStyle.large.value, style: .continuous)
-                .fill(isSelected ? Color.accentColor : Color.clear)
+            RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value, style: .continuous)
+                .fill(isSelected ? Color.posSecondary : Color.clear)
         )
     }
 }


### PR DESCRIPTION
Closes WOOMOB-1162

## Description
This PR updates the UI for POS Settings following the wireframes on pdfdoF-7RJ-p2 and existing POS styles for overall consistency. Note that we do not have final designs yet, what's in this PR will most likely be final for releasing i1. Initial designs have just been published at pdfdoF-80C-p2 so I took loose inspiration for the details while are being discussed and polished. 

Android's UI can be seen in the project update for further reference if needed.

Split view and large font sizes are not handled in this PR, will be done separately.

| Store light | Store dark |
|--------|--------|
| <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-08-31 at 21 19 10" src="https://github.com/user-attachments/assets/cb40b56a-3158-4a55-9b71-dc63b27e0b19" /> | <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-08-31 at 21 32 59" src="https://github.com/user-attachments/assets/b8e60179-bee7-4235-b7b9-edba83e7aa07" /> |

| Hardware main light | Hardware main dark |
|--------|--------|
| <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-08-31 at 21 19 14" src="https://github.com/user-attachments/assets/e2817b7f-9004-435c-8104-ce9cb19a075c" /> | <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-08-31 at 21 33 03" src="https://github.com/user-attachments/assets/7e1ca12a-8777-4d91-b3f2-2b4724042865" /> | 

| Hardware nav light | Hardware nav dark |
|--------|--------|
| <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-08-31 at 21 19 18" src="https://github.com/user-attachments/assets/3dfc1633-917e-4de9-bcdb-a0513e223510" /> | <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-08-31 at 21 33 06" src="https://github.com/user-attachments/assets/e5a7be52-ebaf-44b6-bcb4-a0c84a5b6058" /> | 

| Help light | Help dark |
|--------|--------|
| <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-08-31 at 21 35 08" src="https://github.com/user-attachments/assets/11d1a3b6-858a-4881-9a33-863b16c6a1ac" /> | <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-08-31 at 21 35 17" src="https://github.com/user-attachments/assets/3753e1fe-86ce-4b5d-ae84-2e7029913fc6" /> | 

## Testing

All changes are UI-only. In POS, navigate to `...` > `Settings` and explore them in both light and dark mode.
