### PR TITLE
Ignore build directory in .swiftlint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,7 @@
 swiftlint_version: 0.58.2
 
 excluded:
+  - build
   - BuildTools/.build
   - DerivedData
   - fastlane


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Local build or `rake lint` started failing for me since `.swiftlint` tries to lint packages that are within `build` folder:

> woocommerce-ios/build/SourcePackages/checkouts/swift-algorithms/Sources/Algorithms/AdjacentPairs.swift:157:1: warning: Trailing Whitespace Violation: Lines should not have trailing whitespace (trailing_whitespace)

I cannot find the reason why my packages are now built in a non-ignored directory for `swiftlint`, but given this folder is also within`.gitignore`, I think the change makes sense.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- CI should succeed

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.