### PR TITLE
[WCiOS17] Use `registerForTraitChanges` in refund views 

### DIFF
--- a/Modules/Sources/Networking/Model/POSProductVariation.swift
+++ b/Modules/Sources/Networking/Model/POSProductVariation.swift
@@ -94,7 +94,8 @@ public struct POSProductVariation: Codable, Equatable, GeneratedCopiable, Genera
                     guard value.lowercased() == Values.manageStockParent else {
                         let message = "Unexpected manage stock value: \(value)"
                         assertionFailure(message)
-                        DDLogError(message)
+                        let formattedMessage = DDLogMessageFormat(stringLiteral: message)
+                        DDLogError(formattedMessage)
                         return false
                     }
                     return false

--- a/Modules/Sources/Networking/Model/Product/ProductVariation.swift
+++ b/Modules/Sources/Networking/Model/Product/ProductVariation.swift
@@ -273,7 +273,8 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
                                                                     guard value.lowercased() == Values.manageStockParent else {
                                                                         let message = "Unexpected manage stock value: \(value)"
                                                                         assertionFailure(message)
-                                                                        DDLogError(message)
+                                                                        let formattedMessage = DDLogMessageFormat(stringLiteral: message)
+                                                                        DDLogError(formattedMessage)
                                                                         return false
                                                                     }
                                                                     return false

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSFullScreenCover.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSFullScreenCover.swift
@@ -77,7 +77,7 @@ struct POSFullScreenCoverModifier<CoverContent: View>: ViewModifier {
                     .environmentObject(sheetManager)
                     .environmentObject(coverManager)
             })
-            .onChange(of: isPresented) { newValue in
+            .onChange(of: isPresented) { _, newValue in
                 parentCoverManager.isPresented = newValue
             }
     }
@@ -104,7 +104,7 @@ struct POSFullScreenCoverModifierForItem<Item: Identifiable & Equatable, CoverCo
                     .environmentObject(sheetManager)
                     .environmentObject(coverManager)
             })
-            .onChange(of: item) { newValue in
+            .onChange(of: item) { _, newValue in
                 parentCoverManager.isPresented = newValue != nil
             }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -33,6 +33,7 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
 
     /// Retains the content trait registration token, so it's not deallocated immediately
     ///
+    // periphery: ignore - False negative. Perhaps does not catch non-dreict reads?
     private var contentSizeTraitRegistration: UITraitChangeRegistration?
 
     static func register(for tableView: UITableView) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -31,6 +31,10 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
     ///
     @IBOutlet weak var contentStackView: UIStackView!
 
+    /// Retains the content trait registration token, so it's not deallocated immediately
+    ///
+    private var contentSizeTraitRegistration: UITraitChangeRegistration?
+
     static func register(for tableView: UITableView) {
         tableView.registerNib(for: self)
     }
@@ -75,17 +79,7 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
 
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if traitCollection.preferredContentSizeCategory > .extraExtraLarge {
-            contentStackView.axis = .vertical
-        } else {
-            contentStackView.axis = .horizontal
-        }
-    }
-
     // MARK: - Overridden Methods
-
     override func awakeFromNib() {
         super.awakeFromNib()
         configureBackground()
@@ -107,18 +101,38 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         paymentStatusLabel.layer.borderColor = UIColor.clear.cgColor
+        contentSizeTraitRegistration = nil
     }
 
     override func updateConfiguration(using state: UICellConfigurationState) {
         super.updateConfiguration(using: state)
         updateDefaultBackgroundConfiguration(using: state)
     }
+
+    override func willMove(toSuperview newSuperview: UIView?) {
+        super.willMove(toSuperview: newSuperview)
+        
+        // Registers for trait changes when the cell is about to be added to view hierarchy,
+        // applies initial layout, and cleans up when removed from hierarchy
+        if newSuperview != nil {
+            contentSizeTraitRegistration = registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { [weak self] (_: OrderTableViewCell, _: UITraitCollection) in
+                self?.applyContentSizeCategoryLayout()
+            }
+            applyContentSizeCategoryLayout()
+        } else {
+            contentSizeTraitRegistration = nil
+        }
+    }
 }
 
