### PR TITLE
Tracking request authentication type for order list loading

### DIFF
--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetwork.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetwork.swift
@@ -15,6 +15,12 @@ public struct JetpackSite: Equatable {
     }
 }
 
+public enum RequestAuthenticationMode: String {
+    case appPasswords = "app_passwords"
+    case appPasswordsWithJetpack = "app_passwords_with_jetpack" // switching to app password for Jetpack sites
+    case jetpackTunnel = "jetpack_tunnel"
+}
+
 extension Alamofire.MultipartFormData: MultipartFormData {
     public func append(_ data: Data, withName name: String) {
         self.append(data, withName: name, fileName: nil, mimeType: nil)
@@ -24,6 +30,10 @@ extension Alamofire.MultipartFormData: MultipartFormData {
 /// AlamofireWrapper: Encapsulates all of the Alamofire OP's
 ///
 public class AlamofireNetwork: Network {
+
+    /// authentication mode for requests
+    public private(set) var authenticationMode: RequestAuthenticationMode?
+
     /// Lazy-initialized session manager. Use ensuresSessionManagerIsInitialized=true to avoid race conditions with concurrent requests.
     private lazy var alamofireSession: Alamofire.Session = {
         let sessionConfiguration = URLSessionConfiguration.default
@@ -88,6 +98,18 @@ public class AlamofireNetwork: Network {
         } else if ensuresSessionManagerIsInitialized {
             self.alamofireSession = makeSession(configuration: URLSessionConfiguration.default)
         }
+
+        let authenticationMode: RequestAuthenticationMode? = {
+            switch credentials {
+            case .wporg, .applicationPassword:
+                return .appPasswords
+            case .wpcom:
+                return .jetpackTunnel
+            case .none:
+                return nil
+            }
+        }()
+        updateAuthenticationMode(authenticationMode)
     }
 
     public func updateAppPasswordSwitching(enabled: Bool) {
@@ -98,6 +120,7 @@ public class AlamofireNetwork: Network {
             requestConverter = RequestConverter(siteAddress: nil)
             requestAuthenticator.updateAuthenticator(DefaultRequestAuthenticator(credentials: credentials))
             requestAuthenticator.delegate = nil
+            updateAuthenticationMode(.jetpackTunnel)
         }
     }
 
@@ -276,6 +299,7 @@ private extension AlamofireNetwork {
                     requestConverter = RequestConverter(siteAddress: nil)
                     requestAuthenticator.updateAuthenticator(DefaultRequestAuthenticator(credentials: credentials))
                     requestAuthenticator.delegate = nil
+                    updateAuthenticationMode(.jetpackTunnel)
                     return
                 }
                 requestConverter = RequestConverter(siteAddress: site.siteAddress)
@@ -286,7 +310,14 @@ private extension AlamofireNetwork {
                 ))
                 requestAuthenticator.delegate = self
                 errorHandler.resetFailureCount(for: site.siteID) // reset failure count
+                updateAuthenticationMode(.appPasswordsWithJetpack)
             }
+    }
+
+    func updateAuthenticationMode(_ mode: RequestAuthenticationMode?) {
+        DispatchQueue.main.async { [weak self] in
+            self?.authenticationMode = mode
+        }
     }
 }
 

--- a/Modules/Sources/Yosemite/Base/StoresManager.swift
+++ b/Modules/Sources/Yosemite/Base/StoresManager.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import enum NetworkingCore.RequestAuthenticationMode
 
 /// Abstracts the Stores coordination
 ///
