### PR TITLE
Bookings: Fetch and display assigned staff on booking details

### DIFF
--- a/Modules/Sources/Fakes/Networking.generated.swift
+++ b/Modules/Sources/Fakes/Networking.generated.swift
@@ -344,6 +344,23 @@ extension Networking.Booking {
         )
     }
 }
+extension Networking.BookingResource {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.BookingResource {
+        .init(
+            id: .fake(),
+            name: .fake(),
+            qty: .fake(),
+            role: .fake(),
+            email: .fake(),
+            phoneNumber: .fake(),
+            imageID: .fake(),
+            imageURL: .fake(),
+            description: .fake()
+        )
+    }
+}
 extension Networking.CompositeComponentOptionType {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Modules/Sources/Fakes/Networking.generated.swift
+++ b/Modules/Sources/Fakes/Networking.generated.swift
@@ -349,9 +349,10 @@ extension Networking.BookingResource {
     ///
     public static func fake() -> Networking.BookingResource {
         .init(
-            id: .fake(),
+            siteID: .fake(),
+            bookingID: .fake(),
             name: .fake(),
-            qty: .fake(),
+            quantity: .fake(),
             role: .fake(),
             email: .fake(),
             phoneNumber: .fake(),

--- a/Modules/Sources/Fakes/Networking.generated.swift
+++ b/Modules/Sources/Fakes/Networking.generated.swift
@@ -350,7 +350,7 @@ extension Networking.BookingResource {
     public static func fake() -> Networking.BookingResource {
         .init(
             siteID: .fake(),
-            bookingID: .fake(),
+            resourceID: .fake(),
             name: .fake(),
             quantity: .fake(),
             role: .fake(),

--- a/Modules/Sources/Networking/Mapper/BookingResourceMapper.swift
+++ b/Modules/Sources/Networking/Mapper/BookingResourceMapper.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Mapper: BookingResource
+///
+struct BookingResourceMapper: Mapper {
+    let siteID: Int64
+
+    func map(response: Data) throws -> BookingResource {
+        let decoder = JSONDecoder()
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(BookingResourceEnvelope.self, from: response).bookingResource
+        } else {
+            return try decoder.decode(BookingResource.self, from: response)
+        }
+    }
+}
+
+private struct BookingResourceEnvelope: Decodable {
+    let bookingResource: BookingResource
+
+    private enum CodingKeys: String, CodingKey {
+        case bookingResource = "data"
+    }
+}

--- a/Modules/Sources/Networking/Model/Bookings/BookingResource.swift
+++ b/Modules/Sources/Networking/Model/Bookings/BookingResource.swift
@@ -3,9 +3,9 @@ import Foundation
 
 public struct BookingResource: Hashable, Decodable, GeneratedFakeable, GeneratedCopiable {
     public let siteID: Int64
-    public let id: Int64
+    public let bookingID: Int64
     public let name: String
-    public let qty: Int64
+    public let quantity: Int64
     public let role: String
     public let email: String?
     public let phoneNumber: String?
@@ -14,9 +14,9 @@ public struct BookingResource: Hashable, Decodable, GeneratedFakeable, Generated
     public let description: String?
 
     public init(siteID: Int64,
-                id: Int64,
+                bookingID: Int64,
                 name: String,
-                qty: Int64,
+                quantity: Int64,
                 role: String,
                 email: String?,
                 phoneNumber: String?,
@@ -24,9 +24,9 @@ public struct BookingResource: Hashable, Decodable, GeneratedFakeable, Generated
                 imageURL: String?,
                 description: String?) {
         self.siteID = siteID
-        self.id = id
+        self.bookingID = bookingID
         self.name = name
-        self.qty = qty
+        self.quantity = quantity
         self.role = role
         self.email = email
         self.phoneNumber = phoneNumber
@@ -42,9 +42,9 @@ public struct BookingResource: Hashable, Decodable, GeneratedFakeable, Generated
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let id = try container.decode(Int64.self, forKey: .id)
+        let bookingID = try container.decode(Int64.self, forKey: .bookingID)
         let name = try container.decode(String.self, forKey: .name)
-        let qty = try container.decode(Int64.self, forKey: .qty)
+        let quantity = try container.decode(Int64.self, forKey: .quantity)
         let role = try container.decode(String.self, forKey: .role)
         let email = try container.decodeIfPresent(String.self, forKey: .email)
         let phoneNumber = try container.decodeIfPresent(String.self, forKey: .phoneNumber)
@@ -53,9 +53,9 @@ public struct BookingResource: Hashable, Decodable, GeneratedFakeable, Generated
         let description = try container.decodeIfPresent(String.self, forKey: .description)
 
         self.init(siteID: siteID,
-                  id: id,
+                  bookingID: bookingID,
                   name: name,
-                  qty: qty,
+                  quantity: quantity,
                   role: role,
                   email: email,
                   phoneNumber: phoneNumber,
@@ -67,9 +67,9 @@ public struct BookingResource: Hashable, Decodable, GeneratedFakeable, Generated
 
 private extension BookingResource {
     enum CodingKeys: String, CodingKey {
-        case id
+        case bookingID = "id"
         case name
-        case qty
+        case quantity = "qty"
         case role
         case email
         case phoneNumber = "phone_number"

--- a/Modules/Sources/Networking/Model/Bookings/BookingResource.swift
+++ b/Modules/Sources/Networking/Model/Bookings/BookingResource.swift
@@ -3,7 +3,7 @@ import Foundation
 
 public struct BookingResource: Hashable, Decodable, GeneratedFakeable, GeneratedCopiable {
     public let siteID: Int64
-    public let bookingID: Int64
+    public let resourceID: Int64
     public let name: String
     public let quantity: Int64
     public let role: String
@@ -14,7 +14,7 @@ public struct BookingResource: Hashable, Decodable, GeneratedFakeable, Generated
     public let description: String?
 
     public init(siteID: Int64,
-                bookingID: Int64,
+                resourceID: Int64,
                 name: String,
                 quantity: Int64,
                 role: String,
@@ -24,7 +24,7 @@ public struct BookingResource: Hashable, Decodable, GeneratedFakeable, Generated
                 imageURL: String?,
                 description: String?) {
         self.siteID = siteID
-        self.bookingID = bookingID
+        self.resourceID = resourceID
         self.name = name
         self.quantity = quantity
         self.role = role
@@ -42,7 +42,7 @@ public struct BookingResource: Hashable, Decodable, GeneratedFakeable, Generated
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let bookingID = try container.decode(Int64.self, forKey: .bookingID)
+        let resourceID = try container.decode(Int64.self, forKey: .resourceID)
         let name = try container.decode(String.self, forKey: .name)
         let quantity = try container.decode(Int64.self, forKey: .quantity)
         let role = try container.decode(String.self, forKey: .role)
@@ -53,7 +53,7 @@ public struct BookingResource: Hashable, Decodable, GeneratedFakeable, Generated
         let description = try container.decodeIfPresent(String.self, forKey: .description)
 
         self.init(siteID: siteID,
-                  bookingID: bookingID,
+                  resourceID: resourceID,
                   name: name,
                   quantity: quantity,
                   role: role,
@@ -67,7 +67,7 @@ public struct BookingResource: Hashable, Decodable, GeneratedFakeable, Generated
 
 private extension BookingResource {
     enum CodingKeys: String, CodingKey {
-        case bookingID = "id"
+        case resourceID = "id"
         case name
         case quantity = "qty"
         case role

--- a/Modules/Sources/Networking/Model/Bookings/BookingResource.swift
+++ b/Modules/Sources/Networking/Model/Bookings/BookingResource.swift
@@ -1,0 +1,86 @@
+import Codegen
+import Foundation
+
+public struct BookingResource: Hashable, Decodable, GeneratedFakeable, GeneratedCopiable {
+    public let siteID: Int64
+    public let id: Int64
+    public let name: String
+    public let qty: Int64
+    public let role: String
+    public let email: String?
+    public let phoneNumber: String?
+    public let imageID: Int64
+    public let imageURL: String?
+    public let description: String?
+
+    public init(siteID: Int64,
+                id: Int64,
+                name: String,
+                qty: Int64,
+                role: String,
+                email: String?,
+                phoneNumber: String?,
+                imageID: Int64,
+                imageURL: String?,
+                description: String?) {
+        self.siteID = siteID
+        self.id = id
+        self.name = name
+        self.qty = qty
+        self.role = role
+        self.email = email
+        self.phoneNumber = phoneNumber
+        self.imageID = imageID
+        self.imageURL = imageURL
+        self.description = description
+    }
+
+    public init(from decoder: Decoder) throws {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
+            throw BookingResourceDecodingError.missingSiteID
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let id = try container.decode(Int64.self, forKey: .id)
+        let name = try container.decode(String.self, forKey: .name)
+        let qty = try container.decode(Int64.self, forKey: .qty)
+        let role = try container.decode(String.self, forKey: .role)
+        let email = try container.decodeIfPresent(String.self, forKey: .email)
+        let phoneNumber = try container.decodeIfPresent(String.self, forKey: .phoneNumber)
+        let imageID = try container.decode(Int64.self, forKey: .imageID)
+        let imageURL = try container.decodeIfPresent(String.self, forKey: .imageURL)
+        let description = try container.decodeIfPresent(String.self, forKey: .description)
+
+        self.init(siteID: siteID,
+                  id: id,
+                  name: name,
+                  qty: qty,
+                  role: role,
+                  email: email,
+                  phoneNumber: phoneNumber,
+                  imageID: imageID,
+                  imageURL: imageURL,
+                  description: description)
+    }
+}
+
+private extension BookingResource {
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case qty
+        case role
+        case email
+        case phoneNumber = "phone_number"
+        case imageID = "image_id"
+        case imageURL = "image_url"
+        case description
+    }
+}
+
+// MARK: - Decoding Errors
+//
+enum BookingResourceDecodingError: Error {
+    case missingSiteID
+}

--- a/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -497,7 +497,7 @@ extension Networking.Booking {
 extension Networking.BookingResource {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,
-        bookingID: CopiableProp<Int64> = .copy,
+        resourceID: CopiableProp<Int64> = .copy,
         name: CopiableProp<String> = .copy,
         quantity: CopiableProp<Int64> = .copy,
         role: CopiableProp<String> = .copy,
@@ -508,7 +508,7 @@ extension Networking.BookingResource {
         description: NullableCopiableProp<String> = .copy
     ) -> Networking.BookingResource {
         let siteID = siteID ?? self.siteID
-        let bookingID = bookingID ?? self.bookingID
+        let resourceID = resourceID ?? self.resourceID
         let name = name ?? self.name
         let quantity = quantity ?? self.quantity
         let role = role ?? self.role
@@ -520,7 +520,7 @@ extension Networking.BookingResource {
 
         return Networking.BookingResource(
             siteID: siteID,
-            bookingID: bookingID,
+            resourceID: resourceID,
             name: name,
             quantity: quantity,
             role: role,

--- a/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -494,6 +494,42 @@ extension Networking.Booking {
     }
 }
 
+extension Networking.BookingResource {
+    public func copy(
+        id: CopiableProp<Int64> = .copy,
+        name: CopiableProp<String> = .copy,
+        qty: CopiableProp<Int64> = .copy,
+        role: CopiableProp<String> = .copy,
+        email: NullableCopiableProp<String> = .copy,
+        phoneNumber: NullableCopiableProp<String> = .copy,
+        imageID: CopiableProp<Int64> = .copy,
+        imageURL: NullableCopiableProp<String> = .copy,
+        description: NullableCopiableProp<String> = .copy
+    ) -> Networking.BookingResource {
+        let id = id ?? self.id
+        let name = name ?? self.name
+        let qty = qty ?? self.qty
+        let role = role ?? self.role
+        let email = email ?? self.email
+        let phoneNumber = phoneNumber ?? self.phoneNumber
+        let imageID = imageID ?? self.imageID
+        let imageURL = imageURL ?? self.imageURL
+        let description = description ?? self.description
+
+        return Networking.BookingResource(
+            id: id,
+            name: name,
+            qty: qty,
+            role: role,
+            email: email,
+            phoneNumber: phoneNumber,
+            imageID: imageID,
+            imageURL: imageURL,
+            description: description
+        )
+    }
+}
+
 extension Networking.Coupon {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -496,9 +496,10 @@ extension Networking.Booking {
 
 extension Networking.BookingResource {
     public func copy(
-        id: CopiableProp<Int64> = .copy,
+        siteID: CopiableProp<Int64> = .copy,
+        bookingID: CopiableProp<Int64> = .copy,
         name: CopiableProp<String> = .copy,
-        qty: CopiableProp<Int64> = .copy,
+        quantity: CopiableProp<Int64> = .copy,
         role: CopiableProp<String> = .copy,
         email: NullableCopiableProp<String> = .copy,
         phoneNumber: NullableCopiableProp<String> = .copy,
@@ -506,9 +507,10 @@ extension Networking.BookingResource {
         imageURL: NullableCopiableProp<String> = .copy,
         description: NullableCopiableProp<String> = .copy
     ) -> Networking.BookingResource {
-        let id = id ?? self.id
+        let siteID = siteID ?? self.siteID
+        let bookingID = bookingID ?? self.bookingID
         let name = name ?? self.name
-        let qty = qty ?? self.qty
+        let quantity = quantity ?? self.quantity
         let role = role ?? self.role
         let email = email ?? self.email
         let phoneNumber = phoneNumber ?? self.phoneNumber
@@ -517,9 +519,10 @@ extension Networking.BookingResource {
         let description = description ?? self.description
 
         return Networking.BookingResource(
-            id: id,
+            siteID: siteID,
+            bookingID: bookingID,
             name: name,
-            qty: qty,
+            quantity: quantity,
             role: role,
             email: email,
             phoneNumber: phoneNumber,

--- a/Modules/Sources/Networking/Remote/BookingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/BookingsRemote.swift
@@ -16,6 +16,9 @@ public protocol BookingsRemoteProtocol {
 
     func loadBooking(bookingID: Int64,
                      siteID: Int64) async throws -> Booking?
+
+    func fetchResource(resourceID: Int64,
+                       siteID: Int64) async throws -> BookingResource?
 }
 
 /// Booking: Remote Endpoints
@@ -84,6 +87,24 @@ public final class BookingsRemote: Remote, BookingsRemoteProtocol {
 
         return try await enqueue(request, mapper: mapper)
     }
+
+    public func fetchResource(
+        resourceID: Int64,
+        siteID: Int64
+    ) async throws -> BookingResource? {
+        let path = "\(Path.resources)/\(resourceID)"
+        let request = JetpackRequest(
+            wooApiVersion: .wcBookings,
+            method: .get,
+            siteID: siteID,
+            path: path,
+            availableAsRESTRequest: true
+        )
+
+        let mapper = BookingResourceMapper(siteID: siteID)
+
+        return try await enqueue(request, mapper: mapper)
+    }
 }
 
 // MARK: - Constants
@@ -101,6 +122,7 @@ public extension BookingsRemote {
 
     private enum Path {
         static let bookings = "bookings"
+        static let resources = "resources"
     }
 
     private enum ParameterKey {

--- a/Modules/Sources/Networking/Remote/BookingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/BookingsRemote.swift
@@ -122,7 +122,7 @@ public extension BookingsRemote {
 
     private enum Path {
         static let bookings = "bookings"
-        static let resources = "resources"
+        static let resources = "resources/team-members"
     }
 
     private enum ParameterKey {

--- a/Modules/Sources/Storage/Model/Booking/BookingResource+CoreDataClass.swift
+++ b/Modules/Sources/Storage/Model/Booking/BookingResource+CoreDataClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CoreData
+
+@objc(BookingResource)
+public class BookingResource: NSManagedObject {
+
+}

--- a/Modules/Sources/Storage/Model/Booking/BookingResource+CoreDataProperties.swift
+++ b/Modules/Sources/Storage/Model/Booking/BookingResource+CoreDataProperties.swift
@@ -3,7 +3,7 @@ import CoreData
 
 extension BookingResource {
     @NSManaged public var siteID: Int64
-    @NSManaged public var bookingID: Int64
+    @NSManaged public var resourceID: Int64
     @NSManaged public var name: String?
     @NSManaged public var quantity: Int64
     @NSManaged public var role: String?

--- a/Modules/Sources/Storage/Model/Booking/BookingResource+CoreDataProperties.swift
+++ b/Modules/Sources/Storage/Model/Booking/BookingResource+CoreDataProperties.swift
@@ -1,0 +1,16 @@
+import Foundation
+import CoreData
+
+extension BookingResource {
+    @NSManaged public var siteID: Int64
+    @NSManaged public var bookingID: Int64
+    @NSManaged public var name: String?
+    @NSManaged public var quantity: Int64
+    @NSManaged public var role: String?
+    @NSManaged public var email: String?
+    @NSManaged public var phoneNumber: String?
+    @NSManaged public var imageID: Int64
+    @NSManaged public var imageURL: String?
+    @NSManaged public var descriptionText: String?
+
+}

--- a/Modules/Sources/Storage/Model/MIGRATIONS.md
+++ b/Modules/Sources/Storage/Model/MIGRATIONS.md
@@ -9,6 +9,8 @@ This file documents changes in the WCiOS Storage data model. Please explain any 
   - Added `BookingProductInfo` entity.
   - Added `BookingPaymentInfo` entity.
   - Added `orderInfo` relationship to `Booking` entity.
+- @itsmeichigo 2025-10-16
+  - Added `BookingResource` entity.
 
 ## Model 127 (Release 23.4.0.0)
 - @itsmeichigo 2025-09-23

--- a/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 128.xcdatamodel/contents
+++ b/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 128.xcdatamodel/contents
@@ -118,7 +118,6 @@
         <relationship name="orderInfo" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BookingOrderInfo" inverseName="productInfo" inverseEntity="BookingOrderInfo"/>
     </entity>
     <entity name="BookingResource" representedClassName="BookingResource" syncable="YES">
-        <attribute name="bookingID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="descriptionText" optional="YES" attributeType="String"/>
         <attribute name="email" optional="YES" attributeType="String"/>
         <attribute name="imageID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
@@ -126,6 +125,7 @@
         <attribute name="name" attributeType="String" defaultValueString=""/>
         <attribute name="phoneNumber" optional="YES" attributeType="String"/>
         <attribute name="quantity" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="resourceID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="role" attributeType="String" defaultValueString=""/>
         <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>

--- a/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 128.xcdatamodel/contents
+++ b/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 128.xcdatamodel/contents
@@ -117,6 +117,18 @@
         <attribute name="name" attributeType="String" defaultValueString=""/>
         <relationship name="orderInfo" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BookingOrderInfo" inverseName="productInfo" inverseEntity="BookingOrderInfo"/>
     </entity>
+    <entity name="BookingResource" representedClassName="BookingResource" syncable="YES">
+        <attribute name="bookingID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="descriptionText" optional="YES" attributeType="String"/>
+        <attribute name="email" optional="YES" attributeType="String"/>
+        <attribute name="imageID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="imageURL" optional="YES" attributeType="String"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="phoneNumber" optional="YES" attributeType="String"/>
+        <attribute name="quantity" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="role" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
     <entity name="Country" representedClassName="Country" syncable="YES">
         <attribute name="code" attributeType="String"/>
         <attribute name="name" attributeType="String"/>

--- a/Modules/Sources/Storage/Tools/StorageType+Extensions.swift
+++ b/Modules/Sources/Storage/Tools/StorageType+Extensions.swift
@@ -966,4 +966,10 @@ public extension StorageType {
         let objects = allObjects(ofType: Booking.self, matching: predicate, sortedBy: [descriptor])
         return objects.isEmpty ? nil : objects
     }
+
+    /// Retrieves the store booking resource
+    func loadBookingResource(siteID: Int64, resourceID: Int64) -> BookingResource? {
+        let predicate = \BookingResource.resourceID == resourceID && \BookingResource.siteID == siteID
+        return firstObject(ofType: BookingResource.self, matching: predicate)
+    }
 }

--- a/Modules/Sources/Yosemite/Actions/BookingAction.swift
+++ b/Modules/Sources/Yosemite/Actions/BookingAction.swift
@@ -44,4 +44,12 @@ public enum BookingAction: Action {
                         startDateAfter: String? = nil,
                         order: BookingsRemote.Order = .descending,
                         onCompletion: (Result<[Booking], Error>) -> Void)
+
+    /// Fetches a booking resource by resource ID.
+    ///
+    /// - Parameter onCompletion: called when fetch completes, returns an error or the booking resource.
+    ///
+    case fetchResource(siteID: Int64,
+                       resourceID: Int64,
+                       onCompletion: (Result<BookingResource, Error>) -> Void)
 }

--- a/Modules/Sources/Yosemite/Model/Booking/BookingResource+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Booking/BookingResource+ReadOnlyConvertible.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Storage
+
+// MARK: - Storage.BookingResource: ReadOnlyConvertible
+//
+extension Storage.BookingResource: ReadOnlyConvertible {
+
+    /// Updates the Storage.BookingResource with the a ReadOnly.
+    ///
+    public func update(with resource: Yosemite.BookingResource) {
+        siteID = resource.siteID
+        resourceID = resource.resourceID
+        name = resource.name
+        quantity = resource.quantity
+        role = resource.role
+        email = resource.email
+        phoneNumber = resource.phoneNumber
+        imageID = resource.imageID
+        imageURL = resource.imageURL
+        descriptionText = resource.description
+    }
+
+    /// Returns a ReadOnly version of the receiver.
+    ///
+    public func toReadOnly() -> Yosemite.BookingResource {
+        BookingResource(siteID: siteID,
+                        resourceID: resourceID,
+                        name: name ?? "",
+                        quantity: quantity,
+                        role: role ?? "",
+                        email: email,
+                        phoneNumber: phoneNumber,
+                        imageID: imageID,
+                        imageURL: imageURL,
+                        description: descriptionText)
+    }
+}
+
+extension Yosemite.BookingResource: ReadOnlyType {
+    /// Indicates if the receiver is a representation of a specified Storage.Entity instance.
+    ///
+    public func isReadOnlyRepresentation(of storageEntity: Any) -> Bool {
+        guard let storageResource = storageEntity as? Storage.BookingResource else {
+            return false
+        }
+
+        return siteID == Int(storageResource.siteID) && resourceID == Int(storageResource.resourceID)
+    }
+}

--- a/Modules/Sources/Yosemite/Model/Model.swift
+++ b/Modules/Sources/Yosemite/Model/Model.swift
@@ -30,6 +30,7 @@ public typealias BookingOrderInfo = Networking.BookingOrderInfo
 public typealias BookingCustomerInfo = Networking.BookingCustomerInfo
 public typealias BookingPaymentInfo = Networking.BookingPaymentInfo
 public typealias BookingProductInfo = Networking.BookingProductInfo
+public typealias BookingResource = Networking.BookingResource
 public typealias CreateBlazeCampaign = Networking.CreateBlazeCampaign
 public typealias FallibleCancelable = Hardware.FallibleCancelable
 public typealias CommentStatus = Networking.CommentStatus

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -61,6 +61,8 @@ public class BookingStore: Store {
                            startDateAfter: startDateAfter,
                            order: order,
                            onCompletion: onCompletion)
+        case let .fetchResource(siteID, resourceID, onCompletion):
+            fetchResource(siteID: siteID, resourceID: resourceID, onCompletion: onCompletion)
         }
     }
 }
@@ -214,6 +216,36 @@ private extension BookingStore {
             }
         }
     }
+
+    /// Fetches a booking resource by resource ID and saves it to storage.
+    ///
+    func fetchResource(siteID: Int64,
+                       resourceID: Int64,
+                       onCompletion: @escaping (Result<BookingResource, Error>) -> Void) {
+        enum FetchResourceError: Error {
+            case resourceIsMissing
+        }
+
+        Task { @MainActor in
+            do {
+                let resource = try await remote.fetchResource(
+                    resourceID: resourceID,
+                    siteID: siteID
+                )
+
+                guard let resource else {
+                    onCompletion(.failure(FetchResourceError.resourceIsMissing))
+                    return
+                }
+
+                await upsertBookingResourceInBackground(readOnlyBookingResource: resource)
+
+                onCompletion(.success(resource))
+            } catch {
+                onCompletion(.failure(error))
+            }
+        }
+    }
 }
 
 
@@ -307,6 +339,23 @@ private extension BookingStore {
             }
 
             storageBooking.update(with: readOnlyBooking)
+        }
+    }
+
+    /// Updates (OR Inserts) the specified ReadOnly BookingResource Entities *in a background thread* async.
+    func upsertBookingResourceInBackground(readOnlyBookingResource: BookingResource) async {
+        await withCheckedContinuation { [weak self] continuation in
+            guard let self else {
+                return continuation.resume()
+            }
+
+            storageManager.performAndSave({ storage in
+                let storedItem = storage.loadBookingResource(siteID: readOnlyBookingResource.siteID, resourceID: readOnlyBookingResource.resourceID)
+                let storageResource = storedItem ?? storage.insertNewObject(ofType: Storage.BookingResource.self)
+                storageResource.update(with: readOnlyBookingResource)
+            }, completion: {
+                continuation.resume()
+            }, on: .main)
         }
     }
 }

--- a/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
@@ -95,7 +95,7 @@ struct BookingsRemoteTests {
         // Given
         let remote = BookingsRemote(network: network)
         let resourceID: Int64 = 22
-        network.simulateResponse(requestUrlSuffix: "resources/\(resourceID)", filename: "booking-resource")
+        network.simulateResponse(requestUrlSuffix: "resources/team-members/\(resourceID)", filename: "booking-resource")
 
         // When
         let resource = try await remote.fetchResource(resourceID: resourceID, siteID: sampleSiteID)

--- a/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
@@ -90,4 +90,37 @@ struct BookingsRemoteTests {
         #expect(parameters["per_page"] != nil)
         #expect(parameters["order"] != nil)
     }
+
+    @Test func test_fetchResource_properly_returns_parsed_resource() async throws {
+        // Given
+        let remote = BookingsRemote(network: network)
+        let resourceID: Int64 = 22
+        network.simulateResponse(requestUrlSuffix: "resources/\(resourceID)", filename: "booking-resource")
+
+        // When
+        let resource = try await remote.fetchResource(resourceID: resourceID, siteID: sampleSiteID)
+
+        // Then
+        let unwrappedResource = try #require(resource)
+        #expect(unwrappedResource.id == 22)
+        #expect(unwrappedResource.name == "Joel (Sample resource)")
+        #expect(unwrappedResource.qty == 1)
+        #expect(unwrappedResource.role == "")
+        #expect(unwrappedResource.email == "")
+        #expect(unwrappedResource.phoneNumber == "")
+        #expect(unwrappedResource.imageID == 0)
+        #expect(unwrappedResource.imageURL == "")
+        #expect(unwrappedResource.description == "")
+        #expect(unwrappedResource.siteID == sampleSiteID)
+    }
+
+    @Test func test_fetchResource_properly_relays_networking_errors() async {
+        // Given
+        let remote = BookingsRemote(network: network)
+
+        // Then
+        await #expect(throws: NetworkError.notFound()) {
+            _ = try await remote.fetchResource(resourceID: 22, siteID: sampleSiteID)
+        }
+    }
 }

--- a/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
@@ -102,9 +102,9 @@ struct BookingsRemoteTests {
 
         // Then
         let unwrappedResource = try #require(resource)
-        #expect(unwrappedResource.id == 22)
+        #expect(unwrappedResource.resourceID == 22)
         #expect(unwrappedResource.name == "Joel (Sample resource)")
-        #expect(unwrappedResource.qty == 1)
+        #expect(unwrappedResource.quantity == 1)
         #expect(unwrappedResource.role == "")
         #expect(unwrappedResource.email == "")
         #expect(unwrappedResource.phoneNumber == "")

--- a/Modules/Tests/NetworkingTests/Responses/booking-resource.json
+++ b/Modules/Tests/NetworkingTests/Responses/booking-resource.json
@@ -1,0 +1,12 @@
+{
+    "id": 22,
+    "name": "Joel (Sample resource)",
+    "qty": 1,
+    "role": "",
+    "email": "",
+    "phone_number": "",
+    "image_id": 0,
+    "image_url": "",
+    "description": "",
+    "note": ""
+}

--- a/Modules/Tests/StorageTests/CoreData/MigrationTests.swift
+++ b/Modules/Tests/StorageTests/CoreData/MigrationTests.swift
@@ -3258,7 +3258,7 @@ private extension MigrationTests {
     func insertBookingResource(to context: NSManagedObjectContext) -> NSManagedObject {
         context.insert(entityName: "BookingResource", properties: [
             "siteID": 1,
-            "bookingID": 22,
+            "resourceID": 22,
             "name": "Joel (Sample resource)",
             "quantity": 1
         ])

--- a/Modules/Tests/StorageTests/CoreData/MigrationTests.swift
+++ b/Modules/Tests/StorageTests/CoreData/MigrationTests.swift
@@ -2256,6 +2256,31 @@ final class MigrationTests: XCTestCase {
         let updatedOrderInfo = migratedBooking.value(forKey: "orderInfo") as? NSManagedObject
         XCTAssertEqual(updatedOrderInfo, orderInfo)
     }
+
+    func test_migrating_127_to_128_adds_new_bookingResource_entity() throws {
+        // Given
+        let sourceContainer = try startPersistentContainer("Model 127")
+        let sourceContext = sourceContainer.viewContext
+
+        try sourceContext.save()
+
+        // Confidence Check. BookingResource should not exist in Model 127
+        XCTAssertNil(NSEntityDescription.entity(forEntityName: "BookingResource", in: sourceContext))
+
+        // When
+        let targetContainer = try migrate(sourceContainer, to: "Model 128")
+        let targetContext = targetContainer.viewContext
+
+        // Then
+        XCTAssertEqual(try targetContext.count(entityName: "BookingResource"), 0)
+
+        let resource = insertBookingResource(to: targetContext)
+        XCTAssertNoThrow(try targetContext.save())
+
+        XCTAssertEqual(try targetContext.count(entityName: "BookingResource"), 1)
+        let insertedResource = try XCTUnwrap(targetContext.first(entityName: "BookingResource"))
+        XCTAssertEqual(insertedResource, resource)
+    }
 }
 
 // MARK: - Persistent Store Setup and Migrations
@@ -3226,6 +3251,16 @@ private extension MigrationTests {
             "subtotalTax": "10.00",
             "total": "110.00",
             "totalTax": "10.00"
+        ])
+    }
+
+    @discardableResult
+    func insertBookingResource(to context: NSManagedObjectContext) -> NSManagedObject {
+        context.insert(entityName: "BookingResource", properties: [
+            "siteID": 1,
+            "bookingID": 22,
+            "name": "Joel (Sample resource)",
+            "quantity": 1
         ])
     }
 }

--- a/Modules/Tests/YosemiteTests/Mocks/MockBookingsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockBookingsRemote.swift
@@ -6,6 +6,7 @@ import Foundation
 final class MockBookingsRemote: BookingsRemoteProtocol {
     private var loadAllBookingsResult: Result<[Booking], Error>?
     private var loadBookingResult: Result<Booking?, Error>?
+    private var fetchResourceResult: Result<BookingResource?, Error>?
 
     func whenLoadingAllBookings(thenReturn result: Result<[Booking], Error>) {
         loadAllBookingsResult = result
@@ -13,6 +14,10 @@ final class MockBookingsRemote: BookingsRemoteProtocol {
 
     func whenLoadingBooking(thenReturn result: Result<Booking?, Error>) {
         loadBookingResult = result
+    }
+
+    func whenFetchingResource(thenReturn result: Result<BookingResource?, Error>) {
+        fetchResourceResult = result
     }
 
     func loadAllBookings(for siteID: Int64,
@@ -30,6 +35,13 @@ final class MockBookingsRemote: BookingsRemoteProtocol {
 
     func loadBooking(bookingID: Int64, siteID: Int64) async throws -> Networking.Booking? {
         guard let result = loadBookingResult else {
+            throw NetworkError.timeout()
+        }
+        return try result.get()
+    }
+
+    func fetchResource(resourceID: Int64, siteID: Int64) async throws -> Networking.BookingResource? {
+        guard let result = fetchResourceResult else {
             throw NetworkError.timeout()
         }
         return try result.get()

--- a/Modules/Tests/YosemiteTests/Stores/BookingStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/BookingStoreTests.swift
@@ -762,6 +762,13 @@ private extension BookingStoreTests {
         storedProduct.update(with: product)
         return storedProduct
     }
+
+    @discardableResult
+    func storeBookingResource(_ resource: Networking.BookingResource) -> Storage.BookingResource {
+        let storedResource = storage.insertNewObject(ofType: Storage.BookingResource.self)
+        storedResource.update(with: resource)
+        return storedResource
+    }
 }
 
 private class MockOrdersRemote: OrdersRemoteProtocol {

--- a/WooCommerce/Classes/ViewModels/Booking Details/AppointmentDetailsContent.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/AppointmentDetailsContent.swift
@@ -1,5 +1,5 @@
 import Foundation
-import struct Networking.Booking
+import Yosemite
 
 extension BookingDetailsViewModel {
     struct AppointmentDetailsContent {
@@ -14,17 +14,21 @@ extension BookingDetailsViewModel {
 
         let rows: [Row]
 
-        init(_ booking: Booking) {
+        init(_ booking: Booking, resource: BookingResource?) {
             let appointmentDate = booking.startDate.toString(dateStyle: .short, timeStyle: .none, timeZone: BookingListTab.utcTimeZone)
             let appointmentTimeFrame = [
                 booking.startDate.toString(dateStyle: .none, timeStyle: .short, timeZone: BookingListTab.utcTimeZone),
                 booking.endDate.toString(dateStyle: .none, timeStyle: .short, timeZone: BookingListTab.utcTimeZone)
             ].joined(separator: " - ")
 
+            let resourceRow: Row? = {
+                guard booking.resourceID > 0 else { return nil }
+                return Row(title: Localization.appointmentDetailsAssignedStaffTitle, value: resource?.name ?? "-")
+            }()
             rows = [
                 Row(title: Localization.appointmentDetailsDateRowTitle, value: appointmentDate),
                 Row(title: Localization.appointmentDetailsTimeRowTitle, value: appointmentTimeFrame),
-                Row(title: Localization.appointmentDetailsAssignedStaffTitle, value: "Marianne Renoir"), /// Temporarily hardcoded
+                resourceRow,
                 Row(title: Localization.appointmentDetailsLocationTitle, value: "238 Willow Creek Drive, Montgomery ..."), /// Temporarily hardcoded
                 Row(
                     title: Localization.appointmentDetailsDurationTitle,
@@ -37,7 +41,7 @@ extension BookingDetailsViewModel {
                     title: Localization.appointmentDetailsPriceTitle,
                     value: BookingDetailsViewModel.formatPrice(for: booking, priceString: booking.cost)
                 )
-            ]
+            ].compactMap { $0 }
         }
     }
 }

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -1,10 +1,12 @@
 import Foundation
 import Yosemite
+import protocol Storage.StorageManagerType
 
 final class BookingDetailsViewModel: ObservableObject {
     private let stores: StoresManager
 
     private var booking: Booking
+    private var bookingResource: BookingResource?
 
     // EntityListener: Update / Deletion Notifications.
     ///
@@ -15,16 +17,20 @@ final class BookingDetailsViewModel: ObservableObject {
     let navigationTitle: String
     @Published private(set) var sections: [Section] = []
 
-    init(booking: Booking, stores: StoresManager = ServiceLocator.stores) {
+    init(booking: Booking,
+         stores: StoresManager = ServiceLocator.stores,
+         storage: StorageManagerType = ServiceLocator.storageManager) {
         self.booking = booking
         self.stores = stores
 
         navigationTitle = Self.navigationTitle(for: booking)
-        setupSections(with: booking)
+        let resource = storage.viewStorage.loadBookingResource(siteID: booking.siteID, resourceID: booking.resourceID)?.toReadOnly()
+        self.bookingResource = resource
+        setupSections(with: booking, resource: resource)
         configureEntityListener()
     }
 
-    private func setupSections(with booking: Booking) {
+    private func setupSections(with booking: Booking, resource: BookingResource?) {
         let headerContent = HeaderContent(booking)
         let headerSection = Section(
             content: .header(headerContent)
@@ -32,7 +38,7 @@ final class BookingDetailsViewModel: ObservableObject {
 
         let appointmentDetailsSection = Section(
             header: .title(Localization.appointmentDetailsSectionHeaderTitle.uppercased()),
-            content: .appointmentDetails(AppointmentDetailsContent(booking))
+            content: .appointmentDetails(AppointmentDetailsContent(booking, resource: resource))
         )
 
         let customerSection: Section? = {
@@ -75,6 +81,9 @@ final class BookingDetailsViewModel: ObservableObject {
 
 extension BookingDetailsViewModel {
     func syncData() async {
+        if let resource = await fetchResource() {
+            self.bookingResource = resource // only update resource if fetching succeeds
+        }
         await syncBooking()
     }
 }
@@ -84,7 +93,7 @@ private extension BookingDetailsViewModel {
         entityListener.onUpsert = { [weak self] booking in
             guard let self else { return }
             self.booking = booking
-            self.setupSections(with: booking)
+            self.setupSections(with: booking, resource: bookingResource)
         }
     }
 
@@ -93,6 +102,25 @@ private extension BookingDetailsViewModel {
             try await retrieveBooking()
         } catch {
             DDLogError("⛔️ Error synchronizing Customer for Booking: \(error)")
+        }
+    }
+
+    @MainActor
+    func fetchResource() async -> BookingResource? {
+        do {
+            return try await withCheckedThrowingContinuation { continuation in
+                stores.dispatch(BookingAction.fetchResource(siteID: booking.siteID, resourceID: booking.resourceID) { result in
+                    switch result {
+                    case .success(let resource):
+                        continuation.resume(returning: resource)
+                    case .failure(let error):
+                        continuation.resume(throwing: error)
+                    }
+                })
+            }
+        } catch {
+            DDLogError("⛔️ Error fetching resource for Booking: \(error)")
+            return nil
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1522

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR supports fetching and displaying assigned staff on booking details:
- Adds readonly model for `BookingResource`.
- Integrates `/bookings/v2/resources/{id}` endpoint
- Adds CoreData entity for `BookingResource` to cache results.
- Updates `BookingAction` and `BookingStore` to fetch resources.
- Updates booking details view to fetch and display resources. Due to the time shortage, I could not polish the UI with proper loading state, so for now the Assigned Staff row shows only "-" while fetching is in progress.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log in to a CIAB store with existing bookings.
2. Navigate to the Bookings tab and select a booking with associated order.
3. Confirm that after a few seconds the assigned staff value is displayed.
4. Navigate back out and in again to the same booking detail screen.
5. Confirm that the assigned staff value is available immediately as it was cached from the last fetch.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Tested with simulator iPhone 17.
- Added unit tests.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/966a869a-2250-4af2-969f-0407590e941c



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.