### PR TITLE
[iOS 26] Menu > Payments: fix empty navigation bar item on the trailing edge

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -179,8 +179,10 @@ struct InPersonPaymentsMenu: View {
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                ActivityIndicator(isAnimating: $viewModel.backgroundOnboardingInProgress,
-                                  style: .medium)
+                if viewModel.backgroundOnboardingInProgress {
+                    ActivityIndicator(isAnimating: $viewModel.backgroundOnboardingInProgress,
+                                      style: .medium)
+                }
             }
         }
         .navigationTitle(CardPresentPaymentsOnboardingView.Localization.title)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Progress view remains visible on the navigation bar (toolbar) due to iOS 26 using a different toolbar item style. 

Hide it after loading.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

**Prerequisite**: remove `UIDesignRequiresCompatibility` from `Info.plist` to enable iOS26

1. Menu
2. Payments
3. Confirm progress view appears in the toolbar and disappears after loading

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on iPad 18.5 simulator and iPad 26 device

## Screenshots

### Before
<img width="2360" height="1640" alt="image" src="https://github.com/user-attachments/assets/fa8b45b9-cb72-4ad9-9dff-284b3b9a8efc" />
>

### After


https://github.com/user-attachments/assets/e6043107-c9b0-4401-87d0-8092986b625d


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.