### PR TITLE
Fix crash due to race condition when initiating `AuthenticatedDotcomRequest`

### DIFF
--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -85,10 +85,10 @@ final class SessionManager: SessionManagerProtocol {
             }
         }
         set {
-            credentialsQueue.sync {
+            let shouldUpdateWatchSync = credentialsQueue.sync { () -> Bool in
                 let currentCredentials = loadCredentials()
                 guard newValue != currentCredentials else {
-                    return
+                    return false
                 }
 
                 removeCredentials()
@@ -97,6 +97,12 @@ final class SessionManager: SessionManagerProtocol {
                     saveCredentials(credentials)
                 }
 
+                return true
+            }
+
+            // Update watch synchronizer outside the sync block to avoid potential deadlocks
+            // from @Published property triggering Combine subscribers that might read credentials
+            if shouldUpdateWatchSync {
                 watchDependenciesSynchronizer.credentials = newValue
             }
         }

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -54,6 +54,10 @@ final class SessionManager: SessionManagerProtocol {
     ///
     private let imageCache: ImageCache
 
+    /// Serial queue for thread-safe credentials access
+    ///
+    private let credentialsQueue = DispatchQueue(label: "com.woocommerce.session.credentials", qos: .userInitiated)
+
     /// Makes sure the credentials are in sync with the watch session.
     ///
     private lazy var watchDependenciesSynchronizer = {
@@ -76,20 +80,25 @@ final class SessionManager: SessionManagerProtocol {
     ///
     var defaultCredentials: Credentials? {
         get {
-            return loadCredentials()
+            credentialsQueue.sync {
+                loadCredentials()
+            }
         }
         set {
-            guard newValue != defaultCredentials else {
-                return
+            credentialsQueue.sync {
+                let currentCredentials = loadCredentials()
+                guard newValue != currentCredentials else {
+                    return
+                }
+
+                removeCredentials()
+
+                if let credentials = newValue {
+                    saveCredentials(credentials)
+                }
+
+                watchDependenciesSynchronizer.credentials = newValue
             }
-
-            removeCredentials()
-
-            if let credentials = newValue {
-                saveCredentials(credentials)
-            }
-
-            watchDependenciesSynchronizer.credentials = newValue
         }
     }
 
@@ -235,7 +244,7 @@ final class SessionManager: SessionManagerProtocol {
     /// Deletes application password
     ///
     func deleteApplicationPassword(using creds: Credentials?, locally: Bool) {
-        let useCase: ApplicationPasswordUseCase? = {
+        let useCase: ApplicationPasswordUseCase? = credentialsQueue.sync {
             let credentials = creds ?? loadCredentials()
             switch credentials {
             case let .wporg(username, password, siteAddress):
@@ -253,7 +262,7 @@ final class SessionManager: SessionManagerProtocol {
             case .none:
                 return nil
             }
-        }()
+        }
         guard let useCase else {
             return
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1489

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Problem
Crash reports point to a crash in `AuthenticatedDotcomRequest` when it's trying to access the auth token that has already been deallocated.

### Potential cause
- `loadCredentials()` performs multi-step reads (UserDefaults + Keychain) without synchronization.
- `removeCredentials()` could delete keychain entries while another thread is reading them.
- `AuthenticatedDotcomRequest` is initiated from `RequestAuthenticator` but the auth token has already been deallocated by `removeCredentials()`.

### Solution
- Added `credentialsQueue` serial dispatch queue to synchronize all credential access.
- Kept `watchDependenciesSynchronizer.credentials` update outside sync block to prevent deadlock.
- Protected `loadCredentials()` calls in getter and `deleteApplicationPassword()` with queue synchronization.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

There's no consistent steps to reproduce the race condition. Try the following steps to confirm that the app doesn't crash:
- Log in to a Jetpack store with WPCom credentials.
- Quickly go through the tabs and then to Menu > Settings > Log out.
- Confirm that the app doesn't crash.

Feel free to smoke test the app in logged in state or switching the application password toggle in Menu > Settings > Experimental Features to confirm that the app still works without any issues. 

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Followed the tests described above using simulator iPhone 17

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.