-
-// MARK: - Private
-//
 private extension OrderTableViewCell {
+    func applyContentSizeCategoryLayout() {
+        if traitCollection.preferredContentSizeCategory > .extraExtraLarge {
+            contentStackView.axis = .vertical
+        } else {
+            contentStackView.axis = .horizontal
+        }
+    }
 
     /// Reset the UI to a "no data" state.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -111,11 +111,13 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
 
     override func willMove(toSuperview newSuperview: UIView?) {
         super.willMove(toSuperview: newSuperview)
-        
+
         // Registers for trait changes when the cell is about to be added to view hierarchy,
         // applies initial layout, and cleans up when removed from hierarchy
         if newSuperview != nil {
-            contentSizeTraitRegistration = registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { [weak self] (_: OrderTableViewCell, _: UITraitCollection) in
+            contentSizeTraitRegistration = registerForTraitChanges([
+                UITraitPreferredContentSizeCategory.self
+            ]) { [weak self] (_: OrderTableViewCell, _: UITraitCollection) in
                 self?.applyContentSizeCategoryLayout()
             }
             applyContentSizeCategoryLayout()

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -33,7 +33,7 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
 
     /// Retains the content trait registration token, so it's not deallocated immediately
     ///
-    // periphery: ignore - False negative. Perhaps does not catch non-dreict reads?
+    // periphery: ignore - False negative. Perhaps does not catch non-direct reads?
     private var contentSizeTraitRegistration: UITraitChangeRegistration?
 
     static func register(for tableView: UITableView) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
@@ -41,11 +41,10 @@ final class RefundItemTableViewCell: UITableViewCell {
         super.awakeFromNib()
         applyCellStyles()
         applyAccessibilityChanges()
-    }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        applyAccessibilityChanges()
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { [weak self] (_: RefundItemTableViewCell, _: UITraitCollection) in
+            self?.applyAccessibilityChanges()
+        }
     }
 
     override func updateConfiguration(using state: UICellConfigurationState) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
@@ -41,9 +41,18 @@ final class RefundItemTableViewCell: UITableViewCell {
         super.awakeFromNib()
         applyCellStyles()
         applyAccessibilityChanges()
+    }
 
-        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { [weak self] (_: RefundItemTableViewCell, _: UITraitCollection) in
-            self?.applyAccessibilityChanges()
+    override func willMove(toSuperview newSuperview: UIView?) {
+        super.willMove(toSuperview: newSuperview)
+        let sizeTraits: [UITrait] = [
+            UITraitPreferredContentSizeCategory.self,
+            UITraitUserInterfaceIdiom.self,
+            UITraitVerticalSizeClass.self
+        ]
+
+        registerForTraitChanges(sizeTraits) { (self: Self, _: UITraitCollection) in
+            self.applyAccessibilityChanges()
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
@@ -52,9 +52,15 @@ final class RefundShippingDetailsTableViewCell: UITableViewCell {
         super.awakeFromNib()
         applyCellStyles()
         applyAccessibilityChanges()
+        
+        let traits: [UITrait] = [
+            UITraitPreferredContentSizeCategory.self,
+            UITraitUserInterfaceIdiom.self,
+            UITraitVerticalSizeClass.self
+        ]
 
-        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { [weak self] (_: RefundShippingDetailsTableViewCell, _: UITraitCollection) in
-            self?.applyAccessibilityChanges()
+        registerForTraitChanges(traits) { (self: Self, _: UITraitCollection) in
+            self.applyAccessibilityChanges()
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
@@ -52,11 +52,10 @@ final class RefundShippingDetailsTableViewCell: UITableViewCell {
         super.awakeFromNib()
         applyCellStyles()
         applyAccessibilityChanges()
-    }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        applyAccessibilityChanges()
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { [weak self] (_: RefundShippingDetailsTableViewCell, _: UITraitCollection) in
+            self?.applyAccessibilityChanges()
+        }
     }
 
     override func updateConfiguration(using state: UICellConfigurationState) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
@@ -52,7 +52,7 @@ final class RefundShippingDetailsTableViewCell: UITableViewCell {
         super.awakeFromNib()
         applyCellStyles()
         applyAccessibilityChanges()
-        
+
         let traits: [UITrait] = [
             UITraitPreferredContentSizeCategory.self,
             UITraitUserInterfaceIdiom.self,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -47,6 +47,11 @@ final class IssueRefundViewController: UIViewController {
         observeViewModel()
         viewModel.fetch()
         updateWithViewModelContent()
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { [weak self] (_: IssueRefundViewController, _: UITraitCollection) in
+            self?.configureHeaderStackView()
+            self?.tableView.updateHeaderHeight()
+        }
     }
 
     override func viewWillLayoutSubviews() {
@@ -191,16 +196,6 @@ private extension IssueRefundViewController {
         } else {
             nextButton.hideActivityIndicator()
         }
-    }
-}
-
-// MARK: Accessibility handling
-//
-extension IssueRefundViewController {
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        configureHeaderStackView()
-        tableView.updateHeaderHeight()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -48,9 +48,15 @@ final class IssueRefundViewController: UIViewController {
         viewModel.fetch()
         updateWithViewModelContent()
 
-        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { [weak self] (_: IssueRefundViewController, _: UITraitCollection) in
-            self?.configureHeaderStackView()
-            self?.tableView.updateHeaderHeight()
+        let traits: [UITrait] = [
+            UITraitPreferredContentSizeCategory.self,
+            UITraitUserInterfaceIdiom.self,
+            UITraitVerticalSizeClass.self
+        ]
+
+        registerForTraitChanges(traits) {(self: Self, _: UITraitCollection) in
+            self.configureHeaderStackView()
+            self.tableView.updateHeaderHeight()
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
@@ -14,7 +14,7 @@ final class FilteredOrdersHeaderBar: UIView {
 
     /// Retains the content trait registration token, so it's not deallocated immediately
     ///
-    // periphery: ignore - False negative. Perhaps does not catch non-dreict reads?
+    // periphery: ignore - False negative. Perhaps does not catch non-direct reads?
     private var contentSizeTraitRegistration: UITraitChangeRegistration?
 
     /// The number of filters applied

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
@@ -14,6 +14,7 @@ final class FilteredOrdersHeaderBar: UIView {
 
     /// Retains the content trait registration token, so it's not deallocated immediately
     ///
+    // periphery: ignore - False negative. Perhaps does not catch non-dreict reads?
     private var contentSizeTraitRegistration: UITraitChangeRegistration?
 
     /// The number of filters applied

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
@@ -12,6 +12,10 @@ final class FilteredOrdersHeaderBar: UIView {
 
     private let bottomBorder = CALayer()
 
+    /// Retains the content trait registration token, so it's not deallocated immediately
+    ///
+    private var contentSizeTraitRegistration: UITraitChangeRegistration?
+
     /// The number of filters applied
     ///
     private var numberOfFilters = 0
@@ -28,6 +32,19 @@ final class FilteredOrdersHeaderBar: UIView {
         configureButtons()
         configureBackground()
         updateStackViewAxis(for: traitCollection)
+    }
+
+    override func willMove(toSuperview newSuperview: UIView?) {
+        super.willMove(toSuperview: newSuperview)
+
+        if newSuperview != nil {
+            contentSizeTraitRegistration = registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { [weak self] (_: FilteredOrdersHeaderBar, _: UITraitCollection) in
+                guard let self = self else { return }
+                self.updateStackViewAxis(for: self.traitCollection)
+            }
+        } else {
+            contentSizeTraitRegistration = nil
+        }
     }
 
     override func layoutSubviews() {
@@ -55,16 +72,6 @@ final class FilteredOrdersHeaderBar: UIView {
 /// The `Last updated: time` tends to get truncated at larger text sizes by the filter button.
 /// Laying out the overall stack view vertically avoids this with accessibility sizes.
 extension FilteredOrdersHeaderBar {
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        guard let previousTraitCollection,
-              traitCollection.preferredContentSizeCategory != previousTraitCollection.preferredContentSizeCategory else {
-            return
-        }
-        updateStackViewAxis(for: traitCollection)
-    }
-
     private func updateStackViewAxis(for traitCollection: UITraitCollection) {
         if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
             headerBarLayoutStackView.axis = .vertical

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
@@ -38,7 +38,9 @@ final class FilteredOrdersHeaderBar: UIView {
         super.willMove(toSuperview: newSuperview)
 
         if newSuperview != nil {
-            contentSizeTraitRegistration = registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { [weak self] (_: FilteredOrdersHeaderBar, _: UITraitCollection) in
+            contentSizeTraitRegistration = registerForTraitChanges([
+                UITraitPreferredContentSizeCategory.self
+            ]) { [weak self] (_: FilteredOrdersHeaderBar, _: UITraitCollection) in
                 guard let self = self else { return }
                 self.updateStackViewAxis(for: self.traitCollection)
             }


### PR DESCRIPTION
Part of WOOMOB-1003

## Description
This PR addresses `traitCollectionDidChange' was deprecated in iOS 17.0: Use the trait change registration APIs declared in the UITraitChangeObservable protocol` warning in the refund flow. 

In the new API (iOS17+), we register the traits we care about when initializing the view and the system will call the handler when traits change, rather than doing a subclass override.

## Testing information
- Add a breakpoint to one of the functions that is called on category size updates, example on  `IssueRefundViewController.configureHeaderStackView()` in line 187, and `RefundItemTableViewCell.adjustItemsStackViewAxis()` line 98
- Go to Orders, find a completed order, tap on `Refund`, observe the breakpoint is called. 
- Increase or decrease the category size (`cmd` + `option` + `+`) to trigger the trait observation change, note the breakpoint is triggered again

<img width="885" height="526" alt="Screenshot 2025-09-04 at 11 13 41" src="https://github.com/user-attachments/assets/b28f32c1-e570-4618-bc3b-ad229d664051" />
