### PR TITLE
[Woo POS][Surveys] Schedule notification trigger on opening app, rather than on opening POS

### DIFF
--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -116,21 +116,11 @@ final class POSTabCoordinator {
     }
 
     func onTabSelected() {
-        schedulePOSSurveyNotificationIfNeeded()
         presentPOSView(siteID: siteID)
     }
 }
 
 private extension POSTabCoordinator {
-    func schedulePOSSurveyNotificationIfNeeded() {
-        Task { @MainActor in
-            await POSNotificationScheduler().scheduleLocalNotificationIfEligible(for: .currentMerchant)
-
-            let action = AppSettingsAction.setHasPOSBeenOpenedAtLeastOnce { _ in }
-            storesManager.dispatch(action)
-        }
-    }
-
     func presentPOSView(siteID: Int64) {
         Task { @MainActor [weak self] in
             guard let self else { return }

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -116,11 +116,19 @@ final class POSTabCoordinator {
     }
 
     func onTabSelected() {
+        setPOSHasBeenOpened()
         presentPOSView(siteID: siteID)
     }
 }
 
 private extension POSTabCoordinator {
+    func setPOSHasBeenOpened() {
+        Task { @MainActor in
+            let action = AppSettingsAction.setHasPOSBeenOpenedAtLeastOnce { _ in }
+            storesManager.dispatch(action)
+        }
+    }
+
     func presentPOSView(siteID: Int64) {
         Task { @MainActor [weak self] in
             guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -65,6 +65,8 @@ final class AppCoordinator {
 
         // Configures authenticator first in case `WordPressAuthenticator` is used in other `AppDelegate` launch events.
         configureAuthenticator()
+
+        schedulePOSSurveyNotificationIfNeeded()
     }
 
     func start() {
@@ -98,6 +100,17 @@ final class AppCoordinator {
             self?.handleLocalNotificationResponse(response)
         }
         updateSitePropertiesIfNeeded()
+    }
+}
+
+private extension AppCoordinator {
+    func schedulePOSSurveyNotificationIfNeeded() {
+        Task { @MainActor in
+            await POSNotificationScheduler(stores: stores).scheduleLocalNotificationIfEligible(for: .currentMerchant)
+
+            let action = AppSettingsAction.setHasPOSBeenOpenedAtLeastOnce { _ in }
+            stores.dispatch(action)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -107,9 +107,6 @@ private extension AppCoordinator {
     func schedulePOSSurveyNotificationIfNeeded() {
         Task { @MainActor in
             await POSNotificationScheduler(stores: stores).scheduleLocalNotificationIfEligible(for: .currentMerchant)
-
-            let action = AppSettingsAction.setHasPOSBeenOpenedAtLeastOnce { _ in }
-            stores.dispatch(action)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -19,6 +19,7 @@ final class EditableOrderViewModel: ObservableObject {
     private let currencyFormatter: CurrencyFormatter
     private let featureFlagService: FeatureFlagService
     private let permissionChecker: CaptureDevicePermissionChecker
+    private let posNotificationScheduler: POSNotificationScheduling
 
     @Published var syncRequired: Bool = false
 
@@ -460,6 +461,7 @@ final class EditableOrderViewModel: ObservableObject {
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared,
          permissionChecker: CaptureDevicePermissionChecker = AVCaptureDevicePermissionChecker(),
+         posNotificationScheduler: POSNotificationScheduling = POSNotificationScheduler(),
          initialItem: OrderBaseItem? = nil,
          initialCustomer: (id: Int64, billing: Address?, shipping: Address?)? = nil,
          quantityDebounceDuration: Double = Constants.quantityDebounceDuration) {
@@ -473,6 +475,7 @@ final class EditableOrderViewModel: ObservableObject {
         self.featureFlagService = featureFlagService
         self.orderDurationRecorder = orderDurationRecorder
         self.permissionChecker = permissionChecker
+        self.posNotificationScheduler = posNotificationScheduler
         self.initialItem = initialItem
         self.initialCustomer = initialCustomer
         self.barcodeScannerItemFinder = BarcodeScannerItemFinder(stores: stores)
@@ -1026,7 +1029,7 @@ final class EditableOrderViewModel: ObservableObject {
             self.onFinished(order)
             self.trackCreateOrderSuccess(usesGiftCard: usesGiftCard)
             Task {
-                await POSNotificationScheduler().scheduleLocalNotificationIfEligible(for: .potentialMerchant)
+                await self.posNotificationScheduler.scheduleLocalNotificationIfEligible(for: .potentialMerchant)
             }
         } onFailure: { [weak self] error, usesGiftCard in
             guard let self else { return }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -3362,6 +3362,56 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.canBeDismissed)
     }
+
+    func test_onCreateOrderTapped_schedules_potential_merchant_notification() {
+        // Given
+        let mockScheduler = MockPOSNotificationScheduler()
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               stores: stores,
+                                               posNotificationScheduler: mockScheduler)
+
+        // When
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .createOrder(_, order, _, onCompletion):
+                onCompletion(.success(order))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+        viewModel.onCreateOrderTapped()
+
+        // Then
+        waitUntil {
+            mockScheduler.scheduleCallCount > 0
+        }
+        XCTAssertEqual(mockScheduler.scheduleCallCount, 1)
+        XCTAssertEqual(mockScheduler.lastMerchantType, .potentialMerchant)
+    }
+
+    func test_onCreateOrderTapped_does_not_schedule_notification_on_failure() {
+        // Given
+        let mockScheduler = MockPOSNotificationScheduler()
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               stores: stores,
+                                               posNotificationScheduler: mockScheduler)
+        let error = NSError(domain: "Error", code: 0)
+
+        // When
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .createOrder(_, _, _, onCompletion):
+                onCompletion(.failure(error))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+        viewModel.onCreateOrderTapped()
+
+        // Then
+        XCTAssertEqual(mockScheduler.scheduleCallCount, 0)
+        XCTAssertNil(mockScheduler.lastMerchantType)
+    }
 }
 
 private extension EditableOrderViewModelTests {
@@ -3456,5 +3506,18 @@ private extension EditableOrderViewModelTests {
                        country: "US",
                        phone: "333-333-3333",
                        email: "")
+    }
+}
+
+// MARK: - POS Notification Tests & MockPOSNotificationScheduler
+private extension EditableOrderViewModelTests {
+    final class MockPOSNotificationScheduler: POSNotificationScheduling {
+        private(set) var scheduleCallCount = 0
+        private(set) var lastMerchantType: POSNotificationScheduler.MerchantType?
+
+        func scheduleLocalNotificationIfEligible(for merchantType: POSNotificationScheduler.MerchantType) async {
+            scheduleCallCount += 1
+            lastMerchantType = merchantType
+        }
     }
 }


### PR DESCRIPTION
Closes WOOMOB-1528
Closes WOOMOB-1521

## Description
This PR updates the trigger for the "current merchant" case, so it schedules it when the app is opened, rather than when POS is opened.

## Changes
- Moves survey scheduler checks from `POSTabCoordinator` to `AppCoordinator`
- DI `POSNotificationScheduling` into `EditableOrderViewModel`
- Adds unit tests

## Testing information
1. On a physical device, with notifications turned on, and in a US/UK store:
2. Update `POSNotificationScheduler.timeIntervalInSeconds ` to something like 5 seconds
3. In `AppCoordinator.schedulePOSSurveyNotificationIfNeeded` add the following bit to clear any persisted state
```diff
private extension AppCoordinator {
    func schedulePOSSurveyNotificationIfNeeded() {
+        Task { @MainActor in
+          let action = AppSettingsAction.resetPOSSurveyNotificationScheduled { _ in }
+          stores.dispatch(action)
+        }
        Task { @MainActor in
            await POSNotificationScheduler(stores: stores).scheduleLocalNotificationIfEligible(for: .currentMerchant)

            let action = AppSettingsAction.setHasPOSBeenOpenedAtLeastOnce { _ in }
            stores.dispatch(action)
        }
    }
}
``` 
4. Run the app, and open POS
5. Remove the reset block we've just added to `AppCoordinator.schedulePOSSurveyNotificationIfNeeded`
6. Re-run the app and wait 5 seconds
7. You should see the notification appear
