### PR TITLE
[POS Settings] Update link to barcode scanner docs

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerInformationModal.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerInformationModal.swift
@@ -118,7 +118,7 @@ struct ProductBarcodeSetupInformation: View {
     private var productSetupTextWithLink: AttributedString {
         let mainContent = Localization.productBarcodeSetupMessage
         let linkText = Localization.productBarcodeSetupLinkText
-        let link = Constants.detailsLink?.absoluteString ?? ""
+        let link = Constants.detailsLink.absoluteString
 
         let content = String.localizedStringWithFormat(mainContent, linkText)
         var attributedText = AttributedString(content)
@@ -136,7 +136,7 @@ struct ProductBarcodeSetupInformation: View {
 }
 
 private enum Constants {
-    static let detailsLink = URL(string: "https://woocommerce.com/document/barcode-and-qr-code-scanner/")
+    static let detailsLink = WooConstants.URLs.pointOfSaleBarcodeScannerDocumentation.asURL()
 }
 
 private enum Localization {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerInformationModal.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleBarcodeScannerInformationModal.swift
@@ -136,7 +136,7 @@ struct ProductBarcodeSetupInformation: View {
 }
 
 private enum Constants {
-    static let detailsLink = WooConstants.URLs.pointOfSaleBarcodeScannerDocumentation.asURL()
+    static let detailsLink = POSConstants.URLs.pointOfSaleBarcodeScannerDocumentation.asURL()
 }
 
 private enum Localization {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -204,7 +204,7 @@ private extension PointOfSaleDashboardView {
     }
 
     var documentationView: some View {
-        SafariView(url: WooConstants.URLs.pointOfSaleDocumentation.asURL())
+        SafariView(url: POSConstants.URLs.pointOfSaleDocumentation.asURL())
     }
 
     func paymentsOnboardingView(from onboardingViewModel: CardPresentPaymentsOnboardingViewModel) -> some View {

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -67,7 +67,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                 PointOfSaleBarcodeScannerSetup(isPresented: $showBarcodeScanningSetupModal)
             }
             .posFullScreenCover(isPresented: $showBarcodeScanningDocumentationModal) {
-                SafariView(url: WooConstants.URLs.pointOfSaleBarcodeScannerDocumentation.asURL())
+                SafariView(url: POSConstants.URLs.pointOfSaleBarcodeScannerDocumentation.asURL())
             }
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -67,7 +67,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                 PointOfSaleBarcodeScannerSetup(isPresented: $showBarcodeScanningSetupModal)
             }
             .posFullScreenCover(isPresented: $showBarcodeScanningDocumentationModal) {
-                SafariView(url: WooConstants.URLs.pointOfSaleDocumentation.asURL())
+                SafariView(url: WooConstants.URLs.pointOfSaleBarcodeScannerDocumentation.asURL())
             }
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsHelpDetailView.swift
@@ -82,7 +82,7 @@ struct PointOfSaleSettingsHelpDetailView: View {
         .posFullScreenCover(isPresented: $showDocumentation) {
             // TODO: Remove copy on PointOfSaleDashboardView.documentationView
             // WOOMOB-1168
-            SafariView(url: WooConstants.URLs.pointOfSaleDocumentation.asURL())
+            SafariView(url: POSConstants.URLs.pointOfSaleDocumentation.asURL())
 
         }
         .posFullScreenCover(isPresented: $showSupport) {

--- a/WooCommerce/Classes/POS/Utils/POSConstants.swift
+++ b/WooCommerce/Classes/POS/Utils/POSConstants.swift
@@ -8,6 +8,10 @@ public enum POSConstants {
             Self.trustedURL(self.rawValue)
         }
 
+        /// URL for Point of Sale documentation
+        ///
+        case pointOfSaleDocumentation = "https://woocommerce.com/document/woo-mobile-app-point-of-sale-mode/"
+
         /// URL for Point of Sale's barcode scanner documentation
         ///
         case pointOfSaleBarcodeScannerDocumentation = "https://woocommerce.com/document/barcode-and-qr-code-scanner/"

--- a/WooCommerce/Classes/POS/Utils/POSConstants.swift
+++ b/WooCommerce/Classes/POS/Utils/POSConstants.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+public enum POSConstants {
+    enum URLs: String, CaseIterable {
+        /// Returns the URL version of the receiver
+        ///
+        func asURL() -> URL {
+            Self.trustedURL(self.rawValue)
+        }
+
+        /// URL for Point of Sale's barcode scanner documentation
+        ///
+        case pointOfSaleBarcodeScannerDocumentation = "https://woocommerce.com/document/barcode-and-qr-code-scanner/"
+    }
+}
+
+private extension POSConstants.URLs {
+    /// Convert a `string` to a `URL`. Crash if it is malformed.
+    ///
+    private static func trustedURL(_ url: String) -> URL {
+
+        if let url = URL(string: url) {
+            return url
+        } else if let escapedString = url.addingPercentEncoding(withAllowedCharacters: NSCharacterSet.urlQueryAllowed),
+                  let escapedURL = URL(string: escapedString) {
+            return escapedURL
+        } else {
+            fatalError("Expected URL \(url) to be a well-formed URL.")
+        }
+    }
+}

--- a/WooCommerce/Classes/POS/Utils/POSConstants.swift
+++ b/WooCommerce/Classes/POS/Utils/POSConstants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum POSConstants {
+enum POSConstants {
     enum URLs: String, CaseIterable {
         /// Returns the URL version of the receiver
         ///

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -254,10 +254,6 @@ extension WooConstants {
         ///
         case pointOfSaleDocumentation = "https://woocommerce.com/document/woo-mobile-app-point-of-sale-mode/"
 
-        /// URL for Point of Sale's barcode scanner documentation
-        ///
-        case pointOfSaleBarcodeScannerDocumentation = "https://woocommerce.com/document/barcode-and-qr-code-scanner/"
-
         /// Temporary redirect URL for authenticated web view when authenticating WPCom automatically
         ///
         case wpcomTempRedirectURL = "https://wordpress.com/mobile-redirect"

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -250,10 +250,6 @@ extension WooConstants {
         ///
         case inPersonPaymentsLearnMoreStripe = "https://woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/"
 
-        /// URL for Point of Sale documentation
-        ///
-        case pointOfSaleDocumentation = "https://woocommerce.com/document/woo-mobile-app-point-of-sale-mode/"
-
         /// Temporary redirect URL for authenticated web view when authenticating WPCom automatically
         ///
         case wpcomTempRedirectURL = "https://wordpress.com/mobile-redirect"

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -254,6 +254,10 @@ extension WooConstants {
         ///
         case pointOfSaleDocumentation = "https://woocommerce.com/document/woo-mobile-app-point-of-sale-mode/"
 
+        /// URL for Point of Sale's barcode scanner documentation
+        ///
+        case pointOfSaleBarcodeScannerDocumentation = "https://woocommerce.com/document/barcode-and-qr-code-scanner/"
+
         /// Temporary redirect URL for authenticated web view when authenticating WPCom automatically
         ///
         case wpcomTempRedirectURL = "https://wordpress.com/mobile-redirect"

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1647,6 +1647,7 @@
 		68DF5A8D2CB38EEA000154C9 /* EditableOrderCouponLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68DF5A8C2CB38EEA000154C9 /* EditableOrderCouponLineViewModel.swift */; };
 		68DF5A8F2CB38F20000154C9 /* OrderCouponSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68DF5A8E2CB38F20000154C9 /* OrderCouponSectionView.swift */; };
 		68E141DB2D13107400A70D5B /* PointOfSaleCollectCashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E141DA2D13107200A70D5B /* PointOfSaleCollectCashView.swift */; };
+		68E33B2E2E66AAB500CBE921 /* POSConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E33B2D2E66AAAE00CBE921 /* POSConstants.swift */; };
 		68E4E8B52C0EF39D00CFA0C3 /* PreviewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E4E8B42C0EF39D00CFA0C3 /* PreviewHelpers.swift */; };
 		68E6749F2A4DA01C0034BA1E /* WooWPComPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E6749E2A4DA01C0034BA1E /* WooWPComPlan.swift */; };
 		68E674A12A4DA0B30034BA1E /* InAppPurchasesError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E674A02A4DA0B30034BA1E /* InAppPurchasesError.swift */; };
@@ -4836,6 +4837,7 @@
 		68DF5A8C2CB38EEA000154C9 /* EditableOrderCouponLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderCouponLineViewModel.swift; sourceTree = "<group>"; };
 		68DF5A8E2CB38F20000154C9 /* OrderCouponSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCouponSectionView.swift; sourceTree = "<group>"; };
 		68E141DA2D13107200A70D5B /* PointOfSaleCollectCashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCollectCashView.swift; sourceTree = "<group>"; };
+		68E33B2D2E66AAAE00CBE921 /* POSConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSConstants.swift; sourceTree = "<group>"; };
 		68E4E8B42C0EF39D00CFA0C3 /* PreviewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewHelpers.swift; sourceTree = "<group>"; };
 		68E6749E2A4DA01C0034BA1E /* WooWPComPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooWPComPlan.swift; sourceTree = "<group>"; };
 		68E674A02A4DA0B30034BA1E /* InAppPurchasesError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchasesError.swift; sourceTree = "<group>"; };
@@ -7182,6 +7184,7 @@
 			isa = PBXGroup;
 			children = (
 				01806E122E2F7F400033363C /* POSBrightnessControl.swift */,
+				68E33B2D2E66AAAE00CBE921 /* POSConstants.swift */,
 				689F29192DE4557D004DF52B /* POSStockFormatter.swift */,
 				681BB5FD2D676060008AF8BB /* POSPadding.swift */,
 				681BB5FB2D676043008AF8BB /* POSSpacing.swift */,
@@ -15993,6 +15996,7 @@
 				02C1853D27FF153A00ABD764 /* CardPresentRefundOrchestrator.swift in Sources */,
 				01309A7F2DC4F39E00B77527 /* PointOfSaleCardPresentPaymentCardInsertedMessageViewModel.swift in Sources */,
 				AEC95D432774D07B001571F5 /* CreateOrderAddressFormViewModel.swift in Sources */,
+				68E33B2E2E66AAB500CBE921 /* POSConstants.swift in Sources */,
 				024DF31B23742E1C006658FE /* FormatBarItemViewProperties.swift in Sources */,
 				26B119BB24D0B62E00FED5C7 /* SurveyViewController.swift in Sources */,
 				CCD2F51A26D67BB50010E679 /* ShippingLabelServicePackageList.swift in Sources */,


### PR DESCRIPTION
Closes WOOMOB-1227

## Description
This PR updates the barcode scanner documentation link to the correct one, rather than to POS general documentation.

## Steps to reproduce
- Navigate to POS > Settings > Hardware > Barcode Scanners > Tap on Documentation
- Observe the link opened is `https://woocommerce.com/document/barcode-and-qr-code-scanner/`

| Settings | Webview |
|--------|--------|
| <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-09-02 at 05 32 41" src="https://github.com/user-attachments/assets/a2bf0d38-a7ca-4d4d-8bd4-7f105f9bb388" /> | <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-09-02 at 05 32 47" src="https://github.com/user-attachments/assets/a9cc2587-44b1-42f3-9dbf-17ba69d87481" /> | 
