### PR TITLE
Fix crash from continuation being resumed more than once in `BackgroundTaskSystemInfo.getNetworkInfo`

### DIFF
--- a/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
@@ -175,8 +175,11 @@ private struct BackgroundTaskSystemInfo {
     private static func getNetworkInfo() async -> NetworkInfo {
         return await withCheckedContinuation { continuation in
             let monitor = NWPathMonitor()
+            var hasResumed = false
 
             monitor.pathUpdateHandler = { path in
+                guard !hasResumed else { return }
+                hasResumed = true
                 monitor.cancel()
                 continuation.resume(returning: NetworkInfo(path: path))
             }

--- a/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
@@ -173,19 +173,27 @@ private struct BackgroundTaskSystemInfo {
     }
 
     private static func getNetworkInfo() async -> NetworkInfo {
-        return await withCheckedContinuation { continuation in
-            let monitor = NWPathMonitor()
-            var hasResumed = false
+        let monitor = NWPathMonitor()
+        let queue = DispatchQueue(label: "network.monitor.queue")
 
-            monitor.pathUpdateHandler = { path in
-                guard !hasResumed else { return }
-                hasResumed = true
-                monitor.cancel()
-                continuation.resume(returning: NetworkInfo(path: path))
-            }
+        let (stream, continuation) = AsyncStream.makeStream(of: NWPath.self)
 
-            let queue = DispatchQueue(label: "network.monitor.queue")
-            monitor.start(queue: queue)
+        monitor.pathUpdateHandler = { path in
+            continuation.yield(path)
+        }
+
+        monitor.start(queue: queue)
+
+        defer {
+            continuation.finish()
+            monitor.cancel()
+        }
+
+        if let path = await stream.first(where: { _ in true }) {
+            return NetworkInfo(path: path)
+        } else {
+            // Fallback in case no path is received.
+            return NetworkInfo(type: "unknown", isExpensive: false, isLowDataMode: false)
         }
     }
 }

--- a/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
@@ -189,7 +189,13 @@ private struct BackgroundTaskSystemInfo {
             monitor.cancel()
         }
 
+        let timeoutTask = Task {
+            try await Task.sleep(nanoseconds: 1 * NSEC_PER_SEC)
+            continuation.finish()
+        }
+
         if let path = await stream.first(where: { _ in true }) {
+            timeoutTask.cancel()
             return NetworkInfo(path: path)
         } else {
             // Fallback in case no path is received.


### PR DESCRIPTION
For WOOMOB-1204
Just one review is required.

## What
Fix a crash in `getNetworkInfo()` where the continuation was being resumed more than once.

## Why
The `NWPathMonitor`'s `pathUpdateHandler` can fire multiple times before the monitor is fully canceled, causing the checked continuation to resume more than once and crash with:

```
Level: Fatal
_Concurrency/CheckedContinuation.swift:169: Fatal error: SWIFT TASK CONTINUATION MISUSE: getNetworkInfo() tried to resume its continuation more than once
```

## How
Replaced `withCheckedContinuation` with `AsyncStream` to properly handle multiple path updates from `NWPathMonitor`. The stream collects path updates and we take only the first one using `stream.first(where:)`. This approach:
- Naturally handles multiple handler invocations without crashing
- Properly cleans up the monitor and stream in the `defer` block
- Provides a fallback for the edge case where no path is received

## Testing steps

Follow the testing steps from https://github.com/woocommerce/woocommerce-ios/pull/16052:

1. Launch the app with a breakpoint in `BackgroundTaskRefreshDispatcher.scheduleAppRefresh():23`
2. Background the app and hit the breakpoint
3. Step over the `try BGTaskScheduler.shared.submit(request)` line
4. Use LLDB command `e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"com.automattic.woocommerce.refresh"]` to trigger a refresh
5. Verify that the analytic `background_data_synced` is synced with expected properties

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested the steps above on iPad Pro 11in 3rd generation, iOS 26.0.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.