### PR TITLE
[Woo POS][Local Catalog] Delete data from all grdb tables on logout

### DIFF
--- a/Modules/Sources/Storage/GRDB/GRDBManager.swift
+++ b/Modules/Sources/Storage/GRDB/GRDBManager.swift
@@ -3,6 +3,7 @@ import GRDB
 
 public protocol GRDBManagerProtocol {
     var databaseConnection: GRDBDatabaseConnection { get }
+    func reset() throws
 }
 
 public protocol GRDBDatabaseConnection: DatabaseReader & DatabaseWriter {}
@@ -26,6 +27,31 @@ public final class GRDBManager: GRDBManagerProtocol {
     init() throws {
         self.databaseConnection = try DatabaseQueue()
         try migrateIfNeeded()
+    }
+
+    /// Resets the database by deleting all data from all tables
+    /// Used when user logs out to ensure no data leaks between sessions
+    public func reset() throws {
+        try databaseConnection.write { db in
+            // Disable foreign key constraints temporarily to avoid dependency issues
+            try db.execute(sql: "PRAGMA foreign_keys = OFF")
+
+            // Get all user tables (excluding sqlite internal tables)
+            let tableNames = try String.fetchAll(db, sql: """
+                SELECT name FROM sqlite_master
+                WHERE type = 'table'
+                AND name NOT LIKE 'sqlite_%'
+                AND name NOT LIKE 'grdb_%'
+            """)
+
+            // Delete all data from each table
+            for tableName in tableNames {
+                try db.execute(sql: "DELETE FROM \(tableName)")
+            }
+
+            // Re-enable foreign key constraints
+            try db.execute(sql: "PRAGMA foreign_keys = ON")
+        }
     }
 }
 

--- a/Modules/Tests/StorageTests/GRDB/GRDBManagerTests.swift
+++ b/Modules/Tests/StorageTests/GRDB/GRDBManagerTests.swift
@@ -461,6 +461,46 @@ struct GRDBManagerTests {
             #expect(variations.allSatisfy { $0.siteID == sampleSiteID })
             #expect(variations.allSatisfy { $0.productID == 100 })
         }
+
+        @Test("Cannot insert product without valid site")
+        func test_cannot_insert_product_without_valid_site() throws {
+            // When/Then
+            #expect(throws: DatabaseError.self) {
+                try manager.databaseConnection.write { db in
+                    let product = TestProduct(
+                        siteID: 999, // Non-existent site
+                        id: 100,
+                        name: "Orphaned Product",
+                        productTypeKey: "simple",
+                        price: "10.00",
+                        downloadable: false,
+                        parentID: 0,
+                        manageStock: false,
+                        stockStatusKey: ""
+                    )
+                    try product.insert(db)
+                }
+            }
+        }
+
+        @Test("Cannot insert variation without valid product")
+        func test_cannot_insert_variation_without_valid_product() throws {
+            // When/Then
+            #expect(throws: DatabaseError.self) {
+                try manager.databaseConnection.write { db in
+                    let variation = TestProductVariation(
+                        siteID: sampleSiteID,
+                        id: 200,
+                        productID: 999, // Non-existent product
+                        price: "12.00",
+                        downloadable: false,
+                        manageStock: false,
+                        stockStatusKey: ""
+                    )
+                    try variation.insert(db)
+                }
+            }
+        }
     }
 
     struct ResetTests {
@@ -600,46 +640,6 @@ struct GRDBManagerTests {
             }
 
             #expect(productCount == 0)
-        }
-
-        @Test("Cannot insert product without valid site")
-        func test_cannot_insert_product_without_valid_site() throws {
-            // When/Then
-            #expect(throws: DatabaseError.self) {
-                try manager.databaseConnection.write { db in
-                    let product = TestProduct(
-                        siteID: 999, // Non-existent site
-                        id: 100,
-                        name: "Orphaned Product",
-                        productTypeKey: "simple",
-                        price: "10.00",
-                        downloadable: false,
-                        parentID: 0,
-                        manageStock: false,
-                        stockStatusKey: ""
-                    )
-                    try product.insert(db)
-                }
-            }
-        }
-
-        @Test("Cannot insert variation without valid product")
-        func test_cannot_insert_variation_without_valid_product() throws {
-            // When/Then
-            #expect(throws: DatabaseError.self) {
-                try manager.databaseConnection.write { db in
-                    let variation = TestProductVariation(
-                        siteID: sampleSiteID,
-                        id: 200,
-                        productID: 999, // Non-existent product
-                        price: "12.00",
-                        downloadable: false,
-                        manageStock: false,
-                        stockStatusKey: ""
-                    )
-                    try variation.insert(db)
-                }
-            }
         }
     }
 }

