### PR TITLE
[Woo POS] Modularization: refactor `FormattableAmountTextField` to decouple from POS font

### DIFF
--- a/WooCommerce/Classes/POS/Adaptors/POSServiceLocatorAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/POSServiceLocatorAdaptor.swift
@@ -85,9 +85,10 @@ private struct POSExternalViewAdaptor: POSExternalViewProviding {
     }
 
     func createFormattableAmountTextField(preset: Decimal?,
+                                          font: Font,
                                           onSubmit: @escaping () -> Void,
                                           onChange: @escaping (String) -> Void) -> AnyView {
-        AnyView(POSFormattableAmountTextFieldAdaptor(preset: preset, onSubmit: onSubmit, onChange: onChange))
+        AnyView(POSFormattableAmountTextFieldAdaptor(preset: preset, font: font, onSubmit: onSubmit, onChange: onChange))
     }
 
     func createCouponCreationView(discountType: Coupon.DiscountType,

--- a/WooCommerce/Classes/POS/Adaptors/View Adaptors/POSFormattableAmountTextFieldAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/View Adaptors/POSFormattableAmountTextFieldAdaptor.swift
@@ -6,11 +6,12 @@ import SwiftUI
 ///
 struct POSFormattableAmountTextFieldAdaptor: View {
     @StateObject private var textFieldViewModel: FormattableAmountTextFieldViewModel
-    let preset: Decimal?
-    let onSubmit: () -> Void
-    let onChange: (String) -> Void
+    private let preset: Decimal?
+    private let style: FormattableAmountTextField.Style
+    private let onSubmit: () -> Void
+    private let onChange: (String) -> Void
 
-    init(preset: Decimal?, onSubmit: @escaping () -> Void, onChange: @escaping (String) -> Void) {
+    init(preset: Decimal?, font: Font, onSubmit: @escaping () -> Void, onChange: @escaping (String) -> Void) {
         self._textFieldViewModel = StateObject(wrappedValue: FormattableAmountTextFieldViewModel(
             size: .extraLarge,
             locale: Locale.autoupdatingCurrent,
@@ -18,12 +19,13 @@ struct POSFormattableAmountTextFieldAdaptor: View {
             allowNegativeNumber: false)
         )
         self.preset = preset
+        self.style = .init(showsBorder: false, textAlignment: .center, font: font)
         self.onSubmit = onSubmit
         self.onChange = onChange
     }
 
     var body: some View {
-        FormattableAmountTextField(viewModel: textFieldViewModel, style: .pos)
+        FormattableAmountTextField(viewModel: textFieldViewModel, style: style)
             .dynamicTypeSize(...DynamicTypeSize.accessibility1)
             .onSubmit {
                 onSubmit()

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleCollectCashView.swift
@@ -3,6 +3,7 @@ import Combine
 import WooFoundation
 
 struct PointOfSaleCollectCashView: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.posAnalytics) private var analytics
     @Environment(\.posExternalViews) private var externalViews
     @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
@@ -57,6 +58,7 @@ struct PointOfSaleCollectCashView: View {
                         VStack(alignment: .center, spacing: conditionalPadding(POSSpacing.xSmall)) {
                             externalViews.createFormattableAmountTextField(
                                 preset: viewHelper.parseCurrency(orderTotal),
+                                font: POSFontStyle.posHeadingRegular.font(maximumContentSizeCategory: UIContentSizeCategory(dynamicTypeSize)),
                                 onSubmit: {
                                     Task { @MainActor in
                                         await submitCashAmount()

--- a/WooCommerce/Classes/POS/Protocols/POSDependencyProviding.swift
+++ b/WooCommerce/Classes/POS/Protocols/POSDependencyProviding.swift
@@ -48,6 +48,7 @@ protocol POSExternalNavigationProviding {
 protocol POSExternalViewProviding {
     func createSupportFormView(isPresented: Binding<Bool>, sourceTag: String) -> AnyView
     func createFormattableAmountTextField(preset: Decimal?,
+                                          font: Font,
                                           onSubmit: @escaping () -> Void,
                                           onChange: @escaping (String) -> Void) -> AnyView
     func createCouponCreationView(discountType: Coupon.DiscountType,

--- a/WooCommerce/Classes/POS/Utils/POSEnvironmentKeys.swift
+++ b/WooCommerce/Classes/POS/Utils/POSEnvironmentKeys.swift
@@ -125,6 +125,7 @@ struct EmptyPOSAnalytics: POSAnalyticsProviding {
 struct EmptyPOSExternalView: POSExternalViewProviding {
     func createSupportFormView(isPresented: Binding<Bool>, sourceTag: String) -> AnyView { AnyView(EmptyView()) }
     func createFormattableAmountTextField(preset: Decimal?,
+                                          font: Font,
                                           onSubmit: @escaping () -> Void,
                                           onChange: @escaping (String) -> Void) -> AnyView {
         AnyView(EmptyView())

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FormattableAmountTextField.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FormattableAmountTextField.swift
@@ -27,10 +27,7 @@ struct FormattableAmountTextField: View {
                 .opacity(0)
 
             Text(viewModel.formattedAmount)
-                .if(style == .pos) {
-                    $0.font(.posHeadingRegular)
-                }
-                .font(.system(size: Layout.amountFontSize(size: viewModel.amountTextSize.fontSize, scale: scale), weight: .bold))
+                .font(style.font ?? .system(size: Layout.amountFontSize(size: viewModel.amountTextSize.fontSize, scale: scale), weight: .bold))
                 .foregroundColor(Color(viewModel.amountTextColor))
                 .minimumScaleFactor(0.1)
                 .lineLimit(1)
@@ -48,27 +45,17 @@ struct FormattableAmountTextField: View {
 }
 
 extension FormattableAmountTextField {
-    enum Style {
-        case `default`
-        case pos
+    struct Style: Equatable {
+        let showsBorder: Bool
+        let textAlignment: Alignment
+        /// Optional font to use for the amount text. If nil, a default system font will be used.
+        let font: Font?
 
-        var showsBorder: Bool {
-            switch self {
-            case .default:
-                return true
-            case .pos:
-                return false
-            }
-        }
-
-        var textAlignment: Alignment {
-            switch self {
-            case .default:
-                return .leading
-            case .pos:
-                return .center
-            }
-        }
+        static let `default` = Style(
+            showsBorder: true,
+            textAlignment: .leading,
+            font: nil
+        )
     }
 }
 
@@ -90,7 +77,7 @@ private extension FormattableAmountTextField {
         FormattableAmountTextField(viewModel: viewModel, style: .default)
     }
     VStack {
-        Text("POS style")
-        FormattableAmountTextField(viewModel: viewModel, style: .pos)
+        Text("Other style")
+        FormattableAmountTextField(viewModel: viewModel, style: .init(showsBorder: false, textAlignment: .center, font: .title2))
     }
 }


### PR DESCRIPTION
Part of WOOMOB-935

## Description

Refactored `FormattableAmountTextField` to replace the hardcoded font override with a more flexible `Style` struct that allows dependency injection of fonts, since `.posHeadingRegular` won't be available once POS is in a separate module. As the refactoring affects multiple use cases in the app, I made these changes in one PR.

**Changes made:**
- Replaced `Style` enum with a `Style` struct containing `showsBorder`, `textAlignment`, and optional `font` properties
- Updated `POSFormattableAmountTextFieldAdaptor` to accept and pass font parameter from POS module
- Modified `POSExternalViewProviding` protocol to include font parameter in `createFormattableAmountTextField` method
- Updated POS integration to pass the appropriate font based on dynamic type size

This refactoring maintains the same behavior while improving modularity and allowing better font customization for different use cases.

## Steps to reproduce

1. Open POS cash collection view
2. Verify the amount text field displays with the correct POS font styling
3. Test other uses of `FormattableAmountTextField` (order creation, payment methods, shipping) to ensure they continue working as before
4. Test with different dynamic type sizes to ensure font scaling works correctly

## Testing information

Regression testing:
- [x] POS cash collection view displays amount field with correct font
- [x] Order creation custom amount entry works normally
- [x] Cash payment tender view functions properly
- [x] Order creation shipping amount entry works normally

## Screenshots

I compared the following screens from PR branch & trunk:

**POS cash view:**

<img src="https://github.com/user-attachments/assets/685f9984-d44c-4adb-9b91-7b97b3cb7f5e" width="500" />

**Order creation add custom amount:**

custom amount | custom amount filled | custom percentage
-- | -- | --
<img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2025-09-22 at 16 10 38" src="https://github.com/user-attachments/assets/1f412d99-820b-4bd1-9f86-9984333f858a" /> | <img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2025-09-22 at 16 11 05" src="https://github.com/user-attachments/assets/9458e4d3-4b2c-4fcb-9011-678f404404a7" /> | <img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2025-09-22 at 16 11 13" src="https://github.com/user-attachments/assets/ff8a2250-d0e1-4353-8593-224a0744899a" />

**Order creation shipping line:**

<img src="https://github.com/user-attachments/assets/e3a77146-e5b2-40ec-8e33-f842d7809f8f" width="500" />

**Order cash payment:**

<img src="https://github.com/user-attachments/assets/a413268e-3789-405b-8912-1322e49f3430" width="500" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.