### PR TITLE
[Bookings] Customer data for Booking Details

### DIFF
--- a/Modules/Sources/Yosemite/Actions/CustomerAction.swift
+++ b/Modules/Sources/Yosemite/Actions/CustomerAction.swift
@@ -100,4 +100,7 @@ public enum CustomerAction: Action {
     ///- `siteID`: The site for which customers should be delete.
     ///- `onCompletion`: Invoked when the operation finishes.
     case deleteAllCustomers(siteID: Int64, onCompletion: () -> Void)
+
+    /// Loads a customer for the specified `siteID` and `customerID` from storage.
+    case loadCustomer(siteID: Int64, customerID: Int64, onCompletion: (Result<Customer, Error>) -> Void)
 }

--- a/Modules/Sources/Yosemite/Stores/CustomerStore.swift
+++ b/Modules/Sources/Yosemite/Stores/CustomerStore.swift
@@ -80,6 +80,8 @@ public final class CustomerStore: Store {
             synchronizeAllCustomers(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
         case .deleteAllCustomers(siteID: let siteID, onCompletion: let onCompletion):
             deleteAllCustomers(from: siteID, onCompletion: onCompletion)
+        case let .loadCustomer(siteID, customerID, onCompletion):
+            loadCustomer(siteID: siteID, customerID: customerID, onCompletion: onCompletion)
         }
     }
 
@@ -249,6 +251,16 @@ public final class CustomerStore: Store {
         storageManager.performAndSave({ storage in
             storage.deleteCustomers(siteID: siteID)
         }, completion: onCompletion, on: .main)
+    }
+
+    private func loadCustomer(siteID: Int64, customerID: Int64, onCompletion: @escaping (Result<Networking.Customer, Error>) -> Void) {
+        let customers = storageManager.viewStorage.loadCustomers(siteID: siteID, matching: [customerID])
+        if let storageCustomer = customers.first {
+            let customer = storageCustomer.toReadOnly()
+            onCompletion(.success(customer))
+        } else {
+            onCompletion(.failure(CustomerStoreError.notFound))
+        }
     }
 
     /// Maps CustomerSearchResult to Customer objects
@@ -428,4 +440,10 @@ private extension CustomerStore {
         storedSearchResult?.addToCustomers(storageCustomer)
         storageCustomer.update(with: readOnlyCustomer)
     }
+}
+
+// MARK: - Errors
+
+enum CustomerStoreError: Error {
+    case notFound
 }

--- a/WooCommerce/Classes/View Modifiers/View+Tappable.swift
+++ b/WooCommerce/Classes/View Modifiers/View+Tappable.swift
@@ -8,6 +8,7 @@ private struct TappableViewModifier: ViewModifier {
             onTap()
         } label: {
             content
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -1,7 +1,4 @@
 import Foundation
-import struct Networking.Booking
-import struct Networking.Customer
-import struct Networking.Address
 import Yosemite
 import SwiftUI // Added for withAnimation
 

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -2,7 +2,6 @@ import Foundation
 import struct Networking.Booking
 import struct Networking.Customer
 import struct Networking.Address
-import WooFoundation
 import Yosemite
 import SwiftUI // Added for withAnimation
 

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -60,6 +60,30 @@ final class BookingDetailsViewModel: ObservableObject {
     }
 }
 
