### PR TITLE
[CIAB] Hide Blaze and Payments from hub menu

### DIFF
--- a/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
+++ b/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
@@ -13,9 +13,14 @@ protocol BlazeEligibilityCheckerProtocol {
 /// Checks for Blaze eligibility for a site and its products.
 final class BlazeEligibilityChecker: BlazeEligibilityCheckerProtocol {
     private let stores: StoresManager
+    private let siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol
 
-    init(stores: StoresManager = ServiceLocator.stores) {
+    init(
+        stores: StoresManager = ServiceLocator.stores,
+        siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker()
+    ) {
         self.stores = stores
+        self.siteCIABEligibilityChecker = siteCIABEligibilityChecker
     }
 
     /// Checks if the site is eligible for Blaze.
@@ -39,7 +44,11 @@ final class BlazeEligibilityChecker: BlazeEligibilityCheckerProtocol {
 private extension BlazeEligibilityChecker {
     @MainActor
     func checkSiteEligibility(_ site: Site) async -> Bool {
-        guard site.isAdmin && site.canBlaze else {
+        guard
+            site.isAdmin,
+            site.canBlaze,
+            siteCIABEligibilityChecker.isFeatureSupported(.blaze, for: site)
+        else {
             return false
         }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -85,11 +85,13 @@ final class HubMenuViewModel: ObservableObject {
     private let inboxEligibilityChecker: InboxEligibilityChecker
     private let blazeEligibilityChecker: BlazeEligibilityCheckerProtocol
     private let googleAdsEligibilityChecker: GoogleAdsEligibilityChecker
+    private let siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol
 
     private(set) lazy var inboxViewModel = InboxViewModel(siteID: siteID)
 
     @Published private(set) var shouldShowNewFeatureBadgeOnPayments: Bool = false
 
+    @Published private var isSiteEligibleForPayments = false
     @Published private var isSiteEligibleForBlaze = false
     @Published private var isSiteEligibleForGoogleAds = false
     @Published private var isSiteEligibleForInbox = false
@@ -125,6 +127,7 @@ final class HubMenuViewModel: ObservableObject {
          inboxEligibilityChecker: InboxEligibilityChecker = InboxEligibilityUseCase(),
          blazeEligibilityChecker: BlazeEligibilityCheckerProtocol = BlazeEligibilityChecker(),
          googleAdsEligibilityChecker: GoogleAdsEligibilityChecker = DefaultGoogleAdsEligibilityChecker(),
+         siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker(),
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.credentials = stores.sessionManager.defaultCredentials
@@ -136,6 +139,7 @@ final class HubMenuViewModel: ObservableObject {
         self.inboxEligibilityChecker = inboxEligibilityChecker
         self.blazeEligibilityChecker = blazeEligibilityChecker
         self.googleAdsEligibilityChecker = googleAdsEligibilityChecker
+        self.siteCIABEligibilityChecker = siteCIABEligibilityChecker
         self.cardPresentPaymentsOnboarding = CardPresentPaymentsOnboardingUseCase()
         self.analytics = analytics
         observeSiteForUIUpdates()
@@ -251,30 +255,55 @@ private extension HubMenuViewModel {
     }
 
     func setupGeneralElements() {
-        $shouldShowNewFeatureBadgeOnPayments
-            .combineLatest($isSiteEligibleForInbox,
-                           $isSiteEligibleForBlaze,
-                           $isSiteEligibleForGoogleAds)
-            .map { [weak self] combinedResult -> [HubMenuItem] in
-                guard let self else { return [] }
-                let (shouldShowBadgeOnPayments, eligibleForInbox, eligibleForBlaze, eligibleForGoogleAds) = combinedResult
-                return createGeneralElements(
-                    shouldShowBadgeOnPayments: shouldShowBadgeOnPayments,
-                    eligibleForGoogleAds: eligibleForGoogleAds,
-                    eligibleForBlaze: eligibleForBlaze,
-                    eligibleForInbox: eligibleForInbox
-                )
-            }
-            .assign(to: &$generalElements)
+        Publishers.CombineLatest(
+            $shouldShowNewFeatureBadgeOnPayments,
+            $isSiteEligibleForPayments
+        )
+        .combineLatest(
+            Publishers.CombineLatest3(
+                $isSiteEligibleForInbox,
+                $isSiteEligibleForBlaze,
+                $isSiteEligibleForGoogleAds
+            )
+        )
+        .map { [weak self] combinedResults -> [HubMenuItem] in
+            guard let self else { return [] }
+
+            let ((shouldShowBadgeOnPayments, eligibleForPayments), (eligibleForInbox, eligibleForBlaze, eligibleForGoogleAds)) = combinedResults
+
+            let paymentsEligibility: PaymentsFeatureEligibility = eligibleForPayments ?
+                .eligible(shouldShowBadgeOnPayments: shouldShowBadgeOnPayments) :
+                .ineligible
+
+            return createGeneralElements(
+                paymentsEligibility: paymentsEligibility,
+                eligibleForGoogleAds: eligibleForGoogleAds,
+                eligibleForBlaze: eligibleForBlaze,
+                eligibleForInbox: eligibleForInbox
+            )
+        }
+        .assign(to: &$generalElements)
     }
 
-    func createGeneralElements(shouldShowBadgeOnPayments: Bool,
+    enum PaymentsFeatureEligibility {
+        case ineligible
+        case eligible(shouldShowBadgeOnPayments: Bool)
+    }
+
+    func createGeneralElements(paymentsEligibility: PaymentsFeatureEligibility,
                                eligibleForGoogleAds: Bool,
                                eligibleForBlaze: Bool,
                                eligibleForInbox: Bool) -> [HubMenuItem] {
-        var items: [HubMenuItem] = [
-            Payments(iconBadge: shouldShowBadgeOnPayments ? .dot : nil)
-        ]
+        var items: [HubMenuItem] = []
+
+        switch paymentsEligibility {
+            case .ineligible:
+                break
+            case .eligible(let shouldShowBadgeOnPayments):
+                items.append(
+                    Payments(iconBadge: shouldShowBadgeOnPayments ? .dot : nil)
+                )
+        }
 
         if shouldShowAISettings {
             items.append(AISettings())
@@ -354,7 +383,7 @@ private extension HubMenuViewModel {
     }
 
     func updateMenuItemEligibility(with site: Yosemite.Site) {
-
+        isSiteEligibleForPayments = siteCIABEligibilityChecker.isFeatureSupported(.payments, for: site)
         isSiteEligibleForInbox = inboxEligibilityChecker.isEligibleForInbox(siteID: site.siteID)
 
         Task { @MainActor in

--- a/WooCommerce/WooCommerceTests/Mocks/MockCIABEligibilityChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCIABEligibilityChecker.swift
@@ -26,6 +26,6 @@ final class MockCIABEligibilityChecker: CIABEligibilityCheckerProtocol {
     }
 
     func isFeatureSupported(_ feature: CIABAffectedFeature, for site: Site) -> Bool {
-        return !mockedCIABDisabledFeatures.contains(feature) && mockedCIABSites.contains(site)
+        return !mockedCIABDisabledFeatures.contains(feature) || !mockedCIABSites.contains(site)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEligibilityCheckerTests.swift
@@ -131,6 +131,53 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
         XCTAssertTrue(isEligible)
     }
 
+    @MainActor
+    func test_isEligible_is_true_when_site_is_non_ciab_and_other_requirements_met() async {
+        // Given
+        stores.authenticate(credentials: .wpcom(username: "", authToken: "", siteAddress: ""))
+        let site = mockSite(isEligibleForBlaze: true,
+                            isJetpackThePluginInstalled: false,
+                            isJetpackConnected: true)
+        let siteIsCIABChecker = MockCIABEligibilityChecker(
+            mockedIsCurrentSiteCIAB: false,
+        )
+        let blazeEligibilityChecker = BlazeEligibilityChecker(
+            stores: stores,
+            siteCIABEligibilityChecker: siteIsCIABChecker
+        )
+        mockPluginFetch(remotePlugin: .fake().copy(plugin: Self.pluginSlug, active: true))
+
+        // When
+        let isEligible = await blazeEligibilityChecker.isSiteEligible(site)
+
+        // Then
+        XCTAssertTrue(isEligible)
+    }
+
+    @MainActor
+    func test_isEligible_is_false_when_site_is_ciab_and_other_requirements_met() async {
+        // Given
+        stores.authenticate(credentials: .wpcom(username: "", authToken: "", siteAddress: ""))
+        let site = mockSite(isEligibleForBlaze: true,
+                            isJetpackThePluginInstalled: false,
+                            isJetpackConnected: true)
+        let siteIsCIABChecker = MockCIABEligibilityChecker(
+            mockedIsCurrentSiteCIAB: true,
+            mockedCIABSites: [site]
+        )
+        let blazeEligibilityChecker = BlazeEligibilityChecker(
+            stores: stores,
+            siteCIABEligibilityChecker: siteIsCIABChecker
+        )
+        mockPluginFetch(remotePlugin: .fake().copy(plugin: Self.pluginSlug, active: true))
+
+        // When
+        let isEligible = await blazeEligibilityChecker.isSiteEligible(site)
+
+        // Then
+        XCTAssertFalse(isEligible)
+    }
+
     // MARK: - `isProductEligible`
 
     @MainActor

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -175,7 +175,10 @@ final class HubMenuViewModelTests: XCTestCase {
         stores.updateDefaultStore(.fake().copy(siteID: sampleSiteID))
 
         let blazeEligibilityChecker = MockBlazeEligibilityChecker(isSiteEligible: false)
-        let mockCIABEligibilityChecker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: true)
+        let mockCIABEligibilityChecker = MockCIABEligibilityChecker(
+            mockedIsCurrentSiteCIAB: true,
+            mockedCIABSites: [stores.sessionManager.defaultSite ?? .fake()]
+        )
 
         // When
         let viewModel = HubMenuViewModel(
@@ -201,7 +204,10 @@ final class HubMenuViewModelTests: XCTestCase {
         stores.updateDefaultStore(.fake().copy(siteID: sampleSiteID))
 
         let blazeEligibilityChecker = MockBlazeEligibilityChecker(isSiteEligible: false)
-        let mockCIABEligibilityChecker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: true)
+        let mockCIABEligibilityChecker = MockCIABEligibilityChecker(
+            mockedIsCurrentSiteCIAB: true,
+            mockedCIABSites: [stores.sessionManager.defaultSite ?? .fake()]
+        )
 
         // When
         let viewModel = HubMenuViewModel(

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -167,6 +167,58 @@ final class HubMenuViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_generalElements_does_not_include_blaze_when_site_is_CIAB_site() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        // Setting site ID is required before setting `Site`.
+        stores.updateDefaultStore(storeID: sampleSiteID)
+        stores.updateDefaultStore(.fake().copy(siteID: sampleSiteID))
+
+        let blazeEligibilityChecker = MockBlazeEligibilityChecker(isSiteEligible: false)
+        let mockCIABEligibilityChecker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: true)
+
+        // When
+        let viewModel = HubMenuViewModel(
+            siteID: sampleSiteID,
+            tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
+            stores: stores,
+            blazeEligibilityChecker: blazeEligibilityChecker,
+            siteCIABEligibilityChecker: mockCIABEligibilityChecker
+        )
+
+        viewModel.setupMenuElements()
+
+        // Then
+        XCTAssertNil(viewModel.generalElements.firstIndex(where: { $0.id == HubMenuViewModel.Blaze.id }))
+    }
+
+    @MainActor
+    func test_generalElements_does_not_include_payments_when_site_is_CIAB_site() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        // Setting site ID is required before setting `Site`.
+        stores.updateDefaultStore(storeID: sampleSiteID)
+        stores.updateDefaultStore(.fake().copy(siteID: sampleSiteID))
+
+        let blazeEligibilityChecker = MockBlazeEligibilityChecker(isSiteEligible: false)
+        let mockCIABEligibilityChecker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: true)
+
+        // When
+        let viewModel = HubMenuViewModel(
+            siteID: sampleSiteID,
+            tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
+            stores: stores,
+            blazeEligibilityChecker: blazeEligibilityChecker,
+            siteCIABEligibilityChecker: mockCIABEligibilityChecker
+        )
+
+        viewModel.setupMenuElements()
+
+        // Then
+        XCTAssertNil(viewModel.generalElements.firstIndex(where: { $0.id == HubMenuViewModel.Payments.id }))
+    }
+
+    @MainActor
     func test_generalElements_does_not_include_blaze_when_default_site_is_not_set() {
         // When
         let viewModel = HubMenuViewModel(siteID: sampleSiteID,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1272

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Utilizes `CIABEligibilityChecker` and conditionally removes "Payments" and "Blaze" options from Hub Menu. Also Injects `CIABEligibilityChecker` into `BlazeEligibilityChecker`. `BlazeEligibilityChecker` now takes into account if the site is CIAB.

## Non-CIAB site testing case (default behaviour)
- Use testing site that doesn't contain "garden" or "ciab" in name (this is the temp CIAB / non-CIAB site distinguishing logic).
- Site should be eligible for Blaze.
- Navigate to "Menu" tab.
- Make sure "Payments" and "Blaze" items are presented.

<img width="458" height="385" alt="Снимок экрана 2025-09-10 в 15 48 07" src="https://github.com/user-attachments/assets/2f11db5a-06a4-4838-bc82-4d306e0fd9ea" />

- Navigate to a product on product tab.
- Make sure the "Blaze" item is presented.

<img width="460" height="221" alt="Снимок экрана 2025-09-10 в 15 52 14" src="https://github.com/user-attachments/assets/92b8238e-e056-47bd-9a81-8eb5def2d774" />

## CIAB site testing case
- Add "garden" or "ciab" into site name in admin dashboard
- Restart the app and make sure the name change took place
- Navigate to "Menu" tab.
- Make sure "Payments" and "Blaze" items are NOT presented.

<img width="458" height="280" alt="Снимок экрана 2025-09-10 в 15 41 44" src="https://github.com/user-attachments/assets/263304a4-59c2-4a37-881d-0999503e4b8b" />

- Navigate to a product on product tab.
- Make sure the "Blaze" item is NOT presented.

<img width="457" height="162" alt="Снимок экрана 2025-09-10 в 15 53 27" src="https://github.com/user-attachments/assets/e638d3db-02f1-4a5b-b6bc-bc01744b3d9c" />

## Testing Info
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Tested the above steps on iPhone Simulator 18.4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.