### PR TITLE
[iOS26] Fix store widget background

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 23.4
 -----
 - [*] Order details: Fixes broken country selector navigation and "Non editable banner" width. [https://github.com/woocommerce/woocommerce-ios/pull/16171]
+- [*] Store widget: Fixes widget background colours for default and clean Liquid Glass mode. [https://github.com/woocommerce/woocommerce-ios/pull/16183]
 
 23.3
 -----

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
@@ -33,34 +33,29 @@ private struct StoreInfoView: View {
     }
 
     var body: some View {
-        ZStack {
-            // Background
-            Color(.brand)
-
-            VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
-                VStack(alignment: .leading, spacing: Layout.cardSpacing) {
-                    // Store Name
-                    HStack {
-                        Text(entryData.name)
-                            .storeNameStyle()
-                        Spacer()
-                        Text(entryData.range)
-                            .statRangeStyle()
-                    }
-                    // Updated at
-                    Text(Localization.updatedAt(entryData.updatedTime))
+        VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+            VStack(alignment: .leading, spacing: Layout.cardSpacing) {
+                // Store Name
+                HStack {
+                    Text(entryData.name)
+                        .storeNameStyle()
+                    Spacer()
+                    Text(entryData.range)
                         .statRangeStyle()
                 }
-
-                if category > accessibilityCategory {
-                    AccessibilityStatsCard(entryData: entryData)
-                } else {
-                    StatsCard(entryData: entryData)
-                }
+                // Updated at
+                Text(Localization.updatedAt(entryData.updatedTime))
+                    .statRangeStyle()
             }
-            .padding(.horizontal)
-            .widgetBackground(backgroundView: Color(.brand))
+
+            if category > accessibilityCategory {
+                AccessibilityStatsCard(entryData: entryData)
+            } else {
+                StatsCard(entryData: entryData)
+            }
         }
+        .padding(.horizontal)
+        .widgetBackground(backgroundView: Color(.brand))
     }
 }
 
@@ -144,53 +139,43 @@ private struct AccessibilityStatsCard: View {
 
 private struct NotLoggedInView: View {
     var body: some View {
-        ZStack {
-            // Background
-            Color(.brand)
+        VStack {
+            Image(uiImage: .wooLogo)
+                .resizable()
+                .scaledToFit()
+                .frame(width: Layout.logoWidth)
 
-            VStack {
-                Image(uiImage: .wooLogo)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: Layout.logoWidth)
+            Spacer()
 
-                Spacer()
+            Text(Localization.notLoggedIn)
+                .statTextStyle()
 
-                Text(Localization.notLoggedIn)
-                    .statTextStyle()
+            Spacer()
 
-                Spacer()
-
-                Text(Localization.login)
-                    .statButtonStyle()
-            }
-            .padding(.vertical, Layout.cardVerticalPadding)
+            Text(Localization.login)
+                .statButtonStyle()
         }
+        .padding(.vertical, Layout.cardVerticalPadding)
         .widgetBackground(backgroundView: Color(.brand))
     }
 }
 
 private struct UnableToFetchView: View {
     var body: some View {
-        ZStack {
-            // Background
-            Color(.brand)
+        VStack {
+            Image(uiImage: .wooLogo)
+                .resizable()
+                .scaledToFit()
+                .frame(width: Layout.logoWidth)
 
-            VStack {
-                Image(uiImage: .wooLogo)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: Layout.logoWidth)
+            Spacer()
 
-                Spacer()
+            Text(Localization.unableToFetch)
+                .statTextStyle()
 
-                Text(Localization.unableToFetch)
-                    .statTextStyle()
-
-                Spacer()
-            }
-            .padding(.vertical, Layout.cardVerticalPadding)
+            Spacer()
         }
+        .padding(.vertical, Layout.cardVerticalPadding)
         .widgetBackground(backgroundView: Color(.brand))
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
Part of: WOOMOB-1383

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Looks like due to the rendering differences in iOS 26 the `ZStack` + `Color(.brand)` underlay caused white background in transparent mode and also caused the visible content edges. The underlay was removed in favour of `.widgetBackground(backgroundView: Color(.brand))`

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Build from `trunk` or use prod / beta.
- Run the app and login 
- Add the store widget either to home screen or to the widgets screen.
- Observe that the container frame has slightly deeper purple color than the widget card (see screenshots).
- Enable transparent mode: 
    - long tap the empty space on home screen. Tap "edit".  
    - Tap "customize"
    - Select "Clear" in the bottom
- Check out the widget appearance - it will display blank white rectangle.

## Testing steps

- Switch to the current branch
- Repeat the steps above
- There should be no edges between widget frame purple and content purple rectangle
- In the transparent mode the content should be normally visible

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on iPhone 17 iOS 26 Simulator.

## Default
<!-- Include before and after images or gifs when appropriate. -->
Before | After
--- | ---
<img width="579" height="297" alt="Снимок экрана 2025-09-30 в 15 08 36" src="https://github.com/user-attachments/assets/d21d03d9-4b12-4a13-95ac-550e4fb55692" /> | <img width="594" height="335" alt="Снимок экрана 2025-09-30 в 15 45 30" src="https://github.com/user-attachments/assets/d859c231-408f-44ab-918b-fd6a3924f2dd" />

## Transparent
Before | After
--- | ---
<img width="604" height="316" alt="Снимок экрана 2025-09-30 в 16 42 20" src="https://github.com/user-attachments/assets/7fc284b0-4bd8-493c-8238-45494d6da2a7" /> | <img width="589" height="319" alt="Снимок экрана 2025-09-30 в 15 44 49" src="https://github.com/user-attachments/assets/245f76a5-3559-4705-b017-2453eff53fb1" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
