### PR TITLE
[Tooling] Use Release Version from ReleasesV2 in Code Freeze

### DIFF
--- a/.buildkite/release-pipelines/start-code-freeze.yml
+++ b/.buildkite/release-pipelines/start-code-freeze.yml
@@ -21,7 +21,7 @@ steps:
       bundle exec fastlane run configure_apply
 
       echo '--- :snowflake: Start Code Freeze'
-      bundle exec fastlane start_code_freeze skip_confirm:true
+      bundle exec fastlane start_code_freeze version:"${RELEASE_VERSION}" skip_confirm:true
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -195,25 +195,29 @@ platform :ios do
     # Check out the up-to-date default branch, the designated starting point for the code freeze
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
-    # Validate provided version matches the calculated version
-    expected_version = release_version_next
-    if version && version != expected_version
-      UI.user_error!("Version mismatch: Provided version '#{version}' does not match calculated version '#{expected_version}'. Please check the release scenario version matches the project version.")
+    # Use provided version from release tool, or fall back to calculated version
+    calculated_version = release_version_next
+    release_version = version || calculated_version
+
+    # Warn if provided version differs from calculated version
+    if version && version != calculated_version
+      warning_message = "⚠️ Version mismatch: Release tool version is '#{version}' but calculated version is '#{calculated_version}'. Using '#{version}' from release tool."
+      UI.important(warning_message)
+      buildkite_annotate(style: 'warning', context: 'start-code-freeze-version-mismatch', message: warning_message) if is_ci
     end
-    UI.success("✓ Version validation passed: Version (#{version || expected_version}) matches calculated version") if version
 
     UI.important <<-MESSAGE
 
       Code Freeze:
-      • New release branch from #{DEFAULT_BRANCH}: release/#{expected_version}
+      • New release branch from #{DEFAULT_BRANCH}: release/#{release_version}
       • Current release version and build code: #{release_version_current} (#{build_code_current}).
-      • New release version and build code: #{expected_version} (#{build_code_code_freeze}).
+      • New release version and build code: #{release_version} (#{build_code_code_freeze}).
 
     MESSAGE
     UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
 
     # Create the release branch
-    new_release_branch = "release/#{release_version_next}"
+    new_release_branch = "release/#{release_version}"
     ensure_branch_does_not_exist!(new_release_branch)
 
     UI.message('Creating release branch...')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -184,6 +184,7 @@ platform :ios do
 
   # This lane executes the steps planned on code freeze, creating a new release branch from the current trunk
   #
+  # @param [String] version (optional) The version number for the release from the release tool. If not provided, uses the calculated version.
   # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt before running the rest of the lane
   #
   # @example Running the lane

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -184,7 +184,8 @@ platform :ios do
 
   # This lane executes the steps planned on code freeze, creating a new release branch from the current trunk
   #
-  # @param [String] version (optional) The version number for the release from the release tool. If not provided, uses the calculated version.
+  # @param [String] version (optional) The version to use for the new release version to code freeze for.
+  #                 Typically auto-provided by ReleasesV2. If nil, computes the new version based on current one.
   # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt before running the rest of the lane
   #
   # @example Running the lane
@@ -196,13 +197,17 @@ platform :ios do
     # Check out the up-to-date default branch, the designated starting point for the code freeze
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
-    # Use provided version from release tool, or fall back to calculated version
-    calculated_version = release_version_next
-    release_version = version || calculated_version
+    # Use provided version from release tool, or fall back to computed version
+    computed_version = release_version_next
+    new_version = version || computed_version
 
-    # Warn if provided version differs from calculated version
-    if version && version != calculated_version
-      warning_message = "⚠️ Version mismatch: Release tool version is '#{version}' but calculated version is '#{calculated_version}'. Using '#{version}' from release tool."
+    # Warn if provided version differs from computed version
+    if version && version != computed_version
+      warning_message = <<~WARNING
+        ⚠️ Version mismatch: The explicitly-provided version was '#{version}' while new computed version would have been '#{computed_version}'.
+        If this is unexpected, you might want to investigate the discrepency.
+        Continuing with the explicitly-provided verison '#{version}'.
+      WARNING
       UI.important(warning_message)
       buildkite_annotate(style: 'warning', context: 'start-code-freeze-version-mismatch', message: warning_message) if is_ci
     end
@@ -210,15 +215,15 @@ platform :ios do
     UI.important <<-MESSAGE
 
       Code Freeze:
-      • New release branch from #{DEFAULT_BRANCH}: release/#{release_version}
+      • New release branch from #{DEFAULT_BRANCH}: release/#{new_version}
       • Current release version and build code: #{release_version_current} (#{build_code_current}).
-      • New release version and build code: #{release_version} (#{build_code_code_freeze}).
+      • New release version and build code: #{new_version} (#{build_code_code_freeze}).
 
     MESSAGE
     UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
 
     # Create the release branch
-    new_release_branch = "release/#{release_version}"
+    new_release_branch = "release/#{new_version}"
     ensure_branch_does_not_exist!(new_release_branch)
 
     UI.message('Creating release branch...')
@@ -233,8 +238,6 @@ platform :ios do
     )
     commit_version_bump
     UI.success("Done! New Release Version: #{release_version_current}. New Build Code: #{build_code_current}")
-
-    new_version = release_version_current
 
     extract_release_notes_for_version(
       version: new_version,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -189,18 +189,25 @@ platform :ios do
   # @example Running the lane
   #          bundle exec fastlane start_code_freeze skip_confirm:true
   #
-  lane :start_code_freeze do |skip_confirm: false|
+  lane :start_code_freeze do |version: nil, skip_confirm: false|
     ensure_git_status_clean
 
     # Check out the up-to-date default branch, the designated starting point for the code freeze
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
+    # Validate provided version matches the calculated version
+    expected_version = release_version_next
+    if version && version != expected_version
+      UI.user_error!("Version mismatch: Provided version '#{version}' does not match calculated version '#{expected_version}'. Please check the release scenario version matches the project version.")
+    end
+    UI.success("✓ Version validation passed: Version (#{version || expected_version}) matches calculated version") if version
+
     UI.important <<-MESSAGE
 
       Code Freeze:
-      • New release branch from #{DEFAULT_BRANCH}: release/#{release_version_next}
+      • New release branch from #{DEFAULT_BRANCH}: release/#{expected_version}
       • Current release version and build code: #{release_version_current} (#{build_code_current}).
-      • New release version and build code: #{release_version_next} (#{build_code_code_freeze}).
+      • New release version and build code: #{expected_version} (#{build_code_code_freeze}).
 
     MESSAGE
     UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')


### PR DESCRIPTION
Closes [AINFRA-1376: WCiOS: Validate that release version sent by ReleasesV2 matches the project](https://linear.app/a8c/issue/AINFRA-1376/wcios-validate-that-release-version-sent-by-releasesv2-matches-the)

## Description

This PR updates the code freeze process to use the release version provided by ReleasesV2 as the source of truth.

The code freeze Buildkite pipeline now passes the `RELEASE_VERSION` environment variable to the `code_freeze` Fastlane lane.
If there's a mismatch between the passed version and the project calculated version, a warning is displayed to help identify configuration discrepancies, but the ReleasesV2 version is always used.

## Testing

The code freeze lane has several side effects like potentially changing the version in the main branch, creating a release branch, updating release notes, etc, making it hard to easily test it. We can run a couple of tests locally commenting out parts of the lane, but they'll only test a minor part of the lane.
The changes will then be fully tested in the next release cycle during code freeze.