### PR TITLE
[iPadOS 26][Woo POS] Flexible width and height for card present modals

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift
@@ -29,13 +29,13 @@ struct PointOfSaleCardPresentPaymentBluetoothRequiredAlertView: View {
                 .fixedSize(horizontal: false, vertical: true)
             }
             .frame(maxWidth: .infinity)
-            .scrollVerticallyIfNeeded()
 
             Button(viewModel.openSettingsButtonViewModel.title,
                    action: viewModel.openSettingsButtonViewModel.actionHandler)
             .buttonStyle(POSFilledButtonStyle(size: .normal))
             .matchedGeometryEffect(id: animation.buttonsTransitionId, in: animation.namespace, properties: .position)
         }
+        .scrollVerticallyIfNeeded()
         .posModalCloseButton(action: viewModel.dismissButtonViewModel.actionHandler,
                              accessibilityLabel: viewModel.dismissButtonViewModel.title)
         .multilineTextAlignment(.center)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift
@@ -24,13 +24,13 @@ struct PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView: View {
                 }
             }
             .frame(maxWidth: .infinity)
-            .scrollVerticallyIfNeeded()
 
             Button(viewModel.retryButtonViewModel.title,
                    action: viewModel.retryButtonViewModel.actionHandler)
             .buttonStyle(POSFilledButtonStyle(size: .normal))
             .matchedGeometryEffect(id: animation.buttonsTransitionId, in: animation.namespace, properties: .position)
         }
+        .scrollVerticallyIfNeeded()
         .posModalCloseButton(action: viewModel.cancelButtonViewModel.actionHandler,
                               accessibilityLabel: viewModel.cancelButtonViewModel.title)
         .multilineTextAlignment(.center)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView.swift
@@ -24,13 +24,13 @@ struct PointOfSaleCardPresentPaymentConnectingFailedLocationRequiredAlertView: V
                 }
             }
             .frame(maxWidth: .infinity)
-            .scrollVerticallyIfNeeded()
 
             Button(viewModel.primaryButtonViewModel.title,
                    action: viewModel.primaryButtonViewModel.actionHandler)
             .buttonStyle(POSFilledButtonStyle(size: .normal))
             .matchedGeometryEffect(id: animation.buttonsTransitionId, in: animation.namespace, properties: .position)
         }
+        .scrollVerticallyIfNeeded()
         .posModalCloseButton(action: viewModel.cancelButtonViewModel.actionHandler,
                              accessibilityLabel: viewModel.cancelButtonViewModel.title)
         .multilineTextAlignment(.center)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
@@ -24,13 +24,13 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView: View {
                 }
             }
             .frame(maxWidth: .infinity)
-            .scrollVerticallyIfNeeded()
 
             Button(viewModel.retryButtonViewModel.title,
                    action: viewModel.retryButtonViewModel.actionHandler)
             .buttonStyle(POSFilledButtonStyle(size: .normal))
             .matchedGeometryEffect(id: animation.buttonsTransitionId, in: animation.namespace, properties: .position)
         }
+        .scrollVerticallyIfNeeded()
         .posModalCloseButton(action: viewModel.cancelButtonViewModel.actionHandler,
                              accessibilityLabel: viewModel.cancelButtonViewModel.title)
         .multilineTextAlignment(.center)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedView.swift
@@ -31,13 +31,13 @@ struct PointOfSaleCardPresentPaymentConnectingFailedView: View {
                 .fixedSize(horizontal: false, vertical: true)
             }
             .frame(maxWidth: .infinity)
-            .scrollVerticallyIfNeeded()
 
             Button(viewModel.retryButtonViewModel.title,
                    action: viewModel.retryButtonViewModel.actionHandler)
             .buttonStyle(POSFilledButtonStyle(size: .normal))
             .matchedGeometryEffect(id: animation.buttonsTransitionId, in: animation.namespace, properties: .position)
         }
+        .scrollVerticallyIfNeeded()
         .posModalCloseButton(action: viewModel.cancelButtonViewModel.actionHandler,
                              accessibilityLabel: viewModel.cancelButtonViewModel.title)
         .multilineTextAlignment(.center)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderView.swift
@@ -24,7 +24,6 @@ struct PointOfSaleCardPresentPaymentFoundReaderView: View {
                 }
             }
             .frame(maxWidth: .infinity)
