### PR TITLE
Postpone adoption of liquid glass design for iOS 26

### DIFF
--- a/WooCommerce/Resources/Info.plist
+++ b/WooCommerce/Resources/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.automattic.woocommerce.refresh</string>


### PR DESCRIPTION
For WOOMOB-1222

## Description

Temporarily opt out from iOS 26 liquid glass design by enabling `UIDesignRequiresCompatibility` in Info.plist. This prevents visual compatibility issues with the new design language while allowing the app to continue functioning properly on iOS 26.

This temporarily avoids a critical crash in `NotificationsBadgeController.hideDotOn`:
https://github.com/woocommerce/woocommerce-ios/blob/f2e3e2e85008de5fb4d8aa564bea9628fed38865/WooCommerce/Classes/ViewRelated/NotificationsBadgeController.swift#L68 that occurs on iOS 26 built from Xcode 26 due to UITabBar subview structure changes in the liquid glass design. The crash manifests as an "Index out of range" error when accessing `input.tabBar.orderedTabBarActionableViews[input.tabIndex].subviews.first?.subviews` because the liquid glass design fundamentally alters how UITabBar organizes and manages its internal subview hierarchy. We will have to address this crash, ideally by replacing the existing "custom tab dot" workaround that depends on UITabBar's view hierarchy. This will be included in a p2 for WOOMOB-1213.

## Steps to reproduce

**To reproduce the crash (without this PR):**
1. Build with Xcode 26 beta targeting iOS 26 simulator --> app crashes shortly in logged-in state with index out of range in NotificationsBadgeController.swift:68, with the tab bar displayed with liquid glass design

**To verify the fix:**
1. Build with Xcode 26 beta and run the app on iOS 26 beta with this PR --> app should not crash anymore and the tab bar should remain the same design as before iOS 26 (not the liquid glass design)
2. Feel free tap around the tabs to verify that the app works as before

## Testing information

I tested the following configurations:
- Xcode 26 beta 7 - iPad A16 iOS 26.0 simulator (crashes without PR, fixed with PR)
- Xcode 16.4 - iPad A16 iOS 26.0 simulator
- Xcode 16.4 - iPad A16 iOS 18.4 simulator
- Xcode 16.4 - iPhone 16 Pro iOS 18.5 simulator
- Xcode 16.4 - iPad Pro 11in 3rd generation iOS 18.5 device

## Screenshots

Before this PR, Xcode 26 beta 7 - iPad A16 iOS 26.0 simulator, where the app crashes with tab bar in liquid design:

<img width="1917" height="1000" alt="Screenshot 2025-09-01 at 1 56 15 PM" src="https://github.com/user-attachments/assets/5a94e9fb-5d4c-4625-9614-f79f0094a929" />

After this PR, Xcode 26 beta 7 - iPad A16 iOS 26.0 simulator, where the app does not crash with tab bar in previous design:

<img width="1000" alt="Simulator Screenshot - iPad (A16) - 2025-09-01 at 13 53 29" src="https://github.com/user-attachments/assets/1d537695-df40-4896-b73f-b287ade9997a" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.