### PR TITLE
[POS Settings] Accessibility improvements

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleModalHeader.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleModalHeader.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct PointOfSaleModalHeader: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     @Binding var isPresented: Bool
     @Binding var title: AttributedString
 
@@ -8,7 +10,8 @@ struct PointOfSaleModalHeader: View {
         HStack {
             Text(title)
                 .font(.posHeadingBold)
-                .lineLimit(1)
+                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 1)
             Spacer()
             Button {
                 isPresented = false

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct PointOfSaleSettingsHardwareDetailView: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     let settingsController: PointOfSaleSettingsControllerProtocol
 
     @State private var navigationPath: [NavigationDestination] = []
@@ -36,16 +38,21 @@ struct PointOfSaleSettingsHardwareDetailView: View {
 
             List(HardwareDestination.allCases) { destination in
                 NavigationLink(value: NavigationDestination.hardware(destination)) {
-                    HStack(alignment: .firstTextBaseline) {
+                    DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
                         Image(systemName: destination.icon)
                             .font(.posBodyLargeRegular())
+                            .renderedIf(!dynamicTypeSize.isAccessibilitySize)
+
                         VStack(alignment: .leading, spacing: POSPadding.xSmall) {
                             Text(destination.title)
                                 .font(.posBodyLargeRegular())
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                             Text(destination.subtitle)
                                 .font(.posBodyMediumRegular())
                                 .foregroundStyle(.secondary)
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                         }
+                        Spacer()
                     }
                 }
                 .listRowSeparator(.hidden)
@@ -109,16 +116,21 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                 Button {
                     showCardReaderDocumentationModal = true
                 } label: {
-                    HStack(alignment: .firstTextBaseline) {
+                    DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
                         Image(systemName: "doc.text")
                             .font(.posBodyLargeRegular())
+                            .renderedIf(!dynamicTypeSize.isAccessibilitySize)
+
                         VStack(alignment: .leading, spacing: POSPadding.xSmall) {
                             Text(Localization.cardReaderDocumentationTitle)
                                 .font(.posBodyLargeRegular())
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                             Text(Localization.cardReaderDocumentationSubtitle)
                                 .font(.posBodyMediumRegular())
                                 .foregroundStyle(.secondary)
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                         }
+                        Spacer()
                     }
                 }
                 .buttonStyle(.plain)
@@ -157,16 +169,21 @@ struct PointOfSaleSettingsHardwareDetailView: View {
             Button {
                 handleScannerDestination(destination)
             } label: {
-                HStack(alignment: .firstTextBaseline) {
+                DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
                     Image(systemName: destination.icon)
                         .font(.posBodyLargeRegular())
+                        .renderedIf(!dynamicTypeSize.isAccessibilitySize)
+
                     VStack(alignment: .leading, spacing: POSPadding.xSmall) {
                         Text(destination.title)
                             .font(.posBodyLargeRegular())
+                            .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                         Text(destination.subtitle)
                             .font(.posBodyMediumRegular())
                             .foregroundStyle(.secondary)
+                            .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                     }
+                    Spacer()
                 }
             }
             .buttonStyle(.plain)

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -35,12 +35,14 @@ struct PointOfSaleSettingsHardwareDetailView: View {
         NavigationStack(path: $navigationPath) {
             POSPageHeaderView(title: Localization.hardwareTitle)
             .foregroundColor(.posSurface)
+            .accessibilityAddTraits(.isHeader)
 
             List(HardwareDestination.allCases) { destination in
                 NavigationLink(value: NavigationDestination.hardware(destination)) {
                     DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
                         Image(systemName: destination.icon)
                             .font(.posBodyLargeRegular())
+                            .accessibilityHidden(true)
                             .renderedIf(!dynamicTypeSize.isAccessibilitySize)
 
                         VStack(alignment: .leading, spacing: POSPadding.xSmall) {
@@ -119,6 +121,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                     DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
                         Image(systemName: "doc.text")
                             .font(.posBodyLargeRegular())
+                            .accessibilityHidden(true)
                             .renderedIf(!dynamicTypeSize.isAccessibilitySize)
 
                         VStack(alignment: .leading, spacing: POSPadding.xSmall) {
@@ -134,6 +137,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                     }
                 }
                 .buttonStyle(.plain)
+                .accessibilityAddTraits(.isButton)
                 .listRowSeparator(.hidden)
             }
             .listStyle(.plain)
@@ -172,6 +176,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                 DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
                     Image(systemName: destination.icon)
                         .font(.posBodyLargeRegular())
+                        .accessibilityHidden(true)
                         .renderedIf(!dynamicTypeSize.isAccessibilitySize)
 
                     VStack(alignment: .leading, spacing: POSPadding.xSmall) {
@@ -187,6 +192,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                 }
             }
             .buttonStyle(.plain)
+            .accessibilityAddTraits(.isButton)
             .listRowSeparator(.hidden)
         }
         .listStyle(.plain)

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -39,7 +39,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
 
             List(HardwareDestination.allCases) { destination in
                 NavigationLink(value: NavigationDestination.hardware(destination)) {
-                    DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
+                    HStack(spacing: POSSpacing.medium) {
                         Image(systemName: destination.icon)
                             .font(.posBodyLargeRegular())
                             .accessibilityHidden(true)
@@ -125,7 +125,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                 Button {
                     showCardReaderDocumentationModal = true
                 } label: {
-                    DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
+                    HStack(spacing: POSSpacing.medium) {
                         Image(systemName: "doc.text")
                             .font(.posBodyLargeRegular())
                             .accessibilityHidden(true)

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -144,7 +144,6 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                     }
                 }
                 .padding()
-                .buttonStyle(.plain)
                 .accessibilityAddTraits(.isButton)
                 .listRowSeparator(.hidden)
             }
@@ -190,7 +189,6 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                         Spacer()
                     }
                 }
-                .buttonStyle(.plain)
                 .accessibilityAddTraits(.isButton)
                 .listRowSeparator(.hidden)
             }

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -136,6 +136,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                         Spacer()
                     }
                 }
+                .padding()
                 .buttonStyle(.plain)
                 .accessibilityAddTraits(.isButton)
                 .listRowSeparator(.hidden)

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -173,20 +173,25 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                 Button {
                     handleScannerDestination(destination)
                 } label: {
-                    HStack(alignment: .firstTextBaseline) {
+                    HStack(spacing: POSSpacing.medium) {
                         Image(systemName: destination.icon)
                             .font(.posBodyLargeRegular())
+                            .accessibilityHidden(true)
+                            .renderedIf(!dynamicTypeSize.isAccessibilitySize)
                         VStack(alignment: .leading, spacing: POSPadding.xSmall) {
                             Text(destination.title)
                                 .font(.posBodyLargeRegular())
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                             Text(destination.subtitle)
                                 .font(.posBodyMediumRegular())
                                 .foregroundStyle(.secondary)
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                         }
+                        Spacer()
                     }
-                    Spacer()
                 }
                 .buttonStyle(.plain)
+                .accessibilityAddTraits(.isButton)
                 .listRowSeparator(.hidden)
             }
             .listStyle(.plain)

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct PointOfSaleSettingsHelpDetailView: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    
+
     @State private var showProductRestrictions = false
     @State private var showDocumentation = false
     @State private var showSupport = false

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct PointOfSaleSettingsHelpDetailView: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    
     @State private var showProductRestrictions = false
     @State private var showDocumentation = false
     @State private var showSupport = false
@@ -17,16 +19,20 @@ struct PointOfSaleSettingsHelpDetailView: View {
                 Button {
                     showProductRestrictions = true
                 } label: {
-                    HStack(alignment: .firstTextBaseline) {
+                    DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
                         Image(systemName: "magnifyingglass")
                             .font(.posBodyLargeRegular())
+                            .renderedIf(!dynamicTypeSize.isAccessibilitySize)
                         VStack(alignment: .leading, spacing: POSPadding.xSmall) {
                             Text(Localization.productRestrictionsInfo)
                                 .font(.posBodyLargeRegular())
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                             Text(Localization.productRestrictionsInfoSubtitle)
                                 .font(.posBodyMediumRegular())
                                 .foregroundStyle(.secondary)
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                         }
+                        Spacer()
                     }
                 }
                 .listRowSeparator(.hidden)
@@ -35,16 +41,20 @@ struct PointOfSaleSettingsHelpDetailView: View {
                 Button {
                     showDocumentation = true
                 } label: {
-                    HStack(alignment: .firstTextBaseline) {
+                    DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
                         Image(systemName: "doc.text")
                             .font(.posBodyLargeRegular())
+                            .renderedIf(!dynamicTypeSize.isAccessibilitySize)
                         VStack(alignment: .leading, spacing: POSPadding.xSmall) {
                             Text(Localization.documentationTitle)
                                 .font(.posBodyLargeRegular())
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                             Text(Localization.documentationSubtitle)
                                 .font(.posBodyMediumRegular())
                                 .foregroundStyle(.secondary)
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                         }
+                        Spacer()
                     }
                 }
                 .listRowSeparator(.hidden)
@@ -53,16 +63,20 @@ struct PointOfSaleSettingsHelpDetailView: View {
                 Button {
                     showSupport = true
                 } label: {
-                    HStack(alignment: .firstTextBaseline) {
+                    DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
                         Image(systemName: "questionmark")
                             .font(.posBodyLargeRegular())
+                            .renderedIf(!dynamicTypeSize.isAccessibilitySize)
                         VStack(alignment: .leading, spacing: POSPadding.xSmall) {
                             Text(Localization.getSupportTitle)
                                 .font(.posBodyLargeRegular())
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                             Text(Localization.getSupportSubtitle)
                                 .font(.posBodyMediumRegular())
                                 .foregroundStyle(.secondary)
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                         }
+                        Spacer()
                     }
                 }
                 .listRowSeparator(.hidden)

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
@@ -20,7 +20,7 @@ struct PointOfSaleSettingsHelpDetailView: View {
                 Button {
                     showProductRestrictions = true
                 } label: {
-                    DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
+                    HStack(spacing: POSSpacing.medium) {
                         Image(systemName: "magnifyingglass")
                             .font(.posBodyLargeRegular())
                             .accessibilityHidden(true)
@@ -44,7 +44,7 @@ struct PointOfSaleSettingsHelpDetailView: View {
                 Button {
                     showDocumentation = true
                 } label: {
-                    DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
+                    HStack(spacing: POSSpacing.medium) {
                         Image(systemName: "doc.text")
                             .font(.posBodyLargeRegular())
                             .accessibilityHidden(true)
@@ -68,7 +68,7 @@ struct PointOfSaleSettingsHelpDetailView: View {
                 Button {
                     showSupport = true
                 } label: {
-                    DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
+                    HStack(spacing: POSSpacing.medium) {
                         Image(systemName: "questionmark")
                             .font(.posBodyLargeRegular())
                             .accessibilityHidden(true)

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
@@ -15,6 +15,7 @@ struct PointOfSaleSettingsHelpDetailView: View {
         NavigationStack {
             POSPageHeaderView(title: Localization.helpTitle)
             .foregroundColor(.posSurface)
+            .accessibilityAddTraits(.isHeader)
             List {
                 Button {
                     showProductRestrictions = true
@@ -22,6 +23,7 @@ struct PointOfSaleSettingsHelpDetailView: View {
                     DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
                         Image(systemName: "magnifyingglass")
                             .font(.posBodyLargeRegular())
+                            .accessibilityHidden(true)
                             .renderedIf(!dynamicTypeSize.isAccessibilitySize)
                         VStack(alignment: .leading, spacing: POSPadding.xSmall) {
                             Text(Localization.productRestrictionsInfo)
@@ -35,6 +37,7 @@ struct PointOfSaleSettingsHelpDetailView: View {
                         Spacer()
                     }
                 }
+                .accessibilityAddTraits(.isButton)
                 .listRowSeparator(.hidden)
                 .buttonStyle(.plain)
 
@@ -44,6 +47,7 @@ struct PointOfSaleSettingsHelpDetailView: View {
                     DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
                         Image(systemName: "doc.text")
                             .font(.posBodyLargeRegular())
+                            .accessibilityHidden(true)
                             .renderedIf(!dynamicTypeSize.isAccessibilitySize)
                         VStack(alignment: .leading, spacing: POSPadding.xSmall) {
                             Text(Localization.documentationTitle)
@@ -57,6 +61,7 @@ struct PointOfSaleSettingsHelpDetailView: View {
                         Spacer()
                     }
                 }
+                .accessibilityAddTraits(.isButton)
                 .listRowSeparator(.hidden)
                 .buttonStyle(.plain)
 
@@ -66,6 +71,7 @@ struct PointOfSaleSettingsHelpDetailView: View {
                     DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
                         Image(systemName: "questionmark")
                             .font(.posBodyLargeRegular())
+                            .accessibilityHidden(true)
                             .renderedIf(!dynamicTypeSize.isAccessibilitySize)
                         VStack(alignment: .leading, spacing: POSPadding.xSmall) {
                             Text(Localization.getSupportTitle)
@@ -79,6 +85,7 @@ struct PointOfSaleSettingsHelpDetailView: View {
                         Spacer()
                     }
                 }
+                .accessibilityAddTraits(.isButton)
                 .listRowSeparator(.hidden)
                 .buttonStyle(.plain)
             }

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
@@ -99,7 +99,7 @@ struct PointOfSaleSettingsCard: View {
 
     var body: some View {
         Button(action: onTap) {
-            DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
+            HStack(spacing: POSSpacing.medium) {
                 Image(systemName: item.icon)
                     .font(.posBodyLargeRegular())
                     .foregroundStyle(Color.posOnSurface)

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
@@ -90,23 +90,29 @@ extension PointOfSaleSettingsView {
 }
 
 struct PointOfSaleSettingsCard: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     let item: PointOfSaleSettingsView.SidebarNavigation
     let isSelected: Bool
     let onTap: () -> Void
 
     var body: some View {
         Button(action: onTap) {
-            HStack {
+            DynamicHStack(horizontalAlignment: .leading, spacing: POSSpacing.medium) {
                 Image(systemName: item.icon)
                     .font(.posBodyLargeRegular())
                     .foregroundStyle(Color.posOnSurface)
-                VStack(alignment: .leading) {
+                    .renderedIf(!dynamicTypeSize.isAccessibilitySize)
+
+                VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
                     Text(item.title)
                         .font(.posBodyLargeRegular())
                         .foregroundStyle(Color.posOnSurface)
+                        .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                     Text(item.subtitle)
                         .font(.posBodyMediumRegular())
                         .foregroundStyle(Color.posOnSurface)
+                        .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                 }
                 Spacer()
             }

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
@@ -32,6 +32,7 @@ extension PointOfSaleSettingsView {
                                                },
                                                buttonIcon: "xmark"))
             .foregroundColor(.posSurface)
+            .accessibilityAddTraits(.isHeader)
 
             VStack(spacing: POSSpacing.small) {
                 PointOfSaleSettingsCard(
@@ -102,6 +103,7 @@ struct PointOfSaleSettingsCard: View {
                 Image(systemName: item.icon)
                     .font(.posBodyLargeRegular())
                     .foregroundStyle(Color.posOnSurface)
+                    .accessibilityHidden(true)
                     .renderedIf(!dynamicTypeSize.isAccessibilitySize)
 
                 VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
@@ -121,6 +123,7 @@ struct PointOfSaleSettingsCard: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityAddTraits(.isButton)
         .background(
             RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value, style: .continuous)
                 .fill(isSelected ? Color.posSecondary : Color.clear)


### PR DESCRIPTION
Closes WOOMOB-1221
Closes WOOMOB-1229
Closes WOOMOB-1230

## Description
This PR adds general accessibility improvements to POS Settings by updating `PointOfSaleSettingsView` and its child views by:

- Usage of  `.dynamicTypeSize` for Text
- Conditional rendering of icons in larger sizes
- Added traits like `.isHeader` and `.isButton`
- Updated the title of `PointOfSaleModalHeader` to not force .lineLimit(1) when using larger sizes
- Removed .plain style from buttons, which caused an issue with visual feedback when tapped.

https://github.com/user-attachments/assets/3a888b0e-1732-4f59-ace0-82d60247364b

| Before | After |
|--------|--------|
| <img width="2266" height="1488"  src="https://github.com/user-attachments/assets/157e3763-04c3-4a29-a207-44e8baa0d83f" /> | <img width="2266" height="1488"  src="https://github.com/user-attachments/assets/f2634992-cce6-495e-a53a-eb71c8d91eda" /> | 

## Testing information
- Load the app, navigate to POS > Settings
- Navigate and tap around with different font sizes, observe that all options are readable
- Observe that tapping in buttons that would open modals/webviews (ie: Hardware > Barcode Scanners > Scanner Setup shows visual feedback in the button when tapped. 
- Enable voiceover on a physical device, or run the accessibility inspector in Xcode. Observe that the accessibility traits like header and button are voiced.
