### PR TITLE
[Woo POS][Historical Orders] Order Details: Email Receipt action - Update Order List and Order Details (2/2)

### DIFF
--- a/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
@@ -598,6 +598,24 @@ public extension OrdersRemote {
         case customerID
         case currency
     }
+
+    /// Loads a single order asynchronously for POS
+    /// - Parameters:
+    ///   - siteID: Site for which we'll fetch the order.
+    ///   - orderID: ID of the order to load.
+    /// - Returns: The loaded Order.
+    /// - Throws: Network or parsing errors.
+    func loadPOSOrder(siteID: Int64, orderID: Int64) async throws -> Order {
+        let path = "\(Constants.ordersPath)/\(orderID)"
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                   method: .get,
+                                   siteID: siteID,
+                                   path: path,
+                                   availableAsRESTRequest: true)
+        let mapper = OrderMapper(siteID: siteID)
+
+        return try await enqueue(request, mapper: mapper)
+    }
 }
 
 private extension OrdersRemote.OrderCreationSource {

--- a/Modules/Sources/NetworkingCore/Remote/POSOrdersRemoteProtocol.swift
+++ b/Modules/Sources/NetworkingCore/Remote/POSOrdersRemoteProtocol.swift
@@ -19,6 +19,8 @@ public protocol POSOrdersRemoteProtocol {
                         order: Order,
                         fields: [OrdersRemote.CreateOrderField]) async throws -> Order
 
+    func loadPOSOrder(siteID: Int64, orderID: Int64) async throws -> Order
+
     func loadPOSOrders(siteID: Int64,
                        pageNumber: Int,
                        pageSize: Int) async throws -> PagedItems<Order>

--- a/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -4,6 +4,12 @@ import Codegen
 import Foundation
 import Networking
 import WooFoundation
+import enum NetworkingCore.OrderStatusEnum
+import struct NetworkingCore.Address
+import struct NetworkingCore.MetaData
+import struct NetworkingCore.Order
+import struct NetworkingCore.OrderItem
+import struct NetworkingCore.OrderRefundCondensed
 
 
 extension Yosemite.JustInTimeMessage {
@@ -47,6 +53,60 @@ extension Yosemite.JustInTimeMessage {
             badgeImageUrl: badgeImageUrl,
             badgeImageDarkUrl: badgeImageDarkUrl,
             template: template
+        )
+    }
+}
+
+extension Yosemite.POSOrder {
+    public func copy(
+        id: CopiableProp<Int64> = .copy,
+        number: CopiableProp<String> = .copy,
+        dateCreated: CopiableProp<Date> = .copy,
+        status: CopiableProp<OrderStatusEnum> = .copy,
+        formattedTotal: CopiableProp<String> = .copy,
+        formattedSubtotal: CopiableProp<String> = .copy,
+        customerEmail: NullableCopiableProp<String> = .copy,
+        paymentMethodID: CopiableProp<String> = .copy,
+        paymentMethodTitle: CopiableProp<String> = .copy,
+        lineItems: CopiableProp<[POSOrderItem]> = .copy,
+        refunds: CopiableProp<[POSOrderRefund]> = .copy,
+        formattedDiscountTotal: NullableCopiableProp<String> = .copy,
+        formattedTotalTax: CopiableProp<String> = .copy,
+        formattedPaymentTotal: CopiableProp<String> = .copy,
+        formattedNetAmount: NullableCopiableProp<String> = .copy
+    ) -> Yosemite.POSOrder {
+        let id = id ?? self.id
+        let number = number ?? self.number
+        let dateCreated = dateCreated ?? self.dateCreated
+        let status = status ?? self.status
+        let formattedTotal = formattedTotal ?? self.formattedTotal
+        let formattedSubtotal = formattedSubtotal ?? self.formattedSubtotal
+        let customerEmail = customerEmail ?? self.customerEmail
+        let paymentMethodID = paymentMethodID ?? self.paymentMethodID
+        let paymentMethodTitle = paymentMethodTitle ?? self.paymentMethodTitle
+        let lineItems = lineItems ?? self.lineItems
+        let refunds = refunds ?? self.refunds
+        let formattedDiscountTotal = formattedDiscountTotal ?? self.formattedDiscountTotal
+        let formattedTotalTax = formattedTotalTax ?? self.formattedTotalTax
+        let formattedPaymentTotal = formattedPaymentTotal ?? self.formattedPaymentTotal
+        let formattedNetAmount = formattedNetAmount ?? self.formattedNetAmount
+
+        return Yosemite.POSOrder(
+            id: id,
+            number: number,
+            dateCreated: dateCreated,
+            status: status,
+            formattedTotal: formattedTotal,
+            formattedSubtotal: formattedSubtotal,
+            customerEmail: customerEmail,
+            paymentMethodID: paymentMethodID,
+            paymentMethodTitle: paymentMethodTitle,
+            lineItems: lineItems,
+            refunds: refunds,
+            formattedDiscountTotal: formattedDiscountTotal,
+            formattedTotalTax: formattedTotalTax,
+            formattedPaymentTotal: formattedPaymentTotal,
+            formattedNetAmount: formattedNetAmount
         )
     }
 }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrder.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrder.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Codegen
 import struct NetworkingCore.Address
 import struct NetworkingCore.OrderItem
 import struct NetworkingCore.OrderRefundCondensed
@@ -6,7 +7,7 @@ import struct NetworkingCore.MetaData
 import enum NetworkingCore.OrderStatusEnum
 import struct NetworkingCore.Order
 
