### PR TITLE
Application password experiment: Clear flagged sites after 14 days

### DIFF
--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetwork.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetwork.swift
@@ -360,8 +360,8 @@ extension Alamofire.DataResponse {
 // MARK: - Helper extension to save internal flag for app password availability
 //
 extension UserDefaults {
-    @objc dynamic var applicationPasswordUnsupportedList: [String: String] {
-        get { value(forKey: Key.applicationPasswordUnsupportedList.rawValue) as? [String: String] ?? [:] }
+    @objc dynamic var applicationPasswordUnsupportedList: [String: Date] {
+        get { value(forKey: Key.applicationPasswordUnsupportedList.rawValue) as? [String: Date] ?? [:] }
         set { setValue(newValue, forKey: Key.applicationPasswordUnsupportedList.rawValue) }
     }
 

--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetwork.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetwork.swift
@@ -269,7 +269,10 @@ private extension AlamofireNetwork {
             .sink { [weak self] site, unsupportedList in
                 guard let self else { return }
                 guard let site, site.applicationPasswordAvailable,
-                      unsupportedList.contains(site.siteID) == false else {
+                      errorHandler.siteFlaggedAsUnsupported(
+                        siteID: site.siteID,
+                        unsupportedList: unsupportedList
+                      ) == false else {
                     requestConverter = RequestConverter(siteAddress: nil)
                     requestAuthenticator.updateAuthenticator(DefaultRequestAuthenticator(credentials: credentials))
                     requestAuthenticator.delegate = nil
@@ -357,8 +360,8 @@ extension Alamofire.DataResponse {
 // MARK: - Helper extension to save internal flag for app password availability
 //
 extension UserDefaults {
-    @objc dynamic var applicationPasswordUnsupportedList: [Int64] {
-        get { value(forKey: Key.applicationPasswordUnsupportedList.rawValue) as? [Int64] ?? [] }
+    @objc dynamic var applicationPasswordUnsupportedList: [String: String] {
+        get { value(forKey: Key.applicationPasswordUnsupportedList.rawValue) as? [String: String] ?? [:] }
         set { setValue(newValue, forKey: Key.applicationPasswordUnsupportedList.rawValue) }
     }
 

--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
@@ -135,14 +135,31 @@ final class AlamofireNetworkErrorHandler {
 
     func flagSiteAsUnsupported(for siteID: Int64) {
         queue.sync(flags: .barrier) {
-            let currentList = userDefaults.applicationPasswordUnsupportedList
-            userDefaults.applicationPasswordUnsupportedList = currentList + [siteID]
+            var currentList = userDefaults.applicationPasswordUnsupportedList
+            currentList[String(siteID)] = String(Date().timeIntervalSince1970)
+            userDefaults.applicationPasswordUnsupportedList = currentList
         }
     }
 
-    // MARK: - Private methods
+    func siteFlaggedAsUnsupported(siteID: Int64, unsupportedList: [String: String]) -> Bool {
+        guard let flagDateString = unsupportedList[String(siteID)],
+              let flagDate = TimeInterval(flagDateString) else {
+            return false
+        }
 
-    private func incrementFailureCount(for siteID: Int64) {
+        let timeElapsed = Date().timeIntervalSince1970 - flagDate
+        if timeElapsed < Constants.flagRefreshDuration {
+            return true
+        } else {
+            clearUnsupportedFlag(for: siteID)
+            return false
+        }
+    }
+}
+
+// MARK: Private helpers
+private extension AlamofireNetworkErrorHandler {
+    func incrementFailureCount(for siteID: Int64) {
         let currentFailureCount = appPasswordFailures[siteID] ?? 0
         let updatedCount = currentFailureCount + 1
         if updatedCount == AppPasswordConstants.requestFailureThreshold {
@@ -150,8 +167,20 @@ final class AlamofireNetworkErrorHandler {
         }
         appPasswordFailures[siteID] = updatedCount
     }
-}
 
+    func clearUnsupportedFlag(for siteID: Int64) {
+        queue.sync(flags: .barrier) {
+            let currentList = userDefaults.applicationPasswordUnsupportedList
+            userDefaults.applicationPasswordUnsupportedList = currentList.filter { flag in
+                flag.key != String(siteID)
+            }
+        }
+    }
+
+    enum Constants {
+        static let flagRefreshDuration: Double = 60 * 60 * 24 * 7 // flag can be reset after 7 days.
+    }
+}
 /// Helper type to keep track of retried requests with accompanied error
 struct RetriedJetpackRequest {
     let request: JetpackRequest

--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
@@ -146,7 +146,7 @@ final class AlamofireNetworkErrorHandler {
             return false
         }
 
-        let timeElapsed = Date().timeIntervalSince1970 - flagDate.timeIntervalSince1970
+        let timeElapsed = Date().timeIntervalSince(flagDate)
         if timeElapsed < Constants.flagRefreshDuration {
             return true
         } else {

--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
@@ -136,18 +136,17 @@ final class AlamofireNetworkErrorHandler {
     func flagSiteAsUnsupported(for siteID: Int64) {
         queue.sync(flags: .barrier) {
             var currentList = userDefaults.applicationPasswordUnsupportedList
-            currentList[String(siteID)] = String(Date().timeIntervalSince1970)
+            currentList[String(siteID)] = Date()
             userDefaults.applicationPasswordUnsupportedList = currentList
         }
     }
 
-    func siteFlaggedAsUnsupported(siteID: Int64, unsupportedList: [String: String]) -> Bool {
-        guard let flagDateString = unsupportedList[String(siteID)],
-              let flagDate = TimeInterval(flagDateString) else {
+    func siteFlaggedAsUnsupported(siteID: Int64, unsupportedList: [String: Date]) -> Bool {
+        guard let flagDate = unsupportedList[String(siteID)] else {
             return false
         }
 
-        let timeElapsed = Date().timeIntervalSince1970 - flagDate
+        let timeElapsed = Date().timeIntervalSince1970 - flagDate.timeIntervalSince1970
         if timeElapsed < Constants.flagRefreshDuration {
             return true
         } else {

--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
@@ -177,7 +177,7 @@ private extension AlamofireNetworkErrorHandler {
     }
 
     enum Constants {
-        static let flagRefreshDuration: Double = 60 * 60 * 24 * 7 // flag can be reset after 7 days.
+        static let flagRefreshDuration: Double = 60 * 60 * 24 * 14 // flag can be reset after 14 days.
     }
 }
 /// Helper type to keep track of retried requests with accompanied error

--- a/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
@@ -316,7 +316,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
     func test_siteFlaggedAsUnsupported_returns_false_and_clears_flag_when_expired() {
         // Given
         let siteID: Int64 = 123
-        let expiredDate = Date(timeIntervalSince1970: Date().timeIntervalSince1970 - (60 * 60 * 24 * 8)) // 8 days ago (expired)
+        let expiredDate = Date(timeIntervalSince1970: Date().timeIntervalSince1970 - (60 * 60 * 24 * 15)) // 15 days ago (expired)
         userDefaults.applicationPasswordUnsupportedList = [String(siteID): expiredDate]
 
         // When
@@ -344,7 +344,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
     func test_siteFlaggedAsUnsupported_returns_false_for_flag_just_over_boundary() {
         // Given
         let siteID: Int64 = 123
-        let expiredDate = Date(timeIntervalSince1970: Date().timeIntervalSince1970 - (60 * 60 * 24 * 7 + 1)) // Just over 7 days ago
+        let expiredDate = Date(timeIntervalSince1970: Date().timeIntervalSince1970 - (60 * 60 * 24 * 14 + 1)) // Just over 7 days ago
         userDefaults.applicationPasswordUnsupportedList = [String(siteID): expiredDate]
 
         // When
@@ -362,7 +362,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         let siteID2: Int64 = 456
         let siteID3: Int64 = 789
         let recentDate = Date(timeIntervalSince1970: Date().timeIntervalSince1970 - (60 * 60)) // 1 hour ago
-        let expiredDate = Date(timeIntervalSince1970: Date().timeIntervalSince1970 - (60 * 60 * 24 * 8)) // 8 days ago
+        let expiredDate = Date(timeIntervalSince1970: Date().timeIntervalSince1970 - (60 * 60 * 24 * 15)) // 15 days ago
 
         userDefaults.applicationPasswordUnsupportedList = [
             String(siteID1): recentDate,

--- a/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
@@ -129,7 +129,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         // Given
         let existingSiteID: Int64 = 789
         let newSiteID: Int64 = 456
-        userDefaults.applicationPasswordUnsupportedList = [String(existingSiteID): String(Date().timeIntervalSince1970)]
+        userDefaults.applicationPasswordUnsupportedList = [String(existingSiteID): Date()]
 
         // When
         errorHandler.flagSiteAsUnsupported(for: newSiteID)
@@ -279,7 +279,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
     func test_siteFlaggedAsUnsupported_returns_false_when_site_not_in_list() {
         // Given
         let siteID: Int64 = 123
-        let unsupportedList: [String: String] = [:]
+        let unsupportedList: [String: Date] = [:]
 
         // When
         let isFlagged = errorHandler.siteFlaggedAsUnsupported(siteID: siteID, unsupportedList: unsupportedList)
@@ -291,7 +291,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
     func test_siteFlaggedAsUnsupported_returns_false_when_timestamp_string_invalid() {
         // Given
         let siteID: Int64 = 123
-        let unsupportedList: [String: String] = [String(siteID): "invalid_timestamp"]
+        let unsupportedList: [String: Date] = [String(siteID): Date(timeIntervalSince1970: 0)]
 
         // When
         let isFlagged = errorHandler.siteFlaggedAsUnsupported(siteID: siteID, unsupportedList: unsupportedList)
@@ -303,8 +303,8 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
     func test_siteFlaggedAsUnsupported_returns_true_when_flag_is_recent() {
         // Given
         let siteID: Int64 = 123
-        let recentTimestamp = Date().timeIntervalSince1970 - (60 * 60) // 1 hour ago
-        let unsupportedList: [String: String] = [String(siteID): String(recentTimestamp)]
+        let recentDate = Date(timeIntervalSince1970: Date().timeIntervalSince1970 - (60 * 60)) // 1 hour ago
+        let unsupportedList: [String: Date] = [String(siteID): recentDate]
 
         // When
         let isFlagged = errorHandler.siteFlaggedAsUnsupported(siteID: siteID, unsupportedList: unsupportedList)
@@ -316,8 +316,8 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
     func test_siteFlaggedAsUnsupported_returns_false_and_clears_flag_when_expired() {
         // Given
         let siteID: Int64 = 123
-        let expiredTimestamp = Date().timeIntervalSince1970 - (60 * 60 * 24 * 8) // 8 days ago (expired)
-        userDefaults.applicationPasswordUnsupportedList = [String(siteID): String(expiredTimestamp)]
+        let expiredDate = Date(timeIntervalSince1970: Date().timeIntervalSince1970 - (60 * 60 * 24 * 8)) // 8 days ago (expired)
+        userDefaults.applicationPasswordUnsupportedList = [String(siteID): expiredDate]
 
         // When
         let isFlagged = errorHandler.siteFlaggedAsUnsupported(siteID: siteID, unsupportedList: userDefaults.applicationPasswordUnsupportedList)
@@ -331,8 +331,8 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
     func test_siteFlaggedAsUnsupported_returns_true_for_flag_at_boundary_time() {
         // Given
         let siteID: Int64 = 123
-        let boundaryTimestamp = Date().timeIntervalSince1970 - (60 * 60 * 24 * 7 - 1) // Just under 7 days ago
-        let unsupportedList: [String: String] = [String(siteID): String(boundaryTimestamp)]
+        let boundaryDate = Date(timeIntervalSince1970: Date().timeIntervalSince1970 - (60 * 60 * 24 * 7 - 1)) // Just under 7 days ago
+        let unsupportedList: [String: Date] = [String(siteID): boundaryDate]
 
         // When
         let isFlagged = errorHandler.siteFlaggedAsUnsupported(siteID: siteID, unsupportedList: unsupportedList)
@@ -344,8 +344,8 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
     func test_siteFlaggedAsUnsupported_returns_false_for_flag_just_over_boundary() {
         // Given
         let siteID: Int64 = 123
-        let expiredTimestamp = Date().timeIntervalSince1970 - (60 * 60 * 24 * 7 + 1) // Just over 7 days ago
-        userDefaults.applicationPasswordUnsupportedList = [String(siteID): String(expiredTimestamp)]
+        let expiredDate = Date(timeIntervalSince1970: Date().timeIntervalSince1970 - (60 * 60 * 24 * 7 + 1)) // Just over 7 days ago
+        userDefaults.applicationPasswordUnsupportedList = [String(siteID): expiredDate]
 
         // When
         let isFlagged = errorHandler.siteFlaggedAsUnsupported(siteID: siteID, unsupportedList: userDefaults.applicationPasswordUnsupportedList)
@@ -361,13 +361,13 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         let siteID1: Int64 = 123
         let siteID2: Int64 = 456
         let siteID3: Int64 = 789
-        let recentTimestamp = Date().timeIntervalSince1970 - (60 * 60) // 1 hour ago
-        let expiredTimestamp = Date().timeIntervalSince1970 - (60 * 60 * 24 * 8) // 8 days ago
+        let recentDate = Date(timeIntervalSince1970: Date().timeIntervalSince1970 - (60 * 60)) // 1 hour ago
+        let expiredDate = Date(timeIntervalSince1970: Date().timeIntervalSince1970 - (60 * 60 * 24 * 8)) // 8 days ago
         
         userDefaults.applicationPasswordUnsupportedList = [
-            String(siteID1): String(recentTimestamp),
-            String(siteID2): String(expiredTimestamp),
-            String(siteID3): String(recentTimestamp)
+            String(siteID1): recentDate,
+            String(siteID2): expiredDate,
+            String(siteID3): recentDate
         ]
 
         // When & Then

--- a/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
@@ -33,7 +33,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
 
         // Then - should not flag site as unsupported even after more failures
         simulateFailureCount(5, for: siteID) // Would normally reach threshold
-        XCTAssertFalse(userDefaults.applicationPasswordUnsupportedList.contains(siteID))
+        XCTAssertFalse(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID)))
     }
 
     func test_shouldRetryJetpackRequest_returns_false_for_nil_credentials() {
@@ -122,20 +122,21 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         errorHandler.flagSiteAsUnsupported(for: siteID)
 
         // Then
-        XCTAssertEqual(userDefaults.applicationPasswordUnsupportedList, [siteID])
+        XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID)))
     }
 
     func test_flagSiteAsUnsupported_appends_to_existing_list() {
         // Given
         let existingSiteID: Int64 = 789
         let newSiteID: Int64 = 456
-        userDefaults.applicationPasswordUnsupportedList = [existingSiteID]
+        userDefaults.applicationPasswordUnsupportedList = [String(existingSiteID): String(Date().timeIntervalSince1970)]
 
         // When
         errorHandler.flagSiteAsUnsupported(for: newSiteID)
 
         // Then
-        XCTAssertEqual(userDefaults.applicationPasswordUnsupportedList, [existingSiteID, newSiteID])
+        XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(existingSiteID)))
+        XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(newSiteID)))
     }
 
     // MARK: - Thread Safety Tests
@@ -273,6 +274,114 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         wait(for: [expectation], timeout: 3.0)
     }
 
+    // MARK: - siteFlaggedAsUnsupported Tests
+
+    func test_siteFlaggedAsUnsupported_returns_false_when_site_not_in_list() {
+        // Given
+        let siteID: Int64 = 123
+        let unsupportedList: [String: String] = [:]
+
+        // When
+        let isFlagged = errorHandler.siteFlaggedAsUnsupported(siteID: siteID, unsupportedList: unsupportedList)
+
+        // Then
+        XCTAssertFalse(isFlagged)
+    }
+
+    func test_siteFlaggedAsUnsupported_returns_false_when_timestamp_string_invalid() {
+        // Given
+        let siteID: Int64 = 123
+        let unsupportedList: [String: String] = [String(siteID): "invalid_timestamp"]
+
+        // When
+        let isFlagged = errorHandler.siteFlaggedAsUnsupported(siteID: siteID, unsupportedList: unsupportedList)
+
+        // Then
+        XCTAssertFalse(isFlagged)
+    }
+
+    func test_siteFlaggedAsUnsupported_returns_true_when_flag_is_recent() {
+        // Given
+        let siteID: Int64 = 123
+        let recentTimestamp = Date().timeIntervalSince1970 - (60 * 60) // 1 hour ago
+        let unsupportedList: [String: String] = [String(siteID): String(recentTimestamp)]
+
+        // When
+        let isFlagged = errorHandler.siteFlaggedAsUnsupported(siteID: siteID, unsupportedList: unsupportedList)
+
+        // Then
+        XCTAssertTrue(isFlagged)
+    }
+
+    func test_siteFlaggedAsUnsupported_returns_false_and_clears_flag_when_expired() {
+        // Given
+        let siteID: Int64 = 123
+        let expiredTimestamp = Date().timeIntervalSince1970 - (60 * 60 * 24 * 8) // 8 days ago (expired)
+        userDefaults.applicationPasswordUnsupportedList = [String(siteID): String(expiredTimestamp)]
+
+        // When
+        let isFlagged = errorHandler.siteFlaggedAsUnsupported(siteID: siteID, unsupportedList: userDefaults.applicationPasswordUnsupportedList)
+
+        // Then
+        XCTAssertFalse(isFlagged)
+        // Verify the flag was cleared from UserDefaults
+        XCTAssertFalse(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID)))
+    }
+
+    func test_siteFlaggedAsUnsupported_returns_true_for_flag_at_boundary_time() {
+        // Given
+        let siteID: Int64 = 123
+        let boundaryTimestamp = Date().timeIntervalSince1970 - (60 * 60 * 24 * 7 - 1) // Just under 7 days ago
+        let unsupportedList: [String: String] = [String(siteID): String(boundaryTimestamp)]
+
+        // When
+        let isFlagged = errorHandler.siteFlaggedAsUnsupported(siteID: siteID, unsupportedList: unsupportedList)
+
+        // Then
+        XCTAssertTrue(isFlagged)
+    }
+
+    func test_siteFlaggedAsUnsupported_returns_false_for_flag_just_over_boundary() {
+        // Given
+        let siteID: Int64 = 123
+        let expiredTimestamp = Date().timeIntervalSince1970 - (60 * 60 * 24 * 7 + 1) // Just over 7 days ago
+        userDefaults.applicationPasswordUnsupportedList = [String(siteID): String(expiredTimestamp)]
+
+        // When
+        let isFlagged = errorHandler.siteFlaggedAsUnsupported(siteID: siteID, unsupportedList: userDefaults.applicationPasswordUnsupportedList)
+
+        // Then
+        XCTAssertFalse(isFlagged)
+        // Verify the flag was cleared from UserDefaults
+        XCTAssertFalse(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID)))
+    }
+
+    func test_siteFlaggedAsUnsupported_handles_multiple_sites_correctly() {
+        // Given
+        let siteID1: Int64 = 123
+        let siteID2: Int64 = 456
+        let siteID3: Int64 = 789
+        let recentTimestamp = Date().timeIntervalSince1970 - (60 * 60) // 1 hour ago
+        let expiredTimestamp = Date().timeIntervalSince1970 - (60 * 60 * 24 * 8) // 8 days ago
+        
+        userDefaults.applicationPasswordUnsupportedList = [
+            String(siteID1): String(recentTimestamp),
+            String(siteID2): String(expiredTimestamp),
+            String(siteID3): String(recentTimestamp)
+        ]
+
+        // When & Then
+        let list = userDefaults.applicationPasswordUnsupportedList
+        XCTAssertTrue(errorHandler.siteFlaggedAsUnsupported(siteID: siteID1, unsupportedList: list))
+        XCTAssertFalse(errorHandler.siteFlaggedAsUnsupported(siteID: siteID2, unsupportedList: userDefaults.applicationPasswordUnsupportedList))
+        XCTAssertTrue(errorHandler.siteFlaggedAsUnsupported(siteID: siteID3, unsupportedList: userDefaults.applicationPasswordUnsupportedList))
+        
+        // Verify expired flag was cleared but others remain
+        XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID1)))
+        XCTAssertFalse(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID2)))
+        XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID3)))
+    }
+
     // MARK: - Integration Tests
 
     func test_handleFailureForDirectRequestIfNeeded_calls_correct_callbacks() {
@@ -352,7 +461,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         )
 
         // Then
-        XCTAssertEqual(userDefaults.applicationPasswordUnsupportedList, [siteID])
+        XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID)))
     }
 
     func test_flagSiteAsUnsupportedForAppPasswordIfNeeded_handles_disabled_error_codes() {
@@ -383,7 +492,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         )
 
         // Then
