### PR TITLE
[Woo POS][Surveys] Update final survey URLs and add track events

### DIFF
--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -115,6 +115,7 @@ public enum WooAnalyticsStat: String {
     case localNotificationTapped = "local_notification_tapped"
     case localNotificationDismissed = "local_notification_dismissed"
     case localNotificationScheduled = "local_notification_scheduled"
+    case localNotificationDisplayed = "local_notification_displayed"
     case localNotificationCanceled = "local_notification_canceled"
 
     // MARK: Dashboard View Events

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+LocalNotification.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+LocalNotification.swift
@@ -23,6 +23,11 @@ extension WooAnalyticsEvent {
                                      properties: getTracksProperties(type: type, userInfo: userInfo))
         }
 
+        static func displayed(type: String, userInfo: [AnyHashable: Any]) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .localNotificationDisplayed,
+                              properties: getTracksProperties(type: type, userInfo: userInfo))
+        }
+
         static func canceled(type: String, userInfo: [AnyHashable: Any]) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .localNotificationCanceled,
                                      properties: getTracksProperties(type: type, userInfo: userInfo))

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -72,10 +72,9 @@ struct LocalNotification {
         static let surveyURL = "surveyURL"
     }
 
-    // periphery:ignore - real survey links to be added in WOOMOB-1497
     enum SurveyURL {
-        static let pointOfSalePotentialMerchant = "https://automattic.survey.fm/woo-app-general-feedback-test-survey"
-        static let pointOfSaleCurrentMerchant = "https://automattic.survey.fm/woo-app-general-feedback-test-survey"
+        static let pointOfSalePotentialMerchant = "https://automattic.survey.fm/pos-survey-potential-users"
+        static let pointOfSaleCurrentMerchant = "https://automattic.survey.fm/pos-survey-existing-users"
     }
 }
 

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -35,9 +35,9 @@ struct LocalNotification {
             case .productImageBackgroundUpload:
                 return "product_image_background_upload"
             case .pointOfSalePotentialMerchant:
-                return "point_of_sale_potential_merchant"
+                return "woo_pos_survey_potential_user_survey"
             case .pointOfSaleCurrentMerchant:
-                return "point_of_sale_current_merchant"
+                return "woo_pos_survey_current_user_survey"
             case let .unknown(siteID):
                 return "unknown_" + "\(siteID)"
             }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -287,7 +287,7 @@ extension PushNotificationsManager {
                     guard let self = self else { return }
                     self.presentDetails(for: foregroundNotification)
                     self.foregroundNotificationsToViewSubject.send(foregroundNotification)
-                    self.analytics.track(.viewInAppPushNotificationPressed, //
+                    self.analytics.track(.viewInAppPushNotificationPressed,
                                                    withProperties: [AnalyticKey.type: foregroundNotification.kind.rawValue])
                 }
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -264,6 +264,9 @@ extension PushNotificationsManager {
             // Check if this is a local notification
             if !content.isRemoteNotification {
                 // Display local notifications with banner and sound when app is in foreground
+                let identifier = notification.request.identifier
+                analytics.track(event: .LocalNotification.displayed(type: LocalNotification.Scenario.identifierForAnalytics(identifier),
+                                                                     userInfo: content.userInfo))
                 return [.banner, .sound, .list]
             }
         }
@@ -284,7 +287,7 @@ extension PushNotificationsManager {
                     guard let self = self else { return }
                     self.presentDetails(for: foregroundNotification)
                     self.foregroundNotificationsToViewSubject.send(foregroundNotification)
-                    self.analytics.track(.viewInAppPushNotificationPressed,
+                    self.analytics.track(.viewInAppPushNotificationPressed, //
                                                    withProperties: [AnalyticKey.type: foregroundNotification.kind.rawValue])
                 }
 


### PR DESCRIPTION
Closes WOOMOB-1497
Closes WOOMOB-1479

## Description
In this PR we update the survey URLs to the real surveys, as well as we add tracks for when the notification is displayed, and when is tapped

## 
1. Update `POSNotificationScheduler.timeIntervalInSeconds` to something like 5 seconds. And add the reset trigger to its initializer if you've tested surveys before:
```
Task { @MainActor in
  let action = AppSettingsAction.resetPOSSurveyNotificationScheduled { _ in }
  stores.dispatch(action)
}
```

2. On a physical device, with notifications turned on, and in a US/UK store:
3. Create an order, observe that the displayed and tapped events are tracked for the `woo_pos_survey_potential_user_survey` case:
```
🔵 Tracked local_notification_displayed, type: woo_pos_survey_potential_user_survey,

🔵 Tracked local_notification_tapped, type: woo_pos_survey_potential_user_survey,
```
4. Confirm survey appears properly on screen.
5. Enter POS > stop the app > remove the reset trigger from the initializer to be sure that the POS visited once persists > and re-run the app > Go to POS again
6. Observe that the displayed and tapped events are tracked for the `woo_pos_survey_current_user_survey` case:
```
🔵 Tracked local_notification_displayed,  type: woo_pos_survey_current_user_survey,
🔵 Tracked local_notification_tapped, type: woo_pos_survey_current_user_survey,
```
7. Confirm survey appears properly on screen.

TODO:
- [ ] Register track events @iamgabrielma 