### PR TITLE
Shipping Labels: Fix issue mapping shipments after updating for REST API response

### DIFF
--- a/Modules/Sources/Networking/Mapper/WooShippingUpdateShipmentMapper.swift
+++ b/Modules/Sources/Networking/Mapper/WooShippingUpdateShipmentMapper.swift
@@ -7,9 +7,9 @@ struct WooShippingUpdateShipmentMapper: Mapper {
     ///
     func map(response: Data) throws -> WooShippingShipments {
         let decoder = JSONDecoder()
-        if hasDataEnvelope(in: response) {
+        do {
             return try decoder.decode(WooShippingUpdateShipmentResponseEnvelope.self, from: response).data.shipments
-        } else {
+        } catch {
             return try decoder.decode(WooShippingUpdateShipmentResponse.self, from: response).shipments
         }
     }

--- a/Modules/Tests/NetworkingTests/Mapper/WooShippingUpdateShipmentMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/WooShippingUpdateShipmentMapperTests.swift
@@ -20,7 +20,7 @@ final class WooShippingUpdateShipmentMapperTests: XCTestCase {
     }
 
     func test_shipments_are_properly_parsed_when_response_has_no_data_envelope() throws {
-        guard let shipments = mapLoadShippingLabelConfig() else {
+        guard let shipments = mapLoadShippingLabelConfigWithoutDataEnvelope() else {
             XCTFail()
             return
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1261

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes an issue with parsing data in the response of update shipment endpoint when using REST API.

The cause of the issue is that the response contains `data` field, so the mapper mistakes it with the `data` envelope and expects an object instead of string.

The solution is to use `do-catch` instead when mapping the response.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Log in to a test store with Woo Shipping set up using site credentials.
- Navigate to the Orders tab and select a completed order with more than 1 physical products.
- Select Split shipments and move items around.
- Tap Done to save the update.
- Confirm that saving succeeds and the Split shipments screen is dismissed.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Confirmed the fix with simulator iPhone 16 iOS 18.2 and updated the incorrect unit test.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before:


https://github.com/user-attachments/assets/105f456b-cf34-40f9-87d4-9a33996c1110



After:


https://github.com/user-attachments/assets/19ec40e2-d389-4225-a3d4-05ffaa4b794f



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.