### PR TITLE
[HACK] AI API keys: Register and use keychain to store value safely

### DIFF
--- a/WooCommerce/Classes/Authentication/Keychain+Entries.swift
+++ b/WooCommerce/Classes/Authentication/Keychain+Entries.swift
@@ -26,4 +26,11 @@ extension Keychain {
         get { self[WooConstants.siteCredentialPassword] }
         set { self[WooConstants.siteCredentialPassword] = newValue }
     }
+
+    /// AI key provided by the merchant
+    ///
+    var merchantAIProviderKey: String? {
+        get { self[WooConstants.merchantAIProviderKey] }
+        set { self[WooConstants.merchantAIProviderKey] = newValue }
+    }
 }

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -45,6 +45,10 @@ public enum WooConstants {
     ///
     static let sharedUserDefaultsSuiteName = "group.com.automattic.woocommerce"
 
+    /// Keychain Access's Key for the AI key entered by the merchant in AI settings
+    ///
+    static let merchantAIProviderKey = "merchantAIProviderKey"
+
     /// Push Notifications ApplicationID
     ///
 #if DEBUG

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -27,6 +27,10 @@ import KeychainAccess
         keychain.merchantAIProviderKey = nil
     }
 
+    func loadSettings() {
+        apiKey = keychain.merchantAIProviderKey ?? ""
+    }
+
     private func saveSettings() {
         keychain.merchantAIProviderKey = apiKey
     }
@@ -131,6 +135,9 @@ struct AISettingsView: View {
                 .font(.caption)
                 .foregroundColor(.secondary)
                 .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .onAppear {
+            viewModel.loadSettings()
         }
         .padding()
         .navigationTitle(Localization.navigationTitle)

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
+import KeychainAccess
 
 @Observable final class AISettingsViewModel {
+    var keychain = Keychain(service: WooConstants.keychainServiceName)
+
     var usesJetpackAsDefaultAIProviderSource: Bool = false
     var isEditingApiKey: Bool = false
     var apiKey: String = ""
@@ -20,11 +23,12 @@ import SwiftUI
     }
 
     func clearAPIKey() {
-        // TODO
+        apiKey = ""
+        keychain.merchantAIProviderKey = nil
     }
 
     private func saveSettings() {
-        // TODO
+        keychain.merchantAIProviderKey = apiKey
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/AI Settings/AISettingsView.swift
@@ -69,8 +69,9 @@ struct AISettingsView: View {
                 .textFieldStyle(RoundedBorderTextFieldStyle())
                 .foregroundColor(.primary)
                 .privacySensitive()
+                .disabled(!viewModel.isEditingApiKey)
 
-                if viewModel.isEditingApiKey, !viewModel.apiKey.isEmpty {
+                if viewModel.isEditingApiKey && !viewModel.apiKey.isEmpty {
                     Button(action: viewModel.clearAPIKey) {
                         Image(systemName: "xmark.circle.fill")
                             .foregroundColor(.gray)


### PR DESCRIPTION
HACK week. Part of https://github.com/woocommerce/woocommerce-ios/pull/15372

## Description
This PR registers a new Keychain `merchantAIProviderKey `value for storing the associated merchant's AI API key, to be used in AI Settings when Jetpack AI is not used by default. 

![Simulator Screen Recording - iPhone 16 Plus - US store - 2025-09-17 at 14 05 56](https://github.com/user-attachments/assets/77178e84-fdfd-4006-8af3-5eea969f733f)

## Testing information
- In `AISettingsView` .onAppear method, add:
```
debugPrint("\(viewModel.keychain)")
debugPrint("\(viewModel.keychain[WooConstants.merchantAIProviderKey])")
```
- Enable `allowMerchantAIAPIKey` flag
- Go to Menu > AI Settings.
- Play around with the API field. Save, clear, update, get out, reload the view, etc, .. 
- Note how the key is stored/cleared/updated adequately
- You'll also see the key and value printed in the console:
```
$ [\"key\": \"merchantAIProviderKey\", [ ... ]
$ "Optional(\"This is a test\")"
```
