### PR TITLE
Migrate to UIScene lifecycle

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -3,7 +3,6 @@ import Combine
 import Storage
 import class Networking.UserAgent
 import Experiments
-import class WidgetKit.WidgetCenter
 import protocol WooFoundation.Analytics
 import protocol Yosemite.StoresManager
 import struct Yosemite.Site
@@ -146,44 +145,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         await ServiceLocator.pushNotesManager.handleRemoteNotificationInTheBackground(userInfo: userInfo)
     }
 
-    func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
-        guard let quickAction = QuickAction(rawValue: shortcutItem.type),
-            let tabBarController else {
-            completionHandler(false)
-            return
-        }
-        switch quickAction {
-        case QuickAction.addProduct:
-            MainTabBarController.presentAddProductFlow()
-            completionHandler(true)
-        case QuickAction.addOrder:
-            tabBarController.navigate(to: OrdersDestination.createOrder)
-            completionHandler(true)
-        case QuickAction.openOrders:
-            tabBarController.navigate(to: OrdersDestination.orderList)
-            completionHandler(true)
-        case QuickAction.collectPayment:
-            tabBarController.navigate(to: OrdersDestination.createOrder)
-            completionHandler(true)
-        }
-    }
-
     func applicationWillTerminate(_ application: UIApplication) {
         DDLogVerbose("👀 Application terminating...")
         NotificationCenter.default.post(name: .applicationTerminating, object: nil)
-    }
-
-    func application(_ application: UIApplication,
-                     continue userActivity: NSUserActivity,
-                     restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
-            UIApplication.sceneDelegate?.handleWebActivity(userActivity)
-        }
-
-        SpotlightManager.handleUserActivity(userActivity)
-        trackWidgetTappedIfNeeded(userActivity: userActivity)
-
-        return true
     }
 
     func applicationDidReceiveMemoryWarning(_ application: UIApplication) {
@@ -223,9 +187,6 @@ extension AppDelegate {
         UINavigationBar.applyWooAppearance()
         UILabel.applyWooAppearance()
         UITabBar.applyWooAppearance()
-
-        // Take advantage of a bug in UIAlertController to style all UIAlertControllers with WC color
-        UIApplication.wooKeyWindow?.tintColor = .primary
     }
 
     /// Sets up FancyAlert's UIAppearance.
@@ -398,20 +359,6 @@ extension AppDelegate {
 
     func reconnectToTapToPayReaderIfNeeded() {
         ServiceLocator.tapToPayReconnectionController.reconnectIfNeeded()
-    }
-
-    /// Tracks if the application was opened via a widget tap.
-    ///
-    func trackWidgetTappedIfNeeded(userActivity: NSUserActivity) {
-        switch userActivity.activityType {
-        case WooConstants.storeInfoWidgetKind:
-            let widgetFamily = userActivity.userInfo?[WidgetCenter.UserInfoKey.family] as? String
-            ServiceLocator.analytics.track(event: .Widgets.widgetTapped(name: .todayStats, family: widgetFamily))
-        case WooConstants.appLinkWidgetKind:
-            ServiceLocator.analytics.track(event: .Widgets.widgetTapped(name: .appLink))
-        default:
-            break
-        }
     }
 }
 

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -95,7 +95,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         checkForUpgrades()
 
         // Cache onboarding state to speed IPP process
-        refreshCardPresentPaymentsOnboardingIfNeeded(completion: reconnectToTapToPayReaderIfNeeded)
+        refreshCardPresentPaymentsOnboardingIfNeeded()
 
         return true
     }
@@ -448,8 +448,10 @@ extension AppDelegate {
             }
     }
 
-    func refreshCardPresentPaymentsOnboardingIfNeeded(completion: @escaping (() -> Void)) {
-        ServiceLocator.cardPresentPaymentsOnboardingIPPUsersRefresher.refreshIPPUsersOnboardingState(completion: completion)
+    func refreshCardPresentPaymentsOnboardingIfNeeded() {
+        ServiceLocator
+            .cardPresentPaymentsOnboardingIPPUsersRefresher
+            .refreshIPPUsersOnboardingState(completion: reconnectToTapToPayReaderIfNeeded)
     }
 
     func reconnectToTapToPayReaderIfNeeded() {

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -45,8 +45,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ///
     private var jetpackSetupCoordinator: JetpackSetupCoordinator?
 
-    private var universalLinkRouter: UniversalLinkRouter?
-
     private(set) var requirementsChecker = RequirementsChecker(baseViewController: nil)
 
     /// Handles events to background refresh the app.
@@ -364,6 +362,7 @@ extension AppDelegate {
 
     /// Push Notifications: Authorization + Registration!
     ///
+    /// periphery: ignore - Fails when build on simulator
     func setupPushNotificationsManagerIfPossible(_ pushNotesManager: PushNotesManager, stores: StoresManager) {
         #if targetEnvironment(simulator)
             DDLogVerbose("👀 Push Notifications are not supported in the Simulator!")

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -143,18 +143,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 }
 
-// MARK: - UIScene Configuration
-extension AppDelegate {
-    func application(_ application: UIApplication,
-                     configurationForConnecting connectingSceneSession: UISceneSession,
-                     options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        let config = UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
-        config.delegateClass = SceneDelegate.self
-        return config
-    }
-
-}
-
 // MARK: - Initialization Methods
 //
 extension AppDelegate {

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -146,32 +146,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         await ServiceLocator.pushNotesManager.handleRemoteNotificationInTheBackground(userInfo: userInfo)
     }
 
-    func applicationWillResignActive(_ application: UIApplication) {
-        // Simulate push notification for capturing snapshot.
-        // This is supposed to be called only by the WooCommerceScreenshots target.
-        if ProcessConfiguration.shouldSimulatePushNotification {
-            let content = UNMutableNotificationContent()
-            content.title = NSLocalizedString(
-                "You have a new order! 🎉",
-                comment: "Title for the mocked order notification needed for the AppStore listing screenshot"
-            )
-            content.body = NSLocalizedString(
-                "New order for $13.98 on Your WooCommerce Store",
-                comment: "Message for the mocked order notification needed for the AppStore listing screenshot. " +
-                "'Your WooCommerce Store' is the name of the mocked store."
-            )
-
-            // show this notification seconds from now
-            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 3, repeats: false)
-
-            // choose a random identifier
-            let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
-
-            // add our notification request
-            UNUserNotificationCenter.current().add(request)
-        }
-    }
-
     func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
         guard let quickAction = QuickAction(rawValue: shortcutItem.type),
             let tabBarController else {
@@ -192,22 +166,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             tabBarController.navigate(to: OrdersDestination.createOrder)
             completionHandler(true)
         }
-    }
-
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        // Don't track startup waiting time if app is backgrounded before everything is loaded
-        cancelStartupWaitingTimeTracker()
-    }
-
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        // Handled per-scene in SceneDelegate.sceneWillEnterForeground(_:)
-    }
-
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive.
-        // If the application was previously in the background, optionally refresh the user interface.
-
-        requirementsChecker.checkEligibilityForDefaultStore()
     }
 
     func applicationWillTerminate(_ application: UIApplication) {
@@ -240,14 +198,11 @@ extension AppDelegate {
     func application(_ application: UIApplication,
                      configurationForConnecting connectingSceneSession: UISceneSession,
                      options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        let config = UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+        let config = UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
         config.delegateClass = SceneDelegate.self
         return config
     }
 
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Resources tied to discarded scenes can be released here if needed.
-    }
 }
 
 // MARK: - Initialization Methods

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -34,11 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     /// Tab Bar Controller
     ///
     var tabBarController: MainTabBarController? {
-        guard let sceneDelegate = UIApplication.shared.connectedScenes
-            .compactMap({ $0 as? UIWindowScene })
-            .compactMap({ $0.delegate as? SceneDelegate })
-            .first else { return nil }
-        return sceneDelegate.tabBarController
+        return UIApplication.sceneDelegate?.tabBarController
     }
 
     /// Coordinates the Jetpack setup flow for users authenticated without Jetpack.
