### PR TITLE
[CIAB] Hide grouped and variable products types from selector

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -62,6 +62,7 @@ final class AddProductCoordinator: Coordinator {
 
     private var addProductWithAIEligibilityChecker: ProductCreationAIEligibilityCheckerProtocol
     private var addProductWithAIBottomSheetPresenter: BottomSheetPresenter?
+    private let siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol
 
     private let wooSubscriptionProductsEligibilityChecker: WooSubscriptionProductsEligibilityCheckerProtocol
 
@@ -73,6 +74,7 @@ final class AddProductCoordinator: Coordinator {
          sourceNavigationController: UINavigationController,
          storage: StorageManagerType = ServiceLocator.storageManager,
          addProductWithAIEligibilityChecker: ProductCreationAIEligibilityCheckerProtocol = ProductCreationAIEligibilityChecker(),
+         siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker(),
          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
          analytics: Analytics = ServiceLocator.analytics,
          isFirstProduct: Bool,
@@ -96,6 +98,7 @@ final class AddProductCoordinator: Coordinator {
         self.storage = storage
         self.addProductWithAIEligibilityChecker = addProductWithAIEligibilityChecker
         self.wooSubscriptionProductsEligibilityChecker = WooSubscriptionProductsEligibilityChecker(siteID: siteID, storage: storage)
+        self.siteCIABEligibilityChecker = siteCIABEligibilityChecker
         self.analytics = analytics
         self.isFirstProduct = isFirstProduct
         self.navigateToProductForm = navigateToProductForm
@@ -152,7 +155,8 @@ private extension AddProductCoordinator {
         let viewProperties = BottomSheetListSelectorViewProperties(subtitle: subtitle)
         let command = ProductTypeBottomSheetListSelectorCommand(
             source: .creationForm,
-            subscriptionProductsEligibilityChecker: wooSubscriptionProductsEligibilityChecker
+            subscriptionProductsEligibilityChecker: wooSubscriptionProductsEligibilityChecker,
+            siteCIABEligibilityChecker: siteCIABEligibilityChecker
         ) { [weak self] selectedBottomSheetProductType in
             guard let self else { return }
             self.analytics.track(event: .ProductCreation

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
@@ -16,9 +16,9 @@ final class ProductTypeBottomSheetListSelectorCommand: BottomSheetListSelectorCo
             .simple(isVirtual: false),
             .simple(isVirtual: true),
             isEligibleForSubscriptionProducts ? .subscription : nil,
-            .variable,
+            siteCIABEligibilityChecker.isFeatureSupportedForCurrentSite(.variableProducts) ? .variable : nil,
             isEligibleForSubscriptionProducts ? .variableSubscription : nil,
-            .grouped,
+            siteCIABEligibilityChecker.isFeatureSupportedForCurrentSite(.groupedProducts) ? .grouped : nil,
             .affiliate
         ].compactMap { $0 }
 
@@ -35,13 +35,16 @@ final class ProductTypeBottomSheetListSelectorCommand: BottomSheetListSelectorCo
     private let source: Source
     private let onSelection: (BottomSheetProductType) -> Void
     private let isEligibleForSubscriptionProducts: Bool
+    private let siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol
 
     init(source: Source,
          subscriptionProductsEligibilityChecker: WooSubscriptionProductsEligibilityCheckerProtocol,
+         siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol,
          onSelection: @escaping (BottomSheetProductType) -> Void) {
         self.source = source
         self.onSelection = onSelection
         self.isEligibleForSubscriptionProducts = subscriptionProductsEligibilityChecker.isSiteEligible()
+        self.siteCIABEligibilityChecker = siteCIABEligibilityChecker
         if case let .editForm(selected) = source {
             self.selected = selected
         } else {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
@@ -39,7 +39,7 @@ final class ProductTypeBottomSheetListSelectorCommand: BottomSheetListSelectorCo
 
     init(source: Source,
          subscriptionProductsEligibilityChecker: WooSubscriptionProductsEligibilityCheckerProtocol,
-         siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol,
+         siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker(),
          onSelection: @escaping (BottomSheetProductType) -> Void) {
         self.source = source
         self.onSelection = onSelection

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -79,6 +79,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     private let aiEligibilityChecker: ProductFormAIEligibilityChecker
     private var descriptionAICoordinator: ProductDescriptionAICoordinator?
     private let subscriptionProductsEligibilityChecker: WooSubscriptionProductsEligibilityCheckerProtocol
+    private let siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker()
 
     private lazy var tooltipUseCase = ProductDescriptionAITooltipUseCase(isDescriptionAIEnabled: aiEligibilityChecker.isFeatureEnabled(.description))
     private var didShowTooltip = false {
@@ -1630,7 +1631,8 @@ private extension ProductFormViewController {
         let productType = BottomSheetProductType(productType: viewModel.productModel.productType, isVirtual: viewModel.productModel.virtual)
         let command = ProductTypeBottomSheetListSelectorCommand(
             source: .editForm(selected: productType),
-            subscriptionProductsEligibilityChecker: subscriptionProductsEligibilityChecker
+            subscriptionProductsEligibilityChecker: subscriptionProductsEligibilityChecker,
+            siteCIABEligibilityChecker: siteCIABEligibilityChecker
         ) { [weak self] (selectedProductType) in
             self?.dismiss(animated: true, completion: nil)
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockCIABEligibilityChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCIABEligibilityChecker.swift
@@ -22,7 +22,7 @@ final class MockCIABEligibilityChecker: CIABEligibilityCheckerProtocol {
     }
 
     func isFeatureSupportedForCurrentSite(_ feature: CIABAffectedFeature) -> Bool {
-        return !mockedCIABDisabledFeatures.contains(feature)
+        return !mockedCIABDisabledFeatures.contains(feature) || !isCurrentSiteCIAB
     }
 
     func isFeatureSupported(_ feature: CIABAffectedFeature, for site: Site) -> Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommandTests.swift
@@ -120,4 +120,72 @@ final class ProductTypeBottomSheetListSelectorCommandTests: XCTestCase {
         ]
         XCTAssertEqual(selectedActions, expectedActions)
     }
+
+    func test_creation_form_data_does_not_contain_grouped_and_variable_types_if_site_is_ciab() {
+        // Given
+        let subscriptionEligibilityChecker = MockWooSubscriptionProductsEligibilityChecker(isEligible: true)
+        let siteCIABEligibilityChecker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: true)
+
+        // When
+        let command = ProductTypeBottomSheetListSelectorCommand(
+            source: .creationForm,
+            subscriptionProductsEligibilityChecker: subscriptionEligibilityChecker,
+            siteCIABEligibilityChecker: siteCIABEligibilityChecker
+        ) { _ in }
+
+        // Then
+        XCTAssertFalse(command.data.contains(.grouped), "'command.data' should not contain grouped product type")
+        XCTAssertFalse(command.data.contains(.variable), "'command.data' should not contain variable product type")
+    }
+
+    func test_creation_form_data_contains_grouped_and_variable_types_if_site_is_non_ciab_and_other_requirements_met() {
+        // Given
+        let subscriptionEligibilityChecker = MockWooSubscriptionProductsEligibilityChecker(isEligible: true)
+        let siteCIABEligibilityChecker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: false)
+
+        // When
+        let command = ProductTypeBottomSheetListSelectorCommand(
+            source: .creationForm,
+            subscriptionProductsEligibilityChecker: subscriptionEligibilityChecker,
+            siteCIABEligibilityChecker: siteCIABEligibilityChecker
+        ) { _ in }
+
+        // Then
+        XCTAssertTrue(command.data.contains(.grouped), "'command.data' should contain grouped product type")
+        XCTAssertTrue(command.data.contains(.variable), "'command.data' should contain variable product type")
+    }
+
+    func test_edit_form_data_does_not_contain_grouped_and_variable_types_if_site_is_ciab() {
+        // Given
+        let subscriptionEligibilityChecker = MockWooSubscriptionProductsEligibilityChecker(isEligible: true)
+        let siteCIABEligibilityChecker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: true)
+
+        // When
+        let command = ProductTypeBottomSheetListSelectorCommand(
+            source: .editForm(selected: .simple(isVirtual: false)),
+            subscriptionProductsEligibilityChecker: subscriptionEligibilityChecker,
+            siteCIABEligibilityChecker: siteCIABEligibilityChecker
+        ) { _ in }
+
+        // Then
+        XCTAssertFalse(command.data.contains(.grouped), "'command.data' should not contain grouped product type")
+        XCTAssertFalse(command.data.contains(.variable), "'command.data' should not contain variable product type")
+    }
+
+    func test_edit_form_data_contains_grouped_and_variable_types_if_site_is_non_ciab_and_other_requirements_met() {
+        // Given
+        let subscriptionEligibilityChecker = MockWooSubscriptionProductsEligibilityChecker(isEligible: true)
+        let siteCIABEligibilityChecker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: false)
+
+        // When
+        let command = ProductTypeBottomSheetListSelectorCommand(
+            source: .editForm(selected: .simple(isVirtual: false)),
+            subscriptionProductsEligibilityChecker: subscriptionEligibilityChecker,
+            siteCIABEligibilityChecker: siteCIABEligibilityChecker
+        ) { _ in }
+
+        // Then
+        XCTAssertTrue(command.data.contains(.grouped), "'command.data' should contain grouped product type")
+        XCTAssertTrue(command.data.contains(.variable), "'command.data' should contain variable product type")
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1269

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Hides "grouped" and "variable" product types from selector in product creation and product editing forms. 
- The product types set logic sits in `ProductTypeBottomSheetListSelectorCommand`. From now on it uses `CIABEligibilityChecker` to determine if "grouped" and "variable" product types should be added into data set and thus presented in selector.
- Added tests

## Smoke testing steps (Non-CIAB)
- Use testing site that doesn't contain "garden" or "ciab" in name (this is the temp CIAB / non-CIAB site distinguishing logic).
- Navigate to "products" tab and tap on "+" button in top right to open product creation sheet.
- Select "add manually" if presented
- Make sure "variable product" and "grouped product" entries are presented
- Close the creation sheet and navigate to an existing simple physical product
- In that product details form tap on the "Product type" row to open product type selection sheet
- Make sure "grouped" and "variable" types are presented there

## CIAB site testing steps
- In site admin dashboard add "garden" or "ciab" into site name and shave changes
- Restart the app and make sure the name change took place
- Repeat the steps from "Smoke testing steps (Non-CIAB)" scenario
- The "grouped" and "variable" product types shouldn't be displayed in product type selection sheet

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
|Before|After
---|---
<img width="463" height="615" alt="Снимок экрана 2025-09-15 в 13 41 35" src="https://github.com/user-attachments/assets/aaba5f13-b37e-4be7-9347-e96eafc3af1c" /> | <img width="464" height="432" alt="Снимок экрана 2025-09-15 в 13 40 32" src="https://github.com/user-attachments/assets/5b7226bc-e09e-483c-beee-3edd5ae5d019" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.