### PR TITLE
Bookings: Add sort options

### DIFF
--- a/Modules/Sources/Networking/Remote/BookingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/BookingsRemote.swift
@@ -11,7 +11,8 @@ public protocol BookingsRemoteProtocol {
                          pageSize: Int,
                          startDateBefore: String?,
                          startDateAfter: String?,
-                         searchQuery: String?) async throws -> [Booking]
+                         searchQuery: String?,
+                         order: BookingsRemote.Order) async throws -> [Booking]
 }
 
 /// Booking: Remote Endpoints
@@ -29,16 +30,19 @@ public final class BookingsRemote: Remote, BookingsRemoteProtocol {
     ///     - startDateBefore: Filter bookings with start date before this timestamp.
     ///     - startDateAfter: Filter bookings with start date after this timestamp.
     ///     - searchQuery: Search query to filter bookings.
+    ///     - order: Sort order for bookings (ascending or descending).
     ///
     public func loadAllBookings(for siteID: Int64,
                                 pageNumber: Int = Default.pageNumber,
                                 pageSize: Int = Default.pageSize,
                                 startDateBefore: String? = nil,
                                 startDateAfter: String? = nil,
-                                searchQuery: String? = nil) async throws -> [Booking] {
+                                searchQuery: String? = nil,
+                                order: Order) async throws -> [Booking] {
         var parameters = [
             ParameterKey.page: String(pageNumber),
-            ParameterKey.perPage: String(pageSize)
+            ParameterKey.perPage: String(pageSize),
+            ParameterKey.order: order.rawValue
         ]
 
         if let startDateBefore = startDateBefore {
@@ -69,6 +73,11 @@ public extension BookingsRemote {
         public static let pageNumber: Int = Remote.Default.firstPageNumber
     }
 
+    enum Order: String {
+        case ascending = "asc"
+        case descending = "desc"
+    }
+
     private enum Path {
         static let bookings = "bookings"
     }
@@ -79,5 +88,6 @@ public extension BookingsRemote {
         static let startDateBefore: String = "start_date_before"
         static let startDateAfter: String  = "start_date_after"
         static let search: String          = "search"
+        static let order: String           = "order"
     }
 }

--- a/Modules/Sources/Yosemite/Actions/BookingAction.swift
+++ b/Modules/Sources/Yosemite/Actions/BookingAction.swift
@@ -15,6 +15,7 @@ public enum BookingAction: Action {
                              pageSize: Int = BookingsRemote.Default.pageSize,
                              startDateBefore: String? = nil,
                              startDateAfter: String? = nil,
+                             order: BookingsRemote.Order = .descending,
                              shouldClearCache: Bool = false,
                              onCompletion: (Result<Bool, Error>) -> Void)
 
@@ -34,5 +35,6 @@ public enum BookingAction: Action {
                         pageSize: Int = BookingsRemote.Default.pageSize,
                         startDateBefore: String? = nil,
                         startDateAfter: String? = nil,
+                        order: BookingsRemote.Order = .descending,
                         onCompletion: (Result<[Booking], Error>) -> Void)
 }

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -35,23 +35,25 @@ public class BookingStore: Store {
         }
 
         switch action {
-        case let .synchronizeBookings(siteID, pageNumber, pageSize, startDateBefore, startDateAfter, shouldClearCache, onCompletion):
+        case let .synchronizeBookings(siteID, pageNumber, pageSize, startDateBefore, startDateAfter, order, shouldClearCache, onCompletion):
             synchronizeBookings(siteID: siteID,
                                 pageNumber: pageNumber,
                                 pageSize: pageSize,
                                 startDateBefore: startDateBefore,
                                 startDateAfter: startDateAfter,
+                                order: order,
                                 shouldClearCache: shouldClearCache,
                                 onCompletion: onCompletion)
         case let .checkIfStoreHasBookings(siteID, onCompletion):
             checkIfStoreHasBookings(siteID: siteID, onCompletion: onCompletion)
-        case let .searchBookings(siteID, searchQuery, pageNumber, pageSize, startDateBefore, startDateAfter, onCompletion):
+        case let .searchBookings(siteID, searchQuery, pageNumber, pageSize, startDateBefore, startDateAfter, order, onCompletion):
             searchBookings(siteID: siteID,
                            searchQuery: searchQuery,
                            pageNumber: pageNumber,
                            pageSize: pageSize,
                            startDateBefore: startDateBefore,
                            startDateAfter: startDateAfter,
+                           order: order,
                            onCompletion: onCompletion)
         }
     }
