### PR TITLE
Orders: Add web checkout and wp-admin as options to order sales channel filter

### DIFF
--- a/Modules/Sources/NetworkingCore/Model/SalesChannel.swift
+++ b/Modules/Sources/NetworkingCore/Model/SalesChannel.swift
@@ -2,6 +2,8 @@ import Foundation
 
 public enum SalesChannel {
     case pointOfSale
+    case webCheckout
+    case wpAdmin
 }
 
 extension SalesChannel: RawRepresentable {
@@ -9,6 +11,10 @@ extension SalesChannel: RawRepresentable {
         switch rawValue {
         case "pos-rest-api":
             self = .pointOfSale
+        case "checkout", "store-api":
+            self = .webCheckout
+        case "admin":
+            self = .wpAdmin
         default:
             return nil
         }
@@ -17,6 +23,10 @@ extension SalesChannel: RawRepresentable {
     public var rawValue: String {
         switch self {
         case .pointOfSale:
+            return description
+        case .webCheckout:
+            return description
+        case .wpAdmin:
             return description
         }
     }
@@ -27,6 +37,14 @@ extension SalesChannel: RawRepresentable {
             return NSLocalizedString("salesChannel.pos.description",
                                      value: "POS",
                                      comment: "The acronym for 'Point of Sale'.")
+        case .webCheckout:
+            return NSLocalizedString("salesChannel.webCheckout.description",
+                                     value: "Web Checkout",
+                                     comment: "Orders created through web checkout.")
+        case .wpAdmin:
+            return NSLocalizedString("salesChannel.wpAdmin.description",
+                                     value: "WP-Admin",
+                                     comment: "Orders created through WordPress admin interface.")
         }
     }
 }

--- a/Modules/Sources/Yosemite/Model/Model.swift
+++ b/Modules/Sources/Yosemite/Model/Model.swift
@@ -84,6 +84,7 @@ public typealias OrderStatsV4Totals = Networking.OrderStatsV4Totals
 public typealias OrderStatus = Networking.OrderStatus
 public typealias OrderUpdateField = Networking.OrdersRemote.UpdateOrderField
 public typealias OrderCreateField = Networking.OrdersRemote.CreateOrderField
+public typealias OrderSalesChannel = Networking.SalesChannel
 public typealias PaymentGateway = Networking.PaymentGateway
 public typealias PaymentGatewayAccount = Networking.PaymentGatewayAccount
 public typealias Product = Networking.Product

--- a/Modules/Sources/Yosemite/Model/Orders/SalesChannelFilter.swift
+++ b/Modules/Sources/Yosemite/Model/Orders/SalesChannelFilter.swift
@@ -4,5 +4,7 @@ import Foundation
 ///
 public enum SalesChannelFilter: String, Codable, Hashable {
     case pointOfSale
+    case webCheckout
+    case wpAdmin
     case any
 }

--- a/Modules/Sources/Yosemite/Model/Orders/StoredOrderSettings.swift
+++ b/Modules/Sources/Yosemite/Model/Orders/StoredOrderSettings.swift
@@ -42,7 +42,7 @@ public struct StoredOrderSettings: Codable, Equatable {
             if customerFilter != nil {
                 total += 1
             }
-            if let salesChannelFilter = salesChannelFilter, case .pointOfSale = salesChannelFilter {
+            if let salesChannelFilter = salesChannelFilter, salesChannelFilter != .any {
                 total += 1
             }
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,13 +5,12 @@
 -----
 - [internal] POS code was moved to its own module, including POS specific color and image assets. [https://github.com/woocommerce/woocommerce-ios/pull/16176]
 - [*] Fix Create Coupon screen scrolling issue. [https://github.com/woocommerce/woocommerce-ios/pull/16218]
-
+- [*] Order list: Allow filtering of Web, Point of Sale, and WP-Admin orders. [https://github.com/woocommerce/woocommerce-ios/pull/16228]
 
 23.4
 -----
 - [*] Order details: Fixes broken country selector navigation and "Non editable banner" width. [https://github.com/woocommerce/woocommerce-ios/pull/16171]
 - [*] Store widget: Fixes widget background colours for default and clean Liquid Glass mode. [https://github.com/woocommerce/woocommerce-ios/pull/16183]
-- [*] Order list: Allow filtering of Web, Point of Sale, and WP-Admin orders. [https://github.com/woocommerce/woocommerce-ios/pull/16228]
 
 23.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 -----
 - [*] Order details: Fixes broken country selector navigation and "Non editable banner" width. [https://github.com/woocommerce/woocommerce-ios/pull/16171]
 - [*] Store widget: Fixes widget background colours for default and clean Liquid Glass mode. [https://github.com/woocommerce/woocommerce-ios/pull/16183]
+- [*] Order list: Allow filtering of Web, Point of Sale, and WP-Admin orders. [https://github.com/woocommerce/woocommerce-ios/pull/16228]
 
 23.3
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+OrdersListFilter.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+OrdersListFilter.swift
@@ -30,6 +30,10 @@ fileprivate extension SalesChannelFilter {
         switch self {
         case .pointOfSale:
             return "pos"
+        case .webCheckout:
+            return "checkout"
+        case .wpAdmin:
+            return "admin"
         case .any:
             return nil
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
@@ -66,10 +66,10 @@ struct OrderListCellViewModel {
         return order.status.localizedName
     }
 
-    /// Textual representation of the sales channel
+    /// Sales channel
     ///
-    var salesChannel: String? {
-        order.salesChannel?.description
+    var salesChannel: OrderSalesChannel? {
+        order.salesChannel
     }
 
     /// The localized unabbreviated total for a given order item, which includes the currency.

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -63,10 +63,10 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
         paymentStatusLabel.text = viewModel.statusString
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleOrdersi1),
-           let salesChannel = viewModel.salesChannel {
+           let salesChannel = viewModel.salesChannel, salesChannel == .pointOfSale {
             salesChannelLabel.isHidden = false
             salesChannelLabel.applySalesChannelStyle()
-            salesChannelLabel.text = salesChannel
+            salesChannelLabel.text = salesChannel.description
         } else {
             salesChannelLabel.isHidden = true
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
@@ -268,7 +268,7 @@ extension FilterOrderListViewModel.OrderListFilter {
                                        listSelectorConfig: .customer(siteID: siteID),
                                        selectedValue: filters.customer)
         case .salesChannel:
-            let salesChannelOptions: [SalesChannelFilter] = [.any, .pointOfSale]
+            let salesChannelOptions: [SalesChannelFilter] = [.any, .pointOfSale, .webCheckout, .wpAdmin]
             return FilterTypeViewModel(title: title,
                                        listSelectorConfig: .staticOptions(options: salesChannelOptions),
                                        selectedValue: filters.salesChannel)
@@ -387,6 +387,16 @@ extension SalesChannelFilter: FilterType {
                 "salesChannelFilter.row.pos.description",
                 value: "Point of Sale",
                 comment: "Description for the Sales channel filter option, when selecting 'Point of Sale' orders")
+        case .webCheckout:
+            return NSLocalizedString(
+                "salesChannelFilter.row.webCheckout.description",
+                value: "Web Checkout",
+                comment: "Description for the Sales channel filter option, when selecting 'Web Checkout' orders")
+        case .wpAdmin:
+            return NSLocalizedString(
+                "salesChannelFilter.row.wpAdmin.description",
+                value: "WP-Admin",
+                comment: "Description for the Sales channel filter option, when selecting 'WP-Admin' orders")
         case .any:
             return NSLocalizedString(
                 "salesChannelFilter.row.any.description",
@@ -397,7 +407,7 @@ extension SalesChannelFilter: FilterType {
 
     var isActive: Bool {
         switch self {
-        case .pointOfSale:
+        case .pointOfSale, .webCheckout, .wpAdmin:
             return true
         case .any:
             return false

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
@@ -63,7 +63,18 @@ struct OrderListSyncActionUseCase {
         let endDate = filters?.dateRange?.computedEndDate
         let productID = filters?.product?.id
         let customerID = filters?.customer?.id
-        let createdVia = filters?.salesChannel == .pointOfSale ? "pos-rest-api" : nil
+        let createdVia: String? = {
+            switch filters?.salesChannel {
+            case .pointOfSale:
+                return "pos-rest-api"
+            case .webCheckout:
+                return "checkout,store-api"
+            case .wpAdmin:
+                return "admin"
+            case .any, .none:
+                return nil
+            }
+        }()
 
         if pageNumber == Defaults.pageFirstIndex {
             let deleteAllBeforeSaving = reason == SyncReason.pullToRefresh || reason == SyncReason.newFiltersApplied

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -257,8 +257,11 @@ final class OrderListViewModel {
 
             switch salesChannelFilter {
             case .pointOfSale:
-                let predicate = NSPredicate(format: "createdVia == %@", "pos-rest-api")
-                return predicate
+                return NSPredicate(format: "createdVia == %@", "pos-rest-api")
+            case .webCheckout:
+                return NSPredicate(format: "createdVia IN %@", ["checkout", "store-api"])
+            case .wpAdmin:
+                return NSPredicate(format: "createdVia == %@", "admin")
             case .any:
                 return nil
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
@@ -70,23 +70,12 @@ final class OrderListCellViewModelTests: XCTestCase {
         let viewModel = OrderListCellViewModel(order: order, currencySettings: ServiceLocator.currencySettings)
 
         // Then
-        XCTAssertEqual(viewModel.salesChannel, "POS")
+        XCTAssertEqual(viewModel.salesChannel?.description, "POS")
     }
 
     func test_salesChannel_when_createdVia_is_nil_then_returns_nil() {
         // Given
         let order = MockOrders().sampleOrder().copy(createdVia: nil)
-
-        // When
-        let viewModel = OrderListCellViewModel(order: order, currencySettings: ServiceLocator.currencySettings)
-
-        // Then
-        XCTAssertNil(viewModel.salesChannel)
-    }
-
-    func test_salesChannel_when_createdVia_is_not_pos_rest_api_then_returns_nil() {
-        // Given
-        let order = MockOrders().sampleOrder().copy(createdVia: "checkout")
 
         // When
         let viewModel = OrderListCellViewModel(order: order, currencySettings: ServiceLocator.currencySettings)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListSyncActionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListSyncActionUseCaseTests.swift
@@ -225,6 +225,110 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
         XCTAssertEqual(writeStrategy, .deleteAllBeforeSaving)
         XCTAssertEqual(statuses, [OrderStatusEnum.processing.rawValue])
     }
+
+    func test_sales_channel_filter_point_of_sale_maps_to_pos_rest_api() {
+        // Given
+        let filters = FilterOrderListViewModel.Filters(orderStatus: nil,
+                                                       dateRange: nil,
+                                                       product: nil,
+                                                       customer: nil,
+                                                       salesChannel: .pointOfSale,
+                                                       numberOfActiveFilters: 1)
+        let useCase = OrderListSyncActionUseCase(siteID: siteID, filters: filters)
+
+        // When
+        let action = useCase.actionFor(pageNumber: Defaults.pageFirstIndex,
+                                       pageSize: pageSize,
+                                       reason: nil,
+                                       lastFullSyncTimestamp: nil,
+                                       completionHandler: unimportantCompletionHandler)
+
+        // Then
+        guard case .fetchFilteredOrders(_, _, _, _, _, _, _, let createdVia, _, _, _) = action else {
+            XCTFail("Unexpected OrderAction type: \(action)")
+            return
+        }
+
+        XCTAssertEqual(createdVia, "pos-rest-api")
+    }
+
+    func test_sales_channel_filter_web_checkout_maps_to_checkout() {
+        // Given
+        let filters = FilterOrderListViewModel.Filters(orderStatus: nil,
+                                                       dateRange: nil,
+                                                       product: nil,
+                                                       customer: nil,
+                                                       salesChannel: .webCheckout,
+                                                       numberOfActiveFilters: 1)
+        let useCase = OrderListSyncActionUseCase(siteID: siteID, filters: filters)
+
+        // When
+        let action = useCase.actionFor(pageNumber: Defaults.pageFirstIndex,
+                                       pageSize: pageSize,
+                                       reason: nil,
+                                       lastFullSyncTimestamp: nil,
+                                       completionHandler: unimportantCompletionHandler)
+
+        // Then
+        guard case .fetchFilteredOrders(_, _, _, _, _, _, _, let createdVia, _, _, _) = action else {
+            XCTFail("Unexpected OrderAction type: \(action)")
+            return
+        }
+
+        XCTAssertEqual(createdVia, "checkout,store-api")
+    }
+
+    func test_sales_channel_filter_wp_admin_maps_to_admin() {
+        // Given
+        let filters = FilterOrderListViewModel.Filters(orderStatus: nil,
+                                                       dateRange: nil,
+                                                       product: nil,
+                                                       customer: nil,
+                                                       salesChannel: .wpAdmin,
+                                                       numberOfActiveFilters: 1)
+        let useCase = OrderListSyncActionUseCase(siteID: siteID, filters: filters)
+
+        // When
+        let action = useCase.actionFor(pageNumber: Defaults.pageFirstIndex,
+                                       pageSize: pageSize,
+                                       reason: nil,
+                                       lastFullSyncTimestamp: nil,
+                                       completionHandler: unimportantCompletionHandler)
+
+        // Then
+        guard case .fetchFilteredOrders(_, _, _, _, _, _, _, let createdVia, _, _, _) = action else {
+            XCTFail("Unexpected OrderAction type: \(action)")
+            return
+        }
+
+        XCTAssertEqual(createdVia, "admin")
+    }
+
+    func test_sales_channel_filter_any_maps_to_nil() {
+        // Given
+        let filters = FilterOrderListViewModel.Filters(orderStatus: nil,
+                                                       dateRange: nil,
+                                                       product: nil,
+                                                       customer: nil,
+                                                       salesChannel: .any,
+                                                       numberOfActiveFilters: 0)
+        let useCase = OrderListSyncActionUseCase(siteID: siteID, filters: filters)
+
+        // When
+        let action = useCase.actionFor(pageNumber: Defaults.pageFirstIndex,
+                                       pageSize: pageSize,
+                                       reason: nil,
+                                       lastFullSyncTimestamp: nil,
+                                       completionHandler: unimportantCompletionHandler)
+
+        // Assert
+        guard case .fetchFilteredOrders(_, _, _, _, _, _, _, let createdVia, _, _, _) = action else {
+            XCTFail("Unexpected OrderAction type: \(action)")
+            return
+        }
+
+        XCTAssertNil(createdVia)
+    }
 }
 
 private extension OrderListSyncActionUseCaseTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListSyncActionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListSyncActionUseCaseTests.swift
@@ -321,7 +321,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        lastFullSyncTimestamp: nil,
                                        completionHandler: unimportantCompletionHandler)
 
-        // Assert
+        // Then
         guard case .fetchFilteredOrders(_, _, _, _, _, _, _, let createdVia, _, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adding Web Checkout and WP Admin options to the Order Sales Channel filter.

### Filters and their API equivalents

An important realization is that the `Web Checkout` filter encompasses two values: `store-api` and `checkout`. The same two filters under the hood are also used when filtering within WP-Admin. When filtering, the API accepts both values at the same time. `store-api,checkout`. I tested and it works.

`WP-Admin` only depends on `admin` value.

### Badges

I didn't want to put badges for web checkout orders, so for now, I only kept `POS` badges. This can be an easy change if needed.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open store that has WP-Admin, Web, and POS orders
2. Open Orders tab
3. Select Filter -> Sales Channel
4. Confirm `Any`, `Point of Sale`, `Web Checkout`, and `WP-Admin` are now visible
5. Make selection of any of those filters, and confirm that the filtering works
6. Close the app with the selected filter and relaunch
7. Confirm that the filter is persisted
8. Clear filters
9. Confirm all orders are loaded

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/d1509923-4cdd-4e2f-9b79-abdb47156228



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.