### PR TITLE
[HACK] AI API keys: Settings view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -1,12 +1,12 @@
 import SwiftUI
 
 @Observable final class AISettingsViewModel {
-    var usesJetpackAsDefaultAIProviderSource: Bool = true
+    var usesJetpackAsDefaultAIProviderSource: Bool = false
     var isEditingApiKey: Bool = false
     var apiKey: String = "foo"
     var selectedProvider: String = "OpenAI"
     var selectedModel: String = "gpt-4"
-    
+
     func updateProvider(_ provider: String) {
         // TODO
     }
@@ -19,18 +19,25 @@ struct AISettingsView: View {
         _viewModel = State(initialValue: viewModel)
     }
 
+    // Disable AI settings when the site already uses Jetpack as the default AI source
+    private var aiSettingsDisabled: Bool {
+        viewModel.usesJetpackAsDefaultAIProviderSource
+    }
+
     var body: some View {
         // Enables VM $ Bindables
         @Bindable var viewModel = viewModel
-        VStack {
-            if viewModel.usesJetpackAsDefaultAIProviderSource {
+        VStack(alignment: .leading) {
+            if aiSettingsDisabled {
                 JetpackAsAIDefaultSourceBannerView()
             }
             TextField(
                 Localization.enterAPIKey,
                 text: Binding(
                     get: { viewModel.isEditingApiKey ? viewModel.apiKey : "**********" },
-                    set: { newValue in if viewModel.isEditingApiKey { viewModel.apiKey = newValue } }
+                    set: { newValue in
+                        if viewModel.isEditingApiKey { viewModel.apiKey = newValue }
+                    }
                 )
             )
             .textFieldStyle(RoundedBorderTextFieldStyle())
@@ -40,7 +47,7 @@ struct AISettingsView: View {
             Text(Localization.apiKeyDescription)
                 .font(.caption)
                 .foregroundColor(.secondary)
-            
+
             HStack {
                 Text(Localization.aiProvider)
                     .foregroundColor(.secondary)
@@ -51,9 +58,9 @@ struct AISettingsView: View {
                 .onChange(of: viewModel.selectedProvider) { _, newValue in
                     viewModel.updateProvider(newValue)
                 }
-                .disabled(viewModel.usesJetpackAsDefaultAIProviderSource)
-                .opacity(viewModel.usesJetpackAsDefaultAIProviderSource ? 0.5 : 1.0)
-                
+                .disabled(aiSettingsDisabled)
+                .opacity(aiSettingsDisabled ? 0.5 : 1.0)
+
                 if viewModel.usesJetpackAsDefaultAIProviderSource {
                     Image(systemName: "lock.fill")
                         .foregroundColor(.secondary)
@@ -64,24 +71,26 @@ struct AISettingsView: View {
                     .foregroundColor(.secondary)
                 Picker(Localization.selectModel, selection: $viewModel.selectedModel) {
                     // TODO
-                    Text("model").tag("model")
+                    Text("Default model").tag("model")
                 }
                 .pickerStyle(MenuPickerStyle())
-                .disabled(viewModel.usesJetpackAsDefaultAIProviderSource)
-                .opacity(viewModel.usesJetpackAsDefaultAIProviderSource ? 0.5 : 1.0)
-                
-                if viewModel.usesJetpackAsDefaultAIProviderSource {
+                .disabled(aiSettingsDisabled)
+                .opacity(aiSettingsDisabled ? 0.5 : 1.0)
+
+                if aiSettingsDisabled {
                     Image(systemName: "lock.fill")
                         .foregroundColor(.gray)
                 }
             }
-            
+
             Spacer()
 
             Text(Localization.apiKeyDisclaimer)
                 .font(.caption)
                 .foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, alignment: .center)
         }
+        .padding()
         .navigationTitle(Localization.navigationTitle)
     }
 }
@@ -122,43 +131,43 @@ private extension AISettingsView {
             value: "Enter API Key",
             comment: "Placeholder text for the API key input field"
         )
-        
+
         static let apiKeyDescription = NSLocalizedString(
              "aiSettings.apiKeyDescription",
              value: "Enter your API key to use AI generation at public API costs.",
              comment: "Description text explaining the purpose of the API key"
          )
-        
+
         static let apiKeyDisclaimer = NSLocalizedString(
             "aiSettings.apiKeyDisclaimer",
             value: "API keys open up access to potentially sensitive information. Do not share your API key with others or expose them.",
             comment: "Warning message about keeping API keys secure"
         )
-        
+
         static let aiProvider = NSLocalizedString(
             "aiSettings.aiProvider",
             value: "Provider",
             comment: "Label for the AI provider selection in AI settings"
         )
-        
+
         static let selectProvider = NSLocalizedString(
             "aiSettings.selectProvider",
             value: "Select Provider",
             comment: "Accessibility label for the AI provider picker"
         )
-        
+
         static let openAI = NSLocalizedString(
              "aiSettings.openAI",
              value: "OpenAI",
              comment: "Label for OpenAI provider option"
          )
-        
+
         static let models = NSLocalizedString(
             "aiSettings.models",
             value: "Models",
             comment: "Label for the AI models selection"
         )
-        
+
         static let selectModel = NSLocalizedString(
             "aiSettings.selectModel",
             value: "Select Model",

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -7,7 +7,22 @@ import SwiftUI
     var selectedProvider: String = "OpenAI"
     var selectedModel: String = "gpt-4"
 
+    func toggleEditing() {
+        if isEditingApiKey {
+            saveSettings()
+        }
+        isEditingApiKey.toggle()
+    }
+
     func updateProvider(_ provider: String) {
+        // TODO
+    }
+
+    func clearAPIKey() {
+        // TODO
+    }
+
+    private func saveSettings() {
         // TODO
     }
 }
@@ -31,18 +46,34 @@ struct AISettingsView: View {
             if aiSettingsDisabled {
                 JetpackAsAIDefaultSourceBannerView()
             }
-            TextField(
-                Localization.enterAPIKey,
-                text: Binding(
-                    get: { viewModel.isEditingApiKey ? viewModel.apiKey : "**********" },
-                    set: { newValue in
-                        if viewModel.isEditingApiKey { viewModel.apiKey = newValue }
-                    }
+
+            HStack {
+                TextField(
+                    Localization.enterAPIKey,
+                    text: Binding(
+                        get: { viewModel.isEditingApiKey ? viewModel.apiKey : "**********" },
+                        set: { newValue in
+                            if viewModel.isEditingApiKey { viewModel.apiKey = newValue }
+                        }
+                    )
                 )
-            )
-            .textFieldStyle(RoundedBorderTextFieldStyle())
-            .foregroundColor(.primary)
-            .privacySensitive()
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .foregroundColor(.primary)
+                .privacySensitive()
+
+                if viewModel.isEditingApiKey, !viewModel.apiKey.isEmpty {
+                    Button(action: viewModel.clearAPIKey) {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.gray)
+                    }
+                }
+
+                Button(action: viewModel.toggleEditing) {
+                    Text(viewModel.isEditingApiKey ? Localization.save : Localization.edit)
+                }
+                .disabled(aiSettingsDisabled)
+                .opacity(aiSettingsDisabled ? 0.5 : 1.0)
+            }
 
             Text(Localization.apiKeyDescription)
                 .font(.caption)
@@ -172,6 +203,18 @@ private extension AISettingsView {
             "aiSettings.selectModel",
             value: "Select Model",
             comment: "Accessibility label for the AI model picker"
+        )
+
+        static let edit = NSLocalizedString(
+            "aiSettings.edit",
+            value: "Edit",
+            comment: "Button title to edit API key"
+        )
+
+        static let save = NSLocalizedString(
+            "aiSettings.save",
+            value: "Save",
+            comment: "Button title to save API key"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -1,7 +1,172 @@
 import SwiftUI
 
-struct AISettingsView: View {
-    var body: some View {
-        EmptyView()
+@Observable final class AISettingsViewModel {
+    var usesJetpackAsDefaultAIProviderSource: Bool = true
+    var isEditingApiKey: Bool = false
+    var apiKey: String = "foo"
+    var selectedProvider: String = "OpenAI"
+    var selectedModel: String = "gpt-4"
+    
+    func updateProvider(_ provider: String) {
+        // TODO
     }
+}
+
+struct AISettingsView: View {
+    @State private var viewModel: AISettingsViewModel
+
+    init(viewModel: AISettingsViewModel) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        // Enables VM $ Bindables
+        @Bindable var viewModel = viewModel
+        VStack {
+            if viewModel.usesJetpackAsDefaultAIProviderSource {
+                JetpackAsAIDefaultSourceBannerView()
+            }
+            TextField(
+                Localization.enterAPIKey,
+                text: Binding(
+                    get: { viewModel.isEditingApiKey ? viewModel.apiKey : "**********" },
+                    set: { newValue in if viewModel.isEditingApiKey { viewModel.apiKey = newValue } }
+                )
+            )
+            .textFieldStyle(RoundedBorderTextFieldStyle())
+            .foregroundColor(.primary)
+            .privacySensitive()
+
+            Text(Localization.apiKeyDescription)
+                .font(.caption)
+                .foregroundColor(.secondary)
+            
+            HStack {
+                Text(Localization.aiProvider)
+                    .foregroundColor(.secondary)
+                Picker(Localization.selectProvider, selection: $viewModel.selectedProvider) {
+                    Text(Localization.openAI).tag(Localization.openAI)
+                }
+                .pickerStyle(MenuPickerStyle())
+                .onChange(of: viewModel.selectedProvider) { _, newValue in
+                    viewModel.updateProvider(newValue)
+                }
+                .disabled(viewModel.usesJetpackAsDefaultAIProviderSource)
+                .opacity(viewModel.usesJetpackAsDefaultAIProviderSource ? 0.5 : 1.0)
+                
+                if viewModel.usesJetpackAsDefaultAIProviderSource {
+                    Image(systemName: "lock.fill")
+                        .foregroundColor(.secondary)
+                }
+            }
+            HStack {
+                Text(Localization.models)
+                    .foregroundColor(.secondary)
+                Picker(Localization.selectModel, selection: $viewModel.selectedModel) {
+                    // TODO
+                    Text("model").tag("model")
+                }
+                .pickerStyle(MenuPickerStyle())
+                .disabled(viewModel.usesJetpackAsDefaultAIProviderSource)
+                .opacity(viewModel.usesJetpackAsDefaultAIProviderSource ? 0.5 : 1.0)
+                
+                if viewModel.usesJetpackAsDefaultAIProviderSource {
+                    Image(systemName: "lock.fill")
+                        .foregroundColor(.gray)
+                }
+            }
+            
+            Spacer()
+
+            Text(Localization.apiKeyDisclaimer)
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .navigationTitle(Localization.navigationTitle)
+    }
+}
+
+private extension AISettingsView {
+    @ViewBuilder private func JetpackAsAIDefaultSourceBannerView() -> some View {
+        Text(Localization.builtInAIEnabled)
+            .font(.callout)
+            .foregroundColor(.secondary)
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color(.systemGray6))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color(.gray), lineWidth: 1)
+            )
+    }
+}
+
+private extension AISettingsView {
+    enum Localization {
+        static let navigationTitle = NSLocalizedString(
+            "aiSettings.navigationTitle",
+            value: "AI Settings",
+            comment: "Navigation title for the AI Settings screen"
+        )
+
+        static let builtInAIEnabled = NSLocalizedString(
+            "aiSettings.builtInAIEnabled",
+            value: "AI capabilities are already enabled for this site.",
+            comment: "Message displayed when built-in AI feature is already enabled."
+        )
+
+        static let enterAPIKey = NSLocalizedString(
+            "aiSettings.enterAPIKey",
+            value: "Enter API Key",
+            comment: "Placeholder text for the API key input field"
+        )
+        
+        static let apiKeyDescription = NSLocalizedString(
+             "aiSettings.apiKeyDescription",
+             value: "Enter your API key to use AI generation at public API costs.",
+             comment: "Description text explaining the purpose of the API key"
+         )
+        
+        static let apiKeyDisclaimer = NSLocalizedString(
+            "aiSettings.apiKeyDisclaimer",
+            value: "API keys open up access to potentially sensitive information. Do not share your API key with others or expose them.",
+            comment: "Warning message about keeping API keys secure"
+        )
+        
+        static let aiProvider = NSLocalizedString(
+            "aiSettings.aiProvider",
+            value: "Provider",
+            comment: "Label for the AI provider selection in AI settings"
+        )
+        
+        static let selectProvider = NSLocalizedString(
+            "aiSettings.selectProvider",
+            value: "Select Provider",
+            comment: "Accessibility label for the AI provider picker"
+        )
+        
+        static let openAI = NSLocalizedString(
+             "aiSettings.openAI",
+             value: "OpenAI",
+             comment: "Label for OpenAI provider option"
+         )
+        
+        static let models = NSLocalizedString(
+            "aiSettings.models",
+            value: "Models",
+            comment: "Label for the AI models selection"
+        )
+        
+        static let selectModel = NSLocalizedString(
+            "aiSettings.selectModel",
+            value: "Select Model",
+            comment: "Accessibility label for the AI model picker"
+        )
+    }
+}
+
+#Preview {
+    AISettingsView(viewModel: AISettingsViewModel())
 }

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 @Observable final class AISettingsViewModel {
     var usesJetpackAsDefaultAIProviderSource: Bool = false
     var isEditingApiKey: Bool = false
-    var apiKey: String = "foo"
+    var apiKey: String = ""
     var selectedProvider: String = "OpenAI"
     var selectedModel: String = "gpt-4"
 
@@ -16,6 +16,7 @@ import SwiftUI
 
     func updateProvider(_ provider: String) {
         // TODO
+        // Switches between AI providers
     }
 
     func clearAPIKey() {
@@ -39,9 +40,13 @@ struct AISettingsView: View {
         viewModel.usesJetpackAsDefaultAIProviderSource
     }
 
+    private var fieldOpacity: Double {
+        aiSettingsDisabled ? 0.5 : 1.0
+    }
+
     var body: some View {
-        // Enables VM $ Bindables
         @Bindable var viewModel = viewModel
+
         VStack(alignment: .leading) {
             if aiSettingsDisabled {
                 JetpackAsAIDefaultSourceBannerView()
@@ -72,7 +77,7 @@ struct AISettingsView: View {
                     Text(viewModel.isEditingApiKey ? Localization.save : Localization.edit)
                 }
                 .disabled(aiSettingsDisabled)
-                .opacity(aiSettingsDisabled ? 0.5 : 1.0)
+                .opacity(fieldOpacity)
             }
 
             Text(Localization.apiKeyDescription)
@@ -83,6 +88,7 @@ struct AISettingsView: View {
                 Text(Localization.aiProvider)
                     .foregroundColor(.secondary)
                 Picker(Localization.selectProvider, selection: $viewModel.selectedProvider) {
+                    // TODO
                     Text(Localization.openAI).tag(Localization.openAI)
                 }
                 .pickerStyle(MenuPickerStyle())
@@ -90,7 +96,7 @@ struct AISettingsView: View {
                     viewModel.updateProvider(newValue)
                 }
                 .disabled(aiSettingsDisabled)
-                .opacity(aiSettingsDisabled ? 0.5 : 1.0)
+                .opacity(fieldOpacity)
 
                 if viewModel.usesJetpackAsDefaultAIProviderSource {
                     Image(systemName: "lock.fill")
@@ -102,11 +108,11 @@ struct AISettingsView: View {
                     .foregroundColor(.secondary)
                 Picker(Localization.selectModel, selection: $viewModel.selectedModel) {
                     // TODO
-                    Text("Default model").tag("model")
+                    Text(viewModel.selectedModel).tag(viewModel.selectedModel)
                 }
                 .pickerStyle(MenuPickerStyle())
                 .disabled(aiSettingsDisabled)
-                .opacity(aiSettingsDisabled ? 0.5 : 1.0)
+                .opacity(fieldOpacity)
 
                 if aiSettingsDisabled {
                     Image(systemName: "lock.fill")
@@ -133,17 +139,21 @@ private extension AISettingsView {
             .foregroundColor(.secondary)
             .padding()
             .background(
-                RoundedRectangle(cornerRadius: 8)
+                RoundedRectangle(cornerRadius: Layout.cornerRadius)
                     .fill(Color(.systemGray6))
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 8)
+                RoundedRectangle(cornerRadius: Layout.cornerRadius)
                     .stroke(Color(.gray), lineWidth: 1)
             )
     }
 }
 
 private extension AISettingsView {
+    enum Layout {
+        static let cornerRadius: CGFloat = 8
+    }
+
     enum Localization {
         static let navigationTitle = NSLocalizedString(
             "aiSettings.navigationTitle",

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -152,7 +152,7 @@ private extension HubMenu {
             case .blazeCampaignCreation:
                 BlazeCampaignListHostingControllerRepresentable(siteID: viewModel.siteID, startsCampaignCreationOnAppear: true)
             case .aiSettings:
-                AISettingsView()
+                AISettingsView(viewModel: AISettingsViewModel())
             }
         }
         .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
HACK week. Part of https://github.com/woocommerce/woocommerce-ios/pull/15372

## Description

This PR adds the dummy Settings view where the merchant can introduce their API key, and select provider/model, or be informed that their site is already using built-in AI.

![Simulator Screen Recording - iPhone 16 Plus - US store - 2025-09-17 at 13 16 29](https://github.com/user-attachments/assets/8a6795af-21e2-4878-afb8-79d00ad725df)

## Testing information
- Enable `allowMerchantAIAPIKey` flag
- Go to Menu > AI Settings. 
- Note the new view has fields for key, provider, and model that can be toggled. This is non-functional yet, just the UI.
- Switch `usesJetpackAsDefaultAIProviderSource` to `true`
- Note the new view shows a disclaimer instead that is already using built-in AI, and the fields are locked/disabled

| Merchant key | Jetpack key |
|--------|--------|
| <img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - US store - 2025-09-17 at 13 39 57" src="https://github.com/user-attachments/assets/8789ed0c-cffd-46b4-8ea1-efb3a5ea92ea" /> | <img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - US store - 2025-09-17 at 13 38 12" src="https://github.com/user-attachments/assets/a3d1c37f-5e2a-4cd6-b744-60da7444ab71" /> | 

