### PR TITLE
[Local Catalog] Show items from GRDB in POS

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleItemsController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleItemsController.swift
@@ -41,7 +41,7 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
     init(itemProvider: PointOfSaleItemServiceProtocol,
          itemFetchStrategyFactory: PointOfSaleItemFetchStrategyFactoryProtocol,
          initialState: ItemsViewState = ItemsViewState(containerState: .loading,
-                                                       itemsStack: ItemsStackState(root: .loading([]),
+                                                       itemsStack: ItemsStackState(root: .initial,
                                                                                    itemStates: [:])),
          analyticsProvider: POSAnalyticsProviding) {
         self.itemProvider = itemProvider
@@ -213,8 +213,12 @@ private extension PointOfSaleItemsController {
     func setRootLoadingState() {
         let items = itemsViewState.itemsStack.root.items
 
-        let isInitialState = itemsViewState.containerState == .loading
-        if !isInitialState {
+        let isInitialState = itemsViewState.containerState == .loading && itemsViewState.itemsStack.root == .initial
+        if isInitialState {
+            // Transition from initial to loading on first load
+            itemsViewState.itemsStack.root = .loading([])
+        } else {
+            // Preserve items during refresh
             itemsViewState.itemsStack.root = .loading(items)
         }
     }

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleObservableItemsController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleObservableItemsController.swift
@@ -114,7 +114,7 @@ private extension PointOfSaleObservableItemsController {
         }
 
         // Error state
-        if let error = dataSource.error, items.isEmpty {
+        if let error = dataSource.productError, items.isEmpty {
             return .error(.errorOnLoadingProducts(error: error))
         }
 
@@ -145,7 +145,7 @@ private extension PointOfSaleObservableItemsController {
         }
 
         // Error state
-        if let error = dataSource.error, items.isEmpty {
+        if let error = dataSource.variationError, items.isEmpty {
             return [parentItem: .error(.errorOnLoadingVariations(error: error))]
         }
 

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleObservableItemsController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleObservableItemsController.swift
@@ -40,6 +40,7 @@ final class PointOfSaleObservableItemsController: PointOfSaleItemsControllerProt
         )
     }
 
+    // periphery:ignore used by tests
     init(dataSource: POSObservableDataSourceProtocol) {
         self.dataSource = dataSource
     }

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleObservableItemsController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleObservableItemsController.swift
@@ -40,7 +40,7 @@ final class PointOfSaleObservableItemsController: PointOfSaleItemsControllerProt
         )
     }
 
-    // periphery:ignore used by tests
+    // periphery:ignore - used by tests
     init(dataSource: POSObservableDataSourceProtocol) {
         self.dataSource = dataSource
     }

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleObservableItemsController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleObservableItemsController.swift
@@ -48,8 +48,8 @@ final class PointOfSaleObservableItemsController: PointOfSaleItemsControllerProt
     func loadItems(base: ItemListBaseItem) async {
         switch base {
         case .root:
-            hasLoadedProducts = true
             dataSource.loadProducts()
+            hasLoadedProducts = true
         case .parent(let parent):
             guard case .variableParentProduct(let parentProduct) = parent else {
                 assertionFailure("Unsupported parent type for loading items: \(parent)")
@@ -62,8 +62,8 @@ final class PointOfSaleObservableItemsController: PointOfSaleItemsControllerProt
                 hasLoadedVariationsForCurrentParent = false
             }
 
-            hasLoadedVariationsForCurrentParent = true
             dataSource.loadVariations(for: parentProduct)
+            hasLoadedVariationsForCurrentParent = true
         }
     }
 

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleObservableItemsController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleObservableItemsController.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Observation
+import class WooFoundation.CurrencySettings
+import enum Yosemite.POSItem
+import protocol Yosemite.POSObservableDataSourceProtocol
+import struct Yosemite.POSVariableParentProduct
+import class Yosemite.GRDBObservableDataSource
+import protocol Storage.GRDBManagerProtocol
+
+/// Controller that wraps an observable data source for POS items
+/// Uses computed state based on data source observations for automatic UI updates
+@Observable
+final class PointOfSaleObservableItemsController: PointOfSaleItemsControllerProtocol {
+    private let dataSource: POSObservableDataSourceProtocol
+
+    // Track which items have been loaded at least once
+    private var hasLoadedProducts = false
+    private var hasLoadedVariationsForCurrentParent = false
+
+    // Track current parent for variation state mapping
+    private var currentParentItem: POSItem?
+
+    var itemsViewState: ItemsViewState {
+        ItemsViewState(
+            containerState: containerState,
+            itemsStack: ItemsStackState(
+                root: rootState,
+                itemStates: variationStates
+            )
+        )
+    }
+
+    init(siteID: Int64,
+         grdbManager: GRDBManagerProtocol,
+         currencySettings: CurrencySettings) {
+        self.dataSource = GRDBObservableDataSource(
+            siteID: siteID,
+            grdbManager: grdbManager,
+            currencySettings: currencySettings
+        )
+    }
+
+    init(dataSource: POSObservableDataSourceProtocol) {
+        self.dataSource = dataSource
+    }
+
+    func loadItems(base: ItemListBaseItem) async {
+        switch base {
+        case .root:
+            hasLoadedProducts = true
+            dataSource.loadProducts()
+        case .parent(let parent):
+            guard case .variableParentProduct(let parentProduct) = parent else {
+                assertionFailure("Unsupported parent type for loading items: \(parent)")
+                return
+            }
+
+            // If switching to a different parent, reset the loaded flag
+            if currentParentItem != parent {
+                currentParentItem = parent
+                hasLoadedVariationsForCurrentParent = false
+            }
+
+            hasLoadedVariationsForCurrentParent = true
+            dataSource.loadVariations(for: parentProduct)
+        }
+    }
+
+    func refreshItems(base: ItemListBaseItem) async {
+        switch base {
+        case .root:
+            dataSource.refresh()
+        case .parent(let parent):
+            guard case .variableParentProduct(let parentProduct) = parent else {
+                assertionFailure("Unsupported parent type for refreshing items: \(parent)")
+                return
+            }
+            dataSource.loadVariations(for: parentProduct)
+        }
+    }
+
+    func loadNextItems(base: ItemListBaseItem) async {
+        switch base {
+        case .root:
+            dataSource.loadMoreProducts()
+        case .parent:
+            dataSource.loadMoreVariations()
+        }
+    }
+}
+
+// MARK: - State Computation
+private extension PointOfSaleObservableItemsController {
+    var containerState: ItemsContainerState {
+        // Use .loading during initial load, .content otherwise
+        if !hasLoadedProducts && dataSource.isLoadingProducts {
+            return .loading
+        }
+        return .content
+    }
+
+    var rootState: ItemListState {
+        let items = dataSource.productItems
+
+        // Initial state - not yet loaded
+        if !hasLoadedProducts {
+            return .initial
+        }
+
+        // Loading state - preserve existing items
+        if dataSource.isLoadingProducts {
+            return .loading(items)
+        }
+
+        // Error state
+        if let error = dataSource.error, items.isEmpty {
+            return .error(.errorOnLoadingProducts(error: error))
+        }
+
+        // Empty state
+        if items.isEmpty {
+            return .empty
+        }
+
+        // Loaded state
+        return .loaded(items, hasMoreItems: dataSource.hasMoreProducts)
+    }
+
+    var variationStates: [POSItem: ItemListState] {
+        guard let parentItem = currentParentItem else {
+            return [:]
+        }
+
+        let items = dataSource.variationItems
+
+        // Initial state - not yet loaded
+        if !hasLoadedVariationsForCurrentParent {
+            return [parentItem: .initial]
+        }
+
+        // Loading state - preserve existing items
+        if dataSource.isLoadingVariations {
+            return [parentItem: .loading(items)]
+        }
+
+        // Error state
+        if let error = dataSource.error, items.isEmpty {
+            return [parentItem: .error(.errorOnLoadingVariations(error: error))]
+        }
+
+        // Empty state
+        if items.isEmpty {
+            return [parentItem: .empty]
+        }
+
+        // Loaded state
+        return [parentItem: .loaded(items, hasMoreItems: dataSource.hasMoreVariations)]
+    }
+}

--- a/Modules/Sources/PointOfSale/Models/ItemListState.swift
+++ b/Modules/Sources/PointOfSale/Models/ItemListState.swift
@@ -1,6 +1,7 @@
 import enum Yosemite.POSItem
 
 enum ItemListState {
+    case initial
     case loading(_ currentItems: [POSItem])
     case loaded(_ items: [POSItem], hasMoreItems: Bool)
     case inlineError(_ items: [POSItem], error: PointOfSaleErrorState, context: InlineErrorContext)
@@ -38,7 +39,7 @@ extension ItemListState {
                 .loaded(let items, _),
                 .inlineError(let items, _, _):
             return items
-        case .error, .empty:
+        case .initial, .error, .empty:
             return []
         }
     }

--- a/Modules/Sources/PointOfSale/Presentation/Item Selector/ChildItemList.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Selector/ChildItemList.swift
@@ -34,7 +34,7 @@ struct ChildItemList: View {
     var body: some View {
         VStack {
             switch state {
-            case .loaded([], _):
+            case .initial, .loaded([], _):
                 emptyView
             case .loading, .loaded, .inlineError:
                 listView

--- a/Modules/Sources/PointOfSale/Presentation/Item Selector/ItemList.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Selector/ItemList.swift
@@ -122,7 +122,7 @@ struct ItemList<HeaderView: View>: View {
                     await itemsController.loadNextItems(base: node)
                 }
             })
-        case .loaded, .error, .empty, .none, .inlineError(_, _, .refresh):
+        case .initial, .loaded, .error, .empty, .none, .inlineError(_, _, .refresh):
             EmptyView()
         }
     }
@@ -136,7 +136,7 @@ struct ItemList<HeaderView: View>: View {
                     await itemsController.loadItems(base: .root)
                 }
             })