-        XCTAssertEqual(userDefaults.applicationPasswordUnsupportedList, [siteID])
+        XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID)))
     }
 }
 

--- a/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
@@ -363,7 +363,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         let siteID3: Int64 = 789
         let recentDate = Date(timeIntervalSince1970: Date().timeIntervalSince1970 - (60 * 60)) // 1 hour ago
         let expiredDate = Date(timeIntervalSince1970: Date().timeIntervalSince1970 - (60 * 60 * 24 * 8)) // 8 days ago
-        
+
         userDefaults.applicationPasswordUnsupportedList = [
             String(siteID1): recentDate,
             String(siteID2): expiredDate,
@@ -375,7 +375,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         XCTAssertTrue(errorHandler.siteFlaggedAsUnsupported(siteID: siteID1, unsupportedList: list))
         XCTAssertFalse(errorHandler.siteFlaggedAsUnsupported(siteID: siteID2, unsupportedList: userDefaults.applicationPasswordUnsupportedList))
         XCTAssertTrue(errorHandler.siteFlaggedAsUnsupported(siteID: siteID3, unsupportedList: userDefaults.applicationPasswordUnsupportedList))
-        
+
         // Verify expired flag was cleared but others remain
         XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID1)))
         XCTAssertFalse(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID2)))

