### PR TITLE
[Bookings] Apply attendance status to UI

### DIFF
--- a/Modules/Sources/Networking/Model/Bookings/Booking.swift
+++ b/Modules/Sources/Networking/Model/Bookings/Booking.swift
@@ -29,7 +29,6 @@ public struct Booking: Codable, GeneratedCopiable, Hashable, GeneratedFakeable {
         return BookingStatus(rawValue: statusKey) ?? .unknown
     }
 
-    /// periphery: ignore - will be used in UI in upcoming PRs
     public var attendanceStatus: BookingAttendanceStatus {
         return BookingAttendanceStatus(rawValue: attendanceStatusKey) ?? .unknown
     }
@@ -208,7 +207,6 @@ public enum BookingStatus: String, CaseIterable {
     case unknown
 }
 
-/// periphery: ignore - will be used in UI in upcoming PRs
 public enum BookingAttendanceStatus: String, CaseIterable {
     case booked
     case checkedIn = "checked-in"

--- a/Modules/Sources/Networking/Remote/BookingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/BookingsRemote.swift
@@ -17,6 +17,12 @@ public protocol BookingsRemoteProtocol {
     func loadBooking(bookingID: Int64,
                      siteID: Int64) async throws -> Booking?
 
+    func updateBooking(
+        from siteID: Int64,
+        bookingID: Int64,
+        attendanceStatus: BookingAttendanceStatus
+    ) async throws -> Booking?
+
     func fetchResource(resourceID: Int64,
                        siteID: Int64) async throws -> BookingResource?
 }
@@ -88,6 +94,28 @@ public final class BookingsRemote: Remote, BookingsRemoteProtocol {
         return try await enqueue(request, mapper: mapper)
     }
 
+    public func updateBooking(
+        from siteID: Int64,
+        bookingID: Int64,
+        attendanceStatus: BookingAttendanceStatus
+    ) async throws -> Booking? {
+        let path = "\(Path.bookings)/\(bookingID)"
+        let parameters = [
+            ParameterKey.attendanceStatus: attendanceStatus.rawValue
+        ]
+        let request = JetpackRequest(
+            wooApiVersion: .wcBookings,
+            method: .put,
+            siteID: siteID,
+            path: path,
+            parameters: parameters,
+            availableAsRESTRequest: true
+        )
+
+        let mapper = BookingMapper(siteID: siteID)
+        return try await enqueue(request, mapper: mapper)
+    }
+
     public func fetchResource(
         resourceID: Int64,
         siteID: Int64
@@ -132,5 +160,6 @@ public extension BookingsRemote {
         static let startDateAfter: String  = "start_date_after"
         static let search: String          = "search"
         static let order: String           = "order"
+        static let attendanceStatus        = "attendance_status"
     }
 }

--- a/Modules/Sources/Yosemite/Actions/BookingAction.swift
+++ b/Modules/Sources/Yosemite/Actions/BookingAction.swift
@@ -52,4 +52,16 @@ public enum BookingAction: Action {
     case fetchResource(siteID: Int64,
                        resourceID: Int64,
                        onCompletion: (Result<BookingResource, Error>) -> Void)
+
+    /// Updates a booking attendance status.
+    ///
+    /// - Parameter siteID: The site ID of the booking.
+    /// - Parameter bookingID: The ID of the booking to be updated.
+    /// - Parameter status: The new attendance status.
+    /// - Parameter onCompletion: called when update completes, returns an error in case of a failure.
+    ///
+    case updateBookingAttendanceStatus(siteID: Int64,
+                                       bookingID: Int64,
+                                       status: BookingAttendanceStatus,
+                                       onCompletion: (Error?) -> Void)
 }

--- a/Modules/Sources/Yosemite/Model/Model.swift
+++ b/Modules/Sources/Yosemite/Model/Model.swift
@@ -31,6 +31,7 @@ public typealias BookingCustomerInfo = Networking.BookingCustomerInfo
 public typealias BookingPaymentInfo = Networking.BookingPaymentInfo
 public typealias BookingProductInfo = Networking.BookingProductInfo
 public typealias BookingResource = Networking.BookingResource
+public typealias BookingAttendanceStatus = Networking.BookingAttendanceStatus
 public typealias CreateBlazeCampaign = Networking.CreateBlazeCampaign
 public typealias FallibleCancelable = Hardware.FallibleCancelable
 public typealias CommentStatus = Networking.CommentStatus

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -267,37 +267,9 @@ private extension BookingStore {
             siteID: siteID,
             bookingID: bookingID,
             statusKey: status
-        ) { [weak self] previousStatusKey in
-            guard let self else {
-                return onCompletion(UpdateBookingStatusError.undefinedState)
-            }
-
-            Task {
-                do {
-                    if let remoteBooking = try await self.remote.updateBooking(
-                        from: siteID,
-                        bookingID: bookingID,
-                        attendanceStatus: status
-                    ) {
-                        await self.upsertStoredBookingsInBackground(
-                            readOnlyBookings: [remoteBooking],
-                            readOnlyOrders: [],
-                            siteID: siteID
-                        )
-                    } else {
-                        onCompletion(nil)
-                    }
-                } catch {
-                    /// Revert Optimistic Update
-                    self.updateBookingAttendanceStatusLocally(
-                        siteID: siteID,
-                        bookingID: bookingID,
-                        statusKey: previousStatusKey
-                    ) { _ in
-                        onCompletion(error)
-                    }
-                }
-            }
+        ) { _ in
+            //TODO: - booking status remote update + rollback status in case of error
+            onCompletion(nil)
         }
     }
 

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -63,10 +63,20 @@ public class BookingStore: Store {
                            onCompletion: onCompletion)
         case let .fetchResource(siteID, resourceID, onCompletion):
             fetchResource(siteID: siteID, resourceID: resourceID, onCompletion: onCompletion)
