### PR TITLE
[CIAB] Hide split shipments for CIAB sites

### DIFF
--- a/WooCommerce/Classes/CIAB/CIABEligibilityChecker.swift
+++ b/WooCommerce/Classes/CIAB/CIABEligibilityChecker.swift
@@ -3,15 +3,6 @@
 import Foundation
 import Yosemite
 
-protocol CIABEligibilityCheckerProtocol {
-    var isCurrentSiteCIAB: Bool { get }
-
-    func isSiteCIAB(_ site: Site) -> Bool
-
-    func isFeatureSupportedForCurrentSite(_ feature: CIABAffectedFeature) -> Bool
-    func isFeatureSupported(_ feature: CIABAffectedFeature, for site: Site) -> Bool
-}
-
 final class CIABEligibilityChecker {
     private let stores: StoresManager
 

--- a/WooCommerce/Classes/CIAB/CIABEligibilityCheckerProtocol.swift
+++ b/WooCommerce/Classes/CIAB/CIABEligibilityCheckerProtocol.swift
@@ -1,0 +1,11 @@
+import Foundation
+import Yosemite
+
+protocol CIABEligibilityCheckerProtocol {
+    var isCurrentSiteCIAB: Bool { get }
+
+    func isSiteCIAB(_ site: Site) -> Bool
+
+    func isFeatureSupportedForCurrentSite(_ feature: CIABAffectedFeature) -> Bool
+    func isFeatureSupported(_ feature: CIABAffectedFeature, for site: Site) -> Bool
+}

--- a/WooCommerce/Classes/CIAB/CIABEligibilityCheckerProtocol.swift
+++ b/WooCommerce/Classes/CIAB/CIABEligibilityCheckerProtocol.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Yosemite
 
+/// periphery: ignore - Will be used in upcoming changes for app feature gating
 protocol CIABEligibilityCheckerProtocol {
     var isCurrentSiteCIAB: Bool { get }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -182,7 +182,7 @@ private extension WooShippingCreateLabelsView {
                     .padding(.horizontal)
             }
             .accessibilityHint(Localization.Accessibility.editButtonHint)
-            .renderedIf(viewModel.hasUnfulfilledShipments)
+            .renderedIf(viewModel.editSplitShipmentsOptionVisible)
         }
         .disabled(viewModel.isPurchasingLabel)
     }
