### PR TITLE
[WCiOS17] Update `PaymentsRow` to not use `NavigationLink` API

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncCouponsErrorMessageView.swift
@@ -125,16 +125,12 @@ private extension String {
 
 #if DEBUG
 #Preview {
-    if #available(iOS 17.0, *) {
-        PointOfSaleOrderSyncCouponsErrorMessageView(message: "An error happened!") {}
-            .environment(POSPreviewHelpers.makePreviewAggregateModel())
-    }
+    PointOfSaleOrderSyncCouponsErrorMessageView(message: "An error happened!") {}
+        .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }
 
 #Preview {
-    if #available(iOS 17.0, *) {
-        PointOfSaleOrderSyncCouponsErrorMessageView(message: "Lo sentimos, este cupón no se puede aplicar a los productos seleccionados.") {}
-            .environment(POSPreviewHelpers.makePreviewAggregateModel())
-    }
+    PointOfSaleOrderSyncCouponsErrorMessageView(message: "Lo sentimos, este cupón no se puede aplicar a los productos seleccionados.") {}
+        .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }
 #endif

--- a/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSIneligibleView.swift
@@ -209,48 +209,38 @@ private extension POSIneligibleReason {
 #if DEBUG
 
 #Preview("Unsupported currency") {
-    if #available(iOS 17.0, *) {
-        POSIneligibleView(
-            reason: .unsupportedCurrency(countryCode: .US, supportedCurrencies: [.USD]),
-            onRefresh: {}
-        )
-    }
+    POSIneligibleView(
+        reason: .unsupportedCurrency(countryCode: .US, supportedCurrencies: [.USD]),
+        onRefresh: {}
+    )
 }
 
 #Preview("WooCommerce plugin not found") {
-    if #available(iOS 17.0, *) {
-        POSIneligibleView(
-            reason: .wooCommercePluginNotFound,
-            onRefresh: {}
-        )
-    }
+    POSIneligibleView(
+        reason: .wooCommercePluginNotFound,
+        onRefresh: {}
+    )
 }
 
 #Preview("Feature switch disabled") {
-    if #available(iOS 17.0, *) {
-        POSIneligibleView(
-            reason: .featureSwitchDisabled,
-            onRefresh: {}
-        )
-    }
+    POSIneligibleView(
+        reason: .featureSwitchDisabled,
+        onRefresh: {}
+    )
 }
 
 #Preview("Site settings unavailable") {
-    if #available(iOS 17.0, *) {
-        POSIneligibleView(
-            reason: .siteSettingsNotAvailable,
-            onRefresh: {}
-        )
-    }
+    POSIneligibleView(
+        reason: .siteSettingsNotAvailable,
+        onRefresh: {}
+    )
 }
 
 #Preview("Unsupported WooCommerce version") {