@@ -117,10 +113,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        guard let sceneDelegate = UIApplication.shared.connectedScenes
-            .compactMap({ $0 as? UIWindowScene })
-            .compactMap({ $0.delegate as? SceneDelegate })
-            .first,
+        guard let sceneDelegate = UIApplication.sceneDelegate,
               let rootViewController = sceneDelegate.window?.rootViewController else {
             fatalError()
         }
@@ -202,6 +195,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
+        // Don't track startup waiting time if app is backgrounded before everything is loaded
         cancelStartupWaitingTimeTracker()
     }
 
@@ -225,12 +219,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                      continue userActivity: NSUserActivity,
                      restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
-            if let sceneDelegate = UIApplication.shared.connectedScenes
-                .compactMap({ $0 as? UIWindowScene })
-                .compactMap({ $0.delegate as? SceneDelegate })
-                .first {
-                sceneDelegate.handleWebActivity(userActivity)
-            }
+            UIApplication.sceneDelegate?.handleWebActivity(userActivity)
         }
 
         SpotlightManager.handleUserActivity(userActivity)
@@ -280,10 +269,8 @@ extension AppDelegate {
         UILabel.applyWooAppearance()
         UITabBar.applyWooAppearance()
 
-        // Apply tint to current key window when available
-        if let keyWindow = UIApplication.wooKeyWindow {
-            keyWindow.tintColor = .primary
-        }
+        // Take advantage of a bug in UIAlertController to style all UIAlertControllers with WC color
+        UIApplication.wooKeyWindow?.tintColor = .primary
     }
 
     /// Sets up FancyAlert's UIAppearance.

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -281,10 +281,7 @@ extension AppDelegate {
         UITabBar.applyWooAppearance()
 
         // Apply tint to current key window when available
-        if let keyWindow = UIApplication.shared.connectedScenes
-            .compactMap({ $0 as? UIWindowScene })
-            .flatMap({ $0.windows })
-            .first(where: { $0.isKeyWindow }) {
+        if let keyWindow = UIApplication.wooKeyWindow {
             keyWindow.tintColor = .primary
         }
     }

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -248,6 +248,7 @@ extension AppDelegate {
 
     /// Push Notifications: Authorization + Registration!
     ///
+    // periphery: ignore - Fails when build on simulator
     func setupPushNotificationsManagerIfPossible(_ pushNotesManager: PushNotesManager, stores: StoresManager) {
         #if targetEnvironment(simulator)
             DDLogVerbose("👀 Push Notifications are not supported in the Simulator!")

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -40,7 +40,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ///
     private var jetpackSetupCoordinator: JetpackSetupCoordinator?
 
-    private(set) var requirementsChecker = RequirementsChecker(baseViewController: nil)
+    private(set) lazy var requirementsChecker = RequirementsChecker(baseViewController: tabBarController)
 
     /// Handles events to background refresh the app.
     ///
@@ -109,20 +109,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         appRefreshHandler.registerSystemTaskIdentifier()
 
         return true
-    }
-
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        guard let sceneDelegate = UIApplication.sceneDelegate,
-              let rootViewController = sceneDelegate.window?.rootViewController else {
-            fatalError()
-        }
-
-        if let universalLinkRouter = sceneDelegate.universalLinkRouter, universalLinkRouter.canHandle(url: url) {
-            universalLinkRouter.handle(url: url)
-            return true
-        }
-
-        return handleAuthenticationUrl(url, options: options, rootViewController: rootViewController)
     }
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
@@ -262,7 +248,6 @@ extension AppDelegate {
 
     /// Push Notifications: Authorization + Registration!
     ///
-    /// periphery: ignore - Fails when build on simulator
     func setupPushNotificationsManagerIfPossible(_ pushNotesManager: PushNotesManager, stores: StoresManager) {
         #if targetEnvironment(simulator)
             DDLogVerbose("👀 Push Notifications are not supported in the Simulator!")

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -250,7 +250,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 // MARK: - UIScene Configuration
 extension AppDelegate {
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    func application(_ application: UIApplication,
+                     configurationForConnecting connectingSceneSession: UISceneSession,
+                     options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         let config = UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
         config.delegateClass = SceneDelegate.self
         return config

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -31,21 +31,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return UIApplication.shared.delegate as! AppDelegate
     }
 
-    /// Main Window
-    ///
-    var window: UIWindow?
-
-    /// Coordinates app navigation based on authentication state.
-    ///
-    private var appCoordinator: AppCoordinator?
-
-    /// Initializes storage manager along with AppDelegate
-    private let storageManager = ServiceLocator.storageManager
-
     /// Tab Bar Controller
     ///
     var tabBarController: MainTabBarController? {
-        appCoordinator?.tabBarController
+        guard let sceneDelegate = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .compactMap({ $0.delegate as? SceneDelegate })
+            .first else { return nil }
+        return sceneDelegate.tabBarController
     }
 
     /// Coordinates the Jetpack setup flow for users authenticated without Jetpack.
@@ -54,11 +47,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private var universalLinkRouter: UniversalLinkRouter?
 
-    private lazy var requirementsChecker = RequirementsChecker(baseViewController: tabBarController)
+    private(set) var requirementsChecker = RequirementsChecker(baseViewController: nil)
 
     /// Handles events to background refresh the app.
     ///
-    private let appRefreshHandler = BackgroundTaskRefreshDispatcher()
+    let appRefreshHandler = BackgroundTaskRefreshDispatcher()
 
     private var subscriptions: Set<AnyCancellable> = []
 
@@ -110,11 +103,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Setup the Interface!
-        setupMainWindow()
+        // Global UIAppearance that doesn't require a WindowScene
         setupComponentsAppearance()
-        setupNoticePresenter()
-        setupUniversalLinkRouter()
         disableAnimationsIfNeeded()
 
         // Don't track startup waiting time if user starts logged out
@@ -122,21 +112,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             cancelStartupWaitingTimeTracker()
         }
 
-        // Start app navigation.
-        appCoordinator?.start()
-
-        // Register for background app refresh events.
+        // Register for background app refresh events (scene will schedule actual refreshes)
         appRefreshHandler.registerSystemTaskIdentifier()
 
         return true
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        guard let rootViewController = window?.rootViewController else {
+        guard let sceneDelegate = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .compactMap({ $0.delegate as? SceneDelegate })
+            .first,
+              let rootViewController = sceneDelegate.window?.rootViewController else {
             fatalError()
         }
 
-        if let universalLinkRouter, universalLinkRouter.canHandle(url: url) {
+        if let universalLinkRouter = sceneDelegate.universalLinkRouter, universalLinkRouter.canHandle(url: url) {
             universalLinkRouter.handle(url: url)
             return true
         }
@@ -213,23 +204,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers,
-        // and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-
-        // Don't track startup waiting time if app is backgrounded before everything is loaded
         cancelStartupWaitingTimeTracker()
-
-        // Schedule the background app refresh when sending the app to the background.
-        // The OS is in charge of determining when these tasks will run based on app usage patterns.
-        appRefreshHandler.scheduleAppRefresh()
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {
-        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
-
-        // Cache onboarding state to speed IPP process, then silently connect to Tap to Pay if previously connected, to speed up IPP
-        refreshCardPresentPaymentsOnboardingIfNeeded(completion: reconnectToTapToPayReaderIfNeeded)
+        // Handled per-scene in SceneDelegate.sceneWillEnterForeground(_:)
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {
@@ -248,7 +227,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                      continue userActivity: NSUserActivity,
                      restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
-            handleWebActivity(userActivity)
+            if let sceneDelegate = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene })
+                .compactMap({ $0.delegate as? SceneDelegate })
+                .first {
+                sceneDelegate.handleWebActivity(userActivity)
+            }
         }
 
         SpotlightManager.handleUserActivity(userActivity)
@@ -264,19 +248,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 }
 
+// MARK: - UIScene Configuration
+extension AppDelegate {
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        let config = UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+        config.delegateClass = SceneDelegate.self
+        return config
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Resources tied to discarded scenes can be released here if needed.
+    }
+}
+
 // MARK: - Initialization Methods
 //
-private extension AppDelegate {
-
-    /// Sets up the main UIWindow instance.
-    ///
-    func setupMainWindow() {
-        let window = UIWindow()
-        window.makeKeyAndVisible()
-        self.window = window
-
-        appCoordinator = AppCoordinator(window: window)
-    }
+extension AppDelegate {
 
     /// Sets up all of the component(s) Appearance.
     ///
@@ -293,8 +280,13 @@ private extension AppDelegate {
         UILabel.applyWooAppearance()
         UITabBar.applyWooAppearance()
 
-        // Take advantage of a bug in UIAlertController to style all UIAlertControllers with WC color
-        window?.tintColor = .primary
+        // Apply tint to current key window when available
+        if let keyWindow = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap({ $0.windows })
+            .first(where: { $0.isKeyWindow }) {
+            keyWindow.tintColor = .primary
+        }
     }
 
     /// Sets up FancyAlert's UIAppearance.
@@ -368,13 +360,6 @@ private extension AppDelegate {
         CocoaLumberjackSwift.dynamicLogLevel = level
     }
 
-    /// Setup: Notice Presenter
-    ///
-    func setupNoticePresenter() {
-        var noticePresenter = ServiceLocator.noticePresenter
-        noticePresenter.presentingViewController = appCoordinator?.tabBarController
-    }
-
     /// Push Notifications: Authorization + Registration!
     ///
     func setupPushNotificationsManagerIfPossible(_ pushNotesManager: PushNotesManager, stores: StoresManager) {
@@ -389,11 +374,6 @@ private extension AppDelegate {
 
     func setupUserNotificationCenter() {
         UNUserNotificationCenter.current().delegate = self
-    }
-
-    func setupUniversalLinkRouter() {
-        guard let tabBarController = tabBarController else { return }
-        universalLinkRouter = UniversalLinkRouter.defaultUniversalLinkRouter(tabBarController: tabBarController)
     }
 
     /// Set up app review prompt
@@ -445,7 +425,7 @@ private extension AppDelegate {
         }
 
         if ProcessConfiguration.shouldUseScreenshotsNetworkLayer {
-            ServiceLocator.setStores(ScreenshotStoresManager(storageManager: storageManager))
+            ServiceLocator.setStores(ScreenshotStoresManager(storageManager: ServiceLocator.storageManager))
         }
 
         if ProcessConfiguration.shouldSimulatePushNotification {
@@ -560,20 +540,8 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     }
 }
 
-// MARK: - Universal Links
-
-private extension AppDelegate {
-    func handleWebActivity(_ activity: NSUserActivity) {
-        guard let linkURL = activity.webpageURL else {
-            return
-        }
-
-        universalLinkRouter?.handle(url: linkURL)
-    }
-}
-
 // MARK: - Magic link
-private extension AppDelegate {
+extension AppDelegate {
     func handleAuthenticationUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any], rootViewController: UIViewController) -> Bool {
         return if ServiceLocator.stores.isAuthenticated {
             handleAuthenticationUrlForJetpackSetup(url, rootViewController: rootViewController)

--- a/WooCommerce/Classes/Extensions/UIApplication+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIApplication+Woo.swift
@@ -20,3 +20,13 @@ extension UIApplication.State {
         }
     }
 }
+
+extension UIApplication {
+    /// Returns the current key window from the connected window scenes.
+    static var wooKeyWindow: UIWindow? {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+    }
+}

--- a/WooCommerce/Classes/Extensions/UIApplication+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIApplication+Woo.swift
@@ -29,4 +29,11 @@ extension UIApplication {
             .flatMap { $0.windows }
             .first { $0.isKeyWindow }
     }
+
+    static var sceneDelegate: SceneDelegate? {
+        UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .compactMap({ $0.delegate as? SceneDelegate })
+            .first
+    }
 }

--- a/WooCommerce/Classes/Extensions/UIApplication+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIApplication+Woo.swift
@@ -30,6 +30,11 @@ extension UIApplication {
             .first { $0.isKeyWindow }
     }
 
+    /// Returns the delegate of the first connected scene.
+    ///
+    /// - Note: This approach is valid while the app supports only a single scene.
+    ///       If multi‑window support is introduced in the future,
+    ///       this will need to be revisited to handle multiple scenes safely.
     static var sceneDelegate: SceneDelegate? {
         UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })

--- a/WooCommerce/Classes/SceneDelegate.swift
+++ b/WooCommerce/Classes/SceneDelegate.swift
@@ -1,4 +1,5 @@
 import UIKit
+import class WidgetKit.WidgetCenter
 
 final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
@@ -30,8 +31,16 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             self.scene(scene, continue: activity)
         }
 
+        // Cold-start quick action
+        if let shortcut = connectionOptions.shortcutItem {
+            handle(shortcutItem: shortcut, completion: nil)
+        }
+
         // Update AppDelegate-scoped dependencies that rely on a base VC
         AppDelegate.shared.requirementsChecker.baseViewController = tabBarController
+
+        // Take advantage of a bug in UIAlertController to style all UIAlertControllers with WC color
+        UIApplication.wooKeyWindow?.tintColor = .primary
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
@@ -93,7 +102,38 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
-        handleWebActivity(userActivity)
+        if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
+            handleWebActivity(userActivity)
+        }
+
+        SpotlightManager.handleUserActivity(userActivity)
+        trackWidgetTappedIfNeeded(userActivity: userActivity)
+    }
+
+    func windowScene(_ windowScene: UIWindowScene, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
+        handle(shortcutItem: shortcutItem, completion: completionHandler)
+    }
+
+    private func handle(shortcutItem: UIApplicationShortcutItem, completion: ((Bool) -> Void)?) {
+        guard let quickAction = QuickAction(rawValue: shortcutItem.type),
+              let tabBarController else {
+            completion?(false)
+            return
+        }
+        switch quickAction {
+        case .addProduct:
+            MainTabBarController.presentAddProductFlow()
+            completion?(true)
+        case .addOrder:
+            tabBarController.navigate(to: OrdersDestination.createOrder)
+            completion?(true)
+        case .openOrders:
+            tabBarController.navigate(to: OrdersDestination.orderList)
+            completion?(true)
+        case .collectPayment:
+            tabBarController.navigate(to: OrdersDestination.createOrder)
+            completion?(true)
+        }
     }
 
     // MARK: - Scene-scoped helpers moved from AppDelegate