@@ -191,7 +191,7 @@ private extension WooShippingCreateLabelsView {
     var mainView: some View {
         ScrollView {
             VStack(spacing: Layout.verticalSpacing) {
-                if viewModel.splitShipmentsAvailable {
+                if viewModel.splitShipmentsRowVisible {
                     WooShippingSplitShipmentsRow(onShowingSplitShipments: {
                         showingSplitShipments = true
                     })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -252,7 +252,11 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
          initialNoticeDelay: RunLoop.SchedulerTimeType.Stride = .seconds(2),
          onLabelPurchase: ((Bool) -> Void)? = nil) {
         self.order = order
-        self.itemsDataSource = DefaultWooShippingItemsDataSource(order: order)
+        self.itemsDataSource = DefaultWooShippingItemsDataSource(
+            order: order,
+            storageManager: storageManager,
+            stores: stores
+        )
         self.orderItems = WooShippingItemsViewModel(dataSource: itemsDataSource)
         self.onLabelPurchase = onLabelPurchase
         self.currencySettings = currencySettings

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -235,7 +235,6 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         )
     }()
 
-    
     /// Provides checks for CIAB
     /// Used to determine "Split Shipments" feature availability
     private let siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -235,6 +235,11 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         )
     }()
 
+    
+    /// Provides checks for CIAB
+    /// Used to determine "Split Shipments" feature availability
+    private let siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol
+
     /// Initialize the view model with or without an existing shipping label.
     init(order: Order,
          preselection: WooShippingCreateLabelSelection? = nil,
@@ -243,6 +248,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          analytics: Analytics = ServiceLocator.analytics,
+         siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker(),
          initialNoticeDelay: RunLoop.SchedulerTimeType.Stride = .seconds(2),
          onLabelPurchase: ((Bool) -> Void)? = nil) {
         self.order = order
@@ -255,6 +261,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.stores = stores
         self.storageManager = storageManager
         self.analytics = analytics
+        self.siteCIABEligibilityChecker = siteCIABEligibilityChecker
         self.shippingSettingsService = shippingSettingsService
         self.weightUnit = shippingSettingsService.weightUnit ?? ""
         self.dimensionsUnit = shippingSettingsService.dimensionUnit ?? ""
@@ -506,7 +513,7 @@ extension WooShippingCreateLabelsViewModel {
     }
 
     private var splitShipmentsFeatureAvailable: Bool {
-        return true
+        return siteCIABEligibilityChecker.isFeatureSupportedForCurrentSite(.splitShipments)
     }
 
     /// Determines if the "Edit split shipments" (pencil icon) is visible in top shipments bar.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -80,12 +80,6 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// View model for split shipments.
     private(set) var splitShipmentsViewModel: WooShippingSplitShipmentsViewModel
 
-    var splitShipmentsAvailable: Bool {
-        itemsDataSource.items.map(\.quantity).reduce(0, +) > 1 &&
-        shipments.count == 1 &&
-        canViewLabel == false
-    }
-
     private(set) var shipmentDetailViewModels: [WooShippingShipmentDetailsViewModel] = []
 
     var currentShipmentDetailsViewModel: WooShippingShipmentDetailsViewModel {
@@ -501,6 +495,33 @@ private extension WooShippingCreateLabelsViewModel {
     /// This is useful for checking countries in the customs form and listing countries in the edit address form.
     func syncCountries() {
         stores.dispatch(DataAction.synchronizeCountries(siteID: order.siteID) { _ in })
+    }
+}
+
+// MARK: Split Shipments
+// Accessors describing Split Shipments elements availability
+extension WooShippingCreateLabelsViewModel {
+    private var hasMultipleProducts: Bool {
+        return itemsDataSource.items.map(\.quantity).reduce(0, +) > 1
+    }
+
+    private var splitShipmentsFeatureAvailable: Bool {
+        return true
+    }
+
+    /// Determines if the "Edit split shipments" (pencil icon) is visible in top shipments bar.
+    var editSplitShipmentsOptionVisible: Bool {
+        splitShipmentsFeatureAvailable &&
+        hasMultipleProducts &&
+        hasUnfulfilledShipments
+    }
+
+    /// Determines if the "Split Shipments" row is visible above the "Products" section
+    var splitShipmentsRowVisible: Bool {
+        splitShipmentsFeatureAvailable &&
+        hasMultipleProducts &&
+        shipments.count == 1 &&
+        canViewLabel == false
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1245,6 +1245,8 @@
 		2DB8916E2E27F7840001B175 /* OrderListCellViewModel+Localizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB8916A2E27F6CE0001B175 /* OrderListCellViewModel+Localizations.swift */; };
 		2DCB54FA2E6AE8E100621F90 /* CIABEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCB54F92E6AE8D800621F90 /* CIABEligibilityChecker.swift */; };
 		2DCB54FC2E6AFE6A00621F90 /* CIABAffectedFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCB54FB2E6AFE6900621F90 /* CIABAffectedFeature.swift */; };
+		2DE9DDFB2E6EF4A500155408 /* MockCIABEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE9DDFA2E6EF4A300155408 /* MockCIABEligibilityChecker.swift */; };
+		2DE9DDFD2E6EF53C00155408 /* CIABEligibilityCheckerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE9DDFC2E6EF52E00155408 /* CIABEligibilityCheckerProtocol.swift */; };
 		2DF0D1BC2E2907C100F8995C /* MarkOrderAsReadUseCase+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB88DA32E27DD790001B175 /* MarkOrderAsReadUseCase+Woo.swift */; };
 		310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */; };
 		311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */; };
