### PR TITLE
[POS Settings] Store section design updates

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
@@ -22,105 +22,115 @@ struct PointOfSaleSettingsStoreDetailView: View {
 
                 ScrollView {
                     VStack(spacing: POSSpacing.medium) {
-                        VStack(spacing: POSSpacing.none) {
-                            ZStack {
-                                backgroundColor
-                                Text(Localization.storeInformation)
-                                    .font(.posBodyLargeBold)
-                                    .foregroundColor(.posOnSurface)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(.horizontal, POSPadding.medium)
-                                    .padding(.vertical, POSPadding.small)
-                            }
+                        storeInformationView
 
-                            VStack(spacing: POSSpacing.medium) {
-                                VStack(alignment: .leading, spacing: POSPadding.small) {
-                                    Text(Localization.storeName)
-                                        .font(.posBodyMediumRegular())
-                                    Text(viewModel.storeName)
-                                        .font(.posBodyMediumRegular())
-                                        .foregroundStyle(.secondary)
-                                }
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.horizontal, POSPadding.medium)
-                                
-                                VStack(alignment: .leading, spacing: POSPadding.small) {
-                                    Text(Localization.address)
-                                        .font(.posBodyMediumRegular())
-                                    Text(viewModel.storeAddress)
-                                        .font(.posBodyMediumRegular())
-                                        .foregroundStyle(.secondary)
-                                }
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.horizontal, POSPadding.medium)
-                            }
-                            .padding(.bottom, POSPadding.medium)
-                        }
-
-                        VStack(spacing: POSSpacing.none) {
-                            ZStack {
-                                backgroundColor
-                                Text(Localization.receiptInformation)
-                                    .font(.posBodyLargeBold)
-                                    .foregroundColor(.posOnSurface)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(.horizontal, POSPadding.medium)
-                                    .padding(.vertical, POSPadding.small)
-                            }
-
-                            VStack(spacing: POSSpacing.medium) {
-                                VStack(alignment: .leading, spacing: POSPadding.small) {
-                                    Text(Localization.receiptStoreName)
-                                        .font(.posBodyMediumRegular())
-                                    settingValueView(for: viewModel.receiptInformation.storeName)
-                                }
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.horizontal, POSPadding.medium)
-
-                                VStack(alignment: .leading, spacing: POSPadding.small) {
-                                    Text(Localization.physicalAddress)
-                                        .font(.posBodyMediumRegular())
-                                    settingValueView(for: viewModel.receiptInformation.storeAddress)
-                                }
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.horizontal, POSPadding.medium)
-
-                                VStack(alignment: .leading, spacing: POSPadding.small) {
-                                    Text(Localization.phoneNumber)
-                                        .font(.posBodyMediumRegular())
-                                    settingValueView(for: viewModel.receiptInformation.phone)
-                                }
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.horizontal, POSPadding.medium)
-
-                                VStack(alignment: .leading, spacing: POSPadding.small) {
-                                    Text(Localization.email)
-                                        .font(.posBodyMediumRegular())
-                                    settingValueView(for: viewModel.receiptInformation.email)
-                                }
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.horizontal, POSPadding.medium)
-
-                                VStack(alignment: .leading, spacing: POSPadding.small) {
-                                    Text(Localization.refundReturnsPolicy)
-                                        .font(.posBodyMediumRegular())
-                                    settingValueView(for: viewModel.receiptInformation.refundReturnsPolicy)
-                                }
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.horizontal, POSPadding.medium)
-                            }
-                            .padding(.bottom, POSPadding.medium)
-                        }
+                        receiptInformationView
+                            .renderedIf(viewModel.shouldShowReceiptInformation)
                     }
-                    .renderedIf(viewModel.shouldShowReceiptInformation)
                 }
+                .background(backgroundColor)
             }
-            .background(backgroundColor)
+            .task {
+                isLoading = true
+                await viewModel.retrievePOSReceiptSettings()
+                isLoading = false
+            }
         }