+        case .updateBookingAttendanceStatus(let siteID, let bookingID, let status, let onCompletion):
+            performUpdateBookingAttendanceStatus(
+                siteID: siteID,
+                bookingID: bookingID,
+                status: status,
+                onCompletion: onCompletion
+            )
         }
     }
 }
 
+private enum UpdateBookingStatusError: Error {
+    case undefinedState
+}
 
 // MARK: - Services
 //
@@ -245,6 +255,78 @@ private extension BookingStore {
                 onCompletion(.failure(error))
             }
         }
+    }
+
+    func performUpdateBookingAttendanceStatus(
+        siteID: Int64,
+        bookingID: Int64,
+        status: BookingAttendanceStatus,
+        onCompletion: @escaping (Error?) -> Void
+    ) {
+        updateBookingAttendanceStatusLocally(
+            siteID: siteID,
+            bookingID: bookingID,
+            statusKey: status
+        ) { [weak self] previousStatusKey in
+            guard let self else {
+                return onCompletion(UpdateBookingStatusError.undefinedState)
+            }
+
+            Task {
+                do {
+                    if let remoteBooking = try await self.remote.updateBooking(
+                        from: siteID,
+                        bookingID: bookingID,
+                        attendanceStatus: status
+                    ) {
+                        await self.upsertStoredBookingsInBackground(
+                            readOnlyBookings: [remoteBooking],
+                            readOnlyOrders: [],
+                            siteID: siteID
+                        )
+                    } else {
+                        onCompletion(nil)
+                    }
+                } catch {
+                    /// Revert Optimistic Update
+                    self.updateBookingAttendanceStatusLocally(
+                        siteID: siteID,
+                        bookingID: bookingID,
+                        statusKey: previousStatusKey
+                    ) { _ in
+                        onCompletion(error)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Updates local (Storage) Booking attendance status
+    func updateBookingAttendanceStatusLocally(
+        siteID: Int64,
+        bookingID: Int64,
+        statusKey: BookingAttendanceStatus,
+        onCompletion: @escaping (BookingAttendanceStatus) -> Void
+    ) {
+        storageManager.performAndSave({ storage -> BookingAttendanceStatus in
+            guard let booking = storage.loadBooking(
+                siteID: siteID,
+                bookingID: bookingID
+            ) else {
+                return statusKey
+            }
+
+            let oldStatus = booking.attendanceStatusKey
+            booking.attendanceStatusKey = statusKey.rawValue
+            return BookingAttendanceStatus(rawValue: oldStatus ?? "") ?? .unknown
+        }, completion: { result in
+            switch result {
+            case .success(let status):
+                onCompletion(status)
+            case .failure:
+                onCompletion(statusKey)
+            }
+        }, on: .main)
     }
 }
 

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -74,10 +74,6 @@ public class BookingStore: Store {
     }
 }
 
-private enum UpdateBookingStatusError: Error {
-    case undefinedState
-}
-
 // MARK: - Services
 //
 private extension BookingStore {

--- a/Modules/Tests/YosemiteTests/Mocks/MockBookingsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockBookingsRemote.swift
@@ -46,4 +46,8 @@ final class MockBookingsRemote: BookingsRemoteProtocol {
         }
         return try result.get()
     }
+
+    func updateBooking(from siteID: Int64, bookingID: Int64, attendanceStatus: Networking.BookingAttendanceStatus) async throws -> Networking.Booking? {
+        return nil
+    }
 }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -136,7 +136,7 @@ private extension BookingListView {
                 HStack {
                     // TODO: update this when attendance status is available
                     // Update badge colors if design changes as statuses are not clarified now.
-                    statusBadge(text: "Booked", color: Layout.defaultBadgeColor)
+                    statusBadge(text: booking.attendanceStatus.localizedTitle, color: Layout.defaultBadgeColor)
                     statusBadge(text: booking.bookingStatus.localizedTitle, color: Layout.defaultBadgeColor)
                     Spacer()
                 }

--- a/WooCommerce/Classes/ViewModels/Booking Details/AttendanceContent.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/AttendanceContent.swift
@@ -1,9 +1,12 @@
 import Foundation
+import Networking
 
 extension BookingDetailsViewModel {
-    struct AttendanceContent {
-        /// Hardcoded attendance value
-        /// Will be replaced with model value or binding
-        let value = "Booked"
+    final class AttendanceContent {
+        private(set) var value = ""
+
+        func update(with booking: Booking) {
+            value = booking.attendanceStatus.localizedTitle
+        }
     }
 }

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingAttendanceStatus+Localization.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingAttendanceStatus+Localization.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Networking
+
+extension BookingAttendanceStatus {
+    var localizedTitle: String {
+        switch self {
+        case .booked:
+            return NSLocalizedString(
+                "BookingAttendanceStatus.booked",
+                value: "Booked",
+                comment: "Title for 'Booked' booking attendance status."
+            )
+        case .checkedIn:
+            return NSLocalizedString(
+                "BookingAttendanceStatus.checkedIn",
+                value: "Checked In",
+                comment: "Title for 'Checked In' booking attendance status."
+            )
+        case .cancelled:
+            return NSLocalizedString(
+                "BookingAttendanceStatus.cancelled",
+                value: "Cancelled",
+                comment: "Title for 'Cancelled' booking attendance status."
+            )
+        case .noShow:
+            return NSLocalizedString(
+                "BookingAttendanceStatus.noShow",
+                value: "No Show",
+                comment: "Title for 'No Show' booking attendance status."
+            )
+        case .unknown:
+            return NSLocalizedString(
+                "BookingAttendanceStatus.unknown",
+                value: "Unknown",
+                comment: "Title for 'Unknown' booking attendance status."
+            )
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -142,6 +142,24 @@ extension BookingDetailsViewModel {
     }
 }
 
+// MARK: Attendance status
+
+extension BookingDetailsViewModel {
+    func updateAttendanceStatus(to newStatus: BookingAttendanceStatus) {
+        let action = BookingAction.updateBookingAttendanceStatus(
+            siteID: booking.siteID,
+            bookingID: booking.bookingID,
+            status: newStatus
+        ) { error in
+            if let error {
+                DDLogError("⛔️ Error updating booking attendance status: \(error)")
+                // TODO: Show an error notice to the user
+            }
+        }
+        stores.dispatch(action)
+    }
+}
+
 private extension BookingDetailsViewModel {
     @MainActor
     func fetchResource() async -> BookingResource? {

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -92,6 +92,7 @@ private extension BookingDetailsViewModel {
         }
         headerContent.update(with: booking)
         appointmentDetailsContent.update(with: booking, resource: bookingResource)
+        attendanceContent.update(with: booking)
         paymentContent.update(with: booking)
     }
 

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -28,6 +28,10 @@ final class BookingDetailsViewModel: ObservableObject {
     @Published private(set) var navigationTitle = ""
     @Published private(set) var sections: [Section] = []
 
+    var bookingAttendanceStatus: BookingAttendanceStatus {
+        booking.attendanceStatus
+    }
+
     init(booking: Booking,
          stores: StoresManager = ServiceLocator.stores,
          storage: StorageManagerType = ServiceLocator.storageManager) {

--- a/WooCommerce/Classes/ViewModels/Booking Details/HeaderContent.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/HeaderContent.swift
@@ -18,9 +18,8 @@ extension BookingDetailsViewModel {
             )
             serviceAndCustomerLine = booking.summaryText
 
-            let bookingStatus = booking.bookingStatus
             status = [
-                "Booked",
+                booking.attendanceStatus.localizedTitle,
                 booking.bookingStatus.localizedTitle
             ]
         }

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -84,7 +84,7 @@ struct BookingDetailsView: View {
             $0.toolbarRole(.editor)
         }
         .sheet(isPresented: $showingStatusSheet) {
-            UpdateAttendanceStatusView { selectedStatus in
+            UpdateAttendanceStatusView(selectedStatus: viewModel.bookingAttendanceStatus) { selectedStatus in
                 print("Selected status: \(selectedStatus)")
             }
             .padding(.top)

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -85,7 +85,7 @@ struct BookingDetailsView: View {
         }
         .sheet(isPresented: $showingStatusSheet) {
             UpdateAttendanceStatusView(selectedStatus: viewModel.bookingAttendanceStatus) { selectedStatus in
-                print("Selected status: \(selectedStatus)")
+                viewModel.updateAttendanceStatus(to: selectedStatus)
             }
             .padding(.top)
             .presentationDetents([.medium, .large])

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/UpdateAttendanceStatusView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/UpdateAttendanceStatusView.swift
@@ -44,8 +44,12 @@ struct UpdateAttendanceStatusView: View {
                     .padding(.horizontal)
                     .contentShape(Rectangle())
                     .tappable {
-                        onStatusSelected(status)
-                        dismiss()
+                        DispatchQueue.main.asyncAfter(
+                            deadline: .now() + Constants.statusSelectionDelay
+                        ) {
+                            onStatusSelected(status)
+                            dismiss()
+                        }
                     }
                 }
             }
@@ -98,6 +102,7 @@ private extension BookingAttendanceStatus {
 private extension UpdateAttendanceStatusView {
     enum Constants {
         static let statuses: [BookingAttendanceStatus] = [.booked, .checkedIn, .noShow]
+        static let statusSelectionDelay: TimeInterval = 0.2
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/UpdateAttendanceStatusView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/UpdateAttendanceStatusView.swift
@@ -90,7 +90,7 @@ private extension BookingAttendanceStatus {
         case .booked:
             return "calendar.badge.checkmark"
         case .checkedIn:
-            return "person.fill.checkmark"
+            return "calendar.and.person"
         case .noShow:
             return "calendar.badge.exclamationmark"
         case .cancelled, .unknown:

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/UpdateAttendanceStatusView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/UpdateAttendanceStatusView.swift
@@ -1,12 +1,14 @@
 import SwiftUI
+import Networking
 
 struct UpdateAttendanceStatusView: View {
     @Environment(\.dismiss) private var dismiss
-    private let statuses = AttendanceStatus.allCases
-    private let onStatusSelected: (AttendanceStatus) -> Void
+    private let onStatusSelected: (BookingAttendanceStatus) -> Void
+    @State private var selectedStatus: BookingAttendanceStatus
 
-    init(onStatusSelected: @escaping (AttendanceStatus) -> Void) {
+    init(selectedStatus: BookingAttendanceStatus, onStatusSelected: @escaping (BookingAttendanceStatus) -> Void) {
         self.onStatusSelected = onStatusSelected
+        self._selectedStatus = .init(initialValue: selectedStatus)
     }
 
     var body: some View {
@@ -17,7 +19,7 @@ struct UpdateAttendanceStatusView: View {
                     .foregroundColor(.secondary)
                     .padding(.horizontal)
 
-                ForEach(statuses) { status in
+                ForEach(Constants.statuses, id: \.self) { status in
                     HStack(alignment: .top, spacing: 16) {
                         Image(systemName: status.iconName)
                             .font(.title3.weight(.medium))
@@ -30,6 +32,13 @@ struct UpdateAttendanceStatusView: View {
                                 .font(.subheadline)
                                 .foregroundColor(.secondary)
                                 .fixedSize(horizontal: false, vertical: true)
+                        }
+
+                        if status == selectedStatus {
+                            Spacer()
+                            Image(systemName: "checkmark")
+                                .font(.title3.weight(.medium))
+                                .foregroundStyle(Color.accentColor)
                         }
                     }
                     .padding(.horizontal)
@@ -45,17 +54,7 @@ struct UpdateAttendanceStatusView: View {
     }
 }
 
-extension UpdateAttendanceStatusView {
-    enum AttendanceStatus: CaseIterable, Identifiable {
-        case booked
-        case checkedIn
-        case noShow
-
-        var id: Self { self }
-    }
-}
-
-private extension UpdateAttendanceStatusView.AttendanceStatus {
+private extension BookingAttendanceStatus {
     var title: String {
         switch self {
         case .booked:
@@ -64,6 +63,8 @@ private extension UpdateAttendanceStatusView.AttendanceStatus {
             return UpdateAttendanceStatusView.Localization.checkedInTitle
         case .noShow:
             return UpdateAttendanceStatusView.Localization.noShowTitle
+        case .cancelled, .unknown:
+            return ""
         }
     }
 
@@ -75,6 +76,8 @@ private extension UpdateAttendanceStatusView.AttendanceStatus {
             return UpdateAttendanceStatusView.Localization.checkedInDescription
         case .noShow:
             return UpdateAttendanceStatusView.Localization.noShowDescription
+        case .cancelled, .unknown:
+            return ""
         }
     }
 
@@ -83,14 +86,20 @@ private extension UpdateAttendanceStatusView.AttendanceStatus {
         case .booked:
             return "calendar.badge.checkmark"
         case .checkedIn:
-            return "calendar.and.person"
+            return "person.fill.checkmark"
         case .noShow:
             return "calendar.badge.exclamationmark"
+        case .cancelled, .unknown:
+            return ""
         }
     }
 }
 
 private extension UpdateAttendanceStatusView {
+    enum Constants {
+        static let statuses: [BookingAttendanceStatus] = [.booked, .checkedIn, .noShow]
+    }
+
     enum Localization {
         static let title = NSLocalizedString(
             "UpdateAttendanceStatusView.title",
@@ -136,7 +145,7 @@ private extension UpdateAttendanceStatusView {
 #if DEBUG
 struct UpdateAttendanceStatusView_Previews: PreviewProvider {
     static var previews: some View {
-        UpdateAttendanceStatusView { selectedStatus in
+        UpdateAttendanceStatusView(selectedStatus: .booked) { selectedStatus in
             print("Selected status: \(selectedStatus)")
         }
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1008,6 +1008,7 @@
 		2D880B492DFB2F3F00A6FB2C /* OptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D880B482DFB2F3D00A6FB2C /* OptionalBinding.swift */; };
 		2D88C1112DF883C300A6FB2C /* AttributedString+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D88C1102DF883BD00A6FB2C /* AttributedString+Helpers.swift */; };
 		2DA63E042E69B6D400B0CB28 /* ApplicationPasswordsExperimentAvailabilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA63E032E69B6D200B0CB28 /* ApplicationPasswordsExperimentAvailabilityCheckerTests.swift */; };
+		2DA7D58C2EA6722A007B0F48 /* BookingAttendanceStatus+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA7D58B2EA6722A007B0F48 /* BookingAttendanceStatus+Localization.swift */; };
 		2DAC25202E82A02C008521AF /* BookingDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAC251F2E82A02C008521AF /* BookingDetailsViewModel.swift */; };
 		2DAC2C992E82A185008521AF /* BookingDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAC2C972E82A185008521AF /* BookingDetailsView.swift */; };
 		2DB877522E25466C0001B175 /* ShippingItemRowAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB877512E25466B0001B175 /* ShippingItemRowAccessibility.swift */; };
@@ -3916,6 +3917,7 @@
 		2D880B482DFB2F3D00A6FB2C /* OptionalBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalBinding.swift; sourceTree = "<group>"; };
 		2D88C1102DF883BD00A6FB2C /* AttributedString+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Helpers.swift"; sourceTree = "<group>"; };
 		2DA63E032E69B6D200B0CB28 /* ApplicationPasswordsExperimentAvailabilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordsExperimentAvailabilityCheckerTests.swift; sourceTree = "<group>"; };
+		2DA7D58B2EA6722A007B0F48 /* BookingAttendanceStatus+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BookingAttendanceStatus+Localization.swift"; sourceTree = "<group>"; };
 		2DAC251F2E82A02C008521AF /* BookingDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingDetailsViewModel.swift; sourceTree = "<group>"; };
 		2DAC2C972E82A185008521AF /* BookingDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingDetailsView.swift; sourceTree = "<group>"; };
 		2DB877512E25466B0001B175 /* ShippingItemRowAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingItemRowAccessibility.swift; sourceTree = "<group>"; };
@@ -7977,6 +7979,7 @@
 				2D05D19E2E82D1A3004111FD /* BookingDetailsViewModel+Section.swift */,
 				2D05D1A02E82D1EF004111FD /* BookingDetailsViewModel+SectionContent.swift */,
 				2D05337D2E951A62004111FD /* BookingDetailsViewModel+PriceFormatting.swift */,
+				2DA7D58B2EA6722A007B0F48 /* BookingAttendanceStatus+Localization.swift */,
 			);
 			path = "Booking Details";
 			sourceTree = "<group>";
@@ -14447,6 +14450,7 @@
 				B92639FF293E2D4C00A257E0 /* JustInTimeMessagesProvider.swift in Sources */,
 				02BBD6E529A2678100243BE2 /* StoreOnboardingView.swift in Sources */,
 				02784A03238B8BC800BDD6A8 /* UIView+Border.swift in Sources */,
+				2DA7D58C2EA6722A007B0F48 /* BookingAttendanceStatus+Localization.swift in Sources */,
 				CE1CCB402056F21C000EE3AC /* Style.swift in Sources */,
 				EEC099382BF3C6A900FBCF6C /* MostActiveCouponsCardViewModel.swift in Sources */,
 				B943E7252AFA41CF009CBA20 /* OrderDetailsCustomAmountCellViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
@@ -220,4 +220,82 @@ final class BookingDetailsViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.navigationTitle.contains("12345"))
     }
+
+    func test_updateAttendanceStatus_whenNewStatusIsProvided_dispatchesUpdateBookingAttendanceStatusAction() {
+        // Given
+        let booking = Booking.fake()
+        let viewModel = BookingDetailsViewModel(booking: booking, stores: storesManager)
+        let newStatus = BookingAttendanceStatus.checkedIn
+
+        // When
+        viewModel.updateAttendanceStatus(to: newStatus)
+
+        // Then
+        XCTAssertEqual(storesManager.receivedActions.count, 1)
+        guard let action = storesManager.receivedActions.first as? BookingAction else {
+            XCTFail("Incorrect action type dispatched")
+            return
+        }
+
+        guard case let .updateBookingAttendanceStatus(siteID, bookingID, status, _) = action else {
+            XCTFail("Incorrect action case dispatched")
+            return
+        }
+
+        XCTAssertEqual(siteID, booking.siteID)
+        XCTAssertEqual(bookingID, booking.bookingID)
+        XCTAssertEqual(status, newStatus)
+    }
+
+    func test_init_whenBookingHasStatusAndAttendanceStatus_updatesHeaderContentWithCorrectLocalizedStrings() {
+        // Given
+        let booking = Booking.fake().copy(
+            statusKey: "paid",
+            attendanceStatusKey: "checked-in"
+        )
+
+        // When
+        let viewModel = BookingDetailsViewModel(booking: booking, stores: storesManager)
+
+        // Then
+        let headerSection = viewModel.sections.first { section in
+            if case .header = section.content {
+                return true
+            }
+            return false
+        }
+
+        guard let headerSection = headerSection,
+              case let .header(headerContent) = headerSection.content else {
+            XCTFail("Header section not found")
+            return
+        }
+        XCTAssertEqual(headerContent.status, ["Checked In", "Paid"])
+    }
+
+    func test_init_whenBookingHasAttendanceStatus_updatesAttendanceContentWithCorrectLocalizedString() {
+        // Given
+        let booking = Booking.fake().copy(
+            attendanceStatusKey: "no-show"
+        )
+
+        // When
+        let viewModel = BookingDetailsViewModel(booking: booking, stores: storesManager)
+
+        // Then
+        let attendanceSection = viewModel.sections.first { section in
+            if case .attendance = section.content {
+                return true
+            }
+            return false
+        }
+
+        guard let attendanceSection = attendanceSection,
+              case let .attendance(attendanceContent) = attendanceSection.content else {
+            XCTFail("Attendance section not found")
+            return
+        }
+
+        XCTAssertEqual(attendanceContent.value, "No Show")
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
Part of: WOOMOB-1532

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
- Uses the new `attendanceStatus` value from `Booking`
- Displays the current attendance status for booking in "Attendance" section row in Booking details screen
- Displays the current attendance status for booking in header section of booking details screen
- Displays the current selected attendance status in booking list item
- Pre-selects the current attendance status in selection sheet
- On new status selection update the booking object locally

Note: Doesn't yet implement the remote action.

## Testing steps

- Use CIAB site with existing bookings
- Navigate to a booking
- Scroll down to "Attendance" section in booking details screen
- Tap on attendance status row and select a new status
- Make sure the new value is applied in the status row, booking details header section as badge and in corresponding booking list item as a badge as well.

Note: refreshing the booking should bring back the old status since the remote request isn't yet implemented.

## Demo
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/130b1b35-9ce9-4f1e-9b15-9e2003c0a622

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.