### PR TITLE
Bookings: Update tab eligibility to include booking check

### DIFF
--- a/Modules/Sources/Yosemite/Actions/BookingAction.swift
+++ b/Modules/Sources/Yosemite/Actions/BookingAction.swift
@@ -14,4 +14,10 @@ public enum BookingAction: Action {
                              pageNumber: Int,
                              pageSize: Int = BookingsRemote.Default.pageSize,
                              onCompletion: (Result<Bool, Error>) -> Void)
+
+    /// Checks if the store already has any bookings.
+    /// Returns `false` if the store has no bookings.
+    ///
+    case checkIfStoreHasBookings(siteID: Int64,
+                                 onCompletion: (Result<Bool, Error>) -> Void)
 }

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -37,6 +37,8 @@ public class BookingStore: Store {
         switch action {
         case let .synchronizeBookings(siteID, pageNumber, pageSize, onCompletion):
             synchronizeBookings(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
+        case let .checkIfStoreHasBookings(siteID, onCompletion):
+            checkIfStoreHasBookings(siteID: siteID, onCompletion: onCompletion)
         }
     }
 }
@@ -60,6 +62,31 @@ private extension BookingStore {
                 await upsertStoredBookingsInBackground(readOnlyBookings: bookings, siteID: siteID)
                 let hasNextPage = bookings.count == pageSize
                 onCompletion(.success(hasNextPage))
+            } catch {
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    /// Checks if the store already has any bookings.
+    /// Returns `false` if the store has no bookings.
+    ///
+    func checkIfStoreHasBookings(siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
+        let derivedStorage = storageManager.viewStorage
+        let hasLocalBookings = derivedStorage.countObjects(ofType: StorageBooking.self, matching: NSPredicate(format: "siteID == %lld", siteID)) > 0
+
+        if hasLocalBookings {
+            onCompletion(.success(true))
+            return
+        }
+
+        Task { @MainActor in
+            do {
+                let bookings = try await remote.loadAllBookings(for: siteID,
+                                                                pageNumber: 1,
+                                                                pageSize: 1)
+                let hasRemoteBookings = !bookings.isEmpty
+                onCompletion(.success(hasRemoteBookings))
             } catch {
                 onCompletion(.failure(error))
             }

--- a/Modules/Tests/YosemiteTests/Stores/BookingStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/BookingStoreTests.swift
@@ -206,6 +206,103 @@ struct BookingStoreTests {
         #expect(result.isSuccess)
         #expect(storedBookingCount == 2)
     }
+
+    // MARK: - checkIfStoreHasBookings
+
+    @Test func checkIfStoreHasBookings_returns_true_when_bookings_exist_locally() async throws {
+        // Given
+        let booking = Booking.fake().copy(siteID: sampleSiteID, bookingID: 123)
+        storeBooking(booking)
+        #expect(storedBookingCount == 1)
+
+        let store = BookingStore(dispatcher: Dispatcher(),
+                                 storageManager: storageManager,
+                                 network: network,
+                                 remote: remote)
+
+        // When
+        let result = await withCheckedContinuation { continuation in
+            store.onAction(BookingAction.checkIfStoreHasBookings(siteID: sampleSiteID,
+                                                                onCompletion: { result in
+                continuation.resume(returning: result)
+            }))
+        }
+
+        // Then
+        let hasBookings = try result.get()
+        #expect(hasBookings == true)
+    }
+
+    @Test func checkIfStoreHasBookings_returns_true_when_no_local_bookings_but_remote_has_bookings() async throws {
+        // Given
+        #expect(storedBookingCount == 0)
+        let remoteBooking = Booking.fake()
+        remote.whenLoadingAllBookings(thenReturn: .success([remoteBooking]))
+
+        let store = BookingStore(dispatcher: Dispatcher(),
+                                 storageManager: storageManager,
+                                 network: network,
+                                 remote: remote)
+
+        // When
+        let result = await withCheckedContinuation { continuation in
+            store.onAction(BookingAction.checkIfStoreHasBookings(siteID: sampleSiteID,
+                                                                onCompletion: { result in
+                continuation.resume(returning: result)
+            }))
+        }
+
+        // Then
+        let hasBookings = try result.get()
+        #expect(hasBookings == true)
+    }
+
+    @Test func checkIfStoreHasBookings_returns_false_when_no_bookings_exist_locally_or_remotely() async throws {
+        // Given
+        #expect(storedBookingCount == 0)
+        remote.whenLoadingAllBookings(thenReturn: .success([]))
+
+        let store = BookingStore(dispatcher: Dispatcher(),
+                                 storageManager: storageManager,
+                                 network: network,
+                                 remote: remote)
+
+        // When
+        let result = await withCheckedContinuation { continuation in
+            store.onAction(BookingAction.checkIfStoreHasBookings(siteID: sampleSiteID,
+                                                                onCompletion: { result in
+                continuation.resume(returning: result)
+            }))
+        }
+
+        // Then
+        let hasBookings = try result.get()
+        #expect(hasBookings == false)
+    }
+
+    @Test func checkIfStoreHasBookings_returns_error_on_remote_failure() async throws {
+        // Given
+        #expect(storedBookingCount == 0)
+        remote.whenLoadingAllBookings(thenReturn: .failure(NetworkError.timeout()))
+
+        let store = BookingStore(dispatcher: Dispatcher(),
+                                 storageManager: storageManager,
+                                 network: network,
+                                 remote: remote)
+
+        // When
+        let result = await withCheckedContinuation { continuation in
+            store.onAction(BookingAction.checkIfStoreHasBookings(siteID: sampleSiteID,
+                                                                onCompletion: { result in
+                continuation.resume(returning: result)
+            }))
+        }
+
+        // Then
+        #expect(result.isFailure)
+        let error = result.failure as? NetworkError
+        #expect(error == .timeout())
+    }
 }
 
 private extension BookingStoreTests {

--- a/WooCommerce/Classes/Bookings/BookingsTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/Bookings/BookingsTabEligibilityChecker.swift
@@ -45,16 +45,18 @@ final class BookingsTabEligibilityChecker: BookingsTabEligibilityCheckerProtocol
             return false
         }
 
-        async let hasBookableProducts = await checkIfStoreHasBookableProducts()
-        async let hasBookings = await checkIfStoreHasBookings()
-
-        if await hasBookableProducts == false,
-           await hasBookings == false {
-            return false
-        }
+        // Check if store has bookable products or bookings
+        let isVisible: Bool = await {
+            if await checkIfStoreHasBookableProducts() {
+                return true
+            } else if await checkIfStoreHasBookings() {
+                return true
+            } else {
+                return false
+            }
+        }()
 
         // Cache the result
-        let isVisible = true
         userDefaults.cacheBookingsTabVisibility(siteID: site.siteID, isVisible: isVisible)
 
         return isVisible

--- a/WooCommerce/Classes/Bookings/BookingsTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/Bookings/BookingsTabEligibilityChecker.swift
@@ -45,8 +45,16 @@ final class BookingsTabEligibilityChecker: BookingsTabEligibilityCheckerProtocol
             return false
         }
 
+        async let hasBookableProducts = await checkIfStoreHasBookableProducts()
+        async let hasBookings = await checkIfStoreHasBookings()
+
+        if await hasBookableProducts == false,
+           await hasBookings == false {
+            return false
+        }
+
         // Cache the result
-        let isVisible = await checkIfStoreHasBookableProducts()
+        let isVisible = true
         userDefaults.cacheBookingsTabVisibility(siteID: site.siteID, isVisible: isVisible)
 
         return isVisible
@@ -62,6 +70,16 @@ private extension BookingsTabEligibilityChecker {
             stores.dispatch(ProductAction.checkIfStoreHasProducts(siteID: site.siteID, type: .booking) { result in
                 let hasBookableProducts = (try? result.get()) ?? false
                 continuation.resume(returning: hasBookableProducts)
+            })
+        }
+    }
+
+    @MainActor
+    func checkIfStoreHasBookings() async -> Bool {
+        await withCheckedContinuation { continuation in
+            stores.dispatch(BookingAction.checkIfStoreHasBookings(siteID: site.siteID) { result in
+                let hasBookings = (try? result.get()) ?? false
+                continuation.resume(returning: hasBookings)
             })
         }
     }

