### PR TITLE
Extract country/currency POS eligibility validator

### DIFF
--- a/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSCountryCurrencyValidator.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSCountryCurrencyValidator.swift
@@ -1,0 +1,50 @@
+import Foundation
+import enum WooFoundation.CountryCode
+import enum WooFoundation.CurrencyCode
+
+/// Validator for POS country and currency support
+/// Single source of truth for supported countries and currencies
+public enum POSCountryCurrencyValidator {
+    /// Supported countries for POS feature
+    public static let supportedCountries: [CountryCode] = [.US, .GB]
+
+    /// Supported currencies per country for POS feature
+    public static let supportedCurrencies: [CountryCode: [CurrencyCode]] = [
+        .US: [.USD],
+        .GB: [.GBP]
+    ]
+
+    /// Validates if a country and currency combination is eligible for POS
+    /// - Parameters:
+    ///   - countryCode: The store's country code
+    ///   - currencyCode: The store's currency code
+    /// - Returns: Eligibility state with reason if ineligible
+    public static func validate(countryCode: CountryCode, currencyCode: CurrencyCode) -> ValidationResult {
+        // Check country first
+        guard supportedCountries.contains(countryCode) else {
+            return .ineligible(reason: .unsupportedCountry(supportedCountries: supportedCountries))
+        }
+
+        // Check currency for the country
+        let supportedCurrenciesForCountry = supportedCurrencies[countryCode] ?? []
+        guard supportedCurrenciesForCountry.contains(currencyCode) else {
+            return .ineligible(reason: .unsupportedCurrency(countryCode: countryCode, supportedCurrencies: supportedCurrenciesForCountry))
+        }
+
+        return .eligible
+    }
+}
+
+// MARK: - Validation Result
+
+public extension POSCountryCurrencyValidator {
+    enum ValidationResult: Equatable {
+        case eligible
+        case ineligible(reason: IneligibleReason)
+    }
+
+    enum IneligibleReason: Equatable {
+        case unsupportedCountry(supportedCountries: [CountryCode])
+        case unsupportedCurrency(countryCode: CountryCode, supportedCurrencies: [CurrencyCode])
+    }
+}