-public struct POSOrder: Equatable, Hashable {
+public struct POSOrder: Equatable, Hashable, GeneratedCopiable {
     public let id: Int64
     public let number: String
     public let dateCreated: Date
@@ -34,8 +35,8 @@ public struct POSOrder: Equatable, Hashable {
                 paymentMethodTitle: String,
                 lineItems: [POSOrderItem] = [],
                 refunds: [POSOrderRefund] = [],
-                formattedTotalTax: String,
                 formattedDiscountTotal: String?,
+                formattedTotalTax: String,
                 formattedPaymentTotal: String,
                 formattedNetAmount: String? = nil) {
         self.id = id
@@ -49,8 +50,8 @@ public struct POSOrder: Equatable, Hashable {
         self.paymentMethodTitle = paymentMethodTitle
         self.lineItems = lineItems
         self.refunds = refunds
-        self.formattedTotalTax = formattedTotalTax
         self.formattedDiscountTotal = formattedDiscountTotal
+        self.formattedTotalTax = formattedTotalTax
         self.formattedPaymentTotal = formattedPaymentTotal
         self.formattedNetAmount = formattedNetAmount
     }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderMapper.swift
@@ -45,8 +45,8 @@ struct POSOrderMapper {
             paymentMethodTitle: order.paymentMethodTitle,
             lineItems: posLineItems,
             refunds: posRefunds,
-            formattedTotalTax: currencyFormatter.formatAmount(order.totalTax, with: order.currency) ?? "",
             formattedDiscountTotal: formattedDiscountTotal,
+            formattedTotalTax: currencyFormatter.formatAmount(order.totalTax, with: order.currency) ?? "",
             formattedPaymentTotal: order.paymentTotal(currencyFormatter: currencyFormatter),
             formattedNetAmount: formattedNetAmount
         )

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/PointOfSaleOrderListFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/PointOfSaleOrderListFetchStrategy.swift
@@ -3,6 +3,7 @@ import struct NetworkingCore.PagedItems
 
 public protocol PointOfSaleOrderListFetchStrategy {
     func fetchOrders(pageNumber: Int) async throws -> PagedItems<POSOrder>
+    func loadOrder(orderID: Int64) async throws -> POSOrder
     var supportsCaching: Bool { get }
     var showsLoadingWithItems: Bool { get }
     var id: String { get }
@@ -26,6 +27,10 @@ struct PointOfSaleDefaultOrderListFetchStrategy: PointOfSaleOrderListFetchStrate
     func fetchOrders(pageNumber: Int) async throws -> PagedItems<POSOrder> {
         try await orderListService.providePointOfSaleOrders(pageNumber: pageNumber)
     }
+
+    func loadOrder(orderID: Int64) async throws -> POSOrder {
+        try await orderListService.loadOrder(orderID: orderID)
+    }
 }
 
 struct PointOfSaleSearchOrderListFetchStrategy: PointOfSaleOrderListFetchStrategy {
@@ -42,5 +47,9 @@ struct PointOfSaleSearchOrderListFetchStrategy: PointOfSaleOrderListFetchStrateg
 
     func fetchOrders(pageNumber: Int) async throws -> PagedItems<POSOrder> {
         try await orderListService.searchPointOfSaleOrders(searchTerm: searchTerm, pageNumber: pageNumber)
+    }
+
+    func loadOrder(orderID: Int64) async throws -> POSOrder {
+        try await orderListService.loadOrder(orderID: orderID)
     }
 }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/PointOfSaleOrderListService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/PointOfSaleOrderListService.swift
@@ -70,4 +70,15 @@ public final class PointOfSaleOrderListService: PointOfSaleOrderListServiceProto
             throw PointOfSaleOrderListServiceError.requestFailed
         }
     }
+
+    public func loadOrder(orderID: Int64) async throws -> POSOrder {
+        do {
+            let order = try await ordersRemote.loadPOSOrder(siteID: siteID, orderID: orderID)
+            return mapper.map(order: order)
+        } catch AFError.explicitlyCancelled {
+            throw PointOfSaleOrderListServiceError.requestCancelled
+        } catch {
+            throw PointOfSaleOrderListServiceError.requestFailed
+        }
+    }
 }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/PointOfSaleOrderListServiceProtocol.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/PointOfSaleOrderListServiceProtocol.swift
@@ -9,4 +9,5 @@ public enum PointOfSaleOrderListServiceError: Error, Equatable {
 public protocol PointOfSaleOrderListServiceProtocol {
     func providePointOfSaleOrders(pageNumber: Int) async throws -> PagedItems<POSOrder>
     func searchPointOfSaleOrders(searchTerm: String, pageNumber: Int) async throws -> PagedItems<POSOrder>
+    func loadOrder(orderID: Int64) async throws -> POSOrder
 }

--- a/Modules/Tests/YosemiteTests/Mocks/MockPOSOrdersRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockPOSOrdersRemote.swift
@@ -91,4 +91,21 @@ final class MockPOSOrdersRemote: POSOrdersRemoteProtocol {
             throw error
         }
     }
+
+    var loadPOSOrderCalled = false
+    var spyLoadPOSOrderID: Int64?
+    var loadPOSOrderResult: Result<Order, Error> = .success(Order.fake())
+
+    func loadPOSOrder(siteID: Int64, orderID: Int64) async throws -> Order {
+        loadPOSOrderCalled = true
+        spySiteID = siteID
+        spyLoadPOSOrderID = orderID
+
+        switch loadPOSOrderResult {
+        case .success(let order):
+            return order
+        case .failure(let error):
+            throw error
+        }
+    }
 }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderListController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderListController.swift
@@ -123,6 +123,11 @@ protocol PointOfSaleSearchingOrderListControllerProtocol: PointOfSaleOrderListCo
 
             ordersViewState = allOrders.isEmpty ? .empty : .loaded(allOrders, hasMoreItems: pagedOrders.hasMorePages)
 
+            if let selectedOrderID = selectedOrder?.id,
+               let updatedSelectedOrder = allOrders.first(where: { $0.id == selectedOrderID }) {
+                selectedOrder = updatedSelectedOrder
+            }
+
             if fetchStrategy.supportsCaching {
                 cachedOrders = allOrders
             }

--- a/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderListController.swift
+++ b/WooCommerce/Classes/POS/Controllers/PointOfSaleOrderListController.swift
@@ -16,6 +16,7 @@ protocol PointOfSaleOrderListControllerProtocol {
     func refreshOrders() async
     func loadNextOrders() async
     func selectOrder(_ order: POSOrder?)
+    func updateOrder(orderID: Int64) async throws
 }
 
 protocol PointOfSaleSearchingOrderListControllerProtocol: PointOfSaleOrderListControllerProtocol {
@@ -167,6 +168,23 @@ protocol PointOfSaleSearchingOrderListControllerProtocol: PointOfSaleOrderListCo
             Task {
                 await loadFirstPage()
             }
+        }
+    }
+
+    @MainActor
+    func updateOrder(orderID: Int64) async throws {
+        let updatedOrder = try await fetchStrategy.loadOrder(orderID: orderID)
+        let updatedOrders = ordersViewState.orders.map { order in
+            order.id == orderID ? updatedOrder : order
+        }
+
+        ordersViewState = ordersViewState.updatingOrders(with: updatedOrders)
+        cachedOrders = cachedOrders.map { order in
+            order.id == orderID ? updatedOrder : order
+        }
+
+        if selectedOrder?.id == orderID {
+            selectedOrder = updatedOrder
         }
     }
 }

--- a/WooCommerce/Classes/POS/Models/POSOrdersViewState.swift
+++ b/WooCommerce/Classes/POS/Models/POSOrdersViewState.swift
@@ -45,4 +45,17 @@ enum POSOrderListState: Equatable {
             return []
         }
     }
+
+    func updatingOrders(with updatedOrders: [POSOrder]) -> POSOrderListState {
+        switch self {
+        case .loaded(_, let hasMoreItems):
+            return .loaded(updatedOrders, hasMoreItems: hasMoreItems)
+        case .loading:
+            return .loading(updatedOrders)
+        case .inlineError(_, let error, let context):
+            return .inlineError(updatedOrders, error: error, context: context)
+        case .empty, .error:
+            return self
+        }
+    }
 }

--- a/WooCommerce/Classes/POS/Models/PointOfSaleOrderListModel.swift
+++ b/WooCommerce/Classes/POS/Models/PointOfSaleOrderListModel.swift
@@ -14,5 +14,6 @@ import struct Yosemite.POSOrder
 
     func sendReceipt(order: POSOrder, email: String) async throws {
         try await receiptSender.sendReceipt(orderID: order.id, recipientEmail: email)
+        try await ordersController.updateOrder(orderID: order.id)
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/Buttons/POSButtonStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/Buttons/POSButtonStyle.swift
@@ -6,18 +6,31 @@ enum POSButtonSize {
     case extraSmall
 }
 
-/// Filled button style in POS that can show a loading indicator.
+/// Button state for different visual presentations
+enum POSButtonState {
+    case idle
+    case loading
+    case success
+}
+
+/// Filled button style in POS that can show loading and success states.
 struct POSFilledButtonStyle: ButtonStyle {
     private let size: POSButtonSize
-    private let isLoading: Bool
+    private let state: POSButtonState
 
     init(size: POSButtonSize, isLoading: Bool = false) {
         self.size = size
-        self.isLoading = isLoading
+        self.state = isLoading ? .loading : .idle
+    }
+    
+    init(size: POSButtonSize, state: POSButtonState) {
+        self.size = size
+        self.state = state
     }
 
     func makeBody(configuration: Configuration) -> some View {
-        POSButton(configuration: configuration, variant: .filled, size: size, isLoading: isLoading)
+        POSButtonStyleInternal(configuration: configuration, variant: .filled, size: size, state: state)
+            .disabled(state != .idle)
     }
 }
 
@@ -30,9 +43,10 @@ struct POSOutlinedButtonStyle: ButtonStyle {
     }
 
     func makeBody(configuration: Configuration) -> some View {
-        POSButton(configuration: configuration, variant: .outlined, size: size, isLoading: false)
+        POSButtonStyleInternal(configuration: configuration, variant: .outlined, size: size, state: .idle)
     }
 }
