### PR TITLE
[Release] Update release notes after code freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 Contains editorialized release notes. Raw release notes should go into `RELEASE-NOTES.txt`.
 -->
 ## 23.3
-Enjoy a smoother store management experience with clearer shipping labels for physical items, friendlier product code error messages, more reliable custom fields, and noticeably faster logins for WordPress.com users. All designed to streamline your daily workflow.
+Enjoy a smoother store management experience with clearer shipping labels for physical items, friendlier product code error messages, more reliable custom fields, and better app performance for users authenticated with WordPress.com. All designed to streamline your daily workflow.
 
 ## 23.2
 This update smooths your WooCommerce experience with improved cash payments, easier access to POS settings, and accurate HAZMAT details on shipping labels. Plus, we fixed a Blaze flow issue so campaigns behave as expected. Faster, clearer, and more reliable — just how you need it!

--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -63,7 +63,7 @@ msgstr ""
 
 msgctxt "v23.3-whats-new"
 msgid ""
-"Enjoy a smoother store management experience with clearer shipping labels for physical items, friendlier product code error messages, more reliable custom fields, and noticeably faster logins for WordPress.com users. All designed to streamline your daily workflow.\n"
+"Enjoy a smoother store management experience with clearer shipping labels for physical items, friendlier product code error messages, more reliable custom fields, and better app performance for users authenticated with WordPress.com. All designed to streamline your daily workflow.\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.

--- a/WooCommerce/Resources/release_notes.txt
+++ b/WooCommerce/Resources/release_notes.txt
@@ -1,1 +1,1 @@
-Enjoy a smoother store management experience with clearer shipping labels for physical items, friendlier product code error messages, more reliable custom fields, and noticeably faster logins for WordPress.com users. All designed to streamline your daily workflow.
+Enjoy a smoother store management experience with clearer shipping labels for physical items, friendlier product code error messages, more reliable custom fields, and better app performance for users authenticated with WordPress.com. All designed to streamline your daily workflow.


### PR DESCRIPTION
This PR updates the 23.3 release notes string based on feedback after code freeze https://github.com/woocommerce/woocommerce-ios/pull/16156#issuecomment-3311780597, from a misunderstanding of AI & lack of context from Peacock members.

I'm following the steps in p1758531030419389/1758501339.104309-slack-CC7L49W13 to update the strings. Hopefully the cron job will pick up the updates by the time they are sent for translation on Tuesday p1758558281839089/1758532145.366019-slack-C02AED43D (unsure which time zone).