### PR TITLE
[Woo POS][Surveys] Add feature flag. Define "potential merchant" notification

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -98,6 +98,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .ciabBookings:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .pointOfSaleSurveys:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -203,4 +203,8 @@ public enum FeatureFlag: Int {
     /// Enables a new Bookings tab for CIAB sites
     ///
     case ciabBookings
+
+    /// Enables surveys for potential and current POS merchants
+    ///
+    case pointOfSaleSurveys
 }

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -22,6 +22,7 @@ struct LocalNotification {
         case blazeNoCampaignReminder
         case blazeAbandonedCampaignCreationReminder
         case productImageBackgroundUpload
+        case pointOfSalePotentialMerchant
         case unknown(siteID: Int64)
 
         var identifier: String {
@@ -32,6 +33,8 @@ struct LocalNotification {
                 return "blaze_abandoned_campaign_reminder"
             case .productImageBackgroundUpload:
                 return "product_image_background_upload"
+            case .pointOfSalePotentialMerchant:
+                return "point_of_sale_potential_merchant"
             case let .unknown(siteID):
                 return "unknown_" + "\(siteID)"
             }
@@ -95,6 +98,9 @@ extension LocalNotification {
         case .productImageBackgroundUpload:
             title = Localization.ProductImageBackgroundUpload.title
             body = Localization.ProductImageBackgroundUpload.body
+        case .pointOfSalePotentialMerchant:
+            title = Localization.PointOfSalePotentialMerchant.title
+            body = Localization.PointOfSalePotentialMerchant.body
         case .unknown:
             title = ""
             body = ""
@@ -145,6 +151,18 @@ extension LocalNotification {
                 value: "Your product images are still uploading in the background. Upload speed may be slower, and errors could occur." +
                 " For best results, please keep the app open until uploads are complete.",
                 comment: "Message on the local notification to inform the user about the background upload of product images."
+            )
+        }
+        enum PointOfSalePotentialMerchant {
+            static let title = NSLocalizedString(
+                "localNotification.PointOfSalePotentialMerchant.title",
+                value: "Thinking about in-person sales?",
+                comment: "Title of the local notification sent to potential Point of Sale merchants"
+            )
+            static let body = NSLocalizedString(
+                "localNotification.PointOfSalePotentialMerchant.body",
+                value: "Take a quick 2-minute survey to help us shape features you’ll love.",
+                comment: "Message body of the local notification sent to potential Point of Sale merchants"
             )
         }
     }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -252,19 +252,24 @@ extension PushNotificationsManager {
         unregisterForRemoteNotifications()
     }
 
-    /// Handles a Notification while in Foreground Mode. Currently, only remote notifications are handled in the foreground.
+    /// Handles a notification while the app is in foreground
     ///
-    /// - Parameters:
-    ///     - userInfo: The Notification's Payload
-    ///     - completionHandler: A callback, to be executed on completion
-    ///
-    /// - Returns: True when handled. False otherwise
+    /// - Parameter notification: The delivered `UNNotification`
+    /// - Returns: `UNNotificationPresentationOptions` indicating how (if at all) the system should present its own UI for this notification
     ///
     @MainActor
     func handleNotificationInTheForeground(_ notification: UNNotification) async -> UNNotificationPresentationOptions {
         let content = notification.request.content
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleSurveys) {
+            // Check if this is a local notification
+            if !content.isRemoteNotification {
+                // Display local notifications with banner and sound when app is in foreground
+                return [.banner, .sound]
+            }
+        }
+
         guard applicationState == .active, content.isRemoteNotification, inAppNotices == true else {
-            // Local notifications are currently not handled when the app is in the foreground.
+            // Remote notifications not handled when the app is not active, or in-app notices are disabled
             return UNNotificationPresentationOptions(rawValue: 0)
         }
 


### PR DESCRIPTION
Closes WOOMOB-1456

## Description
This PR adds the feature flag for POS Surveys, as well as defines the `LocalNotification` case for the "potential merchant" case (unused). A potential merchant right now is just anybody that creates an order in the app, later on will narrow down the conditions further to send this notification.

## Changes

We expand the current behavior of `handleNotificationInTheForeground`, which at the moment only handles remote push notifications, not local ones. This method is currently only used for tests, also I've confirmed with Kiwi how current Blaze notifications work at: p1760012173127899-slack-C03L1NF1EA3 just to be sure, and these only happen in the background.

## Testing
The notification code is not currently used:

1. Be sure you've given notification permissions to the app.
2. Go to `PaymentMethodsViewModel`, and add a call to `scheduleNotification()` inside `PaymentMethodsViewModel.trackFlowCompleted`:

```diff
    /// Tracks the `paymentsFlowCompleted` event.
    ///
    func trackFlowCompleted(method: WooAnalyticsEvent.PaymentsFlow.PaymentMethod,
                            cardReaderType: WooAnalyticsEvent.PaymentsFlow.CardReaderType?) {
        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
        let amountNormalized = currencyFormatter.convertToDecimal(total) ?? 0

        let amountInSmallestUnit = amountNormalized
            .multiplying(by: NSDecimalNumber(value: currencySettings.currencyCode.smallestCurrencyUnitMultiplier))
            .intValue

+        scheduleNotification()
```

```
    private func scheduleNotification() {
        Task { @MainActor in
            let seconds = TimeInterval(3)
            let notification = LocalNotification(title: "Hello",
                                                 body: "Some more text",
                                                 scenario: .pointOfSalePotentialMerchant,
                                                 actions: nil,
                                                 userInfo: [:])
            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: seconds, repeats: false)

            await ServiceLocator.pushNotesManager.requestLocalNotification(notification, trigger: trigger)
        }
    }
```
2. On a physical device: Run the app > Orders > Create an Order > Collect the payment
3. Upon success, the local notification will appear after 3 seconds

## Screenshots

https://github.com/user-attachments/assets/c32a036a-52d8-43fa-abb4-dd051012d49f