+
 
 /// The visual variant of the POS button.
 fileprivate enum POSButtonVariant {
@@ -40,22 +54,24 @@ fileprivate enum POSButtonVariant {
     case outlined
 }
 
-private struct POSButton: View {
+private struct POSButtonStyleInternal: View {
     @Environment(\.isEnabled) var isEnabled
 
     let configuration: ButtonStyleConfiguration
     let variant: POSButtonVariant
     let size: POSButtonSize
-    let isLoading: Bool
+    let state: POSButtonState
 
     var body: some View {
         Group {
             containerView {
                 ZStack(alignment: .center) {
                     configuration.label
-                        .opacity(isLoading ? 0 : 1)
+                        .opacity(state == .idle ? 1 : 0)
                     progressView
-                        .renderedIf(isLoading)
+                        .renderedIf(state == .loading)
+                    successView
+                        .renderedIf(state == .success)
                 }
             }
         }
@@ -91,12 +107,18 @@ private struct POSButton: View {
             .progressViewStyle(POSButtonProgressViewStyle(size: size.progressViewDimensions.size, lineWidth: size.progressViewDimensions.lineWidth))
     }
 
+    private var successView: some View {
+        Image(systemName: "checkmark.circle")
+            .font(size == .normal ? .title2 : .body)
+            .foregroundColor(.posOnPrimaryContainer)
+    }
+
     private var backgroundColor: Color {
         switch (variant, isEnabled) {
         case (.filled, true):
                 .posPrimaryContainer
         case (.filled, false):
-                isLoading ? .posPrimaryContainer : .posDisabledContainer
+                state != .idle ? .posPrimaryContainer : .posDisabledContainer
         case (.outlined, _):
                 .clear
         }
@@ -125,9 +147,9 @@ private struct POSButton: View {
     }
 }
 
-// MARK: - POSButton Constants
+// MARK: - POSButtonStyleInternal Constants
 
-private extension POSButton {
+private extension POSButtonStyleInternal {
     enum Constants {
         static let cornerRadius: CGFloat = POSCornerRadiusStyle.medium.value
         static let borderStrokeWidth: CGFloat = 2.0
@@ -190,6 +212,10 @@ struct POSButtonStyle_Previews: View {
                 LoadingPreviewSection(title: "Loading Buttons - Normal", size: .normal)
 
                 LoadingPreviewSection(title: "Loading Buttons - Extra Small", size: .extraSmall)
+                
+                LoadingStatePreviewSection(title: "Loading State Buttons - Normal", size: .normal)
+                
+                LoadingStatePreviewSection(title: "Loading State Buttons - Extra Small", size: .extraSmall)
 
                 // Example with long text
                 VStack(alignment: .leading, spacing: POSSpacing.medium) {
@@ -258,6 +284,40 @@ private struct LoadingPreviewSection: View {
             Button("Disabled Loading Button") {}
                 .buttonStyle(POSFilledButtonStyle(size: size, isLoading: true))
                 .disabled(true)
+        }
+    }
+}
+
+private struct LoadingStatePreviewSection: View {
+    let title: String
+    let size: POSButtonSize
+    @State private var currentState: POSButtonState = .idle
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: POSSpacing.medium) {
+            Text(title)
+                .font(.headline)
+
+            Button("Cycle States") {
+                switch currentState {
+                case .idle:
+                    currentState = .loading
+                case .loading:
+                    currentState = .success
+                case .success:
+                    currentState = .idle
+                }
+            }
+            .buttonStyle(POSFilledButtonStyle(size: size, state: currentState))
+
+            Button("Idle State") {}
+                .buttonStyle(POSFilledButtonStyle(size: size, state: .idle))
+
+            Button("Loading State") {}
+                .buttonStyle(POSFilledButtonStyle(size: size, state: .loading))
+
+            Button("Success State") {}
+                .buttonStyle(POSFilledButtonStyle(size: size, state: .success))
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/Buttons/POSButtonStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/Buttons/POSButtonStyle.swift
@@ -22,7 +22,7 @@ struct POSFilledButtonStyle: ButtonStyle {
         self.size = size
         self.state = isLoading ? .loading : .idle
     }
-    
+
     init(size: POSButtonSize, state: POSButtonState) {
         self.size = size
         self.state = state
@@ -212,9 +212,9 @@ struct POSButtonStyle_Previews: View {
                 LoadingPreviewSection(title: "Loading Buttons - Normal", size: .normal)
 
                 LoadingPreviewSection(title: "Loading Buttons - Extra Small", size: .extraSmall)
-                
+
                 LoadingStatePreviewSection(title: "Loading State Buttons - Normal", size: .normal)
-                
+
                 LoadingStatePreviewSection(title: "Loading State Buttons - Extra Small", size: .extraSmall)
 
                 // Example with long text

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -5,7 +5,7 @@ import class WordPressShared.EmailFormatValidator
 
 struct POSSendReceiptView: View {
     @State private var textFieldInput: String = ""
-    @State private var isLoading: Bool = false
+    @State private var buttonState: POSButtonState = .idle
     @State private var errorMessage: String?
     @FocusState private var isTextFieldFocused: Bool
 
@@ -29,7 +29,7 @@ struct POSSendReceiptView: View {
         ScrollView {
             VStack(alignment: .center, spacing: conditionalPadding(POSSpacing.medium)) {
                 POSPageHeaderView(title: Localization.emailReceiptNavigationText,
-                                  backButtonConfiguration: .init(state: isLoading ? .disabled: .enabled,
+                                  backButtonConfiguration: .init(state: buttonState != .idle ? .disabled: .enabled,
                                                                  action: {
                     withAnimation {
                         isShowingSendReceiptView = false
@@ -74,10 +74,10 @@ struct POSSendReceiptView: View {
                     .measureFrame {
                         buttonFrame = $0
                     }
-                    .buttonStyle(POSFilledButtonStyle(size: .normal, isLoading: isLoading))
+                    .buttonStyle(POSFilledButtonStyle(size: .normal, state: buttonState))
                     .dynamicTypeSize(...DynamicTypeSize.accessibility3)
                     .frame(maxWidth: .infinity)
-                    .disabled(isLoading)
+                    .disabled(buttonState != .idle)
                 }
                 .padding([.horizontal])
                 .padding(.bottom, keyboardFrame.height)
@@ -102,18 +102,21 @@ struct POSSendReceiptView: View {
                 errorMessage = Localization.emailValidationErrorText
                 return
             }
-            isLoading = true
+            buttonState = .loading
             do {
                 errorMessage = nil
                 try await onSendReceipt(textFieldInput)
+
                 withAnimation {
+                    buttonState = .success
+                } completion: {
                     isShowingSendReceiptView = false
                     isTextFieldFocused = false
                 }
             } catch {
                 errorMessage = Localization.sendReceiptErrorText
+                buttonState = .idle
             }
-            isLoading = false
         }
     }
 }

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -381,6 +381,7 @@ final class PointOfSalePreviewOrderListController: PointOfSaleSearchingOrderList
     func loadNextOrders() async {}
     func refreshOrders() async {}
     func selectOrder(_ order: POSOrder?) {}
+    func updateOrder(orderID: Int64) async throws {}
     func searchOrders(searchTerm: String) async {}
     func clearSearchOrders() {}
 }

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -274,8 +274,8 @@ struct POSPreviewHelpers {
                 )
             ],
             refunds: [],
-            formattedTotalTax: "$3.76",
             formattedDiscountTotal: "$0.00",
+            formattedTotalTax: "$3.76",
             formattedPaymentTotal: "$45.75",
             formattedNetAmount: nil
         )
@@ -318,8 +318,8 @@ final class PointOfSalePreviewOrderListController: PointOfSaleSearchingOrderList
                     )
                 ],
                 refunds: [],
-                formattedTotalTax: "$4.75",
                 formattedDiscountTotal: "-$5.24",
+                formattedTotalTax: "$4.75",
                 formattedPaymentTotal: "$45.75",
                 formattedNetAmount: nil
             ),
@@ -363,8 +363,8 @@ final class PointOfSalePreviewOrderListController: PointOfSaleSearchingOrderList
                         reason: "Customer requested partial refund"
                     )
                 ],
-                formattedTotalTax: "$8.95",
                 formattedDiscountTotal: "-$15.00",
+                formattedTotalTax: "$8.95",
                 formattedPaymentTotal: "$89.50",
                 formattedNetAmount: "$69.51"
             )

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -98,6 +98,9 @@
 		01ADC1382C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ADC1372C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift */; };
 		01B3A1F22DB6D48800286B7F /* ItemListType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B3A1F12DB6D48800286B7F /* ItemListType.swift */; };
 		01B744E22D2FCA1400AEB3F4 /* PushNotificationBackgroundSynchronizerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B744E12D2FCA1300AEB3F4 /* PushNotificationBackgroundSynchronizerFactory.swift */; };
+		01B7AFBD2E707FB30004BE9D /* PointOfSaleOrderListModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B7AFBB2E707FB30004BE9D /* PointOfSaleOrderListModelTests.swift */; };
+		01B7AFBE2E707FB30004BE9D /* POSOrderListStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B7AFBC2E707FB30004BE9D /* POSOrderListStateTests.swift */; };
+		01B7AFC02E70801A0004BE9D /* MockPointOfSaleOrderListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B7AFBF2E7080180004BE9D /* MockPointOfSaleOrderListController.swift */; };
 		01BB6C072D09DC560094D55B /* CardPresentModalLocationPreAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BB6C062D09DC470094D55B /* CardPresentModalLocationPreAlert.swift */; };
 		01BB6C0A2D09E9630094D55B /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BB6C092D09E9630094D55B /* LocationService.swift */; };
 		01BD77442C58CED400147191 /* PointOfSaleCardPresentPaymentProcessingMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BD77432C58CED400147191 /* PointOfSaleCardPresentPaymentProcessingMessageView.swift */; };
