### PR TITLE
[Woo POS][Surveys] Add `CurrentMerchant` case, and handle opening survey 

### DIFF
--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -69,6 +69,13 @@ struct LocalNotification {
     enum UserInfoKey {
         static let storeName = "storeName"
         static let isIAPAvailable = WooAnalyticsEvent.LocalNotification.Key.isIAPAvailable
+        static let surveyURL = "surveyURL"
+    }
+
+    enum SurveyURL {
+        // TODO: Real survey links to be added in WOOMOB-1497
+        static let pointOfSalePotentialMerchant = "https://automattic.survey.fm/woo-app-general-feedback-test-survey"
+        static let pointOfSaleCurrentMerchant = "https://automattic.survey.fm/woo-app-general-feedback-test-survey"
     }
 }
 

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -23,6 +23,7 @@ struct LocalNotification {
         case blazeAbandonedCampaignCreationReminder
         case productImageBackgroundUpload
         case pointOfSalePotentialMerchant
+        case pointOfSaleCurrentMerchant
         case unknown(siteID: Int64)
 
         var identifier: String {
@@ -35,6 +36,8 @@ struct LocalNotification {
                 return "product_image_background_upload"
             case .pointOfSalePotentialMerchant:
                 return "point_of_sale_potential_merchant"
+            case .pointOfSaleCurrentMerchant:
+                return "point_of_sale_current_merchant"
             case let .unknown(siteID):
                 return "unknown_" + "\(siteID)"
             }
@@ -101,6 +104,9 @@ extension LocalNotification {
         case .pointOfSalePotentialMerchant:
             title = Localization.PointOfSalePotentialMerchant.title
             body = Localization.PointOfSalePotentialMerchant.body
+        case .pointOfSaleCurrentMerchant:
+            title = Localization.PointOfSaleCurrentMerchant.title
+            body = Localization.PointOfSaleCurrentMerchant.body
         case .unknown:
             title = ""
             body = ""
@@ -163,6 +169,18 @@ extension LocalNotification {
                 "localNotification.PointOfSalePotentialMerchant.body",
                 value: "Take a quick 2-minute survey to help us shape features you’ll love.",
                 comment: "Message body of the local notification sent to potential Point of Sale merchants"
+            )
+        }
+        enum PointOfSaleCurrentMerchant {
+            static let title = NSLocalizedString(
+                "localNotification.PointOfSaleCurrentMerchant.title",
+                value: "How’s POS working for you?",
+                comment: "Title of the local notification for current POS merchants survey."
+            )
+            static let body = NSLocalizedString(
+                "localNotification.PointOfSaleCurrentMerchant.body",
+                value: "Share your experience in a quick 2-minute survey and help us improve.",
+                comment: "Body of the local notification for current POS merchants survey."
             )
         }
     }

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -72,8 +72,8 @@ struct LocalNotification {
         static let surveyURL = "surveyURL"
     }
 
+    // periphery:ignore - real survey links to be added in WOOMOB-1497
     enum SurveyURL {
-        // TODO: Real survey links to be added in WOOMOB-1497
         static let pointOfSalePotentialMerchant = "https://automattic.survey.fm/woo-app-general-feedback-test-survey"
         static let pointOfSaleCurrentMerchant = "https://automattic.survey.fm/woo-app-general-feedback-test-survey"
     }

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -67,7 +67,7 @@ struct LocalNotification {
 
     /// Holds `userInfo` dictionary keys
     enum UserInfoKey {
-        static let storeName = "storeName"
+        // periphery:ignore - will be removed on PR-16128
         static let isIAPAvailable = WooAnalyticsEvent.LocalNotification.Key.isIAPAvailable
         static let surveyURL = "surveyURL"
     }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -264,7 +264,7 @@ extension PushNotificationsManager {
             // Check if this is a local notification
             if !content.isRemoteNotification {
                 // Display local notifications with banner and sound when app is in foreground
-                return [.banner, .sound]
+                return [.banner, .sound, .list]
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -131,7 +131,7 @@ private extension AppCoordinator {
                                                                 userInfo: userInfo))
             return
         }
-        
+
         let posSurveyScenarios = [
             LocalNotification.Scenario.pointOfSalePotentialMerchant.identifier,
             LocalNotification.Scenario.pointOfSaleCurrentMerchant.identifier,

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -1,5 +1,6 @@
 import Combine
 import Experiments
+import SafariServices
 import UIKit
 import WordPressAuthenticator
 import Yosemite
@@ -130,9 +131,31 @@ private extension AppCoordinator {
                                                                 userInfo: userInfo))
             return
         }
+        
+        let posSurveyScenarios = [
+            LocalNotification.Scenario.pointOfSalePotentialMerchant.identifier,
+            LocalNotification.Scenario.pointOfSaleCurrentMerchant.identifier,
+        ]
+
+        if posSurveyScenarios.contains(identifier),
+           let surveyURLString = userInfo[LocalNotification.UserInfoKey.surveyURL] as? String,
+           let surveyURL = URL(string: surveyURLString) {
+            presentSurveyWebView(url: surveyURL)
+        }
 
         analytics.track(event: .LocalNotification.tapped(type: LocalNotification.Scenario.identifierForAnalytics(identifier),
                                                          userInfo: userInfo))
+    }
+
+    private func presentSurveyWebView(url: URL) {
+        let safariViewController = SFSafariViewController(url: url)
+        // POS mode is presented via a UIHostingController as full-screen view on top of the tabBarController, so
+        // we have to target the topmost VC if we want to present a web view on top of this when tapping on the local notification.
+        if let topmostPresentedViewController = window.topmostPresentedViewController {
+            topmostPresentedViewController.present(safariViewController, animated: true)
+        } else {
+            tabBarController.present(safariViewController, animated: true)
+        }
     }
 }
 