-        case .loaded, .error, .empty, .none, .loading, .inlineError(_, _, .pagination):
+        case .initial, .loaded, .error, .empty, .none, .loading, .inlineError(_, _, .pagination):
             EmptyView()
         }
     }

--- a/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
@@ -147,7 +147,8 @@ struct ItemListView: View {
     @ViewBuilder
     private func itemListContent(_ itemListType: ItemListType) -> some View {
         switch itemListState(itemListType) {
-        case .loading,
+        case .initial,
+                .loading,
                 .loaded,
                 .inlineError:
             listView(itemListType: itemListType)

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -66,11 +66,23 @@ public struct PointOfSaleEntryPointView: View {
          services: POSDependencyProviding) {
         self.onPointOfSaleModeActiveStateChange = onPointOfSaleModeActiveStateChange
 
-        self.itemsController = PointOfSaleItemsController(
-            itemProvider: PointOfSaleItemService(currencySettings: services.currency.currencySettings),
-            itemFetchStrategyFactory: itemFetchStrategyFactory,
-            analyticsProvider: services.analytics
-        )
+        // Use observable controller with GRDB if available and feature flag is enabled, otherwise fall back to standard controller
+        // Note: We check feature flag here for eligibility. Once eligibility checking is
+        // refactored to be more centralized, this check can be simplified.
+        let isGRDBEnabled = services.featureFlags.isFeatureFlagEnabled(.pointOfSaleLocalCatalogi1)
+        if let grdbManager = grdbManager, catalogSyncCoordinator != nil, isGRDBEnabled {
+            self.itemsController = PointOfSaleObservableItemsController(
+                siteID: siteID,
+                grdbManager: grdbManager,
+                currencySettings: services.currency.currencySettings
+            )
+        } else {
+            self.itemsController = PointOfSaleItemsController(
+                itemProvider: PointOfSaleItemService(currencySettings: services.currency.currencySettings),
+                itemFetchStrategyFactory: itemFetchStrategyFactory,
+                analyticsProvider: services.analytics
+            )
+        }
         self.purchasableItemsSearchController = PointOfSaleItemsController(
             itemProvider: PointOfSaleItemService(currencySettings: services.currency.currencySettings),
             itemFetchStrategyFactory: itemFetchStrategyFactory,

--- a/Modules/Sources/Yosemite/PointOfSale/Items/GRDBObservableDataSource.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/GRDBObservableDataSource.swift
@@ -16,7 +16,8 @@ public final class GRDBObservableDataSource: POSObservableDataSourceProtocol {
     public private(set) var variationItems: [POSItem] = []
     public private(set) var isLoadingProducts: Bool = false
     public private(set) var isLoadingVariations: Bool = false
-    public private(set) var error: Error? = nil
+    public private(set) var productError: Error? = nil
+    public private(set) var variationError: Error? = nil
 
     public var hasMoreProducts: Bool {
         productItems.count >= (pageSize * currentProductPage) && totalProductCount > productItems.count
@@ -146,7 +147,7 @@ public final class GRDBObservableDataSource: POSObservableDataSourceProtocol {
             .sink(
                 receiveCompletion: { [weak self] completion in
                     if case .failure(let error) = completion {
-                        self?.error = error
+                        self?.productError = error
                         self?.isLoadingProducts = false
                     }
                 },
@@ -154,7 +155,7 @@ public final class GRDBObservableDataSource: POSObservableDataSourceProtocol {
                     guard let self else { return }
                     let posItems = itemMapper.mapProductsToPOSItems(products: observedProducts)
                     productItems = posItems
-                    error = nil
+                    productError = nil
                     isLoadingProducts = false
                 }
             )
@@ -194,7 +195,7 @@ public final class GRDBObservableDataSource: POSObservableDataSourceProtocol {
             .sink(
                 receiveCompletion: { [weak self] completion in
                     if case .failure(let error) = completion {
-                        self?.error = error
+                        self?.variationError = error
                         self?.isLoadingVariations = false
                     }
                 },
@@ -205,7 +206,7 @@ public final class GRDBObservableDataSource: POSObservableDataSourceProtocol {
                         parentProduct: parentProduct
                     )
                     variationItems = posItems
-                    error = nil
+                    variationError = nil
                     isLoadingVariations = false
                 }
             )

--- a/Modules/Sources/Yosemite/PointOfSale/Items/GRDBObservableDataSource.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/GRDBObservableDataSource.swift
@@ -93,6 +93,7 @@ public final class GRDBObservableDataSource: POSObservableDataSourceProtocol {
         currentVariationPage = 1
         isLoadingVariations = true
         variationItems = []
+        variationError = nil
 
         setupVariationObservation(parentProduct: parentProduct)
         setupVariationStatisticsObservation(parentProduct: parentProduct)

--- a/Modules/Sources/Yosemite/PointOfSale/Items/POSObservableDataSource.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/POSObservableDataSource.swift
@@ -21,8 +21,11 @@ public protocol POSObservableDataSourceProtocol {
     /// Whether more variations are available for current parent
     var hasMoreVariations: Bool { get }
 
-    /// Current error, if any
-    var error: Error? { get }
+    /// Error from product loading, if any
+    var productError: Error? { get }
+
+    /// Error from variation loading, if any
+    var variationError: Error? { get }
 
     /// Loads the first page of products
     func loadProducts()

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleObservableItemsControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleObservableItemsControllerTests.swift
@@ -1,0 +1,285 @@
+import Testing
+import Foundation
+@testable import PointOfSale
+@testable import Yosemite
+
+final class PointOfSaleObservableItemsControllerTests {
+
+    // MARK: - Test Helpers
+
+    private func makeSimpleProduct(id: UUID = UUID(), name: String = "Test Product", productID: Int64 = 1) -> POSItem {
+        .simpleProduct(POSSimpleProduct(
+            id: id,
+            name: name,
+            formattedPrice: "$2.00",
+            productID: productID,
+            price: "2.00",
+            manageStock: false,
+            stockQuantity: nil,
+            stockStatusKey: ""
+        ))
+    }
+
+    private func makeVariation(id: UUID = UUID(), name: String = "Test Variation", variationID: Int64 = 1) -> POSItem {
+        .variation(POSVariation(
+            id: id,
+            name: name,
+            formattedPrice: "$2.00",
+            price: "2.00",
+            productID: 100,
+            variationID: variationID,
+            parentProductName: "Parent Product"
+        ))
+    }
+
+    // MARK: - Tests
+
+    @Test func test_initial_state_is_loading_container_with_initial_root() {
+        // Given
+        let dataSource = MockPOSObservableDataSource()
+        dataSource.isLoadingProducts = true
+        let sut = PointOfSaleObservableItemsController(dataSource: dataSource)
+
+        // Then
+        #expect(sut.itemsViewState.containerState == .loading)
+        #expect(sut.itemsViewState.itemsStack.root == .initial)
+        #expect(sut.itemsViewState.itemsStack.itemStates.isEmpty)
+    }
+
+    @Test func test_load_products_transitions_to_loaded_state() async {
+        // Given
+        let dataSource = MockPOSObservableDataSource()
+        let sut = PointOfSaleObservableItemsController(dataSource: dataSource)
+
+        let mockItems = [makeSimpleProduct()]
+        dataSource.productItems = mockItems
+        dataSource.isLoadingProducts = false
+        dataSource.hasMoreProducts = false
+
+        // When
+        await sut.loadItems(base: .root)
+
+        // Then
+        #expect(sut.itemsViewState.containerState == .content)
+        #expect(sut.itemsViewState.itemsStack.root == .loaded(mockItems, hasMoreItems: false))
+    }
+
+    @Test func test_load_products_with_more_pages_sets_hasMoreItems() async {
+        // Given
+        let dataSource = MockPOSObservableDataSource()
+        let sut = PointOfSaleObservableItemsController(dataSource: dataSource)
+
+        let mockItems = [makeSimpleProduct(productID: 1), makeSimpleProduct(productID: 2)]
+        dataSource.productItems = mockItems
+        dataSource.isLoadingProducts = false
+        dataSource.hasMoreProducts = true
+
+        // When
+        await sut.loadItems(base: .root)
+
+        // Then
+        #expect(sut.itemsViewState.itemsStack.root == .loaded(mockItems, hasMoreItems: true))
+    }
+
+    @Test func test_load_products_when_empty_results_in_empty_state() async {
+        // Given
+        let dataSource = MockPOSObservableDataSource()
+        let sut = PointOfSaleObservableItemsController(dataSource: dataSource)
+
+        dataSource.productItems = []
+        dataSource.isLoadingProducts = false
+
+        // When
+        await sut.loadItems(base: .root)
+
+        // Then
+        #expect(sut.itemsViewState.containerState == .content)
+        #expect(sut.itemsViewState.itemsStack.root == .empty)
+    }
+
+    @Test func test_load_variations_for_parent() async {
+        // Given
+        let dataSource = MockPOSObservableDataSource()
+        let sut = PointOfSaleObservableItemsController(dataSource: dataSource)
+
+        let parentProduct = POSVariableParentProduct(
+            id: UUID(),
+            name: "Parent",
+            productImageSource: nil,
+            productID: 100,
+            allAttributes: []
+        )
+        let parentItem = POSItem.variableParentProduct(parentProduct)
+
+        let mockVariations = [makeVariation(variationID: 1), makeVariation(variationID: 2)]
+        dataSource.variationItems = mockVariations
+        dataSource.isLoadingVariations = false
+        dataSource.hasMoreVariations = false
+
+        // When
+        await sut.loadItems(base: .parent(parentItem))
+
+        // Then
+        #expect(sut.itemsViewState.itemsStack.itemStates[parentItem] == .loaded(mockVariations, hasMoreItems: false))
+    }
+
+    @Test func test_load_variations_when_empty_results_in_empty_state() async {
+        // Given
+        let dataSource = MockPOSObservableDataSource()
+        let sut = PointOfSaleObservableItemsController(dataSource: dataSource)
+
+        let parentProduct = POSVariableParentProduct(
+            id: UUID(),
+            name: "Parent",
+            productImageSource: nil,
+            productID: 100,
+            allAttributes: []
+        )
+        let parentItem = POSItem.variableParentProduct(parentProduct)
+
+        dataSource.variationItems = []
+        dataSource.isLoadingVariations = false
+
+        // When
+        await sut.loadItems(base: .parent(parentItem))
+
+        // Then
+        #expect(sut.itemsViewState.itemsStack.itemStates[parentItem] == .empty)
+    }
+
+    @Test func test_products_and_variations_are_independent() async {
+        // Given
+        let dataSource = MockPOSObservableDataSource()
+        let sut = PointOfSaleObservableItemsController(dataSource: dataSource)
+
+        let mockProducts = [makeSimpleProduct(productID: 1), makeSimpleProduct(productID: 2)]
+        let mockVariations = [makeVariation()]
+
+        let parentProduct = POSVariableParentProduct(
+            id: UUID(),
+            name: "Parent",
+            productImageSource: nil,
+            productID: 100,
+            allAttributes: []
+        )
+        let parentItem = POSItem.variableParentProduct(parentProduct)
+
+        // When: Load products
+        dataSource.productItems = mockProducts
+        dataSource.isLoadingProducts = false
+        await sut.loadItems(base: .root)
+
+        // Then: Products loaded, no variations
+        #expect(sut.itemsViewState.itemsStack.root.items.count == 2)
+        #expect(sut.itemsViewState.itemsStack.itemStates.isEmpty)
+
+        // When: Load variations
+        dataSource.variationItems = mockVariations
+        dataSource.isLoadingVariations = false
+        await sut.loadItems(base: .parent(parentItem))
+
+        // Then: Both products and variations present
+        #expect(sut.itemsViewState.itemsStack.root.items.count == 2)
+        #expect(sut.itemsViewState.itemsStack.itemStates[parentItem]?.items.count == 1)
+    }
+
+    @Test func test_load_next_items_delegates_to_data_source() async {
+        // Given
+        let dataSource = MockPOSObservableDataSource()
+        let sut = PointOfSaleObservableItemsController(dataSource: dataSource)
+
+        // Simulate initial load
+        dataSource.productItems = [makeSimpleProduct()]
+        dataSource.isLoadingProducts = false
+        dataSource.hasMoreProducts = true
+        await sut.loadItems(base: .root)
+
+        // When
+        await sut.loadNextItems(base: .root)
+
+        // Then: loadMoreProducts should be called (verified by state change in mock)
+        // Note: Mock doesn't actually track calls, but we can verify the state
+        #expect(sut.itemsViewState.containerState == .content)
+    }
+
+    @Test func test_refresh_delegates_to_data_source() async {
+        // Given
+        let dataSource = MockPOSObservableDataSource()
+        let sut = PointOfSaleObservableItemsController(dataSource: dataSource)
+
+        dataSource.productItems = [makeSimpleProduct()]
+        dataSource.isLoadingProducts = false
+        await sut.loadItems(base: .root)
+
+        // When
+        await sut.refreshItems(base: .root)
+
+        // Then: Should still be in content state
+        #expect(sut.itemsViewState.containerState == .content)
+    }
+
+    @Test func test_switching_parent_resets_variation_state() async {
+        // Given
+        let dataSource = MockPOSObservableDataSource()
+        let sut = PointOfSaleObservableItemsController(dataSource: dataSource)
+
+        let parent1 = POSVariableParentProduct(id: UUID(), name: "Parent 1", productImageSource: nil, productID: 100, allAttributes: [])
+        let parentItem1 = POSItem.variableParentProduct(parent1)
+
+        let parent2 = POSVariableParentProduct(id: UUID(), name: "Parent 2", productImageSource: nil, productID: 200, allAttributes: [])
+        let parentItem2 = POSItem.variableParentProduct(parent2)
+
+        // When: Load parent 1 variations
+        dataSource.variationItems = [makeVariation()]
+        dataSource.isLoadingVariations = false
+        await sut.loadItems(base: .parent(parentItem1))
+
+        #expect(sut.itemsViewState.itemsStack.itemStates[parentItem1]?.items.count == 1)
+
+        // When: Load parent 2 variations
+        dataSource.variationItems = [makeVariation(variationID: 1), makeVariation(variationID: 2)]
+        await sut.loadItems(base: .parent(parentItem2))
+
+        // Then: Parent 2 variations shown, parent 1 not in states anymore
+        #expect(sut.itemsViewState.itemsStack.itemStates[parentItem2]?.items.count == 2)
+        #expect(sut.itemsViewState.itemsStack.itemStates[parentItem1] == nil)
+    }
+
+    @Test func test_error_state_when_data_source_has_error() async {
+        // Given
+        let dataSource = MockPOSObservableDataSource()
+        let sut = PointOfSaleObservableItemsController(dataSource: dataSource)
+
+        dataSource.productItems = []
+        dataSource.isLoadingProducts = false
+        dataSource.error = NSError(domain: "test", code: 1)
+
+        // When
+        await sut.loadItems(base: .root)
+
+        // Then
+        guard case .error = sut.itemsViewState.itemsStack.root else {
+            Issue.record("Expected error state, got \(sut.itemsViewState.itemsStack.root)")
+            return
+        }
+    }
+
+    @Test func test_loading_state_preserves_existing_items() async {
+        // Given
+        let dataSource = MockPOSObservableDataSource()
+        let sut = PointOfSaleObservableItemsController(dataSource: dataSource)
+
+        let mockItems = [makeSimpleProduct(productID: 1), makeSimpleProduct(productID: 2)]
+
+        // Load initial items
+        dataSource.productItems = mockItems
+        dataSource.isLoadingProducts = false
+        await sut.loadItems(base: .root)
+
+        // When: Start loading more
+        dataSource.isLoadingProducts = true
+
+        // Then: Loading state should preserve items
+        #expect(sut.itemsViewState.itemsStack.root == .loading(mockItems))
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleObservableItemsControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleObservableItemsControllerTests.swift
@@ -252,7 +252,7 @@ final class PointOfSaleObservableItemsControllerTests {
 
         dataSource.productItems = []
         dataSource.isLoadingProducts = false
-        dataSource.error = NSError(domain: "test", code: 1)
+        dataSource.productError = NSError(domain: "test", code: 1)
 
         // When
         await sut.loadItems(base: .root)

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSObservableDataSource.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSObservableDataSource.swift
@@ -11,7 +11,8 @@ final class MockPOSObservableDataSource: POSObservableDataSourceProtocol {
     var isLoadingVariations: Bool = false
     var hasMoreProducts: Bool = false
     var hasMoreVariations: Bool = false
-    var error: Error? = nil
+    var productError: Error? = nil
+    var variationError: Error? = nil
 
     init() {}
 

--- a/Modules/Tests/YosemiteTests/PointOfSale/GRDBObservableDataSourceTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/GRDBObservableDataSourceTests.swift
@@ -35,7 +35,8 @@ struct GRDBObservableDataSourceTests {
         #expect(sut.isLoadingVariations == false)
         #expect(sut.hasMoreProducts == false)
         #expect(sut.hasMoreVariations == false)
-        #expect(sut.error == nil)
+        #expect(sut.productError == nil)
+        #expect(sut.variationError == nil)
     }
 
     @Test("Load products sets loading state and fetches items from database")
@@ -51,7 +52,7 @@ struct GRDBObservableDataSourceTests {
         // Then
         #expect(sut.productItems.count == 3)
         #expect(sut.isLoadingProducts == false)
-        #expect(sut.error == nil)
+        #expect(sut.productError == nil)
     }
 
     @Test("Load products maps database products to POSItems correctly")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Merge after: #16231

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR starts using the observable GRDB data source added in #16231 to show items from GRDB in the item list.

Note that there's nothing to enforce that GRDB actually has items in it at the moment... so you can definitely break this, but those guards are covered by other tickets and this is feature flagged.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Check we're not breaking production...
- Set the `pointOfSaleLocalCatalogi1` feature flag to false
- Open the POS
- Observe that browsing and scrolling works as expected, and use WormHoly or a proxy tool to verify that products are loaded from the network.

### Test the GRDB item controller
- Reset the feature flag
- Launch the app
- Wait for console log messages to confirm the catalog sync status for your store
- Open POS
- Observe that products are shown, and that you can open variation lists
- Scroll down, observe that subsequent pages are loaded
- Turn on airplane mode, observe that you can still fully browse the catalog.

Example sync log messages:
```
📋 POSCatalogSyncCoordinator: Site 216335538 has catalog size 91, with 45 products and 46 variations
📋 POSCatalogSyncCoordinator: Last sync for site 216335538 was 16344s ago (max: 86400s), sync not needed
```

### Optional: test with a larger site
- Change the value for `POSCatalogSyncCoordinator.Constants.defaultSizeLimitForPOSCatalog` to 100000
- Run the app and pick a store with a large catalog
- Wait for the sync to complete (it will take some time and gives no progress info before completion)
- Open POS
- Observe that you can interact with the full catalog

Note that with larger catalogs, you start to hit scrolling performance issues. These are outside the scope of current work, but we may want to address them before too long. I don't think it's down to the mapping happening on the main thread, and it may even be that we're hitting some SwiftUI limitations.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Note that Search and Barcode Scanning are still using the network-based controller, so have delays.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/89642075-b4f4-4cf3-8417-c1608a982922


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