--- a/WooCommerce/WooCommerceTests/Bookings/BookingsTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/Bookings/BookingsTabEligibilityCheckerTests.swift
@@ -98,6 +98,7 @@ struct BookingsTabEligibilityCheckerTests {
         let featureFlagService = MockFeatureFlagService(isCIABBookingsEnabled: true)
         let ciabEligibilityChecker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: false)
         setupStoreHasBookableProducts(hasProducts: true)
+        setupStoreHasBookings(hasBookings: true)
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
@@ -111,11 +112,12 @@ struct BookingsTabEligibilityCheckerTests {
         #expect(result == false)
     }
 
-    @Test func checkVisibility_returns_false_when_store_has_no_bookable_products() async throws {
+    @Test func checkVisibility_returns_false_when_store_has_no_bookable_products_and_no_bookings() async throws {
         // Given
         let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
         let featureFlagService = MockFeatureFlagService(isCIABBookingsEnabled: true)
         setupStoreHasBookableProducts(hasProducts: false)
+        setupStoreHasBookings(hasBookings: false)
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
@@ -129,11 +131,12 @@ struct BookingsTabEligibilityCheckerTests {
         #expect(result == false)
     }
 
-    @Test func checkVisibility_returns_true_when_all_conditions_are_satisfied() async throws {
+    @Test func checkVisibility_returns_true_when_store_has_bookable_products() async throws {
         // Given
         let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
         let featureFlagService = MockFeatureFlagService(isCIABBookingsEnabled: true)
         setupStoreHasBookableProducts(hasProducts: true)
+        setupStoreHasBookings(hasBookings: false)
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
@@ -152,6 +155,7 @@ struct BookingsTabEligibilityCheckerTests {
         let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
         let featureFlagService = MockFeatureFlagService(isCIABBookingsEnabled: true)
         setupStoreHasBookableProducts(hasProducts: true)
+        setupStoreHasBookings(hasBookings: false)
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
@@ -171,6 +175,7 @@ struct BookingsTabEligibilityCheckerTests {
         let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
         let featureFlagService = MockFeatureFlagService(isCIABBookingsEnabled: true)
         setupStoreHasBookableProducts(hasProducts: false)
+        setupStoreHasBookings(hasBookings: false)
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
@@ -185,11 +190,88 @@ struct BookingsTabEligibilityCheckerTests {
         #expect(userDefaults.loadCachedBookingsTabVisibility(siteID: siteID) == false)
     }
 
-    @Test func checkVisibility_handles_store_check_failure_gracefully() async throws {
+    @Test func checkVisibility_handles_bookable_products_check_failure_gracefully() async throws {
         // Given
         let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
         let featureFlagService = MockFeatureFlagService(isCIABBookingsEnabled: true)
         setupStoreHasBookableProducts(hasProducts: false, shouldFail: true)
+        setupStoreHasBookings(hasBookings: false)
+        let checker = BookingsTabEligibilityChecker(site: site,
+                                                    stores: stores,
+                                                    featureFlagService: featureFlagService,
+                                                    ciabEligibilityChecker: ciabEligibilityChecker,
+                                                    userDefaults: userDefaults)
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == false)
+    }
+
+    @Test func checkVisibility_returns_true_when_store_has_bookings_but_no_bookable_products() async throws {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        let featureFlagService = MockFeatureFlagService(isCIABBookingsEnabled: true)
+        setupStoreHasBookableProducts(hasProducts: false)
+        setupStoreHasBookings(hasBookings: true)
+        let checker = BookingsTabEligibilityChecker(site: site,
+                                                    stores: stores,
+                                                    featureFlagService: featureFlagService,
+                                                    ciabEligibilityChecker: ciabEligibilityChecker,
+                                                    userDefaults: userDefaults)
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == true)
+    }
+
+    @Test func checkVisibility_returns_true_when_store_has_both_bookings_and_bookable_products() async throws {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        let featureFlagService = MockFeatureFlagService(isCIABBookingsEnabled: true)
+        setupStoreHasBookableProducts(hasProducts: true)
+        setupStoreHasBookings(hasBookings: true)
+        let checker = BookingsTabEligibilityChecker(site: site,
+                                                    stores: stores,
+                                                    featureFlagService: featureFlagService,
+                                                    ciabEligibilityChecker: ciabEligibilityChecker,
+                                                    userDefaults: userDefaults)
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == true)
+    }
+
+    @Test func checkVisibility_handles_bookings_check_failure_gracefully() async throws {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        let featureFlagService = MockFeatureFlagService(isCIABBookingsEnabled: true)
+        setupStoreHasBookableProducts(hasProducts: false)
+        setupStoreHasBookings(hasBookings: false, shouldFail: true)
+        let checker = BookingsTabEligibilityChecker(site: site,
+                                                    stores: stores,
+                                                    featureFlagService: featureFlagService,
+                                                    ciabEligibilityChecker: ciabEligibilityChecker,
+                                                    userDefaults: userDefaults)
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == false)
+    }
+
+    @Test func checkVisibility_handles_both_checks_failure_gracefully() async throws {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        let featureFlagService = MockFeatureFlagService(isCIABBookingsEnabled: true)
+        setupStoreHasBookableProducts(hasProducts: false, shouldFail: true)
+        setupStoreHasBookings(hasBookings: false, shouldFail: true)
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
@@ -270,6 +352,21 @@ private extension BookingsTabEligibilityCheckerTests {
                     } else {
                         completion(.success(hasProducts))
                     }
+                }
+            default:
+                break
+            }
+        }
+    }
+
+    func setupStoreHasBookings(hasBookings: Bool, shouldFail: Bool = false) {
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            switch action {
+            case .checkIfStoreHasBookings(_, let completion):
+                if shouldFail {
+                    completion(.failure(NSError(domain: "test", code: 500)))
+                } else {
+                    completion(.success(hasBookings))
                 }
             default:
                 break


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1372

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

To cover an edge case where bookable products are removed but a CIAB store still has bookings created in the past, this PR updates the eligibility check for the Bookings tab by checking if the store has any bookings.

To avoid triggering updates to the storage with the sync call, a new action for checking bookings has also been added to use in this specific case.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Log in to a CIAB store with Woo Bookings plugin and existing bookable products.
- Confirm that Bookings tab is available.
- Switch to a CIAB store with no bookable products.
- Confirm that Bookings tab is not available.
- In proxyman, put a breakpoint for the site's `wc-bookings/v2/bookings` request.
- Reload the same store (relaunch the app or switch to other store and back).
- When the breakpoint stops, update the response to return at least one booking and ensure that HTTP status code is 200.
- Confirm that Bookings tab is available.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Tested the above steps with simulator iPhone 17.
- Added unit tests for new logic.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.