### PR TITLE
Site credential login: Prevent redirect callback twice

### DIFF
--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -108,7 +108,7 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
     private let cookieJar: HTTPCookieStorage
     private var successHandler: (() -> Void)?
     private var errorHandler: ((SiteCredentialLoginError) -> Void)?
-    private lazy var session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+    private lazy var session = URLSession(configuration: .default)
 
     init(siteURL: String,
          cookieJar: HTTPCookieStorage = HTTPCookieStorage.shared) {
@@ -134,11 +134,9 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
         Task { @MainActor in
             do {
                 try await startLogin(with: loginRequest)
+                successHandler?()
             } catch let error as SiteCredentialLoginError {
                 errorHandler?(error)
-            } catch let nsError as NSError where nsError.domain == NSURLErrorDomain && nsError.code == -999 {
-                /// login request is cancelled upon redirect, ignore this error
-                DDLogDebug("Cancelling auto redirect...")
             } catch {
                 errorHandler?(.genericFailure(underlyingError: error as NSError))
             }
@@ -173,46 +171,7 @@ private extension SiteCredentialLoginUseCase {
             }
             if let errorMessage = html.findLoginErrorMessage() {
                 throw SiteCredentialLoginError.loginFailed(message: errorMessage)
-            } else {
-                throw SiteCredentialLoginError.invalidLoginResponse
             }
-        default:
-            throw SiteCredentialLoginError.unacceptableStatusCode(code: response.statusCode)
-        }
-    }
-
-    @MainActor
-    func checkRedirect(url: URL?) async {
-        guard let url, url.absoluteString.hasSuffix(Constants.wporgNoncePath),
-              let nonceRetrievalURL = URL(string: siteURL + Constants.adminPath + Constants.wporgNoncePath) else {
-            errorHandler?(.invalidLoginResponse)
-            return
-        }
-
-        // Handling redirect to nonce retrieval URL manually
-        do {
-            let nonceRequest = try URLRequest(url: nonceRetrievalURL, method: .get)
-            try await checkAdminPageAccess(with: nonceRequest)
-            successHandler?()
-        } catch let error as SiteCredentialLoginError {
-            errorHandler?(error)
-        } catch {
-            errorHandler?(.genericFailure(underlyingError: error as NSError))
-        }
-    }
-
-    func checkAdminPageAccess(with nonceRequest: URLRequest) async throws {
-        // Use a separate session without delegate to avoid triggering redirect interception
-        let sessionWithoutDelegate = URLSession(configuration: .default)
-        let (_, response) = try await sessionWithoutDelegate.data(for: nonceRequest)
-        guard let response = response as? HTTPURLResponse else {
-            throw SiteCredentialLoginError.invalidLoginResponse
-        }
-        switch response.statusCode {
-        case 200:
-            return // success 🎉
-        case 404:
-            throw SiteCredentialLoginError.inaccessibleAdminPage
         default:
             throw SiteCredentialLoginError.unacceptableStatusCode(code: response.statusCode)
         }
@@ -241,18 +200,6 @@ private extension SiteCredentialLoginUseCase {
         let characterSet = CharacterSet(charactersIn: "+").inverted
         request.httpBody = components.percentEncodedQuery?.addingPercentEncoding(withAllowedCharacters: characterSet)?.data(using: .utf8)
         return request
-    }
-}
-
-extension SiteCredentialLoginUseCase: URLSessionDataDelegate {
-    func urlSession(_ session: URLSession,
-                    task: URLSessionTask,
-                    willPerformHTTPRedirection response: HTTPURLResponse,
-                    newRequest request: URLRequest) async -> URLRequest? {
-        // Disables redirect and check if the redirect is correct
-        task.cancel()
-        await checkRedirect(url: request.url)
-        return nil
     }
 }
 

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -159,18 +159,33 @@ private extension SiteCredentialLoginUseCase {
             throw SiteCredentialLoginError.invalidLoginResponse
         }
 
