### PR TITLE
Fix race condition when flagging site as unsupported for application passwords

### DIFF
--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
@@ -87,11 +87,13 @@ final class AlamofireNetworkErrorHandler {
     ) {
         let retriedRequest: RetriedJetpackRequest? = queue.sync(flags: .barrier) { [weak self] in
             guard let self else { return nil }
-
+            guard let urlRequest = try? originalRequest.asURLRequest() else { return nil }
             let retriedRequestIndex = _retriedJetpackRequests.firstIndex { retriedRequest in
-                let urlRequest = try? originalRequest.asURLRequest()
-                let retriedRequest = try? retriedRequest.request.asURLRequest()
-                return urlRequest == retriedRequest
+                guard let retriedURLRequest = try? retriedRequest.request.asURLRequest() else {
+                    return false
+                }
+                return urlRequest.url == retriedURLRequest.url &&
+                       urlRequest.httpMethod == retriedURLRequest.httpMethod
             }
 
             guard let index = retriedRequestIndex else { return nil }
@@ -147,10 +149,15 @@ final class AlamofireNetworkErrorHandler {
     }
 
     func isRequestRetried(_ request: URLRequestConvertible) -> Bool {
+        guard let urlRequest = try? request.asURLRequest() else {
+            return false
+        }
         retriedJetpackRequests.contains { retriedRequest in
-            let urlRequest = try? request.asURLRequest()
-            let currentItem = try? retriedRequest.request.asURLRequest()
-            return currentItem == urlRequest
+            guard let currentItem = try? retriedRequest.request.asURLRequest() else {
+                return false
+            }
+            return currentItem.url == urlRequest.url &&
+                   currentItem.httpMethod == urlRequest.httpMethod
         }
     }
 

--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
@@ -85,15 +85,21 @@ final class AlamofireNetworkErrorHandler {
         originalRequest: URLRequestConvertible,
         failure: Error?
     ) {
-        let retriedRequestIndex = retriedJetpackRequests.firstIndex { retriedRequest in
-            let urlRequest = try? originalRequest.asURLRequest()
-            let retriedRequest = try? retriedRequest.request.asURLRequest()
-            return urlRequest == retriedRequest
+        let retriedRequest: RetriedJetpackRequest? = queue.sync(flags: .barrier) { [weak self] in
+            guard let self else { return nil }
+
+            let retriedRequestIndex = _retriedJetpackRequests.firstIndex { retriedRequest in
+                let urlRequest = try? originalRequest.asURLRequest()
+                let retriedRequest = try? retriedRequest.request.asURLRequest()
+                return urlRequest == retriedRequest
+            }
+
+            guard let index = retriedRequestIndex else { return nil }
+
+            return _retriedJetpackRequests.remove(at: index)
         }
 
-        guard let index = retriedRequestIndex else { return }
-
-        let retriedRequest = retriedJetpackRequests.remove(at: index)
+        guard let retriedRequest else { return }
 
         if failure == nil {
             let siteID = retriedRequest.request.siteID

--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetworkErrorHandler.swift
@@ -152,7 +152,7 @@ final class AlamofireNetworkErrorHandler {
         guard let urlRequest = try? request.asURLRequest() else {
             return false
         }
-        retriedJetpackRequests.contains { retriedRequest in
+        return retriedJetpackRequests.contains { retriedRequest in
             guard let currentItem = try? retriedRequest.request.asURLRequest() else {
                 return false
             }

--- a/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
@@ -560,6 +560,52 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
         // Then
         XCTAssertTrue(userDefaults.applicationPasswordUnsupportedList.keys.contains(String(siteID)))
     }
+
+    func test_concurrent_flagSiteAsUnsupportedForAppPasswordIfNeeded_no_race_condition() {
+        // Given - test for the race condition fix where multiple threads
+        // try to remove the same item simultaneously
+        let expectation = XCTestExpectation(description: "All concurrent flag operations complete without crash")
+        let threadCount = 50
+        let siteID: Int64 = 999
+        let jetpackRequest = createJetpackRequest(siteID: siteID)
+        let restRequest = createRESTRequest()
+        let error = createNetworkError()
+
+        expectation.expectedFulfillmentCount = threadCount
+
+        // Add a single request to the retry list
+        _ = errorHandler.shouldRetryJetpackRequest(
+            originalRequest: jetpackRequest,
+            convertedRequest: restRequest,
+            failure: error
+        )
+
+        // When - multiple threads simultaneously try to flag and remove the SAME item
+        // This would cause a race condition in the old code where:
+        // 1. Thread A reads the array, finds index 0
+        // 2. Thread B reads the array, finds index 0
+        // 3. Thread A removes at index 0 (succeeds)
+        // 4. Thread B tries to remove at index 0 (crashes - array is now empty)
+        let group = DispatchGroup()
+        for _ in 0..<threadCount {
+            group.enter()
+            DispatchQueue.global().async {
+                // All threads try to remove the same request concurrently
+                self.errorHandler.flagSiteAsUnsupportedForAppPasswordIfNeeded(
+                    originalRequest: jetpackRequest,
+                    failure: nil
+                )
+                group.leave()
+                expectation.fulfill()
+            }
+        }
+
+        // Force threads to start as close together as possible
+        group.wait()
+
+        // Then - no crashes should occur (especially no EXC_BREAKPOINT from array index out of bounds)
+        wait(for: [expectation], timeout: 5.0)
+    }
 }
 
 // MARK: - Helper Methods

--- a/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/AlamofireNetworkErrorHandlerTests.swift
@@ -580,7 +580,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
             failure: error
         )
 
-        // When - multiple threads simultaneously try to flag and remove the SAME item
+        // When - multiple threads concurrently try to flag and remove the SAME item
         // This would cause a race condition in the old code where:
         // 1. Thread A reads the array, finds index 0
         // 2. Thread B reads the array, finds index 0
@@ -600,7 +600,7 @@ final class AlamofireNetworkErrorHandlerTests: XCTestCase {
             }
         }
 
-        // Force threads to start as close together as possible
+        // Wait for all threads to complete
         group.wait()
 
         // Then - no crashes should occur (especially no EXC_BREAKPOINT from array index out of bounds)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1450

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

There are crash reports regarding the removal of retried requests when flagging sites as unsupported for application passwords. These are caused by the race condition when the list of retried requests is altered simultaneously from different threads.

This PR fixes the crash by ensuring that the retried request list is updated atomically with a barrier block.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

It's not straightforward to reproduce race conditions so it's tricky to test the crash. Simply smoke testing the flow should be sufficient.

Use the test plan in pe5sF9-4Am-p2 - run TC4. Confirm that the app doesn't crash.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Added a unit test to confirm the race condition fix. The test fails before the fix.
- Ran TC4 with simulator iPhone 17 and confirmed the app doesn't crash.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.