### PR TITLE
Bookings: Filter bookings for tabs

### DIFF
--- a/Modules/Sources/Networking/Remote/BookingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/BookingsRemote.swift
@@ -8,7 +8,9 @@ import Foundation
 public protocol BookingsRemoteProtocol {
     func loadAllBookings(for siteID: Int64,
                          pageNumber: Int,
-                         pageSize: Int) async throws -> [Booking]
+                         pageSize: Int,
+                         startDateBefore: String?,
+                         startDateAfter: String?) async throws -> [Booking]
 }
 
 /// Booking: Remote Endpoints
@@ -23,14 +25,26 @@ public final class BookingsRemote: Remote, BookingsRemoteProtocol {
     ///     - siteID: Site for which we'll fetch remote bookings.
     ///     - pageNumber: Number of page that should be retrieved.
     ///     - pageSize: Number of bookings to be retrieved per page.
+    ///     - startDateBefore: Filter bookings with start date before this timestamp.
+    ///     - startDateAfter: Filter bookings with start date after this timestamp.
     ///
     public func loadAllBookings(for siteID: Int64,
                                 pageNumber: Int = Default.pageNumber,
-                                pageSize: Int = Default.pageSize) async throws -> [Booking] {
-        let parameters = [
+                                pageSize: Int = Default.pageSize,
+                                startDateBefore: String? = nil,
+                                startDateAfter: String? = nil) async throws -> [Booking] {
+        var parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize)
         ]
+
+        if let startDateBefore = startDateBefore {
+            parameters[ParameterKey.startDateBefore] = startDateBefore
+        }
+
+        if let startDateAfter = startDateAfter {
+            parameters[ParameterKey.startDateAfter] = startDateAfter
+        }
 
         let path = Path.bookings
         let request = JetpackRequest(wooApiVersion: .wcBookings, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
@@ -53,7 +67,9 @@ public extension BookingsRemote {
     }
 
     private enum ParameterKey {
-        static let page: String       = "page"
-        static let perPage: String    = "per_page"
+        static let page: String            = "page"
+        static let perPage: String         = "per_page"
+        static let startDateBefore: String = "start_date_before"
+        static let startDateAfter: String  = "start_date_after"
     }
 }

--- a/Modules/Sources/Yosemite/Actions/BookingAction.swift
+++ b/Modules/Sources/Yosemite/Actions/BookingAction.swift
@@ -13,6 +13,8 @@ public enum BookingAction: Action {
     case synchronizeBookings(siteID: Int64,
                              pageNumber: Int,
                              pageSize: Int = BookingsRemote.Default.pageSize,
+                             startDateBefore: String? = nil,
+                             startDateAfter: String? = nil,
                              onCompletion: (Result<Bool, Error>) -> Void)
 
     /// Checks if the store already has any bookings.

--- a/Modules/Sources/Yosemite/Actions/BookingAction.swift
+++ b/Modules/Sources/Yosemite/Actions/BookingAction.swift
@@ -15,6 +15,7 @@ public enum BookingAction: Action {
                              pageSize: Int = BookingsRemote.Default.pageSize,
                              startDateBefore: String? = nil,
                              startDateAfter: String? = nil,
+                             shouldClearCache: Bool = false,
                              onCompletion: (Result<Bool, Error>) -> Void)
 
     /// Checks if the store already has any bookings.

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -35,8 +35,13 @@ public class BookingStore: Store {
         }
 
         switch action {
-        case let .synchronizeBookings(siteID, pageNumber, pageSize, onCompletion):
-            synchronizeBookings(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
+        case let .synchronizeBookings(siteID, pageNumber, pageSize, startDateBefore, startDateAfter, onCompletion):
+            synchronizeBookings(siteID: siteID,
+                                pageNumber: pageNumber,
+                                pageSize: pageSize,
+                                startDateBefore: startDateBefore,
+                                startDateAfter: startDateAfter,
+                                onCompletion: onCompletion)
         case let .checkIfStoreHasBookings(siteID, onCompletion):
             checkIfStoreHasBookings(siteID: siteID, onCompletion: onCompletion)
         }
@@ -53,12 +58,16 @@ private extension BookingStore {
     func synchronizeBookings(siteID: Int64,
                              pageNumber: Int,
                              pageSize: Int,
+                             startDateBefore: String?,
+                             startDateAfter: String?,
                              onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         Task { @MainActor in
             do {
                 let bookings = try await remote.loadAllBookings(for: siteID,
                                                                 pageNumber: pageNumber,
-                                                                pageSize: pageSize)
+                                                                pageSize: pageSize,
+                                                                startDateBefore: startDateBefore,
+                                                                startDateAfter: startDateAfter)
                 let shouldDeleteExistingBookings = pageNumber == Default.firstPageNumber
                 await upsertStoredBookingsInBackground(
                     readOnlyBookings: bookings,
@@ -89,7 +98,9 @@ private extension BookingStore {
             do {
                 let bookings = try await remote.loadAllBookings(for: siteID,
                                                                 pageNumber: 1,
-                                                                pageSize: 1)
+                                                                pageSize: 1,
+                                                                startDateBefore: nil,
+                                                                startDateAfter: nil)
                 let hasRemoteBookings = !bookings.isEmpty
                 onCompletion(.success(hasRemoteBookings))
             } catch {

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -35,12 +35,13 @@ public class BookingStore: Store {
         }
 
         switch action {
-        case let .synchronizeBookings(siteID, pageNumber, pageSize, startDateBefore, startDateAfter, onCompletion):
+        case let .synchronizeBookings(siteID, pageNumber, pageSize, startDateBefore, startDateAfter, shouldClearCache, onCompletion):
             synchronizeBookings(siteID: siteID,
                                 pageNumber: pageNumber,
                                 pageSize: pageSize,
                                 startDateBefore: startDateBefore,
                                 startDateAfter: startDateAfter,
+                                shouldClearCache: shouldClearCache,
                                 onCompletion: onCompletion)
         case let .checkIfStoreHasBookings(siteID, onCompletion):
             checkIfStoreHasBookings(siteID: siteID, onCompletion: onCompletion)
@@ -60,6 +61,7 @@ private extension BookingStore {
                              pageSize: Int,
                              startDateBefore: String?,
                              startDateAfter: String?,
+                             shouldClearCache: Bool,
                              onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         Task { @MainActor in
             do {
@@ -68,11 +70,10 @@ private extension BookingStore {
                                                                 pageSize: pageSize,
                                                                 startDateBefore: startDateBefore,
                                                                 startDateAfter: startDateAfter)
-                let shouldDeleteExistingBookings = pageNumber == Default.firstPageNumber
                 await upsertStoredBookingsInBackground(
                     readOnlyBookings: bookings,
                     siteID: siteID,
-                    shouldDeleteExistingBookings: shouldDeleteExistingBookings
+                    shouldDeleteExistingBookings: shouldClearCache
                 )
                 let hasNextPage = bookings.count == pageSize
                 onCompletion(.success(hasNextPage))

--- a/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
@@ -1,5 +1,6 @@
 import Testing
 @testable import Networking
+@testable import NetworkingCore
 
 struct BookingsRemoteTests {
 
@@ -34,5 +35,49 @@ struct BookingsRemoteTests {
         await #expect(throws: NetworkError.notFound()) {
             _ = try await remote.loadAllBookings(for: sampleSiteID)
         }
+    }
+
+    @Test func test_loadAllBookings_sends_correct_parameters() async throws {
+        // Given
+        let remote = BookingsRemote(network: network)
+        let startDateBefore = "2024-12-31T23:59:59"
+        let startDateAfter = "2024-01-01T00:00:00"
+        network.simulateResponse(requestUrlSuffix: "bookings", filename: "booking-list")
+
+        // When
+        _ = try await remote.loadAllBookings(for: sampleSiteID,
+                                             pageNumber: 2,
+                                             pageSize: 50,
+                                             startDateBefore: startDateBefore,
+                                             startDateAfter: startDateAfter)
+
+        // Then
+        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
+        let parameters = request.parameters
+
+        #expect((parameters["page"] as? String) == "2")
+        #expect((parameters["per_page"] as? String) == "50")
+        #expect((parameters["start_date_before"] as? String) == startDateBefore)
+        #expect((parameters["start_date_after"] as? String) == startDateAfter)
+    }
+
+    @Test func test_loadAllBookings_omits_nil_date_parameters() async throws {
+        // Given
+        let remote = BookingsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "bookings", filename: "booking-list")
+
+        // When
+        _ = try await remote.loadAllBookings(for: sampleSiteID,
+                                             startDateBefore: nil,
+                                             startDateAfter: nil)
+
+        // Then
+        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
+        let parameters = request.parameters
+
+        #expect(parameters["start_date_before"] == nil)
+        #expect(parameters["start_date_after"] == nil)
+        #expect(parameters["page"] != nil)
+        #expect(parameters["per_page"] != nil)
     }
 }

--- a/Modules/Tests/YosemiteTests/Mocks/MockBookingsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockBookingsRemote.swift
@@ -10,7 +10,11 @@ final class MockBookingsRemote: BookingsRemoteProtocol {
         loadAllBookingsResult = result
     }
 
-    func loadAllBookings(for siteID: Int64, pageNumber: Int, pageSize: Int) async throws -> [Booking] {
+    func loadAllBookings(for siteID: Int64,
+                         pageNumber: Int,
+                         pageSize: Int,
+                         startDateBefore: String?,
+                         startDateAfter: String?) async throws -> [Booking] {
         guard let result = loadAllBookingsResult else {
             throw NetworkError.timeout()
         }

--- a/Modules/Tests/YosemiteTests/Stores/BookingStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/BookingStoreTests.swift
@@ -207,6 +207,77 @@ struct BookingStoreTests {
         #expect(storedBookingCount == 2)
     }
 
+    @Test func synchronizeBookings_clears_existing_bookings_when_shouldClearCache_is_true() async throws {
+        // Given
+        let existingBooking = Booking.fake().copy(siteID: sampleSiteID, bookingID: 999)
+        storeBooking(existingBooking)
+        #expect(storedBookingCount == 1)
+
+        let newBooking = Booking.fake().copy(siteID: sampleSiteID, bookingID: 123)
+        remote.whenLoadingAllBookings(thenReturn: .success([newBooking]))
+        let store = BookingStore(dispatcher: Dispatcher(),
+                                 storageManager: storageManager,
+                                 network: network,
+                                 remote: remote)
+
+        // When
+        let result = await withCheckedContinuation { continuation in
+            store.onAction(BookingAction.synchronizeBookings(siteID: sampleSiteID,
+                                                             pageNumber: defaultPageNumber,
+                                                             pageSize: defaultPageSize,
+                                                             shouldClearCache: true,
+                                                             onCompletion: { result in
+                continuation.resume(returning: result)
+            }))
+        }
+
+        // Then
+        #expect(result.isSuccess)
+        #expect(storedBookingCount == 1)
+        let storedBooking = try #require(viewStorage.loadBooking(siteID: sampleSiteID, bookingID: 123))
+        #expect(storedBooking.bookingID == 123)
+
+        // Verify the existing booking was cleared
+        let existingStoredBooking = viewStorage.loadBooking(siteID: sampleSiteID, bookingID: 999)
+        #expect(existingStoredBooking == nil)
+    }
+
+    @Test func synchronizeBookings_preserves_existing_bookings_when_shouldClearCache_is_false() async throws {
+        // Given
+        let existingBooking = Booking.fake().copy(siteID: sampleSiteID, bookingID: 999)
+        storeBooking(existingBooking)
+        #expect(storedBookingCount == 1)
+
+        let newBooking = Booking.fake().copy(siteID: sampleSiteID, bookingID: 123)
+        remote.whenLoadingAllBookings(thenReturn: .success([newBooking]))
+        let store = BookingStore(dispatcher: Dispatcher(),
+                                 storageManager: storageManager,
+                                 network: network,
+                                 remote: remote)
+
+        // When
+        let result = await withCheckedContinuation { continuation in
+            store.onAction(BookingAction.synchronizeBookings(siteID: sampleSiteID,
+                                                             pageNumber: defaultPageNumber,
+                                                             pageSize: defaultPageSize,
+                                                             shouldClearCache: false,
+                                                             onCompletion: { result in
+                continuation.resume(returning: result)
+            }))
+        }
+
+        // Then
+        #expect(result.isSuccess)
+        #expect(storedBookingCount == 2)
+
+        // Verify both bookings exist
+        let newStoredBooking = try #require(viewStorage.loadBooking(siteID: sampleSiteID, bookingID: 123))
+        #expect(newStoredBooking.bookingID == 123)
+
+        let existingStoredBooking = try #require(viewStorage.loadBooking(siteID: sampleSiteID, bookingID: 999))
+        #expect(existingStoredBooking.bookingID == 999)
+    }
+
     // MARK: - checkIfStoreHasBookings
 
     @Test func checkIfStoreHasBookings_returns_true_when_bookings_exist_locally() async throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
@@ -92,7 +92,7 @@ struct BookingListViewModelTests {
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let booking = Booking.fake().copy(siteID: sampleSiteID)
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, _, _, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, _, _, _, _, _, onCompletion) = action else {
                 return
             }
             self.insertBookings([booking])
@@ -130,7 +130,7 @@ struct BookingListViewModelTests {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, _, _, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, _, _, _, _, _, onCompletion) = action else {
                 return
             }
             onCompletion(.success(false))
@@ -170,7 +170,7 @@ struct BookingListViewModelTests {
         let firstPageItems = [Booking](repeating: .fake().copy(siteID: sampleSiteID), count: 2)
         let secondPageItems = [Booking](repeating: .fake().copy(siteID: sampleSiteID), count: 1)
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, pageNumber, _, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, pageNumber, _, _, _, _, onCompletion) = action else {
                 return
             }
             invocationCountOfLoadBookings += 1
@@ -218,7 +218,7 @@ struct BookingListViewModelTests {
         let booking1 = Booking.fake().copy(siteID: sampleSiteID, bookingID: 9)
         let booking2 = Booking.fake().copy(siteID: sampleSiteID, bookingID: 10)
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, _, _, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, _, _, _, _, _, onCompletion) = action else {
                 return
             }
             self.insertBookings([booking1, booking2])
@@ -243,7 +243,7 @@ struct BookingListViewModelTests {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, _, _, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, _, _, _, _, _, onCompletion) = action else {
                 return
             }
             onCompletion(.success(false))
@@ -266,7 +266,7 @@ struct BookingListViewModelTests {
         let olderBooking = Booking.fake().copy(siteID: sampleSiteID, bookingID: 1, dateCreated: Date(timeIntervalSince1970: 1000))
         let newerBooking = Booking.fake().copy(siteID: sampleSiteID, bookingID: 3, dateCreated: Date(timeIntervalSince1970: 2000))
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, _, _, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, _, _, _, _, _, onCompletion) = action else {
                 return
             }
             let items = [olderBooking, newerBooking]
@@ -295,7 +295,7 @@ struct BookingListViewModelTests {
         var invocationCountOfLoadBookings = 0
         var skip: Int?
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, pageNumber, pageSize, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, pageNumber, pageSize, _, _, _, onCompletion) = action else {
                 return
             }
             invocationCountOfLoadBookings += 1


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of WOOMOB-1392

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the Networking and Yosemite layers to support filter bookings by dates to support different tabs of bookings. The integration of the new fields will be handled in a subsequent PR.

Also updated the logic for clearing cache to avoid clearing cache when switch tabs. I'll update the `BookingListViewModel` to support clearing cache only upon pulling to refresh later.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Since the new fields haven't been used yet, just CI passing is sufficient.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Added unit tests for updates in BookingsRemote and BookingStore.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.