### PR TITLE
Bookings: Update tab handling for booking list

### DIFF
--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
@@ -107,7 +107,6 @@ private extension BookingListContainerView {
 }
 private extension BookingListContainerView {
     enum Layout {
-        static let viewPadding: CGFloat = 16
         static let topTabBarHeight: CGFloat = 44
         static let selectedTabIndicatorHeight: CGFloat = 3.0
     }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
@@ -10,13 +10,15 @@ struct BookingListContainerView: View {
 
     var body: some View {
         NavigationStack {
-            ZStack {
-                ForEach(BookingListTab.allCases, id: \.rawValue) { tab in
-                    BookingListView(viewModel: viewModel.listViewModel(for: tab)) {
-                        headerView
+            VStack {
+                headerView
+                TabView(selection: $viewModel.selectedTab) {
+                    ForEach(BookingListTab.allCases, id: \.rawValue) { tab in
+                        BookingListView(viewModel: viewModel.listViewModel(for: tab))
+                            .tag(tab)
                     }
-                    .opacity(viewModel.selectedTab == tab ? 1 : 0)
                 }
+                .tabViewStyle(.page(indexDisplayMode: .never))
             }
             .navigationTitle(Localization.viewTitle)
             .toolbar {

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+import struct Yosemite.Booking
+
+struct BookingListContainerView: View {
+    @ObservedObject private var viewModel: BookingListContainerViewModel
+
+    init(viewModel: BookingListContainerViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                ForEach(BookingListTab.allCases, id: \.rawValue) { tab in
+                    BookingListView(viewModel: viewModel.listViewModel(for: tab)) {
+                        headerView
+                    }
+                    .opacity(viewModel.selectedTab == tab ? 1 : 0)
+                }
+            }
+            .navigationTitle(Localization.viewTitle)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        // TODO
+                    } label: {
+                        Image(systemName: "magnifyingglass")
+                    }
+                }
+            }
+        }
+    }
+}
+
+private extension BookingListContainerView {
+    var headerView: some View {
+        VStack(spacing: 0) {
+            topTabView
+            Divider()
+            HStack {
+                Button {
+                    // TODO
+                } label: {
+                    Text(Localization.sortBy)
+                        .font(.body)
+                        .foregroundStyle(Color.accentColor)
+                }
+                Spacer()
+                Button {
+                    // TODO
+                } label: {
+                    Text(Localization.filter)
+                        .font(.body)
+                        .foregroundStyle(Color.accentColor)
+                }
+            }
+            .padding()
+            .background(Color(.listForeground(modal: false)))
+            Divider()
+        }
+    }
+
+    var topTabView: some View {
+        GeometryReader { geometry in
+            HStack {
+                ForEach(BookingListTab.allCases, id: \.rawValue) { tab in
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.3)) {
+                            viewModel.selectedTab = tab
+                        }
+                    } label: {
+                        Text(tab.title)
+                            .font(.subheadline)
+                            .foregroundStyle(viewModel.selectedTab == tab ? Color.accentColor : Color.primary)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                }
+            }
+            .overlay(alignment: .bottom) {
+                Color.accentColor
+                    .frame(width: geometry.size.width / CGFloat(BookingListTab.allCases.count),
+                           height: Layout.selectedTabIndicatorHeight)
+                    .offset(x: tabIndicatorOffset(containerWidth: geometry.size.width,
+                                                  tabCount: BookingListTab.allCases.count,
+                                                  selectedIndex: viewModel.selectedTab.rawValue))
+                    .animation(.easeInOut(duration: 0.3), value: viewModel.selectedTab.rawValue)
+            }
+        }
+        .frame(height: Layout.topTabBarHeight)
+        .background(Color(.listForeground(modal: false)))
+    }
+
+    /// SwiftUI's coordinate system places (0,0) at the center of the container, so we need to:
+    /// 1. Calculate how far the selected tab is from the left edge
+    /// 2. Adjust for the center-based coordinate system
+    /// 3. Center the indicator within the selected tab
+    ///
+    func tabIndicatorOffset(containerWidth: CGFloat, tabCount: Int, selectedIndex: Int) -> CGFloat {
+        let tabWidth = containerWidth / CGFloat(tabCount)
+        let distanceFromLeftEdge = tabWidth * CGFloat(selectedIndex)
+        let adjustmentForCenterOrigin = containerWidth / 2
+        let centerWithinTab = tabWidth / 2
+
+        return distanceFromLeftEdge - adjustmentForCenterOrigin + centerWithinTab
+    }
+}
+private extension BookingListContainerView {
+    enum Layout {
+        static let viewPadding: CGFloat = 16
+        static let topTabBarHeight: CGFloat = 44
+        static let selectedTabIndicatorHeight: CGFloat = 3.0
+    }
+
+    enum Localization {
+        static let viewTitle = NSLocalizedString(
+            "bookingListView.view.title",
+            value: "Bookings",
+            comment: "Title of the booking list view"
+        )
+        static let sortBy = NSLocalizedString(
+            "bookingListView.sortBy",
+            value: "Sort by",
+            comment: "Button to select the order of the booking list"
+        )
+        static let filter = NSLocalizedString(
+            "bookingListView.filter",
+            value: "Filter",
+            comment: "Button to filter the booking list"
+        )
+    }
+}

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
@@ -10,7 +10,7 @@ struct BookingListContainerView: View {
 
     var body: some View {
         NavigationStack {
-            VStack {
+            VStack(spacing: 0) {
                 headerView
                 TabView(selection: $viewModel.selectedTab) {
                     ForEach(BookingListTab.allCases, id: \.rawValue) { tab in

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// View model for `BookingListContainerView`
+final class BookingListContainerViewModel: ObservableObject {
+    private let todayListViewModel: BookingListViewModel
+    private let upcomingListViewModel: BookingListViewModel
+    private let allListViewModel: BookingListViewModel
+
+    @Published var selectedTab: BookingListTab = .today
+
+    init(siteID: Int64) {
+        self.todayListViewModel = BookingListViewModel(siteID: siteID, type: .today)
+        self.upcomingListViewModel = BookingListViewModel(siteID: siteID, type: .upcoming)
+        self.allListViewModel = BookingListViewModel(siteID: siteID, type: .all)
+    }
+
+    func listViewModel(for tab: BookingListTab) -> BookingListViewModel {
+        switch tab {
+        case .today:
+            todayListViewModel
+        case .upcoming:
+            upcomingListViewModel
+        case .all:
+            allListViewModel
+        }
+    }
+}
+
+enum BookingListTab: Int, CaseIterable {
+    case today
+    case upcoming
+    case all
+
+    var title: String {
+        switch self {
+        case .today: Localization.today
+        case .upcoming: Localization.upcoming
+        case .all: Localization.all
+        }
+    }
+
+    private enum Localization {
+        static let today = NSLocalizedString(
+            "bookingListView.today",
+            value: "Today",
+            comment: "Tab title for today's bookings"
+        )
+        static let upcoming = NSLocalizedString(
+            "bookingListView.upcoming",
+            value: "Upcoming",
+            comment: "Tab title for upcoming bookings"
+        )
+        static let all = NSLocalizedString(
+            "bookingListView.all",
+            value: "All",
+            comment: "Tab title for all bookings"
+        )
+    }
+}

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -1,32 +1,21 @@
 import SwiftUI
 import struct Yosemite.Booking
 
-struct BookingListView<Header: View>: View {
+struct BookingListView: View {
     @ObservedObject private var viewModel: BookingListViewModel
 
-    @Namespace var topID
-
-    private let headerView: Header
-
-    private let viewPadding: CGFloat = 16
-    private let defaultBadgeColor = Color(uiColor: .init(light: .systemGray6, dark: .systemGray5))
-
-    init(viewModel: BookingListViewModel,
-         @ViewBuilder header: () -> Header) {
+    init(viewModel: BookingListViewModel) {
         self.viewModel = viewModel
-        self.headerView = header()
     }
 
     var body: some View {
         VStack {
             switch viewModel.syncState {
             case .empty:
-                headerView
                 Spacer()
                 Text("No bookings found") // TODO: update this in WOOMOB-1394
                 Spacer()
             case .syncingFirstPage:
-                headerView
                 Spacer()
                 ProgressView().progressViewStyle(.circular)
                 Spacer()
@@ -35,37 +24,31 @@ struct BookingListView<Header: View>: View {
             }
         }
         .task {
-            viewModel.loadBookings()
+            // Only load first page if no content is available.
+            if viewModel.bookings.isEmpty {
+                viewModel.loadBookings()
+            }
         }
     }
 }
 
 private extension BookingListView {
     var bookingList: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                LazyVStack(spacing: 0, pinnedViews: .sectionHeaders) {
-                    Section {
-                        ForEach(viewModel.bookings) { item in
-                            bookingItem(item)
-                        }
-                    } header: {
-                        headerView
-                    }
-                    .id(topID)
-
-                    InfiniteScrollIndicator(showContent: viewModel.shouldShowBottomActivityIndicator)
-                        .padding(.top, viewPadding)
-                        .onAppear {
-                            viewModel.onLoadNextPageAction()
-                        }
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(viewModel.bookings) { item in
+                    bookingItem(item)
                 }
+
+                InfiniteScrollIndicator(showContent: viewModel.shouldShowBottomActivityIndicator)
+                    .padding(.top, Layout.viewPadding)
+                    .onAppear {
+                        viewModel.onLoadNextPageAction()
+                    }
             }
-            .refreshable {
-                await viewModel.onRefreshAction()
-                // workaround as navigation bar is not snapped back after refreshing
-                proxy.scrollTo(topID, anchor: .top)
-            }
+        }
+        .refreshable {
+            await viewModel.onRefreshAction()
         }
     }
 
@@ -86,15 +69,15 @@ private extension BookingListView {
                 HStack {
                     // TODO: update this when attendance status is available
                     // Update badge colors if design changes as statuses are not clarified now.
-                    statusBadge(text: "Booked", color: defaultBadgeColor)
-                    statusBadge(text: booking.bookingStatus.localizedTitle, color: defaultBadgeColor)
+                    statusBadge(text: "Booked", color: Layout.defaultBadgeColor)
+                    statusBadge(text: booking.bookingStatus.localizedTitle, color: Layout.defaultBadgeColor)
                     Spacer()
                 }
             }
-            .padding(viewPadding)
+            .padding(Layout.viewPadding)
 
             Divider()
-                .padding(.leading, viewPadding)
+                .padding(.leading, Layout.viewPadding)
         }
         .background(Color(.listForeground(modal: false))) // TODO: update selected background color as part of selection handling
     }
@@ -105,5 +88,12 @@ private extension BookingListView {
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
             .background(color.clipShape(RoundedRectangle(cornerRadius: 4)))
+    }
+}
+
+private extension BookingListView {
+    enum Layout {
+        static let viewPadding: CGFloat = 16
+        static let defaultBadgeColor = Color(uiColor: .init(light: .systemGray6, dark: .systemGray5))
     }
 }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -1,112 +1,46 @@
 import SwiftUI
 import struct Yosemite.Booking
 
-struct BookingListView: View {
+struct BookingListView<Header: View>: View {
     @ObservedObject private var viewModel: BookingListViewModel
-    @State private var selectedTabIndex = 0
 
     @Namespace var topID
 
-    private let tabs = [Localization.today, Localization.upcoming, Localization.all]
+    private let headerView: Header
 
-    init(viewModel: BookingListViewModel) {
+    private let viewPadding: CGFloat = 16
+    private let defaultBadgeColor = Color(uiColor: .init(light: .systemGray6, dark: .systemGray5))
+
+    init(viewModel: BookingListViewModel,
+         @ViewBuilder header: () -> Header) {
         self.viewModel = viewModel
+        self.headerView = header()
     }
 
     var body: some View {
-        NavigationStack {
-            VStack {
-                switch viewModel.syncState {
-                case .empty:
-                    headerView
-                    Spacer()
-                    Text("No bookings found") // TODO: update this in WOOMOB-1394
-                    Spacer()
-                case .syncingFirstPage:
-                    headerView
-                    Spacer()
-                    ProgressView().progressViewStyle(.circular)
-                    Spacer()
-                case .results:
-                    bookingList
-                }
+        VStack {
+            switch viewModel.syncState {
+            case .empty:
+                headerView
+                Spacer()
+                Text("No bookings found") // TODO: update this in WOOMOB-1394
+                Spacer()
+            case .syncingFirstPage:
+                headerView
+                Spacer()
+                ProgressView().progressViewStyle(.circular)
+                Spacer()
+            case .results:
+                bookingList
             }
-            .navigationTitle(Localization.viewTitle)
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button {
-                        // TODO
-                    } label: {
-                        Image(systemName: "magnifyingglass")
-                    }
-                }
-            }
-            .task {
-                viewModel.loadBookings()
-            }
+        }
+        .task {
+            viewModel.loadBookings()
         }
     }
 }
 
 private extension BookingListView {
-    var headerView: some View {
-        VStack(spacing: 0) {
-            topTabView
-            Divider()
-            HStack {
-                Button {
-                    // TODO
-                } label: {
-                    Text(Localization.sortBy)
-                        .font(.body)
-                        .foregroundStyle(Color.accentColor)
-                }
-                Spacer()
-                Button {
-                    // TODO
-                } label: {
-                    Text(Localization.filter)
-                        .font(.body)
-                        .foregroundStyle(Color.accentColor)
-                }
-            }
-            .padding()
-            .background(Color(.listForeground(modal: false)))
-            Divider()
-        }
-    }
-
-    var topTabView: some View {
-        GeometryReader { geometry in
-            HStack {
-                ForEach(Array(tabs.enumerated()), id: \.element) { (index, title) in
-                    Button {
-                        withAnimation(.easeInOut(duration: 0.3)) {
-                            selectedTabIndex = index
-                        }
-                    } label: {
-                        Text(title)
-                            .font(.subheadline)
-                            .foregroundStyle(selectedTabIndex == index ? Color.accentColor : Color.primary)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 12)
-                }
-            }
-            .overlay(alignment: .bottom) {
-                Color.accentColor
-                    .frame(width: geometry.size.width / CGFloat(tabs.count),
-                           height: Layout.selectedTabIndicatorHeight)
-                    .offset(x: tabIndicatorOffset(containerWidth: geometry.size.width,
-                                                  tabCount: tabs.count,
-                                                  selectedIndex: selectedTabIndex))
-                    .animation(.easeInOut(duration: 0.3), value: selectedTabIndex)
-            }
-        }
-        .frame(height: Layout.topTabBarHeight)
-        .background(Color(.listForeground(modal: false)))
-    }
-
     var bookingList: some View {
         ScrollViewReader { proxy in
             ScrollView {
@@ -121,7 +55,7 @@ private extension BookingListView {
                     .id(topID)
 
                     InfiniteScrollIndicator(showContent: viewModel.shouldShowBottomActivityIndicator)
-                        .padding(.top, Layout.viewPadding)
+                        .padding(.top, viewPadding)
                         .onAppear {
                             viewModel.onLoadNextPageAction()
                         }
@@ -152,15 +86,15 @@ private extension BookingListView {
                 HStack {
                     // TODO: update this when attendance status is available
                     // Update badge colors if design changes as statuses are not clarified now.
-                    statusBadge(text: "Booked", color: Layout.defaultBadgeColor)
-                    statusBadge(text: booking.bookingStatus.localizedTitle, color: Layout.defaultBadgeColor)
+                    statusBadge(text: "Booked", color: defaultBadgeColor)
+                    statusBadge(text: booking.bookingStatus.localizedTitle, color: defaultBadgeColor)
                     Spacer()
                 }
             }
-            .padding(Layout.viewPadding)
+            .padding(viewPadding)
 
             Divider()
-                .padding(.leading, Layout.viewPadding)
+                .padding(.leading, viewPadding)
         }
         .background(Color(.listForeground(modal: false))) // TODO: update selected background color as part of selection handling
     }
@@ -172,63 +106,4 @@ private extension BookingListView {
             .padding(.vertical, 4)
             .background(color.clipShape(RoundedRectangle(cornerRadius: 4)))
     }
-
-    /// SwiftUI's coordinate system places (0,0) at the center of the container, so we need to:
-    /// 1. Calculate how far the selected tab is from the left edge
-    /// 2. Adjust for the center-based coordinate system
-    /// 3. Center the indicator within the selected tab
-    ///
-    func tabIndicatorOffset(containerWidth: CGFloat, tabCount: Int, selectedIndex: Int) -> CGFloat {
-        let tabWidth = containerWidth / CGFloat(tabCount)
-        let distanceFromLeftEdge = tabWidth * CGFloat(selectedIndex)
-        let adjustmentForCenterOrigin = containerWidth / 2
-        let centerWithinTab = tabWidth / 2
-
-        return distanceFromLeftEdge - adjustmentForCenterOrigin + centerWithinTab
-    }
-}
-private extension BookingListView {
-    enum Layout {
-        static let viewPadding: CGFloat = 16
-        static let topTabBarHeight: CGFloat = 44
-        static let selectedTabIndicatorHeight: CGFloat = 3.0
-        static let defaultBadgeColor = Color(uiColor: .init(light: .systemGray6, dark: .systemGray5))
-    }
-
-    enum Localization {
-        static let viewTitle = NSLocalizedString(
-            "bookingListView.view.title",
-            value: "Bookings",
-            comment: "Title of the booking list view"
-        )
-        static let sortBy = NSLocalizedString(
-            "bookingListView.sortBy",
-            value: "Sort by",
-            comment: "Button to select the order of the booking list"
-        )
-        static let filter = NSLocalizedString(
-            "bookingListView.filter",
-            value: "Filter",
-            comment: "Button to filter the booking list"
-        )
-        static let today = NSLocalizedString(
-            "bookingListView.today",
-            value: "Today",
-            comment: "Tab title for today's bookings"
-        )
-        static let upcoming = NSLocalizedString(
-            "bookingListView.upcoming",
-            value: "Upcoming",
-            comment: "Tab title for upcoming bookings"
-        )
-        static let all = NSLocalizedString(
-            "bookingListView.all",
-            value: "All",
-            comment: "Tab title for all bookings"
-        )
-    }
-}
-
-#Preview {
-    BookingListView(viewModel: BookingListViewModel(siteID: 123))
 }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import Foundation
 import Yosemite
 import protocol Storage.StorageManagerType
@@ -9,6 +8,7 @@ final class BookingListViewModel: ObservableObject {
     @Published private(set) var bookings: [Booking] = []
 
     private let siteID: Int64
+    private let type: BookingListTab
     private let stores: StoresManager
     private let storage: StorageManagerType
 
@@ -33,9 +33,11 @@ final class BookingListViewModel: ObservableObject {
     }()
 
     init(siteID: Int64,
+         type: BookingListTab,
          stores: StoresManager = ServiceLocator.stores,
          storage: StorageManagerType = ServiceLocator.storageManager) {
         self.siteID = siteID
+        self.type = type
         self.stores = stores
         self.storage = storage
         self.paginationTracker = PaginationTracker(pageFirstIndex: pageFirstIndex)
@@ -90,7 +92,12 @@ private extension BookingListViewModel {
 
     /// Updates row view models and sync state.
     func updateResults() {
-        bookings = resultsController.fetchedObjects
+        /// TODO: update logic for fetching bookings
+        if type == .all {
+            bookings = resultsController.fetchedObjects
+        } else {
+            bookings = []
+        }
         transitionToResultsUpdatedState()
     }
 }

--- a/WooCommerce/Classes/Bookings/BookingsTabView.swift
+++ b/WooCommerce/Classes/Bookings/BookingsTabView.swift
@@ -47,7 +47,7 @@ struct BookingsTabView: View {
 
     var body: some View {
         NavigationSplitView(columnVisibility: $visibility) {
-            BookingListView(viewModel: BookingListViewModel(siteID: siteID))
+            BookingListContainerView(viewModel: BookingListContainerViewModel(siteID: siteID))
         } detail: {
             Text("Booking Detail Screen")
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
@@ -35,7 +35,7 @@ struct BookingListViewModelTests {
             }
             invocationCountOfLoadBookings += 1
         }
-        let viewModel = BookingListViewModel(siteID: sampleSiteID, stores: stores)
+        let viewModel = BookingListViewModel(siteID: sampleSiteID, type: .all, stores: stores)
 
         // Then
         #expect(viewModel.syncState == .empty)
@@ -52,7 +52,7 @@ struct BookingListViewModelTests {
             }
             invocationCountOfLoadBookings += 1
         }
-        let viewModel = BookingListViewModel(siteID: sampleSiteID, stores: stores)
+        let viewModel = BookingListViewModel(siteID: sampleSiteID, type: .all, stores: stores)
 
         // When
         viewModel.loadBookings()
@@ -63,7 +63,7 @@ struct BookingListViewModelTests {
 
     @Test func state_is_syncing_first_page_upon_load_bookings_if_no_existing_booking_in_storage() {
         // Given
-        let viewModel = BookingListViewModel(siteID: sampleSiteID)
+        let viewModel = BookingListViewModel(siteID: sampleSiteID, type: .all)
 
         // When
         viewModel.loadBookings()
@@ -75,7 +75,10 @@ struct BookingListViewModelTests {
     @Test func state_is_results_upon_load_bookings_if_existing_bookings_in_storage() {
         let existingBooking = Booking.fake().copy(siteID: sampleSiteID, bookingID: 123)
         insertBookings([existingBooking])
-        let viewModel = BookingListViewModel(siteID: sampleSiteID, stores: MockStoresManager(sessionManager: .testingInstance), storage: storageManager)
+        let viewModel = BookingListViewModel(siteID: sampleSiteID,
+                                             type: .all,
+                                             stores: MockStoresManager(sessionManager: .testingInstance),
+                                             storage: storageManager)
 
         // When
         viewModel.loadBookings()
@@ -95,7 +98,10 @@ struct BookingListViewModelTests {
             self.insertBookings([booking])
             onCompletion(.success(true))
         }
-        let viewModel = BookingListViewModel(siteID: sampleSiteID, stores: stores, storage: storageManager)
+        let viewModel = BookingListViewModel(siteID: sampleSiteID,
+                                             type: .all,
+                                             stores: stores,
+                                             storage: storageManager)
 
         var states = [BookingListViewModel.SyncState]()
         await confirmation("State transitions") { confirmation in
@@ -129,7 +135,10 @@ struct BookingListViewModelTests {
             }
             onCompletion(.success(false))
         }
-        let viewModel = BookingListViewModel(siteID: sampleSiteID, stores: stores, storage: storageManager)
+        let viewModel = BookingListViewModel(siteID: sampleSiteID,
+                                             type: .all,
+                                             stores: stores,
+                                             storage: storageManager)
 
         var states = [BookingListViewModel.SyncState]()
         await confirmation("State transitions") { confirmation in
@@ -170,7 +179,10 @@ struct BookingListViewModelTests {
             onCompletion(.success(pageNumber == 1 ? true : false))
         }
 
-        let viewModel = BookingListViewModel(siteID: sampleSiteID, stores: stores, storage: storageManager)
+        let viewModel = BookingListViewModel(siteID: sampleSiteID,
+                                             type: .all,
+                                             stores: stores,
+                                             storage: storageManager)
 
         var states = [BookingListViewModel.SyncState]()
         await confirmation("State transitions") { confirmation in
@@ -212,7 +224,10 @@ struct BookingListViewModelTests {
             self.insertBookings([booking1, booking2])
             onCompletion(.success(true))
         }
-        let viewModel = BookingListViewModel(siteID: sampleSiteID, stores: stores, storage: storageManager)
+        let viewModel = BookingListViewModel(siteID: sampleSiteID,
+                                             type: .all,
+                                             stores: stores,
+                                             storage: storageManager)
 
         // When
         viewModel.loadBookings()
@@ -233,7 +248,10 @@ struct BookingListViewModelTests {
             }
             onCompletion(.success(false))
         }
-        let viewModel = BookingListViewModel(siteID: sampleSiteID, stores: stores, storage: storageManager)
+        let viewModel = BookingListViewModel(siteID: sampleSiteID,
+                                             type: .all,
+                                             stores: stores,
+                                             storage: storageManager)
 
         // When
         viewModel.loadBookings()
@@ -255,7 +273,10 @@ struct BookingListViewModelTests {
             self.insertBookings(items)
             onCompletion(.success(false))
         }
-        let viewModel = BookingListViewModel(siteID: sampleSiteID, stores: stores, storage: storageManager)
+        let viewModel = BookingListViewModel(siteID: sampleSiteID,
+                                             type: .all,
+                                             stores: stores,
+                                             storage: storageManager)
 
         // When
         viewModel.loadBookings()
@@ -282,7 +303,7 @@ struct BookingListViewModelTests {
 
             onCompletion(.success(false))
         }
-        let viewModel = BookingListViewModel(siteID: sampleSiteID, stores: stores)
+        let viewModel = BookingListViewModel(siteID: sampleSiteID, type: .all, stores: stores)
 
         // When
         await viewModel.onRefreshAction()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of WOOMOB-1392

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the view of the booking list to support fetching bookings separately for Today, Upcoming, and All tabs. The idea is to add a container view to keep 3 lists with separate view models, and only show/hide them upon tab selection.

The logic for fetching bookings of each tab will be handled in a subsequent PR.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a CIAB store with Bookings plugin v2.
- Select the Bookings tab.
- Switch between the different tabs.
- Confirm that all bookings are displayed in the All tab, while Today and Upcoming is empty.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested with simulator iPhone 17 iOS 26.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/7e5615cf-3014-47c9-883c-0f5b561dfdd8



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.