### PR TITLE
[Bookings] Handle splitview on iPad

### DIFF
--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
@@ -26,6 +26,7 @@ struct BookingListContainerView: View {
             .tabViewStyle(.page(indexDisplayMode: .never))
         }
         .navigationTitle(Localization.viewTitle)
+        .toolbar(removing: .sidebarToggle)
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
                 Button {

--- a/WooCommerce/Classes/Bookings/BookingsTabView.swift
+++ b/WooCommerce/Classes/Bookings/BookingsTabView.swift
@@ -36,7 +36,7 @@ private extension BookingsTabViewHostingController {
 ///
 struct BookingsTabView: View {
     @State private var selectedBooking: Booking?
-    @State private var visibility: NavigationSplitViewVisibility = .automatic
+    @State private var visibility: NavigationSplitViewVisibility = .all
     @StateObject private var bookingListContainerViewModel: BookingListContainerViewModel
     @StateObject private var connectivityMonitor = ConnectivityMonitor()
 

--- a/WooCommerce/Classes/System/WooTabContainerController.swift
+++ b/WooCommerce/Classes/System/WooTabContainerController.swift
@@ -21,6 +21,11 @@ final class TabContainerController: UIViewController {
             view.addSubview(newWrappedController.view)
             newWrappedController.didMove(toParent: self)
 
+            if #available(iOS 18.0, *), UIDevice.current.userInterfaceIdiom == .pad,
+               let horizontalSize = AppDelegate.shared.window?.traitCollection.horizontalSizeClass {
+                newWrappedController.traitOverrides.horizontalSizeClass = horizontalSize
+            }
+
             newWrappedController.view.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
                 newWrappedController.view.topAnchor.constraint(equalTo: view.topAnchor),


### PR DESCRIPTION
Fixes [WOOMOB-1425](https://linear.app/a8c/issue/WOOMOB-1425)

## Description

Forces the NavigationSplitView to display in the "full" mode on iPad.

**Root**

The `NavigationSplitView` was not actually "broken" but it was _told_ to collapse in MainTabBarController.swift's [fixTabBarTraitCollectionOnIpadForiOS18](https://github.com/woocommerce/woocommerce-ios/blob/f49c71ff48957b8d19580217ce201fe2a3f01ca0/WooCommerce/Classes/ViewRelated/MainTabBarController.swift#L323) by forcing the "old" bottom tab bar.

This works for any child view controllers present at the time this runs.
But later, when we create/replace the Bookings tab:
```swift
// MainTabBarController.swift
let bookingsViewController = createBookingsViewController(siteID: site.siteID)
bookingsContainerController.wrappedController = bookingsViewController
```
the newly wrapped BookingsTabViewHostingController does not get its `traitOverrides.horizontalSizeClass` set to the root value. It inherits the tab bar controller’s .compact override—which makes SwiftUI think the environment is compact width and collapses the NavigationSplitView to a single column (full-screen “master” or “detail”). 

When the app is windowed, traits change, and the collapse stops—hence the split view actually works.

**Solution**

Instead of applying the fix only in `MainTabBarController` at the point where we assign
`bookingsContainerController.wrappedController = bookingsViewController`,
we now handle the trait propagation inside [WooTabContainerController](https://github.com/woocommerce/woocommerce-ios/pull/16224/files#diff-9a17f9ddf44b70fdaf54bd9e929e3e6f6dd1b68d20a09417dc77f81440680babR24).

By forwarding the root horizontalSizeClass to any newly wrapped controller, all SwiftUI-based split views (not just Bookings) receive the correct size class automatically.

## Steps to reproduce

1. Download and install on iPad/Run the branch on iPad.
2. Login to the CIAB site.
3. Navigate to Bookings.
4. Note that the split view is displayed correctly. Both the master and the detail are visible.
5. Resizing the app still keeps the layout.

## Testing information

Tested on the iPhone simulator with iOS 26 and the iPad device with iPadOS 26.

## Screenshots

| Before | After |
| --- | --- |
| <img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-10-08 at 14 06 09" src="https://github.com/user-attachments/assets/cf6ad9da-2192-46a5-aa77-21b6176ef004" /> | <img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-10-08 at 13 59 50" src="https://github.com/user-attachments/assets/4319ccc0-12e4-41ae-809d-848449cde371" /> |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-08 at 14 29 11" src="https://github.com/user-attachments/assets/d44ab784-1efa-4eff-9db3-5641dbd8a3a3" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-08 at 14 30 33" src="https://github.com/user-attachments/assets/88c11f80-11c7-42ef-aa11-09c592303ecd" /> |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
