### PR TITLE
[POS][Local Catalog] Add top level catalog sync coordinator

### DIFF
--- a/Modules/Sources/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -115,7 +115,8 @@ extension Storage.GeneralStoreSettings {
         lastSelectedOrderStatus: NullableCopiableProp<String> = .copy,
         favoriteProductIDs: CopiableProp<[Int64]> = .copy,
         searchTermsByKey: CopiableProp<[String: [String]]> = .copy,
-        isPOSTabVisible: NullableCopiableProp<Bool> = .copy
+        isPOSTabVisible: NullableCopiableProp<Bool> = .copy,
+        posLastFullSyncDate: NullableCopiableProp<Date> = .copy
     ) -> Storage.GeneralStoreSettings {
         let storeID = storeID ?? self.storeID
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable
@@ -137,6 +138,7 @@ extension Storage.GeneralStoreSettings {
         let favoriteProductIDs = favoriteProductIDs ?? self.favoriteProductIDs
         let searchTermsByKey = searchTermsByKey ?? self.searchTermsByKey
         let isPOSTabVisible = isPOSTabVisible ?? self.isPOSTabVisible
+        let posLastFullSyncDate = posLastFullSyncDate ?? self.posLastFullSyncDate
 
         return Storage.GeneralStoreSettings(
             storeID: storeID,
@@ -158,7 +160,8 @@ extension Storage.GeneralStoreSettings {
             lastSelectedOrderStatus: lastSelectedOrderStatus,
             favoriteProductIDs: favoriteProductIDs,
             searchTermsByKey: searchTermsByKey,
-            isPOSTabVisible: isPOSTabVisible
+            isPOSTabVisible: isPOSTabVisible,
+            posLastFullSyncDate: posLastFullSyncDate
         )
     }
 }

--- a/Modules/Sources/Storage/Model/GeneralStoreSettings.swift
+++ b/Modules/Sources/Storage/Model/GeneralStoreSettings.swift
@@ -85,7 +85,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     /// Whether the POS tab is visible for this store.
     ///
     public var isPOSTabVisible: Bool?
-    
+
     /// Last time a POS catalog full sync was completed for this store.
     ///
     public var posLastFullSyncDate: Date?

--- a/Modules/Sources/Storage/Model/GeneralStoreSettings.swift
+++ b/Modules/Sources/Storage/Model/GeneralStoreSettings.swift
@@ -85,6 +85,10 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     /// Whether the POS tab is visible for this store.
     ///
     public var isPOSTabVisible: Bool?
+    
+    /// Last time a POS catalog full sync was completed for this store.
+    ///
+    public var posLastFullSyncDate: Date?
 
     public init(storeID: String? = nil,
                 isTelemetryAvailable: Bool = false,
@@ -105,7 +109,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                 lastSelectedOrderStatus: String? = nil,
                 favoriteProductIDs: [Int64] = [],
                 searchTermsByKey: [String: [String]] = [:],
-                isPOSTabVisible: Bool? = nil) {
+                isPOSTabVisible: Bool? = nil,
+                posLastFullSyncDate: Date? = nil) {
         self.storeID = storeID
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
@@ -126,6 +131,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
         self.favoriteProductIDs = favoriteProductIDs
         self.searchTermsByKey = searchTermsByKey
         self.isPOSTabVisible = isPOSTabVisible
+        self.posLastFullSyncDate = posLastFullSyncDate
     }
 
     public func erasingSelectedTaxRateID() -> GeneralStoreSettings {
@@ -147,7 +153,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                              lastSelectedOrderStatus: lastSelectedOrderStatus,
                              favoriteProductIDs: favoriteProductIDs,
                              searchTermsByKey: searchTermsByKey,
-                             isPOSTabVisible: isPOSTabVisible)
+                             isPOSTabVisible: isPOSTabVisible,
+                             posLastFullSyncDate: posLastFullSyncDate)
     }
 }
 
