### PR TITLE
[POS][Local Catalog] Always full sync, if site not in database

### DIFF
--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Storage
 import CocoaLumberjackSwift
+import GRDB
 
 public protocol POSCatalogSyncCoordinatorProtocol {
     /// Performs a full catalog sync for the specified site
@@ -19,11 +20,14 @@ public protocol POSCatalogSyncCoordinatorProtocol {
 public final class POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
     private let syncService: POSCatalogFullSyncServiceProtocol
     private let settingsStore: SiteSpecificAppSettingsStoreMethodsProtocol
+    private let grdbManager: GRDBManagerProtocol
 
     public init(syncService: POSCatalogFullSyncServiceProtocol,
-                settingsStore: SiteSpecificAppSettingsStoreMethodsProtocol? = nil) {
+                settingsStore: SiteSpecificAppSettingsStoreMethodsProtocol? = nil,
+                grdbManager: GRDBManagerProtocol) {
         self.syncService = syncService
         self.settingsStore = settingsStore ?? SiteSpecificAppSettingsStoreMethods(fileStorage: PListFileStorage())
+        self.grdbManager = grdbManager
     }
 
     public func performFullSync(for siteID: Int64) async throws -> POSCatalog {
@@ -39,6 +43,11 @@ public final class POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol 
     }
 
     public func shouldPerformFullSync(for siteID: Int64, maxAge: TimeInterval) -> Bool {
+        if !siteExistsInDatabase(siteID: siteID) {
+            DDLogInfo("📋 POSCatalogSyncCoordinator: Site \(siteID) not found in database, sync needed")
+            return true
+        }
+
         guard let lastSyncDate = lastFullSyncDate(for: siteID) else {
             DDLogInfo("📋 POSCatalogSyncCoordinator: No previous sync found for site \(siteID), sync needed")
             return true
@@ -60,5 +69,17 @@ public final class POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol 
 
     private func lastFullSyncDate(for siteID: Int64) -> Date? {
         return settingsStore.getPOSLastFullSyncDate(for: siteID)
+    }
+
+    private func siteExistsInDatabase(siteID: Int64) -> Bool {
+        do {
+            return try grdbManager.databaseConnection.read { db in
+                return try PersistedSite.filter(key: siteID).fetchCount(db) > 0
+            }
+        } catch {
+            DDLogError("⛔️ POSCatalogSyncCoordinator: Error checking if site \(siteID) exists in database: \(error)")
+            // On error, assume site exists to avoid unnecessary syncs
+            return true
+        }
     }
 }

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
@@ -1,20 +1,23 @@
 import Foundation
 import Testing
 @testable import Yosemite
-import Storage
+@testable import Storage
 
 struct POSCatalogSyncCoordinatorTests {
     private let mockSyncService: MockPOSCatalogFullSyncService
     private let mockSettingsStore: MockSiteSpecificAppSettingsStoreMethods
+    private let grdbManager: GRDBManager
     private let sut: POSCatalogSyncCoordinator
     private let sampleSiteID: Int64 = 134
 
-    init() {
+    init() throws {
         self.mockSyncService = MockPOSCatalogFullSyncService()
         self.mockSettingsStore = MockSiteSpecificAppSettingsStoreMethods()
+        self.grdbManager = try GRDBManager()
         self.sut = POSCatalogSyncCoordinator(
             syncService: mockSyncService,
-            settingsStore: mockSettingsStore
+            settingsStore: mockSettingsStore,
+            grdbManager: grdbManager
         )
     }
 
@@ -128,16 +131,54 @@ struct POSCatalogSyncCoordinatorTests {
         #expect(shouldSyncB == true)  // No previous sync
     }
 
-    @Test func shouldPerformFullSync_with_zero_maxAge_always_returns_true() {
+    @Test func shouldPerformFullSync_with_zero_maxAge_always_returns_true() throws {
         // Given - previous sync was just now
         let justNow = Date()
         mockSettingsStore.storedDates[sampleSiteID] = justNow
+        try createSiteInDatabase(siteID: sampleSiteID)
 
         // When - max age is 0 (always sync)
         let shouldSync = sut.shouldPerformFullSync(for: sampleSiteID, maxAge: 0)
 
         // Then
         #expect(shouldSync == true)
+    }
+
+    // MARK: - Database Check Tests
+
+    @Test func shouldPerformFullSync_returns_true_when_site_not_in_database() {
+        // Given - site does not exist in database, but has recent sync date
+        let recentSyncDate = Date().addingTimeInterval(-30 * 60) // 30 minutes ago
+        mockSettingsStore.storedDates[sampleSiteID] = recentSyncDate
+        // Note: not creating site in database so it won't exist
+
+        // When - max age is 1 hour (normally wouldn't sync)
+        let shouldSync = sut.shouldPerformFullSync(for: sampleSiteID, maxAge: 60 * 60)
+
+        // Then - should sync because site doesn't exist in database
+        #expect(shouldSync == true)
+    }
+
+    @Test func shouldPerformFullSync_respects_time_when_site_exists_in_database() throws {
+        // Given - site exists in database with recent sync date
+        let recentSyncDate = Date().addingTimeInterval(-30 * 60) // 30 minutes ago
+        mockSettingsStore.storedDates[sampleSiteID] = recentSyncDate
+        try createSiteInDatabase(siteID: sampleSiteID)
+
+        // When - max age is 1 hour
+        let shouldSync = sut.shouldPerformFullSync(for: sampleSiteID, maxAge: 60 * 60)
+
+        // Then - should not sync because site exists and time hasn't passed
+        #expect(shouldSync == false)
+    }
+
+    // MARK: - Helper Methods
+
+    private func createSiteInDatabase(siteID: Int64) throws {
+        try grdbManager.databaseConnection.write { db in
+            let site = PersistedSite(id: siteID)
+            try site.insert(db)
+        }
     }
 }
 

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
@@ -77,9 +77,23 @@ struct POSCatalogSyncCoordinatorTests {
 
     // MARK: - Should Sync Decision Tests
 
-    @Test func shouldPerformFullSync_returns_true_when_no_previous_sync() {
-        // Given - no previous sync date stored
+    @Test func shouldPerformFullSync_site_not_in_database_with_no_sync_history() {
+        // Given - site doesn't exist in database AND has no sync history
         mockSettingsStore.storedDates = [:]
+        // Note: NOT creating site in database
+
+        // When
+        let shouldSync = sut.shouldPerformFullSync(for: sampleSiteID, maxAge: 60 * 60)
+
+        // Then - should sync because site doesn't exist in database
+        #expect(shouldSync == true)
+    }
+
+    @Test func shouldPerformFullSync_returns_true_when_no_previous_sync() throws {
+        // Given - no previous sync date stored, but site exists in database
+        // This is much less likely to happen, but could help at a migration point
+        mockSettingsStore.storedDates = [:]
+        try createSiteInDatabase(siteID: sampleSiteID)
 
         // When
         let shouldSync = sut.shouldPerformFullSync(for: sampleSiteID, maxAge: 3600)
@@ -89,10 +103,11 @@ struct POSCatalogSyncCoordinatorTests {
         #expect(mockSettingsStore.getPOSLastFullSyncDateCallCount == 1)
     }
 
-    @Test func shouldPerformFullSync_returns_true_when_sync_is_stale() {
-        // Given - previous sync was 2 hours ago
+    @Test func shouldPerformFullSync_returns_true_when_sync_is_stale() throws {
+        // Given - previous sync was 2 hours ago, and site exists in database
         let twoHoursAgo = Date().addingTimeInterval(-2 * 60 * 60)
         mockSettingsStore.storedDates[sampleSiteID] = twoHoursAgo
+        try createSiteInDatabase(siteID: sampleSiteID)
 
         // When - max age is 1 hour
         let shouldSync = sut.shouldPerformFullSync(for: sampleSiteID, maxAge: 60 * 60)
@@ -101,10 +116,11 @@ struct POSCatalogSyncCoordinatorTests {
         #expect(shouldSync == true)
     }
 
-    @Test func shouldPerformFullSync_returns_false_when_sync_is_fresh() {
-        // Given - previous sync was 30 minutes ago
+    @Test func shouldPerformFullSync_returns_false_when_sync_is_fresh() throws {
+        // Given - previous sync was 30 minutes ago, and site exists in database
         let thirtyMinutesAgo = Date().addingTimeInterval(-30 * 60)
         mockSettingsStore.storedDates[sampleSiteID] = thirtyMinutesAgo
+        try createSiteInDatabase(siteID: sampleSiteID)
 
         // When - max age is 1 hour
         let shouldSync = sut.shouldPerformFullSync(for: sampleSiteID, maxAge: 60 * 60)
@@ -113,7 +129,7 @@ struct POSCatalogSyncCoordinatorTests {
         #expect(shouldSync == false)
     }
 
-    @Test func shouldPerformFullSync_handles_different_sites_independently() {
+    @Test func shouldPerformFullSync_handles_different_sites_independently() throws {
         // Given
         let siteA: Int64 = 123
         let siteB: Int64 = 456
@@ -121,6 +137,10 @@ struct POSCatalogSyncCoordinatorTests {
 
         mockSettingsStore.storedDates[siteA] = oneHourAgo // Has previous sync
         // siteB has no previous sync
+
+        // Create both sites in database to test timing logic
+        try createSiteInDatabase(siteID: siteA)
+        try createSiteInDatabase(siteID: siteB)
 
         // When
         let shouldSyncA = sut.shouldPerformFullSync(for: siteA, maxAge: 2 * 60 * 60) // 2 hours
@@ -132,7 +152,7 @@ struct POSCatalogSyncCoordinatorTests {
     }
 
     @Test func shouldPerformFullSync_with_zero_maxAge_always_returns_true() throws {
-        // Given - previous sync was just now
+        // Given - previous sync was just now, and site exists in database
         let justNow = Date()
         mockSettingsStore.storedDates[sampleSiteID] = justNow
         try createSiteInDatabase(siteID: sampleSiteID)

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
@@ -75,7 +75,7 @@ struct POSCatalogSyncCoordinatorTests {
 
     // MARK: - Should Sync Decision Tests
 
-    @Test func shouldPerformFullSync_site_not_in_database_with_no_sync_history() {
+    @Test func shouldPerformFullSync_returns_true_when_site_is_not_in_database_with_no_sync_history() {
         // Given - site doesn't exist in database AND has no sync history
         mockSettingsStore.storedDates = [:]
         // Note: NOT creating site in database
@@ -87,7 +87,7 @@ struct POSCatalogSyncCoordinatorTests {
         #expect(shouldSync == true)
     }
 
-    @Test func shouldPerformFullSync_returns_true_when_no_previous_sync() throws {
+    @Test func shouldPerformFullSync_returns_true_when_site_is_in_database_with_no_previous_sync() throws {
         // Given - no previous sync date stored, but site exists in database
         // This is much less likely to happen, but could help at a migration point
         mockSettingsStore.storedDates = [:]

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -799,7 +799,7 @@ private extension MainTabBarController {
             return nil
         }
 
-        return POSCatalogSyncCoordinator(syncService: syncService)
+        return POSCatalogSyncCoordinator(syncService: syncService, grdbManager: ServiceLocator.grdbManager)
     }
 
     func triggerPOSCatalogSyncIfNeeded(for siteID: Int64) async {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
Part of: WOOMOB-1252
Merge after: #16098

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We currently only persist one site at a time in the database. The `lastSyncDate` is stored in UserDefaults (perhaps we should store it on the `Site` entity instead?).

It's possible to have synced the site within the max sync time, but still not have it in the database. In that case, we still want to resync.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and wait for the site's catalog to sync (observe the console)
2. Switch to another POS site, and wait for that catalog to sync – this will replace the previous site's catalog
3. Switch back to the first site – observe that the catalog is synced again, even though it was last synced within 24 hours.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