--- a/Modules/Tests/YosemiteTests/PointOfSale/Eligibility/POSCountryCurrencyValidatorTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/Eligibility/POSCountryCurrencyValidatorTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Testing
+import enum WooFoundation.CountryCode
+import enum WooFoundation.CurrencyCode
+@testable import Yosemite
+
+@Suite("POSCountryCurrencyValidator Tests")
+struct POSCountryCurrencyValidatorTests {
+
+    // MARK: - Eligible Combinations
+
+    @Test("US with USD is eligible")
+    func testUSWithUSDIsEligible() {
+        let result = POSCountryCurrencyValidator.validate(countryCode: .US, currencyCode: .USD)
+        #expect(result == .eligible)
+    }
+
+    @Test("GB with GBP is eligible")
+    func testGBWithGBPIsEligible() {
+        let result = POSCountryCurrencyValidator.validate(countryCode: .GB, currencyCode: .GBP)
+        #expect(result == .eligible)
+    }
+
+    // MARK: - Unsupported Countries
+
+    @Test("CA with USD is ineligible due to unsupported country")
+    func testCAWithUSDIsIneligible() {
+        let result = POSCountryCurrencyValidator.validate(countryCode: .CA, currencyCode: .USD)
+
+        guard case .ineligible(let reason) = result else {
+            Issue.record("Expected ineligible result")
+            return
+        }
+
+        guard case .unsupportedCountry(let supportedCountries) = reason else {
+            Issue.record("Expected unsupportedCountry reason")
+            return
+        }
+
+        #expect(supportedCountries.contains(.US))
+        #expect(supportedCountries.contains(.GB))
+        #expect(!supportedCountries.contains(.CA))
+    }
+
+    @Test("AU with AUD is ineligible due to unsupported country")
+    func testAUWithAUDIsIneligible() {
+        let result = POSCountryCurrencyValidator.validate(countryCode: .AU, currencyCode: .AUD)
+
+        guard case .ineligible(let reason) = result else {
+            Issue.record("Expected ineligible result")
+            return
+        }
+
+        guard case .unsupportedCountry = reason else {
+            Issue.record("Expected unsupportedCountry reason")
+            return
+        }
+    }
+
+    // MARK: - Unsupported Currencies for Supported Countries
+
+    @Test("US with EUR is ineligible due to unsupported currency")
+    func testUSWithEURIsIneligible() {
+        let result = POSCountryCurrencyValidator.validate(countryCode: .US, currencyCode: .EUR)
+
+        guard case .ineligible(let reason) = result else {
+            Issue.record("Expected ineligible result")
+            return
+        }
+
+        guard case .unsupportedCurrency(let countryCode, let supportedCurrencies) = reason else {
+            Issue.record("Expected unsupportedCurrency reason")
+            return
+        }
+
+        #expect(countryCode == .US)
+        #expect(supportedCurrencies == [.USD])
+    }
+
+    @Test("US with GBP is ineligible due to unsupported currency")
+    func testUSWithGBPIsIneligible() {
+        let result = POSCountryCurrencyValidator.validate(countryCode: .US, currencyCode: .GBP)
+
+        guard case .ineligible(let reason) = result else {
+            Issue.record("Expected ineligible result")
+            return
+        }
+
+        guard case .unsupportedCurrency(let countryCode, let supportedCurrencies) = reason else {
+            Issue.record("Expected unsupportedCurrency reason")
+            return
+        }
+
+        #expect(countryCode == .US)
+        #expect(supportedCurrencies == [.USD])
+    }
+
+    @Test("GB with USD is ineligible due to unsupported currency")
+    func testGBWithUSDIsIneligible() {
+        let result = POSCountryCurrencyValidator.validate(countryCode: .GB, currencyCode: .USD)
+
+        guard case .ineligible(let reason) = result else {
+            Issue.record("Expected ineligible result")
+            return
+        }
+
+        guard case .unsupportedCurrency(let countryCode, let supportedCurrencies) = reason else {
+            Issue.record("Expected unsupportedCurrency reason")
+            return
+        }
+
+        #expect(countryCode == .GB)
+        #expect(supportedCurrencies == [.GBP])
+    }
+
+    @Test("GB with EUR is ineligible due to unsupported currency")
+    func testGBWithEURIsIneligible() {
+        let result = POSCountryCurrencyValidator.validate(countryCode: .GB, currencyCode: .EUR)
+
+        guard case .ineligible(let reason) = result else {
+            Issue.record("Expected ineligible result")
+            return
+        }
+
+        guard case .unsupportedCurrency(let countryCode, let supportedCurrencies) = reason else {
+            Issue.record("Expected unsupportedCurrency reason")
+            return
+        }
+
+        #expect(countryCode == .GB)
+        #expect(supportedCurrencies == [.GBP])
+    }
+
+    // MARK: - Supported Countries List
+
+    @Test("Supported countries list contains US and GB")
+    func testSupportedCountriesList() {
+        let supportedCountries = POSCountryCurrencyValidator.supportedCountries
+        #expect(supportedCountries.count == 2)
+        #expect(supportedCountries.contains(.US))
+        #expect(supportedCountries.contains(.GB))
+    }
+
+    // MARK: - Supported Currencies Map
+
+    @Test("Supported currencies map has correct structure")
+    func testSupportedCurrenciesMap() {
+        let supportedCurrencies = POSCountryCurrencyValidator.supportedCurrencies
+
+        #expect(supportedCurrencies[.US] == [.USD])
+        #expect(supportedCurrencies[.GB] == [.GBP])
+        #expect(supportedCurrencies[.CA] == nil)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -20,6 +20,7 @@ import class WooFoundation.VersionHelpers
 import protocol PointOfSale.POSEntryPointEligibilityCheckerProtocol
 import enum PointOfSale.POSEligibilityState
 import enum PointOfSale.POSIneligibleReason
+import enum Yosemite.POSCountryCurrencyValidator
 
 final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
     private let siteID: Int64
@@ -209,20 +210,19 @@ private extension POSTabEligibilityChecker {
     }
 
     func isEligibleFromCountryAndCurrencyCode(countryCode: CountryCode, currencyCode: CurrencyCode) -> SiteSettingsEligibilityState {
-        let supportedCountries: [CountryCode] = [.US, .GB]
-        let supportedCurrencies: [CountryCode: [CurrencyCode]] = [.US: [.USD],
-                                                                  .GB: [.GBP]]
+        let validationResult = POSCountryCurrencyValidator.validate(countryCode: countryCode, currencyCode: currencyCode)
 
-        // Checks country first.
-        guard supportedCountries.contains(countryCode) else {
-            return .ineligible(reason: .unsupportedCountry(supportedCountries: supportedCountries))
+        switch validationResult {
+        case .eligible:
+            return .eligible
+        case .ineligible(let reason):
+            switch reason {
+            case .unsupportedCountry(let supportedCountries):
+                return .ineligible(reason: .unsupportedCountry(supportedCountries: supportedCountries))
+            case .unsupportedCurrency(let countryCode, let supportedCurrencies):
+                return .ineligible(reason: .unsupportedCurrency(countryCode: countryCode, supportedCurrencies: supportedCurrencies))
+            }
         }
-
-        let supportedCurrenciesForCountry = supportedCurrencies[countryCode] ?? []
-        guard supportedCurrenciesForCountry.contains(currencyCode) else {
-            return .ineligible(reason: .unsupportedCurrency(countryCode: countryCode, supportedCurrencies: supportedCurrenciesForCountry))
-        }
-        return .eligible
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
@@ -11,6 +11,7 @@ import protocol Yosemite.StoresManager
 import class Yosemite.POSEligibilityService
 import enum Yosemite.FeatureFlagAction
 import class Yosemite.SiteAddress
+import enum Yosemite.POSCountryCurrencyValidator
 
 final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
     private let site: Site
@@ -106,20 +107,19 @@ private extension POSTabVisibilityChecker {
     }
 
     func isEligibleFromCountryAndCurrencyCode(countryCode: CountryCode, currencyCode: CurrencyCode) -> SiteSettingsEligibilityState {
-        let supportedCountries: [CountryCode] = [.US, .GB]
-        let supportedCurrencies: [CountryCode: [CurrencyCode]] = [.US: [.USD],
-                                                                  .GB: [.GBP]]
+        let validationResult = POSCountryCurrencyValidator.validate(countryCode: countryCode, currencyCode: currencyCode)
 
-        // Checks country first.
-        guard supportedCountries.contains(countryCode) else {
-            return .ineligible(reason: .unsupportedCountry(supportedCountries: supportedCountries))
+        switch validationResult {
+        case .eligible:
+            return .eligible
+        case .ineligible(let reason):
+            switch reason {
+            case .unsupportedCountry(let supportedCountries):
+                return .ineligible(reason: .unsupportedCountry(supportedCountries: supportedCountries))
+            case .unsupportedCurrency(let countryCode, let supportedCurrencies):
+                return .ineligible(reason: .unsupportedCurrency(countryCode: countryCode, supportedCurrencies: supportedCurrencies))
+            }
         }
-
-        let supportedCurrenciesForCountry = supportedCurrencies[countryCode] ?? []
-        guard supportedCurrenciesForCountry.contains(currencyCode) else {
-            return .ineligible(reason: .unsupportedCurrency(countryCode: countryCode, supportedCurrencies: supportedCurrenciesForCountry))
-        }
-        return .eligible
     }
 }
 


### PR DESCRIPTION
Part of: WOOMOB-1287

<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR extracts country/currency validation logic to share between POSTabVisibilityChecker and POSTabEligibilityChecker.

Changes:
- Created POSCountryCurrencyValidator in Yosemite module
- Centralized supported countries ([.US, .GB]) and currencies
- Updated both eligibility checkers to use shared validator

There's no behaviour change in this PR. We still support US and GB with their native currencies only.

## Testing information

Existing unit tests still exist and should pass. 
New unit tests added.

I've checked mismatched currency/country combinations, and supported/unsupported countries also still behave correctly.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