--- a/Modules/Tests/NetworkingTests/Network/AlamofireNetworkTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/AlamofireNetworkTests.swift
@@ -187,21 +187,22 @@ final class AlamofireNetworkTests: XCTestCase {
         network.didFailToAuthenticateRequestWithAppPassword(siteID: siteID)
 
         // Then
-        XCTAssertEqual(userDefaults.applicationPasswordUnsupportedList, [siteID])
+        XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID)))
     }
 
     func test_didFailToAuthenticateRequestWithAppPassword_appends_to_existing_unsupported_list() {
         // Given
         let existingSiteID: Int64 = 456
         let newSiteID: Int64 = 123
-        userDefaults.applicationPasswordUnsupportedList = [existingSiteID]
+        userDefaults.applicationPasswordUnsupportedList = [String(existingSiteID): String(Date().timeIntervalSince1970)]
         let network = AlamofireNetwork(credentials: nil, userDefaults: userDefaults)
 
         // When
         network.didFailToAuthenticateRequestWithAppPassword(siteID: newSiteID)
 
         // Then
-        XCTAssertEqual(userDefaults.applicationPasswordUnsupportedList, [existingSiteID, newSiteID])
+        XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(existingSiteID)))
+        XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(newSiteID)))
     }
 
     // MARK: - Session Initialization Tests