@@ -4434,6 +4436,8 @@
 		2DB8916A2E27F6CE0001B175 /* OrderListCellViewModel+Localizations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderListCellViewModel+Localizations.swift"; sourceTree = "<group>"; };
 		2DCB54F92E6AE8D800621F90 /* CIABEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIABEligibilityChecker.swift; sourceTree = "<group>"; };
 		2DCB54FB2E6AFE6900621F90 /* CIABAffectedFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIABAffectedFeature.swift; sourceTree = "<group>"; };
+		2DE9DDFA2E6EF4A300155408 /* MockCIABEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCIABEligibilityChecker.swift; sourceTree = "<group>"; };
+		2DE9DDFC2E6EF52E00155408 /* CIABEligibilityCheckerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIABEligibilityCheckerProtocol.swift; sourceTree = "<group>"; };
 		310D1B472734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsLiveSiteInTestModeView.swift; sourceTree = "<group>"; };
 		311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalDisplayMessage.swift; sourceTree = "<group>"; };
 		311D21E7264AEDB900102316 /* CardPresentModalScanningForReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalScanningForReader.swift; sourceTree = "<group>"; };
@@ -9058,6 +9062,7 @@
 		2DCB54F82E6AE8C900621F90 /* CIAB */ = {
 			isa = PBXGroup;
 			children = (
+				2DE9DDFC2E6EF52E00155408 /* CIABEligibilityCheckerProtocol.swift */,
 				2DCB54FB2E6AFE6900621F90 /* CIABAffectedFeature.swift */,
 				2DCB54F92E6AE8D800621F90 /* CIABEligibilityChecker.swift */,
 			);
@@ -10093,6 +10098,7 @@
 		746791642108D853007CF1DC /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				2DE9DDFA2E6EF4A300155408 /* MockCIABEligibilityChecker.swift */,
 				022900892E3019020028F6D7 /* MockPluginsService.swift */,
 				02F36C3F2E0130E900DD8CB6 /* MockPOSEligibilityService.swift */,
 				02B8E41A2DFBC33C001D01FD /* MockPOSEligibilityChecker.swift */,
@@ -16257,6 +16263,7 @@
 				B626C71B287659D60083820C /* CustomFieldsListView.swift in Sources */,
 				02ECD1E624FFB4E900735BE5 /* ProductFactory.swift in Sources */,
 				260520F42B87BA23005D5D59 /* WooAnalyticsEvent+ConnectivityTool.swift in Sources */,
+				2DE9DDFD2E6EF53C00155408 /* CIABEligibilityCheckerProtocol.swift in Sources */,
 				579CDEFF274D7E7900E8903D /* StoreStatsUsageTracksEventEmitter.swift in Sources */,
 				203163AD2C1C5C54001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift in Sources */,
 				CEDBDA472B6BEF2E002047D4 /* AnalyticsWebReport.swift in Sources */,
@@ -17150,6 +17157,7 @@
 				EE8B421B2C04D18B0077C4E7 /* LastOrdersDashboardCardViewModelTests.swift in Sources */,
 				095A077E27CF486C007A61D2 /* ValueOneTableViewCellTests.swift in Sources */,
 				E17E3BF9266917C10009D977 /* CardPresentModalScanningFailedTests.swift in Sources */,
+				2DE9DDFB2E6EF4A500155408 /* MockCIABEligibilityChecker.swift in Sources */,
 				DE66C56F2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift in Sources */,
 				EE1905942B62AE9100617C53 /* BlazeCreateCampaignIntroViewModelTests.swift in Sources */,
 				269098B627D2C09D001FEB07 /* ShippingInputTransformerTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockCIABEligibilityChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCIABEligibilityChecker.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Yosemite
+@testable import WooCommerce
+
+final class MockCIABEligibilityChecker: CIABEligibilityCheckerProtocol {
+    private let mockedIsCurrentSiteCIAB: Bool
+    private let mockedCIABSites: [Site]
+    private let mockedCIABDisabledFeatures: [CIABAffectedFeature]
+
+    init(mockedIsCurrentSiteCIAB: Bool, mockedCIABSites: [Site] = [], mockedCIABDisabledFeatures: [CIABAffectedFeature] = CIABAffectedFeature.allCases) {
+        self.mockedIsCurrentSiteCIAB = mockedIsCurrentSiteCIAB
+        self.mockedCIABSites = mockedCIABSites
+        self.mockedCIABDisabledFeatures = mockedCIABDisabledFeatures
+    }
+
+    var isCurrentSiteCIAB: Bool {
+        return mockedIsCurrentSiteCIAB
+    }
+
+    func isSiteCIAB(_ site: Site) -> Bool {
+        return mockedCIABSites.contains(site)
+    }
+
+    func isFeatureSupportedForCurrentSite(_ feature: CIABAffectedFeature) -> Bool {
+        return !mockedCIABDisabledFeatures.contains(feature)
+    }
+
+    func isFeatureSupported(_ feature: CIABAffectedFeature, for site: Site) -> Bool {
+        return !mockedCIABDisabledFeatures.contains(feature) && mockedCIABSites.contains(site)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -1041,14 +1041,19 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
     // MARK: - split shipments feature visibility tests
 
-    func test_splitShipmentsRowVisible_is_false_when_split_shipments_feature_is_unavailable() {
-        let stores = MockStoresManager(sessionManager: .testingInstance)
+    private func initialConfigurationForSplitShipmentsTest(stores: MockStoresManager) {
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             switch action {
             case .verifyDestinationAddress(_, _, let completion):
-                completion(.success(WooShippingVerifyDestinationAddressSuccess(normalizedAddress: WooShippingNormalizedAddress.fake(),
-                                                                               isTrivialNormalization: nil,
-                                                                               isVerified: true)))
+                completion(
+                    .success(
+                        WooShippingVerifyDestinationAddressSuccess(
+                            normalizedAddress: WooShippingNormalizedAddress.fake(),
+                            isTrivialNormalization: nil,
+                            isVerified: true
+                        )
+                    )
+                )
             case .loadAccountSettings(_, let completion):
                 completion(.success(self.settings))
             case .loadOriginAddresses(_, let completion):
@@ -1058,17 +1063,25 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
                 XCTFail("Unexpected action: \(action)")
             }
         }
+    }
 
+    func test_splitShipmentsRowVisible_is_false_when_split_shipments_feature_is_unavailable() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        initialConfigurationForSplitShipmentsTest(stores: stores)
+
+        /// Is CIAB site with the `.splitShipments` disabled
         let mockSiteCIABChecker = MockCIABEligibilityChecker(
             mockedIsCurrentSiteCIAB: true,
             mockedCIABDisabledFeatures: [.splitShipments]
         )
 
-        // There exist 2 shipments, one of which has been fulfilled.
-        let product1 = Product.fake().copy(productID: 1)
-        let product2 = Product.fake().copy(productID: 2)
-        insert(product: product1)
-        insert(product: product2)
+        /// Multiple products
+        let product1 = Product.fake().copy(siteID: siteID, productID: 1)
+        let product2 = Product.fake().copy(siteID: siteID, productID: 2)
+
+        storageManager.insertSampleProduct(readOnlyProduct: product1)
+        storageManager.insertSampleProduct(readOnlyProduct: product2)
 
         let order = Order.fake().copy(
             siteID: siteID,
@@ -1078,6 +1091,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
                 OrderItem.fake().copy(productID: product2.productID, quantity: 1)
             ])
 
+        /// Single unfulfilled shipment
         let shipments = [
             WooShippingShipment.fake().copy(
                 siteID: siteID,
@@ -1108,24 +1122,405 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
     }
 
     func test_splitShipmentsRowVisible_is_false_when_only_single_product_item_exists() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        initialConfigurationForSplitShipmentsTest(stores: stores)
+
+        /// Non-CIAB site
+        let mockSiteCIABChecker = MockCIABEligibilityChecker(
+            mockedIsCurrentSiteCIAB: false,
+            mockedCIABDisabledFeatures: []
+        )
+
+        /// Single product
+        let product1 = Product.fake().copy(siteID: siteID, productID: 1)
+        storageManager.insertSampleProduct(readOnlyProduct: product1)
+
+        let order = Order.fake().copy(
+            siteID: siteID,
+            orderID: orderID,
+            items: [
+                OrderItem.fake().copy(productID: product1.productID, quantity: 1)
+            ])
+
+        /// Single unfulfilled shipment
+        let shipments = [
+            WooShippingShipment.fake().copy(
+                siteID: siteID,
+                orderID: orderID,
+                index: "shipment_0",
+                items: [
+                    .fake().copy(id: product1.productID)
+                ])
+        ]
+        insert(shipments: shipments, order: order)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(
+            order: order,
+            stores: stores,
+            storageManager: storageManager,
+            siteCIABEligibilityChecker: mockSiteCIABChecker,
+            initialNoticeDelay: .seconds(0)
+        )
+
+        waitUntil {
+            viewModel.state == .ready
+        }
+
+        // Then
+        XCTAssertFalse(viewModel.splitShipmentsRowVisible)
     }
 
     func test_splitShipmentsRowVisible_is_false_when_order_has_multiple_shipments() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        initialConfigurationForSplitShipmentsTest(stores: stores)
+
+        /// Non-CIAB site
+        let mockSiteCIABChecker = MockCIABEligibilityChecker(
+            mockedIsCurrentSiteCIAB: false,
+            mockedCIABDisabledFeatures: []
+        )
+
+        /// Multiple products
+        let product1 = Product.fake().copy(siteID: siteID, productID: 1)
+        let product2 = Product.fake().copy(siteID: siteID, productID: 2)
+
+        storageManager.insertSampleProduct(readOnlyProduct: product1)
+        storageManager.insertSampleProduct(readOnlyProduct: product2)
+
+        let order = Order.fake().copy(
+            siteID: siteID,
+            orderID: orderID,
+            items: [
+                OrderItem.fake().copy(productID: product1.productID, quantity: 1),
+                OrderItem.fake().copy(productID: product2.productID, quantity: 1)
+            ])
+
+        /// Multiple shipments
+        let shipments = [
+            WooShippingShipment.fake().copy(
+                siteID: siteID,
+                orderID: orderID,
+                index: "shipment_0",
+                items: [
+                    .fake().copy(id: product1.productID)
+                ]),
+            WooShippingShipment.fake().copy(
+                siteID: siteID,
+                orderID: orderID,
+                index: "shipment_1",
+                items: [
+                    .fake().copy(id: product2.productID)
+                ])
+        ]
+        insert(shipments: shipments, order: order)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(
+            order: order,
+            stores: stores,
+            storageManager: storageManager,
+            siteCIABEligibilityChecker: mockSiteCIABChecker,
+            initialNoticeDelay: .seconds(0)
+        )
+
+        waitUntil {
+            viewModel.state == .ready
+        }
+
+        // Then
+        XCTAssertFalse(viewModel.splitShipmentsRowVisible)
     }
 
     func test_splitShipmentsRowVisible_is_true_when_requirements_met() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        initialConfigurationForSplitShipmentsTest(stores: stores)
+
+        /// Non-CIAB site (feature available)
+        let mockSiteCIABChecker = MockCIABEligibilityChecker(
+            mockedIsCurrentSiteCIAB: false,
+            mockedCIABDisabledFeatures: []
+        )
+
+        /// Multiple products
+        let product1 = Product.fake().copy(siteID: siteID, productID: 1)
+        let product2 = Product.fake().copy(siteID: siteID, productID: 2)
+
+        storageManager.insertSampleProduct(readOnlyProduct: product1)
+        storageManager.insertSampleProduct(readOnlyProduct: product2)
+
+        let order = Order.fake().copy(
+            siteID: siteID,
+            orderID: orderID,
+            items: [
+                OrderItem.fake().copy(productID: product1.productID, quantity: 1),
+                OrderItem.fake().copy(productID: product2.productID, quantity: 1)
+            ])
+
+        /// Single unfulfilled shipment
+        let shipments = [
+            WooShippingShipment.fake().copy(
+                siteID: siteID,
+                orderID: orderID,
+                index: "shipment_0",
+                items: [
+                    .fake().copy(id: product1.productID),
+                    .fake().copy(id: product2.productID)
+                ])
+        ]
+        insert(shipments: shipments, order: order)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(
+            order: order,
+            stores: stores,
+            storageManager: storageManager,
+            siteCIABEligibilityChecker: mockSiteCIABChecker,
+            initialNoticeDelay: .seconds(0)
+        )
+
+        waitUntil {
+            viewModel.state == .ready
+        }
+
+        // Then
+        XCTAssertTrue(viewModel.splitShipmentsRowVisible)
     }
 
     func test_editSplitShipmentsOptionVisible_is_false_when_split_shipments_feature_is_unavailable() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        initialConfigurationForSplitShipmentsTest(stores: stores)
+
+        /// Is CIAB site with the `.splitShipments` disabled
+        let mockSiteCIABChecker = MockCIABEligibilityChecker(
+            mockedIsCurrentSiteCIAB: true,
+            mockedCIABDisabledFeatures: [.splitShipments]
+        )
+
+        /// Multiple products
+        let product1 = Product.fake().copy(siteID: siteID, productID: 1)
+        let product2 = Product.fake().copy(siteID: siteID, productID: 2)
+
+        storageManager.insertSampleProduct(readOnlyProduct: product1)
+        storageManager.insertSampleProduct(readOnlyProduct: product2)
+
+        let order = Order.fake().copy(
+            siteID: siteID,
+            orderID: orderID,
+            items: [
+                OrderItem.fake().copy(productID: product1.productID, quantity: 1),
+                OrderItem.fake().copy(productID: product2.productID, quantity: 1)
+            ])
+
+        /// Single unfulfilled shipment
+        let shipments = [
+            WooShippingShipment.fake().copy(
+                siteID: siteID,
+                orderID: orderID,
+                index: "shipment_0",
+                items: [
+                    .fake().copy(id: product1.productID),
+                    .fake().copy(id: product2.productID)
+                ])
+        ]
+        insert(shipments: shipments, order: order)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(
+            order: order,
+            stores: stores,
+            storageManager: storageManager,
+            siteCIABEligibilityChecker: mockSiteCIABChecker,
+            initialNoticeDelay: .seconds(0)
+        )
+
+        waitUntil {
+            viewModel.state == .ready
+        }
+
+        // Then
+        XCTAssertFalse(viewModel.editSplitShipmentsOptionVisible)
     }
 
     func test_editSplitShipmentsOptionVisible_is_false_when_only_single_product_item_exists() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        initialConfigurationForSplitShipmentsTest(stores: stores)
+
+        /// Non-CIAB site (split shipments available)
+        let mockSiteCIABChecker = MockCIABEligibilityChecker(
+            mockedIsCurrentSiteCIAB: false,
+            mockedCIABDisabledFeatures: []
+        )
+
+        /// Single product
+        let product1 = Product.fake().copy(siteID: siteID, productID: 1)
+        storageManager.insertSampleProduct(readOnlyProduct: product1)
+
+        let order = Order.fake().copy(
+            siteID: siteID,
+            orderID: orderID,
+            items: [
+                OrderItem.fake().copy(productID: product1.productID, quantity: 1)
+            ])
+
+        /// Single unfulfilled shipment
+        let shipments = [
+            WooShippingShipment.fake().copy(
+                siteID: siteID,
+                orderID: orderID,
+                index: "shipment_0",
+                items: [
+                    .fake().copy(id: product1.productID)
+                ])
+        ]
+        insert(shipments: shipments, order: order)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(
+            order: order,
+            stores: stores,
+            storageManager: storageManager,
+            siteCIABEligibilityChecker: mockSiteCIABChecker,
+            initialNoticeDelay: .seconds(0)
+        )
+
+        waitUntil {
+            viewModel.state == .ready
+        }
+
+        // Then
+        XCTAssertFalse(viewModel.editSplitShipmentsOptionVisible)
     }
 
     func test_editSplitShipmentsOptionVisible_is_false_when_all_shipments_fulfilled() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        initialConfigurationForSplitShipmentsTest(stores: stores)
+
+        /// Non-CIAB site (split shipments available)
+        let mockSiteCIABChecker = MockCIABEligibilityChecker(
+            mockedIsCurrentSiteCIAB: false,
+            mockedCIABDisabledFeatures: []
+        )
+
+        /// Multiple products
+        let product1 = Product.fake().copy(siteID: siteID, productID: 1)
+        let product2 = Product.fake().copy(siteID: siteID, productID: 2)
+
+        storageManager.insertSampleProduct(readOnlyProduct: product1)
+        storageManager.insertSampleProduct(readOnlyProduct: product2)
+
+        let order = Order.fake().copy(
+            siteID: siteID,
+            orderID: orderID,
+            items: [
+                OrderItem.fake().copy(productID: product1.productID, quantity: 1),
+                OrderItem.fake().copy(productID: product2.productID, quantity: 1)
+            ])
+
+        /// Each shipment is fulfilled
+        let shippingLabel1 = ShippingLabel.fake().copy(siteID: siteID, orderID: orderID, shippingLabelID: 134)
+        let shippingLabel2 = ShippingLabel.fake().copy(siteID: siteID, orderID: orderID, shippingLabelID: 245)
+
+        /// 2 fulfilled shipments
+        let shipments = [
+            WooShippingShipment.fake().copy(
+                siteID: siteID,
+                orderID: orderID,
+                index: "shipment_0",
+                items: [
+                    .fake().copy(id: product1.productID)
+                ],
+                shippingLabel: shippingLabel1
+            ),
+            WooShippingShipment.fake().copy(
+                siteID: siteID,
+                orderID: orderID,
+                index: "shipment_1",
+                items: [
+                    .fake().copy(id: product2.productID)
+                ],
+                shippingLabel: shippingLabel2
+            )
+        ]
+        insert(shipments: shipments, order: order)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(
+            order: order,
+            stores: stores,
+            storageManager: storageManager,
+            siteCIABEligibilityChecker: mockSiteCIABChecker,
+            initialNoticeDelay: .seconds(0)
+        )
+
+        waitUntil {
+            viewModel.state == .ready
+        }
+
+        // Then
+        XCTAssertFalse(viewModel.editSplitShipmentsOptionVisible)
     }
 
     func test_editSplitShipmentsOptionVisible_is_true_when_all_requirements_met() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        initialConfigurationForSplitShipmentsTest(stores: stores)
+
+        /// Non-CIAB site (split shipments available)
+        let mockSiteCIABChecker = MockCIABEligibilityChecker(
+            mockedIsCurrentSiteCIAB: false,
+            mockedCIABDisabledFeatures: []
+        )
+
+        /// Multiple products
+        let product1 = Product.fake().copy(siteID: siteID, productID: 1)
+        let product2 = Product.fake().copy(siteID: siteID, productID: 2)
+
+        storageManager.insertSampleProduct(readOnlyProduct: product1)
+        storageManager.insertSampleProduct(readOnlyProduct: product2)
+
+        let order = Order.fake().copy(
+            siteID: siteID,
+            orderID: orderID,
+            items: [
+                OrderItem.fake().copy(productID: product1.productID, quantity: 1),
+                OrderItem.fake().copy(productID: product2.productID, quantity: 1)
+            ])
+
+        /// Single unfulfilled shipment
+        let shipments = [
+            WooShippingShipment.fake().copy(
+                siteID: siteID,
+                orderID: orderID,
+                index: "shipment_0",
+                items: [
+                    .fake().copy(id: product1.productID),
+                    .fake().copy(id: product2.productID)
+                ])
+        ]
+        insert(shipments: shipments, order: order)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(
+            order: order,
+            stores: stores,
+            storageManager: storageManager,
+            siteCIABEligibilityChecker: mockSiteCIABChecker,
+            initialNoticeDelay: .seconds(0)
+        )
+
+        waitUntil {
+            viewModel.state == .ready
+        }
+
+        // Then
+        XCTAssertTrue(viewModel.editSplitShipmentsOptionVisible)
     }
 }
 
@@ -1205,11 +1600,6 @@ private extension WooShippingCreateLabelsViewModelTests {
     func insert(accountSettings: ShippingLabelAccountSettings) {
         let storageSettings = storage.insertNewObject(ofType: StorageShippingLabelAccountSettings.self)
         storageSettings.update(with: accountSettings)
-    }
-
-    func insert(product: Product) {
-        let storageProduct = storage.insertNewObject(ofType: StorageProduct.self)
-        storageProduct.update(with: product)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -1038,6 +1038,95 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertTrue(originAddressesLoaded, "Origin addresses should be loaded from remote when missing")
         XCTAssertFalse(viewModel.originAddress.isEmpty, "Origin address should be set from loaded data")
     }
+
+    // MARK: - split shipments feature visibility tests
+
+    func test_splitShipmentsRowVisible_is_false_when_split_shipments_feature_is_unavailable() {
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .verifyDestinationAddress(_, _, let completion):
+                completion(.success(WooShippingVerifyDestinationAddressSuccess(normalizedAddress: WooShippingNormalizedAddress.fake(),
+                                                                               isTrivialNormalization: nil,
+                                                                               isVerified: true)))
+            case .loadAccountSettings(_, let completion):
+                completion(.success(self.settings))
+            case .loadOriginAddresses(_, let completion):
+                let originAddress = WooShippingOriginAddress.fake().copy(address1: "123 Main Street", defaultAddress: true)
+                completion(.success([originAddress]))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        let mockSiteCIABChecker = MockCIABEligibilityChecker(
+            mockedIsCurrentSiteCIAB: true,
+            mockedCIABDisabledFeatures: [.splitShipments]
+        )
+
+        // There exist 2 shipments, one of which has been fulfilled.
+        let product1 = Product.fake().copy(productID: 1)
+        let product2 = Product.fake().copy(productID: 2)
+        insert(product: product1)
+        insert(product: product2)
+
+        let order = Order.fake().copy(
+            siteID: siteID,
+            orderID: orderID,
+            items: [
+                OrderItem.fake().copy(productID: product1.productID, quantity: 1),
+                OrderItem.fake().copy(productID: product2.productID, quantity: 1)
+            ])
+
+        let shipments = [
+            WooShippingShipment.fake().copy(
+                siteID: siteID,
+                orderID: orderID,
+                index: "shipment_0",
+                items: [
+                    .fake().copy(id: product1.productID),
+                    .fake().copy(id: product2.productID)
+                ])
+        ]
+        insert(shipments: shipments, order: order)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(
+            order: order,
+            stores: stores,
+            storageManager: storageManager,
+            siteCIABEligibilityChecker: mockSiteCIABChecker,
+            initialNoticeDelay: .seconds(0)
+        )
+
+        waitUntil {
+            viewModel.state == .ready
+        }
+
+        // Then
+        XCTAssertFalse(viewModel.splitShipmentsRowVisible)
+    }
+
+    func test_splitShipmentsRowVisible_is_false_when_only_single_product_item_exists() {
+    }
+
+    func test_splitShipmentsRowVisible_is_false_when_order_has_multiple_shipments() {
+    }
+
+    func test_splitShipmentsRowVisible_is_true_when_requirements_met() {
+    }
+
+    func test_editSplitShipmentsOptionVisible_is_false_when_split_shipments_feature_is_unavailable() {
+    }
+
+    func test_editSplitShipmentsOptionVisible_is_false_when_only_single_product_item_exists() {
+    }
+
+    func test_editSplitShipmentsOptionVisible_is_false_when_all_shipments_fulfilled() {
+    }
+
+    func test_editSplitShipmentsOptionVisible_is_true_when_all_requirements_met() {
+    }
 }
 
 private extension WooShippingCreateLabelsViewModelTests {
@@ -1055,6 +1144,25 @@ private extension WooShippingCreateLabelsViewModelTests {
     ///
     func mapLoadGeneralSiteSettingsResponse() -> [SiteSetting] {
         return mapGeneralSettings(from: "settings-general")
+    }
+
+    func setupInitialDataLoadingMocks(
+        for stores: MockStoresManager,
+        originAddressesResult: Result<[WooShippingOriginAddress], Error> = .success([.fake().copy(id: "default", defaultAddress: true)]),
+        accountSettingsResult: Result<WooShippingAccountSettings, Error> = .success(.fake())
+    ) {
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .loadOriginAddresses(_, let completion):
+                completion(originAddressesResult)
+            case .loadAccountSettings(_, let completion):
+                completion(accountSettingsResult)
+            case .loadPackages, .verifyDestinationAddress:
+                break // Ignored for these tests
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
     }
 
     func insert(shipments: [WooShippingShipment], order: Order) {
@@ -1091,10 +1199,23 @@ private extension WooShippingCreateLabelsViewModelTests {
     func insert(originAddress: WooShippingOriginAddress) {
         let storageAddress = storage.insertNewObject(ofType: StorageWooShippingOriginAddress.self)
         storageAddress.update(with: originAddress)
+
     }
 
     func insert(accountSettings: ShippingLabelAccountSettings) {
         let storageSettings = storage.insertNewObject(ofType: StorageShippingLabelAccountSettings.self)
         storageSettings.update(with: accountSettings)
+    }
+
+    func insert(product: Product) {
+        let storageProduct = storage.insertNewObject(ofType: StorageProduct.self)
+        storageProduct.update(with: product)
+    }
+}
+
+private extension WooShippingAccountSettings {
+    static func fake() -> WooShippingAccountSettings {
+        .init(storeOptions: .init(currencySymbol: "$", dimensionUnit: "in", weightUnit: "lbs", originCountry: "US"),
+              accountSettings: .fake())
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1271

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Makes sure that the "Split Shipments" feature is not visible for CIAB sites
- Conditionally hides the pencil icon
- Conditionally hides the "Split Shipments" row that's displayed when no shipments yet created.
- Renamed `splitShipmentsAvailable` -> `splitShipmentsRowVisible` `WooShippingCreateLabelsViewModel`. The new `splitShipmentsRowVisible` accounts CIAB site restrictions.
- Added `editSplitShipmentsOptionVisible` to `WooShippingCreateLabelsViewModel` that's determines the pencil icon visibility in shipments panel.
- Added `MockCIABEligibilityChecker` for testing purposes

The majority of changes come from WooShippingCreateLabelsViewModelTests.swift updates

## Non-CIAB site testing case (default behaviour)
- Use a site with shipping plugin active. Make sure the site doesn't contain "garden" or "ciab" in name (this is the temp CIAB / non-CIAB site distinguishing logic).
- Find an order that contains a single shipment with multiple products / items to have the split shipments feature applicable.
- Navigate to the order details
- Navigate to the "Create Shipping Label" flow
- Make sure the "Split shipments" button is displayed next to "Products"

<img width="457" height="304" alt="Снимок экрана 2025-09-10 в 15 00 10" src="https://github.com/user-attachments/assets/f31e52ca-aa61-4c22-9a09-968c52db8670" />

- Find another order that already contains several unfulfilled shipments
- Navigate to order details -> "Create Shipping Label" 
- Make sure the "pencil" icon is displayed in shipments tab
<img width="460" height="280" alt="Снимок экрана 2025-09-10 в 15 04 00" src="https://github.com/user-attachments/assets/e87afe42-aeb4-40ea-b638-39f761db92f9" />

## CIAB site testing case
- Add "garden" or "ciab" into site name in admin dashboard
- Restart the app and make sure the name change took place
- Repeat steps from Non-CIAB scenario
- Make "Split shipments" and "pencil" buttons are not visible.

<img width="461" height="229" alt="Снимок экрана 2025-09-10 в 15 11 19" src="https://github.com/user-attachments/assets/b258f64a-2147-4caf-b405-1c5e098d2109" />

<img width="462" height="282" alt="Снимок экрана 2025-09-10 в 15 12 39" src="https://github.com/user-attachments/assets/231d3eb3-302b-4868-bc28-eff5b3c09a29" />

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested the above scenarios on iPhone Simulator 18.4.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.