### PR TITLE
Fix flaky `test_isExpired_when_current_date_then_returns_true`

### DIFF
--- a/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -5,6 +5,7 @@ import Codegen
 import Foundation
 import WooFoundation
 import struct Alamofire.JSONEncoding
+import struct NetworkingCore.JetpackSite
 
 
 extension Networking.AIProduct {

--- a/Modules/Tests/YosemiteTests/PointOfSale/POSCouponTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/POSCouponTests.swift
@@ -31,10 +31,34 @@ struct POSCouponTests {
 
     @Test func test_isExpired_when_current_date_then_returns_true() {
         // Given
-        let now = Date()
+        let now = fixedDate(daysFromReference: 0)
         let coupon = POSCoupon(id: UUID(), code: "expired-now", dateExpires: now)
 
         // Then
         #expect(coupon.isExpired == true, "A coupon expiring at the current time should be considered expired")
+    }
+}
+
+private extension POSCouponTests {
+    /// Returns a fixed date with optional day offset
+    /// - Parameter daysFromReference: Number of days to add/subtract from the reference date (0 = reference date)
+    /// - Returns: A fixed date
+    func fixedDate(daysFromReference: Int = 0) -> Date {
+        var components = DateComponents()
+        components.year = 2024
+        components.month = 6
+        components.day = 15
+        components.hour = 12
+        components.minute = 0
+        components.second = 0
+        components.timeZone = TimeZone(identifier: "UTC")
+
+        guard let baseDate = Calendar(identifier: .gregorian).date(from: components) else {
+            // Fallback to the same date (2024-06-15 12:00:00 UTC) if calendar creation fails
+            return Date(timeIntervalSince1970: 1718452800)
+        }
+        guard daysFromReference != 0 else { return baseDate }
+
+        return Calendar.current.date(byAdding: .day, value: daysFromReference, to: baseDate) ?? baseDate
     }
 }


### PR DESCRIPTION
Closes WOOMOB-1255

## Description
This PR mocks the `now` date to a fixed date so we avoid flakiness on `test_isExpired_when_current_date_then_returns_true`.

I'm not convinced of the value of the test, since in the implementation of POSCoupon we check the expiration against `Date()`, so a 2nd option could be to just pass "now" as "a few seconds ago" or similar, which should be closer to the real implementation. 

We cannot use the fixed date either in the tests that check for future dates, otherwise sooner or later the fixed date passed in, will not surpass the actual date of comparison, failing the test (ie: future date as tomorrow in 2024, is still < `Date()` ).

As a 3rd option, we could change the details of POSCoupon, but I don't see a good reason to change the interface only because of tests.

Let me know what you think, I might lean to option 2 instead, where "now" is actually a couple of seconds ago, rather than using a fixed date.

## Testing information
- CI should pass.