### PR TITLE
Bookings: Update selector for service/event and customer name filters

### DIFF
--- a/Modules/Sources/Yosemite/Model/Bookings/BookingProductFilter.swift
+++ b/Modules/Sources/Yosemite/Model/Bookings/BookingProductFilter.swift
@@ -7,6 +7,7 @@ public struct BookingProductFilter: Codable, Hashable {
     public let product: Product
 
     /// ID of the product
+    /// periphery:ignore - to be used later when applying filter
     ///
     public let id: Int64
 

--- a/Modules/Sources/Yosemite/Model/Bookings/BookingProductFilter.swift
+++ b/Modules/Sources/Yosemite/Model/Bookings/BookingProductFilter.swift
@@ -1,9 +1,11 @@
-// periphery:ignore:all - will be used for booking filters
 import Foundation
 
 /// Used to filter bookings by product
 ///
 public struct BookingProductFilter: Codable, Hashable {
+    /// The underlying product
+    public let product: Product
+
     /// ID of the product
     ///
     public let id: Int64
@@ -12,9 +14,9 @@ public struct BookingProductFilter: Codable, Hashable {
     ///
     public let name: String
 
-    public init(id: Int64,
-         name: String) {
-        self.id = id
-        self.name = name
+    public init(product: Product) {
+        self.id = product.productID
+        self.name = product.name
+        self.product = product
     }
 }

--- a/Modules/Sources/Yosemite/Model/Bookings/BookingProductFilter.swift
+++ b/Modules/Sources/Yosemite/Model/Bookings/BookingProductFilter.swift
@@ -3,21 +3,17 @@ import Foundation
 /// Used to filter bookings by product
 ///
 public struct BookingProductFilter: Codable, Hashable {
-    /// The underlying product
-    public let product: Product
-
     /// ID of the product
     /// periphery:ignore - to be used later when applying filter
     ///
-    public let id: Int64
+    public let productID: Int64
 
     /// Name of the product
     ///
     public let name: String
 
-    public init(product: Product) {
-        self.id = product.productID
-        self.name = product.name
-        self.product = product
+    public init(productID: Int64, name: String) {
+        self.productID = productID
+        self.name = name
     }
 }

--- a/WooCommerce/Classes/Bookings/BookingFilters/BookableProductListSyncable.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/BookableProductListSyncable.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Yosemite
+
+/// Syncable implementation for booking services/events (bookable product) filtering
+struct BookableProductListSyncable: ListSyncable {
+    typealias StorageType = StorageProduct
+    typealias ModelType = Product
+
+    let siteID: Int64
+
+    var title: String { Localization.title }
+
+    var emptyStateMessage: String { Localization.noMembersFound }
+
+    // MARK: - ResultsController Configuration
+
+    func createPredicate() -> NSPredicate {
+        NSPredicate(format: "siteID == %lld AND productTypeKey == %@", siteID, ProductType.booking.rawValue)
+    }
+
+    func createSortDescriptors() -> [NSSortDescriptor] {
+        [NSSortDescriptor(key: "productID", ascending: false)]
+    }
+
+    // MARK: - Sync Configuration
+
+    func createSyncAction(
+        pageNumber: Int,
+        pageSize: Int,
+        completion: @escaping (Result<Bool, Error>) -> Void
+    ) -> Action {
+        ProductAction.synchronizeProducts(
+            siteID: siteID,
+            pageNumber: pageNumber,
+            pageSize: pageSize,
+            stockStatus: nil,
+            productStatus: nil,
+            productType: .booking,
+            productCategory: nil,
+            sortOrder: .dateDescending,
+            productIDs: [],
+            excludedProductIDs: [],
+            shouldDeleteStoredProductsOnFirstPage: true,
+            onCompletion: completion
+        )
+    }
+
+    // MARK: - Display Configuration
+
+    func displayName(for item: Product) -> String {
+        item.name
+    }
+}
+
+private extension BookableProductListSyncable {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "bookingServiceEventSelectorView.title",
+            value: "Service / Event",
+            comment: "Title of the booking service/event selector view"
+        )
+        static let noMembersFound = NSLocalizedString(
+            "bookingServiceEventSelectorView.noMembersFound",
+            value: "No service or event found",
+            comment: "Text on the empty view of the booking service/event selector view"
+        )
+    }
+}

--- a/WooCommerce/Classes/Bookings/BookingFilters/BookingFiltersViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/BookingFiltersViewModel.swift
@@ -188,7 +188,7 @@ extension BookingFiltersViewModel.BookingListFilter {
                                        selectedValue: filters.teamMember)
         case .product(let siteID):
             return FilterTypeViewModel(title: title,
-                                       listSelectorConfig: .products(siteID: siteID),
+                                       listSelectorConfig: .bookableProduct(siteID: siteID),
                                        selectedValue: filters.product)
         case .customer(let siteID):
             return FilterTypeViewModel(title: title,

--- a/WooCommerce/Classes/Bookings/BookingFilters/BookingFiltersViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/BookingFiltersViewModel.swift
@@ -27,9 +27,9 @@ final class BookingFiltersViewModel: FilterListViewModel {
         filterTypeViewModels = [
             teamMemberFilterViewModel,
             productFilterViewModel,
-            customerFilterViewModel,
             attendanceStatusFilterViewModel,
             paymentStatusFilterViewModel,
+            customerFilterViewModel,
             dateTimeFilterViewModel
         ]
     }

--- a/WooCommerce/Classes/Bookings/BookingFilters/BookingFiltersViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/BookingFiltersViewModel.swift
@@ -192,7 +192,7 @@ extension BookingFiltersViewModel.BookingListFilter {
                                        selectedValue: filters.product)
         case .customer(let siteID):
             return FilterTypeViewModel(title: title,
-                                       listSelectorConfig: .customer(siteID: siteID),
+                                       listSelectorConfig: .customer(siteID: siteID, source: .booking),
                                        selectedValue: filters.customer)
         case .attendanceStatus:
             let options: [BookingAttendanceStatus?] = [nil, .booked, .checkedIn, .cancelled, .noShow]

--- a/WooCommerce/Classes/Bookings/BookingFilters/CustomerSelector+BookingFilter.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/CustomerSelector+BookingFilter.swift
@@ -8,7 +8,8 @@ extension CustomerSelectorViewController.Configuration {
         disallowCreatingCustomer: true,
         showGuestLabel: true,
         shouldTrackCustomerAdded: false,
-        isModal: false
+        isModal: false,
+        hideDetailText: true
     )
 
     enum BookingFilterLocalization {

--- a/WooCommerce/Classes/Bookings/BookingFilters/CustomerSelector+BookingFilter.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/CustomerSelector+BookingFilter.swift
@@ -4,6 +4,7 @@ extension CustomerSelectorViewController.Configuration {
     static let configurationForBookingFilter = CustomerSelectorViewController.Configuration(
         title: BookingFilterLocalization.customerSelectorTitle,
         disallowSelectingGuest: true,
+        guestDisallowedMessage: BookingFilterLocalization.guestSelectionDisallowedError,
         disallowCreatingCustomer: true,
         showGuestLabel: true,
         shouldTrackCustomerAdded: false,
@@ -14,6 +15,12 @@ extension CustomerSelectorViewController.Configuration {
         static let customerSelectorTitle = NSLocalizedString(
             "configurationForBookingFilter.customerName",
             value: "Customer name",
-            comment: "Title for the screen to select customer in booking filtering.")
+            comment: "Title for the screen to select customer in booking filtering."
+        )
+        static let guestSelectionDisallowedError = NSLocalizedString(
+            "configurationForBookingFilter.guestSelectionDisallowedError",
+            value: "This user is a guest, and guests can’t be used for filtering bookings.",
+            comment: "Error message when selecting guest customer in booking filtering"
+        )
     }
 }

--- a/WooCommerce/Classes/Bookings/BookingFilters/CustomerSelector+BookingFilter.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/CustomerSelector+BookingFilter.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+extension CustomerSelectorViewController.Configuration {
+    static let configurationForBookingFilter = CustomerSelectorViewController.Configuration(
+        title: BookingFilterLocalization.customerSelectorTitle,
+        disallowSelectingGuest: true,
+        disallowCreatingCustomer: true,
+        showGuestLabel: true,
+        shouldTrackCustomerAdded: false,
+        isModal: false
+    )
+
+    enum BookingFilterLocalization {
+        static let customerSelectorTitle = NSLocalizedString(
+            "configurationForBookingFilter.customerName",
+            value: "Customer name",
+            comment: "Title for the screen to select customer in booking filtering.")
+    }
+}

--- a/WooCommerce/Classes/Bookings/BookingFilters/SyncableListSelectorView.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/SyncableListSelectorView.swift
@@ -5,17 +5,18 @@ struct SyncableListSelectorView<Syncable: ListSyncable>: View {
     @State var selectedItem: Syncable.ModelType?
 
     private let syncable: Syncable
+    private let initialSelection: (Syncable.ModelType?) -> Bool
     private let onSelection: (Syncable.ModelType?) -> Void
 
     private let viewPadding: CGFloat = 16
 
     init(viewModel: SyncableListSelectorViewModel<Syncable>,
          syncable: Syncable,
-         selectedItem: Syncable.ModelType?,
+         initialSelection: @escaping (Syncable.ModelType?) -> Bool,
          onSelection: @escaping (Syncable.ModelType?) -> Void) {
         self.viewModel = viewModel
         self.syncable = syncable
-        self.selectedItem = selectedItem
+        self.initialSelection = initialSelection
         self.onSelection = onSelection
     }
 
@@ -68,7 +69,7 @@ private extension SyncableListSelectorView {
 
             ForEach(items, id: \.self) { item in
                 optionRow(text: syncable.displayName(for: item),
-                          isSelected: item == selectedItem,
+                          isSelected: isItemSelected(item),
                           onSelection: { selectedItem = item })
             }
 
@@ -80,6 +81,13 @@ private extension SyncableListSelectorView {
         }
         .listStyle(.plain)
         .background(Color(.listBackground))
+    }
+
+    func isItemSelected(_ item: Syncable.ModelType?) -> Bool {
+        if let selectedItem {
+            return item == selectedItem
+        }
+        return initialSelection(item)
     }
 
     func optionRow(text: String, isSelected: Bool, onSelection: @escaping () -> Void) -> some View {

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -96,6 +96,8 @@ enum FilterListValueSelectorConfig {
     case customer(siteID: Int64)
     // Filter list selector for booking team member
     case bookingResource(siteID: Int64)
+    // Filter list selector for bookable product
+    case bookableProduct(siteID: Int64)
 
 }
 
@@ -371,6 +373,27 @@ private extension FilterListViewController {
                     selectedItem: selectedMember,
                     onSelection: { [weak self] resource in
                         selected.selectedValue = resource
+                        self?.updateUI(numberOfActiveFilters: self?.viewModel.filterTypeViewModels.numberOfActiveFilters ?? 0)
+                        self?.listSelector.reloadData()
+                        self?.listSelector.navigationController?.popViewController(animated: true)
+                    }
+                )
+                let hostingController = UIHostingController(rootView: memberListSelectorView)
+                listSelector.navigationController?.pushViewController(hostingController, animated: true)
+
+            case .bookableProduct(let siteID):
+                let selectedProduct = selected.selectedValue as? BookingProductFilter
+                let syncable = BookableProductListSyncable(siteID: siteID)
+                let viewModel = SyncableListSelectorViewModel(syncable: syncable)
+                let memberListSelectorView = SyncableListSelectorView(
+                    viewModel: viewModel,
+                    syncable: syncable,
+                    selectedItem: selectedProduct?.product,
+                    onSelection: { [weak self] product in
+                        selected.selectedValue = {
+                            guard let product else { return BookingProductFilter?.none }
+                            return BookingProductFilter(product: product)
+                        }()
                         self?.updateUI(numberOfActiveFilters: self?.viewModel.filterTypeViewModels.numberOfActiveFilters ?? 0)
                         self?.listSelector.reloadData()
                         self?.listSelector.navigationController?.popViewController(animated: true)

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -93,7 +93,7 @@ enum FilterListValueSelectorConfig {
     // Filter list selector for products
     case products(siteID: Int64)
     // Filter list selector for customer
-    case customer(siteID: Int64)
+    case customer(siteID: Int64, source: FilterSource)
     // Filter list selector for booking team member
     case bookingResource(siteID: Int64)
     // Filter list selector for bookable product
@@ -343,26 +343,30 @@ private extension FilterListViewController {
                 }()
                 self.listSelector.present(controller, animated: true)
 
-            case .customer(let siteID):
+            case .customer(let siteID, let source):
+                let configuration: CustomerSelectorViewController.Configuration = {
+                    switch source {
+                    case .booking: .configurationForBookingFilter
+                    case .orders: .configurationForOrderFilter
+                    case .products: fatalError("Customer filter not supported!")
+                    }
+                }()
                 let controller: CustomerSelectorViewController = {
                     return CustomerSelectorViewController(
                         siteID: siteID,
-                        configuration: .configurationForOrderFilter,
+                        configuration: configuration,
                         addressFormViewModel: nil,
                         onCustomerSelected: { [weak self] customer in
                             selected.selectedValue = CustomerFilter(customer: customer)
 
                             self?.updateUI(numberOfActiveFilters: self?.viewModel.filterTypeViewModels.numberOfActiveFilters ?? 0)
                             self?.listSelector.reloadData()
-                            self?.listSelector.dismiss(animated: true)
+                            self?.listSelector.navigationController?.popViewController(animated: true)
                         }
                     )
                 }()
 
-                self.listSelector.present(
-                    WooNavigationController(rootViewController: controller),
-                    animated: true
-                )
+                self.listSelector.navigationController?.pushViewController(controller, animated: true)
             case .bookingResource(let siteID):
                 let selectedMember = selected.selectedValue as? BookingResource
                 let syncable = TeamMemberListSyncable(siteID: siteID)

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -351,11 +351,13 @@ private extension FilterListViewController {
                     case .products: fatalError("Customer filter not supported!")
                     }
                 }()
+                let selectedCustomerID = (selected.selectedValue as? CustomerFilter)?.id
                 let controller: CustomerSelectorViewController = {
                     return CustomerSelectorViewController(
                         siteID: siteID,
                         configuration: configuration,
                         addressFormViewModel: nil,
+                        selectedCustomerID: selectedCustomerID,
                         onCustomerSelected: { [weak self] customer in
                             selected.selectedValue = CustomerFilter(customer: customer)
 

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -375,7 +375,7 @@ private extension FilterListViewController {
                 let memberListSelectorView = SyncableListSelectorView(
                     viewModel: viewModel,
                     syncable: syncable,
-                    selectedItem: selectedMember,
+                    initialSelection: { $0 == selectedMember },
                     onSelection: { [weak self] resource in
                         selected.selectedValue = resource
                         self?.updateUI(numberOfActiveFilters: self?.viewModel.filterTypeViewModels.numberOfActiveFilters ?? 0)
@@ -392,11 +392,11 @@ private extension FilterListViewController {
                 let memberListSelectorView = SyncableListSelectorView(
                     viewModel: viewModel,
                     syncable: syncable,
-                    selectedItem: selectedProduct?.product,
+                    initialSelection: { $0?.productID == selectedProduct?.productID },
                     onSelection: { [weak self] product in
                         selected.selectedValue = {
                             guard let product else { return BookingProductFilter?.none }
-                            return BookingProductFilter(product: product)
+                            return BookingProductFilter(productID: product.productID, name: product.name)
                         }()
                         self?.updateUI(numberOfActiveFilters: self?.viewModel.filterTypeViewModels.numberOfActiveFilters ?? 0)
                         self?.listSelector.reloadData()

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -363,7 +363,6 @@ private extension FilterListViewController {
 
                             self?.updateUI(numberOfActiveFilters: self?.viewModel.filterTypeViewModels.numberOfActiveFilters ?? 0)
                             self?.listSelector.reloadData()
-                            self?.listSelector.navigationController?.popViewController(animated: true)
                         }
                     )
                 }()
@@ -381,7 +380,6 @@ private extension FilterListViewController {
                         selected.selectedValue = resource
                         self?.updateUI(numberOfActiveFilters: self?.viewModel.filterTypeViewModels.numberOfActiveFilters ?? 0)
                         self?.listSelector.reloadData()
-                        self?.listSelector.navigationController?.popViewController(animated: true)
                     }
                 )
                 let hostingController = UIHostingController(rootView: memberListSelectorView)
@@ -402,7 +400,6 @@ private extension FilterListViewController {
                         }()
                         self?.updateUI(numberOfActiveFilters: self?.viewModel.filterTypeViewModels.numberOfActiveFilters ?? 0)
                         self?.listSelector.reloadData()
-                        self?.listSelector.navigationController?.popViewController(animated: true)
                     }
                 )
                 let hostingController = UIHostingController(rootView: memberListSelectorView)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -157,9 +157,12 @@ final class CustomerSearchUICommand: SearchUICommand {
         let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
         let newCustomerSelectorIsEnabled = featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder)
-        let descriptor = newCustomerSelectorIsEnabled ?
-        NSSortDescriptor(keyPath: \StorageCustomer.firstName, ascending: true) : NSSortDescriptor(keyPath: \StorageCustomer.customerID, ascending: false)
-        return ResultsController<StorageCustomer>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+        let descriptors = newCustomerSelectorIsEnabled ?
+        [
+            NSSortDescriptor(keyPath: \StorageCustomer.firstName, ascending: true),
+            NSSortDescriptor(keyPath: \StorageCustomer.customerID, ascending: true)
+        ] : [NSSortDescriptor(keyPath: \StorageCustomer.customerID, ascending: false)]
+        return ResultsController<StorageCustomer>(storageManager: storageManager, matching: predicate, sortedBy: descriptors)
     }
 
     func createStarterViewController() -> UIViewController? {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -61,12 +61,16 @@ final class CustomerSearchUICommand: SearchUICommand {
     // Whether to hide button for creating customer in empty state
     private let disallowCreatingCustomer: Bool
 
+    // The currently selected customer ID to show checkmark
+    private let selectedCustomerID: Int64?
+
     init(siteID: Int64,
          loadResultsWhenSearchTermIsEmpty: Bool = false,
          showSearchFilters: Bool = false,
          showGuestLabel: Bool = false,
          shouldTrackCustomerAdded: Bool = true,
          disallowCreatingCustomer: Bool = false,
+         selectedCustomerID: Int64? = nil,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
@@ -80,6 +84,7 @@ final class CustomerSearchUICommand: SearchUICommand {
         self.showGuestLabel = showGuestLabel
         self.shouldTrackCustomerAdded = shouldTrackCustomerAdded
         self.disallowCreatingCustomer = disallowCreatingCustomer
+        self.selectedCustomerID = selectedCustomerID
         self.stores = stores
         self.analytics = analytics
         self.featureFlagService = featureFlagService
@@ -172,6 +177,7 @@ final class CustomerSearchUICommand: SearchUICommand {
 
     func createCellViewModel(model: Customer) -> UnderlineableTitleAndSubtitleAndDetailTableViewCell.ViewModel {
         let detail = showGuestLabel && model.customerID == 0 ? Localization.guestLabel : model.username ?? ""
+        let isSelected = selectedCustomerID == model.customerID
 
         return CellViewModel(
             id: "\(model.customerID)",
@@ -181,7 +187,8 @@ final class CustomerSearchUICommand: SearchUICommand {
             subtitle: model.email,
             accessibilityLabel: "",
             detail: detail,
-            underlinedText: searchTerm?.count ?? 0 > 1 ? searchTerm : "" // Only underline the search term if it's longer than 1 character
+            underlinedText: searchTerm?.count ?? 0 > 1 ? searchTerm : "", // Only underline the search term if it's longer than 1 character
+            isSelected: isSelected
         )
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -65,7 +65,7 @@ final class CustomerSearchUICommand: SearchUICommand {
     private let hideDetailText: Bool
 
     // The currently selected customer ID to show checkmark
-    private let selectedCustomerID: Int64?
+    private var selectedCustomerID: Int64?
 
     init(siteID: Int64,
          loadResultsWhenSearchTermIsEmpty: Bool = false,
@@ -97,6 +97,10 @@ final class CustomerSearchUICommand: SearchUICommand {
         self.onDidSelectSearchResult = onDidSelectSearchResult
         self.onDidStartSyncingAllCustomersFirstPage = onDidStartSyncingAllCustomersFirstPage
         self.onDidFinishSyncingAllCustomersFirstPage = onDidFinishSyncingAllCustomersFirstPage
+    }
+
+    func updateSelectedCustomerID(_ customerID: Int64?) {
+        self.selectedCustomerID = customerID
     }
 
     var hideCancelButton: Bool {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -61,6 +61,9 @@ final class CustomerSearchUICommand: SearchUICommand {
     // Whether to hide button for creating customer in empty state
     private let disallowCreatingCustomer: Bool
 
+    // Whether to hide the detail text (username or "Guest") in each customer row
+    private let hideDetailText: Bool
+
     // The currently selected customer ID to show checkmark
     private let selectedCustomerID: Int64?
 
@@ -70,6 +73,7 @@ final class CustomerSearchUICommand: SearchUICommand {
          showGuestLabel: Bool = false,
          shouldTrackCustomerAdded: Bool = true,
          disallowCreatingCustomer: Bool = false,
+         hideDetailText: Bool = false,
          selectedCustomerID: Int64? = nil,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
@@ -84,6 +88,7 @@ final class CustomerSearchUICommand: SearchUICommand {
         self.showGuestLabel = showGuestLabel
         self.shouldTrackCustomerAdded = shouldTrackCustomerAdded
         self.disallowCreatingCustomer = disallowCreatingCustomer
+        self.hideDetailText = hideDetailText
         self.selectedCustomerID = selectedCustomerID
         self.stores = stores
         self.analytics = analytics
@@ -176,7 +181,10 @@ final class CustomerSearchUICommand: SearchUICommand {
     }
 
     func createCellViewModel(model: Customer) -> UnderlineableTitleAndSubtitleAndDetailTableViewCell.ViewModel {
-        let detail = showGuestLabel && model.customerID == 0 ? Localization.guestLabel : model.username ?? ""
+        let detail: String = {
+            guard !hideDetailText else { return "" }
+            return showGuestLabel && model.customerID == 0 ? Localization.guestLabel : model.username ?? ""
+        }()
         let isSelected = selectedCustomerID == model.customerID
 
         return CellViewModel(

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -13,6 +13,7 @@ final class CustomerSelectorViewController: UIViewController, GhostableViewContr
     private let onCustomerSelected: (Customer) -> Void
     private let viewModel: CustomerSelectorViewModel
     private let addressFormViewModel: CreateOrderAddressFormViewModel?
+    private let selectedCustomerID: Int64?
 
     let configuration: CustomerSelectorViewController.Configuration
 
@@ -35,11 +36,13 @@ final class CustomerSelectorViewController: UIViewController, GhostableViewContr
     ///   - siteID: ID of the current site
     ///   - configuration: UI configuration for the view controller
     ///   - addressFormViewModel: Optional, has to be provided if the view has to include new customer creation.
+    ///   - selectedCustomerID: Optional, ID of the currently selected customer to show checkmark
     ///   - onCustomerSelected: Callback to be called when a customer is selected
     ///
     init(siteID: Int64,
          configuration: CustomerSelectorViewController.Configuration,
          addressFormViewModel: CreateOrderAddressFormViewModel?,
+         selectedCustomerID: Int64? = nil,
          onCustomerSelected: @escaping (Customer) -> Void) {
         viewModel = CustomerSelectorViewModel(
             siteID: siteID,
@@ -48,6 +51,7 @@ final class CustomerSelectorViewController: UIViewController, GhostableViewContr
         self.siteID = siteID
         self.configuration = configuration
         self.addressFormViewModel = addressFormViewModel
+        self.selectedCustomerID = selectedCustomerID
         self.onCustomerSelected = onCustomerSelected
 
         super.init(nibName: nil, bundle: nil)
@@ -73,6 +77,9 @@ extension CustomerSelectorViewController {
 
         // Whether guest-type customers can be selected or not
         var disallowSelectingGuest: Bool
+
+        // Error message when selecting guest if disallowed
+        var guestDisallowedMessage = Localization.guestSelectionDisallowedError
 
         // Whether to show or hide button to create customer
         var disallowCreatingCustomer: Bool
@@ -198,6 +205,7 @@ private extension CustomerSelectorViewController {
                                              showGuestLabel: showGuestLabel,
                                              shouldTrackCustomerAdded: shouldTrackCustomerAdded,
                                              disallowCreatingCustomer: disallowCreatingCustomer,
+                                             selectedCustomerID: selectedCustomerID,
                                              onAddCustomerDetailsManually: onAddCustomerDetailsManually,
                                              onDidSelectSearchResult: onCustomerTapped,
                                              onDidStartSyncingAllCustomersFirstPage: {
@@ -290,7 +298,7 @@ private extension CustomerSelectorViewController {
 
     func showGuestSelectionDisallowedNotice() {
         noticePresenter.presentingViewController = self
-        noticePresenter.enqueue(notice: Notice(title: Localization.guestSelectionDisallowedError, feedbackType: .error))
+        noticePresenter.enqueue(notice: Notice(title: configuration.guestDisallowedMessage, feedbackType: .error))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -82,6 +82,9 @@ extension CustomerSelectorViewController {
 
         // Whether to track when a customer cell is tapped.
         var shouldTrackCustomerAdded: Bool
+
+        // Whether the selector is presented modally
+        var isModal: Bool
     }
 }
 
@@ -134,7 +137,9 @@ private extension CustomerSelectorViewController {
 
     func configureNavigation() {
         navigationItem.title = configuration.title
-        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelWasPressed))
+        if configuration.isModal {
+            navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelWasPressed))
+        }
 
         if !configuration.disallowCreatingCustomer {
             navigationItem.rightBarButtonItem = UIBarButtonItem(image: .plusBarButtonItemImage,
@@ -264,13 +269,16 @@ private extension CustomerSelectorViewController {
 
         activityIndicator.startAnimating()
         viewModel.onCustomerSelected(customer, onCompletion: { [weak self] result in
-            self?.activityIndicator.stopAnimating()
+            guard let self else { return }
+            activityIndicator.stopAnimating()
 
             switch result {
             case .success:
-                self?.dismiss(animated: true)
+                if configuration.isModal {
+                    dismiss(animated: true)
+                }
             case .failure:
-                self?.showErrorNotice()
+                showErrorNotice()
             }
         })
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -8,6 +8,7 @@ import Yosemite
 ///
 final class CustomerSelectorViewController: UIViewController, GhostableViewController {
     private var searchViewController: SearchViewController<UnderlineableTitleAndSubtitleAndDetailTableViewCell, CustomerSearchUICommand>?
+    private var customerSearchCommand: CustomerSearchUICommand?
     private var emptyStateViewController: UIViewController?
     private let siteID: Int64
     private let onCustomerSelected: (Customer) -> Void
@@ -200,31 +201,34 @@ private extension CustomerSelectorViewController {
                                  shouldTrackCustomerAdded: Bool,
                                  disallowCreatingCustomer: Bool,
                                  onAddCustomerDetailsManually: (() -> Void)? = nil) {
+        let command = CustomerSearchUICommand(siteID: siteID,
+                                              loadResultsWhenSearchTermIsEmpty: loadResultsWhenSearchTermIsEmpty,
+                                              showSearchFilters: showSearchFilters,
+                                              showGuestLabel: showGuestLabel,
+                                              shouldTrackCustomerAdded: shouldTrackCustomerAdded,
+                                              disallowCreatingCustomer: disallowCreatingCustomer,
+                                              hideDetailText: configuration.hideDetailText,
+                                              selectedCustomerID: selectedCustomerID,
+                                              onAddCustomerDetailsManually: onAddCustomerDetailsManually,
+                                              onDidSelectSearchResult: onCustomerTapped,
+                                              onDidStartSyncingAllCustomersFirstPage: {
+                                                  Task { @MainActor [weak self] in
+                                                      guard let searchTableView = self?.searchViewController?.tableView else {
+                                                          return
+                                                      }
+                                                      self?.displayGhostContent(over: searchTableView)
+                                                  }
+                                              },
+                                              onDidFinishSyncingAllCustomersFirstPage: {
+                                                  Task { @MainActor [weak self] in
+                                                      self?.removeGhostContent()
+                                                  }
+                                              })
+        self.customerSearchCommand = command
+
         let searchViewController = SearchViewController(
             storeID: siteID,
-            command: CustomerSearchUICommand(siteID: siteID,
-                                             loadResultsWhenSearchTermIsEmpty: loadResultsWhenSearchTermIsEmpty,
-                                             showSearchFilters: showSearchFilters,
-                                             showGuestLabel: showGuestLabel,
-                                             shouldTrackCustomerAdded: shouldTrackCustomerAdded,
-                                             disallowCreatingCustomer: disallowCreatingCustomer,
-                                             hideDetailText: configuration.hideDetailText,
-                                             selectedCustomerID: selectedCustomerID,
-                                             onAddCustomerDetailsManually: onAddCustomerDetailsManually,
-                                             onDidSelectSearchResult: onCustomerTapped,
-                                             onDidStartSyncingAllCustomersFirstPage: {
-                                                 Task { @MainActor [weak self] in
-                                                     guard let searchTableView = self?.searchViewController?.tableView else {
-                                                         return
-                                                     }
-                                                     self?.displayGhostContent(over: searchTableView)
-                                                 }
-                                             },
-                                             onDidFinishSyncingAllCustomersFirstPage: {
-                                                 Task { @MainActor [weak self] in
-                                                     self?.removeGhostContent()
-                                                 }
-                                             }),
+            command: command,
             cellType: UnderlineableTitleAndSubtitleAndDetailTableViewCell.self,
             cellSeparator: .none
         )
@@ -283,6 +287,8 @@ private extension CustomerSelectorViewController {
         viewModel.onCustomerSelected(customer, onCompletion: { [weak self] result in
             guard let self else { return }
             activityIndicator.stopAnimating()
+            customerSearchCommand?.updateSelectedCustomerID(customer.customerID)
+            searchViewController?.tableView.reloadData()
 
             switch result {
             case .success:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -92,6 +92,9 @@ extension CustomerSelectorViewController {
 
         // Whether the selector is presented modally
         var isModal: Bool
+
+        // Whether to hide the detail text (username or "Guest") in each customer row
+        var hideDetailText: Bool = false
     }
 }
 
@@ -205,6 +208,7 @@ private extension CustomerSelectorViewController {
                                              showGuestLabel: showGuestLabel,
                                              shouldTrackCustomerAdded: shouldTrackCustomerAdded,
                                              disallowCreatingCustomer: disallowCreatingCustomer,
+                                             hideDetailText: configuration.hideDetailText,
                                              selectedCustomerID: selectedCustomerID,
                                              onAddCustomerDetailsManually: onAddCustomerDetailsManually,
                                              onDidSelectSearchResult: onCustomerTapped,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/Legacy/LegacyOrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/Legacy/LegacyOrderCustomerSection.swift
@@ -47,7 +47,8 @@ private extension CustomerSelectorViewController.Configuration {
         disallowSelectingGuest: false,
         disallowCreatingCustomer: false,
         showGuestLabel: false,
-        shouldTrackCustomerAdded: true
+        shouldTrackCustomerAdded: true,
+        isModal: true
     )
 
     enum OrderCustomerLocalization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -32,7 +32,8 @@ struct OrderCustomerSection: View {
                         disallowSelectingGuest: viewModel.isCustomerAccountRequired,
                         disallowCreatingCustomer: true,
                         showGuestLabel: false,
-                        shouldTrackCustomerAdded: true
+                        shouldTrackCustomerAdded: true,
+                        isModal: true
                     ),
                     addressFormViewModel: viewModel.addressFormViewModel) { customer in
                         viewModel.addCustomerFromSearch(customer)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/CustomerSelector+Filter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/CustomerSelector+Filter.swift
@@ -6,7 +6,8 @@ extension CustomerSelectorViewController.Configuration {
         disallowSelectingGuest: true,
         disallowCreatingCustomer: true,
         showGuestLabel: true,
-        shouldTrackCustomerAdded: false
+        shouldTrackCustomerAdded: false,
+        isModal: false
     )
 
     enum OrderFilterLocalization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
@@ -265,7 +265,7 @@ extension FilterOrderListViewModel.OrderListFilter {
                                        selectedValue: filters.product)
         case .customer(let siteID):
             return FilterTypeViewModel(title: title,
-                                       listSelectorConfig: .customer(siteID: siteID),
+                                       listSelectorConfig: .customer(siteID: siteID, source: .orders),
                                        selectedValue: filters.customer)
         case .salesChannel:
             let salesChannelOptions: [SalesChannelFilter] = [.any, .pointOfSale, .webCheckout, .wpAdmin]

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UnderlineableTitleAndSubtitleAndDetailTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UnderlineableTitleAndSubtitleAndDetailTableViewCell.swift
@@ -13,12 +13,14 @@ final class UnderlineableTitleAndSubtitleAndDetailTableViewCell: UITableViewCell
     override func awakeFromNib() {
         super.awakeFromNib()
         configureBackground()
+        accessoryType = .none
     }
 
     func configureCell(searchModel: ViewModel) {
         accessibilityLabel = searchModel.accessibilityLabel
         setupTitleLabelText(with: searchModel)
         subtitleLabel.attributedText = subtitleAttributedString(from: searchModel)
+        accessoryType = searchModel.isSelected ? .checkmark : .none
     }
 
     override func updateConfiguration(using state: UICellConfigurationState) {
@@ -42,6 +44,7 @@ extension UnderlineableTitleAndSubtitleAndDetailTableViewCell {
         let accessibilityLabel: String
         let detail: String
         let underlinedText: String?
+        let isSelected: Bool
     }
 }
 
@@ -54,7 +57,7 @@ private extension UnderlineableTitleAndSubtitleAndDetailTableViewCell {
                                              attributes: [.font: UIFont.caption1, .foregroundColor: UIColor.textTertiary])
         }
 
-        let subtitle = NSMutableAttributedString(string: viewModel.subtitle, attributes: [.font: UIFont.caption1, .foregroundColor: UIColor.text])
+        let subtitle = NSMutableAttributedString(string: viewModel.subtitle, attributes: [.font: UIFont.caption1, .foregroundColor: UIColor.secondaryLabel])
 
         if let underlinedText = viewModel.underlinedText {
             subtitle.underlineSubstring(underlinedText: underlinedText)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of WOOMOB-1240

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the selector for Service/Event and Customer name filters for bookings:
- Adds a new type conforming to `ListSyncable` to support showing selector for bookable products (named as Service/Event on the UI).
- Updates the Customer selector:
  - Renames the title to match the filter option for bookings
  - Updates the navigation to use push instead of modal.
  - Adds new configuration for the presentation type to ensure that the selector is still presented modally from order creation form.
  - Update UI for the customer rows to better match the design. I'm keeping the search bar for simplicity.
  - Avoid dismiss selector upon selection. We'll need to support multiple selection in a subsequent PR.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Log in to a CIAB site with existing bookings.
- Navigate to Bookings > All > Filter.
- Select Service/Event and confirm that only bookable products are displayed. Selecting any option should show a checkmark next to the option. Dismissing the view should display the product name on the filter screen.
- Select Customer name and confirm that the customer selector is pushed from the same navigation stack. 
- Confirm that the customer selector has the correct title and selecting any option would show a checkmark next to the option. Dismissing the view should display the customer name on the filter screen.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Tested and confirmed with simulator iPhone 17.
- Also checked the customer selector on Order filter and Order creation form and confirmed that no regression was made.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->



https://github.com/user-attachments/assets/fbc9a8ef-2e33-4463-88ae-8bfb59ae70cd




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.