-    if #available(iOS 17.0, *) {
-        POSIneligibleView(
-            reason: .unsupportedWooCommerceVersion(minimumVersion: "9.6.0"),
-            onRefresh: {}
-        )
-    }
+    POSIneligibleView(
+        reason: .unsupportedWooCommerceVersion(minimumVersion: "9.6.0"),
+        onRefresh: {}
+    )
 }
 
 #endif

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -146,8 +146,7 @@ private extension POSTabCoordinator {
                let orderService = POSOrderService(siteID: siteID,
                                                   credentials: credentials,
                                                   selectedSite: defaultSitePublisher,
-                                                  appPasswordSupportState: isAppPasswordSupported),
-               #available(iOS 17.0, *) {
+                                                  appPasswordSupportState: isAppPasswordSupported) {
                 let posView = PointOfSaleEntryPointView(
                     siteID: siteID,
                     itemFetchStrategyFactory: posItemFetchStrategyFactory,

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
@@ -12,7 +12,7 @@ final class OrderPaymentDetailsViewModel {
     }
 
     var subtotalValue: String {
-        return order.subtotalValue(currencyFormatter: currencyFormatter) ?? String()
+        return order.subtotalValue(currencyFormatter: currencyFormatter)
     }
 
     var shouldHideSubtotal: Bool {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -82,13 +82,13 @@ struct InPersonPaymentsMenu: View {
                             viewModel.purchaseCardReaderTapped()
                         } label: {
                             PaymentsRow(image: Image(uiImage: .shoppingCartIcon),
-                                        title: Localization.purchaseCardReader,
-                                        isActive: $viewModel.presentPurchaseCardReader) {
-                                AuthenticatedWebView(isPresented: .constant(true),
-                                                     viewModel: viewModel.purchaseCardReaderWebViewModel)
-                            }
+                                        title: Localization.purchaseCardReader)
                         }
                         .buttonStyle(.scrollViewRow)
+                        .navigationDestination(isPresented: $viewModel.presentPurchaseCardReader) {
+                            AuthenticatedWebView(isPresented: .constant(true),
+                                                 viewModel: viewModel.purchaseCardReaderWebViewModel)
+                        }
 
                         Button {
                             viewModel.manageCardReadersTapped()
@@ -118,12 +118,12 @@ struct InPersonPaymentsMenu: View {
                             viewModel.cardReaderManualsTapped()
                         } label: {
                             PaymentsRow(image: Image(uiImage: .cardReaderManualIcon),
-                                        title: Localization.cardReaderManuals,
-                                        isActive: $viewModel.presentCardReaderManuals) {
-                                CardReaderManualsView()
-                            }
+                                        title: Localization.cardReaderManuals)
                         }
                         .buttonStyle(.scrollViewRow)
+                        .navigationDestination(isPresented: $viewModel.presentCardReaderManuals) {
+                            CardReaderManualsView()
+                        }
                         .accessibilityIdentifier(AccessibilityIdentifiers.cardReaderManualRow)
                     } header: {
                         Text(Localization.cardReaderSectionTitle.uppercased())

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/PaymentsRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/PaymentsRow.swift
@@ -1,25 +1,19 @@
 import SwiftUI
 
-struct PaymentsRow<Destination>: View where Destination: View {
+struct PaymentsRow: View {
     private let image: Image
     private let title: String
     private let subtitle: String?
     private let shouldBadgeImage: Bool
-    private var isActive: Binding<Bool>?
-    @ViewBuilder private let destination: (() -> Destination)?
 
     init(image: Image,
          title: String,
          subtitle: String? = nil,
-         shouldBadgeImage: Bool = false,
-         isActive: Binding<Bool>,
-         @ViewBuilder destination: @escaping () -> Destination) {
+         shouldBadgeImage: Bool = false) {
         self.image = image
         self.title = title
         self.subtitle = subtitle
         self.shouldBadgeImage = shouldBadgeImage
-        self.destination = destination
-        self.isActive = isActive
     }
 
     var body: some View {
@@ -49,36 +43,6 @@ struct PaymentsRow<Destination>: View where Destination: View {
             Spacer()
         }
         .contentShape(Rectangle())
-
-        navigationLink
-    }
-
-    @ViewBuilder
-    private var navigationLink: some View {
-        if let isActive,
-           let destination {
-            NavigationLink(isActive: isActive) {
-                destination()
-            } label: {
-                EmptyView()
-            }
-        } else {
-            EmptyView()
-        }
-    }
-}
-
-extension PaymentsRow where Destination == Never {
-    init(image: Image,
-         title: String,
-         subtitle: String? = nil,
-         shouldBadgeImage: Bool = false) {
-        self.image = image
-        self.title = title
-        self.subtitle = subtitle
-        self.shouldBadgeImage = shouldBadgeImage
-        self.destination = nil
-        self.isActive = nil
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressMapPickerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressMapPickerView.swift
@@ -162,9 +162,5 @@ private extension AddressMapPickerView {
 }
 
 #Preview {
-    if #available(iOS 17, *) {
-        AddressMapPickerView(fields: .constant(.init()), countryByCode: { _ in nil })
-    } else {
-        EmptyView()
-    }
+    AddressMapPickerView(fields: .constant(.init()), countryByCode: { _ in nil })
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -244,9 +244,7 @@ struct SingleAddressForm: View {
                 }
             }
             .sheet(isPresented: $showMapPicker) {
-                if #available(iOS 17, *) {
-                    AddressMapPickerView(fields: $fields, countryByCode: countryByCode)
-                }
+                AddressMapPickerView(fields: $fields, countryByCode: countryByCode)
             }
     }
 
@@ -324,7 +322,7 @@ struct SingleAddressForm: View {
             .padding(.horizontal, insets: safeAreaInsets)
             .accessibility(addTraits: .isHeader)
         VStack(spacing: 0) {
-            if #available(iOS 17, *), ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderAddressMapSearch) {
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderAddressMapSearch) {
                 Button(action: {
                     showMapPicker = true
                     ServiceLocator.analytics.track(.orderDetailEditAddressMapPickerTapped,

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
@@ -96,18 +96,9 @@ private extension BadgeView {
     func backgroundView() -> some View {
         switch backgroundShape {
         case .circle:
-            if #available(iOS 17, *) {
-                Circle()
-                    .fill(customizations.backgroundColor)
-                    .stroke(Color.white, lineWidth: Layout.borderLineWidth)
-            } else {
-                ZStack {
-                    Circle()
-                        .fill(customizations.backgroundColor)
-                    Circle()
-                        .stroke(Color.white, lineWidth: Layout.borderLineWidth)
-                }
-            }
+            Circle()
+                .fill(customizations.backgroundColor)
+                .stroke(Color.white, lineWidth: Layout.borderLineWidth)
         case .roundedRectangle(let cornerRadius):
             RoundedRectangle(cornerRadius: cornerRadius)
                 .stroke(.white, lineWidth: Layout.borderLineWidth)


### PR DESCRIPTION
Closes WOOMOB-1301
Closes WOOMOB-1304

## Description
This PR updates the `PaymentsRow` component from Menu > Settings to not use deprecated `NavigationLink(isActive:)` API for navigation. It also removes the remaining iOS17 availability checks, mainly in previews.

## Changes

The only usage of navigation link with `isActive` binding across the existing payment rows is in 2 instances:
- "Order Card Reader" row
- "Card Reader Manuals" row

The rest of rows either use a `.sheet`, or are wrapped in a button. Since the parent view (`InPersonPaymentsMenu` is already wrapped in a `NavigationStack`, we can simplify the view and handle the rows as we already handle the rest via `.navigationDestination` in the parent.

## Testing information
- Navigate to Menu > Payments
- Observe that tapping the rows, they behave normally. Specifically `Order Card Reader` and `Card Reader Manuals` rows

Tested on iPhone 16 plus - iOS 18.3 simulator, and iPhone 14 18.6.2 physical device

![Simulator Screen Recording - iPhone 16 Plus - US store - 2025-10-02 at 12 43 21](https://github.com/user-attachments/assets/2b6743fc-1e72-4111-83a2-225336464292)

