### PR TITLE
Bookings: Parse currency and update Booking entity accordingly

### DIFF
--- a/Modules/Sources/Fakes/Networking.generated.swift
+++ b/Modules/Sources/Fakes/Networking.generated.swift
@@ -338,7 +338,8 @@ extension Networking.Booking {
             resourceID: .fake(),
             startDate: .fake(),
             statusKey: .fake(),
-            localTimezone: .fake()
+            localTimezone: .fake(),
+            currency: .fake()
         )
     }
 }

--- a/Modules/Sources/Networking/Model/Bookings/Booking.swift
+++ b/Modules/Sources/Networking/Model/Bookings/Booking.swift
@@ -21,6 +21,7 @@ public struct Booking: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
     public let startDate: Date
     public let statusKey: String
     public let localTimezone: String
+    public let currency: String
 
     // periphery: ignore - to be used later
     public var bookingStatus: BookingStatus {
@@ -45,7 +46,8 @@ public struct Booking: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
                 resourceID: Int64,
                 startDate: Date,
                 statusKey: String,
-                localTimezone: String) {
+                localTimezone: String,
+                currency: String) {
         self.siteID = siteID
         self.bookingID = bookingID
         self.allDay = allDay
@@ -63,6 +65,7 @@ public struct Booking: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         self.startDate = startDate
         self.statusKey = statusKey
         self.localTimezone = localTimezone
+        self.currency = currency
     }
 
     /// The public initializer for Booking.
@@ -95,6 +98,7 @@ public struct Booking: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         let startDate = Date(timeIntervalSince1970: try container.decode(Double.self, forKey: .startDate))
         let statusKey = try container.decode(String.self, forKey: .statusKey)
         let localTimezone = try container.decode(String.self, forKey: .localTimezone)
+        let currency = try container.decode(String.self, forKey: .currency)
 
         self.init(siteID: siteID,
                   bookingID: bookingID,
@@ -112,7 +116,8 @@ public struct Booking: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
                   resourceID: resourceID,
                   startDate: startDate,
                   statusKey: statusKey,
-                  localTimezone: localTimezone)
+                  localTimezone: localTimezone,
+                  currency: currency)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -163,6 +168,7 @@ private extension Booking {
         case startDate = "start"
         case statusKey = "status"
         case localTimezone = "local_timezone"
+        case currency
     }
 }
 

--- a/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -446,7 +446,8 @@ extension Networking.Booking {
         resourceID: CopiableProp<Int64> = .copy,
         startDate: CopiableProp<Date> = .copy,
         statusKey: CopiableProp<String> = .copy,
-        localTimezone: CopiableProp<String> = .copy
+        localTimezone: CopiableProp<String> = .copy,
+        currency: CopiableProp<String> = .copy
     ) -> Networking.Booking {
         let siteID = siteID ?? self.siteID
         let bookingID = bookingID ?? self.bookingID
@@ -465,6 +466,7 @@ extension Networking.Booking {
         let startDate = startDate ?? self.startDate
         let statusKey = statusKey ?? self.statusKey
         let localTimezone = localTimezone ?? self.localTimezone
+        let currency = currency ?? self.currency
 
         return Networking.Booking(
             siteID: siteID,
@@ -483,7 +485,8 @@ extension Networking.Booking {
             resourceID: resourceID,
             startDate: startDate,
             statusKey: statusKey,
-            localTimezone: localTimezone
+            localTimezone: localTimezone,
+            currency: currency
         )
     }
 }

--- a/Modules/Sources/Storage/Model/Booking/Booking+CoreDataProperties.swift
+++ b/Modules/Sources/Storage/Model/Booking/Booking+CoreDataProperties.swift
@@ -20,5 +20,6 @@ extension Booking {
     @NSManaged public var orderItemID: Int64
     @NSManaged public var statusKey: String?
     @NSManaged public var localTimezone: String?
+    @NSManaged public var currency: String?
 
 }

--- a/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 127.xcdatamodel/contents
+++ b/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 127.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="24G90" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="25A354" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Account" representedClassName="Account" syncable="YES">
         <attribute name="displayName" optional="YES" attributeType="String"/>
         <attribute name="email" optional="YES" attributeType="String"/>
@@ -66,6 +66,7 @@
         <attribute name="allDay" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="bookingID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="cost" attributeType="String" defaultValueString=""/>
+        <attribute name="currency" optional="YES" attributeType="String"/>
         <attribute name="customerID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>

--- a/Modules/Sources/Yosemite/Model/Booking/Booking+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Booking/Booking+ReadOnlyConvertible.swift
@@ -47,6 +47,7 @@ extension Storage.Booking: ReadOnlyConvertible {
                 resourceID: resourceID,
                 startDate: startDate ?? Date(),
                 statusKey: statusKey ?? "",
-                localTimezone: localTimezone ?? "")
+                localTimezone: localTimezone ?? "",
+                currency: "")
     }
 }

--- a/Modules/Sources/Yosemite/Model/Booking/Booking+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Booking/Booking+ReadOnlyConvertible.swift
@@ -26,6 +26,7 @@ extension Storage.Booking: ReadOnlyConvertible {
         startDate = booking.startDate
         statusKey = booking.statusKey
         localTimezone = booking.localTimezone
+        currency = booking.currency
     }
 
     /// Returns a ReadOnly version of the receiver.
@@ -48,6 +49,6 @@ extension Storage.Booking: ReadOnlyConvertible {
                 startDate: startDate ?? Date(),
                 statusKey: statusKey ?? "",
                 localTimezone: localTimezone ?? "",
-                currency: "")
+                currency: currency ?? "USD")
     }
 }

--- a/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
@@ -24,6 +24,7 @@ struct BookingsRemoteTests {
         #expect(firstBooking.productID == 23)
         #expect(firstBooking.customerID == 0)
         #expect(firstBooking.siteID == sampleSiteID)
+        #expect(firstBooking.currency == "USD")
     }
 
     @Test func test_loadAllBookings_properly_relays_netwoking_errors() async {

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -343,7 +343,8 @@ struct BookingDetailsView_Previews: PreviewProvider {
             resourceID: 113,
             startDate: now,
             statusKey: "paid",
-            localTimezone: "America/New_York"
+            localTimezone: "America/New_York",
+            currency: "USD"
         )
         let viewModel = BookingDetailsViewModel(booking: sampleBooking)
         return BookingDetailsView(viewModel)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1413 

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We need currency of each booking to display the correct costs in case some merchants use plugins that support multiple currencies. 

This PR parse the currency field for bookings and updates the Core Data entity accordingly. No migration is added as the new entity was introduced in this same app version. It would be nice to get this PR merged for 23.4 for that reason.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Log in to a CIAB stores with existing bookings.
- Navigate to the Bookings tab.
- Switch to All tab of the list and confirm that bookings are still loaded.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Added a test for parsing currency.
- Ran the app and opened the Bookings tab and confirmed that bookings are still parsed properly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.