### PR TITLE
Fix/coupon scrolling

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 23.5
 -----
 - [internal] POS code was moved to its own module, including POS specific color and image assets. [https://github.com/woocommerce/woocommerce-ios/pull/16176]
+- [*] Fix Create Coupon screen scrolling issue. [https://github.com/woocommerce/woocommerce-ios/pull/16218]
 
 
 23.4

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -285,6 +285,7 @@ struct AddEditCoupon: View {
                         }
                     }
                 }
+                .scrollDismissesKeyboard(.immediately)
             }
             .sheet(isPresented: $showingSelectProducts) {
                 ProductSelectorNavigationView(configuration: .productsForCoupons,

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
@@ -151,6 +151,7 @@ struct CouponRestrictions: View {
                 .padding(.horizontal, insets: geometry.safeAreaInsets)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
+            .scrollDismissesKeyboard(.immediately)
             .background(Color(.listForeground(modal: false)))
             .ignoresSafeArea(.container, edges: [.horizontal])
             .sheet(isPresented: $showingExcludeProducts) {


### PR DESCRIPTION
Closes [WOOMOB-70](https://linear.app/a8c/issue/WOOMOB-70)

## Description

The "Create Coupon" view did not dismiss the keyboard when the user scrolled if a field was focused. This resulted in a broken scroll behaviour on navigating back and forth from sheets.

This PR resolves the above issue by adding the `.scrollDismissesKeyboard(.immediately)` to the view's main ScrollView. I've also added the behaviour to the "Usage Restrictions" view.

## Steps to reproduce

1. Open the "Create coupon" sheet for any discount type.
1. Tap into "Amount". 
1. Note that the keyboard is presented. You don't have to type anything.
1. Scroll the view.
1. Note that the keyboard is dismissed, and you can scroll the entire view.
1. Open "Usage Restrictions".
1. Tap into any input field.
1. Note that the keyboard is presented. You don't have to type anything.
1. Scroll the view.
1. Note that the keyboard is dismissed, and you can scroll the entire view.

## Testing information

Tested and confirmed with the simulator.

## Screenshots

![Simulator Screen Recording - iPhone 17 Pro - 2025-10-07 at 13 58 00](https://github.com/user-attachments/assets/e4b294db-ee46-48db-8202-bf32713fd9f2)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