### PR DESCRIPTION
Closes WOOMOB-1459

## Description
This PR defines the `LocalNotification` case for the "current merchant" case (unused). A current merchant right now is just anybody that have access to POS, later on will narrow down the conditions further to send this notification.

## Changes
- Add `pointOfSaleCurrentMerchant` case to `LocalNotification`.
- In `AppCoordinator`, we handle presenting a web view with a survey URL in the notification payload when the local notification is tapped.

## Testing information
The notification code is not currently used:
1. Be sure you've given notification permissions to the app.
2. Go to `PaymentMethodsViewModel`, and add the following trigger inside `PaymentMethodsViewModel.trackFlowCompleted`, so it triggers after collecting a payment.

```
        // TESTING - fire from order creation
            Task { @MainActor in
                let seconds = TimeInterval(5)
                let userInfo: [AnyHashable: Any] = [
                    LocalNotification.UserInfoKey.surveyURL: LocalNotification.SurveyURL.pointOfSalePotentialMerchant
                ]
                let notification = LocalNotification(
                    title: LocalNotification.Localization.PointOfSalePotentialMerchant.title,
                    body: LocalNotification.Localization.PointOfSalePotentialMerchant.body,
                    scenario: .pointOfSalePotentialMerchant,
                    actions: nil,
                    userInfo: userInfo
                )
                let trigger = UNTimeIntervalNotificationTrigger(timeInterval: seconds, repeats: false)
                await ServiceLocator.pushNotesManager.requestLocalNotification(notification, trigger: trigger)
            }
```
3. Add the same trigger at the beginning of `POSTabCoordinator. presentPOSView `, so it triggers after loading POS:
```
            // TESTING - Fire from POS:
            Task { @MainActor in
                Task { @MainActor in
                    let seconds = TimeInterval(5)
                    let userInfo: [AnyHashable: Any] = [
                        LocalNotification.UserInfoKey.surveyURL: LocalNotification.SurveyURL.pointOfSaleCurrentMerchant
                    ]
                    let notification = LocalNotification(
                        title: LocalNotification.Localization.PointOfSaleCurrentMerchant.title,
                        body: LocalNotification.Localization.PointOfSaleCurrentMerchant.body,
                        scenario: .pointOfSaleCurrentMerchant,
                        actions: nil,
                        userInfo: userInfo
                    )
                    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: seconds, repeats: false)
                    await ServiceLocator.pushNotesManager.requestLocalNotification(notification, trigger: trigger)
                }
```
4. In the app, collect a payment through Order Creation flow, observe how the local notification will appear at the top of the screen after 5 seconds, tap on it and observe the test survey is presented.
5. Load POS, the local notification will appear at the top of the screen after 5 seconds, tap on it and observe the test survey is presented.

## Screenshots

https://github.com/user-attachments/assets/46eb7d9e-5ea7-4d11-9460-d5d2a6d57922