@@ -110,5 +150,20 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func handleWebActivity(_ activity: NSUserActivity) {
         guard let linkURL = activity.webpageURL else { return }
         universalLinkRouter?.handle(url: linkURL)
+    }
+
+
+    /// Tracks if the application was opened via a widget tap.
+    ///
+    func trackWidgetTappedIfNeeded(userActivity: NSUserActivity) {
+        switch userActivity.activityType {
+        case WooConstants.storeInfoWidgetKind:
+            let widgetFamily = userActivity.userInfo?[WidgetCenter.UserInfoKey.family] as? String
+            ServiceLocator.analytics.track(event: .Widgets.widgetTapped(name: .todayStats, family: widgetFamily))
+        case WooConstants.appLinkWidgetKind:
+            ServiceLocator.analytics.track(event: .Widgets.widgetTapped(name: .appLink))
+        default:
+            break
+        }
     }
 }

--- a/WooCommerce/Classes/SceneDelegate.swift
+++ b/WooCommerce/Classes/SceneDelegate.swift
@@ -34,9 +34,37 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         AppDelegate.shared.requirementsChecker.baseViewController = tabBarController
     }
 
-    func sceneDidBecomeActive(_ scene: UIScene) {}
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive.
+        // If the application was previously in the background, optionally refresh the user interface.
+        AppDelegate.shared.requirementsChecker.checkEligibilityForDefaultStore()
+    }
 
