### PR TITLE
[CIAB] Distinguish between Garden/CIAB and regular sites

### DIFF
--- a/WooCommerce/Classes/CIAB/CIABAffectedFeature.swift
+++ b/WooCommerce/Classes/CIAB/CIABAffectedFeature.swift
@@ -1,0 +1,22 @@
+/// Describes the feature set affected by CIAB sites
+/// By the moment of introduction the features aren't supported by CIAB sites
+
+/// periphery: ignore:all - Used through `.allCases`
+enum CIABAffectedFeature: CaseIterable {
+    case blaze
+    case payments
+    case splitShipments
+    case groupedProducts
+    case variableProducts
+    case giftCardEditing
+    case productsStockDashboardCard
+}
+
+extension CIABAffectedFeature {
+    /// Defines a collection of existing app features unsupported in CIAB sites
+    /// In case if a certain feature is reconsidered and decided to be supported in CIAB
+    /// just remove it from the collection
+    static var unsupportedFeatures: [CIABAffectedFeature] {
+        return CIABAffectedFeature.allCases
+    }
+}

--- a/WooCommerce/Classes/CIAB/CIABEligibilityChecker.swift
+++ b/WooCommerce/Classes/CIAB/CIABEligibilityChecker.swift
@@ -22,13 +22,18 @@ final class CIABEligibilityChecker {
 
 extension CIABEligibilityChecker: CIABEligibilityCheckerProtocol {
     var isCurrentSiteCIAB: Bool {
-        /// Temp mocked value
-        return true
+        guard let currentSite = stores.sessionManager.defaultSite else {
+            return false
+        }
+        return isSiteCIAB(currentSite)
     }
 
     func isSiteCIAB(_ site: Site) -> Bool {
-        /// Temp mocked value
-        return true
+        /// Temp logic
+        /// If site name contains either `garden` or `ciab` then it's considered a CIAB site
+        return isCIABSupportedForBuildEnvironment && CIABUnlockingSiteNameSubstrings.allCases.contains {
+            site.name.lowercased().contains($0.rawValue)
+        }
     }
 
     func isFeatureSupportedForCurrentSite(_ feature: CIABAffectedFeature) -> Bool {
@@ -40,5 +45,25 @@ extension CIABEligibilityChecker: CIABEligibilityCheckerProtocol {
         for site: Site
     ) -> Bool {
         return !isSiteCIAB(site) || !CIABAffectedFeature.unsupportedFeatures.contains(feature)
+    }
+}
+
+// MARK: - Temporary constants for CIAB identifying logic
+
+fileprivate extension CIABEligibilityChecker {
+    enum CIABUnlockingSiteNameSubstrings: String, CaseIterable {
+        case garden
+        case ciab
+    }
+}
+
+// MARK: - Temporary environment checks
+
+import enum WooFoundationCore.BuildConfiguration
+
+private extension CIABEligibilityChecker {
+    var isCIABSupportedForBuildEnvironment: Bool {
+        let buildConfig = BuildConfiguration.current
+        return buildConfig == .localDeveloper || buildConfig == .alpha
     }
 }

--- a/WooCommerce/Classes/CIAB/CIABEligibilityChecker.swift
+++ b/WooCommerce/Classes/CIAB/CIABEligibilityChecker.swift
@@ -1,0 +1,44 @@
+/// periphery: ignore:all - Will be used in upcoming PRs
+
+import Foundation
+import Yosemite
+
+protocol CIABEligibilityCheckerProtocol {
+    var isCurrentSiteCIAB: Bool { get }
+
+    func isSiteCIAB(_ site: Site) -> Bool
+
+    func isFeatureSupportedForCurrentSite(_ feature: CIABAffectedFeature) -> Bool
+    func isFeatureSupported(_ feature: CIABAffectedFeature, for site: Site) -> Bool
+}
+
+final class CIABEligibilityChecker {
+    private let stores: StoresManager
+
+    init(stores: StoresManager = ServiceLocator.stores) {
+        self.stores = stores
+    }
+}
+
+extension CIABEligibilityChecker: CIABEligibilityCheckerProtocol {
+    var isCurrentSiteCIAB: Bool {
+        /// Temp mocked value
+        return true
+    }
+
+    func isSiteCIAB(_ site: Site) -> Bool {
+        /// Temp mocked value
+        return true
+    }
+
+    func isFeatureSupportedForCurrentSite(_ feature: CIABAffectedFeature) -> Bool {
+        return !isCurrentSiteCIAB || !CIABAffectedFeature.unsupportedFeatures.contains(feature)
+    }
+
+    func isFeatureSupported(
+        _ feature: CIABAffectedFeature,
+        for site: Site
+    ) -> Bool {
+        return !isSiteCIAB(site) || !CIABAffectedFeature.unsupportedFeatures.contains(feature)
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1243,6 +1243,8 @@
 		2DB891692E27F6200001B175 /* OrderListCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB891682E27F61C0001B175 /* OrderListCellViewModel.swift */; };
 		2DB8916B2E27F6D90001B175 /* OrderListCellViewModel+Localizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB8916A2E27F6CE0001B175 /* OrderListCellViewModel+Localizations.swift */; };
 		2DB8916E2E27F7840001B175 /* OrderListCellViewModel+Localizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB8916A2E27F6CE0001B175 /* OrderListCellViewModel+Localizations.swift */; };
+		2DCB54FA2E6AE8E100621F90 /* CIABEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCB54F92E6AE8D800621F90 /* CIABEligibilityChecker.swift */; };
+		2DCB54FC2E6AFE6A00621F90 /* CIABAffectedFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCB54FB2E6AFE6900621F90 /* CIABAffectedFeature.swift */; };
 		2DF0D1BC2E2907C100F8995C /* MarkOrderAsReadUseCase+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB88DA32E27DD790001B175 /* MarkOrderAsReadUseCase+Woo.swift */; };
 		310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */; };
 		311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */; };
