### PR TITLE
Order Details: Enhance map picker with search completer region and iOS 17 compatibility

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressMapPickerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressMapPickerView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 import Observation
 import struct Yosemite.Country
 
-@available(iOS 17, *)
 struct AddressMapPickerView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel: AddressMapPickerViewModel
@@ -18,12 +17,15 @@ struct AddressMapPickerView: View {
     var body: some View {
         NavigationStack {
             ZStack(alignment: .top) {
-                Map(coordinateRegion: $viewModel.region,
-                    showsUserLocation: true,
-                    annotationItems: viewModel.annotations) { item in
-                    MapMarker(coordinate: item.coordinate)
+                Map(position: $viewModel.mapPosition) {
+                    ForEach(viewModel.annotations) { item in
+                        Marker(coordinate: item.coordinate) {
+                            RoundedRectangle(cornerRadius: 5)
+                        }
+                    }
                 }
-                    .ignoresSafeArea()
+                .mapStyle(.standard(elevation: .realistic))
+                .ignoresSafeArea()
 
                 VStack(spacing: 0) {
                     searchBar
@@ -134,7 +136,6 @@ struct AddressMapPickerView: View {
     }
 }
 
-@available(iOS 17, *)
 private extension AddressMapPickerView {
     enum Localization {
         static let close = NSLocalizedString("addressMapPicker.button.close", value: "Close", comment: "Text for the close button in the Edit Address Form.")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressMapPickerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressMapPickerView.swift
@@ -120,6 +120,12 @@ struct AddressMapPickerView: View {
                 .autocorrectionDisabled()
                 .textInputAutocapitalization(.never)
                 .focused($isSearchFocused)
+                .onChange(of: isSearchFocused) { _, newValue in
+                    viewModel.isSearchFocused = newValue
+                }
+                .onChange(of: viewModel.isSearchFocused) { _, newValue in
+                    isSearchFocused = newValue
+                }
 
             if !viewModel.searchQuery.isEmpty {
                 Button(action: {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressMapPickerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressMapPickerViewModel.swift
@@ -25,7 +25,6 @@ final class DefaultAddressMapLocalSearchProvider: AddressMapLocalSearchProviding
     }
 }
 
-@available(iOS 17, *)
 @Observable
 final class AddressMapPickerViewModel: NSObject {
     var searchQuery = "" {
@@ -34,10 +33,10 @@ final class AddressMapPickerViewModel: NSObject {
         }
     }
     private(set) var searchResults: [MKLocalSearchCompletion] = []
-    var region = MKCoordinateRegion(
+    var mapPosition: MapCameraPosition = .region(MKCoordinateRegion(
         center: CLLocationCoordinate2D(latitude: 37.3361, longitude: -122.0380),
         span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
-    )
+    ))
     var annotations: [MapAnnotation] = []
     var showsSearchResults: Bool {
         searchResults.isEmpty == false
@@ -124,7 +123,6 @@ final class AddressMapPickerViewModel: NSObject {
     }
 }
 
-@available(iOS 17, *)
 private extension AddressMapPickerViewModel {
     func configureSearchCompleter() {
         searchCompleter.resultTypes = .address
@@ -140,10 +138,10 @@ private extension AddressMapPickerViewModel {
                let currentLocation = locationManager.location {
                 DispatchQueue.main.async { [weak self] in
                     guard let self else { return }
-                    region = MKCoordinateRegion(
+                    mapPosition = .region(MKCoordinateRegion(
                         center: currentLocation.coordinate,
                         span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
-                    )
+                    ))
                 }
                 return
             }
@@ -159,10 +157,10 @@ private extension AddressMapPickerViewModel {
                         return
                     }
 
-                    region = MKCoordinateRegion(
+                    mapPosition = .region(MKCoordinateRegion(
                         center: location.coordinate,
                         span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
-                    )
+                    ))
                     annotations = [MapAnnotation(coordinate: location.coordinate)]
                 } catch {
                     DDLogError("⛔️ Error geocoding initial address: \(error)")
@@ -177,10 +175,10 @@ private extension AddressMapPickerViewModel {
             withAnimation { [weak self] in
                 guard let self else { return }
                 searchResults = []
-                region = MKCoordinateRegion(
+                mapPosition = .region(MKCoordinateRegion(
                     center: placemark.coordinate,
                     span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
-                )
+                ))
                 annotations = [MapAnnotation(coordinate: placemark.coordinate)]
                 selectedPlace = placemark
             } completion: {
@@ -196,7 +194,6 @@ private extension AddressMapPickerViewModel {
     }
 }
 
-@available(iOS 17, *)
 extension AddressMapPickerViewModel: MKLocalSearchCompleterDelegate {
     func completerDidUpdateResults(_ completer: MKLocalSearchCompleter) {
         searchResults = completer.results

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressMapPickerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressMapPickerViewModel.swift
@@ -32,6 +32,8 @@ final class AddressMapPickerViewModel: NSObject {
             searchQueryContinuation.yield(newValue)
         }
     }
+    // Syncs with the focused state of the search text field in `AddressMapPickerView`.
+    var isSearchFocused: Bool = false
     private(set) var searchResults: [MKLocalSearchCompletion] = []
     var mapPosition: MapCameraPosition = .region(MKCoordinateRegion(
         center: CLLocationCoordinate2D(latitude: 37.3361, longitude: -122.0380),
@@ -78,7 +80,12 @@ final class AddressMapPickerViewModel: NSObject {
         for await query in searchQueryStream.debounce(for: .seconds(0.3)) {
             if query.isEmpty {
                 searchResults = []
-            } else {
+            } else if isSearchFocused {
+                if let region = mapPosition.region {
+                    // ~11km centered in the map region.
+                    searchCompleter.region = .init(center: .init(latitude: region.center.latitude, longitude: region.center.longitude),
+                                                   span: .init(latitudeDelta: 0.1, longitudeDelta: 0.1))
+                }
                 searchCompleter.queryFragment = query
             }
         }
@@ -171,20 +178,13 @@ private extension AddressMapPickerViewModel {
 
     @MainActor
     func onSelectedPlacemark(_ placemark: MKPlacemark) async {
-        await withCheckedContinuation { continuation in
-            withAnimation { [weak self] in
-                guard let self else { return }
-                searchResults = []
-                mapPosition = .region(MKCoordinateRegion(
-                    center: placemark.coordinate,
-                    span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
-                ))
-                annotations = [MapAnnotation(coordinate: placemark.coordinate)]
-                selectedPlace = placemark
-            } completion: {
-                continuation.resume()
-            }
-        }
+        searchResults = []
+        mapPosition = .region(MKCoordinateRegion(
+            center: placemark.coordinate,
+            span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+        ))
+        annotations = [MapAnnotation(coordinate: placemark.coordinate)]
+        selectedPlace = placemark
     }
 
     func formatAddressString(fields: AddressFormFields) -> String {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/AddressMapPickerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/AddressMapPickerViewModelTests.swift
@@ -22,7 +22,6 @@ struct AddressMapPickerViewModelTests {
 
     // MARK: - Initialization Tests
 
-    @available(iOS 17, *)
     @Test func initialization_with_empty_fields_sets_properties_with_default_values() {
         // Given
         let emptyFields = AddressFormFields()
@@ -38,7 +37,6 @@ struct AddressMapPickerViewModelTests {
 
     // MARK: - Selection Tests
 
-    @available(iOS 17, *)
     @Test func selectLocation_updates_annotations_and_hasValidSelection() async {
         // Given
         let fields = AddressFormFields()
@@ -56,7 +54,6 @@ struct AddressMapPickerViewModelTests {
 
     // MARK: - Address Field Updates Tests
 
-    @available(iOS 17, *)
     @Test func updateFields_with_no_selected_place_does_not_modify_fields() {
         // Given
         let sut = AddressMapPickerViewModel(fields: .init(), countryByCode: mockCountryByCode)
@@ -72,7 +69,6 @@ struct AddressMapPickerViewModelTests {
         #expect(updatedFields.city == "Original City")
     }
 
-    @available(iOS 17, *)
     @Test func updateFields_when_country_not_found_in_countryByCode_sets_country_and_state_as_strings() async {
         // Given
         let mockSearchProvider = MockAddressMapLocalSearchProvider.withFrenchAddress()
@@ -95,7 +91,6 @@ struct AddressMapPickerViewModelTests {
         #expect(updatedFields.selectedState == nil)
     }
 
-   @available(iOS 17, *)
    @Test func updateFields_when_country_is_found_in_countryByCode_sets_selected_country_and_state() async {
        // Given
        let mockSearchProvider = MockAddressMapLocalSearchProvider.withUSAddress()


### PR DESCRIPTION
Just one review is required.

## Description

This PR enhances the address map picker functionality in order details by setting the map region to the search completer's region to potentially enhance search relevance. Additionally, it fixes iOS 17 warnings related to deprecated Map usage and removes all iOS 17 availability requirements now that the app is iOS 17+.

Previously, Jorge from Kiwi reported an issue from the address map search that resolved itself later p1755255735655679/1755255191.666409-slack-C03L1NF1EA3. While searching for potential causes, it's recommended to set the region to the local search completer so that it prioritizes nearby places. The default region is the world, and it might be too broad for the initial search. I tested that it's still possible to search for addresses in a very far part of the world from the map region.

## Steps to reproduce

1. Go to an order in the Orders tab
2. Tap on the shipping or billing address to edit it
3. Tap on "Find on Map" 
4. Search for an address nearby --> the top results should include nearby places
5. Select a place from the search result --> the map should center on the selected place with its address
6. Now search for an address that is far away in a different country, it might require filling in the country name to get the desired search result
7. Select a place from the search result that is far away from the initial map region --> the map should center on the selected place with its address
8. Search for another address near the new map region --> the results should prioritize places near the new map region, instead of the initial map region

## Testing information

I tested on iOS 18.4 simulator and iOS 26 device.

## Screenshots

Whenever I turned on recording mode in either simulator or device, testing steps 8 stopped working due to `MapCameraPosition.region` being `nil` without a clear reason 😓 . Therefore, just sharing a basic screencast of the flow:


https://github.com/user-attachments/assets/ca8baf29-3c58-4c26-89f7-dc09bb4859a2



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.