@@ -328,7 +329,7 @@ final class AlamofireNetworkTests: XCTestCase {
         // Then
         XCTAssertNil(result.1)
         XCTAssertNotNil(result.0)
-        XCTAssertEqual(userDefaults.applicationPasswordUnsupportedList, [siteID])
+        XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID)))
     }
 
     func test_responseDataAndHeaders_retries_direct_request_when_converted_request_fails() async throws {
@@ -374,7 +375,7 @@ final class AlamofireNetworkTests: XCTestCase {
         // Then
         let responseDict = try JSONSerialization.jsonObject(with: result.0, options: []) as? [String: String]
         XCTAssertEqual(responseDict?["reports"], "data")
-        XCTAssertEqual(userDefaults.applicationPasswordUnsupportedList, [siteID])
+        XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID)))
     }
 
     func test_responseDataPublisher_retries_direct_request_when_converted_request_fails() {
@@ -430,7 +431,7 @@ final class AlamofireNetworkTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertEqual(userDefaults.applicationPasswordUnsupportedList, [siteID])
+        XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID)))
     }
 
     func test_uploadMultipartFormData_retries_direct_request_when_converted_request_fails() {
@@ -491,7 +492,7 @@ final class AlamofireNetworkTests: XCTestCase {
         // Then
         XCTAssertNil(result.1)
         XCTAssertNotNil(result.0)
-        XCTAssertEqual(userDefaults.applicationPasswordUnsupportedList, [siteID])
+        XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID)))
     }
 
     // MARK: - Application Password Error Code Tests
