### PR TITLE
[Woo POS][Surveys] Enable feature flag

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -99,7 +99,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .ciabBookings:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .pointOfSaleSurveys:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         default:
             return true
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 23.6
 -----
-
+- [*] Adds in-app feedback surveys to gauge POS potential interest, and current usage [https://github.com/woocommerce/woocommerce-ios/pull/16267]
 
 23.5
 -----


### PR DESCRIPTION
## Description
This PR enables POS Surveys in release builds.

## Testing information
Testing one of the cases below is enough to assure the feature is enabled in release:

1. Switch the build configuration to `release`. 
2. On a physical device, with notifications turned on, and in a US/UK store:
3. Update `POSNotificationScheduler.timeIntervalInSeconds`  to something like 5 seconds
4. In `AppCoordinator.schedulePOSSurveyNotificationIfNeeded` add the following bit if needed to clear any persisted state from previous tests
```diff
private extension AppCoordinator {
    func schedulePOSSurveyNotificationIfNeeded() {
+        Task { @MainActor in
+          let action = AppSettingsAction.resetPOSSurveyNotificationScheduled { _ in }
+          stores.dispatch(action)
+        }
        Task { @MainActor in
            await POSNotificationScheduler(stores: stores).scheduleLocalNotificationIfEligible(for: .currentMerchant)
        }
    }
}
```
5. Case 1 - Potential merchant case: Navigate to Orders > create an order > observe the survey notification appearing. Creating a second order should not show the notification again.
6. Case 2 - Current merchant case: Visit POS once, restart the app, the notification should appear shortly. 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