+        let isNonceUrl = response.url?.absoluteString.contains(Constants.wporgNoncePath) == true
+
         switch response.statusCode {
         case 404:
-            throw SiteCredentialLoginError.inaccessibleLoginPage
+            if isNonceUrl {
+                throw SiteCredentialLoginError.inaccessibleAdminPage
+            } else {
+                throw SiteCredentialLoginError.inaccessibleLoginPage
+            }
         case 200:
-            guard let html = String(data: data, encoding: .utf8) else {
-                throw SiteCredentialLoginError.invalidLoginResponse
-            }
-            if html.hasInvalidCredentialsPattern() {
-                throw SiteCredentialLoginError.invalidCredentials
-            }
-            if let errorMessage = html.findLoginErrorMessage() {
-                throw SiteCredentialLoginError.loginFailed(message: errorMessage)
+            if isNonceUrl {
+                // Means success
+                // But maybe we can also validate the nonce format like Android https://github.com/woocommerce/woocommerce-android/blob/ea4a48355b5ca4d49dc27e91566aaed304ab5916/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt#L120
+                return
+            } else {
+                // 200 for the login URL, which means a failure
+                guard let html = String(data: data, encoding: .utf8) else {
+                    throw SiteCredentialLoginError.invalidLoginResponse
+                }
+                if html.hasInvalidCredentialsPattern() {
+                    throw SiteCredentialLoginError.invalidCredentials
+                }
+                if let errorMessage = html.findLoginErrorMessage() {
+                    throw SiteCredentialLoginError.loginFailed(message: errorMessage)
+                } else {
+                    throw SiteCredentialLoginError.invalidLoginResponse
+                }
             }
         default:
             throw SiteCredentialLoginError.unacceptableStatusCode(code: response.statusCode)

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -100,8 +100,9 @@ enum SiteCredentialLoginError: LocalizedError {
 /// This use case handles site credential login without the need to use XMLRPC API.
 /// Steps for login:
 /// - Make a request to the site wp-login.php with a redirect to the nonce retrieval URL.
-/// - Upon redirect, cancel the request and verify if the redirect URL is the nonce retrieval URL.
-/// - If it is, make a request to retrieve nonce at that URL, the login succeeds if this is successful.
+/// - If the redirect succeeds with a nonce in the response, login is successful.
+/// - If the request does not redirect or the redirect fails, login fails.
+/// Ref: pe5sF9-1iQ-p2
 ///
 final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
     private let siteURL: String
@@ -161,32 +162,31 @@ private extension SiteCredentialLoginUseCase {
 
         let isNonceUrl = response.url?.absoluteString.hasSuffix(Constants.wporgNoncePath) == true
 
-        switch response.statusCode {
-        case 404:
-            if isNonceUrl {
-                throw SiteCredentialLoginError.inaccessibleAdminPage
-            } else {
-                throw SiteCredentialLoginError.inaccessibleLoginPage
-            }
-        case 200:
-            if isNonceUrl,
-               let nonceString = String(data: data, encoding: .utf8),
+        switch (isNonceUrl, response.statusCode) {
+        case (true, 200):
+            if let nonceString = String(data: data, encoding: .utf8),
                nonceString.isValidNonce() {
                 // success!
                 return
             } else {
-                // 200 for the login URL, which means a failure
-                guard let html = String(data: data, encoding: .utf8) else {
-                    throw SiteCredentialLoginError.invalidLoginResponse
-                }
-                if html.hasInvalidCredentialsPattern() {
-                    throw SiteCredentialLoginError.invalidCredentials
-                }
-                if let errorMessage = html.findLoginErrorMessage() {
-                    throw SiteCredentialLoginError.loginFailed(message: errorMessage)
-                } else {
-                    throw SiteCredentialLoginError.invalidLoginResponse
-                }
+                throw SiteCredentialLoginError.invalidLoginResponse
+            }
+        case (true, 404):
+            throw SiteCredentialLoginError.inaccessibleAdminPage
+        case (false, 404):
+            throw SiteCredentialLoginError.inaccessibleLoginPage
+        case (false, 200):
+            // 200 for the login URL, which means a failure
+            guard let html = String(data: data, encoding: .utf8) else {
+                throw SiteCredentialLoginError.invalidLoginResponse
+            }
+            if html.hasInvalidCredentialsPattern() {
+                throw SiteCredentialLoginError.invalidCredentials
+            }
+            if let errorMessage = html.findLoginErrorMessage() {
+                throw SiteCredentialLoginError.loginFailed(message: errorMessage)
+            } else {
+                throw SiteCredentialLoginError.invalidLoginResponse
             }
         default:
             throw SiteCredentialLoginError.unacceptableStatusCode(code: response.statusCode)

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -138,6 +138,7 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
                 errorHandler?(error)
             } catch let nsError as NSError where nsError.domain == NSURLErrorDomain && nsError.code == -999 {
                 /// login request is cancelled upon redirect, ignore this error
+                DDLogDebug("Cancelling auto redirect...")
             } catch {
                 errorHandler?(.genericFailure(underlyingError: error as NSError))
             }
@@ -187,6 +188,8 @@ private extension SiteCredentialLoginUseCase {
             errorHandler?(.invalidLoginResponse)
             return
         }
+
+        // Handling redirect to nonce retrieval URL manually
         do {
             let nonceRequest = try URLRequest(url: nonceRetrievalURL, method: .get)
             try await checkAdminPageAccess(with: nonceRequest)
@@ -199,7 +202,9 @@ private extension SiteCredentialLoginUseCase {
     }
 
     func checkAdminPageAccess(with nonceRequest: URLRequest) async throws {
-        let (_, response) = try await session.data(for: nonceRequest)
+        // Use a separate session without delegate to avoid triggering redirect interception
+        let sessionWithoutDelegate = URLSession(configuration: .default)
+        let (_, response) = try await sessionWithoutDelegate.data(for: nonceRequest)
         guard let response = response as? HTTPURLResponse else {
             throw SiteCredentialLoginError.invalidLoginResponse
         }

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -159,7 +159,7 @@ private extension SiteCredentialLoginUseCase {
             throw SiteCredentialLoginError.invalidLoginResponse
         }
 
-        let isNonceUrl = response.url?.absoluteString.contains(Constants.wporgNoncePath) == true
+        let isNonceUrl = response.url?.absoluteString.hasSuffix(Constants.wporgNoncePath) == true
 
         switch response.statusCode {
         case 404:
@@ -169,9 +169,10 @@ private extension SiteCredentialLoginUseCase {
                 throw SiteCredentialLoginError.inaccessibleLoginPage
             }
         case 200:
-            if isNonceUrl {
-                // Means success
-                // But maybe we can also validate the nonce format like Android https://github.com/woocommerce/woocommerce-android/blob/ea4a48355b5ca4d49dc27e91566aaed304ab5916/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt#L120
+            if isNonceUrl,
+               let nonceString = String(data: data, encoding: .utf8),
+               nonceString.isValidNonce() {
+                // success!
                 return
             } else {
                 // 200 for the login URL, which means a failure
@@ -276,5 +277,16 @@ private extension String {
     ///
     func hasInvalidCredentialsPattern() -> Bool {
         contains("document.querySelector('form').classList.add('shake')")
+    }
+
+    /// Validates if the string matches the expected nonce format.
+    /// A valid nonce should contain at least 2 alphanumeric characters.
+    ///
+    func isValidNonce() -> Bool {
+        guard let regex = try? Regex("^[0-9a-zA-Z]{2,}$") else {
+            DDLogError("⚠️ Invalid regex pattern")
+            return false
+        }
+        return wholeMatch(of: regex) != nil
     }
 }

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -160,6 +160,9 @@ private extension SiteCredentialLoginUseCase {
             throw SiteCredentialLoginError.invalidLoginResponse
         }
 
+        /// The login request comes with a redirect header to nonce retrieval URL.
+        /// If we get a response from this URL, that means the redirect is successful.
+        /// We need to check the result of this redirect first to determine if login is successful.
         let isNonceUrl = response.url?.absoluteString.hasSuffix(Constants.wporgNoncePath) == true
 
         switch (isNonceUrl, response.statusCode) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1545

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

There's a report that nonce-retrieval requests are sometimes duplicated during site credential login.

The cause is that the delegate method `urlSession(_: task: willPerformHTTPRedirection: newRequest:)` is triggered twice: one during the original login request, and another during the manual nonce-retrieval request, which happens occasionally.

This PR fixes the issue by using a separate session for the nonce retrieval request without any delegate. This ensures that the request doesn't accidentally trigger the check for redirection again.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Uninstall the app. (It seems this happens more frequently on clean installs)
- Enter the address of a self-hosted site.
- Use site credentials to log in to the site.
- Confirm with Proxyman that the nonce-retrieval request (`/wp-admin/admin-ajax.php?action=rest-nonce`) is triggered only once.


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested and confirmed with simulator iPhone 17. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.