### PR TITLE
Add new support tag when using app passwords for jetpack sites

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
@@ -55,7 +55,8 @@ class SupportFormMetadataProvider {
             Constants.platformTag,
             site.isWordPressComStore ? Constants.wpComTag : nil,
             site.plan.isNotEmpty ? site.plan : nil,
-            stores.isAuthenticatedWithoutWPCom ? Constants.authenticatedWithApplicationPasswordTag : nil
+            stores.isAuthenticatedWithoutWPCom ? Constants.authenticatedWithApplicationPasswordTag : nil,
+            stores.requestAuthenticationMode == .appPasswordsWithJetpack ? Constants.jetpackSiteUsingAppPasswords : nil
         ].compactMap { $0 } + getIPPTags()
     }
 
@@ -218,6 +219,7 @@ private extension SupportFormMetadataProvider {
         static let networkWiFi = "WiFi"
         static let networkWWAN = "Mobile"
         static let sourcePlatform = "mobile_-_woo_ios"
+        static let jetpackSiteUsingAppPasswords = "jetpack_site_using_app_passwords"
     }
 
     /// Payments extensions Slugs


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1186

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a new tag `jetpack_site_using_app_passwords` for support tickets when users has application password switching for their Jetpack site.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a Jetpack site with WPCom credentials. Ensure that the site has app passwords enabled.
2. After logging in, confirm that requests are made directly with app password.
3. Go to Menu > Settings > Help & support > Contact support > send a test ticket with message like "Testing, please close ticket".
4. Check on Zendesk for your ticket and confirm that `jetpack_site_using_app_passwords` is listed as one of the tags.
5. In the app, turn off app password in Menu > Settings > Experimental Features. Confirm that requests are made with Jetpack proxy.
6. Repeat step 3 and confirm that the new ticket doesn't have tag `jetpack_site_using_app_passwords`.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested and confirmed the above cases with simulator iPhone 16 iOS 18.2

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.