### PR TITLE
Products tab: Check horizontal size class before selecting first product

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -227,7 +227,9 @@ private extension ProductsSplitViewCoordinator {
                 guard let self else {
                     return false
                 }
-                return selectedProduct == nil && !splitViewController.isCollapsed
+                return selectedProduct == nil &&
+                    !splitViewController.isCollapsed &&
+                    splitViewController.traitCollection.horizontalSizeClass == .regular
             }
             .first()
             .sink { [weak self] selectedProduct, onDataReloaded in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1365

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When built with Xcode 26, for some reason the `splitViewController.isCollapsed` is not sufficient to determine when the app is run on iPhones, so this PR adds an additional check for size class before auto-selecting the first product upon initial load of the product list.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Build the app with Xcode 26 to an iPhone simulator.
- Navigate to the Products tab and confirm that the product list is displayed.
- Optional: Build the app to an iPad and confirm that the product list is displayed when the app is in side-by-side mode, and auto select works in full size mode.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Tested with simulator iPhone 17 and iPad mini.
- Also tested alpha build.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before: 


https://github.com/user-attachments/assets/d336c71a-62c5-45dc-adcf-55c6339460ae

After:


https://github.com/user-attachments/assets/b2e0acda-9636-4cee-8d99-e5cef9c92698



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.