### PR TITLE
[Woo POS][Historical Orders] Order Details - Load product images

### DIFF
--- a/Modules/Sources/Fakes/NetworkingCore.generated.swift
+++ b/Modules/Sources/Fakes/NetworkingCore.generated.swift
@@ -270,6 +270,7 @@ extension NetworkingCore.OrderItem {
             totalTax: .fake(),
             attributes: .fake(),
             addOns: .fake(),
+            image: .fake(),
             parent: .fake(),
             bundleConfiguration: .fake()
         )

--- a/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -5,6 +5,7 @@ import Codegen
 import Foundation
 import WooFoundation
 import struct Alamofire.JSONEncoding
+import struct NetworkingCore.JetpackSite
 
 
 extension Networking.AIProduct {

--- a/Modules/Sources/NetworkingCore/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/NetworkingCore/Model/Copiable/Models+Copiable.generated.swift
@@ -444,6 +444,7 @@ extension NetworkingCore.OrderItem {
         totalTax: CopiableProp<String> = .copy,
         attributes: CopiableProp<[OrderItemAttribute]> = .copy,
         addOns: CopiableProp<[OrderItemProductAddOn]> = .copy,
+        image: NullableCopiableProp<OrderItemProductImage> = .copy,
         parent: NullableCopiableProp<Int64> = .copy,
         bundleConfiguration: CopiableProp<[OrderItemBundleItem]> = .copy
     ) -> NetworkingCore.OrderItem {
@@ -462,6 +463,7 @@ extension NetworkingCore.OrderItem {
         let totalTax = totalTax ?? self.totalTax
         let attributes = attributes ?? self.attributes
         let addOns = addOns ?? self.addOns
+        let image = image ?? self.image
         let parent = parent ?? self.parent
         let bundleConfiguration = bundleConfiguration ?? self.bundleConfiguration
 
@@ -481,6 +483,7 @@ extension NetworkingCore.OrderItem {
             totalTax: totalTax,
             attributes: attributes,
             addOns: addOns,
+            image: image,
             parent: parent,
             bundleConfiguration: bundleConfiguration
         )

--- a/Modules/Sources/NetworkingCore/Model/OrderItem.swift
+++ b/Modules/Sources/NetworkingCore/Model/OrderItem.swift
@@ -241,8 +241,4 @@ private struct OrderItemProductAddOnContainer: Decodable {
 //
 public struct OrderItemProductImage: Codable, Equatable, Hashable, Sendable {
     public let src: String
-
-    public init(src: String) {
-        self.src = src
-    }
 }

--- a/Modules/Sources/NetworkingCore/Model/OrderItem.swift
+++ b/Modules/Sources/NetworkingCore/Model/OrderItem.swift
@@ -240,11 +240,9 @@ private struct OrderItemProductAddOnContainer: Decodable {
 // MARK: - Order Item Product Image
 //
 public struct OrderItemProductImage: Codable, Equatable, Hashable, Sendable {
-    public let id: String
     public let src: String
 
-    public init(id: String, src: String) {
-        self.id = id
+    public init(src: String) {
         self.src = src
     }
 }

--- a/Modules/Sources/NetworkingCore/Model/OrderItem.swift
+++ b/Modules/Sources/NetworkingCore/Model/OrderItem.swift
@@ -240,5 +240,19 @@ private struct OrderItemProductAddOnContainer: Decodable {
 // MARK: - Order Item Product Image
 //
 public struct OrderItemProductImage: Codable, Equatable, Hashable, Sendable {
-    public let src: String
+    public let src: String?
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.src = try? container.decodeIfPresent(String.self, forKey: .src)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(src, forKey: .src)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case src
+    }
 }

--- a/Modules/Sources/NetworkingCore/Model/OrderItem.swift
+++ b/Modules/Sources/NetworkingCore/Model/OrderItem.swift
@@ -30,6 +30,8 @@ public struct OrderItem: Codable, Equatable, Hashable, Sendable, GeneratedFakeab
 
     public let addOns: [OrderItemProductAddOn]
 
+    public let image: OrderItemProductImage?
+
     /// Item ID of parent `OrderItem`, if any.
     ///
     /// An `OrderItem` can have a parent if, for example, it is a bundled item within a product bundle.
@@ -58,6 +60,7 @@ public struct OrderItem: Codable, Equatable, Hashable, Sendable, GeneratedFakeab
                 totalTax: String,
                 attributes: [OrderItemAttribute],
                 addOns: [OrderItemProductAddOn],
+                image: OrderItemProductImage?,
                 parent: Int64?,
                 bundleConfiguration: [OrderItemBundleItem]) {
         self.itemID = itemID
@@ -75,6 +78,7 @@ public struct OrderItem: Codable, Equatable, Hashable, Sendable, GeneratedFakeab
         self.totalTax = totalTax
         self.attributes = attributes
         self.addOns = addOns
+        self.image = image
         self.parent = parent
         self.bundleConfiguration = bundleConfiguration
     }
@@ -123,6 +127,9 @@ public struct OrderItem: Codable, Equatable, Hashable, Sendable, GeneratedFakeab
                                                               forKey: .attributes)
             .first(where: { $0.key == "_pao_ids" })?.value ?? []
 
+        // Order item product image
+        let image = try container.decodeIfPresent(OrderItemProductImage.self, forKey: .image)
+
         // Product Bundle extension properties:
         // If the order item is part of a product bundle, `bundledBy` is the parent order item (product bundle).
         // If it's not a bundled item, the API returns an empty string for `bundledBy` and the value will be `nil`.
@@ -149,6 +156,7 @@ public struct OrderItem: Codable, Equatable, Hashable, Sendable, GeneratedFakeab
                   totalTax: totalTax,
                   attributes: attributes,
                   addOns: productAddOns,
+                  image: image,
                   parent: bundledBy ?? compositeParent,
                   bundleConfiguration: [])
     }
@@ -172,6 +180,10 @@ public struct OrderItem: Codable, Equatable, Hashable, Sendable, GeneratedFakeab
 
         if !total.isEmpty {
             try container.encode(total, forKey: .total)
+        }
+
+        if let image = image {
+            try container.encode(image, forKey: .image)
         }
 
         if !bundleConfiguration.isEmpty {
@@ -204,6 +216,7 @@ extension OrderItem {
         case bundledBy      = "bundled_by"
         case compositeParent = "composite_parent"
         case bundleConfiguration = "bundle_configuration"
+        case image
     }
 }
 
@@ -221,4 +234,17 @@ extension OrderItem: Comparable {
 private struct OrderItemProductAddOnContainer: Decodable {
     let key: String
     let value: [OrderItemProductAddOn]
+}
+
+
+// MARK: - Order Item Product Image
+//
+public struct OrderItemProductImage: Codable, Equatable, Hashable, Sendable {
+    public let id: String
+    public let src: String
+
+    public init(id: String, src: String) {
+        self.id = id
+        self.src = src
+    }
 }

--- a/Modules/Sources/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -222,6 +222,7 @@ extension MockObjectGraph {
             totalTax: "0",
             attributes: [],
             addOns: [],
+            image: nil,
             parent: nil,
             bundleConfiguration: []
         )

--- a/Modules/Sources/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
@@ -55,6 +55,7 @@ extension Storage.OrderItem: ReadOnlyConvertible {
                          totalTax: totalTax ?? "",
                          attributes: attributes,
                          addOns: addOns,
+                         image: nil,
                          parent: parent?.int64Value,
                          bundleConfiguration: [])
     }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderItem.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderItem.swift
@@ -3,10 +3,6 @@ import Foundation
 public struct POSOrderItem: Equatable, Hashable {
     public let itemID: Int64
     public let name: String
-    // periphery:ignore - Will be used for images
-    public let productID: Int64
-    // periphery:ignore - Will be used for images
-    public let variationID: Int64
     public let quantity: Decimal
     public let formattedPrice: String
     public let formattedTotal: String
@@ -15,8 +11,6 @@ public struct POSOrderItem: Equatable, Hashable {
 
     public init(itemID: Int64,
                 name: String,
-                productID: Int64,
-                variationID: Int64,
                 quantity: Decimal,
                 formattedPrice: String,
                 formattedTotal: String,
@@ -24,8 +18,6 @@ public struct POSOrderItem: Equatable, Hashable {
                 attributes: [OrderItemAttribute]) {
         self.itemID = itemID
         self.name = name
-        self.productID = productID
-        self.variationID = variationID
         self.quantity = quantity
         self.formattedPrice = formattedPrice
         self.formattedTotal = formattedTotal

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderItem.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderItem.swift
@@ -10,6 +10,7 @@ public struct POSOrderItem: Equatable, Hashable {
     public let quantity: Decimal
     public let formattedPrice: String
     public let formattedTotal: String
+    public let imageSrc: String?
     public let attributes: [OrderItemAttribute]
 
     public init(itemID: Int64,
@@ -19,6 +20,7 @@ public struct POSOrderItem: Equatable, Hashable {
                 quantity: Decimal,
                 formattedPrice: String,
                 formattedTotal: String,
+                imageSrc: String?,
                 attributes: [OrderItemAttribute]) {
         self.itemID = itemID
         self.name = name
@@ -27,6 +29,7 @@ public struct POSOrderItem: Equatable, Hashable {
         self.quantity = quantity
         self.formattedPrice = formattedPrice
         self.formattedTotal = formattedTotal
+        self.imageSrc = imageSrc
         self.attributes = attributes
     }
 }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderMapper.swift
@@ -56,8 +56,6 @@ struct POSOrderMapper {
         return POSOrderItem(
             itemID: orderItem.itemID,
             name: orderItem.name,
-            productID: orderItem.productID,
-            variationID: orderItem.variationID,
             quantity: orderItem.quantity,
             formattedPrice: currencyFormatter.formatAmount(orderItem.price, with: currency) ?? "",
             formattedTotal: currencyFormatter.formatAmount(orderItem.total, with: currency) ?? "",

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderMapper.swift
@@ -61,6 +61,7 @@ struct POSOrderMapper {
             quantity: orderItem.quantity,
             formattedPrice: currencyFormatter.formatAmount(orderItem.price, with: currency) ?? "",
             formattedTotal: currencyFormatter.formatAmount(orderItem.total, with: currency) ?? "",
+            imageSrc: orderItem.image?.src,
             attributes: orderItem.attributes
         )
     }

--- a/Modules/Sources/Yosemite/Stores/Order/ProductInputTransformer.swift
+++ b/Modules/Sources/Yosemite/Stores/Order/ProductInputTransformer.swift
@@ -241,6 +241,7 @@ private extension ProductInputTransformer {
                          totalTax: "",
                          attributes: [],
                          addOns: [],
+                         image: nil,
                          parent: nil,
                          bundleConfiguration: input.bundleConfiguration.map {
             switch $0.productOrVariation {

--- a/Modules/Tests/NetworkingTests/Mapper/OrderListMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/OrderListMapperTests.swift
@@ -163,8 +163,35 @@ class OrderListMapperTests: XCTestCase {
             }
         }
     }
-}
 
+    /// Verifies that OrderItem decoding is robust for various image field scenarios from WooCommerce API
+    ///
+    func test_order_item_image_decoding_robustness() {
+        let orders = mapOrders(from: "order-item-image")
+        XCTAssertEqual(orders.count, 1)
+
+        let order = orders[0]
+        XCTAssertEqual(order.items.count, 4)
+
+        // Item 1: Product with valid image src
+        let item1 = order.items[0]
+        XCTAssertNotNil(item1.image)
+        XCTAssertEqual(item1.image?.src, "https://example.com/image.jpg")
+
+        // Item 2: Product with no image field
+        let item2 = order.items[1]
+        XCTAssertNil(item2.image)
+
+        // Item 3: Product with image but no src field
+        let item3 = order.items[2]
+        XCTAssertNotNil(item3.image)
+        XCTAssertNil(item3.image?.src)
+
+        // Item 4: Product with wrong src type
+        let item4 = order.items[3]
+        XCTAssertNil(item4.image?.src)
+    }
+}
 
 /// Private Methods.
 ///

--- a/Modules/Tests/NetworkingTests/Responses/order-item-image.json
+++ b/Modules/Tests/NetworkingTests/Responses/order-item-image.json
@@ -1,0 +1,138 @@
+{
+    "data": [
+        {
+            "id": 963,
+            "parent_id": 0,
+            "is_editable": true,
+            "needs_payment": true,
+            "needs_processing": true,
+            "number": "963",
+            "status": "processing",
+            "order_key": "abc123",
+            "currency": "USD",
+            "currency_symbol": "$",
+            "date_created_gmt": "2018-04-03T23:05:12",
+            "date_modified_gmt": "2018-04-03T23:05:14",
+            "discount_total": "30.00",
+            "discount_tax": "1.20",
+            "shipping_total": "0.00",
+            "shipping_tax": "0.00",
+            "cart_tax": "1.20",
+            "total": "31.20",
+            "total_tax": "1.20",
+            "customer_id": 11,
+            "customer_note": "",
+            "billing": {
+                "first_name": "Johnny",
+                "last_name": "Appleseed",
+                "company": "",
+                "address_1": "234 70th Street",
+                "address_2": "",
+                "city": "Niagara Falls",
+                "state": "NY",
+                "postcode": "14304",
+                "country": "US",
+                "email": "scrambled@scrambled.com",
+                "phone": "333-333-3333"
+            },
+            "shipping": {
+                "first_name": "Johnny",
+                "last_name": "Appleseed",
+                "company": "",
+                "address_1": "234 70th Street",
+                "address_2": "",
+                "city": "Niagara Falls",
+                "state": "NY",
+                "postcode": "14304",
+                "country": "US",
+                "email": "scrambled@scrambled.com",
+                "phone": "333-333-3333"
+            },
+            "shipping_lines": [],
+            "fee_lines": [],
+            "tax_lines": [],
+            "payment_method": "stripe",
+            "payment_method_title": "Credit Card (Stripe)",
+            "payment_url": "http://www.automattic.com",
+            "date_paid_gmt": "2018-04-03T23:05:14",
+            "date_completed_gmt": null,
+            "line_items": [
+                {
+                    "id": 1,
+                    "name": "Product with valid image src",
+                    "product_id": 123,
+                    "variation_id": 0,
+                    "quantity": 1,
+                    "price": 10.0,
+                    "sku": "",
+                    "subtotal": "10.00",
+                    "subtotal_tax": "0.00",
+                    "tax_class": "",
+                    "taxes": [],
+                    "total": "10.00",
+                    "total_tax": "0.00",
+                    "meta_data": [],
+                    "image": {
+                        "src": "https://example.com/image.jpg"
+                    }
+                },
+                {
+                    "id": 2,
+                    "name": "Product with no image field",
+                    "product_id": 124,
+                    "variation_id": 0,
+                    "quantity": 1,
+                    "price": 10.0,
+                    "sku": "",
+                    "subtotal": "10.00",
+                    "subtotal_tax": "0.00",
+                    "tax_class": "",
+                    "taxes": [],
+                    "total": "10.00",
+                    "total_tax": "0.00",
+                    "meta_data": []
+                },
+                {
+                    "id": 3,
+                    "name": "Product with image but no src",
+                    "product_id": 125,
+                    "variation_id": 0,
+                    "quantity": 1,
+                    "price": 10.0,
+                    "sku": "",
+                    "subtotal": "10.00",
+                    "subtotal_tax": "0.00",
+                    "tax_class": "",
+                    "taxes": [],
+                    "total": "10.00",
+                    "total_tax": "0.00",
+                    "meta_data": [],
+                    "image": {
+                        "alt": "Product image alt text"
+                    }
+                },
+                {
+                    "id": 4,
+                    "name": "Product with wrong src type",
+                    "product_id": 126,
+                    "variation_id": 0,
+                    "quantity": 1,
+                    "price": 10.0,
+                    "sku": "",
+                    "subtotal": "10.00",
+                    "subtotal_tax": "0.00",
+                    "tax_class": "",
+                    "taxes": [],
+                    "total": "10.00",
+                    "total_tax": "0.00",
+                    "meta_data": [],
+                    "image": {
+                        "src": 12345
+                    }
+                }
+            ],
+            "coupon_lines": [],
+            "refunds": []
+        }
+    ]
+}

--- a/Modules/Tests/YosemiteTests/PointOfSale/POSOrderMapperTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/POSOrderMapperTests.swift
@@ -193,7 +193,8 @@ private extension POSOrderMapperTests {
             quantity: quantity,
             price: price,
             subtotal: subtotal,
-            total: total
+            total: total,
+            image: nil
         )
     }
 

--- a/Modules/Tests/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -549,6 +549,7 @@ private extension OrdersUpsertUseCaseTests {
                   totalTax: "",
                   attributes: [],
                   addOns: [],
+                  image: nil,
                   parent: nil,
                   bundleConfiguration: [])
     }
@@ -573,6 +574,7 @@ private extension OrdersUpsertUseCaseTests {
               totalTax: "0.00",
               attributes: attributes,
               addOns: [],
+              image: nil,
               parent: nil,
               bundleConfiguration: [])
     }

--- a/Modules/Tests/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/OrderStoreTests.swift
@@ -1848,6 +1848,7 @@ private extension OrderStoreTests {
                               totalTax: "1.20",
                               attributes: [],
                               addOns: [],
+                              image: nil,
                               parent: nil,
                               bundleConfiguration: [])
 
@@ -1866,6 +1867,7 @@ private extension OrderStoreTests {
                               totalTax: "0.00",
                               attributes: [],
                               addOns: [],
+                              image: nil,
                               parent: nil,
                               bundleConfiguration: [])
 
@@ -1888,6 +1890,7 @@ private extension OrderStoreTests {
                               totalTax: "4.00",
                               attributes: [],
                               addOns: [],
+                              image: nil,
                               parent: nil,
                               bundleConfiguration: [])
 
@@ -1906,6 +1909,7 @@ private extension OrderStoreTests {
                               totalTax: "0.40",
                               attributes: [],
                               addOns: [],
+                              image: nil,
                               parent: nil,
                               bundleConfiguration: [])
 
@@ -1924,6 +1928,7 @@ private extension OrderStoreTests {
                               totalTax: "10.40",
                               attributes: [],
                               addOns: [],
+                              image: nil,
                               parent: nil,
                               bundleConfiguration: [])
 
@@ -1946,6 +1951,7 @@ private extension OrderStoreTests {
                               totalTax: "4.00",
                               attributes: [],
                               addOns: [],
+                              image: nil,
                               parent: nil,
                               bundleConfiguration: [])
 

--- a/Modules/Tests/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -1099,6 +1099,7 @@ private extension ProductVariationStoreTests {
               totalTax: "1.20",
               attributes: [],
               addOns: [],
+              image: nil,
               parent: nil,
               bundleConfiguration: [])
     }

--- a/Modules/Tests/YosemiteTests/Stores/ReceiptStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ReceiptStoreTests.swift
@@ -645,6 +645,7 @@ private extension ReceiptStoreTests {
                            totalTax: "",
                            attributes: [],
                            addOns: [],
+                           image: nil,
                            parent: nil,
                            bundleConfiguration: [])
     }

--- a/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrderDetailsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Orders/PointOfSaleOrderDetailsView.swift
@@ -116,7 +116,7 @@ private extension PointOfSaleOrderDetailsView {
     @ViewBuilder
     func productRow(item: POSOrderItem) -> some View {
         HStack(alignment: .top, spacing: POSSpacing.medium) {
-            productImageView()
+            productImageView(item: item)
             productDetailsView(item: item)
             Spacer()
             productTotalView(item: item)
@@ -125,8 +125,9 @@ private extension PointOfSaleOrderDetailsView {
     }
 
     @ViewBuilder
-    func productImageView() -> some View {
-        POSItemImageView(imageSource: nil, imageSize: 40, scale: 1)
+
+    func productImageView(item: POSOrderItem) -> some View {
+        POSItemImageView(imageSource: item.imageSrc, imageSize: 40, scale: 1)
             .frame(width: 40, height: 40)
             .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value))
     }

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -255,8 +255,6 @@ struct POSPreviewHelpers {
             lineItems: [
                 POSOrderItem(itemID: 1,
                              name: "Premium Coffee Beans",
-                             productID: 101,
-                             variationID: 0,
                              quantity: 2.0,
                              formattedPrice: "$12.50",
                              formattedTotal: "$25.00",
@@ -265,8 +263,6 @@ struct POSPreviewHelpers {
                 POSOrderItem(
                     itemID: 2,
                     name: "Organic Tea - Earl Grey",
-                    productID: 102,
-                    variationID: 203,
                     quantity: 1.0,
                     formattedPrice: "$15.99",
                     formattedTotal: "$15.99",
@@ -303,8 +299,6 @@ final class PointOfSalePreviewOrderListController: PointOfSaleOrderListControlle
                 lineItems: [
                     POSOrderItem(itemID: 1,
                                  name: "Premium Coffee Beans",
-                                 productID: 101,
-                                 variationID: 0,
                                  quantity: 2.0,
                                  formattedPrice: "$12.50",
                                  formattedTotal: "$25.00",
@@ -313,8 +307,6 @@ final class PointOfSalePreviewOrderListController: PointOfSaleOrderListControlle
                     POSOrderItem(
                         itemID: 2,
                         name: "Organic Tea - Earl Grey",
-                        productID: 102,
-                        variationID: 203,
                         quantity: 1.0,
                         formattedPrice: "$15.99",
                         formattedTotal: "$15.99",
@@ -345,8 +337,6 @@ final class PointOfSalePreviewOrderListController: PointOfSaleOrderListControlle
                     POSOrderItem(
                         itemID: 3,
                         name: "Artisan Chocolate Box",
-                        productID: 103,
-                        variationID: 0,
                         quantity: 3.0,
                         formattedPrice: "$19.99",
                         formattedTotal: "$59.97",
@@ -356,8 +346,6 @@ final class PointOfSalePreviewOrderListController: PointOfSaleOrderListControlle
                     POSOrderItem(
                         itemID: 4,
                         name: "Gourmet Cookie Set - Mixed",
-                        productID: 104,
-                        variationID: 401,
                         quantity: 1.0,
                         formattedPrice: "$29.99",
                         formattedTotal: "$29.99",

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -260,6 +260,7 @@ struct POSPreviewHelpers {
                              quantity: 2.0,
                              formattedPrice: "$12.50",
                              formattedTotal: "$25.00",
+                             imageSrc: nil,
                              attributes: []),
                 POSOrderItem(
                     itemID: 2,
@@ -269,6 +270,7 @@ struct POSPreviewHelpers {
                     quantity: 1.0,
                     formattedPrice: "$15.99",
                     formattedTotal: "$15.99",
+                    imageSrc: nil,
                     attributes: [
                         OrderItemAttribute(metaID: 1, name: "Size", value: "Large"),
                         OrderItemAttribute(metaID: 2, name: "Type", value: "Loose Leaf")
@@ -306,6 +308,7 @@ final class PointOfSalePreviewOrderListController: PointOfSaleOrderListControlle
                                  quantity: 2.0,
                                  formattedPrice: "$12.50",
                                  formattedTotal: "$25.00",
+                                 imageSrc: nil,
                                  attributes: []),
                     POSOrderItem(
                         itemID: 2,
@@ -315,6 +318,7 @@ final class PointOfSalePreviewOrderListController: PointOfSaleOrderListControlle
                         quantity: 1.0,
                         formattedPrice: "$15.99",
                         formattedTotal: "$15.99",
+                        imageSrc: nil,
                         attributes: [
                             OrderItemAttribute(metaID: 1, name: "Size", value: "Large"),
                             OrderItemAttribute(metaID: 2, name: "Type", value: "Loose Leaf")
@@ -346,6 +350,7 @@ final class PointOfSalePreviewOrderListController: PointOfSaleOrderListControlle
                         quantity: 3.0,
                         formattedPrice: "$19.99",
                         formattedTotal: "$59.97",
+                        imageSrc: nil,
                         attributes: []
                     ),
                     POSOrderItem(
@@ -356,6 +361,7 @@ final class PointOfSalePreviewOrderListController: PointOfSaleOrderListControlle
                         quantity: 1.0,
                         formattedPrice: "$29.99",
                         formattedTotal: "$29.99",
+                        imageSrc: nil,
                         attributes: [
                             OrderItemAttribute(metaID: 3, name: "Flavor", value: "Mixed"),
                             OrderItemAttribute(metaID: 4, name: "Packaging", value: "Gift Box")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -541,6 +541,7 @@ extension ShippingLabelPackagesFormViewModel {
                               totalTax: "1.20",
                               attributes: [],
                               addOns: [],
+                              image: nil,
                               parent: nil,
                               bundleConfiguration: [])
 
@@ -559,6 +560,7 @@ extension ShippingLabelPackagesFormViewModel {
                               totalTax: "0.00",
                               attributes: [],
                               addOns: [],
+                              image: nil,
                               parent: nil,
                               bundleConfiguration: [])
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelSampleData.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelSampleData.swift
@@ -123,6 +123,7 @@ private extension ShippingLabelSampleData {
                               totalTax: "1.20",
                               attributes: [],
                               addOns: [],
+                              image: nil,
                               parent: nil,
                               bundleConfiguration: [])
 
@@ -141,6 +142,7 @@ private extension ShippingLabelSampleData {
                               totalTax: "0.00",
                               attributes: [],
                               addOns: [],
+                              image: nil,
                               parent: nil,
                               bundleConfiguration: [])
 

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleOrderListService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleOrderListService.swift
@@ -80,8 +80,6 @@ extension MockPointOfSaleOrderListService {
                 POSOrderItem(
                     itemID: 1,
                     name: "Coffee",
-                    productID: 101,
-                    variationID: 0,
                     quantity: 2,
                     formattedPrice: "$10.00",
                     formattedTotal: "$20.00",
@@ -91,8 +89,6 @@ extension MockPointOfSaleOrderListService {
                 POSOrderItem(
                     itemID: 2,
                     name: "Muffin",
-                    productID: 102,
-                    variationID: 0,
                     quantity: 1,
                     formattedPrice: "$5.99",
                     formattedTotal: "$5.99",
@@ -121,8 +117,6 @@ extension MockPointOfSaleOrderListService {
                 POSOrderItem(
                     itemID: 3,
                     name: "Tea",
-                    productID: 103,
-                    variationID: 0,
                     quantity: 1,
                     formattedPrice: "$15.50",
                     formattedTotal: "$15.50",
@@ -157,8 +151,6 @@ extension MockPointOfSaleOrderListService {
                 POSOrderItem(
                     itemID: 4,
                     name: "Sandwich",
-                    productID: 104,
-                    variationID: 0,
                     quantity: 1,
                     formattedPrice: "$12.00",
                     formattedTotal: "$12.00",
@@ -168,8 +160,6 @@ extension MockPointOfSaleOrderListService {
                 POSOrderItem(
                     itemID: 5,
                     name: "Soup",
-                    productID: 105,
-                    variationID: 0,
                     quantity: 2,
                     formattedPrice: "$15.38",
                     formattedTotal: "$30.75",
@@ -198,8 +188,6 @@ extension MockPointOfSaleOrderListService {
                 POSOrderItem(
                     itemID: 6,
                     name: "Cookies",
-                    productID: 106,
-                    variationID: 0,
                     quantity: 1,
                     formattedPrice: "$12.00",
                     formattedTotal: "$12.00",

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleOrderListService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleOrderListService.swift
@@ -85,6 +85,7 @@ extension MockPointOfSaleOrderListService {
                     quantity: 2,
                     formattedPrice: "$10.00",
                     formattedTotal: "$20.00",
+                    imageSrc: nil,
                     attributes: []
                 ),
                 POSOrderItem(
@@ -95,6 +96,7 @@ extension MockPointOfSaleOrderListService {
                     quantity: 1,
                     formattedPrice: "$5.99",
                     formattedTotal: "$5.99",
+                    imageSrc: nil,
                     attributes: []
                 )
             ],
@@ -124,6 +126,7 @@ extension MockPointOfSaleOrderListService {
                     quantity: 1,
                     formattedPrice: "$15.50",
                     formattedTotal: "$15.50",
+                    imageSrc: nil,
                     attributes: []
                 )
             ],
@@ -159,6 +162,7 @@ extension MockPointOfSaleOrderListService {
                     quantity: 1,
                     formattedPrice: "$12.00",
                     formattedTotal: "$12.00",
+                    imageSrc: nil,
                     attributes: []
                 ),
                 POSOrderItem(
@@ -169,6 +173,7 @@ extension MockPointOfSaleOrderListService {
                     quantity: 2,
                     formattedPrice: "$15.38",
                     formattedTotal: "$30.75",
+                    imageSrc: nil,
                     attributes: []
                 )
             ],
@@ -198,6 +203,7 @@ extension MockPointOfSaleOrderListService {
                     quantity: 1,
                     formattedPrice: "$12.00",
                     formattedTotal: "$12.00",
+                    imageSrc: nil,
                     attributes: []
                 )
             ],

--- a/WooCommerce/WooCommerceTests/Tools/MockOrderItem.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrderItem.swift
@@ -34,6 +34,7 @@ public struct MockOrderItem {
                          totalTax: totalTax,
                          attributes: attributes,
                          addOns: [],
+                         image: nil,
                          parent: parent,
                          bundleConfiguration: [])
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -1104,6 +1104,7 @@ private extension OrderDetailsDataSourceTests {
                   totalTax: "1",
                   attributes: [],
                   addOns: [],
+                  image: nil,
                   parent: nil,
                   bundleConfiguration: [])
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/ProductDetailsCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/ProductDetailsCellViewModelTests.swift
@@ -271,6 +271,7 @@ private extension ProductDetailsCellViewModelTests {
                   totalTax: "",
                   attributes: attributes,
                   addOns: [],
+                  image: nil,
                   parent: nil,
                   bundleConfiguration: [])
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product Loader/ProductLoaderViewControllerModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product Loader/ProductLoaderViewControllerModelTests.swift
@@ -106,6 +106,7 @@ private extension ProductLoaderViewControllerModelTests {
                   totalTax: "",
                   attributes: [],
                   addOns: [],
+                  image: nil,
                   parent: nil,
                   bundleConfiguration: [])
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Added `image` to `OrderItem` and `POSOrderItem`
- Setting `image.src` to `POSItemImageView`

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS -> Menu -> Orders
2. When order appears, confirm that order item products that contain the image, loads the image succesfuly
3. Close and reopen the view
4. Confirm the image is loaded immediatelly

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air 18.5, reopening orders, quickly selecting different orders, products with and without variations

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/c4c57dae-3e82-4d1f-9cd1-e2a4cf1d0e9a

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.