@@ -69,6 +71,7 @@ private extension BookingStore {
                              pageSize: Int,
                              startDateBefore: String?,
                              startDateAfter: String?,
+                             order: BookingsRemote.Order,
                              shouldClearCache: Bool,
                              onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         Task { @MainActor in
@@ -78,7 +81,8 @@ private extension BookingStore {
                                                                 pageSize: pageSize,
                                                                 startDateBefore: startDateBefore,
                                                                 startDateAfter: startDateAfter,
-                                                                searchQuery: nil)
+                                                                searchQuery: nil,
+                                                                order: order)
                 await upsertStoredBookingsInBackground(
                     readOnlyBookings: bookings,
                     siteID: siteID,
@@ -111,7 +115,8 @@ private extension BookingStore {
                                                                 pageSize: 1,
                                                                 startDateBefore: nil,
                                                                 startDateAfter: nil,
-                                                                searchQuery: nil)
+                                                                searchQuery: nil,
+                                                                order: .descending)
                 let hasRemoteBookings = !bookings.isEmpty
                 onCompletion(.success(hasRemoteBookings))
             } catch {
@@ -129,6 +134,7 @@ private extension BookingStore {
                        pageSize: Int,
                        startDateBefore: String?,
                        startDateAfter: String?,
+                       order: BookingsRemote.Order,
                        onCompletion: @escaping (Result<[Booking], Error>) -> Void) {
         Task { @MainActor in
             do {
@@ -137,7 +143,8 @@ private extension BookingStore {
                                                                 pageSize: pageSize,
                                                                 startDateBefore: startDateBefore,
                                                                 startDateAfter: startDateAfter,
-                                                                searchQuery: searchQuery)
+                                                                searchQuery: searchQuery,
+                                                                order: order)
                 onCompletion(.success(bookings))
             } catch {
                 onCompletion(.failure(error))

--- a/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
@@ -13,7 +13,7 @@ struct BookingsRemoteTests {
         network.simulateResponse(requestUrlSuffix: "bookings", filename: "booking-list")
 
         // When
-        let bookings = try await remote.loadAllBookings(for: sampleSiteID)
+        let bookings = try await remote.loadAllBookings(for: sampleSiteID, order: .descending)
 
         // Then
         #expect(bookings.count == 2)
@@ -34,7 +34,7 @@ struct BookingsRemoteTests {
 
         // Then
         await #expect(throws: NetworkError.notFound()) {
-            _ = try await remote.loadAllBookings(for: sampleSiteID)
+            _ = try await remote.loadAllBookings(for: sampleSiteID, order: .descending)
         }
     }
 
@@ -52,7 +52,8 @@ struct BookingsRemoteTests {
                                              pageSize: 50,
                                              startDateBefore: startDateBefore,
                                              startDateAfter: startDateAfter,
-                                             searchQuery: searchQuery)
+                                             searchQuery: searchQuery,
+                                             order: .ascending)
 
         // Then
         let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
@@ -63,6 +64,7 @@ struct BookingsRemoteTests {
         #expect((parameters["start_date_before"] as? String) == startDateBefore)
         #expect((parameters["start_date_after"] as? String) == startDateAfter)
         #expect((parameters["search"] as? String) == searchQuery)
+        #expect((parameters["order"] as? String) == "asc")
     }
 
     @Test func test_loadAllBookings_omits_nil_parameters() async throws {
@@ -74,7 +76,8 @@ struct BookingsRemoteTests {
         _ = try await remote.loadAllBookings(for: sampleSiteID,
                                              startDateBefore: nil,
                                              startDateAfter: nil,
-                                             searchQuery: nil)
+                                             searchQuery: nil,
+                                             order: .descending)
 
         // Then
         let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
@@ -85,5 +88,6 @@ struct BookingsRemoteTests {
         #expect(parameters["s"] == nil)
         #expect(parameters["page"] != nil)
         #expect(parameters["per_page"] != nil)
+        #expect(parameters["order"] != nil)
     }
 }

--- a/Modules/Tests/YosemiteTests/Mocks/MockBookingsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockBookingsRemote.swift
@@ -15,7 +15,8 @@ final class MockBookingsRemote: BookingsRemoteProtocol {
                          pageSize: Int,
                          startDateBefore: String?,
                          startDateAfter: String?,
-                         searchQuery: String?) async throws -> [Booking] {
+                         searchQuery: String?,
+                         order: BookingsRemote.Order) async throws -> [Booking] {
         guard let result = loadAllBookingsResult else {
             throw NetworkError.timeout()
         }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
@@ -138,7 +138,6 @@ private extension BookingListContainerView {
                 Text(Localization.sortBy)
                     .font(.subheadline.weight(.medium))
                     .foregroundStyle(.secondary)
-                    .padding(.top, Layout.SortingOptions.contentSpacing)
 
                 ForEach(BookingListViewModel.SortBy.allCases, id: \.rawValue) { sortBy in
                     Button {
@@ -165,7 +164,7 @@ private extension BookingListContainerView {
                 Spacer()
             }
             .padding(.horizontal, Layout.SortingOptions.margin)
-            .padding(.vertical, Layout.SortingOptions.contentSpacing)
+            .padding(.vertical, Layout.SortingOptions.topPadding)
         }
     }
 }
@@ -178,6 +177,7 @@ private extension BookingListContainerView {
         enum SortingOptions {
             static let contentSpacing: CGFloat = 24
             static let margin: CGFloat = 16
+            static let topPadding: CGFloat = 52
         }
     }
 

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
@@ -52,7 +52,7 @@ struct BookingListContainerView: View {
         }
         .sheet(isPresented: $showingSortOptions) {
             sortingOptions
-                .presentationDetents([.fraction(0.2), .medium, .large])
+                .presentationDetents([.fraction(0.25), .medium, .large])
         }
     }
 }
@@ -133,37 +133,40 @@ private extension BookingListContainerView {
     }
 
     var sortingOptions: some View {
-        VStack(alignment: .leading, spacing: Layout.SortingOptions.contentSpacing) {
-            Text(Localization.sortBy)
-                .font(.subheadline.weight(.medium))
-                .foregroundStyle(.secondary)
-                .padding(.top, Layout.SortingOptions.contentSpacing)
+        ScrollView {
+            VStack(alignment: .leading, spacing: Layout.SortingOptions.contentSpacing) {
+                Text(Localization.sortBy)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .padding(.top, Layout.SortingOptions.contentSpacing)
 
-            ForEach(BookingListViewModel.SortBy.allCases, id: \.rawValue) { sortBy in
-                Button {
-                    viewModel.sortBy = sortBy
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                        showingSortOptions = false
+                ForEach(BookingListViewModel.SortBy.allCases, id: \.rawValue) { sortBy in
+                    Button {
+                        viewModel.sortBy = sortBy
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                            showingSortOptions = false
+                        }
+                    } label: {
+                        HStack(alignment: .firstTextBaseline) {
+                            Text(sortBy.title)
+                                .font(.body.weight(.medium))
+                                .foregroundStyle(Color.primary)
+                            Spacer()
+                            Image(systemName: "checkmark")
+                                .font(.title3.weight(.medium))
+                                .foregroundStyle(Color.accentColor)
+                                .renderedIf(viewModel.sortBy == sortBy)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .multilineTextAlignment(.leading)
                     }
-                } label: {
-                    HStack(alignment: .firstTextBaseline) {
-                        Text(sortBy.title)
-                            .font(.body.weight(.medium))
-                            .foregroundStyle(Color.primary)
-                        Spacer()
-                        Image(systemName: "checkmark")
-                            .font(.title3.weight(.medium))
-                            .foregroundStyle(Color.accentColor)
-                            .renderedIf(viewModel.sortBy == sortBy)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
-            }
 
-            Spacer()
+                Spacer()
+            }
+            .padding(.horizontal, Layout.SortingOptions.margin)
+            .padding(.vertical, Layout.SortingOptions.contentSpacing)
         }
-        .padding(.horizontal, Layout.SortingOptions.margin)
-        .padding(.vertical, Layout.SortingOptions.contentSpacing)
     }
 }
 

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
@@ -4,6 +4,9 @@ import struct Yosemite.Booking
 struct BookingListContainerView: View {
     @ObservedObject private var viewModel: BookingListContainerViewModel
     @State private var isSearching = false
+    @State private var showingSortOptions = false
+    @State private var sortBy: BookingListViewModel.SortBy = .newestToOldest
+
     @ScaledMetric private var scale: CGFloat = 1.0
     @Binding var selectedBooking: Booking?
 
@@ -48,6 +51,10 @@ struct BookingListContainerView: View {
                 }
             }
         }
+        .sheet(isPresented: $showingSortOptions) {
+            sortingOptions
+                .presentationDetents([.fraction(0.2), .medium, .large])
+        }
     }
 }
 
@@ -58,7 +65,7 @@ private extension BookingListContainerView {
             Divider()
             HStack {
                 Button {
-                    // TODO
+                    showingSortOptions = true
                 } label: {
                     Text(Localization.sortBy)
                         .font(.body)
@@ -125,11 +132,51 @@ private extension BookingListContainerView {
 
         return distanceFromLeftEdge - adjustmentForCenterOrigin + centerWithinTab
     }
+
+    var sortingOptions: some View {
+        VStack(alignment: .leading, spacing: Layout.SortingOptions.contentSpacing) {
+            Text(Localization.sortBy)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.secondary)
+                .padding(.top, Layout.SortingOptions.contentSpacing)
+
+            ForEach(BookingListViewModel.SortBy.allCases, id: \.rawValue) { sortBy in
+                Button {
+                    self.sortBy = sortBy
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        showingSortOptions = false
+                    }
+                } label: {
+                    HStack(alignment: .firstTextBaseline) {
+                        Text(sortBy.title)
+                            .font(.body.weight(.medium))
+                            .foregroundStyle(Color.primary)
+                        Spacer()
+                        Image(systemName: "checkmark")
+                            .font(.title3.weight(.medium))
+                            .foregroundStyle(Color.accentColor)
+                            .renderedIf(self.sortBy == sortBy)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, Layout.SortingOptions.margin)
+        .padding(.vertical, Layout.SortingOptions.contentSpacing)
+    }
 }
+
+
 private extension BookingListContainerView {
     enum Layout {
         static let topTabBarHeight: CGFloat = 44
         static let selectedTabIndicatorHeight: CGFloat = 3.0
+        enum SortingOptions {
+            static let contentSpacing: CGFloat = 24
+            static let margin: CGFloat = 16
+        }
     }
 
     enum Localization {

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
@@ -5,7 +5,6 @@ struct BookingListContainerView: View {
     @ObservedObject private var viewModel: BookingListContainerViewModel
     @State private var isSearching = false
     @State private var showingSortOptions = false
-    @State private var sortBy: BookingListViewModel.SortBy = .newestToOldest
 
     @ScaledMetric private var scale: CGFloat = 1.0
     @Binding var selectedBooking: Booking?
@@ -142,7 +141,7 @@ private extension BookingListContainerView {
 
             ForEach(BookingListViewModel.SortBy.allCases, id: \.rawValue) { sortBy in
                 Button {
-                    self.sortBy = sortBy
+                    viewModel.sortBy = sortBy
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                         showingSortOptions = false
                     }
@@ -155,7 +154,7 @@ private extension BookingListContainerView {
                         Image(systemName: "checkmark")
                             .font(.title3.weight(.medium))
                             .foregroundStyle(Color.accentColor)
-                            .renderedIf(self.sortBy == sortBy)
+                            .renderedIf(viewModel.sortBy == sortBy)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
@@ -58,9 +58,12 @@ final class BookingListContainerViewModel: ObservableObject {
         sortBySubscription = $sortBy
             .sink { [weak self] sortBy in
                 guard let self else { return }
-                self.todayListViewModel.updateSortOrder(sortBy)
-                self.upcomingListViewModel.updateSortOrder(sortBy)
-                self.allListViewModel.updateSortOrder(sortBy)
+                todayListViewModel.updateSortOrder(sortBy)
+                upcomingListViewModel.updateSortOrder(sortBy)
+                allListViewModel.updateSortOrder(sortBy)
+                todaySearchViewModel.updateSortOrder(sortBy)
+                upcomingSearchViewModel.updateSortOrder(sortBy)
+                allSearchViewModel.updateSortOrder(sortBy)
             }
     }
 

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
@@ -56,6 +56,7 @@ final class BookingListContainerViewModel: ObservableObject {
             }
 
         sortBySubscription = $sortBy
+            .removeDuplicates()
             .sink { [weak self] sortBy in
                 guard let self else { return }
                 todayListViewModel.updateSortOrder(sortBy)

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
@@ -17,6 +17,7 @@ final class BookingListContainerViewModel: ObservableObject {
 
     private let searchQuerySubject = PassthroughSubject<String, Never>()
     private var searchQuerySubscription: AnyCancellable?
+    private var sortBySubscription: AnyCancellable?
 
     init(siteID: Int64) {
         let searchQueryPublisher = searchQuerySubject.eraseToAnyPublisher()
@@ -52,6 +53,14 @@ final class BookingListContainerViewModel: ObservableObject {
         searchQuerySubscription = $searchQuery
             .sink { [weak self] query in
                 self?.searchQuerySubject.send(query)
+            }
+
+        sortBySubscription = $sortBy
+            .sink { [weak self] sortBy in
+                guard let self else { return }
+                self.todayListViewModel.updateSortOrder(sortBy)
+                self.upcomingListViewModel.updateSortOrder(sortBy)
+                self.allListViewModel.updateSortOrder(sortBy)
             }
     }
 

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
@@ -13,6 +13,7 @@ final class BookingListContainerViewModel: ObservableObject {
 
     @Published var selectedTab: BookingListTab = .today
     @Published var searchQuery: String = ""
+    @Published var sortBy: BookingListViewModel.SortBy = .newestToOldest
 
     private let searchQuerySubject = PassthroughSubject<String, Never>()
     private var searchQuerySubscription: AnyCancellable?

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import Yosemite
 import Combine
 import protocol Storage.StorageManagerType
+import class Networking.BookingsRemote
 
 /// View model for `BookingListView`
 final class BookingListViewModel: ObservableObject {
@@ -29,8 +30,10 @@ final class BookingListViewModel: ObservableObject {
     private let stores: StoresManager
     private let storage: StorageManagerType
     private let currentDate: Date
+    private var currentOrder: SortBy = .newestToOldest
 
     private static let refreshCacheReason = "refresh-cache"
+    private static let reorderReason = "reorder"
 
     /// Keeps track of the current state of the syncing
     @Published private(set) var syncState: SyncState = .empty
@@ -102,10 +105,16 @@ final class BookingListViewModel: ObservableObject {
 
     /// Updates the sort order and reloads the results controller.
     func updateSortOrder(_ sortBy: SortBy) {
+        currentOrder = sortBy
         let ascending = sortBy == .oldestToNewest
         let sortDescriptorByDate = NSSortDescriptor(key: "startDate", ascending: ascending)
         resultsController.sortDescriptors = [sortDescriptorByDate]
-        updateResults()
+        paginationTracker.resync(reason: Self.reorderReason) {}
+    }
+
+    /// Converts SortBy to BookingsRemote.Order
+    private func remoteOrder(from sortBy: SortBy) -> BookingsRemote.Order {
+        sortBy == .oldestToNewest ? .ascending : .descending
     }
 }
 
@@ -152,6 +161,7 @@ extension BookingListViewModel: PaginationTrackerDelegate {
             pageSize: pageSize,
             startDateBefore: type.startDateBefore(currentDate: currentDate)?.ISO8601Format(),
             startDateAfter: type.startDateAfter(currentDate: currentDate)?.ISO8601Format(),
+            order: remoteOrder(from: currentOrder),
             shouldClearCache: shouldClearCache
         ) { [weak self] result in
             switch result {

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
@@ -222,12 +222,12 @@ extension BookingListViewModel {
         enum Localization {
             static let newestToOldest = NSLocalizedString(
                 "bookingList.sort.newestToOldest",
-                value: "Newest to oldest",
+                value: "Date: Newest to Oldest",
                 comment: "Option to sort bookings from newest to oldest"
             )
             static let oldestToNewest = NSLocalizedString(
                 "bookingList.sort.oldestToNewest",
-                value: "Oldest to newest",
+                value: "Date: Oldest to Newest",
                 comment: "Option to sort bookings from oldest to newest"
             )
         }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
@@ -99,6 +99,14 @@ final class BookingListViewModel: ObservableObject {
             }
         }
     }
+
+    /// Updates the sort order and reloads the results controller.
+    func updateSortOrder(_ sortBy: SortBy) {
+        let ascending = sortBy == .oldestToNewest
+        let sortDescriptorByDate = NSSortDescriptor(key: "startDate", ascending: ascending)
+        resultsController.sortDescriptors = [sortDescriptorByDate]
+        updateResults()
+    }
 }
 
 // MARK: Configuration

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
@@ -188,3 +188,30 @@ extension BookingListViewModel {
         syncState = bookings.isNotEmpty ? .results : .empty
     }
 }
+
+extension BookingListViewModel {
+    enum SortBy: Int, CaseIterable {
+        case newestToOldest
+        case oldestToNewest
+
+        var title: String {
+            switch self {
+            case .newestToOldest: Localization.newestToOldest
+            case .oldestToNewest: Localization.oldestToNewest
+            }
+        }
+
+        enum Localization {
+            static let newestToOldest = NSLocalizedString(
+                "bookingList.sort.newestToOldest",
+                value: "Newest to oldest",
+                comment: "Option to sort bookings from newest to oldest"
+            )
+            static let oldestToNewest = NSLocalizedString(
+                "bookingList.sort.oldestToNewest",
+                value: "Oldest to newest",
+                comment: "Option to sort bookings from oldest to newest"
+            )
+        }
+    }
+}

--- a/WooCommerce/Classes/Bookings/BookingList/BookingSearchViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingSearchViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 import Yosemite
 import Combine
+import class Networking.BookingsRemote
 
 /// View model for booking search functionality
 final class BookingSearchViewModel: ObservableObject {
@@ -17,6 +18,7 @@ final class BookingSearchViewModel: ObservableObject {
     private let stores: StoresManager
     private let currentDate: Date
     private var searchQuerySubscription: AnyCancellable?
+    private var currentOrder: BookingListViewModel.SortBy = .newestToOldest
 
     /// Tracks if the infinite scroll indicator should be displayed.
     @Published private(set) var shouldShowBottomActivityIndicator = false
@@ -57,6 +59,20 @@ final class BookingSearchViewModel: ObservableObject {
     func onLoadNextPageAction() {
         guard !currentSearchQuery.isEmpty else { return }
         searchPaginationTracker.ensureNextPageIsSynced()
+    }
+
+    /// Updates the sort order for search results.
+    func updateSortOrder(_ sortBy: BookingListViewModel.SortBy) {
+        currentOrder = sortBy
+        // Trigger a new search if we have a query
+        if !currentSearchQuery.isEmpty {
+            searchPaginationTracker.syncFirstPage()
+        }
+    }
+
+    /// Converts SortBy to BookingsRemote.Order
+    private func remoteOrder(from sortBy: BookingListViewModel.SortBy) -> BookingsRemote.Order {
+        sortBy == .oldestToNewest ? .ascending : .descending
     }
 }
 
@@ -108,7 +124,8 @@ extension BookingSearchViewModel: PaginationTrackerDelegate {
             pageNumber: pageNumber,
             pageSize: pageSize,
             startDateBefore: type.startDateBefore(currentDate: currentDate)?.ISO8601Format(),
-            startDateAfter: type.startDateAfter(currentDate: currentDate)?.ISO8601Format()
+            startDateAfter: type.startDateAfter(currentDate: currentDate)?.ISO8601Format(),
+            order: remoteOrder(from: currentOrder)
         ) { [weak self] result in
             guard let self else { return }
             switch result {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
@@ -5,6 +5,7 @@ import Yosemite
 import protocol Storage.StorageManagerType
 import protocol Storage.StorageType
 @testable import WooCommerce
+@testable import Networking
 
 @MainActor
 struct BookingListViewModelTests {
@@ -576,6 +577,134 @@ struct BookingListViewModelTests {
         #expect(viewModel.bookings.count == 1, "Should only show bookings for the correct site")
         #expect(viewModel.bookings.first?.bookingID == correctSiteBooking.bookingID, "Should contain only the booking for the correct site")
         #expect(viewModel.bookings.first?.siteID == sampleSiteID, "Booking should have the correct site ID")
+    }
+
+    // MARK: - Sort order
+
+    @Test func update_sort_order_sorts_bookings_from_oldest_to_newest() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            guard case let .synchronizeBookings(_, _, _, _, _, _, _, onCompletion) = action else {
+                return
+            }
+            onCompletion(.success(false))
+        }
+
+        let olderBooking = Booking.fake().copy(
+            siteID: sampleSiteID,
+            bookingID: 1,
+            dateCreated: Date(timeIntervalSince1970: 1000),
+            startDate: Date(timeIntervalSince1970: 1000)
+        )
+        let newerBooking = Booking.fake().copy(
+            siteID: sampleSiteID,
+            bookingID: 2,
+            dateCreated: Date(timeIntervalSince1970: 2000),
+            startDate: Date(timeIntervalSince1970: 2000)
+        )
+        insertBookings([olderBooking, newerBooking])
+
+        let viewModel = BookingListViewModel(siteID: sampleSiteID,
+                                             type: .all,
+                                             stores: stores,
+                                             storage: storageManager)
+
+        // Initial state - should be sorted newest to oldest (default)
+        #expect(viewModel.bookings[0].bookingID == newerBooking.bookingID)
+        #expect(viewModel.bookings[1].bookingID == olderBooking.bookingID)
+
+        // When
+        viewModel.updateSortOrder(.oldestToNewest)
+
+        // Then - should be sorted oldest to newest
+        #expect(viewModel.bookings[0].bookingID == olderBooking.bookingID)
+        #expect(viewModel.bookings[1].bookingID == newerBooking.bookingID)
+    }
+
+    @Test func update_sort_order_sorts_bookings_from_newest_to_oldest() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            guard case let .synchronizeBookings(_, _, _, _, _, _, _, onCompletion) = action else {
+                return
+            }
+            onCompletion(.success(false))
+        }
+
+        let olderBooking = Booking.fake().copy(
+            siteID: sampleSiteID,
+            bookingID: 1,
+            dateCreated: Date(timeIntervalSince1970: 1000),
+            startDate: Date(timeIntervalSince1970: 1000)
+        )
+        let newerBooking = Booking.fake().copy(
+            siteID: sampleSiteID,
+            bookingID: 2,
+            dateCreated: Date(timeIntervalSince1970: 2000),
+            startDate: Date(timeIntervalSince1970: 2000)
+        )
+        insertBookings([olderBooking, newerBooking])
+
+        let viewModel = BookingListViewModel(siteID: sampleSiteID,
+                                             type: .all,
+                                             stores: stores,
+                                             storage: storageManager)
+
+        // Change to oldest first
+        viewModel.updateSortOrder(.oldestToNewest)
+        #expect(viewModel.bookings[0].bookingID == olderBooking.bookingID)
+
+        // When - change back to newest first
+        viewModel.updateSortOrder(.newestToOldest)
+
+        // Then - should be sorted newest to oldest
+        #expect(viewModel.bookings[0].bookingID == newerBooking.bookingID)
+        #expect(viewModel.bookings[1].bookingID == olderBooking.bookingID)
+    }
+
+    @Test func update_sort_order_triggers_resync_with_correct_order() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var capturedOrder: BookingsRemote.Order?
+
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            guard case let .synchronizeBookings(_, _, _, _, _, order, _, onCompletion) = action else {
+                return
+            }
+            capturedOrder = order
+            onCompletion(.success(false))
+        }
+
+        let viewModel = BookingListViewModel(siteID: sampleSiteID, type: .all, stores: stores)
+
+        // When
+        viewModel.updateSortOrder(.oldestToNewest)
+
+        // Then
+        #expect(capturedOrder == .ascending, "Should dispatch action with ascending order")
+    }
+
+    @Test func update_sort_order_to_newest_first_triggers_resync_with_descending_order() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var capturedOrder: BookingsRemote.Order?
+
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            guard case let .synchronizeBookings(_, _, _, _, _, order, _, onCompletion) = action else {
+                return
+            }
+            capturedOrder = order
+            onCompletion(.success(false))
+        }
+
+        let viewModel = BookingListViewModel(siteID: sampleSiteID, type: .all, stores: stores)
+
+        // When
+        viewModel.updateSortOrder(.newestToOldest)
+
+        // Then
+        #expect(capturedOrder == .descending, "Should dispatch action with descending order")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
@@ -92,7 +92,7 @@ struct BookingListViewModelTests {
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let booking = createBooking(id: 1, startDate: Date())
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, _, _, _, _, _, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, _, _, _, _, _, _, onCompletion) = action else {
                 return
             }
             self.insertBookings([booking])
@@ -130,7 +130,7 @@ struct BookingListViewModelTests {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, _, _, _, _, _, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, _, _, _, _, _, _, onCompletion) = action else {
                 return
             }
             onCompletion(.success(false))
@@ -170,7 +170,7 @@ struct BookingListViewModelTests {
         let firstPageItems = (1...2).map { createBooking(id: Int64($0), startDate: Date()) }
         let secondPageItems = [createBooking(id: 3, startDate: Date())]
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, pageNumber, _, _, _, _, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, pageNumber, _, _, _, _, _, onCompletion) = action else {
                 return
             }
             invocationCountOfLoadBookings += 1
@@ -218,7 +218,7 @@ struct BookingListViewModelTests {
         let booking1 = createBooking(id: 9, startDate: Date())
         let booking2 = createBooking(id: 10, startDate: Date())
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, _, _, _, _, _, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, _, _, _, _, _, _, onCompletion) = action else {
                 return
             }
             self.insertBookings([booking1, booking2])
@@ -243,7 +243,7 @@ struct BookingListViewModelTests {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, _, _, _, _, _, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, _, _, _, _, _, _, onCompletion) = action else {
                 return
             }
             onCompletion(.success(false))
@@ -266,7 +266,7 @@ struct BookingListViewModelTests {
         let olderBooking = Booking.fake().copy(siteID: sampleSiteID, bookingID: 1, dateCreated: Date(timeIntervalSince1970: 1000), startDate: Date())
         let newerBooking = Booking.fake().copy(siteID: sampleSiteID, bookingID: 3, dateCreated: Date(timeIntervalSince1970: 2000), startDate: Date())
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, _, _, _, _, _, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, _, _, _, _, _, _, onCompletion) = action else {
                 return
             }
             let items = [olderBooking, newerBooking]
@@ -295,7 +295,7 @@ struct BookingListViewModelTests {
         var invocationCountOfLoadBookings = 0
         var skip: Int?
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, pageNumber, pageSize, _, _, _, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, pageNumber, pageSize, _, _, _, _, onCompletion) = action else {
                 return
             }
             invocationCountOfLoadBookings += 1
@@ -323,7 +323,7 @@ struct BookingListViewModelTests {
         var capturedStartDateAfter: String?
 
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, _, _, startDateBefore, startDateAfter, _, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, _, _, startDateBefore, startDateAfter, _, _, onCompletion) = action else {
                 return
             }
             capturedStartDateBefore = startDateBefore
@@ -349,7 +349,7 @@ struct BookingListViewModelTests {
         var capturedStartDateAfter: String?
 
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, _, _, startDateBefore, startDateAfter, _, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, _, _, startDateBefore, startDateAfter, _, _, onCompletion) = action else {
                 return
             }
             capturedStartDateBefore = startDateBefore
@@ -378,7 +378,7 @@ struct BookingListViewModelTests {
         var capturedStartDateAfter: String?
 
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, _, _, startDateBefore, startDateAfter, _, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, _, _, startDateBefore, startDateAfter, _, _, onCompletion) = action else {
                 return
             }
             capturedStartDateBefore = startDateBefore
@@ -404,7 +404,7 @@ struct BookingListViewModelTests {
         var capturedShouldClearCache: Bool?
 
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, _, _, _, _, shouldClearCache, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, _, _, _, _, _, shouldClearCache, onCompletion) = action else {
                 return
             }
             capturedShouldClearCache = shouldClearCache
@@ -427,7 +427,7 @@ struct BookingListViewModelTests {
         var actionCallCount = 0
 
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, _, _, _, _, shouldClearCache, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, _, _, _, _, _, shouldClearCache, onCompletion) = action else {
                 return
             }
             actionCallCount += 1
@@ -452,7 +452,7 @@ struct BookingListViewModelTests {
         var capturedShouldClearCache: Bool?
 
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .synchronizeBookings(_, _, _, _, _, shouldClearCache, onCompletion) = action else {
+            guard case let .synchronizeBookings(_, _, _, _, _, _, shouldClearCache, onCompletion) = action else {
                 return
             }
             capturedShouldClearCache = shouldClearCache

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingSearchViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingSearchViewModelTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import Testing
 import Yosemite
 @testable import WooCommerce
+@testable import Networking
 
 @MainActor
 struct BookingSearchViewModelTests {
@@ -364,5 +365,141 @@ struct BookingSearchViewModelTests {
 
         // Then
         #expect(searchCount == 2, "Should have searched twice")
+    }
+
+    // MARK: - Sort order
+
+    @Test func update_sort_order_triggers_new_search_with_ascending_order() async throws {
+        // Given
+        let searchQuerySubject = PassthroughSubject<String, Never>()
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var capturedOrder: BookingsRemote.Order?
+
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            guard case let .searchBookings(_, _, _, _, _, _, order, onCompletion) = action else {
+                return
+            }
+            capturedOrder = order
+            onCompletion(.success([]))
+        }
+
+        let viewModel = BookingSearchViewModel(
+            siteID: sampleSiteID,
+            type: .all,
+            searchQueryPublisher: searchQuerySubject.eraseToAnyPublisher(),
+            stores: stores
+        )
+
+        // Setup initial search
+        searchQuerySubject.send("test")
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        // When
+        viewModel.updateSortOrder(.oldestToNewest)
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then
+        #expect(capturedOrder == .ascending, "Should search with ascending order")
+    }
+
+    @Test func update_sort_order_triggers_new_search_with_descending_order() async throws {
+        // Given
+        let searchQuerySubject = PassthroughSubject<String, Never>()
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var capturedOrder: BookingsRemote.Order?
+
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            guard case let .searchBookings(_, _, _, _, _, _, order, onCompletion) = action else {
+                return
+            }
+            capturedOrder = order
+            onCompletion(.success([]))
+        }
+
+        let viewModel = BookingSearchViewModel(
+            siteID: sampleSiteID,
+            type: .all,
+            searchQueryPublisher: searchQuerySubject.eraseToAnyPublisher(),
+            stores: stores
+        )
+
+        // Setup initial search
+        searchQuerySubject.send("test")
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        // When
+        viewModel.updateSortOrder(.newestToOldest)
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then
+        #expect(capturedOrder == .descending, "Should search with descending order")
+    }
+
+    @Test func update_sort_order_does_not_trigger_search_when_query_is_empty() async throws {
+        // Given
+        let searchQuerySubject = PassthroughSubject<String, Never>()
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var searchCount = 0
+
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            guard case .searchBookings = action else {
+                return
+            }
+            searchCount += 1
+        }
+
+        let viewModel = BookingSearchViewModel(
+            siteID: sampleSiteID,
+            type: .all,
+            searchQueryPublisher: searchQuerySubject.eraseToAnyPublisher(),
+            stores: stores
+        )
+
+        // When - update sort order without any search query
+        viewModel.updateSortOrder(.oldestToNewest)
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then
+        #expect(searchCount == 0, "Should not trigger search when query is empty")
+    }
+
+    @Test func update_sort_order_uses_current_sort_for_subsequent_searches() async throws {
+        // Given
+        let searchQuerySubject = PassthroughSubject<String, Never>()
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var capturedOrders: [BookingsRemote.Order] = []
+
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            guard case let .searchBookings(_, _, _, _, _, _, order, onCompletion) = action else {
+                return
+            }
+            capturedOrders.append(order)
+            onCompletion(.success([]))
+        }
+
+        let viewModel = BookingSearchViewModel(
+            siteID: sampleSiteID,
+            type: .all,
+            searchQueryPublisher: searchQuerySubject.eraseToAnyPublisher(),
+            stores: stores
+        )
+
+        // When - first search with default order
+        searchQuerySubject.send("test")
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        // Update sort order
+        viewModel.updateSortOrder(.oldestToNewest)
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // Second search should use updated sort order
+        searchQuerySubject.send("another test")
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        // Then
+        #expect(capturedOrders.count == 3, "Should have three searches")
+        #expect(capturedOrders[0] == .descending, "First search uses default descending order")
+        #expect(capturedOrders[1] == .ascending, "Second search from updateSortOrder uses ascending")
+        #expect(capturedOrders[2] == .ascending, "Third search should maintain ascending order")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingSearchViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingSearchViewModelTests.swift
@@ -38,7 +38,7 @@ struct BookingSearchViewModelTests {
         let stores = MockStoresManager(sessionManager: .testingInstance)
         var invocationCount = 0
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .searchBookings(_, _, _, _, _, _, onCompletion) = action else {
+            guard case let .searchBookings(_, _, _, _, _, _, _, onCompletion) = action else {
                 return
             }
             invocationCount += 1
@@ -66,7 +66,7 @@ struct BookingSearchViewModelTests {
         let stores = MockStoresManager(sessionManager: .testingInstance)
         var capturedSearchQuery: String?
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .searchBookings(_, searchQuery, _, _, _, _, onCompletion) = action else {
+            guard case let .searchBookings(_, searchQuery, _, _, _, _, _, onCompletion) = action else {
                 return
             }
             capturedSearchQuery = searchQuery
@@ -95,7 +95,7 @@ struct BookingSearchViewModelTests {
         let booking1 = Booking.fake().copy(siteID: sampleSiteID, bookingID: 1, startDate: Date())
         let booking2 = Booking.fake().copy(siteID: sampleSiteID, bookingID: 2, startDate: Date())
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .searchBookings(_, _, _, _, _, _, onCompletion) = action else {
+            guard case let .searchBookings(_, _, _, _, _, _, _, onCompletion) = action else {
                 return
             }
             onCompletion(.success([booking1, booking2]))
@@ -123,7 +123,7 @@ struct BookingSearchViewModelTests {
         let searchQuerySubject = PassthroughSubject<String, Never>()
         let stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .searchBookings(_, _, _, _, _, _, onCompletion) = action else {
+            guard case let .searchBookings(_, _, _, _, _, _, _, onCompletion) = action else {
                 return
             }
             onCompletion(.failure(NSError(domain: "test", code: 1)))
@@ -157,7 +157,7 @@ struct BookingSearchViewModelTests {
         let secondPageBookings = [Booking.fake().copy(siteID: sampleSiteID, bookingID: 26, startDate: Date())]
 
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .searchBookings(_, _, pageNumber, _, _, _, onCompletion) = action else {
+            guard case let .searchBookings(_, _, pageNumber, _, _, _, _, onCompletion) = action else {
                 return
             }
             capturedPageNumbers.append(pageNumber)
@@ -195,7 +195,7 @@ struct BookingSearchViewModelTests {
         var searchCount = 0
 
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .searchBookings(_, _, _, _, _, _, onCompletion) = action else {
+            guard case let .searchBookings(_, _, _, _, _, _, _, onCompletion) = action else {
                 return
             }
             searchCount += 1
@@ -237,7 +237,7 @@ struct BookingSearchViewModelTests {
         var capturedStartDateAfter: String?
 
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .searchBookings(_, _, _, _, startDateBefore, startDateAfter, onCompletion) = action else {
+            guard case let .searchBookings(_, _, _, _, startDateBefore, startDateAfter, _, onCompletion) = action else {
                 return
             }
             capturedStartDateBefore = startDateBefore
@@ -271,7 +271,7 @@ struct BookingSearchViewModelTests {
         var capturedStartDateAfter: String?
 
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .searchBookings(_, _, _, _, startDateBefore, startDateAfter, onCompletion) = action else {
+            guard case let .searchBookings(_, _, _, _, startDateBefore, startDateAfter, _, onCompletion) = action else {
                 return
             }
             capturedStartDateBefore = startDateBefore
@@ -305,7 +305,7 @@ struct BookingSearchViewModelTests {
         var capturedStartDateAfter: String?
 
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .searchBookings(_, _, _, _, startDateBefore, startDateAfter, onCompletion) = action else {
+            guard case let .searchBookings(_, _, _, _, startDateBefore, startDateAfter, _, onCompletion) = action else {
                 return
             }
             capturedStartDateBefore = startDateBefore
@@ -339,7 +339,7 @@ struct BookingSearchViewModelTests {
         var searchCount = 0
 
         stores.whenReceivingAction(ofType: BookingAction.self) { action in
-            guard case let .searchBookings(_, _, _, _, _, _, onCompletion) = action else {
+            guard case let .searchBookings(_, _, _, _, _, _, _, onCompletion) = action else {
                 return
             }
             searchCount += 1


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1238

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR implements the sorting feature for the booking list:
- Adds an action sheet for sorting options.
- Sends selected order to booking list and search view models.
- Updates BookingsRemote, BookingAction and BookingStore to support sending order to the remote.
- Updates the view models to reload when the order changes.

Note: Upon change of order, I reload the lists disregard of whether the list is empty or not - to avoid edge cases. Let me know if you think it makes more sense to not reload when the list is empty.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a CIAB store with existing bookings.
2. In the booking list, select Sort by. Confirm that the action sheet matches the design.
3. Select an option and confirm that both the list and the search view are updated for all tabs. 

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Tested with simulator iPhone 17.
- Added unit tests for the view models.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/39038035-083e-4e12-b12c-84347e18a6e1



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.