### PR TITLE
Log and track new events for Jetpack site performance improvements 

### DIFF
--- a/Modules/Sources/NetworkingCore/ApplicationPassword/RequestProcessor.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/RequestProcessor.swift
@@ -2,7 +2,7 @@ import Alamofire
 import Foundation
 
 protocol RequestProcessorDelegate: AnyObject {
-    func didFailToAuthenticateRequestWithAppPassword(siteID: Int64)
+    func didFailToAuthenticateRequestWithAppPassword(siteID: Int64, error: Error)
 }
 
 /// Authenticates and retries requests
@@ -85,7 +85,7 @@ private extension RequestProcessor {
                     generateApplicationPassword()
                 } else {
                     isAuthenticating = false
-                    completeRequests(false)
+                    completeRequests(false, error: error)
                     if let currentSiteID {
                         notifyFailureIfNeeded(error, for: currentSiteID)
                     }
@@ -131,7 +131,7 @@ private extension RequestProcessor {
             }
         }()
         if appPasswordNotSupported {
-            delegate?.didFailToAuthenticateRequestWithAppPassword(siteID: siteID)
+            delegate?.didFailToAuthenticateRequestWithAppPassword(siteID: siteID, error: error)
         }
     }
 
@@ -146,8 +146,16 @@ private extension RequestProcessor {
         }
     }
 
-    func completeRequests(_ shouldRetry: Bool) {
-        let result: RetryResult = shouldRetry ? .retryWithDelay(0) : .doNotRetry
+    func completeRequests(_ shouldRetry: Bool, error: Error? = nil) {
+        let result: RetryResult = {
+            if shouldRetry {
+                .retryWithDelay(0)
+            } else if let error {
+                .doNotRetryWithError(error)
+            } else {
+                .doNotRetry
+            }
+        }()
         requestsToRetry.forEach { (completion) in
             completion(result)
         }
@@ -165,4 +173,12 @@ public extension NSNotification.Name {
     /// Posted when generating an application password fails
     ///
     static let ApplicationPasswordsGenerationFailed = NSNotification.Name(rawValue: "ApplicationPasswordsGenerationFailed")
+
+    /// Posted when site is flagged as unsupported for app password
+    ///
+    static let JetpackSiteFlaggedUnsupportedForApplicationPassword = NSNotification.Name(rawValue: "JetpackSiteFlaggedUnsupportedForApplicationPassword")
+
+    /// Posted when site is detected as eligible for app password authentication
+    ///
+    static let JetpackSiteEligibleForAppPasswordSupport = NSNotification.Name(rawValue: "JetpackSiteEligibleForAppPasswordSupport")
 }

--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetwork.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetwork.swift
@@ -285,7 +285,7 @@ private extension AlamofireNetwork {
                     network: self
                 ))
                 requestAuthenticator.delegate = self
-                errorHandler.resetFailureCount(for: site.siteID) // reset failure count
+                errorHandler.prepareAppPasswordSupport(for: site.siteID) // reset failure count
             }
     }
 }
