### PR TITLE
[Woo POS] Don't ignore safe area at the root of POS modal

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -43,7 +43,6 @@ struct POSRootModalViewModifier: ViewModifier {
                 }
             }
             .animation(.easeInOut(duration: animationDuration), value: modalManager.isPresented)
-            .ignoresSafeArea()
     }
 
     private func updateModalParentSize(with size: CGSize) {
@@ -212,3 +211,50 @@ extension EnvironmentValues {
         set { self[POSModalParentSizeKey.self] = newValue }
     }
 }
+
+// MARK: - Previews for testing popular modals
+
+#if DEBUG
+#Preview("Card Present Alert") {
+    @Previewable @StateObject var modalManager = POSModalManager()
+    @Previewable @StateObject var coverManager = POSFullScreenCoverManager()
+    @Previewable @State var showModal = false
+
+    return VStack {
+        Color.blue
+            .ignoresSafeArea(.all)
+        .onAppear {
+            showModal = true
+        }
+    }
+    .posModal(isPresented: $showModal) {
+        PointOfSaleCardPresentPaymentAlert(alertType: .connectionSuccess(
+            viewModel: PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel(doneAction: {
+            })
+        ))
+    }
+    .posRootModal()
+    .environmentObject(modalManager)
+    .environmentObject(coverManager)
+}
+
+#Preview("Barcode Scanner Setup") {
+    @Previewable @StateObject var modalManager = POSModalManager()
+    @Previewable @StateObject var coverManager = POSFullScreenCoverManager()
+    @Previewable @State var showModal = false
+
+    return VStack {
+        Color.blue
+            .ignoresSafeArea(.all)
+        .onAppear {
+            showModal = true
+        }
+    }
+    .posModal(isPresented: $showModal) {
+        PointOfSaleBarcodeScannerSetup(isPresented: $showModal)
+    }
+    .posRootModal()
+    .environmentObject(modalManager)
+    .environmentObject(coverManager)
+}
+#endif


### PR DESCRIPTION
Ignoring a safe area at the root of the POS modal removes the safe area for the whole POS

<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As a regression after https://github.com/woocommerce/woocommerce-ios/pull/16104, POS headers and the floating button appeared too close to the edges due to the removal of the safe area at the root of the POS modal code.

For now, I just removed this ignore, which will make the modal window only expand up until the top and bottom safe areas.  I spent some time trying to find the solution, but it looks like just setting `.cornerRadius` is enough to trigger safe area. Putting cornerRadius on the background worked on card-present payment modals, but broke other modals in the process. 

Here are various fixes that I tried if interested:

https://github.com/user-attachments/assets/3cfa694b-4d91-45ca-9eee-cce4535fa6e4

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

The payment modals should behave as in https://github.com/woocommerce/woocommerce-ios/pull/16104, but don't grow past the top and bottom of safe area.

Payment modals:
1. Open POS on an iPad 26.0 device or simulator
2. Start card reader connection
3. Change window sizes
4. Confirm the modal view adapts to different view widths and heights, and can be scrolled when needed

Regression:
1. Try opening barcode scanning or product restriction modals and confirm they continue to work


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Tested on iPad Air 26 simulator
- Added previews to facilitate development and testing

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/2be4ab54-4541-433b-9780-8be62cca6957

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.