--- a/Modules/Tests/StorageTests/GRDB/GRDBManagerTests.swift
+++ b/Modules/Tests/StorageTests/GRDB/GRDBManagerTests.swift
@@ -461,6 +461,146 @@ struct GRDBManagerTests {
             #expect(variations.allSatisfy { $0.siteID == sampleSiteID })
             #expect(variations.allSatisfy { $0.productID == 100 })
         }
+    }
+
+    struct ResetTests {
+        let manager: GRDBManager
+        let sampleSiteID: Int64 = 1
+
+        init() throws {
+            self.manager = try GRDBManager()
+            try manager.databaseConnection.write { db in
+                let record = TestSite(id: sampleSiteID)
+                try record.insert(db)
+            }
+        }
+
+        @Test("Reset clears all data from database")
+        func test_reset_clears_all_data_from_database() throws {
+            // Given - Insert comprehensive test data
+            try manager.databaseConnection.write { db in
+                // Insert second site for more comprehensive test
+                let site2 = TestSite(id: 2)
+                try site2.insert(db)
+
+                // Insert products for both sites
+                for siteID in [sampleSiteID, Int64(2)] {
+                    for i in 1...2 {
+                        let product = TestProduct(
+                            siteID: siteID,
+                            id: Int64(i + (siteID == 1 ? 0 : 10)),
+                            name: "Product \(i) Site \(siteID)",
+                            productTypeKey: "variable",
+                            price: "\(i * 10).00",
+                            downloadable: false,
+                            parentID: 0,
+                            manageStock: false,
+                            stockStatusKey: ""
+                        )
+                        try product.insert(db)
+
+                        // Insert variations
+                        let variation = TestProductVariation(
+                            siteID: siteID,
+                            id: Int64(200 + i + (siteID == 1 ? 0 : 10)),
+                            productID: product.id,
+                            price: "\(i * 12).00",
+                            downloadable: false,
+                            manageStock: false,
+                            stockStatusKey: ""
+                        )
+                        try variation.insert(db)
+
+                        // Insert product attributes
+                        let productAttribute = TestProductAttribute(
+                            productID: product.id,
+                            name: "Color \(i)",
+                            position: i,
+                            visible: true,
+                            variation: true,
+                            options: ["Red", "Blue", "Green"]
+                        )
+                        try productAttribute.insert(db)
+
+                        // Insert variation attributes
+                        let variationAttribute = TestProductVariationAttribute(
+                            productVariationID: variation.id,
+                            name: "Size \(i)",
+                            option: "Large"
+                        )
+                        try variationAttribute.insert(db)
+                    }
+                }
+            }
+
+            // Verify data exists before reset
+            let countsBefore = try manager.databaseConnection.read { db in
+                return (
+                    sites: try TestSite.fetchCount(db),
+                    products: try TestProduct.fetchCount(db),
+                    variations: try TestProductVariation.fetchCount(db),
+                    productAttributes: try TestProductAttribute.fetchCount(db),
+                    variationAttributes: try TestProductVariationAttribute.fetchCount(db)
+                )
+            }
+
+            #expect(countsBefore.sites == 2) // Original site + new site
+            #expect(countsBefore.products == 4)
+            #expect(countsBefore.variations == 4)
+            #expect(countsBefore.productAttributes == 4)
+            #expect(countsBefore.variationAttributes == 4)
+
+            // When - Reset database
+            try manager.reset()
+
+            // Then - All data should be cleared
+            let countsAfter = try manager.databaseConnection.read { db in
+                return (
+                    sites: try TestSite.fetchCount(db),
+                    products: try TestProduct.fetchCount(db),
+                    variations: try TestProductVariation.fetchCount(db),
+                    productAttributes: try TestProductAttribute.fetchCount(db),
+                    variationAttributes: try TestProductVariationAttribute.fetchCount(db)
+                )
+            }
+
+            #expect(countsAfter.sites == 0)
+            #expect(countsAfter.products == 0)
+            #expect(countsAfter.variations == 0)
+            #expect(countsAfter.productAttributes == 0)
+            #expect(countsAfter.variationAttributes == 0)
+        }
+
+        @Test("Reset can be called multiple times without error")
+        func test_reset_can_be_called_multiple_times() throws {
+            // Given - Some test data
+            try manager.databaseConnection.write { db in
+                let product = TestProduct(
+                    siteID: sampleSiteID,
+                    id: 100,
+                    name: "Test Product",
+                    productTypeKey: "simple",
+                    price: "10.00",
+                    downloadable: false,
+                    parentID: 0,
+                    manageStock: false,
+                    stockStatusKey: ""
+                )
+                try product.insert(db)
+            }
+
+            // When - Reset multiple times
+            try manager.reset()
+            try manager.reset()
+            try manager.reset()
+
+            // Then - Should not throw and database should be empty
+            let productCount = try manager.databaseConnection.read { db in
+                try TestProduct.fetchCount(db)
+            }
+
+            #expect(productCount == 0)
+        }
 
         @Test("Cannot insert product without valid site")
         func test_cannot_insert_product_without_valid_site() throws {

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -269,6 +269,11 @@ class DefaultStoresManager: StoresManager {
         ServiceLocator.analytics.refreshUserData()
         ZendeskProvider.shared.reset()
         ServiceLocator.storageManager.reset()
+        do {
+            try ServiceLocator.grdbManager.reset()
+        } catch {
+            DDLogError("Could not reset GRDB database: \(error)")
+        }
         ServiceLocator.productImageUploader.reset()
 
         updateAndReloadWidgetInformation(with: nil)

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -269,11 +269,15 @@ class DefaultStoresManager: StoresManager {
         ServiceLocator.analytics.refreshUserData()
         ZendeskProvider.shared.reset()
         ServiceLocator.storageManager.reset()
-        do {
-            try ServiceLocator.grdbManager.reset()
-        } catch {
-            DDLogError("Could not reset GRDB database: \(error)")
+
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleLocalCatalogi1) {
+            do {
+                try ServiceLocator.grdbManager.reset()
+            } catch {
+                DDLogError("Could not reset GRDB database: \(error)")
+            }
         }
+
         ServiceLocator.productImageUploader.reset()
 
         updateAndReloadWidgetInformation(with: nil)

--- a/WooCommerce/WooCommerceTests/Mocks/MockStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockStoresManager.swift
@@ -50,6 +50,10 @@ final class MockStoresManager: DefaultStoresManager {
     func reset() {
         receivedActions = []
     }
+
+    override func deauthenticate() -> any StoresManager {
+        self
+    }
 }
 
 // MARK: - Mocking

--- a/WooCommerce/WooCommerceTests/Mocks/MockStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockStoresManager.swift
@@ -50,10 +50,6 @@ final class MockStoresManager: DefaultStoresManager {
     func reset() {
         receivedActions = []
     }
-
-    override func deauthenticate() -> any StoresManager {
-        self
-    }
 }
 
 // MARK: - Mocking


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a reset function which is called on logout, to delete data from all tables when someone logs out of the app.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Check unit tests pass.

I tested by adding the following to the top of `POSCatalogSyncCoordinator.shouldPerformFullSync(for:maxAge:)`:

```
try? await grdbManager.databaseConnection.read { db in
            let productCount = try PersistedProduct.fetchCount(db)
            let productImageCount = try PersistedProductImage.fetchCount(db)
            let productAttributeCount = try PersistedProductAttribute.fetchCount(db)
            let variationCount = try PersistedProductVariation.fetchCount(db)
            let variationImageCount = try PersistedProductVariationImage.fetchCount(db)
            let variationAttributeCount = try PersistedProductVariationAttribute.fetchCount(db)

            DDLogInfo("Initially found \(productCount) products, \(productImageCount) product images, " +
                      "\(productAttributeCount) product attributes, \(variationCount) variations, " +
                      "\(variationImageCount) variation images, \(variationAttributeCount) variation attributes")
        }
```

1. Launch the app and select a POS eligible site
2. Wait until the sync completes and is persisted
3. Log out, and then log back in to the same site
4. When you log in, observe that all the counts logged are 0

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