+// MARK: Local Data
+
+extension BookingDetailsViewModel {
+    func loadLocalData() {
+        loadCustomerData()
+    }
+}
+
+private extension BookingDetailsViewModel {
+    func loadCustomerData() {
+        guard booking.customerID > 0 else {
+            return
+        }
+
+        let action = CustomerAction.loadCustomer(siteID: booking.siteID, customerID: booking.customerID) { [weak self] result in
+            guard let self = self else { return }
+            if case .success(let customer) = result {
+                self.updateCustomerSection(with: customer)
+            }
+        }
+        stores.dispatch(action)
+    }
+}
+
 // MARK: Syncing
 
 extension BookingDetailsViewModel {
@@ -76,15 +100,7 @@ private extension BookingDetailsViewModel {
 
         do {
             let fetchedCustomer = try await retrieveCustomer()
-            customerContent.update(with: fetchedCustomer)
-
-            let customerSection = Section(
-                header: .title(Localization.customerSectionHeaderTitle.uppercased()),
-                content: .customer(customerContent)
-            )
-            withAnimation {
-                sections.insert(customerSection, at: 2)
-            }
+            updateCustomerSection(with: fetchedCustomer)
         } catch {
             DDLogError("⛔️ Error synchronizing Customer for Booking: \(error)")
         }
@@ -104,6 +120,23 @@ private extension BookingDetailsViewModel {
                 }
             }
             stores.dispatch(action)
+        }
+    }
+
+    private func updateCustomerSection(with customer: Customer) {
+        customerContent.update(with: customer)
+
+        // Avoid adding if it already exists
+        guard !sections.contains(where: { if case .customer = $0.content { return true } else { return false } }) else {
+            return
+        }
+
+        let customerSection = Section(
+            header: .title(Localization.customerSectionHeaderTitle.uppercased()),
+            content: .customer(customerContent)
+        )
+        withAnimation {
+            sections.insert(customerSection, at: 2)
         }
     }
 

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -140,12 +140,7 @@ private extension BookingDetailsViewModel {
 
     /// Returns true when the `customerID` is non-zero and customer section doesn't exist
     var shouldSyncCustomer: Bool {
-        return booking.customerID > 0 && !sections.contains(where: {
-            if case .customer = $0.content {
-                return true
-            }
-            return false
-        })
+        return booking.customerID > 0
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -1,14 +1,31 @@
 import Foundation
 import struct Networking.Booking
+import struct Networking.Customer
+import struct Networking.Address
+import WooFoundation
+import Yosemite
+import SwiftUI // Added for withAnimation
 
+@MainActor
 final class BookingDetailsViewModel: ObservableObject {
-    let sections: [Section]
+    private let stores: StoresManager
+
     let navigationTitle: String
 
-    init(booking: Booking) {
-        navigationTitle = Self.navigationTitle(for: booking)
+    private let booking: Booking
+    private let customerContent = CustomerContent()
 
-        let headerSection = Section.init(
+    @Published private(set) var sections: [Section] = []
+
+    init(booking: Booking, stores: StoresManager = ServiceLocator.stores) {
+        self.booking = booking
+        self.stores = stores
+        navigationTitle = Self.navigationTitle(for: booking)
+        setupSections()
+    }
+
+    private func setupSections() {
+        let headerSection = Section(
             content: .header(HeaderContent(booking))
         )
 
@@ -21,21 +38,6 @@ final class BookingDetailsViewModel: ObservableObject {
             header: .title(Localization.attendanceSectionHeaderTitle.uppercased()),
             footerText: Localization.attendanceSectionFooterText,
             content: .attendance(AttendanceContent())
-        )
-
-        let customerSection = Section(
-            header: .title(Localization.customerSectionHeaderTitle.uppercased()),
-            content: .customer(
-                /// Temporary hardcode
-                CustomerContent(
-                    nameText: "Margarita Nikolaevna",
-                    emailText: "margarita.n@mail.com",
-                    phoneText: "+1 742582943798",
-                    billingAddressText: """
-                        238 Willow Creek Drive Montgomery AL 36109
-                        """
-                )
-            )
         )
 
         let paymentSection = Section(
@@ -51,11 +53,68 @@ final class BookingDetailsViewModel: ObservableObject {
         sections = [
             headerSection,
             appointmentDetailsSection,
-            customerSection,
             attendanceSection,
             paymentSection,
             bookingNotes
         ]
+    }
+}
+
+// MARK: Syncing
+
+extension BookingDetailsViewModel {
+    func syncData() async {
+        await syncCustomer()
+    }
+}
+
+private extension BookingDetailsViewModel {
+    func syncCustomer() async {
+        guard shouldSyncCustomer else {
+            return
+        }
+
+        do {
+            let fetchedCustomer = try await retrieveCustomer()
+            customerContent.update(with: fetchedCustomer)
+
+            let customerSection = Section(
+                header: .title(Localization.customerSectionHeaderTitle.uppercased()),
+                content: .customer(customerContent)
+            )
+            withAnimation {
+                sections.insert(customerSection, at: 2)
+            }
+        } catch {
+            DDLogError("⛔️ Error synchronizing Customer for Booking: \(error)")
+        }
+    }
+
+    func retrieveCustomer() async throws -> Customer {
+        try await withCheckedThrowingContinuation { continuation in
+            let action = CustomerAction.retrieveCustomer(
+                siteID: booking.siteID,
+                customerID: booking.customerID
+            ) { result in
+                switch result {
+                case .success(let customer):
+                    continuation.resume(returning: customer)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+            stores.dispatch(action)
+        }
+    }
+
+    /// Returns true when the `customerID` is non-zero and customer section doesn't exist
+    var shouldSyncCustomer: Bool {
+        return booking.customerID > 0 && !sections.contains(where: {
+            if case .customer = $0.content {
+                return true
+            }
+            return false
+        })
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/Booking Details/CustomerContent.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/CustomerContent.swift
@@ -1,10 +1,42 @@
 import Foundation
+import Networking
 
 extension BookingDetailsViewModel {
-    struct CustomerContent {
-        let nameText: String
-        let emailText: String
-        let phoneText: String
-        let billingAddressText: String?
+    final class CustomerContent: ObservableObject {
+        @Published var nameText: String?
+        @Published var emailText: String?
+        @Published var phoneText: String?
+        @Published var billingAddressText: String?
+
+        func update(with customer: Customer) {
+            let name = [
+                customer.firstName,
+                customer.lastName
+            ]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+
+            let billingAddress = customer.billing.flatMap(formatAddress)
+
+            nameText = name
+            emailText = customer.email
+            phoneText = customer.billing?.phone ?? ""
+            billingAddressText = billingAddress
+        }
+
+        private func formatAddress(_ address: Address) -> String {
+            [
+                address.address1,
+                address.address2,
+                address.city,
+                address.state,
+                address.postcode,
+                address.country
+            ]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView+RowTextStyle.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView+RowTextStyle.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+private extension BookingDetailsView {
+    struct RowTextStyle: ViewModifier {
+        func body(content: Content) -> some View {
+            content
+                .font(TextFont.bodyMedium)
+                .foregroundStyle(.primary)
+                .multilineTextAlignment(.leading)
+        }
+    }
+}
+
+extension View {
+    func rowTextStyle() -> some View {
+        self.modifier(BookingDetailsView.RowTextStyle())
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -318,13 +318,6 @@ extension BookingDetailsView {
             comment: "'Status' row title in attendance section in booking details view."
         )
 
-        /// Customer section
-        static let billingAddressRowTitle = NSLocalizedString(
-            "BookingDetailsView.customer.billingAddress.title",
-            value: "Billing address",
-            comment: "Billing address row title in customer section in booking details view."
-        )
-
         /// Booking notes
         static let bookingNotesRowText = NSLocalizedString(
             "BookingDetailsView.bookingNotes.addANoteRow.title",

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -27,6 +27,10 @@ struct BookingDetailsView: View {
     init(_ viewModel: BookingDetailsViewModel) {
         self.viewModel = viewModel
 
+        /// Trigger local data load
+        viewModel.loadLocalData()
+
+        /// Trigger remote data sync
         Task {
             await viewModel.syncData()
         }

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -26,6 +26,10 @@ struct BookingDetailsView: View {
 
     init(_ viewModel: BookingDetailsViewModel) {
         self.viewModel = viewModel
+
+        Task {
+            await viewModel.syncData()
+        }
     }
 
     var body: some View {
@@ -34,11 +38,6 @@ struct BookingDetailsView: View {
                 ForEach(viewModel.sections) { section in
                     sectionView(with: section)
                 }
-            }
-        }
-        .onAppear {
-            Task {
-                await viewModel.syncData()
             }
         }
         .refreshable {

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -9,7 +9,7 @@ struct BookingDetailsView: View {
 
     @ObservedObject private var viewModel: BookingDetailsViewModel
 
-    private enum Layout {
+    enum Layout {
         static let contentSidePadding: CGFloat = 16
         static let contentVerticalPadding: CGFloat = 16
         static let headerContentVerticalPadding: CGFloat = 6
@@ -18,7 +18,7 @@ struct BookingDetailsView: View {
         static let rowTextVerticalPadding: CGFloat = 11
     }
 
-    fileprivate enum TextFont {
+    enum TextFont {
         static var bodyMedium: Font {
             Font.body.weight(.medium)
         }
@@ -36,8 +36,13 @@ struct BookingDetailsView: View {
                 }
             }
         }
+        .onAppear {
+            Task {
+                await viewModel.syncData()
+            }
+        }
         .refreshable {
-            print("Refresh triggered")
+            await viewModel.syncData()
         }
         .navigationBarTitleDisplayMode(.inline)
         .navigationTitle(viewModel.navigationTitle)
@@ -127,7 +132,7 @@ private extension BookingDetailsView {
         case .attendance(let content):
             attendanceView(with: content)
         case .customer(let content):
-            customerDetailsView(with: content)
+            CustomerDetailsView(content: content)
         case .payment(let content):
             paymentDetailsView(with: content)
         case .bookingNotes:
@@ -194,71 +199,6 @@ private extension BookingDetailsView {
         }
     }
 
-    func customerDetailsView(with content: BookingDetailsViewModel.CustomerContent) -> some View {
-        VStack(spacing: 0) {
-            /// Name
-            HStack {
-                Text(content.nameText)
-                    .rowTextStyle()
-                Spacer()
-            }
-            .padding(.vertical, Layout.rowTextVerticalPadding)
-
-            Divider()
-                .padding(.trailing, -Layout.contentSidePadding)
-
-            /// Email
-            HStack {
-                Text(content.emailText)
-                    .rowTextStyle()
-                Spacer()
-                Image(systemName: "doc.on.doc")
-                    .font(TextFont.bodyMedium)
-                    .foregroundStyle(Color.accentColor)
-            }
-            .padding(.vertical, Layout.rowTextVerticalPadding)
-            .tappable {
-                print("On email copy")
-            }
-
-            Divider()
-                .padding(.trailing, -Layout.contentSidePadding)
-
-            /// Phone
-            HStack {
-                Text(content.phoneText)
-                    .rowTextStyle()
-                Spacer()
-                Image(systemName: "ellipsis")
-                    .font(TextFont.bodyMedium)
-                    .foregroundStyle(Color.accentColor)
-            }
-            .padding(.vertical, Layout.rowTextVerticalPadding)
-            .tappable {
-                print("On phone ellipsis")
-            }
-
-            Divider()
-                .padding(.trailing, -Layout.contentSidePadding)
-
-            /// Billing address
-            if let billingAddressText = content.billingAddressText, !billingAddressText.isEmpty {
-                HStack {
-                    VStack(alignment: .leading) {
-                        Text(Localization.billingAddressRowTitle)
-                            .rowTextStyle()
-                        Text(billingAddressText)
-                            .font(TextFont.bodyMedium)
-                            .foregroundStyle(.secondary)
-                            .multilineTextAlignment(.leading)
-                    }
-                    Spacer()
-                }
-                .padding(.vertical, Layout.rowTextVerticalPadding)
-            }
-        }
-    }
-
     func paymentDetailsView(with content: BookingDetailsViewModel.PaymentContent) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             VStack(alignment: .leading, spacing: 8) {
@@ -317,22 +257,7 @@ private extension BookingDetailsView {
     }
 }
 
-private struct RowTextStyle: ViewModifier {
-    func body(content: Content) -> some View {
-        content
-            .font(BookingDetailsView.TextFont.bodyMedium)
-            .foregroundStyle(.primary)
-            .multilineTextAlignment(.leading)
-    }
-}
-
-private extension View {
-    func rowTextStyle() -> some View {
-        self.modifier(RowTextStyle())
-    }
-}
-
-private extension BookingDetailsView {
+extension BookingDetailsView {
     enum Localization {
         static let markAsPaid = NSLocalizedString(
             "BookingDetailsView.options.markAsPaid",

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -7,6 +7,7 @@ struct BookingDetailsView: View {
     @State private var showingOptions = false
     @State private var showingStatusSheet = false
     @State private var showingCancelAlert = false
+    @State private var notice: Notice?
 
     @ObservedObject private var viewModel: BookingDetailsViewModel
 
@@ -95,6 +96,7 @@ struct BookingDetailsView: View {
         } message: {
             Text(viewModel.cancellationAlertMessage)
         }
+        .notice($notice)
     }
 }
 
@@ -144,7 +146,9 @@ private extension BookingDetailsView {
         case .attendance(let content):
             attendanceView(with: content)
         case .customer(let content):
-            CustomerDetailsView(content: content)
+            CustomerDetailsView(content: content, showNotice: {
+                notice = $0
+            })
         case .payment(let content):
             paymentDetailsView(with: content)
         case .bookingNotes:

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/CustomerDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/CustomerDetailsView.swift
@@ -76,7 +76,9 @@ extension BookingDetailsView {
             }
             .padding(.vertical, Layout.rowTextVerticalPadding)
             .tappable {
-                print("On email copy")
+                emailText.sendToPasteboard()
+                let notice = Notice(title: Localization.emailCopiedMessage, feedbackType: .success)
+                ServiceLocator.noticePresenter.enqueue(notice: notice)
             }
         }
 
@@ -98,8 +100,6 @@ extension BookingDetailsView {
         private func billingAddressView(with billingAddressText: String) -> some View {
             HStack {
                 VStack(alignment: .leading) {
-                    Text(Localization.billingAddressRowTitle)
-                        .rowTextStyle()
                     Text(billingAddressText)
                         .font(TextFont.bodyMedium)
                         .foregroundStyle(.secondary)
@@ -109,5 +109,15 @@ extension BookingDetailsView {
             }
             .padding(.vertical, Layout.rowTextVerticalPadding)
         }
+    }
+}
+
+private extension BookingDetailsView.CustomerDetailsView {
+    enum Localization {
+        static let emailCopiedMessage = NSLocalizedString(
+            "BookingDetailsView.customer.emailCopied.toastMessage",
+            value: "Email address copied",
+            comment: "Toast message shown when the user copies the customer's email address."
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/CustomerDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/CustomerDetailsView.swift
@@ -100,6 +100,8 @@ extension BookingDetailsView {
         private func billingAddressView(with billingAddressText: String) -> some View {
             HStack {
                 VStack(alignment: .leading) {
+                    Text(Localization.billingAddressRowTitle)
+                        .rowTextStyle()
                     Text(billingAddressText)
                         .font(TextFont.bodyMedium)
                         .foregroundStyle(.secondary)
@@ -118,6 +120,13 @@ private extension BookingDetailsView.CustomerDetailsView {
             "BookingDetailsView.customer.emailCopied.toastMessage",
             value: "Email address copied",
             comment: "Toast message shown when the user copies the customer's email address."
+        )
+
+        /// Customer section
+        static let billingAddressRowTitle = NSLocalizedString(
+            "BookingDetailsView.customer.billingAddress.title",
+            value: "Billing address",
+            comment: "Billing address row title in customer section in booking details view."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/CustomerDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/CustomerDetailsView.swift
@@ -5,76 +5,109 @@ extension BookingDetailsView {
     struct CustomerDetailsView: View {
         @ObservedObject var content: BookingDetailsViewModel.CustomerContent
 
+        private enum Row: Hashable {
+            case name(String)
+            case email(String)
+            case phone(String)
+            case billingAddress(String)
+        }
+
+        private var rows: [Row] {
+            var result = [Row]()
+            if let name = content.nameText, !name.isEmpty {
+                result.append(.name(name))
+            }
+            if let email = content.emailText, !email.isEmpty {
+                result.append(.email(email))
+            }
+            if let phone = content.phoneText, !phone.isEmpty {
+                result.append(.phone(phone))
+            }
+            if let address = content.billingAddressText, !address.isEmpty {
+                result.append(.billingAddress(address))
+            }
+            return result
+        }
+
         var body: some View {
             VStack(spacing: 0) {
-                /// Name
-                if let nameText = content.nameText, !nameText.isEmpty {
-                    HStack {
-                        Text(nameText)
-                            .rowTextStyle()
-                        Spacer()
+                ForEach(Array(rows.enumerated()), id: \.element) { index, row in
+                    view(for: row)
+
+                    if index < rows.count - 1 {
+                        Divider()
+                            .padding(.trailing, -Layout.contentSidePadding)
                     }
-                    .padding(.vertical, Layout.rowTextVerticalPadding)
-
-                    Divider()
-                        .padding(.trailing, -Layout.contentSidePadding)
-                }
-
-                /// Email
-                if let emailText = content.emailText, !emailText.isEmpty {
-                    HStack {
-                        Text(emailText)
-                            .rowTextStyle()
-                        Spacer()
-                        Image(systemName: "doc.on.doc")
-                            .font(TextFont.bodyMedium)
-                            .foregroundStyle(Color.accentColor)
-                    }
-                    .padding(.vertical, Layout.rowTextVerticalPadding)
-                    .tappable {
-                        print("On email copy")
-                    }
-
-                    Divider()
-                        .padding(.trailing, -Layout.contentSidePadding)
-                }
-
-                /// Phone
-                if let phoneText = content.phoneText, !phoneText.isEmpty {
-                    HStack {
-                        Text(phoneText)
-                            .rowTextStyle()
-                        Spacer()
-                        Image(systemName: "ellipsis")
-                            .font(TextFont.bodyMedium)
-                            .foregroundStyle(Color.accentColor)
-                    }
-                    .padding(.vertical, Layout.rowTextVerticalPadding)
-                    .tappable {
-                        print("On phone ellipsis")
-                    }
-
-                    Divider()
-                        .padding(.trailing, -Layout.contentSidePadding)
-                }
-
-
-                /// Billing address
-                if let billingAddressText = content.billingAddressText, !billingAddressText.isEmpty {
-                    HStack {
-                        VStack(alignment: .leading) {
-                            Text(Localization.billingAddressRowTitle)
-                                .rowTextStyle()
-                            Text(billingAddressText)
-                                .font(TextFont.bodyMedium)
-                                .foregroundStyle(.secondary)
-                                .multilineTextAlignment(.leading)
-                        }
-                        Spacer()
-                    }
-                    .padding(.vertical, Layout.rowTextVerticalPadding)
                 }
             }
+        }
+
+        @ViewBuilder
+        private func view(for row: Row) -> some View {
+            switch row {
+            case .name(let nameText):
+                nameView(with: nameText)
+            case .email(let emailText):
+                emailView(with: emailText)
+            case .phone(let phoneText):
+                phoneView(with: phoneText)
+            case .billingAddress(let billingAddressText):
+                billingAddressView(with: billingAddressText)
+            }
+        }
+
+        private func nameView(with nameText: String) -> some View {
+            HStack {
+                Text(nameText)
+                    .rowTextStyle()
+                Spacer()
+            }
+            .padding(.vertical, Layout.rowTextVerticalPadding)
+        }
+
+        private func emailView(with emailText: String) -> some View {
+            HStack {
+                Text(emailText)
+                    .rowTextStyle()
+                Spacer()
+                Image(systemName: "doc.on.doc")
+                    .font(TextFont.bodyMedium)
+                    .foregroundStyle(Color.accentColor)
+            }
+            .padding(.vertical, Layout.rowTextVerticalPadding)
+            .tappable {
+                print("On email copy")
+            }
+        }
+
+        private func phoneView(with phoneText: String) -> some View {
+            HStack {
+                Text(phoneText)
+                    .rowTextStyle()
+                Spacer()
+                Image(systemName: "ellipsis")
+                    .font(TextFont.bodyMedium)
+                    .foregroundStyle(Color.accentColor)
+            }
+            .padding(.vertical, Layout.rowTextVerticalPadding)
+            .tappable {
+                print("On phone ellipsis")
+            }
+        }
+
+        private func billingAddressView(with billingAddressText: String) -> some View {
+            HStack {
+                VStack(alignment: .leading) {
+                    Text(Localization.billingAddressRowTitle)
+                        .rowTextStyle()
+                    Text(billingAddressText)
+                        .font(TextFont.bodyMedium)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.leading)
+                }
+                Spacer()
+            }
+            .padding(.vertical, Layout.rowTextVerticalPadding)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/CustomerDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/CustomerDetailsView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 extension BookingDetailsView {
     struct CustomerDetailsView: View {
         @ObservedObject var content: BookingDetailsViewModel.CustomerContent
+        let showNotice: (Notice) -> Void
 
         private enum Row: Hashable {
             case name(String)
@@ -77,8 +78,12 @@ extension BookingDetailsView {
             .padding(.vertical, Layout.rowTextVerticalPadding)
             .tappable {
                 emailText.sendToPasteboard()
-                let notice = Notice(title: Localization.emailCopiedMessage, feedbackType: .success)
-                ServiceLocator.noticePresenter.enqueue(notice: notice)
+                showNotice(
+                    Notice(
+                        title: Localization.emailCopiedMessage,
+                        feedbackType: .success
+                    )
+                )
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/CustomerDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/CustomerDetailsView.swift
@@ -1,0 +1,80 @@
+import Combine
+import SwiftUI
+
+extension BookingDetailsView {
+    struct CustomerDetailsView: View {
+        @ObservedObject var content: BookingDetailsViewModel.CustomerContent
+
+        var body: some View {
+            VStack(spacing: 0) {
+                /// Name
+                if let nameText = content.nameText, !nameText.isEmpty {
+                    HStack {
+                        Text(nameText)
+                            .rowTextStyle()
+                        Spacer()
+                    }
+                    .padding(.vertical, Layout.rowTextVerticalPadding)
+
+                    Divider()
+                        .padding(.trailing, -Layout.contentSidePadding)
+                }
+
+                /// Email
+                if let emailText = content.emailText, !emailText.isEmpty {
+                    HStack {
+                        Text(emailText)
+                            .rowTextStyle()
+                        Spacer()
+                        Image(systemName: "doc.on.doc")
+                            .font(TextFont.bodyMedium)
+                            .foregroundStyle(Color.accentColor)
+                    }
+                    .padding(.vertical, Layout.rowTextVerticalPadding)
+                    .tappable {
+                        print("On email copy")
+                    }
+
+                    Divider()
+                        .padding(.trailing, -Layout.contentSidePadding)
+                }
+
+                /// Phone
+                if let phoneText = content.phoneText, !phoneText.isEmpty {
+                    HStack {
+                        Text(phoneText)
+                            .rowTextStyle()
+                        Spacer()
+                        Image(systemName: "ellipsis")
+                            .font(TextFont.bodyMedium)
+                            .foregroundStyle(Color.accentColor)
+                    }
+                    .padding(.vertical, Layout.rowTextVerticalPadding)
+                    .tappable {
+                        print("On phone ellipsis")
+                    }
+
+                    Divider()
+                        .padding(.trailing, -Layout.contentSidePadding)
+                }
+
+
+                /// Billing address
+                if let billingAddressText = content.billingAddressText, !billingAddressText.isEmpty {
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(Localization.billingAddressRowTitle)
+                                .rowTextStyle()
+                            Text(billingAddressText)
+                                .font(TextFont.bodyMedium)
+                                .foregroundStyle(.secondary)
+                                .multilineTextAlignment(.leading)
+                        }
+                        Spacer()
+                    }
+                    .padding(.vertical, Layout.rowTextVerticalPadding)
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -986,6 +986,7 @@
 		26FFC50D2BED7C5B0067B3A4 /* WatchDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B249702BEC801400730730 /* WatchDependencies.swift */; };
 		2D052FB42E9408AF004111FD /* CustomerDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D052FB32E9408AF004111FD /* CustomerDetailsView.swift */; };
 		2D052FB52E9408AF004111FD /* BookingDetailsView+RowTextStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D052FB22E9408AF004111FD /* BookingDetailsView+RowTextStyle.swift */; };
+		2D054A2A2E953E3C004111FD /* BookingDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D054A292E953E3C004111FD /* BookingDetailsViewModelTests.swift */; };
 		2D05D19F2E82D1A8004111FD /* BookingDetailsViewModel+Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D05D19E2E82D1A3004111FD /* BookingDetailsViewModel+Section.swift */; };
 		2D05D1A22E82D235004111FD /* HeaderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D05D1A12E82D233004111FD /* HeaderContent.swift */; };
 		2D05D1A42E82D266004111FD /* AppointmentDetailsContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D05D1A32E82D25F004111FD /* AppointmentDetailsContent.swift */; };
@@ -3881,6 +3882,7 @@
 		26FFD32928C6A0F4002E5E5E /* UIImage+Widgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Widgets.swift"; sourceTree = "<group>"; };
 		2D052FB22E9408AF004111FD /* BookingDetailsView+RowTextStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BookingDetailsView+RowTextStyle.swift"; sourceTree = "<group>"; };
 		2D052FB32E9408AF004111FD /* CustomerDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerDetailsView.swift; sourceTree = "<group>"; };
+		2D054A292E953E3C004111FD /* BookingDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		2D05D19E2E82D1A3004111FD /* BookingDetailsViewModel+Section.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BookingDetailsViewModel+Section.swift"; sourceTree = "<group>"; };
 		2D05D1A02E82D1EF004111FD /* BookingDetailsViewModel+SectionContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BookingDetailsViewModel+SectionContent.swift"; sourceTree = "<group>"; };
 		2D05D1A12E82D233004111FD /* HeaderContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderContent.swift; sourceTree = "<group>"; };
@@ -12515,6 +12517,7 @@
 			isa = PBXGroup;
 			children = (
 				DED1E3152E8556270089909C /* BookingListViewModelTests.swift */,
+				2D054A292E953E3C004111FD /* BookingDetailsViewModelTests.swift */,
 			);
 			path = Bookings;
 			sourceTree = "<group>";
@@ -15825,6 +15828,7 @@
 				DE61979528A25842005E4362 /* StorePickerViewModelTests.swift in Sources */,
 				EEB4E2D329B2047700371C3C /* StoreOnboardingViewHostingControllerTests.swift in Sources */,
 				B57C745120F56EE900EEFC87 /* UITableViewCellHelpersTests.swift in Sources */,
+				2D054A2A2E953E3C004111FD /* BookingDetailsViewModelTests.swift in Sources */,
 				267D6882296485850072ED0C /* ProductVariationGeneratorTests.swift in Sources */,
 				0225C42824768A4C00C5B4F0 /* FilterProductListViewModelTests.swift in Sources */,
 				D85136C9231E12B600DD0539 /* ReviewViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -984,6 +984,8 @@
 		26FE09E124DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */; };
 		26FFC50C2BED7C5A0067B3A4 /* WatchDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B249702BEC801400730730 /* WatchDependencies.swift */; };
 		26FFC50D2BED7C5B0067B3A4 /* WatchDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B249702BEC801400730730 /* WatchDependencies.swift */; };
+		2D052FB42E9408AF004111FD /* CustomerDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D052FB32E9408AF004111FD /* CustomerDetailsView.swift */; };
+		2D052FB52E9408AF004111FD /* BookingDetailsView+RowTextStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D052FB22E9408AF004111FD /* BookingDetailsView+RowTextStyle.swift */; };
 		2D05D19F2E82D1A8004111FD /* BookingDetailsViewModel+Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D05D19E2E82D1A3004111FD /* BookingDetailsViewModel+Section.swift */; };
 		2D05D1A22E82D235004111FD /* HeaderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D05D1A12E82D233004111FD /* HeaderContent.swift */; };
 		2D05D1A42E82D266004111FD /* AppointmentDetailsContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D05D1A32E82D25F004111FD /* AppointmentDetailsContent.swift */; };
@@ -3877,6 +3879,8 @@
 		26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCoordinatorControllerTests.swift; sourceTree = "<group>"; };
 		26FFD32628C6A0A4002E5E5E /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		26FFD32928C6A0F4002E5E5E /* UIImage+Widgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Widgets.swift"; sourceTree = "<group>"; };
+		2D052FB22E9408AF004111FD /* BookingDetailsView+RowTextStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BookingDetailsView+RowTextStyle.swift"; sourceTree = "<group>"; };
+		2D052FB32E9408AF004111FD /* CustomerDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerDetailsView.swift; sourceTree = "<group>"; };
 		2D05D19E2E82D1A3004111FD /* BookingDetailsViewModel+Section.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BookingDetailsViewModel+Section.swift"; sourceTree = "<group>"; };
 		2D05D1A02E82D1EF004111FD /* BookingDetailsViewModel+SectionContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BookingDetailsViewModel+SectionContent.swift"; sourceTree = "<group>"; };
 		2D05D1A12E82D233004111FD /* HeaderContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderContent.swift; sourceTree = "<group>"; };
@@ -7959,6 +7963,8 @@
 		2DAC2C962E82A169008521AF /* Booking Details */ = {
 			isa = PBXGroup;
 			children = (
+				2D052FB22E9408AF004111FD /* BookingDetailsView+RowTextStyle.swift */,
+				2D052FB32E9408AF004111FD /* CustomerDetailsView.swift */,
 				2DAC2C972E82A185008521AF /* BookingDetailsView.swift */,
 				2D05FE952E8D71EA004111FD /* UpdateAttendanceStatusView.swift */,
 			);
@@ -14837,6 +14843,8 @@
 				020B2F8F23BD9F1F00BD79AD /* IntegerInputFormatter.swift in Sources */,
 				0204F0CA29C047A400CFC78F /* SelfSizingHostingController.swift in Sources */,
 				7441EBC9226A71AA008BF83D /* TitleBodyTableViewCell.swift in Sources */,
+				2D052FB42E9408AF004111FD /* CustomerDetailsView.swift in Sources */,
+				2D052FB52E9408AF004111FD /* BookingDetailsView+RowTextStyle.swift in Sources */,
 				EECB6D1E2AFBFE0000040BC9 /* WooSubscriptionProductsEligibilityChecker.swift in Sources */,
 				CEA455C72BB5CA5E00D932CF /* AnalyticsSessionsUnavailableCard.swift in Sources */,
 				EE45E29D2A381A250085F227 /* ProductDescriptionGenerationCelebrationView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+import TestKit
+import Yosemite
+import Storage
+import Fakes
+import Networking
+
+@testable import WooCommerce
+
+@MainActor
+final class BookingDetailsViewModelTests: XCTestCase {
+    private var storesManager: MockStoresManager!
+    private var storageManager: MockStorageManager!
+
+    override func setUp() {
+        super.setUp()
+        storesManager = MockStoresManager(sessionManager: .makeForTesting())
+        storageManager = MockStorageManager()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        storesManager = nil
+        storageManager = nil
+    }
+
+    func testLoadCustomerDataPopulatesCustomerContent() {
+        // Given
+        let customerID: Int64 = 123
+        let mockBooking = Networking.Booking.fake().copy(customerID: customerID)
+
+        let billingAddress = Networking.Address.fake().copy(
+            address1: "123 Fake St",
+            address2: "Apt 4B",
+            city: "Faketown",
+            state: "FS",
+            postcode: "12345",
+            country: "FK",
+            phone: "123-456-7890"
+        )
+        let mockReadOnlyCustomer = Networking.Customer.fake().copy(
+            customerID: customerID,
+            email: "john.doe@example.com",
+            firstName: "John",
+            lastName: "Doe",
+            billing: billingAddress
+        )
+        let mockStorageCustomer = storageManager.insertSampleCustomer(readOnlyCustomer: mockReadOnlyCustomer)
+        let viewModel = BookingDetailsViewModel(booking: mockBooking, stores: storesManager)
+
+        storesManager.whenReceivingAction(ofType: CustomerAction.self) { action in
+            guard case let .loadCustomer(_, _, onCompletion) = action else {
+                return
+            }
+            onCompletion(.success(mockStorageCustomer.toReadOnly()))
+        }
+
+        // When
+        viewModel.loadLocalData()
+
+        // Then
+        let customerSection = viewModel.sections.first { section in
+            if case .customer = section.content {
+                return true
+            }
+            return false
+        }
+
+        guard let customerSection = customerSection,
+              case let .customer(customerContent) = customerSection.content else {
+            XCTFail("Customer section not found in view model sections")
+            return
+        }
+
+        XCTAssertEqual(customerContent.nameText, "\(mockStorageCustomer.firstName ?? "") \(mockStorageCustomer.lastName ?? "")")
+        XCTAssertEqual(customerContent.emailText, mockStorageCustomer.email)
+        XCTAssertEqual(customerContent.phoneText, mockStorageCustomer.billingPhone)
+
+        let expectedBillingAddress = [
+            mockStorageCustomer.billingAddress1,
+            mockStorageCustomer.billingAddress2,
+            mockStorageCustomer.billingCity,
+            mockStorageCustomer.billingState,
+            mockStorageCustomer.billingPostcode,
+            mockStorageCustomer.billingCountry
+        ]
+        .compactMap { $0 }
+        .filter { !$0.isEmpty }
+        .joined(separator: "\n")
+
+        XCTAssertEqual(customerContent.billingAddressText, expectedBillingAddress)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
Part of: WOOMOB-1426

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Loads and displays customer data in Booking Details screen.

- Adds `loadCustomer` as `CustomerAction` that fetches local `Storage.Customer` with given site ID and customer ID.
- Replaces `customerDetailsView` method with distinct `CustomerDetailsView` for better data binding and code organizing.
- Adds `BookingDetailsViewModel.CustomerContent` as a model for `CustomerDetailsView` as an `ObservableObject` with `@Published` properties.
- In `BookingDetailsViewModel` implements customer data local fetching and API syncing. 
- Implements customer email copying to pasteboard on row tap.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Use a testing CIAB site with bookings
- Navigate to Bookings tab
- Locate a booking that contains a customer with non-empty readable content like name, email, phone and address. 
- Select the booking and navigate to details view.
- Make sure the "Customer" section appears upon loading.
- Make sure the "Customer" section contains correct data.
- Locate a booking that doesn't have a customer / Or simulate this condition by setting `customerID` to `0` in bookings response by using Proxyman.
- Select the booking and navigate to details view.
- Make sure the "Customer" section disappeared.
- Select the 1st booking with the valid customer details again and make sure the "Customer" section re-appeared.
- Also in Booking Details with valid Customer section data - tap on email row that presents the "copy" icon. Make sure the email is copied to clipboard and the confirmation toast is presented.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested on iOS 26 iPhone 17 and iPad simulators.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="826" height="815" alt="Снимок экрана 2025-10-08 в 17 36 06" src="https://github.com/user-attachments/assets/6c94ce0a-8fed-4f60-9d88-95a5d202ed8f" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.