### PR TITLE
Login: Update root endpoint parsing

### DIFF
--- a/Modules/Sources/Networking/Model/SiteAPI.swift
+++ b/Modules/Sources/Networking/Model/SiteAPI.swift
@@ -50,7 +50,8 @@ public struct SiteAPI: Decodable, Equatable, GeneratedFakeable {
         /// This workaround transforms the unexpected dictionary to extract the values in the dictionary.
         let namespaces = siteAPIContainer.failsafeDecodeIfPresent(
             targetType: [String].self,
-            forKey: .namespaces, alternativeTypes: [
+            forKey: .namespaces,
+            alternativeTypes: [
                 .dictionary(transform: { Array($0.values) })
             ]
         ) ?? []

--- a/Modules/Sources/Networking/Model/SiteAPI.swift
+++ b/Modules/Sources/Networking/Model/SiteAPI.swift
@@ -45,7 +45,16 @@ public struct SiteAPI: Decodable, Equatable, GeneratedFakeable {
         }
 
         let siteAPIContainer = try decoder.container(keyedBy: SiteAPIKeys.self)
-        let namespaces = siteAPIContainer.failsafeDecodeIfPresent([String].self, forKey: .namespaces) ?? []
+
+        /// Some third-party plugins (like CoCart API) alter the response of `namespaces` field into a dictionary instead of array.
+        /// This workaround transforms the unexpected dictionary to extract the values in the dictionary.
+        let namespaces = siteAPIContainer.failsafeDecodeIfPresent(
+            targetType: [String].self,
+            forKey: .namespaces, alternativeTypes: [
+                .dictionary(transform: { Array($0.values) })
+            ]
+        ) ?? []
+
         let authentication = try? siteAPIContainer.decode(Authentication.self, forKey: .authentication)
         let applicationPasswordAvailable = authentication?.applicationPasswords?.endpoints?.authorization != nil
 

--- a/Modules/Sources/NetworkingCore/Extensions/KeyedDecodingContainer+Woo.swift
+++ b/Modules/Sources/NetworkingCore/Extensions/KeyedDecodingContainer+Woo.swift
@@ -6,6 +6,7 @@ public enum AlternativeDecodingType<T> {
     case string(transform: (String) -> T)
     case bool(transform: (Bool) -> T)
     case integer(transform: (Int) -> T)
+    case dictionary(transform: ([String: String]) -> T)
 }
 
 // MARK: - KeyedDecodingContainer: Bulletproof JSON Decoding.
@@ -58,6 +59,10 @@ public extension KeyedDecodingContainer {
                 }
             case .integer(transform: let transform):
                 if let result = failsafeDecodeIfPresent(integerForKey: key) {
+                    return transform(result)
+                }
+            case .dictionary(let transform):
+                if let result = failsafeDecodeIfPresent([String: String].self, forKey: key) {
                     return transform(result)
                 }
             }

--- a/Modules/Tests/NetworkingTests/Mapper/SiteAPIMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/SiteAPIMapperTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 /// SiteAPIMapperTests Unit Tests
 ///
-class SiteAPIMapperTests: XCTestCase {
+final class SiteAPIMapperTests: XCTestCase {
 
     /// Dummy Site ID.
     ///
@@ -54,6 +54,18 @@ class SiteAPIMapperTests: XCTestCase {
         XCTAssertEqual(apiSettings?.namespaces, dummyBrokenNamespaces)
         XCTAssertEqual(apiSettings?.highestWooVersion, WooAPIVersion.none)
     }
+
+    /// Verifies the SiteSetting fields are parsed correctly.
+    ///
+    func test_SiteSetting_with_malformed_namespaces_fields_are_properly_parsed() {
+        let apiSettings = mapLoadSiteAPIResponseWithMalformedNamespaces()
+
+        XCTAssertNotNil(apiSettings)
+        XCTAssertEqual(apiSettings?.siteID, dummySiteID)
+        XCTAssertNotNil(apiSettings?.namespaces)
+        XCTAssertEqual(apiSettings?.namespaces.sorted(), dummyNamespaces.sorted())
+        XCTAssertEqual(apiSettings?.highestWooVersion, WooAPIVersion.mark3)
+    }
 }
 
 
@@ -87,5 +99,11 @@ private extension SiteAPIMapperTests {
     ///
     func mapLoadBrokenSiteAPIResponse() -> SiteAPI? {
         return mapSiteAPIData(from: "site-api-no-woo")
+    }
+
+    /// Returns the SiteAPIMapper output with malformed namespaces
+    ///
+    func mapLoadSiteAPIResponseWithMalformedNamespaces() -> SiteAPI? {
+        return mapSiteAPIData(from: "site-api-malformed")
     }
 }

--- a/Modules/Tests/NetworkingTests/Responses/site-api-malformed.json
+++ b/Modules/Tests/NetworkingTests/Responses/site-api-malformed.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "namespaces": {
+      "0": "oembed\/1.0",
+      "1": "akismet\/v1",
+      "2": "jetpack\/v4",
+      "3": "wpcom\/v2",
+      "4": "wc\/v1",
+      "5": "wc\/v2",
+      "6": "wc\/v3",
+      "7": "wc-pb\/v3",
+      "8": "wp\/v2"
+    },
+    "authentication": [],
+    "_links": {
+      "help": [
+        {
+          "href": "http:\/\/v2.wp-api.org\/"
+        }
+      ]
+    }
+  }
+}

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -252,6 +252,7 @@ class DefaultStoresManager: StoresManager {
     @discardableResult
     func deauthenticate() -> StoresManager {
         applicationPasswordGenerationFailureObserver = nil
+        invalidWPCOMTokenNotificationObserver = nil
 
         if isAuthenticated {
             let resetAction = CardPresentPaymentAction.reset

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -166,8 +166,10 @@ class DefaultStoresManager: StoresManager {
 
         if case .wpcom = credentials {
             listenToWPCOMInvalidWPCOMTokenNotification()
+            applicationPasswordGenerationFailureObserver = nil
         } else {
             listenToApplicationPasswordGenerationFailureNotification()
+            invalidWPCOMTokenNotificationObserver = nil
         }
 
         return self


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1315

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As part of the Jetpack site improvements project, we are fetching the root endpoint upon app launch and switching sites. This PR adds a similar change with Android in https://github.com/woocommerce/woocommerce-android/pull/14524 PR to support the altered form of the `namespace` field in the response to avoid blocking the app.

Additionally, redundant observers are removed upon changes of authentication.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Install the [CoCart API plugin](https://wordpress.org/plugins/cart-rest-api-for-woocommerce/)
2. Open the app and sign in to the site, or switch to it (after switching to a different site)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

In trunk the above steps will lead to an error, but should succeed in this branch.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.