### PR TITLE
[WCiOS17] Update trait update API for product flows

### DIFF
--- a/WooCommerce/Classes/Extensions/UICollectionViewCell+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UICollectionViewCell+Helpers.swift
@@ -22,4 +22,14 @@ extension UICollectionViewCell {
     func applyGrayBackgroundStyle() {
         backgroundColor = .systemColor(.secondarySystemGroupedBackground)
     }
+
+    func applyContentBorderColorOnInterfaceStyleChange(borderColor: @escaping () -> UIColor) {
+        let traits: [UITrait] = [
+            UITraitUserInterfaceStyle.self,
+            UITraitAccessibilityContrast.self
+        ]
+        registerForTraitChanges(traits) { (self: Self, _: UITraitCollection) in
+            self.contentView.layer.borderColor = borderColor().cgColor
+        }
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/Collection View Cells/AddProductImageCollectionViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/Collection View Cells/AddProductImageCollectionViewCell.swift
@@ -10,12 +10,7 @@ final class AddProductImageCollectionViewCell: UICollectionViewCell {
         configureBackground()
         configureImageView()
         configureCellAppearance()
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        // Border color is not automatically updated on trait collection changes and thus manually updated here.
-        contentView.layer.borderColor = Colors.borderColor.cgColor
+        observeInterfaceStyleTraits()
     }
 }
 
@@ -37,6 +32,17 @@ private extension AddProductImageCollectionViewCell {
         contentView.layer.borderWidth = Constants.borderWidth
         contentView.layer.borderColor = Colors.borderColor.cgColor
         contentView.layer.masksToBounds = Settings.maskToBounds
+    }
+
+    func observeInterfaceStyleTraits() {
+        /// The border color is not automatically updated on trait collection changes so we observe for changes and update it manually.
+        let traits: [UITrait] = [
+            UITraitUserInterfaceStyle.self,
+            UITraitAccessibilityContrast.self
+        ]
+        registerForTraitChanges(traits) { (self: Self, _: UITraitCollection) in
+            self.contentView.layer.borderColor = Colors.borderColor.cgColor
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/Collection View Cells/AddProductImageCollectionViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/Collection View Cells/AddProductImageCollectionViewCell.swift
@@ -10,7 +10,7 @@ final class AddProductImageCollectionViewCell: UICollectionViewCell {
         configureBackground()
         configureImageView()
         configureCellAppearance()
-        observeInterfaceStyleTraits()
+        observeInterfaceStyleChange()
     }
 }
 
@@ -34,14 +34,10 @@ private extension AddProductImageCollectionViewCell {
         contentView.layer.masksToBounds = Settings.maskToBounds
     }
 
-    func observeInterfaceStyleTraits() {
+    func observeInterfaceStyleChange() {
         /// The border color is not automatically updated on trait collection changes so we observe for changes and update it manually.
-        let traits: [UITrait] = [
-            UITraitUserInterfaceStyle.self,
-            UITraitAccessibilityContrast.self
-        ]
-        registerForTraitChanges(traits) { (self: Self, _: UITraitCollection) in
-            self.contentView.layer.borderColor = Colors.borderColor.cgColor
+        applyContentBorderColorOnInterfaceStyleChange {
+            return Colors.borderColor
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/Collection View Cells/ProductImageCollectionViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/Collection View Cells/ProductImageCollectionViewCell.swift
@@ -35,12 +35,7 @@ final class ProductImageCollectionViewCell: UICollectionViewCell {
         configureImageView()
         configureCellAppearance()
         configureCoverTagView()
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        // Border color is not automatically updated on trait collection changes and thus manually updated here.
-        contentView.layer.borderColor = Colors.borderColor.cgColor
+        observeInterfaceStyleChange()
     }
 
     override func prepareForReuse() {
@@ -85,6 +80,13 @@ private extension ProductImageCollectionViewCell {
             contentView.leadingAnchor.constraint(equalTo: coverTagView.leadingAnchor, constant: -Constants.tagPadding),
             contentView.topAnchor.constraint(equalTo: coverTagView.topAnchor, constant: -Constants.tagPadding),
         ])
+    }
+
+    func observeInterfaceStyleChange() {
+        /// Border color is not automatically updated on trait collection changes and thus manually updated here.
+        applyContentBorderColorOnInterfaceStyleChange {
+            return Colors.borderColor
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderTableViewCell.swift
@@ -36,6 +36,7 @@ final class ProductImagesHeaderTableViewCell: UITableViewCell {
         configureBackground()
         configureSeparator()
         updateCollectionViewHeight()
+        observeInterfaceTraitChanges()
     }
 
     /// Configure cell
@@ -53,19 +54,6 @@ final class ProductImagesHeaderTableViewCell: UITableViewCell {
 
         if viewModel.shouldScrollToStart {
             collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .centeredHorizontally, animated: false)
-        }
-    }
-
-    /// Rotation management and accessibility changes
-    ///
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if traitCollection != previousTraitCollection {
-            // Update collection view height for accessibility changes
-            updateCollectionViewHeight()
-            // Invalidate layout when trait collection changes (including accessibility changes)
-            collectionView.collectionViewLayout.invalidateLayout()
-            collectionView.reloadData()
         }
     }
 
@@ -164,6 +152,29 @@ private extension ProductImagesHeaderTableViewCell {
             // Use dynamic sizing based on current accessibility settings
             let dynamicSize = ProductImagesHeaderViewModel.cellSize(for: traitCollection.preferredContentSizeCategory)
             collectionView.collectionViewLayout = ProductImagesFlowLayout(itemSize: dynamicSize, config: config)
+        }
+    }
+
+    /// Rotation management and accessibility changes
+    ///
+    func observeInterfaceTraitChanges() {
+        let traits: [UITrait] = [
+            UITraitPreferredContentSizeCategory.self,
+            UITraitHorizontalSizeClass.self,
+            UITraitVerticalSizeClass.self,
+            UITraitUserInterfaceStyle.self,
+            UITraitAccessibilityContrast.self
+        ]
+        registerForTraitChanges(traits) { (self: Self, previousTraitCollection: UITraitCollection) in
+            guard self.traitCollection != previousTraitCollection else {
+                return
+            }
+
+            /// Update collection view height for accessibility changes
+            self.updateCollectionViewHeight()
+            /// Invalidate layout when trait collection changes (including accessibility changes)
+            self.collectionView.collectionViewLayout.invalidateLayout()
+            self.collectionView.reloadData()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -39,6 +39,7 @@ final class ProductsTabProductTableViewCell: UITableViewCell {
         configureDetailsLabel()
         configureProductImageView()
         configureBottomBorderView()
+        observeInterfaceTraitChanges()
         // From iOS 15.0, a focus effect will be applied automatically to a selected cell
         // modifying its style (e.g: by adding a border)
         focusEffect = nil
@@ -46,12 +47,6 @@ final class ProductsTabProductTableViewCell: UITableViewCell {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        // Border color is not automatically updated on trait collection changes and thus manually updated here.
-        productImageView.layer.borderColor = Colors.imageBorderColor.cgColor
     }
 
     override func updateConfiguration(using state: UICellConfigurationState) {
@@ -265,6 +260,17 @@ private extension ProductsTabProductTableViewCell {
 
         productImageView.addSubview(view)
         productImageView.pinSubviewToAllEdges(view)
+    }
+
+    func observeInterfaceTraitChanges() {
+        /// Border color is not automatically updated on trait collection changes and thus manually updated here.
+        let traits: [UITrait] = [
+            UITraitUserInterfaceStyle.self,
+            UITraitAccessibilityContrast.self
+        ]
+        registerForTraitChanges(traits) { (self: Self, _: UITraitCollection) in
+            self.productImageView.layer.borderColor = Colors.imageBorderColor.cgColor
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -168,6 +168,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         observeUpdateCTAVisibility()
         observeVariationsPriceChanges()
         observeUpdateBlazeEligibility()
+        observeTraitChanges()
 
         productImageStatusesSubscription = productImageActionHandler.addUpdateObserver(self) { [weak self] productImageStatuses in
             guard let self = self else {
@@ -201,12 +202,6 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 
     override var shouldShowOfflineBanner: Bool {
         return true
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        updateNavigationBarTitle()
     }
 
     // MARK: - Navigation actions handling
@@ -948,6 +943,16 @@ private extension ProductFormViewController {
         }, onFailedImageUpload: { [weak self] (asset, error) in
             self?.displayImageUploadErrorAlert(error: error, for: asset)
         })
+    }
+
+    func observeTraitChanges() {
+        let traits: [UITrait] = [
+            UITraitHorizontalSizeClass.self,
+            UITraitVerticalSizeClass.self
+        ]
+        registerForTraitChanges(traits) { (self: Self, _) in
+            self.updateNavigationBarTitle()
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1303

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Fixes warnings for trait collection update deprecated API. Replaces `traitCollectionDidChange(_ previousTraitCollection:)` with new API calls in:
- `AddProductImageCollectionViewCell`
- `ProductImageCollectionViewCell`
- `ProductImagesHeaderTableViewCell`
- `ProductsTabProductTableViewCell`
- `ProductFormViewController`

## Testing steps
Since the behaviour is not supposed to change - pls smoke the product list and product details screens for ui trait changes like light/dark appearance, accessibility font and contrast, orientation rotations.
For the following tests use Xcode debug and iOS simulator. 

### For `AddProductImageCollectionViewCell`
- Put breakpoint in `applyContentBorderColorOnInterfaceStyleChange` handler in `AddProductImageCollectionViewCell.swift` on line 40
- Navigate to Product details screen
- Toggle light/dark appearance in iOS Simulator -> Features -> Toggle Appearance 
- Make sure the breakpoint is hit

### For `ProductImageCollectionViewCell`
- Put breakpoint in `applyContentBorderColorOnInterfaceStyleChange` handler in `ProductImageCollectionViewCell.swift` on line 88
- Navigate to Product details screen
- Toggle light/dark appearance in iOS Simulator -> Features -> Toggle Appearance 
- Make sure the breakpoint is hit

### For `ProductImagesHeaderTableViewCell`
- Put breakpoint in `registerForTraitChanges` handler in `ProductImagesHeaderTableViewCell.swift` on line 174
- Toggle dark/light appearance
- Rotate device
- Toggle accessibility sizes
- Make sure the trait changes handler is triggered by the actions above and the breakpoint is hit.

### For `ProductsTabProductTableViewCell`
- Put breakpoint in `registerForTraitChanges` handler in `ProductsTabProductTableViewCell.swift` on line 272
- Navigate to products list
- Toggle light/dark appearance in iOS Simulator -> Features -> Toggle Appearance 
- Make sure the `registerForTraitChanges` handler is triggered and breakpoint is hit

### For `ProductFormViewController`
- Put breakpoint in `ProductFormViewController.swift` on line 954
- Navigate to product details form
- Rotate the simulator to different orientations
- Make sure the `registerForTraitChanges` handler is triggered and breakpoint is hit.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested in iOS 26 Simulator

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.