-    func sceneWillResignActive(_ scene: UIScene) {}
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Simulate push notification for capturing snapshot.
+        // This is supposed to be called only by the WooCommerceScreenshots target.
+        if ProcessConfiguration.shouldSimulatePushNotification {
+            let content = UNMutableNotificationContent()
+            content.title = NSLocalizedString(
+                "You have a new order! 🎉",
+                comment: "Title for the mocked order notification needed for the AppStore listing screenshot"
+            )
+            content.body = NSLocalizedString(
+                "New order for $13.98 on Your WooCommerce Store",
+                comment: "Message for the mocked order notification needed for the AppStore listing screenshot. " +
+                "'Your WooCommerce Store' is the name of the mocked store."
+            )
+
+            // show this notification seconds from now
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 3, repeats: false)
+
+            // choose a random identifier
+            let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
+
+            // add our notification request
+            UNUserNotificationCenter.current().add(request)
+        }
+    }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Cache onboarding state to speed IPP process, then silently connect to Tap to Pay if previously connected, to speed up IPP
@@ -44,6 +72,9 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
+        // Don't track startup waiting time if app is backgrounded before everything is loaded
+        AppDelegate.shared.cancelStartupWaitingTimeTracker()
+
         // Schedule the background app refresh when sending the app to the background.
         // The OS is in charge of determining when these tasks will run based on app usage patterns.
         AppDelegate.shared.appRefreshHandler.scheduleAppRefresh()

