### PR TITLE
Use `applicationPasswordExperiment` local FF as condition for feature toggle visibility

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/ApplicationPasswordsExperimentState.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/ApplicationPasswordsExperimentState.swift
@@ -58,7 +58,10 @@ final class ApplicationPasswordsExperimentAvailabilityChecker: ApplicationPasswo
     func fetchAvailability() async -> Bool {
         await withCheckedContinuation { continuation in
             //TODO: - put the remote FF checking here
-            let mockResultValue = true
+            //For now rely on local FF for mocked value to avoid unwanted exposure
+            let mockResultValue = ServiceLocator.featureFlagService.isFeatureFlagEnabled(
+                .applicationPasswordExperiment
+            )
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
                 continuation.resume(returning: mockResultValue)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
[WOOMOB-1189](https://linear.app/a8c/issue/WOOMOB-1189)

This is a follow UP PR to also include local FF value in release since the [Make Application Passwords toggle visible only for WP.com authenticated users](https://github.com/woocommerce/woocommerce-ios/pull/16086) didn't make it in code freeze. Only including the local FF value usage according to [suggestion](https://github.com/woocommerce/woocommerce-ios/pull/16086#discussion_r2324360937).

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.