### PR TITLE
Blaze: Fix issue dismissing product selector in the campaign list view

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 23.2
 -----
+- [*] Blaze: Fixed issue dismissing the Blaze flow from an empty campaign list. [https://github.com/woocommerce/woocommerce-ios/pull/16085]
 - [*] POS: Enhanced cash payment experience with pre-filled amounts. [https://github.com/woocommerce/woocommerce-ios/pull/16058]
 - [*] POS: Point of Sale settings are now accessible in POS mode [https://github.com/woocommerce/woocommerce-ios/pull/16067]
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -32,7 +32,12 @@ final class BlazeCampaignListHostingController: UIHostingController<BlazeCampaig
         super.init(rootView: BlazeCampaignListView(viewModel: viewModel))
 
         rootView.onCreateCampaign = { [weak self] productID in
-            self?.startCampaignCreation(productID: productID)
+            self?.startCampaignCoordinator(productID: productID)
+        }
+
+        rootView.onShowIntro = { [weak self] in
+            guard self?.coordinator == nil else { return }
+            self?.startCampaignCoordinator(showsIntro: true)
         }
     }
 
@@ -45,14 +50,14 @@ final class BlazeCampaignListHostingController: UIHostingController<BlazeCampaig
         super.viewDidAppear(animated)
         if startsCampaignCreationOnAppear {
             startsCampaignCreationOnAppear = false
-            startCampaignCreation()
+            startCampaignCoordinator()
         }
     }
 }
 
 /// Private helper
 private extension BlazeCampaignListHostingController {
-    func startCampaignCreation(productID: Int64? = nil) {
+    func startCampaignCoordinator(productID: Int64? = nil, showsIntro: Bool = false) {
         guard let navigationController else {
             return
         }
@@ -61,7 +66,7 @@ private extension BlazeCampaignListHostingController {
             siteURL: viewModel.siteURL,
             productID: productID,
             source: .campaignList,
-            shouldShowIntro: viewModel.shouldShowIntroView,
+            shouldShowIntro: showsIntro,
             navigationController: navigationController,
             onCampaignCreated: { [weak self] in
                 self?.viewModel.didCreateCampaign()
@@ -104,6 +109,7 @@ struct BlazeCampaignListView: View {
     @ObservedObject private var viewModel: BlazeCampaignListViewModel
 
     var onCreateCampaign: (Int64?) -> Void = { _ in }
+    var onShowIntro: () -> Void = {}
 
     init(viewModel: BlazeCampaignListViewModel) {
         self.viewModel = viewModel
@@ -155,9 +161,12 @@ struct BlazeCampaignListView: View {
         }) { url in
             detailView(url: url)
         }
-        .onChange(of: viewModel.shouldShowIntroView) { shouldShow in
+        .onChange(of: viewModel.shouldShowIntroView) { _, shouldShow in
+            /// Hack: since the campaign creation coordinator takes care of the intro modal,
+            /// the view triggers creating coordinator in the hosting controller
+            /// and manually sets shouldShowIntroView to false.
             if shouldShow {
-                onCreateCampaign(nil)
+                onShowIntro()
                 viewModel.shouldShowIntroView = false
             }
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1247

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

**Problem**
The product selector cannot be dismissed when tapping on Create button in the Menu > Blaze campaign list view.

**Cause**
- `BlazeCampaignCreationCoordinator` handles both creation flow and the presentation of the introduction modal.
- The campaign list uses a hack to display the intro modal by triggering the creation of the coordinator.
- When opening an empty campaign list, the view would try to present the intro modal. If one taps the Create button quickly before the intro modal can be presented, the coordinator is overwritten in an attempt to display the intro modal. As a result, the old coordinator is deallocated and cannot handle the dismissal of the product selector.

**Solution**
The best solution would be to separate the introduction modal from the `BlazeCampaignCreationCoordinator`. However, due to the limited time, this PR addresses the issue by preventing the overwriting of the coordinator when attempting to present the intro modal.


## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Log in to a Jetpack store with existing products but no Blaze campaign yet.
- Navigate to Menu > Blaze > quickly tap Create button before the intro modal can be displayed.
- Confirm that you can dismiss the product selector.
- Navigate out and back to Blaze again. Confirm that the intro modal can still be displayed.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested and confirmed with simulator iPad mini iOS 18.4.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/d20c6748-08b7-427d-a627-6cc5990efc1f



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.