--- a/WooCommerce/Classes/SceneDelegate.swift
+++ b/WooCommerce/Classes/SceneDelegate.swift
@@ -38,9 +38,6 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             handle(shortcutItem: shortcut, completion: nil)
         }
 
-        // Update AppDelegate-scoped dependencies that rely on a base VC
-        AppDelegate.shared.requirementsChecker.baseViewController = tabBarController
-
         // Take advantage of a bug in UIAlertController to style all UIAlertControllers with WC color
         UIApplication.wooKeyWindow?.tintColor = .primary
     }

--- a/WooCommerce/Classes/SceneDelegate.swift
+++ b/WooCommerce/Classes/SceneDelegate.swift
@@ -2,12 +2,14 @@ import UIKit
 import class WidgetKit.WidgetCenter
 
 final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    // MARK: - Properties
     var window: UIWindow?
     private(set) var appCoordinator: AppCoordinator?
     var universalLinkRouter: UniversalLinkRouter?
-
     var tabBarController: MainTabBarController? { appCoordinator?.tabBarController }
 
+    // MARK: - Scene lifecycle
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = scene as? UIWindowScene else { return }
 
@@ -110,6 +112,13 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         trackWidgetTappedIfNeeded(userActivity: userActivity)
     }
 
+
+    private func handleWebActivity(_ activity: NSUserActivity) {
+        guard let linkURL = activity.webpageURL else { return }
+        universalLinkRouter?.handle(url: linkURL)
+    }
+
+    // MARK: - Home Screen Quick Actions
     func windowScene(_ windowScene: UIWindowScene, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
         handle(shortcutItem: shortcutItem, completion: completionHandler)
     }
@@ -136,7 +145,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
 
-    // MARK: - Scene-scoped helpers moved from AppDelegate
+    // MARK: - Routers & Presenters
     private func setupNoticePresenter() {
         var noticePresenter = ServiceLocator.noticePresenter
         noticePresenter.presentingViewController = tabBarController
@@ -147,11 +156,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         universalLinkRouter = UniversalLinkRouter.defaultUniversalLinkRouter(tabBarController: tabBarController)
     }
 
-    func handleWebActivity(_ activity: NSUserActivity) {
-        guard let linkURL = activity.webpageURL else { return }
-        universalLinkRouter?.handle(url: linkURL)
-    }
-
+    // MARK: - Analytics & Widgets
 
     /// Tracks if the application was opened via a widget tap.
     ///

