### PR TITLE
[Local Catalog] Create full sync service that syncs catalog with batches of paginated products/variations requests

### DIFF
--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -1,8 +1,45 @@
 import Foundation
 
+/// Protocol for POS Catalog Sync Remote operations.
+public protocol POSCatalogSyncRemoteProtocol {
+    /// Loads POS products modified after the specified date for incremental sync.
+    ///
+    /// - Parameters:
+    ///   - modifiedAfter: Only products modified after this date will be returned.
+    ///   - siteID: Site ID to load products from.
+    ///   - pageNumber: Page number for pagination.
+    /// - Returns: Paginated list of POS products.
+    func loadProducts(modifiedAfter: Date, siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProduct>
+
+    /// Loads POS product variations modified after the specified date for incremental sync.
+    ///
+    /// - Parameters:
+    ///   - modifiedAfter: Only variations modified after this date will be returned.
+    ///   - siteID: Site ID to load variations from.
+    ///   - pageNumber: Page number for pagination.
+    /// - Returns: Paginated list of POS product variations.
+    func loadProductVariations(modifiedAfter: Date, siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation>
+
+    /// Loads POS products for full sync.
+    ///
+    /// - Parameters:
+    ///   - siteID: Site ID to load products from.
+    ///   - pageNumber: Page number for pagination.
+    /// - Returns: Paginated list of POS products.
+    func loadProducts(siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProduct>
+
+    /// Loads POS product variations for full sync.
+    ///
+    /// - Parameters:
+    ///   - siteID: Site ID to load variations from.
+    ///   - pageNumber: Page number for pagination.
+    /// - Returns: Paginated list of POS product variations.
+    func loadProductVariations(siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation>
+}
+
 /// POS Catalog Sync: Remote Endpoints
 ///
-public class POSCatalogSyncRemote: Remote {
+public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     private let dateFormatter = ISO8601DateFormatter()
 
     // MARK: - Incremental Sync Endpoints

--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -9,6 +9,8 @@ public protocol POSCatalogSyncRemoteProtocol {
     ///   - siteID: Site ID to load products from.
     ///   - pageNumber: Page number for pagination.
     /// - Returns: Paginated list of POS products.
+    // TODO - remove the periphery ignore comment when the incremental sync is integrated with POS.
+    // periphery:ignore
     func loadProducts(modifiedAfter: Date, siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProduct>
 
     /// Loads POS product variations modified after the specified date for incremental sync.
@@ -18,6 +20,8 @@ public protocol POSCatalogSyncRemoteProtocol {
     ///   - siteID: Site ID to load variations from.
     ///   - pageNumber: Page number for pagination.
     /// - Returns: Paginated list of POS product variations.
+    // TODO - remove the periphery ignore comment when the incremental sync is integrated with POS.
+    // periphery:ignore
     func loadProductVariations(modifiedAfter: Date, siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation>
 
     /// Loads POS products for full sync.

--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetwork.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetwork.swift
@@ -24,6 +24,7 @@ extension Alamofire.MultipartFormData: MultipartFormData {
 /// AlamofireWrapper: Encapsulates all of the Alamofire OP's
 ///
 public class AlamofireNetwork: Network {
+    /// Lazy-initialized session manager. Use ensuresSessionManagerIsInitialized=true to avoid race conditions with concurrent requests.
     private lazy var alamofireSession: Alamofire.Session = {
         let sessionConfiguration = URLSessionConfiguration.default
         let sessionManager = makeSession(configuration: sessionConfiguration)
@@ -48,10 +49,16 @@ public class AlamofireNetwork: Network {
 
     /// Public Initializer
     ///
-    ///
+    /// - Parameters:
+    ///   - credentials: Authentication credentials for requests.
+    ///   - selectedSite: Publisher for site selection changes.
+    ///   - sessionManager: Optional pre-configured session manager.
+    ///   - ensuresSessionManagerIsInitialized: If true, the session is always set during initialization immediately to avoid lazy initialization race conditions.
+    ///     Defaults to false for backward compatibility. Set to true when making concurrent requests immediately after initialization.
     public required init(credentials: Credentials?,
                          selectedSite: AnyPublisher<JetpackSite?, Never>? = nil,
-                         sessionManager: Alamofire.Session? = nil) {
+                         sessionManager: Alamofire.Session? = nil,
+                         ensuresSessionManagerIsInitialized: Bool = false) {
         self.credentials = credentials
         self.selectedSite = selectedSite
         self.requestConverter = {
@@ -70,6 +77,8 @@ public class AlamofireNetwork: Network {
         self.requestAuthenticator = RequestProcessor(requestAuthenticator: DefaultRequestAuthenticator(credentials: credentials))
         if let sessionManager {
             self.alamofireSession = sessionManager
+        } else if ensuresSessionManagerIsInitialized {
+            self.alamofireSession = makeSession(configuration: URLSessionConfiguration.default)
         }
     }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
@@ -21,6 +21,8 @@ public struct POSCatalog {
     public let variations: [POSProductVariation]
 }
 
+// TODO - remove the periphery ignore comment when the service is integrated with POS.
+// periphery:ignore
 public final class POSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol {
     private let syncRemote: POSCatalogSyncRemoteProtocol
     private let batchSize: Int

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
@@ -92,7 +92,7 @@ public final class POSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol 
             let newProducts = batchResults.flatMap { $0.items.items }
             allProducts.append(contentsOf: newProducts)
 
-            let highestPageResult = batchResults.last(where: { $0.pageNumber == pagesToFetch.max() })?.items
+            let highestPageResult = batchResults.last?.items
             hasMorePages = (highestPageResult?.hasMorePages ?? false) && !newProducts.isEmpty
             currentPage += batchSize
 
@@ -132,7 +132,7 @@ public final class POSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol 
             let newVariations = batchResults.flatMap { $0.items.items }
             allVariations.append(contentsOf: newVariations)
 
-            let highestPageResult = batchResults.last(where: { $0.pageNumber == pagesToFetch.max() })?.items
+            let highestPageResult = batchResults.last?.items
             hasMorePages = (highestPageResult?.hasMorePages ?? false) && !newVariations.isEmpty
             currentPage += batchSize
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
@@ -53,7 +53,7 @@ public final class POSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol 
             let (products, variations) = try await (productsTask, variationsTask)
             let catalog = POSCatalog(products: products, variations: variations)
             DDLogInfo("✅ Loaded \(catalog.products.count) products and \(catalog.variations.count) variations for siteID \(siteID)")
-            return .init(products: products, variations: [])
+            return .init(products: products, variations: variations)
         } catch {
             throw error
         }

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
@@ -1,0 +1,148 @@
+import Foundation
+import protocol Networking.POSCatalogSyncRemoteProtocol
+import class Networking.AlamofireNetwork
+import class Networking.POSCatalogSyncRemote
+import CocoaLumberjackSwift
+
+// TODO - remove the periphery ignore comment when the catalog is integrated with POS.
+// periphery:ignore
+public protocol POSCatalogFullSyncServiceProtocol {
+    /// Starts a full catalog sync process
+    /// - Parameter siteID: The site ID to sync catalog for
+    /// - Returns: The synced catalog containing products and variations
+    func startFullSync(for siteID: Int64) async throws -> POSCatalog
+}
+
+/// POS catalog from full sync.
+// TODO - remove the periphery ignore comment when the catalog is integrated with POS.
+// periphery:ignore
+public struct POSCatalog {
+    public let products: [POSProduct]
+    public let variations: [POSProductVariation]
+}
+
+public final class POSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol {
+    private let syncRemote: POSCatalogSyncRemoteProtocol
+    private let batchSize: Int
+
+    public convenience init?(credentials: Credentials?, batchSize: Int = 2) {
+        guard let credentials else {
+            DDLogError("⛔️ Could not create POSCatalogFullSyncService due missing credentials")
+            return nil
+        }
+        let network = AlamofireNetwork(credentials: credentials, ensuresSessionManagerIsInitialized: true)
+        let syncRemote = POSCatalogSyncRemote(network: network)
+        self.init(syncRemote: syncRemote, batchSize: batchSize)
+    }
+
+    init(syncRemote: POSCatalogSyncRemoteProtocol, batchSize: Int) {
+        self.syncRemote = syncRemote
+        self.batchSize = batchSize
+    }
+
+    // MARK: - Protocol Conformance
+
+    public func startFullSync(for siteID: Int64) async throws -> POSCatalog {
+        DDLogInfo("🔄 Starting full catalog sync for site ID: \(siteID)")
+
+        do {
+            // Loads products and variations in batches in parallel.
+            async let productsTask = loadAllProducts(for: siteID, syncRemote: syncRemote)
+            async let variationsTask = loadAllProductVariations(for: siteID, syncRemote: syncRemote)
+
+            let (products, variations) = try await (productsTask, variationsTask)
+            let catalog = POSCatalog(products: products, variations: variations)
+            DDLogInfo("✅ Loaded \(catalog.products.count) products and \(catalog.variations.count) variations for siteID \(siteID)")
+            return .init(products: products, variations: [])
+        } catch {
+            throw error
+        }
+    }
+
+    // MARK: - Private Methods
+
+    private func loadAllProducts(for siteID: Int64, syncRemote: POSCatalogSyncRemoteProtocol) async throws -> [POSProduct] {
+        DDLogInfo("🔄 Starting products sync for site ID: \(siteID)")
+
+        var allProducts: [POSProduct] = []
+        var currentPage = 1
+        var hasMorePages = true
+
+        while hasMorePages {
+            let pagesToFetch = Array(currentPage..<(currentPage + batchSize))
+
+            let batchResults = try await withThrowingTaskGroup(of: PageResult<POSProduct>.self) { group in
+                for pageNumber in pagesToFetch {
+                    group.addTask {
+                        let result = try await syncRemote.loadProducts(siteID: siteID, pageNumber: pageNumber)
+                        return PageResult(pageNumber: pageNumber, items: result)
+                    }
+                }
+
+                var results: [PageResult<POSProduct>] = []
+                for try await result in group {
+                    results.append(result)
+                }
+                return results.sorted(by: { $0.pageNumber < $1.pageNumber })
+            }
+
+            // Processes results in order and checks if there are more pages.
+            let newProducts = batchResults.flatMap { $0.items.items }
+            allProducts.append(contentsOf: newProducts)
+
+            let highestPageResult = batchResults.last(where: { $0.pageNumber == pagesToFetch.max() })?.items
+            hasMorePages = (highestPageResult?.hasMorePages ?? false) && !newProducts.isEmpty
+            currentPage += batchSize
+
+            DDLogInfo("📥 Loaded batch: \(batchResults.count) pages, total products: \(allProducts.count), hasMorePages: \(hasMorePages)")
+        }
+
+        DDLogInfo("✅ Products sync complete: \(allProducts.count) products loaded")
+        return allProducts
+    }
+
+    private func loadAllProductVariations(for siteID: Int64, syncRemote: POSCatalogSyncRemoteProtocol) async throws -> [POSProductVariation] {
+        DDLogInfo("🔄 Starting variations sync for site ID: \(siteID)")
+
+        var allVariations: [POSProductVariation] = []
+        var currentPage = 1
+        var hasMorePages = true
+
+        while hasMorePages {
+            let pagesToFetch = Array(currentPage..<(currentPage + batchSize))
+
+            let batchResults = try await withThrowingTaskGroup(of: PageResult<POSProductVariation>.self) { group in
+                for pageNumber in pagesToFetch {
+                    group.addTask {
+                        let result = try await syncRemote.loadProductVariations(siteID: siteID, pageNumber: pageNumber)
+                        return PageResult(pageNumber: pageNumber, items: result)
+                    }
+                }
+
+                var results: [PageResult<POSProductVariation>] = []
+                for try await result in group {
+                    results.append(result)
+                }
+                return results.sorted(by: { $0.pageNumber < $1.pageNumber })
+            }
+
+            // Processes results in order and checks if there are more pages.
+            let newVariations = batchResults.flatMap { $0.items.items }
+            allVariations.append(contentsOf: newVariations)
+
+            let highestPageResult = batchResults.last(where: { $0.pageNumber == pagesToFetch.max() })?.items
+            hasMorePages = (highestPageResult?.hasMorePages ?? false) && !newVariations.isEmpty
+            currentPage += batchSize
+
+            DDLogInfo("📥 Loaded batch: \(batchResults.count) pages, total variations: \(allVariations.count), hasMorePages: \(hasMorePages)")
+        }
+
+        DDLogInfo("✅ Variations sync complete: \(allVariations.count) variations loaded")
+        return allVariations
+    }
+}
+
+private struct PageResult<T> {
+    let pageNumber: Int
+    let items: PagedItems<T>
+}

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
@@ -48,22 +48,28 @@ public final class POSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol 
         DDLogInfo("🔄 Starting full catalog sync for site ID: \(siteID)")
 
         do {
-            // Loads products and variations in batches in parallel.
-            async let productsTask = loadAllProducts(for: siteID, syncRemote: syncRemote)
-            async let variationsTask = loadAllProductVariations(for: siteID, syncRemote: syncRemote)
-
-            let (products, variations) = try await (productsTask, variationsTask)
-            let catalog = POSCatalog(products: products, variations: variations)
+            let catalog = try await loadCatalog(for: siteID, syncRemote: syncRemote)
             DDLogInfo("✅ Loaded \(catalog.products.count) products and \(catalog.variations.count) variations for siteID \(siteID)")
-            return .init(products: products, variations: variations)
+            return catalog
         } catch {
             throw error
         }
     }
+}
 
-    // MARK: - Private Methods
+// MARK: - Remote Loading
 
-    private func loadAllProducts(for siteID: Int64, syncRemote: POSCatalogSyncRemoteProtocol) async throws -> [POSProduct] {
+private extension POSCatalogFullSyncService {
+    func loadCatalog(for siteID: Int64, syncRemote: POSCatalogSyncRemoteProtocol) async throws -> POSCatalog {
+        // Loads products and variations in batches in parallel.
+        async let productsTask = loadAllProducts(for: siteID, syncRemote: syncRemote)
+        async let variationsTask = loadAllProductVariations(for: siteID, syncRemote: syncRemote)
+
+        let (products, variations) = try await (productsTask, variationsTask)
+        return POSCatalog(products: products, variations: variations)
+    }
+
+    func loadAllProducts(for siteID: Int64, syncRemote: POSCatalogSyncRemoteProtocol) async throws -> [POSProduct] {
         DDLogInfo("🔄 Starting products sync for site ID: \(siteID)")
 
         var allProducts: [POSProduct] = []
@@ -103,7 +109,7 @@ public final class POSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol 
         return allProducts
     }
 
-    private func loadAllProductVariations(for siteID: Int64, syncRemote: POSCatalogSyncRemoteProtocol) async throws -> [POSProductVariation] {
+    func loadAllProductVariations(for siteID: Int64, syncRemote: POSCatalogSyncRemoteProtocol) async throws -> [POSProductVariation] {
         DDLogInfo("🔄 Starting variations sync for site ID: \(siteID)")
 
         var allVariations: [POSProductVariation] = []

--- a/Modules/Tests/NetworkingTests/Network/AlamofireNetworkTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/AlamofireNetworkTests.swift
@@ -167,6 +167,50 @@ final class AlamofireNetworkTests: XCTestCase {
         // Then
         XCTAssertTrue(result.isSuccess)
     }
+
+    // MARK: - Session Initialization Tests
+
+    func test_concurrent_requests_do_not_fail_with_sessionDeinitialized_error_when_ensuresSessionManagerIsInitialized_is_true() async throws {
+        // Given
+        let request = JetpackRequest(wooApiVersion: .mark1, method: .get, siteID: -1, path: "test")
+        let network = AlamofireNetwork(credentials: nil, ensuresSessionManagerIsInitialized: true)
+
+        // When
+        async let request1 = network.responseDataAndHeaders(for: request)
+        async let request2 = network.responseDataAndHeaders(for: request)
+        async let request3 = network.responseDataAndHeaders(for: request)
+
+        do {
+            _ = try await [request1, request2, request3]
+            XCTFail("Requests should fail")
+        } catch Alamofire.AFError.sessionDeinitialized {
+            XCTFail("Requests should not fail with sessionDeinitialized error")
+        } catch {
+            // Then
+            XCTAssertTrue(true)
+        }
+    }
+
+    func test_concurrent_requests_fail_with_sessionDeinitialized_error_when_ensuresSessionManagerIsInitialized_is_false() async throws {
+        // Given
+        let request = JetpackRequest(wooApiVersion: .mark1, method: .get, siteID: 1, path: "test")
+        let network = AlamofireNetwork(credentials: nil, ensuresSessionManagerIsInitialized: false)
+
+        // When
+        async let request1 = network.responseDataAndHeaders(for: request)
+        async let request2 = network.responseDataAndHeaders(for: request)
+        async let request3 = network.responseDataAndHeaders(for: request)
+
+        do {
+            _ = try await [request1, request2, request3]
+            XCTFail("Requests should fail with sessionDeinitialized error")
+        } catch Alamofire.AFError.sessionDeinitialized {
+            // Then
+            XCTAssertTrue(true)
+        } catch {
+            XCTFail("Requests should fail with sessionDeinitialized error")
+        }
+    }
 }
 
 private extension AlamofireNetworkTests {

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogFullSyncServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogFullSyncServiceTests.swift
@@ -1,0 +1,233 @@
+import Foundation
+import Testing
+@testable import Networking
+@testable import Yosemite
+
+struct POSCatalogFullSyncServiceTests {
+    private let sut: POSCatalogFullSyncService
+    private let mockSyncRemote: MockPOSCatalogSyncRemote
+    private let sampleSiteID: Int64 = 134
+
+    init() {
+        self.mockSyncRemote = MockPOSCatalogSyncRemote()
+        self.sut = POSCatalogFullSyncService(syncRemote: mockSyncRemote, batchSize: 2)
+    }
+
+    // MARK: - Full Sync Tests
+
+    @Test func startFullSync_loads_products_and_variations() async throws {
+        // Given
+        let expectedProducts = [POSProduct.fake(), POSProduct.fake()]
+        let expectedVariations = [POSProductVariation.fake()]
+
+        mockSyncRemote.setProductResult(pageNumber: 1, result: .success(PagedItems(items: expectedProducts, hasMorePages: false, totalItems: 0)))
+        mockSyncRemote.setVariationResult(pageNumber: 1, result: .success(PagedItems(items: expectedVariations, hasMorePages: false, totalItems: 0)))
+
+        // When
+        let result = try await sut.startFullSync(for: sampleSiteID)
+
+        // Then
+        #expect(result.products.count == expectedProducts.count)
+        #expect(result.variations.count == expectedVariations.count)
+        #expect(mockSyncRemote.loadProductsCallCount == 2) // 1 batch of 2 requests
+        #expect(mockSyncRemote.loadProductVariationsCallCount == 2) // 1 batch of 2 requests
+    }
+
+    @Test func startFullSync_handles_paginated_products_correctly() async throws {
+        // Given - Multiple pages of products
+        let page1Products = [POSProduct.fake()]
+        let page2Products = [POSProduct.fake()]
+        let page3Products = [POSProduct.fake()]
+
+        mockSyncRemote.setProductResults([
+            PagedItems(items: page1Products, hasMorePages: true, totalItems: 3),
+            PagedItems(items: page2Products, hasMorePages: true, totalItems: 3),
+            PagedItems(items: page3Products, hasMorePages: false, totalItems: 3)
+        ])
+
+        // When
+        let result = try await sut.startFullSync(for: sampleSiteID)
+
+        // Then
+        #expect(result.products.count == 3)
+        #expect(mockSyncRemote.loadProductsCallCount == 4) // 2 batches of 2 requests
+        #expect(mockSyncRemote.loadProductVariationsCallCount == 2) // 1 batch of 2 requests
+    }
+
+    @Test func startFullSync_handles_paginated_variations_correctly() async throws {
+        // Given - Multiple pages of variations
+        let page1Variations = [POSProductVariation.fake(), POSProductVariation.fake()]
+        let page2Variations = [POSProductVariation.fake()]
+        let page3Variations = [POSProductVariation.fake()]
+
+        mockSyncRemote.setVariationResults([
+            PagedItems(items: page1Variations, hasMorePages: true, totalItems: 2),
+            PagedItems(items: page2Variations, hasMorePages: true, totalItems: 2),
+            PagedItems(items: page3Variations, hasMorePages: false, totalItems: 2)
+        ])
+
+        // When
+        let result = try await sut.startFullSync(for: sampleSiteID)
+
+        // Then
+        #expect(result.variations.count == 4)
+        #expect(mockSyncRemote.loadProductsCallCount == 2) // 1 batch of 2 requests
+        #expect(mockSyncRemote.loadProductVariationsCallCount == 4) // 2 batches of 2 requests
+    }
+
+    @Test func startFullSync_stops_pagination_when_no_new_items_returned_and_hasMorePages_is_inaccurate() async throws {
+        // Given
+        let page1Products = [POSProduct.fake()]
+        let emptyPage: [POSProduct] = []
+
+        mockSyncRemote.setProductResults([
+            PagedItems(items: page1Products, hasMorePages: true, totalItems: 1),
+            PagedItems(items: emptyPage, hasMorePages: true, totalItems: 1)
+        ])
+        mockSyncRemote.setVariationResult(pageNumber: 1, result: .success(PagedItems(items: [], hasMorePages: false, totalItems: 0)))
+
+        // When
+        let result = try await sut.startFullSync(for: sampleSiteID)
+
+        // Then - Should stop after empty page
+        #expect(result.products.count == 1)
+        #expect(mockSyncRemote.loadProductsCallCount == 4) // The results from the second batch are empty
+    }
+
+    @Test func startFullSync_handles_batch_processing_correctly() async throws {
+        // Given - Service with batch size 2
+        let products = (1...5).map { _ in POSProduct.fake() }
+
+        mockSyncRemote.setProductResults([
+            PagedItems(items: [products[0]], hasMorePages: true, totalItems: 5),  // Page 1
+            PagedItems(items: [products[1]], hasMorePages: true, totalItems: 5),  // Page 2 (batch 1)
+            PagedItems(items: [products[2]], hasMorePages: true, totalItems: 5),  // Page 3
+            PagedItems(items: [products[3]], hasMorePages: true, totalItems: 5),  // Page 4 (batch 2)
+            PagedItems(items: [products[4]], hasMorePages: false, totalItems: 5)  // Page 5 (batch 3)
+        ])
+        mockSyncRemote.setVariationResult(pageNumber: 1, result: .success(PagedItems(items: [], hasMorePages: false, totalItems: 0)))
+
+        // When
+        let result = try await sut.startFullSync(for: sampleSiteID)
+
+        // Then
+        #expect(result.products.count == 5)
+        #expect(mockSyncRemote.loadProductsCallCount == 6)
+    }
+
+    @Test func startFullSync_propagates_network_errors() async throws {
+        // Given
+        let expectedError = NSError(domain: "network", code: 500, userInfo: [NSLocalizedDescriptionKey: "Network error"])
+        mockSyncRemote.setProductResult(pageNumber: 1, result: .failure(expectedError))
+
+        // When/Then
+        await #expect(throws: expectedError) {
+            _ = try await sut.startFullSync(for: sampleSiteID)
+        }
+    }
+
+    // MARK: - Initialization Tests
+
+    @Test func init_with_valid_credentials_creates_service() {
+        // Given
+        let credentials = Credentials.wpcom(username: "test", authToken: "token", siteAddress: "site.com")
+
+        // When
+        let service = POSCatalogFullSyncService(credentials: credentials)
+
+        // Then
+        #expect(service != nil)
+    }
+
+    @Test func init_with_nil_credentials_returns_nil() {
+        // Given/When
+        let service = POSCatalogFullSyncService(credentials: nil)
+
+        // Then
+        #expect(service == nil)
+    }
+
+    @Test func init_with_custom_batch_size_uses_specified_size() async throws {
+        // Given
+        let customBatchSize = 5
+
+        // When
+        let service = POSCatalogFullSyncService(syncRemote: mockSyncRemote, batchSize: customBatchSize)
+        _ = try await service.startFullSync(for: sampleSiteID)
+
+        // Then
+        #expect(mockSyncRemote.loadProductsCallCount == 5)
+        #expect(mockSyncRemote.loadProductVariationsCallCount == 5)
+    }
+}
+
+// MARK: - Mock POSCatalogSyncRemote
+
+final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
+    // Dictionary mapping pageNumber to Result for products and variations.
+    private(set) var productResults: [Int: Result<PagedItems<POSProduct>, Error>] = [:]
+    private(set) var variationResults: [Int: Result<PagedItems<POSProductVariation>, Error>] = [:]
+
+    private(set) var loadProductsCallCount = 0
+    private(set) var loadProductVariationsCallCount = 0
+
+    // Fallback result when no specific page result is configured
+    private let fallbackResult = PagedItems(items: [] as [POSProduct], hasMorePages: false, totalItems: 0)
+    private let fallbackVariationResult = PagedItems(items: [] as [POSProductVariation], hasMorePages: false, totalItems: 0)
+
+    func setProductResult(pageNumber: Int, result: Result<PagedItems<POSProduct>, Error>) {
+        productResults[pageNumber] = result
+    }
+
+    func setVariationResult(pageNumber: Int, result: Result<PagedItems<POSProductVariation>, Error>) {
+        variationResults[pageNumber] = result
+    }
+
+    func setProductResults(_ results: [PagedItems<POSProduct>]) {
+        for (index, pagedItems) in results.enumerated() {
+            productResults[index + 1] = .success(pagedItems)
+        }
+    }
+
+    func setVariationResults(_ results: [PagedItems<POSProductVariation>]) {
+        for (index, pagedItems) in results.enumerated() {
+            variationResults[index + 1] = .success(pagedItems)
+        }
+    }
+
+    func loadProducts(modifiedAfter: Date, siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProduct> {
+        try await loadProducts(siteID: siteID, pageNumber: pageNumber)
+    }
+
+    func loadProductVariations(modifiedAfter: Date, siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
+        try await loadProductVariations(siteID: siteID, pageNumber: pageNumber)
+    }
+
+    func loadProducts(siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProduct> {
+        loadProductsCallCount += 1
+
+        if let result = productResults[pageNumber] {
+            switch result {
+            case .success(let pagedItems):
+                return pagedItems
+            case .failure(let error):
+                throw error
+            }
+        }
+        return fallbackResult
+    }
+
+    func loadProductVariations(siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
+        loadProductVariationsCallCount += 1
+
+        if let result = variationResults[pageNumber] {
+            switch result {
+            case .success(let pagedItems):
+                return pagedItems
+            case .failure(let error):
+                throw error
+            }
+        }
+        return fallbackVariationResult
+    }
+}


### PR DESCRIPTION
For WOOMOB-1225

## Description

This PR implements a new full catalog synchronization service for the POS local catalog feature, tentatively sync products and variations using batched, concurrent paginated API requests, while the catalog API is paused.

Future work:
- Handle foreground/background transitions, including when background tasks cannot be scheduled (e.g. permission in app settings)
- Handle when any of the paginated requests fails with retries
- Integration with full sync use cases

### Key Changes

**POSCatalogFullSyncService**
- Created a new service that performs parallel synchronization of products and variations using `async let` concurrency
  - There might be some opportunities making the products/variations code generic, I hadn't got to it 
- Implements configurable batch processing (default: 2 concurrent requests per batch) to balance performance and API rate limits
- Uses pagination with `hasMorePages` detection and includes safety checks to prevent infinite loops when API metadata is inaccurate

**Alamofire Session Race Condition Fix**

The challenge that I got stuck today was to resolve the Alamofire `sessionDeinitialized` error that occurred specifically when:
1. Creating a new `AlamofireNetwork` instance
2. Shortly making multiple concurrent requests
3. The lazy `alamofireSession` variable experiencing initialization races, since it's still being created while other concurrent request(s) is accessing it

At first, I thought it was due to the remote/service/request being deallocated, or from recent networking layer changes. But if I changed the batch size to 1, there were no issues. The fix was to ensure the `alamofireSession: Alamofire.Session` is set in the initializer behind a parameter for backward compatibility.

## Steps to reproduce

Just CI is sufficient since the endpoints are integrated with the app yet.

## Test plan

Locally, I tested with the following where site ID is available and storing the service:

```swift
Task {
    do {
        let catalog = try await syncService.startFullSync(for: siteID)
        print("Full sync completed with \(catalog.products.count) products and \(catalog.variations.count) variations for siteID \(siteID)")
    } catch {
        print("Full sync failed for siteID \(siteID) with error: \(error)")
    }
}
```

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