@@ -524,7 +525,7 @@ final class AlamofireNetworkTests: XCTestCase {
         // Then
         XCTAssertNil(result.1)
         XCTAssertNotNil(result.0)
-        XCTAssertEqual(userDefaults.applicationPasswordUnsupportedList, [siteID])
+        XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID)))
     }
 
     func test_responseData_increments_failure_count_when_jetpack_retry_succeeds_after_unknown_error() throws {
@@ -590,7 +591,7 @@ final class AlamofireNetworkTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(userDefaults.applicationPasswordUnsupportedList, [siteID])
+        XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID)))
     }
 
     func test_responseData_does_not_retry_when_jetpack_request_not_available_as_rest() throws {

--- a/Modules/Tests/NetworkingTests/Network/AlamofireNetworkTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/AlamofireNetworkTests.swift
@@ -194,7 +194,7 @@ final class AlamofireNetworkTests: XCTestCase {
         // Given
         let existingSiteID: Int64 = 456
         let newSiteID: Int64 = 123
-        userDefaults.applicationPasswordUnsupportedList = [String(existingSiteID): String(Date().timeIntervalSince1970)]
+        userDefaults.applicationPasswordUnsupportedList = [String(existingSiteID): Date()]
         let network = AlamofireNetwork(credentials: nil, userDefaults: userDefaults)
 
         // When


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1187

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the capability to clear sites flagged as unsupported for network switching to direct requests after 14 days. This is to ensure that sites can take advantage of the switch if app passwords are enabled again.

Changes include:
- Changed the type of `applicationPasswordUnsupportedList` to dictionary of type [String: Date] to store site IDs along with the flagged date. String is required as dictionaries stored in `UserDefaults` need to be compliant to property list type with keys being strings.
- Added a helper method to check if a site is flagged and clear the the flag if the flag has expired (created more than 14 days ago).
- Updated tests.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Follow the TC7 test steps from here pe5sF9-4Am-p2.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested and confirmed TC7 with the alpha build on my iPhone.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.