--- a/WooCommerce/Classes/SceneDelegate.swift
+++ b/WooCommerce/Classes/SceneDelegate.swift
@@ -39,7 +39,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillResignActive(_ scene: UIScene) {}
 
     func sceneWillEnterForeground(_ scene: UIScene) {
-        AppDelegate.shared.refreshCardPresentPaymentsOnboardingIfNeeded(completion: AppDelegate.shared.reconnectToTapToPayReaderIfNeeded)
+        AppDelegate.shared.refreshCardPresentPaymentsOnboardingIfNeeded()
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {

--- a/WooCommerce/Classes/SceneDelegate.swift
+++ b/WooCommerce/Classes/SceneDelegate.swift
@@ -39,10 +39,13 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillResignActive(_ scene: UIScene) {}
 
     func sceneWillEnterForeground(_ scene: UIScene) {
+        // Cache onboarding state to speed IPP process, then silently connect to Tap to Pay if previously connected, to speed up IPP
         AppDelegate.shared.refreshCardPresentPaymentsOnboardingIfNeeded()
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
+        // Schedule the background app refresh when sending the app to the background.
+        // The OS is in charge of determining when these tasks will run based on app usage patterns.
         AppDelegate.shared.appRefreshHandler.scheduleAppRefresh()
     }
 

--- a/WooCommerce/Classes/SceneDelegate.swift
+++ b/WooCommerce/Classes/SceneDelegate.swift
@@ -1,0 +1,80 @@
+import UIKit
+
+final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+    private(set) var appCoordinator: AppCoordinator?
+    var universalLinkRouter: UniversalLinkRouter?
+
+    var tabBarController: MainTabBarController? { appCoordinator?.tabBarController }
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+
+        let window = UIWindow(windowScene: windowScene)
+        window.makeKeyAndVisible()
+        self.window = window
+
+        let coordinator = AppCoordinator(window: window)
+        self.appCoordinator = coordinator
+        coordinator.start()
+
+        // Scene-scoped initializations that need UI
+        setupNoticePresenter()
+        setupUniversalLinkRouter()
+
+        // Cold-start deep links / activities
+        if let urlContext = connectionOptions.urlContexts.first {
+            self.scene(scene, openURLContexts: [urlContext])
+        }
+        if let activity = connectionOptions.userActivities.first {
+            self.scene(scene, continue: activity)
+        }
+
+        // Update AppDelegate-scoped dependencies that rely on a base VC
+        AppDelegate.shared.requirementsChecker.baseViewController = tabBarController
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {}
+
+    func sceneWillResignActive(_ scene: UIScene) {}
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        AppDelegate.shared.refreshCardPresentPaymentsOnboardingIfNeeded(completion: AppDelegate.shared.reconnectToTapToPayReaderIfNeeded)
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        AppDelegate.shared.appRefreshHandler.scheduleAppRefresh()
+    }
+
+    // MARK: - URL / Activity Handling
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        guard let url = URLContexts.first?.url else { return }
+        if let universalLinkRouter, universalLinkRouter.canHandle(url: url) {
+            universalLinkRouter.handle(url: url)
+            return
+        }
+        if let rootVC = window?.rootViewController {
+            _ = AppDelegate.shared.handleAuthenticationUrl(url, options: [:], rootViewController: rootVC)
+        }
+    }
+
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        handleWebActivity(userActivity)
+    }
+
+    // MARK: - Scene-scoped helpers moved from AppDelegate
+    private func setupNoticePresenter() {
+        var noticePresenter = ServiceLocator.noticePresenter
+        noticePresenter.presentingViewController = tabBarController
+    }
+
+    private func setupUniversalLinkRouter() {
+        guard let tabBarController = tabBarController else { return }
+        universalLinkRouter = UniversalLinkRouter.defaultUniversalLinkRouter(tabBarController: tabBarController)
+    }
+
+    func handleWebActivity(_ activity: NSUserActivity) {
+        guard let linkURL = activity.webpageURL else { return }
+        universalLinkRouter?.handle(url: linkURL)
+    }
+}

