### PR TITLE
[WCiOS17] Use `registerForTraitChanges` in order views, and miscellanea warnings around POS/variations

### DIFF
--- a/Modules/Sources/Networking/Model/POSProductVariation.swift
+++ b/Modules/Sources/Networking/Model/POSProductVariation.swift
@@ -94,7 +94,8 @@ public struct POSProductVariation: Codable, Equatable, GeneratedCopiable, Genera
                     guard value.lowercased() == Values.manageStockParent else {
                         let message = "Unexpected manage stock value: \(value)"
                         assertionFailure(message)
-                        DDLogError(message)
+                        let formattedMessage = DDLogMessageFormat(stringLiteral: message)
+                        DDLogError(formattedMessage)
                         return false
                     }
                     return false

--- a/Modules/Sources/Networking/Model/Product/ProductVariation.swift
+++ b/Modules/Sources/Networking/Model/Product/ProductVariation.swift
@@ -273,7 +273,8 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
                                                                     guard value.lowercased() == Values.manageStockParent else {
                                                                         let message = "Unexpected manage stock value: \(value)"
                                                                         assertionFailure(message)
-                                                                        DDLogError(message)
+                                                                        let formattedMessage = DDLogMessageFormat(stringLiteral: message)
+                                                                        DDLogError(formattedMessage)
                                                                         return false
                                                                     }
                                                                     return false

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSFullScreenCover.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSFullScreenCover.swift
@@ -77,7 +77,7 @@ struct POSFullScreenCoverModifier<CoverContent: View>: ViewModifier {
                     .environmentObject(sheetManager)
                     .environmentObject(coverManager)
             })
-            .onChange(of: isPresented) { newValue in
+            .onChange(of: isPresented) { _, newValue in
                 parentCoverManager.isPresented = newValue
             }
     }
@@ -104,7 +104,7 @@ struct POSFullScreenCoverModifierForItem<Item: Identifiable & Equatable, CoverCo
                     .environmentObject(sheetManager)
                     .environmentObject(coverManager)
             })
-            .onChange(of: item) { newValue in
+            .onChange(of: item) { _, newValue in
                 parentCoverManager.isPresented = newValue != nil
             }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -33,6 +33,7 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
 
     /// Retains the content trait registration token, so it's not deallocated immediately
     ///
+    // periphery: ignore - False negative. Perhaps does not catch non-dreict reads?
     private var contentSizeTraitRegistration: UITraitChangeRegistration?
 
     static func register(for tableView: UITableView) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -31,6 +31,10 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
     ///
     @IBOutlet weak var contentStackView: UIStackView!
 
+    /// Retains the content trait registration token, so it's not deallocated immediately
+    ///
+    private var contentSizeTraitRegistration: UITraitChangeRegistration?
+
     static func register(for tableView: UITableView) {
         tableView.registerNib(for: self)
     }
@@ -75,17 +79,7 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
 
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if traitCollection.preferredContentSizeCategory > .extraExtraLarge {
-            contentStackView.axis = .vertical
-        } else {
-            contentStackView.axis = .horizontal
-        }
-    }
-
     // MARK: - Overridden Methods
-
     override func awakeFromNib() {
         super.awakeFromNib()
         configureBackground()
@@ -107,18 +101,38 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         paymentStatusLabel.layer.borderColor = UIColor.clear.cgColor
+        contentSizeTraitRegistration = nil
     }
 
     override func updateConfiguration(using state: UICellConfigurationState) {
         super.updateConfiguration(using: state)
         updateDefaultBackgroundConfiguration(using: state)
     }
+
+    override func willMove(toSuperview newSuperview: UIView?) {
+        super.willMove(toSuperview: newSuperview)
+        
+        // Registers for trait changes when the cell is about to be added to view hierarchy,
+        // applies initial layout, and cleans up when removed from hierarchy
+        if newSuperview != nil {
+            contentSizeTraitRegistration = registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { [weak self] (_: OrderTableViewCell, _: UITraitCollection) in
+                self?.applyContentSizeCategoryLayout()
+            }
+            applyContentSizeCategoryLayout()
+        } else {
+            contentSizeTraitRegistration = nil
+        }
+    }
 }
 
