### PR TITLE
[Bookings] Booking details part 7

### DIFF
--- a/WooCommerce/Classes/ViewModels/Booking Details/AppointmentDetailsContent.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/AppointmentDetailsContent.swift
@@ -1,5 +1,6 @@
 import Foundation
 import struct Networking.Booking
+import Yosemite
 
 extension BookingDetailsViewModel {
     struct AppointmentDetailsContent {
@@ -15,10 +16,10 @@ extension BookingDetailsViewModel {
         let rows: [Row]
 
         init(_ booking: Booking) {
-            let appointmentDate = booking.startDate.formatted(date: .numeric, time: .omitted)
+            let appointmentDate = booking.startDate.toString(dateStyle: .short, timeStyle: .none, timeZone: BookingListTab.utcTimeZone)
             let appointmentTimeFrame = [
-                booking.startDate.formatted(date: .omitted, time: .shortened),
-                booking.endDate.formatted(date: .omitted, time: .shortened)
+                booking.startDate.toString(dateStyle: .none, timeStyle: .short, timeZone: BookingListTab.utcTimeZone),
+                booking.endDate.toString(dateStyle: .none, timeStyle: .short, timeZone: BookingListTab.utcTimeZone)
             ].joined(separator: " - ")
 
             rows = [

--- a/WooCommerce/Classes/ViewModels/Booking Details/AppointmentDetailsContent.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/AppointmentDetailsContent.swift
@@ -1,6 +1,5 @@
 import Foundation
 import struct Networking.Booking
-import Yosemite
 
 extension BookingDetailsViewModel {
     struct AppointmentDetailsContent {

--- a/WooCommerce/Classes/ViewModels/Booking Details/HeaderContent.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/HeaderContent.swift
@@ -10,9 +10,10 @@ extension BookingDetailsViewModel {
         @Published var serviceAndCustomerLine: String
 
         init(_ booking: Booking, customerName: String? = nil) {
-            bookingDate = booking.startDate.formatted(
-                date: .numeric,
-                time: .shortened
+            bookingDate = booking.startDate.toString(
+                dateStyle: .short,
+                timeStyle: .short,
+                timeZone: BookingListTab.utcTimeZone
             )
 
             /// Temporary hardcode for service name

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/CustomerDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/CustomerDetailsView.swift
@@ -5,6 +5,8 @@ extension BookingDetailsView {
     struct CustomerDetailsView: View {
         @ObservedObject var content: BookingDetailsViewModel.CustomerContent
         let showNotice: (Notice) -> Void
+        @State private var showingPhoneOptions = false
+        @State private var selectedPhoneNumber: String?
 
         private enum Row: Hashable {
             case name(String)
@@ -98,7 +100,25 @@ extension BookingDetailsView {
             }
             .padding(.vertical, Layout.rowTextVerticalPadding)
             .tappable {
-                print("On phone ellipsis")
+                selectedPhoneNumber = phoneText
+                showingPhoneOptions = true
+            }
+            .confirmationDialog(
+                String(format: Localization.phoneNumberOptionsTitle, selectedPhoneNumber ?? ""),
+                isPresented: $showingPhoneOptions,
+                titleVisibility: .visible
+            ) {
+                Button(Localization.callActionTitle) {
+                    guard let phoneNumber = selectedPhoneNumber else { return }
+                    if PhoneHelper.callPhoneNumber(phone: phoneNumber) == false {
+                        showNotice(Notice(title: Localization.phoneNumberErrorNotice, feedbackType: .error))
+                    }
+                }
+                Button(Localization.copyActionTitle) {
+                    guard let phoneNumber = selectedPhoneNumber else { return }
+                    phoneNumber.sendToPasteboard()
+                    showNotice(Notice(title: Localization.phoneNumberCopied, feedbackType: .success))
+                }
             }
         }
 
@@ -125,6 +145,36 @@ private extension BookingDetailsView.CustomerDetailsView {
             "BookingDetailsView.customer.emailCopied.toastMessage",
             value: "Email address copied",
             comment: "Toast message shown when the user copies the customer's email address."
+        )
+
+        static let phoneNumberOptionsTitle = NSLocalizedString(
+            "BookingDetailsView.phoneNumberOptions.title",
+            value: "%@",
+            comment: "Title for the phone number action sheet, where %@ is the phone number."
+        )
+
+        static let callActionTitle = NSLocalizedString(
+            "BookingDetailsView.phoneNumberOptions.call",
+            value: "Call",
+            comment: "Action to call the phone number."
+        )
+
+        static let copyActionTitle = NSLocalizedString(
+            "BookingDetailsView.phoneNumberOptions.copy",
+            value: "Copy",
+            comment: "Action to copy the phone number."
+        )
+
+        static let phoneNumberCopied = NSLocalizedString(
+            "BookingDetailsView.phoneNumberOptions.copied",
+            value: "Phone number copied",
+            comment: "Notice message shown when the phone number is copied."
+        )
+
+        static let phoneNumberErrorNotice = NSLocalizedString(
+            "BookingDetailsView.phoneNumberOptions.error",
+            value: "Could not place a call to this number.",
+            comment: "Notice message shown when a phone call cannot be initiated."
         )
 
         /// Customer section

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/CustomerDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/CustomerDetailsView.swift
@@ -79,7 +79,7 @@ extension BookingDetailsView {
             }
             .padding(.vertical, Layout.rowTextVerticalPadding)
             .tappable {
-                emailText.sendToPasteboard()
+                emailText.sendToPasteboard(includeTrailingNewline: false)
                 showNotice(
                     Notice(
                         title: Localization.emailCopiedMessage,
@@ -116,7 +116,7 @@ extension BookingDetailsView {
                 }
                 Button(Localization.copyActionTitle) {
                     guard let phoneNumber = selectedPhoneNumber else { return }
-                    phoneNumber.sendToPasteboard()
+                    phoneNumber.sendToPasteboard(includeTrailingNewline: false)
                     showNotice(Notice(title: Localization.phoneNumberCopied, feedbackType: .success))
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/CustomerDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/CustomerDetailsView.swift
@@ -104,7 +104,7 @@ extension BookingDetailsView {
                 showingPhoneOptions = true
             }
             .confirmationDialog(
-                String(format: Localization.phoneNumberOptionsTitle, selectedPhoneNumber ?? ""),
+                selectedPhoneNumber ?? "",
                 isPresented: $showingPhoneOptions,
                 titleVisibility: .visible
             ) {
@@ -145,12 +145,6 @@ private extension BookingDetailsView.CustomerDetailsView {
             "BookingDetailsView.customer.emailCopied.toastMessage",
             value: "Email address copied",
             comment: "Toast message shown when the user copies the customer's email address."
-        )
-
-        static let phoneNumberOptionsTitle = NSLocalizedString(
-            "BookingDetailsView.phoneNumberOptions.title",
-            value: "%@",
-            comment: "Title for the phone number action sheet, where %@ is the phone number."
         )
 
         static let callActionTitle = NSLocalizedString(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
Part of: WOOMOB-1236

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
- Implements UTC timezone dates formatting for booking details screen following the approach in bookings list.
- Implements the customer phone actions sheet / popover
    - Presents popover from customer phone row in iPad
    - Presents bottom action sheet for customer phone on iPhone
    - Copy and call actions
    - "Phone number copied" confirmation toast for copy action
    -  "Could not place a call to this number." error toast if the call is impossible (for example on simulators)

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Test on both iPhone and iPad
- Use a CIAB site with existing bookings
- Find a booking with a customer that has a phone number specified (or create one)
- Open booking details
- Scroll down to customer phone row
- Tap on the row (make sure it's tappable in whole area)
- Make sure a popover or action sheet is presented containing phone number as a title and copy + call as actions
- Select the "Copy" action. Make sure the copy confirmation toast is presented upon copying.
- Select the "Call" action. Make sure the failure toast is presented on iOS Simulator.
- Consider testing on a device to make sure that the phone call is happening.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
iPhone | iPad
--- | ---
<img width="501" height="492" alt="Снимок экрана 2025-10-10 в 16 05 41" src="https://github.com/user-attachments/assets/579714cd-f8c3-4c62-8d74-754be73f0d6e" /> | <img width="523" height="259" alt="Снимок экрана 2025-10-10 в 16 03 36" src="https://github.com/user-attachments/assets/ded1d704-5f91-4117-b427-c96891587355" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.