@@ -182,6 +189,7 @@ extension GeneralStoreSettings {
         self.searchTermsByKey = try container.decodeIfPresent([String: [String]].self, forKey: .searchTermsByKey) ?? [:]
 
         self.isPOSTabVisible = try container.decodeIfPresent(Bool.self, forKey: .isPOSTabVisible)
+        self.posLastFullSyncDate = try container.decodeIfPresent(Date.self, forKey: .posLastFullSyncDate)
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/Modules/Sources/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
+++ b/Modules/Sources/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
@@ -11,6 +11,10 @@ public protocol SiteSpecificAppSettingsStoreMethodsProtocol {
     // Search history methods
     func getSearchTerms(for itemType: POSItemType, siteID: Int64) -> [String]
     func setSearchTerms(_ terms: [String], for itemType: POSItemType, siteID: Int64)
+
+    // POS catalog sync timestamp methods
+    func getPOSLastFullSyncDate(for siteID: Int64) -> Date?
+    func setPOSLastFullSyncDate(_ date: Date?, for siteID: Int64)
 }
 
 /// Methods for managing site-specific app settings
@@ -94,6 +98,20 @@ extension SiteSpecificAppSettingsStoreMethods {
         var updatedSearchTermsByKey = storeSettings.searchTermsByKey
         updatedSearchTermsByKey[key] = terms
         let updatedSettings = storeSettings.copy(searchTermsByKey: updatedSearchTermsByKey)
+        setStoreSettings(settings: updatedSettings, for: siteID)
+    }
+}
+
+// MARK: - POS Catalog Sync Timestamps
+extension SiteSpecificAppSettingsStoreMethods {
+    func getPOSLastFullSyncDate(for siteID: Int64) -> Date? {
+        let storeSettings = getStoreSettings(for: siteID)
+        return storeSettings.posLastFullSyncDate
+    }
+
+    func setPOSLastFullSyncDate(_ date: Date?, for siteID: Int64) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let updatedSettings = storeSettings.copy(posLastFullSyncDate: date)
         setStoreSettings(settings: updatedSettings, for: siteID)
     }
 }

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Storage
-import CocoaLumberjackSwift
 
 public protocol POSCatalogSyncCoordinatorProtocol {
     /// Performs a full catalog sync for the specified site

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Storage
+import CocoaLumberjackSwift
+
+public protocol POSCatalogSyncCoordinatorProtocol {
+    /// Performs a full catalog sync for the specified site
+    /// - Parameter siteID: The site ID to sync catalog for
+    /// - Returns: The synced catalog containing products and variations
+    func performFullSync(for siteID: Int64) async throws -> POSCatalog
+
+    /// Determines if a full sync should be performed based on the age of the last sync
+    /// - Parameters:
+    ///   - siteID: The site ID to check
+    ///   - maxAge: Maximum age before a sync is considered stale
+    /// - Returns: True if a sync should be performed
+    func shouldPerformFullSync(for siteID: Int64, maxAge: TimeInterval) -> Bool
+}
+
+public final class POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
+    private let syncService: POSCatalogFullSyncServiceProtocol
+    private let settingsStore: SiteSpecificAppSettingsStoreMethodsProtocol
+
+    public init(syncService: POSCatalogFullSyncServiceProtocol,
+                settingsStore: SiteSpecificAppSettingsStoreMethodsProtocol? = nil) {
+        self.syncService = syncService
+        self.settingsStore = settingsStore ?? SiteSpecificAppSettingsStoreMethods(fileStorage: PListFileStorage())
+    }
+
+    public func performFullSync(for siteID: Int64) async throws -> POSCatalog {
+        DDLogInfo("🔄 POSCatalogSyncCoordinator starting full sync for site \(siteID)")
+
+        let catalog = try await syncService.startFullSync(for: siteID)
+
+        // Record the sync timestamp
+        settingsStore.setPOSLastFullSyncDate(Date(), for: siteID)
+
+        DDLogInfo("✅ POSCatalogSyncCoordinator completed full sync for site \(siteID)")
+        return catalog
+    }
+
+    public func shouldPerformFullSync(for siteID: Int64, maxAge: TimeInterval) -> Bool {
+        guard let lastSyncDate = lastFullSyncDate(for: siteID) else {
+            DDLogInfo("📋 POSCatalogSyncCoordinator: No previous sync found for site \(siteID), sync needed")
+            return true
+        }
+
+        let age = Date().timeIntervalSince(lastSyncDate)
+        let shouldSync = age > maxAge
+
+        if shouldSync {
+            DDLogInfo("📋 POSCatalogSyncCoordinator: Last sync for site \(siteID) was \(Int(age))s ago (max: \(Int(maxAge))s), sync needed")
+        } else {
+            DDLogInfo("📋 POSCatalogSyncCoordinator: Last sync for site \(siteID) was \(Int(age))s ago (max: \(Int(maxAge))s), sync not needed")
+        }
+
+        return shouldSync
+    }
+
+    // MARK: - Private
+
+    private func lastFullSyncDate(for siteID: Int64) -> Date? {
+        return settingsStore.getPOSLastFullSyncDate(for: siteID)
+    }
+}

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -4,8 +4,7 @@ import Storage
 public protocol POSCatalogSyncCoordinatorProtocol {
     /// Performs a full catalog sync for the specified site
     /// - Parameter siteID: The site ID to sync catalog for
-    /// - Returns: The synced catalog containing products and variations
-    func performFullSync(for siteID: Int64) async throws -> POSCatalog
+    func performFullSync(for siteID: Int64) async throws
 
     /// Determines if a full sync should be performed based on the age of the last sync
     /// - Parameters:
@@ -16,25 +15,24 @@ public protocol POSCatalogSyncCoordinatorProtocol {
 }
 
 public final class POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
-    private let syncService: POSCatalogFullSyncServiceProtocol
+    private let fullSyncService: POSCatalogFullSyncServiceProtocol
     private let settingsStore: SiteSpecificAppSettingsStoreMethodsProtocol
 
-    public init(syncService: POSCatalogFullSyncServiceProtocol,
+    public init(fullSyncService: POSCatalogFullSyncServiceProtocol,
                 settingsStore: SiteSpecificAppSettingsStoreMethodsProtocol? = nil) {
-        self.syncService = syncService
+        self.fullSyncService = fullSyncService
         self.settingsStore = settingsStore ?? SiteSpecificAppSettingsStoreMethods(fileStorage: PListFileStorage())
     }
 
-    public func performFullSync(for siteID: Int64) async throws -> POSCatalog {
+    public func performFullSync(for siteID: Int64) async throws {
         DDLogInfo("🔄 POSCatalogSyncCoordinator starting full sync for site \(siteID)")
 
-        let catalog = try await syncService.startFullSync(for: siteID)
+        let catalog = try await fullSyncService.startFullSync(for: siteID)
 
         // Record the sync timestamp
         settingsStore.setPOSLastFullSyncDate(Date(), for: siteID)
 
         DDLogInfo("✅ POSCatalogSyncCoordinator completed full sync for site \(siteID)")
-        return catalog
     }
 
     public func shouldPerformFullSync(for siteID: Int64, maxAge: TimeInterval) -> Bool {

--- a/Modules/Tests/YosemiteTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
@@ -28,6 +28,13 @@ final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStor
     var spySetSearchTermsSiteID: Int64?
     var mockSearchTerms: [POSItemType: [String]] = [:]
 
+    // POS sync timestamp properties
+    var storedDates: [Int64: Date] = [:]
+    private(set) var getPOSLastFullSyncDateCallCount = 0
+    private(set) var setPOSLastFullSyncDateCallCount = 0
+    private(set) var lastSetSiteID: Int64?
+    private(set) var lastSetDate: Date?
+
     func getStoreSettings(for siteID: Int64) -> GeneralStoreSettings {
         getStoreSettingsCalled = true
         return storeSettings
@@ -86,8 +93,14 @@ final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStor
     }
 
     func getPOSLastFullSyncDate(for siteID: Int64) -> Date? {
-        return Date.now
+        getPOSLastFullSyncDateCallCount += 1
+        return storedDates[siteID]
     }
 
-    func setPOSLastFullSyncDate(_ date: Date?, for siteID: Int64) { }
+    func setPOSLastFullSyncDate(_ date: Date?, for siteID: Int64) {
+        setPOSLastFullSyncDateCallCount += 1
+        lastSetSiteID = siteID
+        lastSetDate = date
+        storedDates[siteID] = date
+    }
 }

--- a/Modules/Tests/YosemiteTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
@@ -1,4 +1,5 @@
 @testable import Yosemite
+import Foundation
 import Storage
 
 final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStoreMethodsProtocol {
@@ -83,4 +84,10 @@ final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStor
         spySetSearchTermsSiteID = siteID
         mockSearchTerms[itemType] = terms
     }
+
+    func getPOSLastFullSyncDate(for siteID: Int64) -> Date? {
+        return Date.now
+    }
+
+    func setPOSLastFullSyncDate(_ date: Date?, for siteID: Int64) { }
 }

--- a/Modules/Tests/YosemiteTests/Stores/Helpers/SiteSpecificAppSettingsStoreMethodsTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/Helpers/SiteSpecificAppSettingsStoreMethodsTests.swift
@@ -230,8 +230,6 @@ struct SiteSpecificAppSettingsStoreMethodsTests {
         #expect(retrievedCouponTerms == couponTerms)
     }
 
-
-
     // MARK: - POS Last Full Sync Date Tests
 
     @Test func getPOSLastFullSyncDate_returns_nil_when_no_date_exists() {

--- a/Modules/Tests/YosemiteTests/Stores/Helpers/SiteSpecificAppSettingsStoreMethodsTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/Helpers/SiteSpecificAppSettingsStoreMethodsTests.swift
@@ -229,6 +229,144 @@ struct SiteSpecificAppSettingsStoreMethodsTests {
         #expect(retrievedVariationTerms == variationTerms)
         #expect(retrievedCouponTerms == couponTerms)
     }
+
+
+
+    // MARK: - POS Last Full Sync Date Tests
+
+    @Test func getPOSLastFullSyncDate_returns_nil_when_no_date_exists() {
+        // When
+        let syncDate = sut.getPOSLastFullSyncDate(for: siteID)
+
+        // Then
+        #expect(syncDate == nil)
+    }
+
+    @Test func getPOSLastFullSyncDate_returns_saved_date() throws {
+        // Given
+        let expectedDate = Date()
+        let storeSettings = GeneralStoreSettings(posLastFullSyncDate: expectedDate)
+        let existingData = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: storeSettings])
+        try fileStorage.write(existingData, to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+
+        // When
+        let syncDate = sut.getPOSLastFullSyncDate(for: siteID)
+
+        // Then
+        #expect(syncDate == expectedDate)
+    }
+
+    @Test func setPOSLastFullSyncDate_saves_date_successfully() throws {
+        // Given
+        let dateToSave = Date()
+        let existingData = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: GeneralStoreSettings()])
+        try fileStorage.write(existingData, to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+
+        // When
+        sut.setPOSLastFullSyncDate(dateToSave, for: siteID)
+
+        // Then
+        let savedData: GeneralStoreSettingsBySite = try fileStorage.data(for: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+        #expect(savedData.storeSettingsBySite[siteID]?.posLastFullSyncDate == dateToSave)
+    }
+
+    @Test func setPOSLastFullSyncDate_can_set_nil_date() throws {
+        // Given
+        let existingDate = Date()
+        let storeSettings = GeneralStoreSettings(posLastFullSyncDate: existingDate)
+        let existingData = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: storeSettings])
+        try fileStorage.write(existingData, to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+
+        // When
+        sut.setPOSLastFullSyncDate(nil, for: siteID)
+
+        // Then
+        let savedData: GeneralStoreSettingsBySite = try fileStorage.data(for: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+        #expect(savedData.storeSettingsBySite[siteID]?.posLastFullSyncDate == nil)
+    }
+
+    @Test func setPOSLastFullSyncDate_preserves_other_settings() throws {
+        // Given
+        let existingStoreID = "existing-store"
+        let existingTerms = ["existing", "terms"]
+        let storeSettings = GeneralStoreSettings(
+            storeID: existingStoreID,
+            searchTermsByKey: ["product_search_terms": existingTerms]
+        )
+        let existingData = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: storeSettings])
+        try fileStorage.write(existingData, to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+
+        let dateToSave = Date()
+
+        // When
+        sut.setPOSLastFullSyncDate(dateToSave, for: siteID)
+
+        // Then
+        let savedData: GeneralStoreSettingsBySite = try fileStorage.data(for: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+        let savedSettings = savedData.storeSettingsBySite[siteID]
+        #expect(savedSettings?.posLastFullSyncDate == dateToSave)
+        #expect(savedSettings?.storeID == existingStoreID)
+        #expect(savedSettings?.searchTermsByKey["product_search_terms"] == existingTerms)
+    }
+
+    @Test func setPOSLastFullSyncDate_preserves_dates_for_other_sites() throws {
+        // Given
+        let otherSiteID: Int64 = 456
+        let otherSiteDate = Date().addingTimeInterval(-3600)
+        let otherSiteSettings = GeneralStoreSettings(posLastFullSyncDate: otherSiteDate)
+        let existingData = GeneralStoreSettingsBySite(storeSettingsBySite: [otherSiteID: otherSiteSettings])
+        try fileStorage.write(existingData, to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+
+        let newDate = Date()
+
+        // When
+        sut.setPOSLastFullSyncDate(newDate, for: siteID)
+
+        // Then
+        let savedData: GeneralStoreSettingsBySite = try fileStorage.data(for: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+        #expect(savedData.storeSettingsBySite[siteID]?.posLastFullSyncDate == newDate)
+        #expect(savedData.storeSettingsBySite[otherSiteID]?.posLastFullSyncDate == otherSiteDate)
+    }
+
+    @Test func getPOSLastFullSyncDate_handles_different_sites_independently() throws {
+        // Given
+        let siteA: Int64 = 123
+        let siteB: Int64 = 456
+        let dateA = Date()
+        let dateB = Date().addingTimeInterval(-3600)
+
+        let storeSettingsA = GeneralStoreSettings(posLastFullSyncDate: dateA)
+        let storeSettingsB = GeneralStoreSettings(posLastFullSyncDate: dateB)
+        let existingData = GeneralStoreSettingsBySite(storeSettingsBySite: [
+            siteA: storeSettingsA,
+            siteB: storeSettingsB
+        ])
+        try fileStorage.write(existingData, to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+
+        // When
+        let retrievedDateA = sut.getPOSLastFullSyncDate(for: siteA)
+        let retrievedDateB = sut.getPOSLastFullSyncDate(for: siteB)
+
+        // Then
+        #expect(retrievedDateA == dateA)
+        #expect(retrievedDateB == dateB)
+    }
+
+    @Test func resetStoreSettings_clears_pos_sync_date() throws {
+        // Given
+        let syncDate = Date()
+        let storeSettings = GeneralStoreSettings(posLastFullSyncDate: syncDate)
+        let existingData = GeneralStoreSettingsBySite(storeSettingsBySite: [siteID: storeSettings])
+        try fileStorage.write(existingData, to: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+
+        // When
+        sut.resetStoreSettings()
+
+        // Then
+        #expect(fileStorage.deleteIsHit == true)
+        let retrievedDate = sut.getPOSLastFullSyncDate(for: siteID)
+        #expect(retrievedDate == nil)
+    }
 }
 
 // MARK: - Mock FileStorage

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
@@ -161,4 +161,3 @@ final class MockPOSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol {
         return startFullSyncResult
     }
 }
-

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
@@ -13,7 +13,7 @@ struct POSCatalogSyncCoordinatorTests {
         self.mockSyncService = MockPOSCatalogFullSyncService()
         self.mockSettingsStore = MockSiteSpecificAppSettingsStoreMethods()
         self.sut = POSCatalogSyncCoordinator(
-            syncService: mockSyncService,
+            fullSyncService: mockSyncService,
             settingsStore: mockSettingsStore
         )
     }
@@ -26,14 +26,12 @@ struct POSCatalogSyncCoordinatorTests {
             products: [POSProduct.fake()],
             variations: [POSProductVariation.fake()]
         )
-        mockSyncService.startFullSyncResult = expectedCatalog
+        mockSyncService.startFullSyncResult = .success(expectedCatalog)
 
         // When
-        let result = try await sut.performFullSync(for: sampleSiteID)
+        try await sut.performFullSync(for: sampleSiteID)
 
         // Then
-        #expect(result.products.count == expectedCatalog.products.count)
-        #expect(result.variations.count == expectedCatalog.variations.count)
         #expect(mockSyncService.startFullSyncCallCount == 1)
         #expect(mockSyncService.lastSyncSiteID == sampleSiteID)
     }
@@ -42,7 +40,7 @@ struct POSCatalogSyncCoordinatorTests {
         // Given
         let beforeSync = Date()
         let expectedCatalog = POSCatalog(products: [], variations: [])
-        mockSyncService.startFullSyncResult = expectedCatalog
+        mockSyncService.startFullSyncResult = .success(expectedCatalog)
 
         // When
         _ = try await sut.performFullSync(for: sampleSiteID)
@@ -61,7 +59,7 @@ struct POSCatalogSyncCoordinatorTests {
     @Test func performFullSync_propagates_errors() async throws {
         // Given
         let expectedError = NSError(domain: "sync", code: 500, userInfo: [NSLocalizedDescriptionKey: "Sync failed"])
-        mockSyncService.startFullSyncError = expectedError
+        mockSyncService.startFullSyncResult = .failure(expectedError)
 
         // When/Then
         await #expect(throws: expectedError) {
@@ -144,8 +142,7 @@ struct POSCatalogSyncCoordinatorTests {
 // MARK: - Mock Services
 
 final class MockPOSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol {
-    var startFullSyncResult: POSCatalog = POSCatalog(products: [], variations: [])
-    var startFullSyncError: Error?
+    var startFullSyncResult: Result<POSCatalog, Error> = .success(POSCatalog(products: [], variations: []))
 
     private(set) var startFullSyncCallCount = 0
     private(set) var lastSyncSiteID: Int64?
@@ -154,10 +151,11 @@ final class MockPOSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol {
         startFullSyncCallCount += 1
         lastSyncSiteID = siteID
 
-        if let error = startFullSyncError {
+        switch startFullSyncResult {
+        case .success(let catalog):
+            return catalog
+        case .failure(let error):
             throw error
         }
-
-        return startFullSyncResult
     }
 }

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Testing
+@testable import Yosemite
+import Storage
+
+struct POSCatalogSyncCoordinatorTests {
+    private let mockSyncService: MockPOSCatalogFullSyncService
+    private let mockSettingsStore: MockSiteSpecificAppSettingsStoreMethods
+    private let sut: POSCatalogSyncCoordinator
+    private let sampleSiteID: Int64 = 134
+
+    init() {
+        self.mockSyncService = MockPOSCatalogFullSyncService()
+        self.mockSettingsStore = MockSiteSpecificAppSettingsStoreMethods()
+        self.sut = POSCatalogSyncCoordinator(
+            syncService: mockSyncService,
+            settingsStore: mockSettingsStore
+        )
+    }
+
+    // MARK: - Full Sync Tests
+
+    @Test func performFullSync_delegates_to_sync_service() async throws {
+        // Given
+        let expectedCatalog = POSCatalog(
+            products: [POSProduct.fake()],
+            variations: [POSProductVariation.fake()]
+        )
+        mockSyncService.startFullSyncResult = expectedCatalog
+
+        // When
+        let result = try await sut.performFullSync(for: sampleSiteID)
+
+        // Then
+        #expect(result.products.count == expectedCatalog.products.count)
+        #expect(result.variations.count == expectedCatalog.variations.count)
+        #expect(mockSyncService.startFullSyncCallCount == 1)
+        #expect(mockSyncService.lastSyncSiteID == sampleSiteID)
+    }
+
+    @Test func performFullSync_stores_sync_timestamp() async throws {
+        // Given
+        let beforeSync = Date()
+        let expectedCatalog = POSCatalog(products: [], variations: [])
+        mockSyncService.startFullSyncResult = expectedCatalog
+
+        // When
+        _ = try await sut.performFullSync(for: sampleSiteID)
+        let afterSync = Date()
+
+        // Then
+        #expect(mockSettingsStore.setPOSLastFullSyncDateCallCount == 1)
+        #expect(mockSettingsStore.lastSetSiteID == sampleSiteID)
+
+        let storedDate = mockSettingsStore.lastSetDate
+        #expect(storedDate != nil)
+        #expect(storedDate! >= beforeSync)
+        #expect(storedDate! <= afterSync)
+    }
+
+    @Test func performFullSync_propagates_errors() async throws {
+        // Given
+        let expectedError = NSError(domain: "sync", code: 500, userInfo: [NSLocalizedDescriptionKey: "Sync failed"])
+        mockSyncService.startFullSyncError = expectedError
+
+        // When/Then
+        await #expect(throws: expectedError) {
+            _ = try await sut.performFullSync(for: sampleSiteID)
+        }
+
+        // Should not store timestamp on failure
+        #expect(mockSettingsStore.setPOSLastFullSyncDateCallCount == 0)
+    }
+
+    // MARK: - Should Sync Decision Tests
+
+    @Test func shouldPerformFullSync_returns_true_when_no_previous_sync() {
+        // Given - no previous sync date stored
+        mockSettingsStore.storedDates = [:]
+
+        // When
+        let shouldSync = sut.shouldPerformFullSync(for: sampleSiteID, maxAge: 3600)
+
+        // Then
+        #expect(shouldSync == true)
+        #expect(mockSettingsStore.getPOSLastFullSyncDateCallCount == 1)
+    }
+
+    @Test func shouldPerformFullSync_returns_true_when_sync_is_stale() {
+        // Given - previous sync was 2 hours ago
+        let twoHoursAgo = Date().addingTimeInterval(-2 * 60 * 60)
+        mockSettingsStore.storedDates[sampleSiteID] = twoHoursAgo
+
+        // When - max age is 1 hour
+        let shouldSync = sut.shouldPerformFullSync(for: sampleSiteID, maxAge: 60 * 60)
+
+        // Then
+        #expect(shouldSync == true)
+    }
+
+    @Test func shouldPerformFullSync_returns_false_when_sync_is_fresh() {
+        // Given - previous sync was 30 minutes ago
+        let thirtyMinutesAgo = Date().addingTimeInterval(-30 * 60)
+        mockSettingsStore.storedDates[sampleSiteID] = thirtyMinutesAgo
+
+        // When - max age is 1 hour
+        let shouldSync = sut.shouldPerformFullSync(for: sampleSiteID, maxAge: 60 * 60)
+
+        // Then
+        #expect(shouldSync == false)
+    }
+
+    @Test func shouldPerformFullSync_handles_different_sites_independently() {
+        // Given
+        let siteA: Int64 = 123
+        let siteB: Int64 = 456
+        let oneHourAgo = Date().addingTimeInterval(-60 * 60)
+
+        mockSettingsStore.storedDates[siteA] = oneHourAgo // Has previous sync
+        // siteB has no previous sync
+
+        // When
+        let shouldSyncA = sut.shouldPerformFullSync(for: siteA, maxAge: 2 * 60 * 60) // 2 hours
+        let shouldSyncB = sut.shouldPerformFullSync(for: siteB, maxAge: 2 * 60 * 60) // 2 hours
+
+        // Then
+        #expect(shouldSyncA == false) // Recent sync exists
+        #expect(shouldSyncB == true)  // No previous sync
+    }
+
+    @Test func shouldPerformFullSync_with_zero_maxAge_always_returns_true() {
+        // Given - previous sync was just now
+        let justNow = Date()
+        mockSettingsStore.storedDates[sampleSiteID] = justNow
+
+        // When - max age is 0 (always sync)
+        let shouldSync = sut.shouldPerformFullSync(for: sampleSiteID, maxAge: 0)
+
+        // Then
+        #expect(shouldSync == true)
+    }
+}
+
+// MARK: - Mock Services
+
+final class MockPOSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol {
+    var startFullSyncResult: POSCatalog = POSCatalog(products: [], variations: [])
+    var startFullSyncError: Error?
+
+    private(set) var startFullSyncCallCount = 0
+    private(set) var lastSyncSiteID: Int64?
+
+    func startFullSync(for siteID: Int64) async throws -> POSCatalog {
+        startFullSyncCallCount += 1
+        lastSyncSiteID = siteID
+
+        if let error = startFullSyncError {
+            throw error
+        }
+
+        return startFullSyncResult
+    }
+}
+

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -4,7 +4,6 @@ import SwiftUI
 import Yosemite
 import class WooFoundation.CurrencySettings
 import protocol Storage.StorageManagerType
-import protocol Storage.GRDBManagerProtocol
 import class WooFoundationCore.CurrencyFormatter
 
 /// View controller that provides the tab bar item for the Point of Sale tab.
@@ -28,7 +27,6 @@ final class POSTabCoordinator {
     private let storesManager: StoresManager
     private let credentials: Credentials?
     private let storageManager: StorageManagerType
-    private let grdbManager: GRDBManagerProtocol?
     private let currencySettings: CurrencySettings
     private let pushNotesManager: PushNotesManager
     private let eligibilityChecker: POSEntryPointEligibilityCheckerProtocol
@@ -80,13 +78,6 @@ final class POSTabCoordinator {
         self.eligibilityChecker = eligibilityChecker
 
         tabContainerController.wrappedController = POSTabViewController()
-
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleLocalCatalogi1) {
-            self.grdbManager = ServiceLocator.grdbManager
-            logDatabaseSchema()
-        } else {
-            self.grdbManager = nil
-        }
     }
 
     func onTabSelected() {
@@ -179,13 +170,5 @@ private extension POSTabCoordinator {
     /// Decorates track events with a different prefix when Point of Sale is active.
     func updateTrackEventPrefix(_ isPointOfSaleActive: Bool) {
         TracksProvider.setPOSMode(isPointOfSaleActive)
-    }
-}
-
-private extension POSTabCoordinator {
-    func logDatabaseSchema() {
-        try? grdbManager?.databaseConnection.read { db in
-            return try db.dumpSchema()
-        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -130,6 +130,7 @@ final class MainTabBarController: UITabBarController {
 
     private var posEligibilityChecker: POSEntryPointEligibilityCheckerProtocol?
     private var posEligibilityCheckTask: Task<Void, Never>?
+    private var posCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol?
 
     private var isPOSTabVisible: Bool = false
 
@@ -685,6 +686,11 @@ private extension MainTabBarController {
             cachePOSTabVisibility(siteID: siteID, isPOSTabVisible: isPOSTabVisible)
             updateTabViewControllers(isPOSTabVisible: isPOSTabVisible)
             viewModel.loadHubMenuTabBadge()
+
+            // Trigger POS catalog sync if tab is visible and feature flag is enabled
+            if isPOSTabVisible, ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleLocalCatalogi1) {
+                await triggerPOSCatalogSyncIfNeeded(for: siteID)
+            }
         }
     }
 
@@ -760,6 +766,11 @@ private extension MainTabBarController {
             eligibilityChecker: posEligibilityChecker
         )
 
+        // Configure POS catalog sync coordinator for local catalog syncing
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleLocalCatalogi1) {
+            posCatalogSyncCoordinator = createPOSCatalogSyncCoordinator(siteID: siteID)
+        }
+
         // Configure hub menu tab coordinator once per logged in session potentially with multiple sites.
         if hubMenuTabCoordinator == nil {
             let hubTabCoordinator = createHubMenuTabCoordinator()
@@ -779,6 +790,37 @@ private extension MainTabBarController {
 
     func createOrdersViewController(siteID: Int64) -> UIViewController {
         OrdersSplitViewWrapperController(siteID: siteID)
+    }
+
+    func createPOSCatalogSyncCoordinator(siteID: Int64) -> POSCatalogSyncCoordinatorProtocol? {
+        guard let credentials = ServiceLocator.stores.sessionManager.defaultCredentials,
+              let syncService = POSCatalogFullSyncService(credentials: credentials, grdbManager: ServiceLocator.grdbManager)
+        else {
+            return nil
+        }
+
+        return POSCatalogSyncCoordinator(syncService: syncService)
+    }
+
+    func triggerPOSCatalogSyncIfNeeded(for siteID: Int64) async {
+        guard let coordinator = posCatalogSyncCoordinator else {
+            return
+        }
+
+        // Check if sync is needed (older than 24 hours)
+        let maxAge: TimeInterval = 24 * 60 * 60
+        guard coordinator.shouldPerformFullSync(for: siteID, maxAge: maxAge) else {
+            return
+        }
+
+        // Perform background sync
+        Task.detached {
+            do {
+                _ = try await coordinator.performFullSync(for: siteID)
+            } catch {
+                DDLogError("⚠️ POS catalog sync failed: \(error)")
+            }
+        }
     }
 
     func createHubMenuTabCoordinator() -> HubMenuCoordinator {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -794,12 +794,12 @@ private extension MainTabBarController {
 
     func createPOSCatalogSyncCoordinator() -> POSCatalogSyncCoordinatorProtocol? {
         guard let credentials = ServiceLocator.stores.sessionManager.defaultCredentials,
-              let syncService = POSCatalogFullSyncService(credentials: credentials, grdbManager: ServiceLocator.grdbManager)
+              let fullSyncService = POSCatalogFullSyncService(credentials: credentials, grdbManager: ServiceLocator.grdbManager)
         else {
             return nil
         }
 
-        return POSCatalogSyncCoordinator(syncService: syncService)
+        return POSCatalogSyncCoordinator(fullSyncService: fullSyncService)
     }
 
     func triggerPOSCatalogSyncIfNeeded(for siteID: Int64) async {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -768,7 +768,7 @@ private extension MainTabBarController {
 
         // Configure POS catalog sync coordinator for local catalog syncing
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleLocalCatalogi1) {
-            posCatalogSyncCoordinator = createPOSCatalogSyncCoordinator(siteID: siteID)
+            posCatalogSyncCoordinator = createPOSCatalogSyncCoordinator()
         }
 
         // Configure hub menu tab coordinator once per logged in session potentially with multiple sites.
@@ -792,7 +792,7 @@ private extension MainTabBarController {
         OrdersSplitViewWrapperController(siteID: siteID)
     }
 
-    func createPOSCatalogSyncCoordinator(siteID: Int64) -> POSCatalogSyncCoordinatorProtocol? {
+    func createPOSCatalogSyncCoordinator() -> POSCatalogSyncCoordinatorProtocol? {
         guard let credentials = ServiceLocator.stores.sessionManager.defaultCredentials,
               let syncService = POSCatalogFullSyncService(credentials: credentials, grdbManager: ServiceLocator.grdbManager)
         else {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of: WOOMOB-1252
Closes: WOOMOB-1094
Merge after: #16097 

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a basic catalog sync coordinator. For now, it only supports full syncs.

I've removed the previous code for creating the database – this will happen automatically at the end of a successful sync.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app logged in to a POS-eligible site – observe that the full sync starts (check the console)
2. Switch to an ineligible store – observe that sync does not start for that store
3. Switch to a different eligible store – observe that the full sync starts for that store
4. Switch back to the first store – observe that the full sync doesn't start.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->


Note that if you switch during a sync, it will carry on, and start syncing the other site if needed.

This doesn't actually cause a problem, it's just a bit wasteful. Only the last one to save will be persisted in the end, because we currently only persist one site at a time. In future, we will change the primary keys to properly support multiple sites, and then they'll be saved as expected.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