@@ -305,8 +305,13 @@ private extension AlamofireNetwork {
 // MARK: `RequestProcessorDelegate` conformance
 //
 extension AlamofireNetwork: RequestProcessorDelegate {
-    func didFailToAuthenticateRequestWithAppPassword(siteID: Int64) {
-        errorHandler.flagSiteAsUnsupported(for: siteID)
+    func didFailToAuthenticateRequestWithAppPassword(siteID: Int64, error: Error) {
+        errorHandler.flagSiteAsUnsupported(
+            for: siteID,
+            flow: .appPasswordGeneration,
+            cause: .majorError,
+            error: error
+        )
     }
 }
 
@@ -346,8 +351,8 @@ extension Alamofire.DataResponse {
             return error
         }
 
-        if case .some(AFError.requestAdaptationFailed) = error?.asAFError {
-            return error
+        if case .some(AFError.requestRetryFailed) = error?.asAFError {
+            return error?.asAFError
         }
 
         return response.flatMap { response in

--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
@@ -256,7 +256,6 @@ private extension AlamofireNetworkErrorHandler {
             - Error message: \(apiErrorCode)
             """
         )
-        
     }
 
     enum Constants {

--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
@@ -47,7 +47,7 @@ final class AlamofireNetworkErrorHandler {
 
     func prepareAppPasswordSupport(for siteID: Int64) {
         appPasswordFailures.removeValue(forKey: siteID)
-        notificationCenter.post(name: .JetpackSiteEligibleForAppPasswordSupport, object: nil)
+        notificationCenter.post(name: .JetpackSiteEligibleForAppPasswordSupport, object: siteID)
     }
 
     func shouldRetryJetpackRequest(originalRequest: URLRequestConvertible,

--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
@@ -6,13 +6,17 @@ final class AlamofireNetworkErrorHandler {
     private let queue = DispatchQueue(label: "com.networkingcore.errorhandler", attributes: .concurrent)
     private let userDefaults: UserDefaults
     private let credentials: Credentials?
+    private let notificationCenter: NotificationCenter
 
     private var _appPasswordFailures: [Int64: Int] = [:]
     private var _retriedJetpackRequests: [RetriedJetpackRequest] = []
 
-    init(credentials: Credentials?, userDefaults: UserDefaults = .standard) {
+    init(credentials: Credentials?,
+         userDefaults: UserDefaults = .standard,
+         notificationCenter: NotificationCenter = .default) {
         self.credentials = credentials
         self.userDefaults = userDefaults
+        self.notificationCenter = notificationCenter
     }
 
     // MARK: - Thread-safe property access
@@ -41,8 +45,9 @@ final class AlamofireNetworkErrorHandler {
 
     // MARK: - Public interface
 
-    func resetFailureCount(for siteID: Int64) {
+    func prepareAppPasswordSupport(for siteID: Int64) {
         appPasswordFailures.removeValue(forKey: siteID)
+        notificationCenter.post(name: .JetpackSiteEligibleForAppPasswordSupport, object: nil)
     }
 
     func shouldRetryJetpackRequest(originalRequest: URLRequestConvertible,
@@ -51,13 +56,14 @@ final class AlamofireNetworkErrorHandler {
         guard let error = failure,
               let request = originalRequest as? JetpackRequest,
               convertedRequest is RESTRequest,
+              let convertedURLRequest = try? convertedRequest.asURLRequest(),
               case .some(.wpcom) = self.credentials else {
             return false
         }
 
         let isExpectedError: Bool = {
             switch error {
-            case AFError.requestAdaptationFailed:
+            case AFError.requestRetryFailed:
                 return true
             case _ as NetworkError:
                 return true
@@ -69,6 +75,7 @@ final class AlamofireNetworkErrorHandler {
         if isExpectedError {
             let retriedRequest = RetriedJetpackRequest(request: request, error: error)
             retriedJetpackRequests.append(retriedRequest)
+            logRequestFailure(request: convertedURLRequest, error: error)
             return true
         }
         return false
@@ -86,7 +93,7 @@ final class AlamofireNetworkErrorHandler {
 
         guard let index = retriedRequestIndex else { return }
 
-        let retriedRequest = retriedJetpackRequests[index]
+        let retriedRequest = retriedJetpackRequests.remove(at: index)
 
         if failure == nil {
             let siteID = retriedRequest.request.siteID
@@ -95,19 +102,27 @@ final class AlamofireNetworkErrorHandler {
             case NetworkError.unacceptableStatusCode(statusCode: 401, _),
                 NetworkError.unacceptableStatusCode(statusCode: 403, _),
                 NetworkError.unacceptableStatusCode(statusCode: 429, _):
-                flagSiteAsUnsupported(for: siteID)
+                flagSiteAsUnsupported(
+                    for: siteID,
+                    flow: .apiRequest,
+                    cause: .majorError,
+                    error: originalFailure
+                )
             default:
                 if let networkError = originalFailure as? NetworkError,
                    let code = networkError.errorCode,
                     AppPasswordConstants.disabledCodes.contains(code) {
-                    flagSiteAsUnsupported(for: siteID)
+                    flagSiteAsUnsupported(
+                        for: siteID,
+                        flow: .apiRequest,
+                        cause: .majorError,
+                        error: originalFailure
+                    )
                 } else {
-                    incrementFailureCount(for: siteID)
+                    incrementFailureCount(for: siteID, originalFailure: originalFailure)
                 }
             }
         }
-
-        retriedJetpackRequests.remove(at: index)
     }
 
     func handleFailureForDirectRequestIfNeeded(originalRequest: URLRequestConvertible,
@@ -133,12 +148,24 @@ final class AlamofireNetworkErrorHandler {
         }
     }
 
-    func flagSiteAsUnsupported(for siteID: Int64) {
+    func flagSiteAsUnsupported(for siteID: Int64, flow: RequestFlow, cause: AppPasswordFlagCause, error: Error) {
         queue.sync(flags: .barrier) {
             var currentList = userDefaults.applicationPasswordUnsupportedList
             currentList[String(siteID)] = Date()
             userDefaults.applicationPasswordUnsupportedList = currentList
         }
+
+        /// Tracks error
+        let apiErrorCode = (error as? NetworkError)?.errorCode ?? error.localizedDescription
+        let httpStatusCode = (error as? NetworkError)?.responseCode  ?? (error as NSError).code
+
+        let tracksProperties: [String: Any] = [
+            TracksProperty.flow.rawValue: flow.rawValue,
+            TracksProperty.cause.rawValue: cause.rawValue,
+            TracksProperty.apiErrorCode.rawValue: apiErrorCode,
+            TracksProperty.httpStatusCode.rawValue: httpStatusCode
+        ]
+        notificationCenter.post(name: .JetpackSiteFlaggedUnsupportedForApplicationPassword, object: tracksProperties)
     }
 
     func siteFlaggedAsUnsupported(siteID: Int64, unsupportedList: [String: Date]) -> Bool {
@@ -156,13 +183,38 @@ final class AlamofireNetworkErrorHandler {
     }
 }
 
+enum RequestFlow: String {
+    case appPasswordGeneration = "app_password_generation"
+    case apiRequest = "api_request"
+}
+
+enum AppPasswordFlagCause: String {
+    case majorError = "major_error"
+    case generalFailuresThresholdReached = "general_failures_threshold_reached"
+}
+
 // MARK: Private helpers
 private extension AlamofireNetworkErrorHandler {
-    func incrementFailureCount(for siteID: Int64) {
+    func incrementFailureCount(for siteID: Int64, originalFailure: Error) {
         let currentFailureCount = appPasswordFailures[siteID] ?? 0
         let updatedCount = currentFailureCount + 1
         if updatedCount == AppPasswordConstants.requestFailureThreshold {
-            flagSiteAsUnsupported(for: siteID)
+            let flow: RequestFlow
+            let failure: Error
+            switch originalFailure {
+            case AFError.requestRetryFailed(let error, _):
+                flow = .appPasswordGeneration
+                failure = error
+            default:
+                flow = .apiRequest
+                failure = originalFailure
+            }
+            flagSiteAsUnsupported(
+                for: siteID,
+                flow: flow,
+                cause: .generalFailuresThresholdReached,
+                error: failure
+            )
         }
         appPasswordFailures[siteID] = updatedCount
     }
@@ -176,8 +228,46 @@ private extension AlamofireNetworkErrorHandler {
         }
     }
 
+    func logRequestFailure(request: URLRequest, error: Error) {
+        let networkError: NetworkError? = {
+            switch error {
+            case AFError.requestRetryFailed(let retryError, _):
+                return (retryError as? NetworkError)
+            case let networkError as NetworkError:
+                return networkError
+            default:
+                return nil
+            }
+        }()
+
+        let siteURL = request.url?.host() ?? ""
+        let path = request.url?.path(percentEncoded: false) ?? ""
+        let method = request.httpMethod ?? ""
+        let apiErrorCode = networkError?.errorCode ?? error.localizedDescription
+        let httpCode = networkError?.responseCode ?? (error as NSError).code
+
+        DDLogError(
+            """
+            ⛔️ Request failed using Application Passwords for Jetpack Site:
+            - Site URL: \(siteURL)
+            - Path: \(path)
+            - Method: \(method)
+            - Error: HTTP status code \(httpCode)
+            - Error message: \(apiErrorCode)
+            """
+        )
+        
+    }
+
     enum Constants {
         static let flagRefreshDuration: Double = 60 * 60 * 24 * 14 // flag can be reset after 14 days.
+    }
+
+    enum TracksProperty: String {
+        case flow
+        case cause
+        case apiErrorCode = "api_error_code"
+        case httpStatusCode = "http_status_code"
     }
 }
 /// Helper type to keep track of retried requests with accompanied error

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
@@ -525,7 +525,7 @@ private class MockRequest: Alamofire.DataRequest, @unchecked Sendable {
 private class MockRequestProcessorDelegate: RequestProcessorDelegate {
     private(set) var didFailToAuthenticateRequestForSiteID: Int64?
 
-    func didFailToAuthenticateRequestWithAppPassword(siteID: Int64) {
+    func didFailToAuthenticateRequestWithAppPassword(siteID: Int64, error: Error) {
         didFailToAuthenticateRequestForSiteID = siteID
     }
 }

--- a/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
@@ -21,7 +21,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
 
     // MARK: - Basic Functionality Tests
 
-    func test_resetFailureCount_removes_failure_count_for_site() {
+    func test_prepareAppPasswordSupport_removes_failure_count_for_site() {
         // Given
         let siteID: Int64 = 123
 
@@ -29,7 +29,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         simulateFailureCount(5, for: siteID)
 
         // When
-        errorHandler.resetFailureCount(for: siteID)
+        errorHandler.prepareAppPasswordSupport(for: siteID)
 
         // Then - should not flag site as unsupported even after more failures
         simulateFailureCount(5, for: siteID) // Would normally reach threshold
@@ -79,7 +79,10 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         let restRequest = createRESTRequest()
 
         let testCases: [Error] = [
-            AFError.requestAdaptationFailed(error: NSError(domain: "test", code: 1)),
+            AFError.requestRetryFailed(
+                retryError: createNetworkError(),
+                originalError: AFError.requestAdaptationFailed(error: NSError(domain: "test", code: 0))
+            ),
             createNetworkError()
         ]
 
@@ -119,7 +122,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.isEmpty)
 
         // When
-        errorHandler.flagSiteAsUnsupported(for: siteID)
+        errorHandler.flagSiteAsUnsupported(for: siteID, flow: .apiRequest, cause: .majorError, error: NetworkError.notFound(response: nil))
 
         // Then
         XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID)))
@@ -132,7 +135,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         userDefaults.applicationPasswordUnsupportedList = [String(existingSiteID): Date()]
 
         // When
-        errorHandler.flagSiteAsUnsupported(for: newSiteID)
+        errorHandler.flagSiteAsUnsupported(for: newSiteID, flow: .apiRequest, cause: .majorError, error: NetworkError.notFound(response: nil))
 
         // Then
         XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(existingSiteID)))
@@ -141,7 +144,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
 
     // MARK: - Thread Safety Tests
 
-    func test_concurrent_resetFailureCount_operations_are_thread_safe() {
+    func test_concurrent_prepareAppPasswordSupport_operations_are_thread_safe() {
         let expectation = XCTestExpectation(description: "All reset operations complete")
         let operationCount = 3
         let siteIDs = Array(1...3).map { Int64($0) }
@@ -152,7 +155,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         for i in 0..<operationCount {
             DispatchQueue.global().async {
                 let siteID = siteIDs[i % siteIDs.count]
-                self.errorHandler.resetFailureCount(for: siteID)
+                self.errorHandler.prepareAppPasswordSupport(for: siteID)
                 expectation.fulfill()
             }
         }
@@ -194,7 +197,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         // When - perform many concurrent flag operations
         for i in 0..<operationCount {
             DispatchQueue.global().async {
-                self.errorHandler.flagSiteAsUnsupported(for: Int64(i))
+                self.errorHandler.flagSiteAsUnsupported(for: Int64(i), flow: .apiRequest, cause: .majorError, error: NetworkError.notFound(response: nil))
                 expectation.fulfill()
             }
         }
@@ -219,9 +222,9 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
 
                 switch i % 3 {
                 case 0:
-                    self.errorHandler.resetFailureCount(for: siteID)
+                    self.errorHandler.prepareAppPasswordSupport(for: siteID)
                 case 1:
-                    self.errorHandler.flagSiteAsUnsupported(for: siteID)
+                    self.errorHandler.flagSiteAsUnsupported(for: siteID, flow: .apiRequest, cause: .majorError, error: NetworkError.notFound(response: nil))
                 case 2:
                     let jetpackRequest = self.createJetpackRequest(siteID: siteID)
                     let restRequest = self.createRESTRequest()

--- a/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
@@ -6,16 +6,19 @@ import Alamofire
 final class AlamofireNetworkErrorHandlerTests: XCTestCase {
     private var userDefaults: UserDefaults!
     private var errorHandler: AlamofireNetworkErrorHandler!
+    private var notificationCenter: NotificationCenter!
 
     override func setUp() {
         super.setUp()
         userDefaults = UserDefaults(suiteName: UUID().uuidString)
-        errorHandler = AlamofireNetworkErrorHandler(credentials: createWPComCredentials(), userDefaults: userDefaults)
+        notificationCenter = NotificationCenter()
+        errorHandler = AlamofireNetworkErrorHandler(credentials: createWPComCredentials(), userDefaults: userDefaults, notificationCenter: notificationCenter)
     }
 
     override func tearDown() {
         userDefaults = nil
         errorHandler = nil
+        notificationCenter = nil
         super.tearDown()
     }
 
@@ -38,7 +41,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
 
     func test_shouldRetryJetpackRequest_returns_false_for_nil_credentials() {
         // Given
-        let errorHandlerWithNilCredentials = AlamofireNetworkErrorHandler(credentials: nil, userDefaults: userDefaults)
+        let errorHandlerWithNilCredentials = AlamofireNetworkErrorHandler(credentials: nil, userDefaults: userDefaults, notificationCenter: notificationCenter)
         let jetpackRequest = createJetpackRequest(siteID: 123)
         let restRequest = createRESTRequest()
         let error = createNetworkError()
@@ -57,7 +60,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
     func test_shouldRetryJetpackRequest_returns_false_for_non_wpcom_credentials() {
         // Given
         let wporgCredentials = Credentials.wporg(username: "user", password: "pass", siteAddress: "https://example.com")
-        let errorHandlerWithWporg = AlamofireNetworkErrorHandler(credentials: wporgCredentials, userDefaults: userDefaults)
+        let errorHandlerWithWporg = AlamofireNetworkErrorHandler(credentials: wporgCredentials, userDefaults: userDefaults, notificationCenter: notificationCenter)
         let jetpackRequest = createJetpackRequest(siteID: 123)
         let restRequest = createRESTRequest()
         let error = createNetworkError()
@@ -140,6 +143,66 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         // Then
         XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(existingSiteID)))
         XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(newSiteID)))
+    }
+
+    // MARK: - Notification Tests
+
+    func test_prepareAppPasswordSupport_posts_eligible_notification() {
+        // Given
+        let siteID: Int64 = 123
+        var receivedNotifications: [Notification] = []
+
+        let observer = notificationCenter.addObserver(
+            forName: .JetpackSiteEligibleForAppPasswordSupport,
+            object: nil,
+            queue: nil
+        ) { notification in
+            receivedNotifications.append(notification)
+        }
+
+        // When
+        errorHandler.prepareAppPasswordSupport(for: siteID)
+
+        // Then
+        XCTAssertEqual(receivedNotifications.count, 1)
+        XCTAssertEqual(receivedNotifications.first?.name, .JetpackSiteEligibleForAppPasswordSupport)
+        XCTAssertNil(receivedNotifications.first?.object)
+
+        notificationCenter.removeObserver(observer)
+    }
+
+    func test_flagSiteAsUnsupported_posts_flagged_notification_with_properties() {
+        // Given
+        let siteID: Int64 = 456
+        let error = NetworkError.unacceptableStatusCode(statusCode: 401, response: Data())
+        var receivedNotifications: [Notification] = []
+
+        let observer = notificationCenter.addObserver(
+            forName: .JetpackSiteFlaggedUnsupportedForApplicationPassword,
+            object: nil,
+            queue: nil
+        ) { notification in
+            receivedNotifications.append(notification)
+        }
+
+        // When
+        errorHandler.flagSiteAsUnsupported(for: siteID, flow: .apiRequest, cause: .majorError, error: error)
+
+        // Then
+        XCTAssertEqual(receivedNotifications.count, 1)
+        XCTAssertEqual(receivedNotifications.first?.name, .JetpackSiteFlaggedUnsupportedForApplicationPassword)
+
+        guard let tracksProperties = receivedNotifications.first?.object as? [String: Any] else {
+            XCTFail("Expected tracks properties dictionary")
+            return
+        }
+
+        XCTAssertEqual(tracksProperties["flow"] as? String, "api_request")
+        XCTAssertEqual(tracksProperties["cause"] as? String, "major_error")
+        XCTAssertEqual(tracksProperties["http_status_code"] as? Int, 401)
+        XCTAssertNotNil(tracksProperties["api_error_code"])
+
+        notificationCenter.removeObserver(observer)
     }
 
     // MARK: - Thread Safety Tests

--- a/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
@@ -166,7 +166,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         // Then
         XCTAssertEqual(receivedNotifications.count, 1)
         XCTAssertEqual(receivedNotifications.first?.name, .JetpackSiteEligibleForAppPasswordSupport)
-        XCTAssertNil(receivedNotifications.first?.object)
+        XCTAssertEqual(receivedNotifications.first?.object as? Int64, siteID)
 
         notificationCenter.removeObserver(observer)
     }

--- a/Modules/Tests/NetworkingTests/Network/AlamofireNetworkTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/AlamofireNetworkTests.swift
@@ -184,7 +184,7 @@ final class AlamofireNetworkTests: XCTestCase {
         XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.isEmpty)
 
         // When
-        network.didFailToAuthenticateRequestWithAppPassword(siteID: siteID)
+        network.didFailToAuthenticateRequestWithAppPassword(siteID: siteID, error: NetworkError.notFound(response: nil))
 
         // Then
         XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID)))
@@ -198,7 +198,7 @@ final class AlamofireNetworkTests: XCTestCase {
         let network = AlamofireNetwork(credentials: nil, userDefaults: userDefaults)
 
         // When
-        network.didFailToAuthenticateRequestWithAppPassword(siteID: newSiteID)
+        network.didFailToAuthenticateRequestWithAppPassword(siteID: newSiteID, error: NetworkError.notFound(response: nil))
 
         // Then
         XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(existingSiteID)))

--- a/WooCommerce/Classes/Analytics/TrackEventRequestNotificationHandler.swift
+++ b/WooCommerce/Classes/Analytics/TrackEventRequestNotificationHandler.swift
@@ -46,7 +46,27 @@ private extension TrackEventRequestNotificationHandler {
             self?.trackJSONParsingFailed(note: note)
         }
 
-        trackingObservers = [newPasswordCreatedObserver, passwordGenerationFailedObserver, jsonParsingFailedObserver]
+        let networkSwitchingObserver = notificationCenter.addObserver(
+            forName: .JetpackSiteEligibleForAppPasswordSupport,
+            object: nil,
+            queue: .main) { [weak self] _ in
+                self?.trackNetworkSwitchingStart()
+            }
+
+        let siteFlaggedObserver = notificationCenter.addObserver(
+            forName: .JetpackSiteFlaggedUnsupportedForApplicationPassword,
+            object: nil,
+            queue: .main) { [weak self] note in
+                self?.trackSiteFlagged(note: note)
+            }
+
+        trackingObservers = [
+            newPasswordCreatedObserver,
+            passwordGenerationFailedObserver,
+            jsonParsingFailedObserver,
+            networkSwitchingObserver,
+            siteFlaggedObserver
+        ]
     }
 
     /// Tracks an event when an application password is created
@@ -73,5 +93,16 @@ private extension TrackEventRequestNotificationHandler {
         let path = note.userInfo?[Remote.JSONParsingErrorUserInfoKey.path] as? String
         let entityName = note.userInfo?[Remote.JSONParsingErrorUserInfoKey.entityName] as? String
         analytics.track(event: .RemoteRequest.jsonParsingError(error, path: path, entityName: entityName))
+    }
+
+    func trackNetworkSwitchingStart() {
+        analytics.track(.jetpackSiteEligibleForAppPasswordSupport)
+    }
+
+    func trackSiteFlagged(note: Notification) {
+        guard let properties = note.object as? [String: Any] else {
+            return
+        }
+        analytics.track(.jetpackSiteFlaggedUnsupportedForAppPasswords, withProperties: properties)
     }
 }

--- a/WooCommerce/Classes/Analytics/TrackEventRequestNotificationHandler.swift
+++ b/WooCommerce/Classes/Analytics/TrackEventRequestNotificationHandler.swift
@@ -46,26 +46,10 @@ private extension TrackEventRequestNotificationHandler {
             self?.trackJSONParsingFailed(note: note)
         }
 
-        let networkSwitchingObserver = notificationCenter.addObserver(
-            forName: .JetpackSiteEligibleForAppPasswordSupport,
-            object: nil,
-            queue: .main) { [weak self] _ in
-                self?.trackNetworkSwitchingStart()
-            }
-
-        let siteFlaggedObserver = notificationCenter.addObserver(
-            forName: .JetpackSiteFlaggedUnsupportedForApplicationPassword,
-            object: nil,
-            queue: .main) { [weak self] note in
-                self?.trackSiteFlagged(note: note)
-            }
-
         trackingObservers = [
             newPasswordCreatedObserver,
             passwordGenerationFailedObserver,
-            jsonParsingFailedObserver,
-            networkSwitchingObserver,
-            siteFlaggedObserver
+            jsonParsingFailedObserver
         ]
     }
 
@@ -93,16 +77,5 @@ private extension TrackEventRequestNotificationHandler {
         let path = note.userInfo?[Remote.JSONParsingErrorUserInfoKey.path] as? String
         let entityName = note.userInfo?[Remote.JSONParsingErrorUserInfoKey.entityName] as? String
         analytics.track(event: .RemoteRequest.jsonParsingError(error, path: path, entityName: entityName))
-    }
-
-    func trackNetworkSwitchingStart() {
-        analytics.track(.jetpackSiteEligibleForAppPasswordSupport)
-    }
-
-    func trackSiteFlagged(note: Notification) {
-        guard let properties = note.object as? [String: Any] else {
-            return
-        }
-        analytics.track(.jetpackSiteFlaggedUnsupportedForAppPasswords, withProperties: properties)
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1163,6 +1163,10 @@ enum WooAnalyticsStat: String {
     case applicationPasswordsNewPasswordCreated = "application_passwords_new_password_created"
     case applicationPasswordsGenerationFailed = "application_passwords_generation_failed"
 
+    // MARK: Jetpack site performance improvements
+    case jetpackSiteEligibleForAppPasswordSupport = "jetpack_site_eligible_for_app_password_support"
+    case jetpackSiteFlaggedUnsupportedForAppPasswords = "jetpack_site_flagged_unsupported_for_app_passwords"
+
     // MARK: Free Trial
     case freeTrialUpgradeNowTapped = "free_trial_upgrade_now_tapped"
     case planUpgradeSuccess = "plan_upgrade_success"

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -46,6 +46,14 @@ class DefaultStoresManager: StoresManager {
     ///
     private let cardPresentPaymentOnboardingStateCache: CardPresentPaymentOnboardingStateCache
 
+    /// Tracks site IDs that are eligible for app password support to prevent duplicate analytics events
+    ///
+    private var trackedEligibleSites: Set<Int64> = []
+
+    /// Network switching notification observers
+    ///
+    private var networkNotificationObservers: [NSObjectProtocol]?
+
     /// SessionManager: Persistent Storage for Session-Y Properties.
     /// This property is thread safe
     private(set) var sessionManager: SessionManagerProtocol {
@@ -148,6 +156,9 @@ class DefaultStoresManager: StoresManager {
         self.cardPresentPaymentOnboardingStateCache = cardPresentPaymentOnboardingStateCache
 
         isLoggedIn = isAuthenticated
+        if isLoggedIn, case .some(.wpcom) = sessionManager.defaultCredentials {
+            startObservingNetworkNotifications()
+        }
     }
 
     /// This should only be invoked after all the ServiceLocator dependencies in this function are initialized to avoid circular reference.
@@ -182,9 +193,11 @@ class DefaultStoresManager: StoresManager {
         if case .wpcom = credentials {
             listenToWPCOMInvalidWPCOMTokenNotification()
             applicationPasswordGenerationFailureObserver = nil
+            startObservingNetworkNotifications()
         } else {
             listenToApplicationPasswordGenerationFailureNotification()
             invalidWPCOMTokenNotificationObserver = nil
+            stopObservingNetworkNotifications()
         }
 
         return self
@@ -265,6 +278,8 @@ class DefaultStoresManager: StoresManager {
     func deauthenticate() -> StoresManager {
         applicationPasswordGenerationFailureObserver = nil
         invalidWPCOMTokenNotificationObserver = nil
+        stopObservingNetworkNotifications()
+        trackedEligibleSites.removeAll()
 
         if isAuthenticated {
             let resetAction = CardPresentPaymentAction.reset
@@ -822,6 +837,62 @@ private extension DefaultStoresManager {
                                           numberOfProducts: numberOfProducts,
                                           systemPlugins: systemPlugins)
         }
+    }
+
+    /// Sets up network switching notification observers
+    ///
+    func startObservingNetworkNotifications() {
+        let eligibleSiteObserver = notificationCenter.addObserver(
+            forName: .JetpackSiteEligibleForAppPasswordSupport,
+            object: nil,
+            queue: .main) { [weak self] note in
+                self?.trackJetpackSiteEligible(note: note)
+            }
+
+        let siteFlaggedObserver = notificationCenter.addObserver(
+            forName: .JetpackSiteFlaggedUnsupportedForApplicationPassword,
+            object: nil,
+            queue: .main) { [weak self] note in
+                self?.trackJetpackSiteFlagged(note: note)
+            }
+
+        networkNotificationObservers = [eligibleSiteObserver, siteFlaggedObserver]
+    }
+
+    /// Removes network switching notification observers
+    ///
+    func stopObservingNetworkNotifications() {
+        networkNotificationObservers?.forEach { observer in
+            notificationCenter.removeObserver(observer)
+        }
+        networkNotificationObservers = nil
+    }
+
+    /// Tracks Jetpack site eligible for app password support with deduplication
+    ///
+    func trackJetpackSiteEligible(note: Notification) {
+        guard let siteID = note.object as? Int64,
+              sessionManager.defaultSite?.siteID == siteID else {
+            return
+        }
+        // Only track if we haven't already tracked this site
+        if !trackedEligibleSites.contains(siteID) {
+            trackedEligibleSites.insert(siteID)
+            ServiceLocator.analytics.track(.jetpackSiteEligibleForAppPasswordSupport)
+        }
+    }
+
+    /// Tracks Jetpack site flagged as unsupported and removes from eligible tracking
+    ///
+    private func trackJetpackSiteFlagged(note: Notification) {
+        guard let properties = note.object as? [String: Any] else {
+            return
+        }
+        // Get the current site ID and remove from tracked sites
+        if let siteID = sessionManager.defaultStoreID {
+            trackedEligibleSites.remove(siteID)
+        }
+        ServiceLocator.analytics.track(.jetpackSiteFlaggedUnsupportedForAppPasswords, withProperties: properties)
     }
 }
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -229,10 +229,7 @@ class DefaultStoresManager: StoresManager {
     /// Prepares for changing the selected store and remains Authenticated.
     ///
     func removeDefaultStore() {
-        /// In case of store switching, new password might be saved locally before the deletion of old password is done.
-        /// Here we delete the password remotely only to avoid the race condition
-        /// when the new password is removed from the local storage by mistake.
-        sessionManager.deleteApplicationPassword(locally: false)
+        sessionManager.deleteApplicationPassword(locally: true)
         ServiceLocator.analytics.refreshUserData()
         ZendeskProvider.shared.reset()
         ServiceLocator.pushNotesManager.unregisterForRemoteNotifications()

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -332,7 +332,7 @@ final class StoresManagerTests: XCTestCase {
 
         // Then
         XCTAssertTrue(mockSessionManager.deleteApplicationPasswordInvoked)
-        XCTAssertFalse(mockSessionManager.deleteApplicationPasswordLocally)
+        XCTAssertTrue(mockSessionManager.deleteApplicationPasswordLocally)
     }
 
     func test_updating_default_storeID_sets_storePhoneNumber_to_nil() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of WOOMOB-1125

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR tracks new events for the network switching:
- `jetpack_site_eligible_for_app_password_support`: tracked when a Jetpack site is detected as eligible to switch to application password authentication for network requests.
- `jetpack_site_flagged_unsupported_for_app_passwords` tracked when a site is flagged as not supported for app passwords. This comes with properties:
  - `flow`: `app_password_generation` or `api_request`
  - `cause`: `major_error` or `general_failures_threshold_reached`.
  - `api_error_code`
  - `http_status_code`

To add these events, the error handling needs to be updated to pass the errors for tracking:
- `RequestProcessor`:
  - Sends the failure when app password generation fails with expected errors to the delegate.
  - Sends the failure when the generation fails with general errors.
- `AlamofireNetworkErrorHandler`:
  - Sends notification for tracking when network switching starts
  - Determines the flow, cause, error codes to send notification for tracking failures.
  - Adds logs for when network switched requests fail. This would be helpful during support when users disable tracking on the app.
- `DefaultStoresManager`: clear app password locally to avoid the app picking up the password from a previous site upon switching sites, causing requests to fail with HTTP code 401 and error `incorrect_username`.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Use the test plan in pe5sF9-4Am-p2:

1. With TC1, confirm that `jetpack_site_eligible_for_app_password_support` is tracked after login (with an acceptable delay)
2. With TC3 to TC6 confirm that at the end, `jetpack_site_flagged_unsupported_for_app_passwords` is tracked with the following properties:

\ | `flow` | `cause` | `api_error_code` | `http_status_code` 
--- | --- | --- | --- | ---
TC3 | `app_password_generation` | `major_error` | `application_passwords_disabled` | 501
TC4 (snippet 1) | `api_request` | `major_error` | `incorrect_password` | 501
TC5 | `api_request` | `general_failures_threshold_reached` | `error` | 500
TC6 | `app_password_generation` | `general_failures_threshold_reached` | `general_error` | 500

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested and confirm the above cases with simulator iPhone 16 iOS 18.2.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.