### PR TITLE
Treat coupons as expired when we reach expiry date

### DIFF
--- a/Modules/Sources/Yosemite/PointOfSale/Coupons/POSCoupon.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Coupons/POSCoupon.swift
@@ -17,6 +17,6 @@ public struct POSCoupon: Equatable, Hashable {
         guard let dateExpires = dateExpires else {
             return false
         }
-        return dateExpires < Date()
+        return dateExpires <= Date()
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We have a test for `test_isExpired_when_current_date_then_returns_true`, however, we didn’t quite match that. We actually relied on a small amount of time elapsing between the call to create the POSCoupon with `Date.now` and the check for whether the coupon had expired.

In some test runs, there was no measurable time change, so the test would fail.

This fixes the implementation to match the test, and general understanding of an expiry time – when you reach the time, the coupon expires.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Find the test `POSCouponTests.test_isExpired_when_current_date_then_returns_true` in the test navigator
2. Right click and select "Run test repeatedly", then run it 100 times
3. Observe that all the test runs pass.

Previously, one of them was likely to fail, at least.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="1510" height="822" alt="CleanShot 2025-09-04 at 12 04 00@2x" src="https://github.com/user-attachments/assets/5e1c4868-135c-463f-a3ac-7740b1028c8e" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
