### PR TITLE
Shipping Labels: Filter virtual products from the default shipment

### DIFF
--- a/Modules/Sources/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
@@ -82,7 +82,6 @@ extension Storage.Order: ReadOnlyConvertible {
         let orderCustomFields = customFields?.map { $0.toReadOnly() } ?? [Yosemite.MetaData]()
         let orderGiftCards = appliedGiftCards?.map { $0.toReadOnly() } ?? [Yosemite.OrderGiftCard]()
         let orderShippingLabels = shippingLabels?.map { $0.toReadOnly() } ?? [Yosemite.ShippingLabel]()
-        let orderShipments = shipments?.map { $0.toReadOnly() } ?? [Yosemite.WooShippingShipment]()
 
         return Order(siteID: siteID,
                      orderID: orderID,

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 23.3
 -----
+- [*] Order details: Display only physical items in the Shipping Labels section. [https://github.com/woocommerce/woocommerce-ios/pull/16127]
 - [internal] Address deprecated view modifiers usage following iOS17 API updates [https://github.com/woocommerce/woocommerce-ios/pull/16080]
 
 23.2

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1241,13 +1241,18 @@ extension OrderDetailsDataSource {
                 siteID: order.siteID,
                 orderID: order.orderID,
                 index: "0",
-                items: order.items.map { item in
-                    var subItems: [String] = []
-                    for index in 0..<item.quantity.intValue {
-                        subItems.append("\(item.itemID)-sub-\(index)")
+                items: order.items
+                    .filter { item in
+                        let matchingProduct = products.first(where: { $0.productID == item.productOrVariationID })
+                        return matchingProduct?.virtual == false
                     }
-                    return WooShippingShipmentItem(id: item.itemID, subItems: subItems)
-                },
+                    .map { item in
+                        var subItems: [String] = []
+                        for index in 0..<item.quantity.intValue {
+                            subItems.append("\(item.itemID)-sub-\(index)")
+                        }
+                        return WooShippingShipmentItem(id: item.itemID, subItems: subItems)
+                    },
                 shippingLabel: nil
             )]
         }()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1288
Also closes WOOMOB-1291

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously I added a default shipment in the Shipping Label section on the Order details screen and mapped all order items as the content of the shipment. However, only physical products are eligible for shipping.

This PR adds a small fix to filter out virtual products from the default shipments.

Additionally, an unused variable is removed from the conversion of read-only orders.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Log in to a test store with Woo Shipping plugin set up.
- Create an order with both physical and virtual products.
- Open the created order on the app and confirm that only physical items are listed in the shipping label section.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested and confirmed with simulator.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/629782ca-7a4f-40ec-b9d2-84d394e879b7



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.