### PR TITLE
[iOS 26] Fix broken country select navigation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 23.4
 -----
-
+- [*] Order details: Fixes broken country selector navigation and "Non editable banner" width. [https://github.com/woocommerce/woocommerce-ios/pull/16171]
 
 23.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -241,6 +241,12 @@ struct OrderForm: View {
                 viewModel.saveInFlightOrderNotes()
                 viewModel.saveInflightCustomerDetails()
             }
+            .background(
+                GeometryReader { geometryProxy in
+                    Color.clear
+                        .preference(key: WidthPreferenceKey.self, value: geometryProxy.size.width)
+                }
+            )
     }
 
     private func updateSelectionSyncApproach(for presentationStyle: AdaptiveModalContainerPresentationStyle?) {
@@ -383,12 +389,6 @@ struct OrderForm: View {
             .accessibilityIdentifier(Accessibility.orderFormScrollViewIdentifier)
             .background(Color(.listBackground).ignoresSafeArea())
             .ignoresSafeArea(.container, edges: [.horizontal])
-            .background(
-                GeometryReader { geometryProxy in
-                    Color.clear
-                        .preference(key: WidthPreferenceKey.self, value: geometryProxy.size.width)
-                }
-            )
         }
         .onPreferenceChange(WidthPreferenceKey.self) { newWidth in
             bannerWidth = newWidth

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -222,6 +222,8 @@ struct OrderForm: View {
 
     @State private var shouldShowGiftCardForm = false
 
+    @State private var bannerWidth: CGFloat = 0
+
     @Environment(\.adaptiveModalContainerPresentationStyle) var presentationStyle
 
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
@@ -251,137 +253,145 @@ struct OrderForm: View {
     }
 
     @ViewBuilder private func orderFormSummary(_ presentProductSelector: (() -> Void)?) -> some View {
-        GeometryReader { geometry in
-            ScrollViewReader { scroll in
-                ScrollView {
-                    Group {
-                        VStack(spacing: Layout.noSpacing) {
-                            Spacer(minLength: Layout.sectionSpacing)
+        ScrollViewReader { scroll in
+            ScrollView {
+                Group {
+                    VStack(spacing: Layout.noSpacing) {
+                        Spacer(minLength: Layout.sectionSpacing)
 
+                        if viewModel.shouldShowNonEditableIndicators {
                             Group {
                                 Divider() // Needed because `NonEditableOrderBanner` does not have a top divider
-                                NonEditableOrderBanner(width: geometry.size.width)
+                                NonEditableOrderBanner(width: bannerWidth)
                             }
-                            .renderedIf(viewModel.shouldShowNonEditableIndicators)
+                        }
 
-                            Group {
-                                OrderStatusSection(viewModel: viewModel, topDivider: !viewModel.shouldShowNonEditableIndicators)
-                                Spacer(minLength: Layout.sectionSpacing)
-                            }
-                            .renderedIf(flow == .editing)
+                        Group {
+                            OrderStatusSection(viewModel: viewModel, topDivider: !viewModel.shouldShowNonEditableIndicators)
+                            Spacer(minLength: Layout.sectionSpacing)
+                        }
+                        .renderedIf(flow == .editing)
 
-                            ProductsSection(scroll: scroll,
-                                            flow: flow,
-                                            presentProductSelector: presentProductSelector,
-                                            viewModel: viewModel,
-                                            navigationButtonID: $navigationButtonID,
-                                            isLoading: isLoading)
+                        ProductsSection(scroll: scroll,
+                                        flow: flow,
+                                        presentProductSelector: presentProductSelector,
+                                        viewModel: viewModel,
+                                        navigationButtonID: $navigationButtonID,
+                                        isLoading: isLoading)
+                        .disabled(viewModel.shouldShowNonEditableIndicators)
+
+                        Group {
+                            Divider()
+                            Spacer(minLength: Layout.sectionSpacing)
+                            Divider()
+                        }
+                        .renderedIf(viewModel.shouldSplitProductsAndCustomAmountsSections)
+
+                        OrderCustomAmountsSection(viewModel: viewModel, sectionViewModel: viewModel.customAmountsSectionViewModel)
                             .disabled(viewModel.shouldShowNonEditableIndicators)
 
-                            Group {
-                                Divider()
-                                Spacer(minLength: Layout.sectionSpacing)
-                                Divider()
-                            }
-                            .renderedIf(viewModel.shouldSplitProductsAndCustomAmountsSections)
+                        Divider()
 
-                            OrderCustomAmountsSection(viewModel: viewModel, sectionViewModel: viewModel.customAmountsSectionViewModel)
+                        Spacer(minLength: Layout.sectionSpacing)
+
+                        Group {
+                            OrderShippingSection(viewModel: viewModel.shippingLineViewModel)
                                 .disabled(viewModel.shouldShowNonEditableIndicators)
-
-                            Divider()
-
-                            Spacer(minLength: Layout.sectionSpacing)
-
-                            Group {
-                                OrderShippingSection(viewModel: viewModel.shippingLineViewModel)
-                                    .disabled(viewModel.shouldShowNonEditableIndicators)
-                                Spacer(minLength: Layout.sectionSpacing)
-                            }
-                            .renderedIf(viewModel.shippingLineViewModel.shippingLineRows.isNotEmpty)
-
-                            Group {
-                                OrderCouponSectionView(viewModel: viewModel, couponViewModel: viewModel.couponLineViewModel)
-                                    .disabled(viewModel.shouldShowNonEditableIndicators)
-                                Spacer(minLength: Layout.sectionSpacing)
-                            }
-                            .renderedIf(viewModel.couponLineViewModel.couponLineRows.isNotEmpty)
-
-                            AddOrderComponentsSection(
-                                viewModel: viewModel.paymentDataViewModel,
-                                shippingLineViewModel: viewModel.shippingLineViewModel,
-                                couponLineViewModel: viewModel.couponLineViewModel,
-                                shouldShowCouponsInfoTooltip: $shouldShowInformationalCouponTooltip,
-                                shouldShowGiftCardForm: $shouldShowGiftCardForm)
-                            .addingTopAndBottomDividers()
-                            .disabled(viewModel.shouldShowNonEditableIndicators)
-
                             Spacer(minLength: Layout.sectionSpacing)
                         }
+                        .renderedIf(viewModel.shippingLineViewModel.shippingLineRows.isNotEmpty)
 
-                        VStack(spacing: Layout.noSpacing) {
-                            Group {
-                                NewTaxRateSection(text: viewModel.taxRateRowText) {
-                                    viewModel.onSetNewTaxRateTapped()
-                                    switch viewModel.taxRateRowAction {
-                                    case .storedTaxRateSheet:
-                                        shouldShowStoredTaxRateSheet = true
-                                        viewModel.onStoredTaxRateBottomSheetAppear()
-                                    case .taxSelector:
-                                        shouldShowNewTaxRateSelector = true
-                                    }
-
-                                }
-                                .sheet(isPresented: $shouldShowNewTaxRateSelector) {
-                                    NewTaxRateSelectorView(viewModel: NewTaxRateSelectorViewModel(siteID: viewModel.siteID,
-                                                                                                  onTaxRateSelected: { taxRate in
-                                        viewModel.onTaxRateSelected(taxRate)
-                                    }),
-                                                           taxEducationalDialogViewModel: viewModel.paymentDataViewModel.taxEducationalDialogViewModel,
-                                                           onDismissWpAdminWebView: viewModel.paymentDataViewModel.onDismissWpAdminWebViewClosure,
-                                                           storeSelectedTaxRate: viewModel.shouldStoreTaxRateInSelectorByDefault)
-                                }
-                                .sheet(isPresented: $shouldShowStoredTaxRateSheet) {
-                                    if #available(iOS 16.0, *) {
-                                        storedTaxRateBottomSheetContent
-                                            .presentationDetents([.medium])
-                                            .presentationDragIndicator(.visible)
-                                    } else {
-                                        storedTaxRateBottomSheetContent
-                                    }
-                                }
-
-                                Spacer(minLength: Layout.sectionSpacing)
-                            }
-                            .renderedIf(viewModel.shouldShowNewTaxRateSection)
-
-                            Divider()
-
-                            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.subscriptionsInOrderCreationCustomers) {
-                                OrderCustomerSection(viewModel: viewModel.customerSectionViewModel)
-                            } else {
-                                LegacyOrderCustomerSection(viewModel: viewModel, addressFormViewModel: viewModel.addressFormViewModel)
-                            }
-
-                            Group {
-                                Divider()
-
-                                Spacer(minLength: Layout.sectionSpacing)
-
-                                Divider()
-                            }
-                            .renderedIf(viewModel.shouldSplitCustomerAndNoteSections)
-
-                            CustomerNoteSection(viewModel: viewModel)
-
-                            Divider()
+                        Group {
+                            OrderCouponSectionView(viewModel: viewModel, couponViewModel: viewModel.couponLineViewModel)
+                                .disabled(viewModel.shouldShowNonEditableIndicators)
+                            Spacer(minLength: Layout.sectionSpacing)
                         }
+                        .renderedIf(viewModel.couponLineViewModel.couponLineRows.isNotEmpty)
+
+                        AddOrderComponentsSection(
+                            viewModel: viewModel.paymentDataViewModel,
+                            shippingLineViewModel: viewModel.shippingLineViewModel,
+                            couponLineViewModel: viewModel.couponLineViewModel,
+                            shouldShowCouponsInfoTooltip: $shouldShowInformationalCouponTooltip,
+                            shouldShowGiftCardForm: $shouldShowGiftCardForm)
+                        .addingTopAndBottomDividers()
+                        .disabled(viewModel.shouldShowNonEditableIndicators)
+
+                        Spacer(minLength: Layout.sectionSpacing)
                     }
-                    .disabled(viewModel.disabled)
+
+                    VStack(spacing: Layout.noSpacing) {
+                        Group {
+                            NewTaxRateSection(text: viewModel.taxRateRowText) {
+                                viewModel.onSetNewTaxRateTapped()
+                                switch viewModel.taxRateRowAction {
+                                case .storedTaxRateSheet:
+                                    shouldShowStoredTaxRateSheet = true
+                                    viewModel.onStoredTaxRateBottomSheetAppear()
+                                case .taxSelector:
+                                    shouldShowNewTaxRateSelector = true
+                                }
+
+                            }
+                            .sheet(isPresented: $shouldShowNewTaxRateSelector) {
+                                NewTaxRateSelectorView(viewModel: NewTaxRateSelectorViewModel(siteID: viewModel.siteID,
+                                                                                              onTaxRateSelected: { taxRate in
+                                    viewModel.onTaxRateSelected(taxRate)
+                                }),
+                                                       taxEducationalDialogViewModel: viewModel.paymentDataViewModel.taxEducationalDialogViewModel,
+                                                       onDismissWpAdminWebView: viewModel.paymentDataViewModel.onDismissWpAdminWebViewClosure,
+                                                       storeSelectedTaxRate: viewModel.shouldStoreTaxRateInSelectorByDefault)
+                            }
+                            .sheet(isPresented: $shouldShowStoredTaxRateSheet) {
+                                if #available(iOS 16.0, *) {
+                                    storedTaxRateBottomSheetContent
+                                        .presentationDetents([.medium])
+                                        .presentationDragIndicator(.visible)
+                                } else {
+                                    storedTaxRateBottomSheetContent
+                                }
+                            }
+
+                            Spacer(minLength: Layout.sectionSpacing)
+                        }
+                        .renderedIf(viewModel.shouldShowNewTaxRateSection)
+
+                        Divider()
+
+                        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.subscriptionsInOrderCreationCustomers) {
+                            OrderCustomerSection(viewModel: viewModel.customerSectionViewModel)
+                        } else {
+                            LegacyOrderCustomerSection(viewModel: viewModel, addressFormViewModel: viewModel.addressFormViewModel)
+                        }
+
+                        Group {
+                            Divider()
+
+                            Spacer(minLength: Layout.sectionSpacing)
+
+                            Divider()
+                        }
+                        .renderedIf(viewModel.shouldSplitCustomerAndNoteSections)
+
+                        CustomerNoteSection(viewModel: viewModel)
+
+                        Divider()
+                    }
                 }
-                .accessibilityIdentifier(Accessibility.orderFormScrollViewIdentifier)
-                .background(Color(.listBackground).ignoresSafeArea())
-                .ignoresSafeArea(.container, edges: [.horizontal])
+                .disabled(viewModel.disabled)
             }
+            .accessibilityIdentifier(Accessibility.orderFormScrollViewIdentifier)
+            .background(Color(.listBackground).ignoresSafeArea())
+            .ignoresSafeArea(.container, edges: [.horizontal])
+            .background(
+                GeometryReader { geometryProxy in
+                    Color.clear
+                        .preference(key: WidthPreferenceKey.self, value: geometryProxy.size.width)
+                }
+            )
+        }
+        .onPreferenceChange(WidthPreferenceKey.self) { newWidth in
+            bannerWidth = newWidth
         }
         .safeAreaInset(edge: .bottom) {
             VStack {
@@ -860,6 +870,15 @@ private extension OrderForm {
         static let addProductButtonIdentifier = "new-order-add-product-button"
         static let addProductViaSKUScannerButtonIdentifier = "new-order-add-product-via-sku-scanner-button"
         static let orderFormScrollViewIdentifier = "order-form-scroll-view"
+    }
+}
+
+private extension OrderForm {
+    struct WidthPreferenceKey: PreferenceKey {
+        static var defaultValue: CGFloat = .zero
+        static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+            value = max(value, nextValue())
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1371, WOOMOB-1387

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
- Fixes the issue where tapping on a search bar in country selected caused a pop-back navigation
- Additionally fixes the issue where the `NonEditableOrderBanner` was stuck at landscape width and made the whole order editing UI remain of a landscape width.

The issue was likely caused by a difference in the view hierarchy rendering on iOS. It could not be reproduced on iOS 18. In OrderForm, the parent GeometryReader container and NonEditableOrderBanner(width: geometry.size.width) caused the view to re-render whenever the keyboard appeared.
As a result, when presenting the country selector and focusing the search bar, the keyboard triggered a re-render. This broke the active NavigationLink, causing the country selector to dismiss unexpectedly.

The main idea of the fix is:
- applying the `GeometryReader` to the parent view in `body` and applying the with value to a preference:
```
.background(
    GeometryReader { geometryProxy in
        Color.clear
            .preference(key: WidthPreferenceKey.self, value: geometryProxy.size.width)
    }
)
```
- Introducing the `bannerWidth` state var:
```
@State private var bannerWidth: CGFloat = 0
```
- Listen for preference change:
```
.onPreferenceChange(WidthPreferenceKey.self) { newWidth in
    bannerWidth = newWidth
}
```
- Applying the width state for `NonEditableOrderBanner`:
```
NonEditableOrderBanner(width: bannerWidth)
```

Note: The majority of changes in the diff are caused by removing the parent `GeometryReader {}`. 

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Build and run from trunk or use latest beta / prod.
- Run on iOS 26
- Navigate to a product creation
- Start with adding customer details from scratch
- Input an address line, postal code just in case
- Tap on country setting and select a country
- Save
- Back in order creation form select a product and apply
- Go back to customer address creation
- Open the country selector and wait for couple settings
- Tap on search bar - the country selector will be auto closed.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested on iPhone 17 simulator (iOS 26)

## Broken navigation before fix
https://github.com/user-attachments/assets/e3aa60df-0215-4229-9008-5942389dc7a4

## Navigation after fix
https://github.com/user-attachments/assets/429a48fd-491c-48a2-ac87-fd29892260bd

## Broken banner before fix
https://github.com/user-attachments/assets/70f2a425-8b75-40c0-8ac0-ecd4864ca678

## Banner after fix
https://github.com/user-attachments/assets/0f8e5a79-f982-4f6e-8f94-80dd7f8b9e4f




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.