-
-// MARK: - Private
-//
 private extension OrderTableViewCell {
+    func applyContentSizeCategoryLayout() {
+        if traitCollection.preferredContentSizeCategory > .extraExtraLarge {
+            contentStackView.axis = .vertical
+        } else {
+            contentStackView.axis = .horizontal
+        }
+    }
 
     /// Reset the UI to a "no data" state.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -111,11 +111,13 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
 
     override func willMove(toSuperview newSuperview: UIView?) {
         super.willMove(toSuperview: newSuperview)
-        
+
         // Registers for trait changes when the cell is about to be added to view hierarchy,
         // applies initial layout, and cleans up when removed from hierarchy
         if newSuperview != nil {
-            contentSizeTraitRegistration = registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { [weak self] (_: OrderTableViewCell, _: UITraitCollection) in
+            contentSizeTraitRegistration = registerForTraitChanges([
+                UITraitPreferredContentSizeCategory.self
+            ]) { [weak self] (_: OrderTableViewCell, _: UITraitCollection) in
                 self?.applyContentSizeCategoryLayout()
             }
             applyContentSizeCategoryLayout()

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -33,7 +33,7 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
 
     /// Retains the content trait registration token, so it's not deallocated immediately
     ///
-    // periphery: ignore - False negative. Perhaps does not catch non-dreict reads?
+    // periphery: ignore - False negative. Perhaps does not catch non-direct reads?
     private var contentSizeTraitRegistration: UITraitChangeRegistration?
 
     static func register(for tableView: UITableView) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
@@ -14,7 +14,7 @@ final class FilteredOrdersHeaderBar: UIView {
 
     /// Retains the content trait registration token, so it's not deallocated immediately
     ///
-    // periphery: ignore - False negative. Perhaps does not catch non-dreict reads?
+    // periphery: ignore - False negative. Perhaps does not catch non-direct reads?
     private var contentSizeTraitRegistration: UITraitChangeRegistration?
 
     /// The number of filters applied

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
@@ -14,6 +14,7 @@ final class FilteredOrdersHeaderBar: UIView {
 
     /// Retains the content trait registration token, so it's not deallocated immediately
     ///
+    // periphery: ignore - False negative. Perhaps does not catch non-dreict reads?
     private var contentSizeTraitRegistration: UITraitChangeRegistration?
 
     /// The number of filters applied

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
@@ -12,6 +12,10 @@ final class FilteredOrdersHeaderBar: UIView {
 
     private let bottomBorder = CALayer()
 
+    /// Retains the content trait registration token, so it's not deallocated immediately
+    ///
+    private var contentSizeTraitRegistration: UITraitChangeRegistration?
+
     /// The number of filters applied
     ///
     private var numberOfFilters = 0
@@ -28,6 +32,19 @@ final class FilteredOrdersHeaderBar: UIView {
         configureButtons()
         configureBackground()
         updateStackViewAxis(for: traitCollection)
+    }
+
+    override func willMove(toSuperview newSuperview: UIView?) {
+        super.willMove(toSuperview: newSuperview)
+
+        if newSuperview != nil {
+            contentSizeTraitRegistration = registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { [weak self] (_: FilteredOrdersHeaderBar, _: UITraitCollection) in
+                guard let self = self else { return }
+                self.updateStackViewAxis(for: self.traitCollection)
+            }
+        } else {
+            contentSizeTraitRegistration = nil
+        }
     }
 
     override func layoutSubviews() {
@@ -55,16 +72,6 @@ final class FilteredOrdersHeaderBar: UIView {
 /// The `Last updated: time` tends to get truncated at larger text sizes by the filter button.
 /// Laying out the overall stack view vertically avoids this with accessibility sizes.
 extension FilteredOrdersHeaderBar {
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        guard let previousTraitCollection,
-              traitCollection.preferredContentSizeCategory != previousTraitCollection.preferredContentSizeCategory else {
-            return
-        }
-        updateStackViewAxis(for: traitCollection)
-    }
-
     private func updateStackViewAxis(for traitCollection: UITraitCollection) {
         if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
             headerBarLayoutStackView.axis = .vertical

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
@@ -38,7 +38,9 @@ final class FilteredOrdersHeaderBar: UIView {
         super.willMove(toSuperview: newSuperview)
 
         if newSuperview != nil {
-            contentSizeTraitRegistration = registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { [weak self] (_: FilteredOrdersHeaderBar, _: UITraitCollection) in
+            contentSizeTraitRegistration = registerForTraitChanges([
+                UITraitPreferredContentSizeCategory.self
+            ]) { [weak self] (_: FilteredOrdersHeaderBar, _: UITraitCollection) in
                 guard let self = self else { return }
                 self.updateStackViewAxis(for: self.traitCollection)
             }


### PR DESCRIPTION
Part of WOOMOB-1003

This PR addresses several iOS17 warnings of work Peacock has done recently around Orders/POS:

## Description & Testing

**1. DDLog deprecation. Use interpolated DDLogMessageFormat instead.**

- Make variation `manage_stock` decode fail (or easier: copy-paste the logging block at the beginning of the mapping flow with any value), observe the error message logged in the console `Unexpected manage stock value: parent`.
- Go to `Help and support` > `view application log` > `current` > scroll almost to the bottom > see the error logged normally:

<img width="780" height="355" alt="Screenshot 2025-09-04 at 11 46 17" src="https://github.com/user-attachments/assets/d629c26d-8ccb-4d8c-a22f-9bb262aa009a" />


**2. POSFullScreenCover usage of new .onChange API**

We just add the unused `_` param for `oldValue`, which is not used.


**3. Use `registerForTraitChanges` API **

In iOS17, overriding `traitCollectionDidChange` is deprecated in favor of registering the trait in the system via `contentSizeTraitRegistration`, then react to changes. I've updated this in 2 places in the Orders view
- OrderTableViewCell.swift
- FilteredOrdersHeaderBar.swift

In `OrderTableViewCell`, add a debugprint in lines 133 and 135, navigate to Orders, update the dynamic font size `cmd` + `option` + `(+/-)`, and observe that the print is called in each change:
```
func applyContentSizeCategoryLayout() {
        if traitCollection.preferredContentSizeCategory > .extraExtraLarge {
            debugPrint("🍍 > .extraLarge")
            contentStackView.axis = .vertical
        } else {
            debugPrint("🍍 ...")
            contentStackView.axis = .horizontal
        }
    }
```
Note as well how the Filter button in the order list stack vertically when we exceed the dynamic size, and returns back to be horizontal in smaller sizes (the _Last Update_ date is still cut-off, but this is unrelated to the changes):

https://github.com/user-attachments/assets/48bce3bf-365e-4e0f-af18-5caa23d0051c
