### PR TITLE
Watch app: Fix crash when authenticated with site credentials

### DIFF
--- a/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -3,8 +3,10 @@ import enum Alamofire.AFError
 import struct Alamofire.HTTPMethod
 import KeychainAccess
 
-#if canImport(UIKit)
+#if !os(watchOS)
 import UIKit
+#else
+import WatchKit
 #endif
 
 public enum ApplicationPasswordUseCaseError: Error {
@@ -148,13 +150,16 @@ final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
 private extension DefaultApplicationPasswordUseCase {
     /// Helper method to create password name from device
     static func createPasswordName() -> String {
-        #if !os(watchOS)
         let bundleIdentifier = Bundle.main.bundleIdentifier ?? "Unknown"
+        #if !os(watchOS)
         let model = UIDevice.current.model
         let identifierForVendor = UIDevice.current.identifierForVendor?.uuidString ?? ""
         return "\(bundleIdentifier).ios-app-client.\(model).\(identifierForVendor)"
         #else
-        fatalError("Unexpected error: Application password should not be generated through watch app")
+        let model = WKInterfaceDevice.current().model
+        let identifierForVendor =
+        WKInterfaceDevice.current().identifierForVendor?.uuidString ?? ""
+        return "\(bundleIdentifier).watch-app-client.\(model).\(identifierForVendor)"
         #endif
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1279

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

There are recently a few crashes on the watch app in version 23.0, the crashlog indicates an assertion failure in `DefaultRequestAuthenticator.generateApplicationPassword()`. In `DefaultApplicationPasswordUseCase`, we do have a `fatalError` when the app attempts to generate password from the watch, assuming this doesn't happen because the watch should be able to pick up the app password from the keychain after it was created upon iOS app login. The crash on 23.0 therefore is quite hard to reproduce.

When trying the app on 23.2, the watch app crashes 100% when logging in to the app with site credentials. In this version, I moved the creation of app name to the initializer of `DefaultApplicationPasswordUseCase` to help with unit tests. This causes the watch app to crash whenever `AlamofireNetwork` is initalized.

This PR addresses the crash by properly getting the model name from WatchKit. This is used to set as the name for the app password if generating a password from the watch app is needed.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Log in to the iOS app with site credentials. Ensure to go through the credentials-only path, not the web view path. If you're shown the web view, proceed to log in then log out and try again.
- Once login succeeds, open the watch app. Confirm that the app doesn't crash upon launch and the order list is loaded successfully.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested with both simulator (debug build) and physical devices (alpha build).

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.