@@ -52,6 +53,9 @@ public protocol StoresManager {
     /// Indicates if the StoresManager is currently authenticated with site credentials only.
     ///
     var isAuthenticatedWithoutWPCom: Bool { get }
+
+    /// Authentication mode for network requests
+    var requestAuthenticationMode: RequestAuthenticationMode? { get }
 
     /// Publishes signal that indicates if the user is currently logged in with credentials.
     ///

--- a/Modules/Sources/Yosemite/Model/Mocks/MockStoresManager.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/MockStoresManager.swift
@@ -1,5 +1,6 @@
 import Combine
 import Storage
+import enum NetworkingCore.RequestAuthenticationMode
 
 public class MockStoresManager: StoresManager {
 
@@ -221,6 +222,10 @@ public class MockStoresManager: StoresManager {
 
     public var isAuthenticatedWithoutWPCom: Bool {
         false
+    }
+
+    public var requestAuthenticationMode: RequestAuthenticationMode? {
+        .jetpackTunnel
     }
 
     public var needsDefaultStore: Bool {

--- a/Modules/Tests/NetworkingTests/Network/AlamofireNetworkTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/AlamofireNetworkTests.swift
@@ -668,6 +668,142 @@ final class AlamofireNetworkTests: XCTestCase {
         let networkError = result.1 as? NetworkError
         XCTAssertEqual(networkError?.errorCode, "failed")
     }
+
+    // MARK: - Authentication Mode Tests
+
+    func test_authenticationMode_is_appPasswords_for_wporg_credentials() {
+        // Given
+        let wporgCredentials = Credentials.wporg(username: "user", password: "pass", siteAddress: "https://example.com")
+
+        // When
+        let network = AlamofireNetwork(credentials: wporgCredentials, sessionManager: createSessionWithMockURLProtocol())
+
+        // Then
+        let expectation = XCTestExpectation(description: "Authentication mode should be set")
+        DispatchQueue.main.async {
+            XCTAssertEqual(network.authenticationMode, .appPasswords)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_authenticationMode_is_appPasswords_for_applicationPassword_credentials() {
+        // Given
+        let appPasswordCredentials = Credentials.applicationPassword(username: "user", password: "pass", siteAddress: "https://example.com")
+
+        // When
+        let network = AlamofireNetwork(credentials: appPasswordCredentials, sessionManager: createSessionWithMockURLProtocol())
+
+        // Then
+        let expectation = XCTestExpectation(description: "Authentication mode should be set")
+        DispatchQueue.main.async {
+            XCTAssertEqual(network.authenticationMode, .appPasswords)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_authenticationMode_is_jetpackTunnel_for_wpcom_credentials() {
+        // Given
+        let wpcomCredentials = createWPComCredentials()
+
+        // When
+        let network = AlamofireNetwork(credentials: wpcomCredentials, sessionManager: createSessionWithMockURLProtocol())
+
+        // Then
+        let expectation = XCTestExpectation(description: "Authentication mode should be set")
+        DispatchQueue.main.async {
+            XCTAssertEqual(network.authenticationMode, .jetpackTunnel)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_authenticationMode_is_nil_for_no_credentials() {
+        // When
+        let network = AlamofireNetwork(credentials: nil, sessionManager: createSessionWithMockURLProtocol())
+
+        // Then
+        let expectation = XCTestExpectation(description: "Authentication mode should be set")
+        DispatchQueue.main.async {
+            XCTAssertNil(network.authenticationMode)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_authenticationMode_changes_to_appPasswordsWithJetpack_when_app_password_switching_enabled() {
+        // Given
+        let siteID: Int64 = 123
+        let wpcomCredentials = createWPComCredentials()
+        let network = createNetworkWithSelectedSite(siteID: siteID, credentials: wpcomCredentials, userDefaults: userDefaults)
+
+        // When - Enable app password switching
+        network.updateAppPasswordSwitching(enabled: true)
+
+        // Then
+        let expectation = XCTestExpectation(description: "Authentication mode should change")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertEqual(network.authenticationMode, .appPasswordsWithJetpack)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_authenticationMode_reverts_to_jetpackTunnel_when_app_password_switching_disabled() {
+        // Given
+        let siteID: Int64 = 456
+        let wpcomCredentials = createWPComCredentials()
+        let network = createNetworkWithSelectedSite(siteID: siteID, credentials: wpcomCredentials, userDefaults: userDefaults)
+
+        // When - Enable then disable app password switching
+        network.updateAppPasswordSwitching(enabled: true)
+        network.updateAppPasswordSwitching(enabled: false)
+
+        // Then
+        let expectation = XCTestExpectation(description: "Authentication mode should revert")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertEqual(network.authenticationMode, .jetpackTunnel)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_authenticationMode_remains_jetpackTunnel_when_site_flagged_as_unsupported() {
+        // Given
+        let siteID: Int64 = 789
+        let wpcomCredentials = createWPComCredentials()
+        userDefaults.applicationPasswordUnsupportedList = [String(siteID): Date()]
+        let network = createNetworkWithSelectedSite(siteID: siteID, credentials: wpcomCredentials, userDefaults: userDefaults)
+
+        // When - Enable app password switching for an unsupported site
+        network.updateAppPasswordSwitching(enabled: true)
+
+        // Then
+        let expectation = XCTestExpectation(description: "Authentication mode should remain jetpackTunnel")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertEqual(network.authenticationMode, .jetpackTunnel)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_authenticationMode_does_not_change_for_non_wpcom_credentials() {
+        // Given
+        let wporgCredentials = Credentials.wporg(username: "user", password: "pass", siteAddress: "https://example.com")
+        let network = AlamofireNetwork(credentials: wporgCredentials, sessionManager: createSessionWithMockURLProtocol())
+
+        // When - Try to enable app password switching (should have no effect)
+        network.updateAppPasswordSwitching(enabled: true)
+
+        // Then
+        let expectation = XCTestExpectation(description: "Authentication mode should remain unchanged")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertEqual(network.authenticationMode, .appPasswords)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
 }
 
 private extension AlamofireNetworkTests {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -147,12 +147,19 @@ extension WooAnalyticsEvent {
                                  pageNumber: Int,
                                  filters: FilterOrderListViewModel.Filters?,
                                  totalCompletedOrders: Int?) -> WooAnalyticsEvent {
+        let requestAuthMode: String = {
+            guard let authState = ServiceLocator.stores.requestAuthenticationMode else {
+                return "none"
+            }
+            return authState.rawValue
+        }()
         let properties: [String: WooAnalyticsEventPropertyType?] = [
             "status": (filters?.orderStatus ?? []).map { $0.rawValue }.joined(separator: ","),
             "page_number": Int64(pageNumber),
             "total_duration": Double(totalDuration),
             "date_range": filters?.dateRange?.analyticsDescription ?? String(),
-            "total_completed_orders": totalCompletedOrders
+            "total_completed_orders": totalCompletedOrders,
+            "request_type": requestAuthMode
         ]
         return WooAnalyticsEvent(statName: .ordersListLoaded, properties: properties.compactMapValues { $0 })
     }

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -3,10 +3,15 @@ import Yosemite
 import Networking
 import Storage
 import Combine
+import enum NetworkingCore.RequestAuthenticationMode
 
 // MARK: - AuthenticatedState
 //
 class AuthenticatedState: StoresManagerState {
+
+    var requestAuthenticationMode: RequestAuthenticationMode? {
+        network.authenticationMode
+    }
 
     /// Dispatcher: Glues all of the Stores!
     ///

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -8,6 +8,7 @@ import KeychainAccess
 import class WidgetKit.WidgetCenter
 import Experiments
 import WordPressAuthenticator
+import enum NetworkingCore.RequestAuthenticationMode
 
 // MARK: - DefaultStoresManager
 //
@@ -77,6 +78,14 @@ class DefaultStoresManager: StoresManager {
     ///
     var isAuthenticated: Bool {
         return state is AuthenticatedState
+    }
+
+    /// Authentication mode for network requests
+    var requestAuthenticationMode: RequestAuthenticationMode? {
+        guard let state = state as? AuthenticatedState else {
+            return nil
+        }
+        return state.requestAuthenticationMode
     }
 
     /// Indicates if the StoresManager is currently authenticated with site credentials only.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of WOOMOB-1125

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds support to track request authentication type for analytics purposes. The type is only sent in `orders_list_loaded` event as this is the most used feature in the app. We'll use this property to analyze the performance of the order list request and compare the result between Jetpack-proxied and direct requests similar to this post: pe5sF9-4me-p2.

Changes: 
- Adds new property in `AlamofireNetwork` to determine the current request authentication type.
- Updates `AuthenticatedState` and `StoresManager` to make it possible to check for authentication type.
- Sends new property `request_type` to `order_list_loaded` event.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

TC1: Application password authenticated
1. Log in to a self-hosted store with site credentials (native or web flows).
2. Navigate to the Orders tab to load orders.
3. Confirm that `order_list_loaded` is tracked with `request_type: app_passwords`.

TC2: WPCom authenticated.
1. Log in to a Jetpack store with WPCom credentials. Ensure that the site has app password enabled.
2. Navigate to the Orders tab to load orders.
3. Confirm that `order_list_loaded` is tracked with `app_passwords_with_jetpack`.
4. Navigate to Menu > Settings > Experimental features > disable app password experiment.
5. Navigate back to the Orders tab and refresh the list.
6. Confirm that `order_list_loaded` is tracked with `jetpack_tunnel `.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested the above cases with simulator iPhone 16 iOS 18.2

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.