--- a/WooCommerce/Classes/System/WooTabContainerController.swift
+++ b/WooCommerce/Classes/System/WooTabContainerController.swift
@@ -22,7 +22,7 @@ final class TabContainerController: UIViewController {
             newWrappedController.didMove(toParent: self)
 
             if #available(iOS 18.0, *), UIDevice.current.userInterfaceIdiom == .pad,
-               let horizontalSize = AppDelegate.shared.window?.traitCollection.horizontalSizeClass {
+               let horizontalSize = UIApplication.wooKeyWindow?.traitCollection.horizontalSizeClass {
                 newWrappedController.traitOverrides.horizontalSizeClass = horizontalSize
             }
 

--- a/WooCommerce/Classes/Tools/RequirementsChecker.swift
+++ b/WooCommerce/Classes/Tools/RequirementsChecker.swift
@@ -25,7 +25,7 @@ enum RequirementCheckResult: Int, CaseIterable {
 final class RequirementsChecker {
 
     private let stores: StoresManager
-    var baseViewController: UIViewController?
+    private let baseViewController: UIViewController?
 
     init(stores: StoresManager = ServiceLocator.stores,
          baseViewController: UIViewController? = nil) {

--- a/WooCommerce/Classes/Tools/RequirementsChecker.swift
+++ b/WooCommerce/Classes/Tools/RequirementsChecker.swift
@@ -25,7 +25,7 @@ enum RequirementCheckResult: Int, CaseIterable {
 final class RequirementsChecker {
 
     private let stores: StoresManager
-    private let baseViewController: UIViewController?
+    var baseViewController: UIViewController?
 
     init(stores: StoresManager = ServiceLocator.stores,
          baseViewController: UIViewController? = nil) {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -323,11 +323,7 @@ final class MainTabBarController: UITabBarController {
     private func fixTabBarTraitCollectionOnIpadForiOS18() {
         if #available(iOS 18.0, *), UIDevice.current.userInterfaceIdiom == .pad {
             traitOverrides.horizontalSizeClass = .compact
-            if let rootHorizontalSizeClass = UIApplication.shared.connectedScenes
-                .compactMap({ $0 as? UIWindowScene })
-                .flatMap({ $0.windows })
-                .first(where: { $0.isKeyWindow })?
-                .traitCollection.horizontalSizeClass {
+            if let rootHorizontalSizeClass = UIApplication.wooKeyWindow?.traitCollection.horizontalSizeClass {
                 tabBar.traitOverrides.horizontalSizeClass = rootHorizontalSizeClass
                 if let viewControllers {
                     for vc in viewControllers {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -323,7 +323,11 @@ final class MainTabBarController: UITabBarController {
     private func fixTabBarTraitCollectionOnIpadForiOS18() {
         if #available(iOS 18.0, *), UIDevice.current.userInterfaceIdiom == .pad {
             traitOverrides.horizontalSizeClass = .compact
-            if let rootHorizontalSizeClass = AppDelegate.shared.window?.traitCollection.horizontalSizeClass {
+            if let rootHorizontalSizeClass = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene })
+                .flatMap({ $0.windows })
+                .first(where: { $0.isKeyWindow })?
+                .traitCollection.horizontalSizeClass {
                 tabBar.traitOverrides.horizontalSizeClass = rootHorizontalSizeClass
                 if let viewControllers {
                     for vc in viewControllers {

--- a/WooCommerce/Resources/Info.plist
+++ b/WooCommerce/Resources/Info.plist
@@ -157,5 +157,24 @@
 	<true/>
 	<key>BuildConfigurationName</key>
 	<string>$(CONFIGURATION)</string>
+  <key>UIApplicationSceneManifest</key>
+  <dict>
+    <key>UIApplicationSupportsMultipleScenes</key>
+    <false/>
+    <key>UISceneConfigurations</key>
+    <dict>
+        <key>UIWindowSceneSessionRoleApplication</key>
+        <array>
+            <dict>
+                <key>UISceneConfigurationName</key>
+                <string>Default Configuration</string>
+                <key>UISceneDelegateClassName</key>
+                <string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+                <key>UISceneStoryboardFile</key>
+                <string>Main</string>
+            </dict>
+        </array>
+    </dict>
+  </dict>
 </dict>
 </plist>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1341,6 +1341,7 @@
 		57F2C6CD246DECC10074063B /* SummaryTableViewCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F2C6CC246DECC10074063B /* SummaryTableViewCellViewModelTests.swift */; };
 		57F42E40253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F42E3F253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift */; };
 		68051E1E2E9DFE5500228196 /* POSNotificationSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68051E1D2E9DFE5100228196 /* POSNotificationSchedulerTests.swift */; };
+		640DA3482E97DE4F00317FB2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640DA3472E97DE4F00317FB2 /* SceneDelegate.swift */; };
 		680BA59A2A4C377900F5559D /* UpgradeViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680BA5992A4C377900F5559D /* UpgradeViewState.swift */; };
 		680E36B52BD8B9B900E8BCEA /* OrderSubscriptionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 680E36B42BD8B9B900E8BCEA /* OrderSubscriptionTableViewCell.xib */; };
 		680E36B72BD8C49F00E8BCEA /* OrderSubscriptionTableViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680E36B62BD8C49F00E8BCEA /* OrderSubscriptionTableViewCellViewModel.swift */; };
@@ -4248,6 +4249,7 @@
 		57CFCD292488496F003F51EC /* PrimarySectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PrimarySectionHeaderView.xib; sourceTree = "<group>"; };
 		57F2C6CC246DECC10074063B /* SummaryTableViewCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryTableViewCellViewModelTests.swift; sourceTree = "<group>"; };
 		57F42E3F253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndEditableValueTableViewCellViewModelTests.swift; sourceTree = "<group>"; };
+		640DA3472E97DE4F00317FB2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		68051E1D2E9DFE5100228196 /* POSNotificationSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSNotificationSchedulerTests.swift; sourceTree = "<group>"; };
 		680BA5992A4C377900F5559D /* UpgradeViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradeViewState.swift; sourceTree = "<group>"; };
 		680E36B42BD8B9B900E8BCEA /* OrderSubscriptionTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OrderSubscriptionTableViewCell.xib; sourceTree = "<group>"; };
@@ -9769,6 +9771,7 @@
 		B56DB3F12049C0B800D4AA8E /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				640DA3472E97DE4F00317FB2 /* SceneDelegate.swift */,
 				DEDB5D342E7A68950022E5A1 /* Bookings */,
 				2DCB54F82E6AE8C900621F90 /* CIAB */,
 				DEB387932C2E7A540025256E /* GoogleAds */,
@@ -14650,6 +14653,7 @@
 				4524CD9E242D01FD00B2F20A /* ProductStatusSettingListSelectorCommand.swift in Sources */,
 				02F6800325807C9B00C3BAD2 /* ShippingLabelPaperSizeOptionListView.swift in Sources */,
 				02DFD5042B20486C0048CD70 /* ProductStepper.swift in Sources */,
+				640DA3482E97DE4F00317FB2 /* SceneDelegate.swift in Sources */,
 				02E8B17723E2C49000A43403 /* InProgressProductImageCollectionViewCell.swift in Sources */,
 				0365986929AFB0C100F297D3 /* SetUpTapToPayInformationViewModel.swift in Sources */,
 				CE5F462C23AACBC4006B1A5C /* RefundDetailsResultController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1342,6 +1342,7 @@
 		57F42E40253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F42E3F253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift */; };
 		68051E1E2E9DFE5500228196 /* POSNotificationSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68051E1D2E9DFE5100228196 /* POSNotificationSchedulerTests.swift */; };
 		640DA3482E97DE4F00317FB2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640DA3472E97DE4F00317FB2 /* SceneDelegate.swift */; };
+		64D355A52E99048E005F53F7 /* TestingSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D355A42E99048E005F53F7 /* TestingSceneDelegate.swift */; };
 		680BA59A2A4C377900F5559D /* UpgradeViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680BA5992A4C377900F5559D /* UpgradeViewState.swift */; };
 		680E36B52BD8B9B900E8BCEA /* OrderSubscriptionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 680E36B42BD8B9B900E8BCEA /* OrderSubscriptionTableViewCell.xib */; };
 		680E36B72BD8C49F00E8BCEA /* OrderSubscriptionTableViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680E36B62BD8C49F00E8BCEA /* OrderSubscriptionTableViewCellViewModel.swift */; };
@@ -4250,6 +4251,7 @@
 		57F2C6CC246DECC10074063B /* SummaryTableViewCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryTableViewCellViewModelTests.swift; sourceTree = "<group>"; };
 		57F42E3F253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndEditableValueTableViewCellViewModelTests.swift; sourceTree = "<group>"; };
 		640DA3472E97DE4F00317FB2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		64D355A42E99048E005F53F7 /* TestingSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingSceneDelegate.swift; sourceTree = "<group>"; };
 		68051E1D2E9DFE5100228196 /* POSNotificationSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSNotificationSchedulerTests.swift; sourceTree = "<group>"; };
 		680BA5992A4C377900F5559D /* UpgradeViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradeViewState.swift; sourceTree = "<group>"; };
 		680E36B42BD8B9B900E8BCEA /* OrderSubscriptionTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OrderSubscriptionTableViewCell.xib; sourceTree = "<group>"; };
@@ -9536,6 +9538,7 @@
 		B53B898A20D4606400EDB467 /* System */ = {
 			isa = PBXGroup;
 			children = (
+				64D355A42E99048E005F53F7 /* TestingSceneDelegate.swift */,
 				B53B898820D450AF00EDB467 /* SessionManagerTests.swift */,
 				934CB124224EAB540005CCB9 /* TestingAppDelegate.swift */,
 				9379E1A22255365F006A6BE4 /* TestingMode.storyboard */,
@@ -15737,6 +15740,7 @@
 				CEC8188E2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift in Sources */,
 				CEEF74302B9A0E8900B03948 /* SessionsReportCardViewModelTests.swift in Sources */,
 				02C2756D24F4EEBF00286C04 /* ProductShippingSettingsViewModelTests.swift in Sources */,
+				64D355A52E99048E005F53F7 /* TestingSceneDelegate.swift in Sources */,
 				CE55F2D82B23961B005D53D7 /* CollapsibleProductCardPriceSummaryViewModelTests.swift in Sources */,
 				025678052575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift in Sources */,
 				0211252E25773FB00075AD2A /* MockAggregateOrderItem.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/System/TestingAppDelegate.swift
+++ b/WooCommerce/WooCommerceTests/System/TestingAppDelegate.swift
@@ -26,12 +26,4 @@ class TestingAppDelegate: AppDelegate {
 
         return true
     }
-
-    override func application(_ application: UIApplication,
-                              configurationForConnecting connectingSceneSession: UISceneSession,
-                              options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        let config = UISceneConfiguration(name: "Testing Configuration", sessionRole: connectingSceneSession.role)
-        config.delegateClass = TestingSceneDelegate.self
-        return config
-    }
 }

--- a/WooCommerce/WooCommerceTests/System/TestingAppDelegate.swift
+++ b/WooCommerce/WooCommerceTests/System/TestingAppDelegate.swift
@@ -35,20 +35,3 @@ class TestingAppDelegate: AppDelegate {
         return config
     }
 }
-
-// MARK: - Testing Scene Delegate (UIWindowSceneDelegate)
-final class TestingSceneDelegate: UIResponder, UIWindowSceneDelegate {
-    var window: UIWindow?
-
-    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        guard let windowScene = scene as? UIWindowScene else { return }
-
-        let bundle = Bundle(for: TestingAppDelegate.self)
-        let storyboard = UIStoryboard(name: "TestingMode", bundle: bundle)
-
-        let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = storyboard.instantiateInitialViewController()
-        window.makeKeyAndVisible()
-        self.window = window
-    }
-}

--- a/WooCommerce/WooCommerceTests/System/TestingAppDelegate.swift
+++ b/WooCommerce/WooCommerceTests/System/TestingAppDelegate.swift
@@ -18,10 +18,6 @@ class TestingAppDelegate: AppDelegate {
         let bundle = Bundle(for: type(of: self))
         let storyboard = UIStoryboard(name: "TestingMode", bundle: bundle)
 
-        window = UIWindow()
-        window?.rootViewController = storyboard.instantiateInitialViewController()
-        window?.makeKeyAndVisible()
-
         return true
     }
 
@@ -29,5 +25,30 @@ class TestingAppDelegate: AppDelegate {
         // Don't call super so nothing gets set up.
 
         return true
+    }
+
+    override func application(_ application: UIApplication,
+                              configurationForConnecting connectingSceneSession: UISceneSession,
+                              options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        let config = UISceneConfiguration(name: "Testing Configuration", sessionRole: connectingSceneSession.role)
+        config.delegateClass = TestingSceneDelegate.self
+        return config
+    }
+}
+
+// MARK: - Testing Scene Delegate (UIWindowSceneDelegate)
+final class TestingSceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+
+        let bundle = Bundle(for: TestingAppDelegate.self)
+        let storyboard = UIStoryboard(name: "TestingMode", bundle: bundle)
+
+        let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = storyboard.instantiateInitialViewController()
+        window.makeKeyAndVisible()
+        self.window = window
     }
 }

--- a/WooCommerce/WooCommerceTests/System/TestingSceneDelegate.swift
+++ b/WooCommerce/WooCommerceTests/System/TestingSceneDelegate.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+final class TestingSceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+
+        let bundle = Bundle(for: TestingAppDelegate.self)
+        let storyboard = UIStoryboard(name: "TestingMode", bundle: bundle)
+
+        let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = storyboard.instantiateInitialViewController()
+        window.makeKeyAndVisible()
+        self.window = window
+    }
+}


### PR DESCRIPTION
Closes [WOOMOB-1440](https://linear.app/a8c/issue/WOOMOB-1440)

## Description

Starting from the next major release after iOS 26, using UIScene [will be a hard requirement](https://developer.apple.com/documentation/technotes/tn3187-migrating-to-the-uikit-scene-based-life-cycle). This PR migrates to a UIScene-based lifecycle.

Changes
- Introduces `SceneDelegate` and moves functions related to window and app lifecycle management from AppDelegate to SceneDelegate.
  - Handle Home Screen Quick Actions in SceneDelegate (cold & warm start)
- Removes direct management of UIWindow and navigation logic from `AppDelegate` by shifting this responsibility to the `SceneDelegate`.
- [Adds](https://github.com/woocommerce/woocommerce-ios/pull/16230/files?new_files_changed=true#diff-a3de1e5a8f05978325a356c5ea3cb266564be3a42395cd072356eb80e98d1ca0) helpers for `UIApplication` for accessing the key Window and the SceneDelegate.
- Defines `UIApplicationSupportsMultipleScenes` with `false` to only support a single window of the app on iPad.

## Steps to reproduce

- Build and run the app locally to validate that the "`UIScene` lifecycle will soon be required. Failure to adopt will result in an assert in the future." warning is gone from the console.
- Cold and warm start via searching for "Orders" in Spotlight.
- Cold and warm start via shortcut and selecting any options.
- General smoke test the app

## Testing information

I've tested on both iPad and iPhone device running *OS26.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