-            .scrollVerticallyIfNeeded()
 
             VStack(spacing: PointOfSaleReaderConnectionModalLayout.buttonSpacing) {
                 Button(viewModel.connectButton.title,
@@ -37,6 +36,7 @@ struct PointOfSaleCardPresentPaymentFoundReaderView: View {
             }
             .matchedGeometryEffect(id: animation.buttonsTransitionId, in: animation.namespace, properties: .position)
         }
+        .scrollVerticallyIfNeeded()
         .posModalCloseButton(action: viewModel.cancelSearchButton.actionHandler,
                              accessibilityLabel: viewModel.cancelSearchButton.title)
         .multilineTextAlignment(.center)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedView.swift
@@ -23,13 +23,13 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedView: View {
                     .matchedGeometryEffect(id: animation.titleTransitionId, in: animation.namespace, properties: .position)
             }
             .frame(maxWidth: .infinity)
-            .scrollVerticallyIfNeeded()
 
             Button(viewModel.retryButtonViewModel.title,
                    action: viewModel.retryButtonViewModel.actionHandler)
             .buttonStyle(POSFilledButtonStyle(size: .normal))
             .matchedGeometryEffect(id: animation.buttonsTransitionId, in: animation.namespace, properties: .position)
         }
+        .scrollVerticallyIfNeeded()
         .posModalCloseButton(action: viewModel.cancelButtonViewModel.actionHandler,
                              accessibilityLabel: viewModel.cancelButtonViewModel.title)
         .multilineTextAlignment(.center)

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalSizing.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalSizing.swift
@@ -9,6 +9,7 @@ extension View {
 
 struct POSModalSizing: ViewModifier {
     @Environment(\.sizeCategory) private var sizeCategory
+    @Environment(\.posModalParentSize) private var parentSize
 
     func body(content: Content) -> some View {
         content
@@ -19,6 +20,10 @@ struct POSModalSizing: ViewModifier {
 
 private extension POSModalSizing {
     var frameWidth: CGFloat {
+        return min(preferredFrameWidth, maxAvailableFrameWidth)
+    }
+
+    var preferredFrameWidth: CGFloat {
         switch sizeCategory {
         case .extraSmall, .small:
             return 560
@@ -37,7 +42,15 @@ private extension POSModalSizing {
         }
     }
 
+    var maxAvailableFrameWidth: CGFloat {
+        return parentSize.width
+    }
+
     var frameHeight: CGFloat {
+        return min(preferredFrameHeight, parentSize.height)
+    }
+
+    var preferredFrameHeight: CGFloat {
         switch sizeCategory {
         case .extraSmall, .small:
             return 640
@@ -54,6 +67,10 @@ private extension POSModalSizing {
         @unknown default:
             return 656
         }
+    }
+
+    var maxAvailableFrameHeight: CGFloat {
+        parentSize.height
     }
 
     var windowBounds: CGRect {

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalSizing.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalSizing.swift
@@ -47,7 +47,7 @@ private extension POSModalSizing {
     }
 
     var frameHeight: CGFloat {
-        return min(preferredFrameHeight, parentSize.height)
+        return min(preferredFrameHeight, maxAvailableFrameHeight)
     }
 
     var preferredFrameHeight: CGFloat {

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -8,42 +8,41 @@ struct POSRootModalViewModifier: ViewModifier {
     private let scaleTransitionAmount = Constants.scaleTransitionAmount
 
     func body(content: Content) -> some View {
-        ZStack {
-            content
-                .blur(radius: modalManager.isPresented ? 8 : 0)
-                .disabled(modalManager.isPresented)
-                .accessibilityElement(children: modalManager.isPresented ? .ignore : .contain)
-
-            if modalManager.isPresented {
-                Color.posSurfaceDim.opacity(0.8)
-                    .edgesIgnoringSafeArea(.all)
-                    .onTapGesture {
-                        if modalManager.allowsInteractiveDismissal {
-                            modalManager.dismiss()
-                        }
-                    }
-                // Don't scale/fade in the backdrop
-                    .animation(nil, value: modalManager.isPresented)
-                ZStack {
-                    modalManager.getContent()
-                        .environment(\.posModalParentSize, modalParentSize)
-                        .background(Color.posSurfaceBright)
-                        .cornerRadius(POSCornerRadiusStyle.extraLarge.value)
-                        .posShadow(.large, cornerRadius: POSCornerRadiusStyle.extraLarge.value)
-                        .padding()
-                }
-                .zIndex(1)
-                // Scale the modal container in and out, fading appropriately.
-                // Unfortunately combined doesn't work on removal.
-                // The extra ZStack prevents changing modalContent from scaling and fading, but the ZIndex needs to be
-                // consistent even when animating out, which it wouldn't be if unspecified.
-                .transition(.scale(scale: scaleTransitionAmount).combined(with: .opacity))
+        content
+            .blur(radius: modalManager.isPresented ? 8 : 0)
+            .disabled(modalManager.isPresented)
+            .accessibilityElement(children: modalManager.isPresented ? .ignore : .contain)
+            .measureFrame { frame in
+                updateModalParentSize(with: frame.size)
             }
-        }
-        .measureFrame { frame in
-            updateModalParentSize(with: frame.size)
-        }
-        .animation(.easeInOut(duration: animationDuration), value: modalManager.isPresented)
+            .overlay {
+                if modalManager.isPresented {
+                    Color.posSurfaceDim.opacity(0.8)
+                        .edgesIgnoringSafeArea(.all)
+                        .onTapGesture {
+                            if modalManager.allowsInteractiveDismissal {
+                                modalManager.dismiss()
+                            }
+                        }
+                    // Don't scale/fade in the backdrop
+                        .animation(nil, value: modalManager.isPresented)
+                    ZStack {
+                        modalManager.getContent()
+                            .environment(\.posModalParentSize, modalParentSize)
+                            .background(Color.posSurfaceBright)
+                            .cornerRadius(POSCornerRadiusStyle.extraLarge.value)
+                            .posShadow(.large, cornerRadius: POSCornerRadiusStyle.extraLarge.value)
+                            .padding()
+                    }
+                    .zIndex(1)
+                    // Unfortunately combined doesn't work on removal.
+                    // The extra ZStack prevents changing modalContent from scaling and fading, but the ZIndex needs to be
+                    // consistent even when animating out, which it wouldn't be if unspecified.
+                    .transition(.scale(scale: scaleTransitionAmount).combined(with: .opacity))
+                }
+            }
+            .animation(.easeInOut(duration: animationDuration), value: modalManager.isPresented)
+            .ignoresSafeArea()
     }
 
     private func updateModalParentSize(with size: CGSize) {

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -35,6 +35,7 @@ struct POSRootModalViewModifier: ViewModifier {
                             .padding()
                     }
                     .zIndex(1)
+                    // Scale the modal container in and out, fading appropriately.
                     // Unfortunately combined doesn't work on removal.
                     // The extra ZStack prevents changing modalContent from scaling and fading, but the ZIndex needs to be
                     // consistent even when animating out, which it wouldn't be if unspecified.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

WOOMOB-1248

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Make modals, specifically card-present payment and onboarding modals, more flexible for different window sizes. It became more important with iPadOS 26 updates that allow changing window sizes like on macOS. Also, it facilitates any future work for more flexible POS.

## Solution

The solution looked straightforward - constrain `POSModalSizing` modifier, that payment modals rely on, to the parent view size. However, the current mechanism to determine parent view size only worked up to an extent, and didn't report all the screen view changes as I would expect, even if the calculation was moved at the root level of the whole POS. I focused on finding some different ways to use `GeometryReader` but it didn't work. What worked in the end is moving the modal from `ZStack` into `overlay` on top of the blue effect. This way the modal parent size started to be reported as expected through `.measureFrame` modifier.

Therefore, changes:
- Moved `POSRootModalViewModifier` content into `.overlay` which solved some parent view sizing reporting issues
- Constrained `POSModalSizing` modifier to parent view size
- Updated card present modals to include buttons in scrolling, otherwise the view content can get squeezed too much. Also, it makes the behavior between card-present payment and card payment onboarding modals identical.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Payment modals:
1. Open POS on an iPad 26.0 device or simulator
2. Start card reader connection
3. Change window sizes
4. Confirm the modal view adapts to different view widths and heights, and can be scrolled when needed

### Regression:
- Try opening barcode scanning or product restriction modals and confirm they continue to work

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Tested on iPad Air 18.5 and 26.0 simulators and 26.0 iPad Air M2 device

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/13470f11-1cc8-493e-b544-8fc467c532f3

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.