### PR TITLE
[POS][Local Catalog] Use SwiftTesting in SiteSettingsStoreMethodsTests

### DIFF
--- a/Modules/Tests/YosemiteTests/Stores/Helpers/SiteSpecificAppSettingsStoreMethodsTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/Helpers/SiteSpecificAppSettingsStoreMethodsTests.swift
@@ -1,35 +1,29 @@
-import XCTest
+import Foundation
+import Testing
 @testable import Yosemite
 import Storage
 
-final class SiteSpecificAppSettingsStoreMethodsTests: XCTestCase {
-    private var sut: SiteSpecificAppSettingsStoreMethods!
-    private var fileStorage: MockFileStorage!
+struct SiteSpecificAppSettingsStoreMethodsTests {
+    private let fileStorage: MockFileStorage
+    private let sut: SiteSpecificAppSettingsStoreMethods
     private let siteID: Int64 = 123
 
-    override func setUp() {
-        super.setUp()
-        fileStorage = MockFileStorage()
-        sut = SiteSpecificAppSettingsStoreMethods(fileStorage: fileStorage)
-    }
-
-    override func tearDown() {
-        sut = nil
-        fileStorage = nil
-        super.tearDown()
+    init() {
+        self.fileStorage = MockFileStorage()
+        self.sut = SiteSpecificAppSettingsStoreMethods(fileStorage: fileStorage)
     }
 
     // MARK: - Store Settings Tests
 
-    func test_getStoreSettings_returns_default_settings_when_no_data_exists() {
+    @Test func getStoreSettings_returns_default_settings_when_no_data_exists() {
         // When
         let settings = sut.getStoreSettings(for: siteID)
 
         // Then
-        XCTAssertEqual(settings, GeneralStoreSettings())
+        #expect(settings == GeneralStoreSettings())
     }
 
-    func test_getStoreSettings_returns_saved_settings_when_data_exists() throws {
+    @Test func getStoreSettings_returns_saved_settings_when_data_exists() throws {
         // Given
         let expectedSettings = GeneralStoreSettings(storeID: "test-store")
         let existingData = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: expectedSettings])
@@ -39,31 +33,26 @@ final class SiteSpecificAppSettingsStoreMethodsTests: XCTestCase {
         let settings = sut.getStoreSettings(for: siteID)
 
         // Then
-        XCTAssertEqual(settings.storeID, expectedSettings.storeID)
+        #expect(settings.storeID == expectedSettings.storeID)
     }
 
-    func test_setStoreSettings_saves_settings_successfully() throws {
+    @Test func setStoreSettings_saves_settings_successfully() async throws {
         // Given
         let settings = GeneralStoreSettings(storeID: "test-store")
-        let expectation = self.expectation(description: "Settings saved")
 
         // When
-        sut.setStoreSettings(settings: settings, for: siteID) { result in
-            switch result {
-            case .success:
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Expected success but got failure")
+        try await withCheckedThrowingContinuation { continuation in
+            sut.setStoreSettings(settings: settings, for: siteID) { result in
+                continuation.resume(with: result)
             }
         }
 
         // Then
-        wait(for: [expectation], timeout: 1)
         let savedData: GeneralStoreSettingsBySite = try fileStorage.data(for: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
-        XCTAssertEqual(savedData.storeSettingsBySite[siteID]?.storeID, settings.storeID)
+        #expect(savedData.storeSettingsBySite[siteID]?.storeID == settings.storeID)
     }
 
-    func test_setStoreSettings_preserves_existing_settings_for_other_sites() throws {
+    @Test func setStoreSettings_preserves_existing_settings_for_other_sites() async throws {
         // Given
         let otherSiteID: Int64 = 456
         let otherSiteSettings = GeneralStoreSettings(storeID: "other-store")
@@ -71,41 +60,36 @@ final class SiteSpecificAppSettingsStoreMethodsTests: XCTestCase {
         try fileStorage.write(existingData, to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
 
         let newSettings = GeneralStoreSettings(storeID: "test-store")
-        let expectation = self.expectation(description: "Settings saved")
 
         // When
-        sut.setStoreSettings(settings: newSettings, for: siteID) { result in
-            switch result {
-            case .success:
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Expected success but got failure")
+        try await withCheckedThrowingContinuation { continuation in
+            sut.setStoreSettings(settings: newSettings, for: siteID) { result in
+                continuation.resume(with: result)
             }
         }
 
         // Then
-        wait(for: [expectation], timeout: 1)
         let savedData: GeneralStoreSettingsBySite = try fileStorage.data(for: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
-        XCTAssertEqual(savedData.storeSettingsBySite[siteID]?.storeID, newSettings.storeID)
-        XCTAssertEqual(savedData.storeSettingsBySite[otherSiteID]?.storeID, otherSiteSettings.storeID)
+        #expect(savedData.storeSettingsBySite[siteID]?.storeID == newSettings.storeID)
+        #expect(savedData.storeSettingsBySite[otherSiteID]?.storeID == otherSiteSettings.storeID)
     }
 
-    func test_resetStoreSettings_deletes_the_settings_file() throws {
+    @Test func resetStoreSettings_deletes_the_settings_file() throws {
         // Given
         let settings = GeneralStoreSettings(storeID: "test-store")
         try fileStorage.write(GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: settings]),
-                            to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+                              to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
 
         // When
         sut.resetStoreSettings()
 
         // Then
-        XCTAssertTrue(fileStorage.deleteIsHit)
+        #expect(fileStorage.deleteIsHit == true)
     }
 
     // MARK: - Store ID Tests
 
-    func test_setStoreID_updates_store_settings() throws {
+    @Test func setStoreID_updates_store_settings() throws {
         // Given
         let storeID = "test-store-id"
         let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings()])
@@ -116,10 +100,10 @@ final class SiteSpecificAppSettingsStoreMethodsTests: XCTestCase {
 
         // Then
         let savedData: GeneralStoreSettingsBySite = try fileStorage.data(for: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
-        XCTAssertEqual(savedData.storeSettingsBySite[siteID]?.storeID, storeID)
+        #expect(savedData.storeSettingsBySite[siteID]?.storeID == storeID)
     }
 
-    func test_getStoreID_retrieves_saved_store_id() throws {
+    @Test func getStoreID_retrieves_saved_store_id() throws {
         // Given
         let storeID = "test-store-id"
         let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings(storeID: storeID)])
@@ -132,20 +116,20 @@ final class SiteSpecificAppSettingsStoreMethodsTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(retrievedStoreID, storeID)
+        #expect(retrievedStoreID == storeID)
     }
 
     // MARK: - Search Terms Tests
 
-    func test_getSearchTerms_returns_empty_array_when_no_terms_exist() {
+    @Test func getSearchTerms_returns_empty_array_when_no_terms_exist() {
         // When
         let terms = sut.getSearchTerms(for: .product, siteID: siteID)
 
         // Then
-        XCTAssertTrue(terms.isEmpty)
+        #expect(terms.isEmpty)
     }
 
-    func test_getSearchTerms_returns_saved_terms() throws {
+    @Test func getSearchTerms_returns_saved_terms() throws {
         // Given
         let expectedTerms = ["term1", "term2", "term3"]
         let storeSettings = GeneralStoreSettings(searchTermsByKey: ["product_search_terms": expectedTerms])
@@ -156,10 +140,10 @@ final class SiteSpecificAppSettingsStoreMethodsTests: XCTestCase {
         let terms = sut.getSearchTerms(for: .product, siteID: siteID)
 
         // Then
-        XCTAssertEqual(terms, expectedTerms)
+        #expect(terms == expectedTerms)
     }
 
-    func test_setSearchTerms_saves_terms_successfully() throws {
+    @Test func setSearchTerms_saves_terms_successfully() throws {
         // Given
         let terms = ["term1", "term2", "term3"]
         let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings()])
@@ -170,10 +154,10 @@ final class SiteSpecificAppSettingsStoreMethodsTests: XCTestCase {
 
         // Then
         let savedData: GeneralStoreSettingsBySite = try fileStorage.data(for: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
-        XCTAssertEqual(savedData.storeSettingsBySite[siteID]?.searchTermsByKey["product_search_terms"], terms)
+        #expect(savedData.storeSettingsBySite[siteID]?.searchTermsByKey["product_search_terms"] == terms)
     }
 
-    func test_setSearchTerms_preserves_existing_terms_for_other_item_types() throws {
+    @Test func setSearchTerms_preserves_existing_terms_for_other_item_types() throws {
         // Given
         let existingTerms = ["existing1", "existing2"]
         let storeSettings = GeneralStoreSettings(searchTermsByKey: ["variation_search_terms": existingTerms])
@@ -185,11 +169,11 @@ final class SiteSpecificAppSettingsStoreMethodsTests: XCTestCase {
 
         // Then
         let savedData: GeneralStoreSettingsBySite = try fileStorage.data(for: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
-        XCTAssertEqual(savedData.storeSettingsBySite[siteID]?.searchTermsByKey["product_search_terms"], newTerms)
-        XCTAssertEqual(savedData.storeSettingsBySite[siteID]?.searchTermsByKey["variation_search_terms"], existingTerms)
+        #expect(savedData.storeSettingsBySite[siteID]?.searchTermsByKey["product_search_terms"] == newTerms)
+        #expect(savedData.storeSettingsBySite[siteID]?.searchTermsByKey["variation_search_terms"] == existingTerms)
     }
 
-    func test_setSearchTerms_preserves_existing_terms_for_other_sites() throws {
+    @Test func setSearchTerms_preserves_existing_terms_for_other_sites() throws {
         // Given
         let otherSiteID: Int64 = 456
         let otherSiteTerms = ["other1", "other2"]
@@ -202,11 +186,11 @@ final class SiteSpecificAppSettingsStoreMethodsTests: XCTestCase {
 
         // Then
         let savedData: GeneralStoreSettingsBySite = try fileStorage.data(for: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
-        XCTAssertEqual(savedData.storeSettingsBySite[siteID]?.searchTermsByKey["product_search_terms"], newTerms)
-        XCTAssertEqual(savedData.storeSettingsBySite[otherSiteID]?.searchTermsByKey["product_search_terms"], otherSiteTerms)
+        #expect(savedData.storeSettingsBySite[siteID]?.searchTermsByKey["product_search_terms"] == newTerms)
+        #expect(savedData.storeSettingsBySite[otherSiteID]?.searchTermsByKey["product_search_terms"] == otherSiteTerms)
     }
 
-    func test_resetStoreSettings_clears_search_terms() throws {
+    @Test func resetStoreSettings_clears_search_terms() throws {
         // Given
         let terms = ["term1", "term2"]
         let storeSettings = GeneralStoreSettings(searchTermsByKey: ["product_search_terms": terms])
@@ -217,12 +201,12 @@ final class SiteSpecificAppSettingsStoreMethodsTests: XCTestCase {
         sut.resetStoreSettings()
 
         // Then
-        XCTAssertTrue(fileStorage.deleteIsHit)
+        #expect(fileStorage.deleteIsHit == true)
         let savedTerms = sut.getSearchTerms(for: .product, siteID: siteID)
-        XCTAssertTrue(savedTerms.isEmpty)
+        #expect(savedTerms.isEmpty)
     }
 
-    func test_search_terms_work_for_all_item_types() throws {
+    @Test func search_terms_work_for_all_item_types() throws {
         // Given
         let productTerms = ["product1", "product2"]
         let variationTerms = ["variation1", "variation2"]
@@ -241,9 +225,9 @@ final class SiteSpecificAppSettingsStoreMethodsTests: XCTestCase {
         let retrievedCouponTerms = sut.getSearchTerms(for: .coupon, siteID: siteID)
 
         // Then
-        XCTAssertEqual(retrievedProductTerms, productTerms)
-        XCTAssertEqual(retrievedVariationTerms, variationTerms)
-        XCTAssertEqual(retrievedCouponTerms, couponTerms)
+        #expect(retrievedProductTerms == productTerms)
+        #expect(retrievedVariationTerms == variationTerms)
+        #expect(retrievedCouponTerms == couponTerms)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
Part of: WOOMOB-1252

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates `SiteSpecificAppSettingsStoreMethodsTests` to use SwiftTesting, in preparation for new tests to be added in WOOMOB-1252 for storing the last sync date.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Check tests pass locally and in CI

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
