### PR TITLE
Product Form: Show clear error message for duplicated GTIN/UPC/EAN/ISBN

### DIFF
--- a/Modules/Sources/Yosemite/Stores/ProductStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductStore.swift
@@ -1368,6 +1368,7 @@ public enum ProductUpdateError: Error, Equatable {
     case duplicatedSKU
     case invalidSKU
     case invalidGlobalUniqueIdentifier
+    case invalidOrDuplicatedGlobalUniqueID
     case passwordCannotBeUpdated
     case notFoundInStorage
     case variationInvalidImageId
@@ -1394,6 +1395,7 @@ public enum ProductUpdateError: Error, Equatable {
 
     private enum ErrorCode: String {
         case invalidSKU = "product_invalid_sku"
+        case invalidOrDuplicatedGlobalUniqueID = "product_invalid_global_unique_id"
         case variationInvalidImageId = "woocommerce_variation_invalid_image_id"
         case invalidMaxQuantity = "woocommerce_rest_invalid_max_quantity"
         case invalidMinQuantity = "woocommerce_rest_invalid_min_quantity"
@@ -1408,6 +1410,8 @@ public enum ProductUpdateError: Error, Equatable {
                 return .variationInvalidImageId
             case .invalidMaxQuantity, .invalidMinQuantity, .invalidVariationMaxQuantity, .invalidVariationMinQuantity:
                 return .generic(message: message ?? "")
+            case .invalidOrDuplicatedGlobalUniqueID:
+                return .invalidOrDuplicatedGlobalUniqueID
             }
         }
     }
@@ -1426,6 +1430,10 @@ extension ProductUpdateError: LocalizedError {
             return NSLocalizedString("productInventorySettings.invalidGlobalUniqueIdentifier.error",
                                      value: "Please enter only numbers and hyphens (-).",
                                      comment: "The message of the alert when there is an error updating the product global unique identifier")
+        case .invalidOrDuplicatedGlobalUniqueID:
+            return NSLocalizedString("productInventorySettings.error.invalidOrDuplicatedGlobalUniqueID",
+                                     value: "Invalid or duplicated GTIN, UPC, EAN or ISBN.",
+                                     comment: "Error message when saving an invalid or duplicated product global unique ID")
         case .generic(let message):
             return message
         case .unknown(let error):

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 23.3
 -----
 - [*] Order details: Display only physical items in the Shipping Labels section. [https://github.com/woocommerce/woocommerce-ios/pull/16127]
+- [*] Product form: Display user-friendly error message when saving duplicated GTIN/UPC/EAN/ISBN. [https://github.com/woocommerce/woocommerce-ios/pull/16146]
 - [internal] Address deprecated view modifiers usage following iOS17 API updates [https://github.com/woocommerce/woocommerce-ios/pull/16080]
 - [internal] POS Modularization: Removed direct ServiceLocator usage within POS by requiring complex Woo app target dependencies to be injected via POS dependency protocols, and moved reusable dependencies to WooFoundation and Yosemite [https://github.com/woocommerce/woocommerce-ios/pull/16132]
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1349

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR catches the error of duplicated GTIN/UPC/EAN/ISBN when saving products and show a user-friend error message instead of generic message.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a store with existing products.
2. Edit a product
3. Scan or manually enter a GTIN/UPC/EAN/ISBN that already exists on another product/variation
4. Attempt to save the changes
5. Confirm that a clear error message is displayed.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested with simulator iPhone 17 iOS 26.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before | After 
--- | ---
<img width="320" alt="before" src="https://github.com/user-attachments/assets/92bd3bb7-792f-4678-bfb9-8502fde336f3" /> | <img width="320" alt="after" src="https://github.com/user-attachments/assets/cb2024ca-47c3-499f-bb97-7133d3d0a442" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.