### PR TITLE
[WCiOS17] Notice presenter trait updates

### DIFF
--- a/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
+++ b/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
@@ -348,6 +348,7 @@ private class NoticeContainerView: UIView {
         ])
 
         activateNoticeWidthIfNeeded()
+        observeTraitChanges()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -359,20 +360,24 @@ private class NoticeContainerView: UIView {
         return noticeView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 0.5)
     }()
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        activateNoticeWidthIfNeeded()
-
-        layoutIfNeeded()
+    private func activateNoticeWidthIfNeeded() {
+        noticeWidthConstraint.isActive = traitCollection.horizontalSizeClass == .regular
     }
 
-    private func activateNoticeWidthIfNeeded() {
-        let isRegularWidth = traitCollection.containsTraits(in: UITraitCollection(horizontalSizeClass: .regular))
-        noticeWidthConstraint.isActive = isRegularWidth
+    private func observeTraitChanges() {
+        let traits: [UITrait] = [
+            UITraitPreferredContentSizeCategory.self,
+            UITraitUserInterfaceIdiom.self,
+            UITraitVerticalSizeClass.self,
+            UITraitHorizontalSizeClass.self
+        ]
+
+        registerForTraitChanges(traits) {(self: Self, _: UITraitCollection) in
+            self.activateNoticeWidthIfNeeded()
+            self.layoutIfNeeded()
+        }
     }
 }
-
 
 // MARK: - UNMutableNotificationContent Notice Methods
 //


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1306

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Replaces old deprecated `traitCollectionDidChange(_:)` override with model API alternative to resolve warnings.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Invoke any notice toast presentation. For example switch between stores in "Menu" -> Store selector.
- Wait until the "Switched to <Store name>" toast is presented.
- While the toast is presented rotate the device to landscape mode and back.
- Make sure the toast is properly resized.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on iOS 26 iPhone 17 simulator.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Portrait | Landscape
--- | ---
<img width="1206" height="554" alt="image" src="https://github.com/user-attachments/assets/eabe3cec-0979-462e-bb11-a90809aa1ccb" /> | <img width="2622" height="470" alt="image" src="https://github.com/user-attachments/assets/9275b841-e2fa-4d9d-9acd-a9debb49bbdf" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
