### PR TITLE
Remove localization for debug-only Wormholy string

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -269,7 +269,7 @@ private extension SettingsViewController {
     func configureWormholy(cell: BasicTableViewCell) {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.textLabel?.text = Localization.launchWormHolyDebug
+        cell.textLabel?.text = "Launch Wormholy Debug"
     }
 
     func configureWhatsNew(cell: BasicTableViewCell) {
@@ -887,11 +887,6 @@ private extension SettingsViewController {
         static let openDeviceSettings = NSLocalizedString(
             "Open Device Settings",
             comment: "Opens iOS's Device Settings for the app"
-        )
-
-        static let launchWormHolyDebug = NSLocalizedString(
-            "Launch Wormholy Debug",
-            comment: "Opens an internal library called Wormholy. Not visible to users."
         )
 
         static let whatsNew = NSLocalizedString(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
Following up on [this comment](https://github.com/woocommerce/woocommerce-ios/pull/15771#discussion_r2153739423) by @jaclync 

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We should the debug menu entry to toggle Wormholy only in non-public-facing builds. Therefore, we can avoid sending the UI string for localization and save the effort there.

Granted, once the string is localized, there is basically no overhead in having it in the code. Still, from a tidiness point of view, it's neat to remove it.



## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Launch the app on device and verify the menu reads as expected:

<img width="300" alt="IMG_4696" src="https://github.com/user-attachments/assets/411afc07-e013-4920-bafa-98d40901b31c" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