-        .task {
-            isLoading = true
-            await viewModel.retrievePOSReceiptSettings()
-            isLoading = false
+    }
+
+    @ViewBuilder
+    private var storeInformationView: some View {
+        VStack(spacing: POSSpacing.none) {
+            ZStack {
+                backgroundColor
+                Text(Localization.storeInformation)
+                    .font(.posBodyLargeBold)
+                    .foregroundColor(.posOnSurface)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, POSPadding.medium)
+                    .padding(.vertical, POSPadding.small)
+            }
+
+            VStack(spacing: POSSpacing.medium) {
+                VStack(alignment: .leading, spacing: POSPadding.small) {
+                    Text(Localization.storeName)
+                        .font(.posBodyMediumRegular())
+                    Text(viewModel.storeName)
+                        .font(.posBodyMediumRegular())
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, POSPadding.medium)
+
+                VStack(alignment: .leading, spacing: POSPadding.small) {
+                    Text(Localization.address)
+                        .font(.posBodyMediumRegular())
+                    Text(viewModel.storeAddress)
+                        .font(.posBodyMediumRegular())
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, POSPadding.medium)
+            }
+            .padding(.bottom, POSPadding.medium)
+        }
+    }
+
+    @ViewBuilder
+    private var receiptInformationView: some View {
+        VStack(spacing: POSSpacing.none) {
+            ZStack {
+                backgroundColor
+                Text(Localization.receiptInformation)
+                    .font(.posBodyLargeBold)
+                    .foregroundColor(.posOnSurface)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, POSPadding.medium)
+                    .padding(.vertical, POSPadding.small)
+            }
+
+            VStack(spacing: POSSpacing.medium) {
+                VStack(alignment: .leading, spacing: POSPadding.small) {
+                    Text(Localization.receiptStoreName)
+                        .font(.posBodyMediumRegular())
+                    settingValueView(for: viewModel.receiptInformation.storeName)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, POSPadding.medium)
+
+                VStack(alignment: .leading, spacing: POSPadding.small) {
+                    Text(Localization.physicalAddress)
+                        .font(.posBodyMediumRegular())
+                    settingValueView(for: viewModel.receiptInformation.storeAddress)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, POSPadding.medium)
+
+                VStack(alignment: .leading, spacing: POSPadding.small) {
+                    Text(Localization.phoneNumber)
+                        .font(.posBodyMediumRegular())
+                    settingValueView(for: viewModel.receiptInformation.phone)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, POSPadding.medium)
+
+                VStack(alignment: .leading, spacing: POSPadding.small) {
+                    Text(Localization.email)
+                        .font(.posBodyMediumRegular())
+                    settingValueView(for: viewModel.receiptInformation.email)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, POSPadding.medium)
+
+                VStack(alignment: .leading, spacing: POSPadding.small) {
+                    Text(Localization.refundReturnsPolicy)
+                        .font(.posBodyMediumRegular())
+                    settingValueView(for: viewModel.receiptInformation.refundReturnsPolicy)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, POSPadding.medium)
+            }
+            .padding(.bottom, POSPadding.medium)
         }
     }
 

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
@@ -15,102 +15,112 @@ struct PointOfSaleSettingsStoreDetailView: View {
 
     var body: some View {
         NavigationStack {
-            POSPageHeaderView(title: Localization.storeTitle)
-            .foregroundColor(.posSurface)
-            .accessibilityAddTraits(.isHeader)
-            List {
-                Section {
-                    VStack(alignment: .leading, spacing: POSPadding.small) {
-                        Text(Localization.storeName)
-                            .font(.posBodyMediumRegular())
-                        Text(viewModel.storeName)
-                            .font(.posBodyMediumRegular())
-                            .foregroundStyle(.secondary)
-                    }
-                    .listRowSeparator(.hidden)
+            VStack(spacing: POSSpacing.none) {
+                POSPageHeaderView(title: Localization.storeTitle)
+                    .foregroundColor(.posSurface)
+                    .accessibilityAddTraits(.isHeader)
 
-                    VStack(alignment: .leading, spacing: POSPadding.small) {
-                        Text(Localization.address)
-                            .font(.posBodyMediumRegular())
-                        Text(viewModel.storeAddress)
-                            .font(.posBodyMediumRegular())
-                            .foregroundStyle(.secondary)
+                ScrollView {
+                    VStack(spacing: POSSpacing.medium) {
+                        VStack(spacing: POSSpacing.none) {
+                            ZStack {
+                                backgroundColor
+                                Text(Localization.storeInformation)
+                                    .font(.posBodyLargeBold)
+                                    .foregroundColor(.posOnSurface)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.horizontal, POSPadding.medium)
+                                    .padding(.vertical, POSPadding.small)
+                            }
+
+                            VStack(spacing: POSSpacing.medium) {
+                                VStack(alignment: .leading, spacing: POSPadding.small) {
+                                    Text(Localization.storeName)
+                                        .font(.posBodyMediumRegular())
+                                    Text(viewModel.storeName)
+                                        .font(.posBodyMediumRegular())
+                                        .foregroundStyle(.secondary)
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, POSPadding.medium)
+                                
+                                VStack(alignment: .leading, spacing: POSPadding.small) {
+                                    Text(Localization.address)
+                                        .font(.posBodyMediumRegular())
+                                    Text(viewModel.storeAddress)
+                                        .font(.posBodyMediumRegular())
+                                        .foregroundStyle(.secondary)
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, POSPadding.medium)
+                            }
+                            .padding(.bottom, POSPadding.medium)
+                        }
+
+                        VStack(spacing: POSSpacing.none) {
+                            ZStack {
+                                backgroundColor
+                                Text(Localization.receiptInformation)
+                                    .font(.posBodyLargeBold)
+                                    .foregroundColor(.posOnSurface)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.horizontal, POSPadding.medium)
+                                    .padding(.vertical, POSPadding.small)
+                            }
+
+                            VStack(spacing: POSSpacing.medium) {
+                                VStack(alignment: .leading, spacing: POSPadding.small) {
+                                    Text(Localization.receiptStoreName)
+                                        .font(.posBodyMediumRegular())
+                                    settingValueView(for: viewModel.receiptInformation.storeName)
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, POSPadding.medium)
+
+                                VStack(alignment: .leading, spacing: POSPadding.small) {
+                                    Text(Localization.physicalAddress)
+                                        .font(.posBodyMediumRegular())
+                                    settingValueView(for: viewModel.receiptInformation.storeAddress)
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, POSPadding.medium)
+
+                                VStack(alignment: .leading, spacing: POSPadding.small) {
+                                    Text(Localization.phoneNumber)
+                                        .font(.posBodyMediumRegular())
+                                    settingValueView(for: viewModel.receiptInformation.phone)
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, POSPadding.medium)
+
+                                VStack(alignment: .leading, spacing: POSPadding.small) {
+                                    Text(Localization.email)
+                                        .font(.posBodyMediumRegular())
+                                    settingValueView(for: viewModel.receiptInformation.email)
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, POSPadding.medium)
+
+                                VStack(alignment: .leading, spacing: POSPadding.small) {
+                                    Text(Localization.refundReturnsPolicy)
+                                        .font(.posBodyMediumRegular())
+                                    settingValueView(for: viewModel.receiptInformation.refundReturnsPolicy)
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, POSPadding.medium)
+                            }
+                            .padding(.bottom, POSPadding.medium)
+                        }
                     }
-                    .listRowSeparator(.hidden)
-                } header: {
-                    ZStack {
-                        backgroundColor
-                        Text(Localization.storeInformation)
-                            .font(.posHeadingBold)
-                            .foregroundColor(.posOnSurface)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal, POSPadding.medium)
-                            .padding(.vertical, POSPadding.small)
-                            .textCase(nil)
-                    }
-                    .listRowInsets(EdgeInsets())
+                    .renderedIf(viewModel.shouldShowReceiptInformation)
                 }
-
-                Section {
-                    VStack(alignment: .leading, spacing: POSPadding.small) {
-                        Text(Localization.receiptStoreName)
-                            .font(.posBodyMediumRegular())
-                        settingValueView(for: viewModel.receiptInformation.storeName)
-                    }
-                    .listRowSeparator(.hidden)
-
-                    VStack(alignment: .leading, spacing: POSPadding.small) {
-                        Text(Localization.physicalAddress)
-                            .font(.posBodyMediumRegular())
-                        settingValueView(for: viewModel.receiptInformation.storeAddress)
-                    }
-                    .listRowSeparator(.hidden)
-
-                    VStack(alignment: .leading, spacing: POSPadding.small) {
-                        Text(Localization.phoneNumber)
-                            .font(.posBodyMediumRegular())
-                        settingValueView(for: viewModel.receiptInformation.phone)
-                    }
-                    .listRowSeparator(.hidden)
-
-                    VStack(alignment: .leading, spacing: POSPadding.small) {
-                        Text(Localization.email)
-                            .font(.posBodyMediumRegular())
-                        settingValueView(for: viewModel.receiptInformation.email)
-                    }
-                    .listRowSeparator(.hidden)
-
-                    VStack(alignment: .leading, spacing: POSPadding.small) {
-                        Text(Localization.refundReturnsPolicy)
-                            .font(.posBodyMediumRegular())
-                        settingValueView(for: viewModel.receiptInformation.refundReturnsPolicy)
-                    }
-                    .listRowSeparator(.hidden)
-                } header: {
-                    ZStack {
-                        backgroundColor
-                        Text(Localization.receiptInformation)
-                            .font(.posHeadingBold)
-                            .foregroundColor(.posOnSurface)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal, POSPadding.medium)
-                            .padding(.vertical, POSPadding.small)
-                            .textCase(nil)
-                    }
-                    .listRowInsets(EdgeInsets())
-                }
-                .renderedIf(viewModel.shouldShowReceiptInformation)
             }
-            .listStyle(.plain)
-            .scrollContentBackground(.hidden)
             .background(backgroundColor)
-            .listRowSeparator(.hidden)
-            .listSectionSeparator(.hidden)
-            .task {
-                isLoading = true
-                await viewModel.retrievePOSReceiptSettings()
-                isLoading = false
-            }
+        }
+        .task {
+            isLoading = true
+            await viewModel.retrievePOSReceiptSettings()
+            isLoading = false
         }
     }
 

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
@@ -15,6 +15,9 @@ struct PointOfSaleSettingsStoreDetailView: View {
 
     var body: some View {
         NavigationStack {
+            POSPageHeaderView(title: Localization.storeTitle)
+            .foregroundColor(.posSurface)
+            .accessibilityAddTraits(.isHeader)
             List {
                 Section {
                     VStack(alignment: .leading, spacing: POSPadding.small) {
@@ -135,6 +138,12 @@ private extension PointOfSaleSettingsStoreDetailView {
     }
 
     enum Localization {
+        static let storeTitle = NSLocalizedString(
+            "pointOfSaleSettingsStoreDetailView.storeTitle",
+            value: "Store",
+            comment: "Navigation title for the store details in POS settings."
+        )
+
         static let notSet = NSLocalizedString(
             "pointOfSaleSettingsStoreDetailView.notSet",
             value: "Not set",

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
@@ -41,36 +41,11 @@ struct PointOfSaleSettingsStoreDetailView: View {
     @ViewBuilder
     private var storeInformationView: some View {
         VStack(spacing: POSSpacing.none) {
-            ZStack {
-                backgroundColor
-                Text(Localization.storeInformation)
-                    .font(.posBodyLargeBold)
-                    .foregroundColor(.posOnSurface)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, POSPadding.medium)
-                    .padding(.vertical, POSPadding.small)
-            }
+            sectionHeaderView(title: Localization.storeInformation)
 
             VStack(spacing: POSSpacing.medium) {
-                VStack(alignment: .leading, spacing: POSPadding.small) {
-                    Text(Localization.storeName)
-                        .font(.posBodyMediumRegular())
-                    Text(viewModel.storeName)
-                        .font(.posBodyMediumRegular())
-                        .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, POSPadding.medium)
-
-                VStack(alignment: .leading, spacing: POSPadding.small) {
-                    Text(Localization.address)
-                        .font(.posBodyMediumRegular())
-                    Text(viewModel.storeAddress)
-                        .font(.posBodyMediumRegular())
-                        .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, POSPadding.medium)
+                fieldRowView(label: Localization.storeName, value: viewModel.storeName)
+                fieldRowView(label: Localization.address, value: viewModel.storeAddress)
             }
             .padding(.bottom, POSPadding.medium)
         }
@@ -79,59 +54,54 @@ struct PointOfSaleSettingsStoreDetailView: View {
     @ViewBuilder
     private var receiptInformationView: some View {
         VStack(spacing: POSSpacing.none) {
-            ZStack {
-                backgroundColor
-                Text(Localization.receiptInformation)
-                    .font(.posBodyLargeBold)
-                    .foregroundColor(.posOnSurface)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, POSPadding.medium)
-                    .padding(.vertical, POSPadding.small)
-            }
+            sectionHeaderView(title: Localization.receiptInformation)
 
             VStack(spacing: POSSpacing.medium) {
-                VStack(alignment: .leading, spacing: POSPadding.small) {
-                    Text(Localization.receiptStoreName)
-                        .font(.posBodyMediumRegular())
-                    settingValueView(for: viewModel.receiptInformation.storeName)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, POSPadding.medium)
-
-                VStack(alignment: .leading, spacing: POSPadding.small) {
-                    Text(Localization.physicalAddress)
-                        .font(.posBodyMediumRegular())
-                    settingValueView(for: viewModel.receiptInformation.storeAddress)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, POSPadding.medium)
-
-                VStack(alignment: .leading, spacing: POSPadding.small) {
-                    Text(Localization.phoneNumber)
-                        .font(.posBodyMediumRegular())
-                    settingValueView(for: viewModel.receiptInformation.phone)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, POSPadding.medium)
-
-                VStack(alignment: .leading, spacing: POSPadding.small) {
-                    Text(Localization.email)
-                        .font(.posBodyMediumRegular())
-                    settingValueView(for: viewModel.receiptInformation.email)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, POSPadding.medium)
-
-                VStack(alignment: .leading, spacing: POSPadding.small) {
-                    Text(Localization.refundReturnsPolicy)
-                        .font(.posBodyMediumRegular())
-                    settingValueView(for: viewModel.receiptInformation.refundReturnsPolicy)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, POSPadding.medium)
+                receiptFieldRowView(label: Localization.receiptStoreName, value: viewModel.receiptInformation.storeName)
+                receiptFieldRowView(label: Localization.physicalAddress, value: viewModel.receiptInformation.storeAddress)
+                receiptFieldRowView(label: Localization.phoneNumber, value: viewModel.receiptInformation.phone)
+                receiptFieldRowView(label: Localization.email, value: viewModel.receiptInformation.email)
+                receiptFieldRowView(label: Localization.refundReturnsPolicy, value: viewModel.receiptInformation.refundReturnsPolicy)
             }
             .padding(.bottom, POSPadding.medium)
         }
+    }
+
+    @ViewBuilder
+    private func sectionHeaderView(title: String) -> some View {
+        ZStack {
+            backgroundColor
+            Text(title)
+                .font(.posBodyLargeBold)
+                .foregroundColor(.posOnSurface)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, POSPadding.medium)
+                .padding(.vertical, POSPadding.small)
+        }
+    }
+
+    @ViewBuilder
+    private func fieldRowView(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: POSPadding.small) {
+            Text(label)
+                .font(.posBodyMediumRegular())
+            Text(value)
+                .font(.posBodyMediumRegular())
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, POSPadding.medium)
+    }
+
+    @ViewBuilder
+    private func receiptFieldRowView(label: String, value: String?) -> some View {
+        VStack(alignment: .leading, spacing: POSPadding.small) {
+            Text(label)
+                .font(.posBodyMediumRegular())
+            settingValueView(for: value)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, POSPadding.medium)
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Settings/PointOfSaleSettingsView.swift
@@ -92,10 +92,16 @@ extension PointOfSaleSettingsView {
 
 struct PointOfSaleSettingsCard: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.colorScheme) private var colorScheme
 
     let item: PointOfSaleSettingsView.SidebarNavigation
     let isSelected: Bool
     let onTap: () -> Void
+
+    private var selectionBackgroundColor: Color {
+        guard isSelected else { return Color.clear }
+        return colorScheme == .dark ? Color.posPrimary : Color.posSecondary
+    }
 
     var body: some View {
         Button(action: onTap) {
@@ -126,7 +132,7 @@ struct PointOfSaleSettingsCard: View {
         .accessibilityAddTraits(.isButton)
         .background(
             RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value, style: .continuous)
-                .fill(isSelected ? Color.posSecondary : Color.clear)
+                .fill(selectionBackgroundColor)
         )
     }
 }


### PR DESCRIPTION
Closes WOOMOB-1228

## Description
This PR addresses feedback from the CFT by:
- Adding a `Store` title to the top of the Store section
- Switching from `List` for `Scrollview`
- Refactoring into smaller subviews
- Updated the selection color on dark mode to be more prominent

## Testing information
- Go to POS > Settings > Store section. Observe that all fields load appropiately in normal and larger accessibility sizes.

| Default | Larger size |
|--------|--------|
| <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-09-02 at 09 12 43" src="https://github.com/user-attachments/assets/cfe130b7-0762-49fc-903b-0fc5625529e1" /> | <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-09-02 at 09 12 51" src="https://github.com/user-attachments/assets/cb73b24d-2137-40f8-a286-1f8e5ff6014c" /> |

| Selection dark before | selection dark after |
|--------|--------|
| <img width="250" height="69" alt="Screenshot 2025-09-02 at 11 55 25" src="https://github.com/user-attachments/assets/9671f8b7-d04f-426c-863e-e8e9c9297fa0" /> | <img width="242" height="92" alt="Screenshot 2025-09-02 at 11 53 36" src="https://github.com/user-attachments/assets/10fdcbab-a98c-4e41-adc0-499e59b3ef0f" /> | 


