### PR TITLE
Update tests for iOS 26

### DIFF
--- a/Modules/Tests/YosemiteTests/Model/Extensions/OrderStatsV4Interval+DateTests.swift
+++ b/Modules/Tests/YosemiteTests/Model/Extensions/OrderStatsV4Interval+DateTests.swift
@@ -11,7 +11,9 @@ final class OrderStatsV4Interval_DateTests: XCTestCase {
                                             dateEnd: dateStringInSiteTimeZone,
                                             subtotals: mockIntervalSubtotals)
         // As long as the dates are parsed and formatted in the same time zone, they should be consistent.
-        let timeZone = TimeZone(secondsFromGMT: 29302)!
+        // Note that iOS 26 has changed behaviour here, and excess seconds in the timezone break the calculation
+        // This is 488 minutes, or 8 hours and 8 minutes
+        let timeZone = TimeZone(secondsFromGMT: 29280)!
         [interval.dateStart(timeZone: timeZone), interval.dateEnd(timeZone: timeZone)].forEach { date in
             let dateComponents = Calendar(identifier: .iso8601).dateComponents(in: timeZone, from: date)
             XCTAssertEqual(dateComponents.year, 2019)

--- a/Modules/Tests/YosemiteTests/Tools/Media/MediaTypeTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/Media/MediaTypeTests.swift
@@ -24,8 +24,12 @@ final class MediaTypeTests: XCTestCase {
 
     func testInitWithAudioFileExtensions() throws {
         try XCTSkipIf(testingOnRosetta())
-        // Note: "ogg" isn't supported on iOS.
-        let audioFileExtensions = ["mp3", "m4a", "wav", "ogg"]
+        var audioFileExtensions = ["mp3", "m4a", "wav"]
+        // Note: "ogg" is only supported on iOS 26 and above.
+        if #available(iOS 26.0, *) {
+            audioFileExtensions.append("ogg")
+        }
+
         audioFileExtensions.forEach { fileExtension in
             XCTAssertEqual(MediaType(fileExtension: fileExtension), .audio, "Unexpected media type for file extension: \(fileExtension)")
         }
@@ -41,11 +45,16 @@ final class MediaTypeTests: XCTestCase {
 
     func testInitWithOtherFileExtensions() throws {
         try XCTSkipIf(testingOnRosetta())
-        let presentationFileExtensions = [
+        var presentationFileExtensions = [
             "pdf", "doc", "odt", "xls", "xlsx",
             // Video formats that are not supported on iOS
             "ogv"
         ]
+
+        // Note: "ogg" is only supported on iOS 26 and above.
+        if #unavailable(iOS 26.0) {
+            presentationFileExtensions.append("ogg")
+        }
         presentationFileExtensions.forEach { fileExtension in
             XCTAssertEqual(MediaType(fileExtension: fileExtension), .other, "Unexpected media type for file extension: \(fileExtension)")
         }
@@ -80,7 +89,11 @@ final class MediaTypeTests: XCTestCase {
 
     func testInitWithAudioMimeType() throws {
         try XCTSkipIf(testingOnRosetta())
-        let audioMimeTypes = ["audio/midi", "audio/x-midi", "audio/mpeg", "audio/wav", "audio/ogg"]
+        var audioMimeTypes = ["audio/midi", "audio/x-midi", "audio/mpeg", "audio/wav"]
+        // Note: "ogg" is only supported on iOS 26 and above.
+        if #available(iOS 26.0, *) {
+            audioMimeTypes.append("audio/ogg")
+        }
         audioMimeTypes.forEach { mimeType in
             XCTAssertEqual(MediaType(mimeType: mimeType), .audio, "Unexpected media type for file extension: \(mimeType)")
         }
@@ -96,7 +109,7 @@ final class MediaTypeTests: XCTestCase {
 
     func testInitWithOtherMimeType() throws {
         try XCTSkipIf(testingOnRosetta())
-        let otherMimeTypes = [
+        var otherMimeTypes = [
             "application/pdf", "application/msword", "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "application/vnd.oasis.opendocument.text", "application/vnd.ms-excel", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             // Video formats that are not supported on iOS
@@ -104,6 +117,11 @@ final class MediaTypeTests: XCTestCase {
             // Audio formats that are not supported on iOS
             "audio/opus", "audio/webm"
         ]
+
+        // Note: "ogg" is only supported on iOS 26 and above.
+        if #unavailable(iOS 26.0) {
+            otherMimeTypes.append("audio/ogg")
+        }
         otherMimeTypes.forEach { mimeType in
             XCTAssertEqual(MediaType(mimeType: mimeType), .other, "Unexpected media type for file extension: \(mimeType)")
         }

--- a/Modules/Tests/YosemiteTests/Tools/Media/MediaTypeTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/Media/MediaTypeTests.swift
@@ -25,7 +25,7 @@ final class MediaTypeTests: XCTestCase {
     func testInitWithAudioFileExtensions() throws {
         try XCTSkipIf(testingOnRosetta())
         // Note: "ogg" isn't supported on iOS.
-        let audioFileExtensions = ["mp3", "m4a", "wav"]
+        let audioFileExtensions = ["mp3", "m4a", "wav", "ogg"]
         audioFileExtensions.forEach { fileExtension in
             XCTAssertEqual(MediaType(fileExtension: fileExtension), .audio, "Unexpected media type for file extension: \(fileExtension)")
         }
@@ -43,8 +43,8 @@ final class MediaTypeTests: XCTestCase {
         try XCTSkipIf(testingOnRosetta())
         let presentationFileExtensions = [
             "pdf", "doc", "odt", "xls", "xlsx",
-            // Audio/video formats that are not supported on iOS
-            "ogg", "ogv"
+            // Video formats that are not supported on iOS
+            "ogv"
         ]
         presentationFileExtensions.forEach { fileExtension in
             XCTAssertEqual(MediaType(fileExtension: fileExtension), .other, "Unexpected media type for file extension: \(fileExtension)")
@@ -80,7 +80,7 @@ final class MediaTypeTests: XCTestCase {
 
     func testInitWithAudioMimeType() throws {
         try XCTSkipIf(testingOnRosetta())
-        let audioMimeTypes = ["audio/midi", "audio/x-midi", "audio/mpeg", "audio/wav"]
+        let audioMimeTypes = ["audio/midi", "audio/x-midi", "audio/mpeg", "audio/wav", "audio/ogg"]
         audioMimeTypes.forEach { mimeType in
             XCTAssertEqual(MediaType(mimeType: mimeType), .audio, "Unexpected media type for file extension: \(mimeType)")
         }
@@ -102,7 +102,7 @@ final class MediaTypeTests: XCTestCase {
             // Video formats that are not supported on iOS
             "video/ogg", "video/mp2t", "video/webm",
             // Audio formats that are not supported on iOS
-            "audio/ogg", "audio/opus", "audio/webm"
+            "audio/opus", "audio/webm"
         ]
         otherMimeTypes.forEach { mimeType in
             XCTAssertEqual(MediaType(mimeType: mimeType), .other, "Unexpected media type for file extension: \(mimeType)")

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "298b0576b8fba2136af19221385c7ff56047cb08dc2f781a9e3976c3952d7918",
+  "originHash" : "e329c60517f495559737ad5c4a61cb95f2113a3305cf852552014fd6c0fef5e1",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -373,8 +373,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nalexn/ViewInspector",
       "state" : {
-        "revision" : "5acfa0a3c095ac9ad050abe51c60d1831e8321da",
-        "version" : "0.10.0"
+        "revision" : "e9a06346499a3a889165647e3f23f8a7b2609a1c",
+        "version" : "0.10.3"
       }
     },
     {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes various tests that were broken under iOS 26

Changes:
- Update ViewInspector to fix `find(viewWithAccessibilityLabel:)`
- Decode OGG extension/mime types as `MediaType.audio` as they're now supported
- Use an exact minute's number of seconds when creating a timezone for tests

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Check tests pass in CI.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