@@ -4430,6 +4432,8 @@
 		2DB891652E27F07E0001B175 /* Address+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Address+Shared.swift"; sourceTree = "<group>"; };
 		2DB891682E27F61C0001B175 /* OrderListCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListCellViewModel.swift; sourceTree = "<group>"; };
 		2DB8916A2E27F6CE0001B175 /* OrderListCellViewModel+Localizations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderListCellViewModel+Localizations.swift"; sourceTree = "<group>"; };
+		2DCB54F92E6AE8D800621F90 /* CIABEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIABEligibilityChecker.swift; sourceTree = "<group>"; };
+		2DCB54FB2E6AFE6900621F90 /* CIABAffectedFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIABAffectedFeature.swift; sourceTree = "<group>"; };
 		310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLiveSiteInTestModeView.swift; sourceTree = "<group>"; };
 		311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalDisplayMessage.swift; sourceTree = "<group>"; };
 		311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReader.swift; sourceTree = "<group>"; };
@@ -9051,6 +9055,15 @@
 			path = Images;
 			sourceTree = "<group>";
 		};
+		2DCB54F82E6AE8C900621F90 /* CIAB */ = {
+			isa = PBXGroup;
+			children = (
+				2DCB54FB2E6AFE6900621F90 /* CIABAffectedFeature.swift */,
+				2DCB54F92E6AE8D800621F90 /* CIABEligibilityChecker.swift */,
+			);
+			path = CIAB;
+			sourceTree = "<group>";
+		};
 		318853452639FE7F00F66A9C /* CardReadersV2 */ = {
 			isa = PBXGroup;
 			children = (
@@ -10870,6 +10883,7 @@
 		B56DB3F12049C0B800D4AA8E /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				2DCB54F82E6AE8C900621F90 /* CIAB */,
 				DEB387932C2E7A540025256E /* GoogleAds */,
 				20AE33C32B0510AD00527B60 /* Destinations */,
 				B9F3DAAB29BB714900DDD545 /* App Intents */,
@@ -15342,6 +15356,7 @@
 				029D025E2C231F2A00CB1E75 /* PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressView.swift in Sources */,
 				B95A45E92A77AE2C0073A91F /* CustomerSelectorViewModel.swift in Sources */,
 				024DF3072372C18D006658FE /* AztecUIConfigurator.swift in Sources */,
+				2DCB54FC2E6AFE6A00621F90 /* CIABAffectedFeature.swift in Sources */,
 				EE1B07F32C81CB4B006D9769 /* BlazeLocalNotificationScheduler.swift in Sources */,
 				DE02ABBE2B578D0E008E0AC4 /* CreditCardType.swift in Sources */,
 				020BE74823B05CF2007FE54C /* ProductInventoryEditableData.swift in Sources */,
@@ -16235,6 +16250,7 @@
 				029F29FA24D93E9E004751CA /* EditableProductModel.swift in Sources */,
 				027179E22C08817F0049F0BD /* CardPresentPaymentService.swift in Sources */,
 				20D3D4332C65E59B004CE6E3 /* OrdersRoute.swift in Sources */,
+				2DCB54FA2E6AE8E100621F90 /* CIABEligibilityChecker.swift in Sources */,
 				31FC8CE927B476BA004B9456 /* CardReaderSettingsResultsControllers.swift in Sources */,
 				022266BC2AE7707000614F34 /* ConfigurableBundleItemViewModel.swift in Sources */,
 				D449C52926DFBCCC00D75B02 /* WhatsNewHostingController.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1268

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
- Adds `CIABEligibilityChecker` responsible for checking a site if it's a CIAB site.
- Defines a set of CIAB affected features that won't be supported for CIAB sites. Uses the set for availability checker.
- Temporary evaluates `buildConfig == .localDeveloper || buildConfig == .alpha` and checks if a site name contains either `garden` or `ciab` substrings to determine if a site is CIAB site. This approach will be replaced soon with new API field values. See the tread for more details: p1757415059130279-slack-C03L1NF1EA3  

The checker is not yet used - will be used in upcoming PRs.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
A review and passing CI should be enough. The implemented `CIABEligibilityChecker` isn't yet used around the app and relies on temporary logic.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.