@@ -3319,6 +3322,9 @@
 		01ADC1372C9AB6050036F7D2 /* PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentIntentCreationErrorMessageView.swift; sourceTree = "<group>"; };
 		01B3A1F12DB6D48800286B7F /* ItemListType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListType.swift; sourceTree = "<group>"; };
 		01B744E12D2FCA1300AEB3F4 /* PushNotificationBackgroundSynchronizerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationBackgroundSynchronizerFactory.swift; sourceTree = "<group>"; };
+		01B7AFBB2E707FB30004BE9D /* PointOfSaleOrderListModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleOrderListModelTests.swift; sourceTree = "<group>"; };
+		01B7AFBC2E707FB30004BE9D /* POSOrderListStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSOrderListStateTests.swift; sourceTree = "<group>"; };
+		01B7AFBF2E7080180004BE9D /* MockPointOfSaleOrderListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPointOfSaleOrderListController.swift; sourceTree = "<group>"; };
 		01BB6C062D09DC470094D55B /* CardPresentModalLocationPreAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalLocationPreAlert.swift; sourceTree = "<group>"; };
 		01BB6C092D09E9630094D55B /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
 		01BD77432C58CED400147191 /* PointOfSaleCardPresentPaymentProcessingMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentProcessingMessageView.swift; sourceTree = "<group>"; };
@@ -7808,6 +7814,7 @@
 		02CD3BFC2C35D01600E575C4 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				01B7AFBF2E7080180004BE9D /* MockPointOfSaleOrderListController.swift */,
 				019460E12E70121A00FCB9AB /* MockPOSReceiptController.swift */,
 				012ACB812E5D8DCD00A49458 /* MockPointOfSaleOrderListFetchStrategyFactory.swift */,
 				012ACB792E5C84D200A49458 /* MockPointOfSaleOrderListService.swift */,
@@ -13193,6 +13200,8 @@
 		DAD988C72C4A9D49009DE9E3 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				01B7AFBB2E707FB30004BE9D /* PointOfSaleOrderListModelTests.swift */,
+				01B7AFBC2E707FB30004BE9D /* POSOrderListStateTests.swift */,
 				685A305E2E608F29001E667B /* POSSettingsStoreViewModelTests.swift */,
 				20FCBCDE2CE241810082DCA3 /* PointOfSaleAggregateModelTests.swift */,
 			);
@@ -17177,6 +17186,7 @@
 				269098B627D2C09D001FEB07 /* ShippingInputTransformerTests.swift in Sources */,
 				02BA128B24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift in Sources */,
 				DEA88F522AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift in Sources */,
+				01B7AFC02E70801A0004BE9D /* MockPointOfSaleOrderListController.swift in Sources */,
 				DE2BF4FD2846192B00FBE68A /* CouponAllowedEmailsViewModelTests.swift in Sources */,
 				FEEB2F6E268A2F7B0075A6E0 /* RoleEligibilityUseCaseTests.swift in Sources */,
 				31E906A326CC91A70099A985 /* CardReaderConnectionControllerTests.swift in Sources */,
@@ -17406,6 +17416,8 @@
 				45EF798624509B4C00B22BA2 /* ArrayIndexPathTests.swift in Sources */,
 				D8610BDD256F5ABF00A5DF27 /* JetpackErrorViewModelTests.swift in Sources */,
 				746791632108D7C0007CF1DC /* WooAnalyticsTests.swift in Sources */,
