### PR TITLE
[WCiOS17] Address scanner deprecations

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Scanner/CodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Scanner/CodeScannerViewController.swift
@@ -163,10 +163,8 @@ private extension CodeScannerViewController {
     /// Enables and starts live stream video, if available.
     func startLiveVideo() {
         session.sessionPreset = .photo
-        if #available(iOS 16.0, *) {
-            if session.isMultitaskingCameraAccessSupported {
-                session.isMultitaskingCameraAccessEnabled = true
-            }
+        if session.isMultitaskingCameraAccessSupported {
+            session.isMultitaskingCameraAccessEnabled = true
         }
 
         guard let captureDevice = AVCaptureDevice.default(for: .video),

--- a/WooCommerce/Classes/ViewRelated/Products/Scanner/CodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Scanner/CodeScannerViewController.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import Combine
 import UIKit
 import Vision
 
@@ -36,6 +37,8 @@ final class CodeScannerViewController: UIViewController {
     private let sessionQueue = DispatchQueue(label: "qrlogincamerasession.queue.serial")
     private let session = AVCaptureSession()
     private var requests = [VNRequest]()
+    private var rotationCoordinator: AVCaptureDevice.RotationCoordinator?
+    private var cancellables = Set<AnyCancellable>()
 
     private lazy var throttler: Throttler = Throttler(seconds: 0.1)
 
@@ -187,6 +190,15 @@ private extension CodeScannerViewController {
         previewLayer.videoGravity = .resizeAspectFill
         previewLayer.frame = videoOutputImageView.bounds
         videoOutputImageView.layer.addSublayer(previewLayer)
+        rotationCoordinator = AVCaptureDevice.RotationCoordinator(device: captureDevice, previewLayer: previewLayer)
+
+        rotationCoordinator?.publisher(for: \.videoRotationAngleForHorizonLevelPreview)
+            .sink { [weak self] angle in
+                guard let self = self,
+                      let connection = self.previewLayer?.connection else { return }
+                connection.videoRotationAngle = angle
+            }
+            .store(in: &cancellables)
 
         sessionQueue.async { [weak self] in
             self?.session.startRunning()
@@ -290,27 +302,27 @@ private extension CodeScannerViewController {
 //
 private extension CodeScannerViewController {
     func updatePreviewLayerOrientation() {
-        if let connection = previewLayer?.connection, connection.isVideoOrientationSupported {
+        if let connection = previewLayer?.connection {
             let orientation = view.window?.windowScene?.interfaceOrientation
-            let videoOrientation: AVCaptureVideoOrientation
+            let videoRotationAngle: CGFloat
             switch orientation {
             case .portrait:
-                videoOrientation = .portrait
+                videoRotationAngle = 90
             case .landscapeRight:
-                videoOrientation = .landscapeRight
+                videoRotationAngle = 0
             case .landscapeLeft:
-                videoOrientation = .landscapeLeft
+                videoRotationAngle = 180
             case .portraitUpsideDown:
-                videoOrientation = .portraitUpsideDown
+                videoRotationAngle = 270
             default:
-                videoOrientation = .portrait
+                videoRotationAngle = 90
             }
-            updatePreviewLayerVideoOrientation(connection: connection, orientation: videoOrientation)
+            updatePreviewLayerVideoRotationAngle(connection: connection, angle: videoRotationAngle)
         }
     }
 
-    func updatePreviewLayerVideoOrientation(connection: AVCaptureConnection, orientation: AVCaptureVideoOrientation) {
-        connection.videoOrientation = orientation
+    func updatePreviewLayerVideoRotationAngle(connection: AVCaptureConnection, angle: CGFloat) {
+        connection.videoRotationAngle = angle
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Scanner/CodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Scanner/CodeScannerViewController.swift
@@ -301,21 +301,28 @@ private extension CodeScannerViewController {
 // MARK: Orientation Handling
 //
 private extension CodeScannerViewController {
+    enum VideoRotationAngle {
+        static let portrait: CGFloat = 90
+        static let landscapeRight: CGFloat = 0
+        static let landscapeLeft: CGFloat = 180
+        static let portraitUpsideDown: CGFloat = 270
+    }
+
     func updatePreviewLayerOrientation() {
         if let connection = previewLayer?.connection {
             let orientation = view.window?.windowScene?.interfaceOrientation
             let videoRotationAngle: CGFloat
             switch orientation {
             case .portrait:
-                videoRotationAngle = 90
+                videoRotationAngle = VideoRotationAngle.portrait
             case .landscapeRight:
-                videoRotationAngle = 0
+                videoRotationAngle = VideoRotationAngle.landscapeRight
             case .landscapeLeft:
-                videoRotationAngle = 180
+                videoRotationAngle = VideoRotationAngle.landscapeLeft
             case .portraitUpsideDown:
-                videoRotationAngle = 270
+                videoRotationAngle = VideoRotationAngle.portraitUpsideDown
             default:
-                videoRotationAngle = 90
+                videoRotationAngle = VideoRotationAngle.portrait
             }
             updatePreviewLayerVideoRotationAngle(connection: connection, angle: videoRotationAngle)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Scanner/CodeScannerViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Scanner/CodeScannerViewController.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -36,14 +35,14 @@
                             <rect key="frame" x="0.0" y="0.0" width="414" height="269"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wCb-QS-xTf">
-                                    <rect key="frame" x="20" y="20" width="75" height="34.5"/>
+                                    <rect key="frame" x="20" y="20" width="75" height="40.5"/>
                                     <state key="normal" title="Button"/>
                                     <buttonConfiguration key="configuration" style="plain" title="Button"/>
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uYb-k2-4wm">
                                     <rect key="frame" x="338.5" y="20" width="55.5" height="34"/>
                                     <state key="normal" title="Button"/>
-                                    <buttonConfiguration key="configuration" style="plain" image="arrow.triangle.2.circlepath.camera" catalog="system"/>
+                                    <buttonConfiguration key="configuration" style="plain" image="arrow.trianglehead.2.clockwise.rotate.90.camera" catalog="system"/>
                                 </button>
                             </subviews>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -94,7 +93,7 @@
         </view>
     </objects>
     <resources>
-        <image name="arrow.triangle.2.circlepath.camera" catalog="system" width="128" height="93"/>
+        <image name="arrow.trianglehead.2.clockwise.rotate.90.camera" catalog="system" width="128" height="93"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>


### PR DESCRIPTION
Closes WOOMOB-1294

## Description
This PR takes care of 4 warnings regarding the app scanner:
- 'isVideoOrientationSupported' was deprecated in iOS 17.0: Use -isVideoRotationAngleSupported: instead
- 'AVCaptureVideoOrientation' was deprecated in iOS 17.0: Use AVCaptureDeviceRotationCoordinator instead
- 'videoOrientation' was deprecated in iOS 17.0: Use -videoRotationAngle instead
- SF Symbol 'arrow.triangle.2.circlepath.camera' is deprecated, use 'arrow.trianglehead.2.clockwise.rotate.90.camera' instead.

## Testing information
The changes only affect the camera orientation logic, feel free to test the scanner functionality as well, but is not needed.
- Run the app on a phone, navigate to Orders > tap on the scanner icon > Observe that changing the device orientation changes the scanner adequately (except for upside-down if the scanner is open on a sheet)
- Perform the same test on an iPad, the scanner shows modally so device orientation will work for 4 orientations.

## Screenshots

https://github.com/user-attachments/assets/bf6bbe9f-b078-47ed-9796-90ad395ea4b3

https://github.com/user-attachments/assets/fe52d94d-b6c4-40f1-992a-b9e2a6052600

