### PR TITLE
Bookings: Add booking list UI

### DIFF
--- a/Modules/Sources/Networking/Model/Bookings/Booking.swift
+++ b/Modules/Sources/Networking/Model/Bookings/Booking.swift
@@ -137,6 +137,10 @@ public struct Booking: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
     }
 }
 
+extension Booking: Identifiable {
+    public var id: Int64 { bookingID }
+}
+
 /// Defines all of the Booking CodingKeys
 ///
 private extension Booking {

--- a/Modules/Sources/Networking/Model/Bookings/Booking.swift
+++ b/Modules/Sources/Networking/Model/Bookings/Booking.swift
@@ -184,6 +184,5 @@ public enum BookingStatus: String, CaseIterable {
     case cancelled
     case pendingConfirmation = "pending-confirmation"
     case confirmed
-    case inCart = "in-cart"
     case unknown
 }

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -57,7 +57,12 @@ private extension BookingStore {
                 let bookings = try await remote.loadAllBookings(for: siteID,
                                                                 pageNumber: pageNumber,
                                                                 pageSize: pageSize)
-                await upsertStoredBookingsInBackground(readOnlyBookings: bookings, siteID: siteID)
+                let shouldDeleteExistingBookings = pageNumber == Default.firstPageNumber
+                await upsertStoredBookingsInBackground(
+                    readOnlyBookings: bookings,
+                    siteID: siteID,
+                    shouldDeleteExistingBookings: shouldDeleteExistingBookings
+                )
                 let hasNextPage = bookings.count == pageSize
                 onCompletion(.success(hasNextPage))
             } catch {

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -24,7 +24,9 @@ struct BookingListView: View {
                     Spacer()
                 case .syncingFirstPage:
                     headerView
+                    Spacer()
                     ProgressView().progressViewStyle(.circular)
+                    Spacer()
                 case .results:
                     bookingList
                 }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -5,6 +5,8 @@ struct BookingListView: View {
     @ObservedObject private var viewModel: BookingListViewModel
     @State private var selectedTabIndex = 0
 
+    @Namespace var topID
+
     private let tabs = [Localization.today, Localization.upcoming, Localization.all]
 
     init(viewModel: BookingListViewModel) {
@@ -28,6 +30,7 @@ struct BookingListView: View {
                 }
             }
             .navigationTitle(Localization.viewTitle)
+            .toolbarBackground(Color(.listForeground(modal: false)), for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button {
@@ -99,26 +102,30 @@ private extension BookingListView {
     }
 
     var bookingList: some View {
-        ScrollView {
-            LazyVStack(spacing: 0, pinnedViews: .sectionHeaders) {
-                Section {
-                    ForEach(viewModel.bookings) { item in
-                        bookingItem(item)
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 0, pinnedViews: .sectionHeaders) {
+                    Section {
+                        ForEach(viewModel.bookings) { item in
+                            bookingItem(item)
+                        }
+                    } header: {
+                        headerView
                     }
-                } header: {
-                    headerView
+                    .id(topID)
+
+                    InfiniteScrollIndicator(showContent: viewModel.shouldShowBottomActivityIndicator)
+                        .padding(.top, Layout.viewPadding)
+                        .onAppear {
+                            viewModel.onLoadNextPageAction()
+                        }
                 }
-                InfiniteScrollIndicator(showContent: viewModel.shouldShowBottomActivityIndicator)
-                    .padding(.top, Layout.viewPadding)
-                    .onAppear {
-                        viewModel.onLoadNextPageAction()
-                    }
             }
-        }
-        .refreshable {
-            viewModel.onRefreshAction(completion: {
-                // TODO: show/hide ghost animation if needed
-            })
+            .refreshable {
+                await viewModel.onRefreshAction()
+                // workaround as navigation bar is not snapped back after refreshing
+                proxy.scrollTo(topID, anchor: .top)
+            }
         }
     }
 

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -5,7 +5,7 @@ struct BookingListView: View {
     @ObservedObject private var viewModel: BookingListViewModel
     @State private var selectedTabIndex = 0
 
-    private let tabs = ["Today", "Upcoming", "All"]
+    private let tabs = [Localization.today, Localization.upcoming, Localization.all]
 
     init(viewModel: BookingListViewModel) {
         self.viewModel = viewModel
@@ -169,6 +169,21 @@ private extension BookingListView {
             "bookingListView.filter",
             value: "Filter",
             comment: "Button to filter the booking list"
+        )
+        static let today = NSLocalizedString(
+            "bookingListView.today",
+            value: "Today",
+            comment: "Tab title for today's bookings"
+        )
+        static let upcoming = NSLocalizedString(
+            "bookingListView.upcoming",
+            value: "Upcoming",
+            comment: "Tab title for upcoming bookings"
+        )
+        static let all = NSLocalizedString(
+            "bookingListView.all",
+            value: "All",
+            comment: "Tab title for all bookings"
         )
     }
 }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -30,7 +30,6 @@ struct BookingListView: View {
                 }
             }
             .navigationTitle(Localization.viewTitle)
-            .toolbarBackground(Color(.listForeground(modal: false)), for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button {

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -1,7 +1,11 @@
 import SwiftUI
+import struct Yosemite.Booking
 
 struct BookingListView: View {
     @ObservedObject private var viewModel: BookingListViewModel
+    @State private var selectedTabIndex = 0
+
+    private let tabs = ["Today", "Upcoming", "All"]
 
     init(viewModel: BookingListViewModel) {
         self.viewModel = viewModel
@@ -9,19 +13,12 @@ struct BookingListView: View {
 
     var body: some View {
         NavigationStack {
-            VStack {
+            VStack(spacing: 0) {
                 headerView
+                Divider()
                 contentView
-
-                Spacer()
             }
             .navigationTitle(Localization.viewTitle)
-            .toolbarBackground(Color.clear, for: .navigationBar)
-            .safeAreaInset(edge: .top) {
-                Color.clear
-                    .frame(height: 0)
-                    .background(Material.bar)
-            }
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button {
@@ -31,24 +28,62 @@ struct BookingListView: View {
                     }
                 }
             }
+            .task {
+                viewModel.loadBookings()
+            }
         }
     }
 }
 
 private extension BookingListView {
     var headerView: some View {
-        VStack(alignment: .leading) {
-            Text(Localization.allBookings)
-                .bodyStyle()
-                .bold()
-            Text(String.localizedStringWithFormat(
-                Localization.lastUpdated,
-                Date().formatted(date: .omitted, time: .shortened)
-            )) // TODO: update date
-            .footnoteStyle()
+        VStack(spacing: 0) {
+            topTabView
+            Divider()
+            HStack {
+                Button {
+                    // TODO
+                } label: {
+                    Text(Localization.sortBy)
+                        .font(.body)
+                        .foregroundStyle(Color.accentColor)
+                }
+                Spacer()
+                Button {
+                    // TODO
+                } label: {
+                    Text(Localization.filter)
+                        .font(.body)
+                        .foregroundStyle(Color.accentColor)
+                }
+            }
+            .padding()
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(Layout.viewPadding)
+    }
+
+    var topTabView: some View {
+        HStack {
+            ForEach(Array(tabs.enumerated()), id: \.element) { (index, title) in
+                Button {
+                    selectedTabIndex = index
+                } label: {
+                    Text(title)
+                        .font(.subheadline)
+                        .foregroundStyle(selectedTabIndex == index ? Color.accentColor : Color.primary)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .overlay {
+                    VStack {
+                        Spacer()
+                        if selectedTabIndex == index {
+                            Color.accentColor
+                                .frame(height: 3)
+                        }
+                    }
+                }
+            }
+        }
     }
 
     var contentView: some View {
@@ -67,22 +102,49 @@ private extension BookingListView {
     }
 
     var bookingList: some View {
-        ScrollView {
-            Divider()
-            ForEach(viewModel.bookings) { booking in
-                VStack(alignment: .leading) {
-                    Text(booking.dateCreated.formatted(date: .numeric, time: .shortened))
-                        .captionStyle()
-                    
-                }
+        RefreshableInfiniteScrollList(spacing: Layout.viewPadding,
+                                      isLoading: viewModel.shouldShowBottomActivityIndicator,
+                                      loadAction: viewModel.onLoadNextPageAction,
+                                      refreshAction: { completion in
+            viewModel.onRefreshAction(completion: completion)
+        }) {
+            ForEach(viewModel.bookings) { item in
+                bookingItem(item)
+                    .padding([.top, .horizontal], Layout.viewPadding)
+                Divider()
+                    .padding(.leading, Layout.viewPadding)
             }
-            Divider()
+        }
+    }
+
+    func bookingItem(_ booking: Booking) -> some View {
+        VStack(alignment: .leading) {
+            Text(booking.dateCreated.formatted(date: .numeric, time: .shortened))
+                .captionStyle()
+                .foregroundStyle(Color.secondary)
+
+            HStack {
+                Text("Women's Hair cut")
+                    .font(.body)
+                    .fontWeight(.medium)
+                Spacer()
+                Text(String(format: "$%@", booking.cost))
+                Image(systemName: "chevron.forward")
+                    .fontWeight(.medium)
+                    .foregroundStyle(Color.secondary)
+            }
+
+            Text("Marianne")
+                .font(.body)
+                .fontWeight(.medium)
+                .foregroundStyle(Color.secondary)
         }
     }
 }
 private extension BookingListView {
     enum Layout {
         static let viewPadding: CGFloat = 16
+        static let selectedTabIndicatorHeight: CGFloat = 3.0
     }
 
     enum Localization {
@@ -91,15 +153,15 @@ private extension BookingListView {
             value: "Bookings",
             comment: "Title of the booking list view"
         )
-        static let allBookings = NSLocalizedString(
-            "bookingListView.tabs.all.title",
-            value: "All bookings",
-            comment: "Title of the All tab of the booking list view"
+        static let sortBy = NSLocalizedString(
+            "bookingListView.sortBy",
+            value: "Sort by",
+            comment: "Button to select the order of the booking list"
         )
-        static let lastUpdated = NSLocalizedString(
-            "bookingListView.lastUpdated",
-            value: "Last updated at %1$@",
-            comment: "Text for the timestamp that the booking list was last updated"
+        static let filter = NSLocalizedString(
+            "bookingListView.filter",
+            value: "Filter",
+            comment: "Button to filter the booking list"
         )
     }
 }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct BookingListView: View {
-    // periphery:ignore
     @ObservedObject private var viewModel: BookingListViewModel
 
     init(viewModel: BookingListViewModel) {
@@ -9,6 +8,102 @@ struct BookingListView: View {
     }
 
     var body: some View {
-        Text("Hello, World!")
+        NavigationStack {
+            VStack {
+                headerView
+                contentView
+
+                Spacer()
+            }
+            .navigationTitle(Localization.viewTitle)
+            .toolbarBackground(Color.clear, for: .navigationBar)
+            .safeAreaInset(edge: .top) {
+                Color.clear
+                    .frame(height: 0)
+                    .background(Material.bar)
+            }
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        // TODO
+                    } label: {
+                        Image(systemName: "magnifyingglass")
+                    }
+                }
+            }
+        }
     }
+}
+
+private extension BookingListView {
+    var headerView: some View {
+        VStack(alignment: .leading) {
+            Text(Localization.allBookings)
+                .bodyStyle()
+                .bold()
+            Text(String.localizedStringWithFormat(
+                Localization.lastUpdated,
+                Date().formatted(date: .omitted, time: .shortened)
+            )) // TODO: update date
+            .footnoteStyle()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Layout.viewPadding)
+    }
+
+    var contentView: some View {
+        VStack {
+            switch viewModel.syncState {
+            case .empty:
+                Spacer()
+                Text("No bookings found") // TODO: update this
+                Spacer()
+            case .syncingFirstPage:
+                ProgressView().progressViewStyle(.circular)
+            case .results:
+                bookingList
+            }
+        }
+    }
+
+    var bookingList: some View {
+        ScrollView {
+            Divider()
+            ForEach(viewModel.bookings) { booking in
+                VStack(alignment: .leading) {
+                    Text(booking.dateCreated.formatted(date: .numeric, time: .shortened))
+                        .captionStyle()
+                    
+                }
+            }
+            Divider()
+        }
+    }
+}
+private extension BookingListView {
+    enum Layout {
+        static let viewPadding: CGFloat = 16
+    }
+
+    enum Localization {
+        static let viewTitle = NSLocalizedString(
+            "bookingListView.view.title",
+            value: "Bookings",
+            comment: "Title of the booking list view"
+        )
+        static let allBookings = NSLocalizedString(
+            "bookingListView.tabs.all.title",
+            value: "All bookings",
+            comment: "Title of the All tab of the booking list view"
+        )
+        static let lastUpdated = NSLocalizedString(
+            "bookingListView.lastUpdated",
+            value: "Last updated at %1$@",
+            comment: "Text for the timestamp that the booking list was last updated"
+        )
+    }
+}
+
+#Preview {
+    BookingListView(viewModel: BookingListViewModel(siteID: 123))
 }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -130,7 +130,7 @@ private extension BookingListView {
                     .fontWeight(.medium)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
-                // TODO: fetch bookable products & customer to get name or wait for API update
+                // TODO: fetch bookable products & customer to get names or wait for API update
                 Text(String(format: "%@  •  %@", "Women's Hair cut", "Marianne"))
                     .font(.footnote)
                     .fontWeight(.medium)
@@ -138,8 +138,9 @@ private extension BookingListView {
 
                 HStack {
                     // TODO: update this when attendance status is available
-                    statusBadge(text: "Booked", color: Color(.systemGray5))
-                    statusBadge(text: booking.bookingStatus.localizedTitle, color: Color(.systemGray5))
+                    // Update badge colors if design changes as statuses are not clarified now.
+                    statusBadge(text: "Booked", color: Layout.defaultBadgeColor)
+                    statusBadge(text: booking.bookingStatus.localizedTitle, color: Layout.defaultBadgeColor)
                     Spacer()
                 }
             }
@@ -148,7 +149,7 @@ private extension BookingListView {
             Divider()
                 .padding(.leading, Layout.viewPadding)
         }
-        .background(Color(.listForeground(modal: false)))
+        .background(Color(.listForeground(modal: false))) // TODO: update selected background color as part of selection handling
     }
 
     func statusBadge(text: String, color: Color) -> some View {
@@ -163,6 +164,7 @@ private extension BookingListView {
     enum Layout {
         static let viewPadding: CGFloat = 16
         static let selectedTabIndicatorHeight: CGFloat = 3.0
+        static let defaultBadgeColor = Color(uiColor: .init(light: .systemGray6, dark: .systemGray5))
     }
 
     enum Localization {

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -13,10 +13,19 @@ struct BookingListView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
-                headerView
-                Divider()
-                contentView
+            VStack {
+                switch viewModel.syncState {
+                case .empty:
+                    headerView
+                    Spacer()
+                    Text("No bookings found") // TODO: update this
+                    Spacer()
+                case .syncingFirstPage:
+                    headerView
+                    ProgressView().progressViewStyle(.circular)
+                case .results:
+                    bookingList
+                }
             }
             .navigationTitle(Localization.viewTitle)
             .toolbar {
@@ -58,6 +67,8 @@ private extension BookingListView {
                 }
             }
             .padding()
+            .background(Color(.listForeground(modal: false)))
+            Divider()
         }
     }
 
@@ -78,42 +89,38 @@ private extension BookingListView {
                         Spacer()
                         if selectedTabIndex == index {
                             Color.accentColor
-                                .frame(height: 3)
+                                .frame(height: Layout.selectedTabIndicatorHeight)
                         }
                     }
                 }
             }
         }
-    }
-
-    var contentView: some View {
-        VStack {
-            switch viewModel.syncState {
-            case .empty:
-                Spacer()
-                Text("No bookings found") // TODO: update this
-                Spacer()
-            case .syncingFirstPage:
-                ProgressView().progressViewStyle(.circular)
-            case .results:
-                bookingList
-            }
-        }
+        .background(Color(.listForeground(modal: false)))
     }
 
     var bookingList: some View {
-        RefreshableInfiniteScrollList(spacing: Layout.viewPadding,
-                                      isLoading: viewModel.shouldShowBottomActivityIndicator,
-                                      loadAction: viewModel.onLoadNextPageAction,
-                                      refreshAction: { completion in
-            viewModel.onRefreshAction(completion: completion)
-        }) {
-            ForEach(viewModel.bookings) { item in
-                bookingItem(item)
-                    .padding([.top, .horizontal], Layout.viewPadding)
-                Divider()
-                    .padding(.leading, Layout.viewPadding)
+        ScrollView {
+            LazyVStack(spacing: Layout.viewPadding, pinnedViews: .sectionHeaders) {
+                Section {
+                    ForEach(viewModel.bookings) { item in
+                        bookingItem(item)
+                            .padding([.top, .horizontal], Layout.viewPadding)
+                        Divider()
+                            .padding(.leading, Layout.viewPadding)
+                    }
+                } header: {
+                    headerView
+                }
+                InfiniteScrollIndicator(showContent: viewModel.shouldShowBottomActivityIndicator)
+                    .onAppear {
+                        viewModel.onLoadNextPageAction()
+                    }
             }
+        }
+        .refreshable {
+            viewModel.onRefreshAction(completion: {
+                // TODO: show/hide ghost animation if needed
+            })
         }
     }
 

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -75,28 +75,33 @@ private extension BookingListView {
     }
 
     var topTabView: some View {
-        HStack {
-            ForEach(Array(tabs.enumerated()), id: \.element) { (index, title) in
-                Button {
-                    selectedTabIndex = index
-                } label: {
-                    Text(title)
-                        .font(.subheadline)
-                        .foregroundStyle(selectedTabIndex == index ? Color.accentColor : Color.primary)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 12)
-                .overlay {
-                    VStack {
-                        Spacer()
-                        if selectedTabIndex == index {
-                            Color.accentColor
-                                .frame(height: Layout.selectedTabIndicatorHeight)
+        GeometryReader { geometry in
+            HStack {
+                ForEach(Array(tabs.enumerated()), id: \.element) { (index, title) in
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.3)) {
+                            selectedTabIndex = index
                         }
+                    } label: {
+                        Text(title)
+                            .font(.subheadline)
+                            .foregroundStyle(selectedTabIndex == index ? Color.accentColor : Color.primary)
                     }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
                 }
             }
+            .overlay(alignment: .bottom) {
+                Color.accentColor
+                    .frame(width: geometry.size.width / CGFloat(tabs.count),
+                           height: Layout.selectedTabIndicatorHeight)
+                    .offset(x: tabIndicatorOffset(containerWidth: geometry.size.width,
+                                                  tabCount: tabs.count,
+                                                  selectedIndex: selectedTabIndex))
+                    .animation(.easeInOut(duration: 0.3), value: selectedTabIndex)
+            }
         }
+        .frame(height: Layout.topTabBarHeight)
         .background(Color(.listForeground(modal: false)))
     }
 
@@ -165,10 +170,25 @@ private extension BookingListView {
             .padding(.vertical, 4)
             .background(color.clipShape(RoundedRectangle(cornerRadius: 4)))
     }
+
+    /// SwiftUI's coordinate system places (0,0) at the center of the container, so we need to:
+    /// 1. Calculate how far the selected tab is from the left edge
+    /// 2. Adjust for the center-based coordinate system
+    /// 3. Center the indicator within the selected tab
+    ///
+    func tabIndicatorOffset(containerWidth: CGFloat, tabCount: Int, selectedIndex: Int) -> CGFloat {
+        let tabWidth = containerWidth / CGFloat(tabCount)
+        let distanceFromLeftEdge = tabWidth * CGFloat(selectedIndex)
+        let adjustmentForCenterOrigin = containerWidth / 2
+        let centerWithinTab = tabWidth / 2
+
+        return distanceFromLeftEdge - adjustmentForCenterOrigin + centerWithinTab
+    }
 }
 private extension BookingListView {
     enum Layout {
         static let viewPadding: CGFloat = 16
+        static let topTabBarHeight: CGFloat = 44
         static let selectedTabIndicatorHeight: CGFloat = 3.0
         static let defaultBadgeColor = Color(uiColor: .init(light: .systemGray6, dark: .systemGray5))
     }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -18,7 +18,7 @@ struct BookingListView: View {
                 case .empty:
                     headerView
                     Spacer()
-                    Text("No bookings found") // TODO: update this
+                    Text("No bookings found") // TODO: update this in WOOMOB-1394
                     Spacer()
                 case .syncingFirstPage:
                     headerView
@@ -100,18 +100,16 @@ private extension BookingListView {
 
     var bookingList: some View {
         ScrollView {
-            LazyVStack(spacing: Layout.viewPadding, pinnedViews: .sectionHeaders) {
+            LazyVStack(spacing: 0, pinnedViews: .sectionHeaders) {
                 Section {
                     ForEach(viewModel.bookings) { item in
                         bookingItem(item)
-                            .padding([.top, .horizontal], Layout.viewPadding)
-                        Divider()
-                            .padding(.leading, Layout.viewPadding)
                     }
                 } header: {
                     headerView
                 }
                 InfiniteScrollIndicator(showContent: viewModel.shouldShowBottomActivityIndicator)
+                    .padding(.top, Layout.viewPadding)
                     .onAppear {
                         viewModel.onLoadNextPageAction()
                     }
@@ -125,27 +123,40 @@ private extension BookingListView {
     }
 
     func bookingItem(_ booking: Booking) -> some View {
-        VStack(alignment: .leading) {
-            Text(booking.dateCreated.formatted(date: .numeric, time: .shortened))
-                .captionStyle()
-                .foregroundStyle(Color.secondary)
-
-            HStack {
-                Text("Women's Hair cut")
+        VStack(spacing: 0) {
+            VStack(alignment: .leading) {
+                Text(booking.startDate.formatted(date: .numeric, time: .shortened))
                     .font(.body)
                     .fontWeight(.medium)
-                Spacer()
-                Text(String(format: "$%@", booking.cost))
-                Image(systemName: "chevron.forward")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                // TODO: fetch bookable products & customer to get name or wait for API update
+                Text(String(format: "%@  •  %@", "Women's Hair cut", "Marianne"))
+                    .font(.footnote)
                     .fontWeight(.medium)
                     .foregroundStyle(Color.secondary)
-            }
 
-            Text("Marianne")
-                .font(.body)
-                .fontWeight(.medium)
-                .foregroundStyle(Color.secondary)
+                HStack {
+                    // TODO: update this when attendance status is available
+                    statusBadge(text: "Booked", color: Color(.systemGray5))
+                    statusBadge(text: booking.bookingStatus.localizedTitle, color: Color(.systemGray5))
+                    Spacer()
+                }
+            }
+            .padding(Layout.viewPadding)
+
+            Divider()
+                .padding(.leading, Layout.viewPadding)
         }
+        .background(Color(.listForeground(modal: false)))
+    }
+
+    func statusBadge(text: String, color: Color) -> some View {
+        Text(text)
+            .font(.caption2)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(color.clipShape(RoundedRectangle(cornerRadius: 4)))
     }
 }
 private extension BookingListView {

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
@@ -55,10 +55,12 @@ final class BookingListViewModel: ObservableObject {
     }
 
     /// Called when the user pulls down the list to refresh.
-    /// - Parameter completion: called when the refresh completes.
-    func onRefreshAction(completion: @escaping () -> Void) {
-        paginationTracker.resync(reason: nil) {
-            completion()
+    @MainActor
+    func onRefreshAction() async {
+        await withCheckedContinuation { continuation in
+            paginationTracker.resync(reason: nil) {
+                continuation.resume(returning: ())
+            }
         }
     }
 }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingStatus+Helpers.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingStatus+Helpers.swift
@@ -1,0 +1,51 @@
+import Foundation
+import enum Networking.BookingStatus
+
+extension BookingStatus {
+    var localizedTitle: String {
+        switch self {
+        case .complete:
+            NSLocalizedString(
+                "bookingStatus.title.complete",
+                value: "Complete",
+                comment: "Status of a complete booking"
+            )
+        case .paid:
+            NSLocalizedString(
+                "bookingStatus.title.paid",
+                value: "Paid",
+                comment: "Status of a paid booking"
+            )
+        case .unpaid:
+            NSLocalizedString(
+                "bookingStatus.title.unpaid",
+                value: "Unpaid",
+                comment: "Status of an unpaid booking"
+            )
+        case .cancelled:
+            NSLocalizedString(
+                "bookingStatus.title.canceled",
+                value: "Cancelled",
+                comment: "Status of a canceled booking"
+            )
+        case .pendingConfirmation:
+            NSLocalizedString(
+                "bookingStatus.title.pendingConfirmation",
+                value: "Pending confirmation",
+                comment: "Status of a pending confirmation booking"
+            )
+        case .confirmed:
+            NSLocalizedString(
+                "bookingStatus.title.confirmed",
+                value: "Confirmed",
+                comment: "Status of a confirmed booking"
+            )
+        case .unknown:
+            NSLocalizedString(
+                "bookingStatus.title.unknown",
+                value: "Unknown",
+                comment: "Status of a booking with unexpected status"
+            )
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
@@ -285,11 +285,7 @@ struct BookingListViewModelTests {
         let viewModel = BookingListViewModel(siteID: sampleSiteID, stores: stores)
 
         // When
-        await confirmation("Refresh completion") { confirmation in
-            viewModel.onRefreshAction {
-                confirmation()
-            }
-        }
+        await viewModel.onRefreshAction()
 
         // Then
         #expect(skip == 0)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1391

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the basic UI for the booking list including:
- Navigation bar with search button
- Header bar with time tab and sort/filter buttons.
- Booking list with refresh control and pagination.

A few things to be updated later: 
- Product name, customer name, and attendance status: these are to be added to the API later.
- Booking status badge color: no clear design yet.
- Selection of items.
- Empty state and error handling: to be handled in a separate PR.

Known issues from my testing with simulator iOS 26:
- The screen is built with SwiftUI so the UX is a bit different compared to Orders and Products tab. On these tabs, the navigation bar and the header view are not pulled down; the refresh control is displayed between the header and the list.
- After refreshing the list, sometimes the navigation bar doesn't snap back. 
I'm keeping the current implementation for now to focus on wrapping the feature first.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Log in to a CIAB store with Woo Bookings plugin v2 and existing bookings.
- Navigate to the Bookings tab and confirm that the UI is correct.
- Confirm that the booking items displays correct start date and booking status. Please note: the web plugin displays dates in UTC while on the app we're displaying local timezone. I'm keeping this behavior to follow [Android's](https://github.com/woocommerce/woocommerce-android/pull/14658#discussion_r2381461877).

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested with simulator iPhone 17 iOS 26.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Light mode | Dark mode
--- | ---
<img width="320" src="https://github.com/user-attachments/assets/05cae8a4-0631-407f-a257-74d9977dea90" /> | <img width="320" src="https://github.com/user-attachments/assets/931e7c1a-f70f-4ecb-9da2-6c31ef73babb" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.