+				01B7AFBD2E707FB30004BE9D /* PointOfSaleOrderListModelTests.swift in Sources */,
+				01B7AFBE2E707FB30004BE9D /* POSOrderListStateTests.swift in Sources */,
 				200BA15E2CF0A9EB0006DC5B /* PointOfSaleItemsControllerTests.swift in Sources */,
 				2667BFDD252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift in Sources */,
 				DE7B479727A3C4980018742E /* CouponDetailsViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderListControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderListControllerTests.swift
@@ -325,23 +325,7 @@ final class PointOfSaleOrderListControllerTests {
 
         // Setup updated order
         let orderToUpdate = initialOrders[0]
-        let updatedOrder = POSOrder(
-            id: orderToUpdate.id,
-            number: orderToUpdate.number,
-            dateCreated: orderToUpdate.dateCreated,
-            status: orderToUpdate.status,
-            formattedTotal: orderToUpdate.formattedTotal,
-            formattedSubtotal: orderToUpdate.formattedSubtotal,
-            customerEmail: "updated@example.com", // Updated email
-            paymentMethodID: orderToUpdate.paymentMethodID,
-            paymentMethodTitle: orderToUpdate.paymentMethodTitle,
-            lineItems: orderToUpdate.lineItems,
-            refunds: orderToUpdate.refunds,
-            formattedTotalTax: orderToUpdate.formattedTotalTax,
-            formattedDiscountTotal: orderToUpdate.formattedDiscountTotal,
-            formattedPaymentTotal: orderToUpdate.formattedPaymentTotal,
-            formattedNetAmount: orderToUpdate.formattedNetAmount
-        )
+        let updatedOrder = orderToUpdate.copy(customerEmail: .some("updated@example.com"))
         orderListService.loadOrderResult = updatedOrder
 
         // When
@@ -371,23 +355,7 @@ final class PointOfSaleOrderListControllerTests {
         #expect(sut.selectedOrder?.id == orderToUpdate.id)
 
         // Setup updated order
-        let updatedOrder = POSOrder(
-            id: orderToUpdate.id,
-            number: orderToUpdate.number,
-            dateCreated: orderToUpdate.dateCreated,
-            status: orderToUpdate.status,
-            formattedTotal: orderToUpdate.formattedTotal,
-            formattedSubtotal: orderToUpdate.formattedSubtotal,
-            customerEmail: "selected-updated@example.com",
-            paymentMethodID: orderToUpdate.paymentMethodID,
-            paymentMethodTitle: orderToUpdate.paymentMethodTitle,
-            lineItems: orderToUpdate.lineItems,
-            refunds: orderToUpdate.refunds,
-            formattedTotalTax: orderToUpdate.formattedTotalTax,
-            formattedDiscountTotal: orderToUpdate.formattedDiscountTotal,
-            formattedPaymentTotal: orderToUpdate.formattedPaymentTotal,
-            formattedNetAmount: orderToUpdate.formattedNetAmount
-        )
+        let updatedOrder = orderToUpdate.copy(customerEmail: .some("selected-updated@example.com"))
         orderListService.loadOrderResult = updatedOrder
 
         // When

--- a/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderListControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Controllers/PointOfSaleOrderListControllerTests.swift
@@ -4,6 +4,7 @@ import Foundation
 import enum Yosemite.PointOfSaleOrderListServiceError
 import struct NetworkingCore.Order
 import Observation
+import struct Yosemite.POSOrder
 
 final class PointOfSaleOrderListControllerTests {
     private let orderListService = MockPointOfSaleOrderListService()
@@ -314,5 +315,85 @@ final class PointOfSaleOrderListControllerTests {
         }
         #expect(orders == searchOrders)
         #expect(orderListService.lastSearchTerm == "test")
+    }
+
+    @Test func updateOrder_when_order_loaded_from_API_then_order_list_updates() async throws {
+        // Given - load initial orders
+        let initialOrders = MockPointOfSaleOrderListService.makeInitialOrders()
+        orderListService.orderPages = [initialOrders]
+        await sut.loadOrders()
+
+        // Setup updated order
+        let orderToUpdate = initialOrders[0]
+        let updatedOrder = POSOrder(
+            id: orderToUpdate.id,
+            number: orderToUpdate.number,
+            dateCreated: orderToUpdate.dateCreated,
+            status: orderToUpdate.status,
+            formattedTotal: orderToUpdate.formattedTotal,
+            formattedSubtotal: orderToUpdate.formattedSubtotal,
+            customerEmail: "updated@example.com", // Updated email
+            paymentMethodID: orderToUpdate.paymentMethodID,
+            paymentMethodTitle: orderToUpdate.paymentMethodTitle,
+            lineItems: orderToUpdate.lineItems,
+            refunds: orderToUpdate.refunds,
+            formattedTotalTax: orderToUpdate.formattedTotalTax,
+            formattedDiscountTotal: orderToUpdate.formattedDiscountTotal,
+            formattedPaymentTotal: orderToUpdate.formattedPaymentTotal,
+            formattedNetAmount: orderToUpdate.formattedNetAmount
+        )
+        orderListService.loadOrderResult = updatedOrder
+
+        // When
+        try await sut.updateOrder(orderID: orderToUpdate.id)
+
+        // Then
+        guard case .loaded(let orders, _) = sut.ordersViewState else {
+            Issue.record("Expected loaded state after update, but got \(sut.ordersViewState)")
+            return
+        }
+
+        let foundOrder = orders.first { $0.id == orderToUpdate.id }
+        #expect(foundOrder != nil)
+        #expect(foundOrder?.customerEmail == "updated@example.com")
+        #expect(orderListService.loadOrderWasCalled)
+        #expect(orderListService.lastLoadOrderID == orderToUpdate.id)
+    }
+
+    @Test func updateOrder_when_order_loaded_from_API_then_selected_order_updates() async throws {
+        // Given
+        let initialOrders = MockPointOfSaleOrderListService.makeInitialOrders()
+        orderListService.orderPages = [initialOrders]
+        await sut.loadOrders()
+
+        let orderToUpdate = initialOrders[0]
+        await sut.selectOrder(orderToUpdate)
+        #expect(sut.selectedOrder?.id == orderToUpdate.id)
+
+        // Setup updated order
+        let updatedOrder = POSOrder(
+            id: orderToUpdate.id,
+            number: orderToUpdate.number,
+            dateCreated: orderToUpdate.dateCreated,
+            status: orderToUpdate.status,
+            formattedTotal: orderToUpdate.formattedTotal,
+            formattedSubtotal: orderToUpdate.formattedSubtotal,
+            customerEmail: "selected-updated@example.com",
+            paymentMethodID: orderToUpdate.paymentMethodID,
+            paymentMethodTitle: orderToUpdate.paymentMethodTitle,
+            lineItems: orderToUpdate.lineItems,
+            refunds: orderToUpdate.refunds,
+            formattedTotalTax: orderToUpdate.formattedTotalTax,
+            formattedDiscountTotal: orderToUpdate.formattedDiscountTotal,
+            formattedPaymentTotal: orderToUpdate.formattedPaymentTotal,
+            formattedNetAmount: orderToUpdate.formattedNetAmount
+        )
+        orderListService.loadOrderResult = updatedOrder
+
+        // When
+        try await sut.updateOrder(orderID: orderToUpdate.id)
+
+        // Then
+        #expect(sut.selectedOrder?.customerEmail == "selected-updated@example.com")
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSReceiptController.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSReceiptController.swift
@@ -8,11 +8,15 @@ final class MockPOSReceiptSender: POSReceiptSending {
     var sendReceiptCalledWithOrderID: Int64?
     var sendReceiptCalledWithEmail: String?
 
+    enum TestError: Error {
+        case sendReceiptFailed
+    }
+
     func sendReceipt(orderID: Int64, recipientEmail: String) async throws {
         sendReceiptWasCalled = true
         sendReceiptCalledWithOrderID = orderID
         sendReceiptCalledWithEmail = recipientEmail
-
+        
         if let sendReceiptErrorToThrow {
             throw sendReceiptErrorToThrow
         }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSReceiptController.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSReceiptController.swift
@@ -16,7 +16,7 @@ final class MockPOSReceiptSender: POSReceiptSending {
         sendReceiptWasCalled = true
         sendReceiptCalledWithOrderID = orderID
         sendReceiptCalledWithEmail = recipientEmail
-        
+
         if let sendReceiptErrorToThrow {
             throw sendReceiptErrorToThrow
         }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleOrderListController.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleOrderListController.swift
@@ -1,0 +1,38 @@
+import Foundation
+@testable import WooCommerce
+import struct Yosemite.POSOrder
+
+final class MockPointOfSaleOrderListController: PointOfSaleSearchingOrderListControllerProtocol {
+    var ordersViewState: POSOrderListState = .empty
+    var selectedOrder: POSOrder?
+    var updateOrderCalled = false
+    var spyUpdateOrderID: Int64?
+    var shouldThrowError = false
+
+    enum TestError: Error {
+        case updateOrderFailed
+    }
+
+    func loadOrders() async {}
+
+    func refreshOrders() async {}
+
+    func loadNextOrders() async {}
+
+    func selectOrder(_ order: POSOrder?) {
+        selectedOrder = order
+    }
+
+    func updateOrder(orderID: Int64) async throws {
+        updateOrderCalled = true
+        spyUpdateOrderID = orderID
+
+        if shouldThrowError {
+            throw TestError.updateOrderFailed
+        }
+    }
+
+    func searchOrders(searchTerm: String) async {}
+
+    func clearSearchOrders() {}
+}

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleOrderListFetchStrategyFactory.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleOrderListFetchStrategyFactory.swift
@@ -32,6 +32,10 @@ private struct MockPointOfSaleOrderListFetchStrategy: PointOfSaleOrderListFetchS
     func fetchOrders(pageNumber: Int) async throws -> PagedItems<POSOrder> {
         try await orderService.providePointOfSaleOrders(pageNumber: pageNumber)
     }
+
+    func loadOrder(orderID: Int64) async throws -> POSOrder {
+        try await orderService.loadOrder(orderID: orderID)
+    }
 }
 
 private struct MockPointOfSaleOrderListSearchFetchStrategy: PointOfSaleOrderListFetchStrategy {
@@ -44,5 +48,9 @@ private struct MockPointOfSaleOrderListSearchFetchStrategy: PointOfSaleOrderList
 
     func fetchOrders(pageNumber: Int) async throws -> PagedItems<POSOrder> {
         try await orderService.searchPointOfSaleOrders(searchTerm: searchTerm, pageNumber: pageNumber)
+    }
+
+    func loadOrder(orderID: Int64) async throws -> POSOrder {
+        try await orderService.loadOrder(orderID: orderID)
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleOrderListService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleOrderListService.swift
@@ -172,8 +172,8 @@ extension MockPointOfSaleOrderListService {
                 )
             ],
             refunds: [],
-            formattedTotalTax: "$0.00",
             formattedDiscountTotal: nil,
+            formattedTotalTax: "$0.00",
             formattedPaymentTotal: "$25.99",
             formattedNetAmount: nil
         )
@@ -200,8 +200,8 @@ extension MockPointOfSaleOrderListService {
                 )
             ],
             refunds: [],
-            formattedTotalTax: "$0.00",
             formattedDiscountTotal: nil,
+            formattedTotalTax: "$0.00",
             formattedPaymentTotal: "$15.50",
             formattedNetAmount: nil
         )
@@ -243,8 +243,8 @@ extension MockPointOfSaleOrderListService {
                 )
             ],
             refunds: [],
-            formattedTotalTax: "$0.00",
             formattedDiscountTotal: nil,
+            formattedTotalTax: "$0.00",
             formattedPaymentTotal: "$42.75",
             formattedNetAmount: nil
         )
@@ -273,8 +273,8 @@ extension MockPointOfSaleOrderListService {
             refunds: [
                 POSOrderRefund(refundID: 1001, formattedTotal: "-$12.00", reason: "Customer request")
             ],
-            formattedTotalTax: "$0.00",
             formattedDiscountTotal: nil,
+            formattedTotalTax: "$0.00",
             formattedPaymentTotal: "$12.00",
             formattedNetAmount: "$0.00"
         )
@@ -307,8 +307,8 @@ extension MockPointOfSaleOrderListService {
                 )
             ],
             refunds: [],
-            formattedTotalTax: "$0.00",
             formattedDiscountTotal: nil,
+            formattedTotalTax: "$0.00",
             formattedPaymentTotal: "$18.50",
             formattedNetAmount: nil
         )

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleOrderListService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPointOfSaleOrderListService.swift
@@ -19,6 +19,11 @@ final class MockPointOfSaleOrderListService: PointOfSaleOrderListServiceProtocol
     var spyLastSearchTerm: String?
     var lastSearchTerm: String?
 
+    // LoadOrder properties
+    var loadOrderResult: POSOrder?
+    var loadOrderWasCalled = false
+    var lastLoadOrderID: Int64?
+
     func providePointOfSaleOrders(pageNumber: Int) async throws -> PagedItems<POSOrder> {
         spyLastRequestedPageNumber = pageNumber
         spyCallCount += 1
@@ -104,6 +109,31 @@ final class MockPointOfSaleOrderListService: PointOfSaleOrderListServiceProtocol
             hasMorePages: false,
             totalItems: filteredOrders.count
         )
+    }
+
+    func loadOrder(orderID: Int64) async throws -> POSOrder {
+        loadOrderWasCalled = true
+        lastLoadOrderID = orderID
+
+        if shouldThrowError {
+            throw PointOfSaleOrderListServiceError.requestFailed
+        }
+
+        if let errorToThrow {
+            throw errorToThrow
+        }
+
+        if let result = loadOrderResult {
+            return result
+        }
+
+        // Fallback - find order from existing orders
+        let allOrders = MockPointOfSaleOrderListService.makeInitialOrders() + MockPointOfSaleOrderListService.makeSecondPageOrders()
+        if let foundOrder = allOrders.first(where: { $0.id == orderID }) {
+            return foundOrder
+        }
+
+        throw PointOfSaleOrderListServiceError.requestFailed
     }
 }
 

--- a/WooCommerce/WooCommerceTests/POS/Models/POSOrderListStateTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/POSOrderListStateTests.swift
@@ -125,12 +125,12 @@ private extension POSOrderListStateTests {
             POSOrder(id: 1, number: "1001", dateCreated: Date(), status: .completed,
                      formattedTotal: "$10.00", formattedSubtotal: "$10.00", customerEmail: "test1@example.com",
                      paymentMethodID: "stripe", paymentMethodTitle: "Credit Card", lineItems: [],
-                     refunds: [], formattedTotalTax: "$0.00", formattedDiscountTotal: nil,
+                     refunds: [], formattedDiscountTotal: nil, formattedTotalTax: "$0.00",
                      formattedPaymentTotal: "$10.00", formattedNetAmount: nil),
             POSOrder(id: 2, number: "1002", dateCreated: Date(), status: .completed,
                      formattedTotal: "$20.00", formattedSubtotal: "$20.00", customerEmail: "test2@example.com",
                      paymentMethodID: "cash", paymentMethodTitle: "Cash", lineItems: [],
-                     refunds: [], formattedTotalTax: "$0.00", formattedDiscountTotal: nil,
+                     refunds: [], formattedDiscountTotal: nil, formattedTotalTax: "$0.00",
                      formattedPaymentTotal: "$20.00", formattedNetAmount: nil)
         ]
     }

--- a/WooCommerce/WooCommerceTests/POS/Models/POSOrderListStateTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/POSOrderListStateTests.swift
@@ -25,7 +25,7 @@ struct POSOrderListStateTests {
     }
 
     @Test
-    func updatingOrders_whenLoading_preservesLoadingState() {
+    func updatingOrders_when_loading_then_preserves_loading_state() {
         // Given
         let state = POSOrderListState.loading(sampleOrders)
         let updatedOrders = [sampleOrders[1]]
@@ -43,7 +43,7 @@ struct POSOrderListStateTests {
     }
 
     @Test
-    func updatingOrders_whenInlineError_preservesErrorAndContext() {
+    func updatingOrders_when_inline_error_then_preserves_error_and_context() {
         // Given
         let errorState = PointOfSaleErrorState.errorOnLoadingOrders(error: NSError(domain: "test", code: 0))
         let state = POSOrderListState.inlineError(sampleOrders, error: errorState, context: .refresh)
@@ -64,7 +64,7 @@ struct POSOrderListStateTests {
     }
 
     @Test
-    func updatingOrders_whenEmpty_returnsUnchanged() {
+    func updatingOrders_when_empty_then_returns_unchanged() {
         // Given
         let state = POSOrderListState.empty
         let updatedOrders = sampleOrders
@@ -81,7 +81,7 @@ struct POSOrderListStateTests {
     }
 
     @Test
-    func updatingOrders_whenError_returnsUnchanged() {
+    func updatingOrders_when_error_then_returns_unchanged() {
         // Given
         let errorState = PointOfSaleErrorState.errorOnLoadingOrders(error: NSError(domain: "test", code: 0))
         let state = POSOrderListState.error(errorState)
@@ -99,7 +99,7 @@ struct POSOrderListStateTests {
     }
 
     @Test
-    func orders_returnsCorrectOrdersForEachState() {
+    func orders_when_various_states_then_returns_correct_orders() {
         // Given & When & Then
         let loadedState = POSOrderListState.loaded(sampleOrders, hasMoreItems: false)
         #expect(loadedState.orders.count == 2)

--- a/WooCommerce/WooCommerceTests/POS/Models/POSOrderListStateTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/POSOrderListStateTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+@testable import WooCommerce
+import struct Yosemite.POSOrder
+import enum NetworkingCore.OrderStatusEnum
+
+struct POSOrderListStateTests {
+    @Test
+    func updatingOrders_when_loaded_then_preserves_hasMoreItems_flag() {
+        // Given
+        let state = POSOrderListState.loaded(sampleOrders, hasMoreItems: true)
+        let updatedOrders = [sampleOrders[0]]
+
+        // When
+        let newState = state.updatingOrders(with: updatedOrders)
+
+        // Then
+        if case .loaded(let orders, let hasMoreItems) = newState {
+            #expect(orders.count == 1)
+            #expect(orders[0].id == 1)
+            #expect(hasMoreItems == true)
+        } else {
+            #expect(Bool(false), "Expected loaded state")
+        }
+    }
+
+    @Test
+    func updatingOrders_whenLoading_preservesLoadingState() {
+        // Given
+        let state = POSOrderListState.loading(sampleOrders)
+        let updatedOrders = [sampleOrders[1]]
+
+        // When
+        let newState = state.updatingOrders(with: updatedOrders)
+
+        // Then
+        if case .loading(let orders) = newState {
+            #expect(orders.count == 1)
+            #expect(orders[0].id == 2)
+        } else {
+            #expect(Bool(false), "Expected loading state")
+        }
+    }
+
+    @Test
+    func updatingOrders_whenInlineError_preservesErrorAndContext() {
+        // Given
+        let errorState = PointOfSaleErrorState.errorOnLoadingOrders(error: NSError(domain: "test", code: 0))
+        let state = POSOrderListState.inlineError(sampleOrders, error: errorState, context: .refresh)
+        let updatedOrders = [sampleOrders[0]]
+
+        // When
+        let newState = state.updatingOrders(with: updatedOrders)
+
+        // Then
+        if case .inlineError(let orders, let error, let context) = newState {
+            #expect(orders.count == 1)
+            #expect(orders[0].id == 1)
+            #expect(error == errorState)
+            #expect(context == .refresh)
+        } else {
+            #expect(Bool(false), "Expected inlineError state")
+        }
+    }
+
+    @Test
+    func updatingOrders_whenEmpty_returnsUnchanged() {
+        // Given
+        let state = POSOrderListState.empty
+        let updatedOrders = sampleOrders
+
+        // When
+        let newState = state.updatingOrders(with: updatedOrders)
+
+        // Then
+        if case .empty = newState {
+            // Expected - state should remain empty
+        } else {
+            #expect(Bool(false), "Expected empty state to remain unchanged")
+        }
+    }
+
+    @Test
+    func updatingOrders_whenError_returnsUnchanged() {
+        // Given
+        let errorState = PointOfSaleErrorState.errorOnLoadingOrders(error: NSError(domain: "test", code: 0))
+        let state = POSOrderListState.error(errorState)
+        let updatedOrders = sampleOrders
+
+        // When
+        let newState = state.updatingOrders(with: updatedOrders)
+
+        // Then
+        if case .error(let error) = newState {
+            #expect(error == errorState)
+        } else {
+            #expect(Bool(false), "Expected error state to remain unchanged")
+        }
+    }
+
+    @Test
+    func orders_returnsCorrectOrdersForEachState() {
+        // Given & When & Then
+        let loadedState = POSOrderListState.loaded(sampleOrders, hasMoreItems: false)
+        #expect(loadedState.orders.count == 2)
+
+        let loadingState = POSOrderListState.loading(sampleOrders)
+        #expect(loadingState.orders.count == 2)
+
+        let errorState = PointOfSaleErrorState.errorOnLoadingOrders(error: NSError(domain: "test", code: 0))
+        let inlineErrorState = POSOrderListState.inlineError(sampleOrders, error: errorState, context: .refresh)
+        #expect(inlineErrorState.orders.count == 2)
+
+        let emptyState = POSOrderListState.empty
+        #expect(emptyState.orders.count == 0)
+
+        let fullErrorState = POSOrderListState.error(errorState)
+        #expect(fullErrorState.orders.count == 0)
+    }
+}
+
+private extension POSOrderListStateTests {
+    private var sampleOrders: [POSOrder] {
+        [
+            POSOrder(id: 1, number: "1001", dateCreated: Date(), status: .completed,
+                     formattedTotal: "$10.00", formattedSubtotal: "$10.00", customerEmail: "test1@example.com",
+                     paymentMethodID: "stripe", paymentMethodTitle: "Credit Card", lineItems: [],
+                     refunds: [], formattedTotalTax: "$0.00", formattedDiscountTotal: nil,
+                     formattedPaymentTotal: "$10.00", formattedNetAmount: nil),
+            POSOrder(id: 2, number: "1002", dateCreated: Date(), status: .completed,
+                     formattedTotal: "$20.00", formattedSubtotal: "$20.00", customerEmail: "test2@example.com",
+                     paymentMethodID: "cash", paymentMethodTitle: "Cash", lineItems: [],
+                     refunds: [], formattedTotalTax: "$0.00", formattedDiscountTotal: nil,
+                     formattedPaymentTotal: "$20.00", formattedNetAmount: nil)
+        ]
+    }
+}

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleOrderListModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleOrderListModelTests.swift
@@ -1,0 +1,87 @@
+import Testing
+import Foundation
+@testable import WooCommerce
+import struct Yosemite.POSOrder
+import enum NetworkingCore.OrderStatusEnum
+
+final class PointOfSaleOrderListModelTests {
+    private let mockOrdersController = MockPointOfSaleOrderListController()
+    private let mockReceiptController = MockPOSReceiptController()
+    private lazy var sut = PointOfSaleOrderListModel(
+        ordersController: mockOrdersController,
+        receiptController: mockReceiptController
+    )
+
+    @Test func sendReceipt_when_successful_then_calls_receipt_controller_and_updates_order() async throws {
+        // Given
+        let testOrder = makeTestOrder(id: 123, email: "original@example.com")
+        let testEmail = "updated@example.com"
+
+        // When
+        try await sut.sendReceipt(order: testOrder, email: testEmail)
+
+        // Then
+        #expect(mockReceiptController.sendReceiptWasCalled == true)
+        #expect(mockReceiptController.sendReceiptCalledWithOrderID == 123)
+        #expect(mockReceiptController.sendReceiptCalledWithEmail == testEmail)
+        #expect(mockOrdersController.updateOrderCalled == true)
+        #expect(mockOrdersController.spyUpdateOrderID == 123)
+    }
+
+    @Test func sendReceipt_when_receipt_fails_then_throws_error_and_does_not_update_order() async throws {
+        // Given
+        let testOrder = makeTestOrder(id: 789, email: "fail@example.com")
+        let testEmail = "error@example.com"
+        mockReceiptController.shouldThrowReceiptError = true
+
+        // When & Then
+        await #expect(throws: MockPOSReceiptController.TestError.sendReceiptFailed) {
+            try await sut.sendReceipt(order: testOrder, email: testEmail)
+        }
+
+        // Receipt controller should have been called
+        #expect(mockReceiptController.sendReceiptWasCalled == true)
+
+        // But order update should NOT have been called since receipt failed
+        #expect(mockOrdersController.updateOrderCalled == false)
+    }
+
+    @Test func sendReceipt_when_updateOrder_fails_then_throws_error() async throws {
+        // Given
+        let testOrder = makeTestOrder(id: 999, email: "update-fail@example.com")
+        let testEmail = "success@example.com"
+        mockOrdersController.shouldThrowError = true
+
+        // When & Then
+        await #expect(throws: MockPointOfSaleOrderListController.TestError.updateOrderFailed) {
+            try await sut.sendReceipt(order: testOrder, email: testEmail)
+        }
+
+        // Receipt should have succeeded before update failed
+        #expect(mockReceiptController.sendReceiptWasCalled == true)
+        #expect(mockReceiptController.sendReceiptCalledWithOrderID == 999)
+        #expect(mockReceiptController.sendReceiptCalledWithEmail == testEmail)
+        #expect(mockOrdersController.updateOrderCalled == true)
+        #expect(mockOrdersController.spyUpdateOrderID == 999)
+    }
+
+    private func makeTestOrder(id: Int64, email: String) -> POSOrder {
+        POSOrder(
+            id: id,
+            number: "\(id)",
+            dateCreated: Date(),
+            status: .completed,
+            formattedTotal: "$10.00",
+            formattedSubtotal: "$10.00",
+            customerEmail: email,
+            paymentMethodID: "test",
+            paymentMethodTitle: "Test Payment",
+            lineItems: [],
+            refunds: [],
+            formattedTotalTax: "$0.00",
+            formattedDiscountTotal: nil,
+            formattedPaymentTotal: "$10.00",
+            formattedNetAmount: nil
+        )
+    }
+}

--- a/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleOrderListModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Models/PointOfSaleOrderListModelTests.swift
@@ -6,10 +6,10 @@ import enum NetworkingCore.OrderStatusEnum
 
 final class PointOfSaleOrderListModelTests {
     private let mockOrdersController = MockPointOfSaleOrderListController()
-    private let mockReceiptController = MockPOSReceiptController()
+    private let mockReceiptSender = MockPOSReceiptSender()
     private lazy var sut = PointOfSaleOrderListModel(
         ordersController: mockOrdersController,
-        receiptController: mockReceiptController
+        receiptSender: mockReceiptSender
     )
 
     @Test func sendReceipt_when_successful_then_calls_receipt_controller_and_updates_order() async throws {
@@ -21,9 +21,9 @@ final class PointOfSaleOrderListModelTests {
         try await sut.sendReceipt(order: testOrder, email: testEmail)
 
         // Then
-        #expect(mockReceiptController.sendReceiptWasCalled == true)
-        #expect(mockReceiptController.sendReceiptCalledWithOrderID == 123)
-        #expect(mockReceiptController.sendReceiptCalledWithEmail == testEmail)
+        #expect(mockReceiptSender.sendReceiptWasCalled == true)
+        #expect(mockReceiptSender.sendReceiptCalledWithOrderID == 123)
+        #expect(mockReceiptSender.sendReceiptCalledWithEmail == testEmail)
         #expect(mockOrdersController.updateOrderCalled == true)
         #expect(mockOrdersController.spyUpdateOrderID == 123)
     }
@@ -32,15 +32,15 @@ final class PointOfSaleOrderListModelTests {
         // Given
         let testOrder = makeTestOrder(id: 789, email: "fail@example.com")
         let testEmail = "error@example.com"
-        mockReceiptController.shouldThrowReceiptError = true
+        mockReceiptSender.sendReceiptErrorToThrow = MockPOSReceiptSender.TestError.sendReceiptFailed
 
         // When & Then
-        await #expect(throws: MockPOSReceiptController.TestError.sendReceiptFailed) {
+        await #expect(throws: MockPOSReceiptSender.TestError.sendReceiptFailed) {
             try await sut.sendReceipt(order: testOrder, email: testEmail)
         }
 
         // Receipt controller should have been called
-        #expect(mockReceiptController.sendReceiptWasCalled == true)
+        #expect(mockReceiptSender.sendReceiptWasCalled == true)
 
         // But order update should NOT have been called since receipt failed
         #expect(mockOrdersController.updateOrderCalled == false)
@@ -58,9 +58,9 @@ final class PointOfSaleOrderListModelTests {
         }
 
         // Receipt should have succeeded before update failed
-        #expect(mockReceiptController.sendReceiptWasCalled == true)
-        #expect(mockReceiptController.sendReceiptCalledWithOrderID == 999)
-        #expect(mockReceiptController.sendReceiptCalledWithEmail == testEmail)
+        #expect(mockReceiptSender.sendReceiptWasCalled == true)
+        #expect(mockReceiptSender.sendReceiptCalledWithOrderID == 999)
+        #expect(mockReceiptSender.sendReceiptCalledWithEmail == testEmail)
         #expect(mockOrdersController.updateOrderCalled == true)
         #expect(mockOrdersController.spyUpdateOrderID == 999)
     }
@@ -78,8 +78,8 @@ final class PointOfSaleOrderListModelTests {
             paymentMethodTitle: "Test Payment",
             lineItems: [],
             refunds: [],
-            formattedTotalTax: "$0.00",
             formattedDiscountTotal: nil,
+            formattedTotalTax: "$0.00",
             formattedPaymentTotal: "$10.00",
             formattedNetAmount: nil
         )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

[WOOMOB-1140](https://linear.app/a8c/issue/WOOMOB-1140)

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Continuation of https://github.com/woocommerce/woocommerce-ios/pull/16110, to update order list and order details after the receipt is sent:

- Fetch the order from the API after the receipt is sent
- In `PointOfSaleOrderListController` update the order list and the selected order
- Bonus: Improve `POSButtonStyle` to add a success state to the button that is shown in `POSSendReceiptView` when the receipt is successfully sent

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS -> Menu -> Orders
2. Select a completed order
3. Select "Email receipt"
4. Confirm a loading state is shown when the email is being sent
5. Confirm a success state is shown when the email is sent
6. Confirm the view is automatically dismissed
7. Confirm new email details are reflected in the order list and order details views

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad Air 26.0 simulator

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/baf495ac-bba0-43e3-afc3-822043d9a216

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.