### PR TITLE
[Woo POS][Settings] i2: Feature flag and initial reader connection

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -100,6 +100,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .pointOfSaleSurveys:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .pointOfSaleSettingsCardReaderFlow:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -207,4 +207,8 @@ public enum FeatureFlag: Int {
     /// Enables surveys for potential and current POS merchants
     ///
     case pointOfSaleSurveys
+
+    /// Enables card reader connection flow within POS settings
+    ///
+    case pointOfSaleSettingsCardReaderFlow
 }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsCardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsCardView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct POSSettingsCardView: View {
+    let title: String
+    let subtitle: String
+    let action: () -> Void
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: POSPadding.xSmall) {
+                Text(title)
+                    .font(.posBodyLargeRegular())
+                    .foregroundStyle(Color.posOnSurface)
+                    .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                Text(subtitle)
+                    .font(.posBodyMediumRegular())
+                    .foregroundStyle(.secondary)
+                    .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.posSurfaceContainerLowest)
+            .posItemCardBorderStyles()
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel("\(title), \(subtitle)")
+    }
+}
+
+#if DEBUG
+#Preview {
+    POSSettingsCardView(
+        title: "Documentation",
+        subtitle: "Learn more about accepting mobile payments",
+        action: { }
+    )
+}
+#endif

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsCardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsCardView.swift
@@ -5,8 +5,6 @@ struct POSSettingsCardView: View {
     let subtitle: String
     let action: () -> Void
 
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-
     var body: some View {
         Button(action: action) {
             VStack(alignment: .leading, spacing: POSPadding.xSmall) {

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsCardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsCardView.swift
@@ -11,15 +11,14 @@ struct POSSettingsCardView: View {
                 Text(title)
                     .font(.posBodyLargeRegular())
                     .foregroundStyle(Color.posOnSurface)
-                    .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                 Text(subtitle)
                     .font(.posBodyMediumRegular())
                     .foregroundStyle(.secondary)
-                    .dynamicTypeSize(...DynamicTypeSize.accessibility2)
             }
             .padding()
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color.posSurfaceContainerLowest)
+            .dynamicTypeSize(...DynamicTypeSize.accessibility2)
             .posItemCardBorderStyles()
         }
         .buttonStyle(.plain)

--- a/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -198,27 +198,9 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                     }
                     .padding()
                 }
-                Button {
-                    showCardReaderDocumentationModal = true
-                } label: {
-                    HStack(spacing: POSSpacing.medium) {
-                        Image(systemName: "doc.text")
-                            .font(.posBodyLargeRegular())
-                            .accessibilityHidden(true)
-                            .renderedIf(!dynamicTypeSize.isAccessibilitySize)
-
-                        VStack(alignment: .leading, spacing: POSPadding.xSmall) {
-                            Text(Localization.cardReaderDocumentationTitle)
-                                .font(.posBodyLargeRegular())
-                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
-                            Text(Localization.cardReaderDocumentationSubtitle)
-                                .font(.posBodyMediumRegular())
-                                .foregroundStyle(.secondary)
-                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
-                        }
-                        Spacer()
-                    }
-                }
+                POSSettingsCardView(title: Localization.cardReaderDocumentationTitle,
+                                    subtitle: Localization.cardReaderDocumentationSubtitle,
+                                    action: { showCardReaderDocumentationModal = true })
                 .padding()
                 .accessibilityAddTraits(.isButton)
                 .listRowSeparator(.hidden)
@@ -461,46 +443,5 @@ private extension PointOfSaleSettingsHardwareDetailView {
 #if DEBUG
 #Preview {
     PointOfSaleSettingsHardwareDetailView(settingsController: PointOfSaleSettingsPreviewController())
-}
-#endif
-
-
-struct POSSettingsCardView: View {
-    let title: String
-    let subtitle: String
-    let action: () -> Void
-
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-
-    var body: some View {
-        Button(action: action) {
-            VStack(alignment: .leading, spacing: POSPadding.xSmall) {
-                Text(title)
-                    .font(.posBodyLargeRegular())
-                    .foregroundStyle(Color.posOnSurface)
-                    .dynamicTypeSize(...DynamicTypeSize.accessibility2)
-                Text(subtitle)
-                    .font(.posBodyMediumRegular())
-                    .foregroundStyle(.secondary)
-                    .dynamicTypeSize(...DynamicTypeSize.accessibility2)
-            }
-            .padding()
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color.posSurfaceContainerLowest)
-            .posItemCardBorderStyles()
-        }
-        .buttonStyle(.plain)
-        .accessibilityAddTraits(.isButton)
-        .accessibilityLabel("\(title), \(subtitle)")
-    }
-}
-
-#if DEBUG
-#Preview {
-    POSSettingsCardView(
-        title: "Documentation",
-        subtitle: "Learn more about accepting mobile payments",
-        action: { }
-    )
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -74,6 +74,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                     if featureFlags.isFeatureFlagEnabled(.pointOfSaleSettingsCardReaderFlow) {
                         cardReadersView
                     } else {
+                        // TODO: Legacy view to be removed along feature flag on WOOMOB-1591
                         legacyCardReadersView
                     }
                 case .hardware(.scanners):
@@ -204,7 +205,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                     POSSettingsCardView(title: Localization.cardReaderConnectTitle,
                                         subtitle: Localization.cardReaderConnectSubtitle,
                                         action: {
-                        /* TODO: Trigger reader connection*/
+                        posModel.connectCardReader()
                     })
                 }
 
@@ -269,7 +270,8 @@ struct PointOfSaleSettingsHardwareDetailView: View {
     }
 }
 
-extension PointOfSaleSettingsHardwareDetailView {
+// MARK: - Navigation
+private extension PointOfSaleSettingsHardwareDetailView {
     enum HardwareDestination: Identifiable, CaseIterable {
         case cardReaders
         case scanners

--- a/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import struct WooFoundation.SafariView
 
 struct PointOfSaleSettingsHardwareDetailView: View {
+    @Environment(\.posFeatureFlags) private var featureFlags
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.posAnalytics) private var analytics
 
@@ -69,7 +70,11 @@ struct PointOfSaleSettingsHardwareDetailView: View {
             .navigationDestination(for: NavigationDestination.self) { destination in
                 switch destination {
                 case .hardware(.cardReaders):
-                    cardReadersView
+                    if featureFlags.isFeatureFlagEnabled(.pointOfSaleSettingsCardReaderFlow) {
+                        cardReadersView
+                    } else {
+                        legacyCardReadersView
+                    }
                 case .hardware(.scanners):
                     scannersView
                 }
@@ -89,6 +94,75 @@ struct PointOfSaleSettingsHardwareDetailView: View {
             showBarcodeScanningSetupModal = true
         case .documentation:
             showBarcodeScanningDocumentationModal = true
+        }
+    }
+
+    private var legacyCardReadersView: some View {
+        VStack(spacing: POSSpacing.none) {
+            POSPageHeaderView(
+                title: Localization.cardReadersTitle,
+                backButtonConfiguration: .init(state: .enabled, action: {
+                    navigationPath.removeLast()
+                }, buttonIcon: "chevron.left"))
+            .foregroundColor(.posSurface)
+
+            List {
+                VStack(spacing: POSPadding.xSmall) {
+                    HStack {
+                        Text(Localization.readerModelTitle)
+                            .font(.posBodyMediumRegular())
+                            .foregroundStyle(.primary)
+                        Spacer()
+                        Text(cardReaderName)
+                            .font(.posBodyMediumRegular())
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding()
+                    HStack {
+                        Text(Localization.readerBatteryTitle)
+                            .font(.posBodyMediumRegular())
+                            .foregroundStyle(.primary)
+                        Spacer()
+                        Text(formattedBatteryLevel)
+                            .font(.posBodyMediumRegular())
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding()
+                }
+                Button {
+                    showCardReaderDocumentationModal = true
+                } label: {
+                    HStack(spacing: POSSpacing.medium) {
+                        Image(systemName: "doc.text")
+                            .font(.posBodyLargeRegular())
+                            .accessibilityHidden(true)
+                            .renderedIf(!dynamicTypeSize.isAccessibilitySize)
+
+                        VStack(alignment: .leading, spacing: POSPadding.xSmall) {
+                            Text(Localization.cardReaderDocumentationTitle)
+                                .font(.posBodyLargeRegular())
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                            Text(Localization.cardReaderDocumentationSubtitle)
+                                .font(.posBodyMediumRegular())
+                                .foregroundStyle(.secondary)
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                        }
+                        Spacer()
+                    }
+                }
+                .padding()
+                .accessibilityAddTraits(.isButton)
+                .listRowSeparator(.hidden)
+            }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .listRowBackground(Color.clear)
+            .background(backgroundColor)
+            .foregroundColor(.posOnSurface)
+        }
+        .navigationBarBackButtonHidden(true)
+        .posFullScreenCover(isPresented: $showCardReaderDocumentationModal) {
+            SafariView(url: POSConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL())
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import struct WooFoundation.SafariView
 
 struct PointOfSaleSettingsHardwareDetailView: View {
+    @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.posFeatureFlags) private var featureFlags
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.posAnalytics) private var analytics
@@ -176,32 +177,40 @@ struct PointOfSaleSettingsHardwareDetailView: View {
             .foregroundColor(.posSurface)
 
             List {
-                VStack(spacing: POSPadding.xSmall) {
-                    HStack {
-                        Text(Localization.readerModelTitle)
-                            .font(.posBodyMediumRegular())
-                            .foregroundStyle(.primary)
-                        Spacer()
-                        Text(cardReaderName)
-                            .font(.posBodyMediumRegular())
-                            .foregroundStyle(.secondary)
+                if case .connected = posModel.cardReaderConnectionStatus {
+                    VStack(spacing: POSPadding.xSmall) {
+                        HStack {
+                            Text(Localization.readerModelTitle)
+                                .font(.posBodyMediumRegular())
+                                .foregroundStyle(.primary)
+                            Spacer()
+                            Text(cardReaderName)
+                                .font(.posBodyMediumRegular())
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding()
+                        HStack {
+                            Text(Localization.readerBatteryTitle)
+                                .font(.posBodyMediumRegular())
+                                .foregroundStyle(.primary)
+                            Spacer()
+                            Text(formattedBatteryLevel)
+                                .font(.posBodyMediumRegular())
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding()
                     }
-                    .padding()
-                    HStack {
-                        Text(Localization.readerBatteryTitle)
-                            .font(.posBodyMediumRegular())
-                            .foregroundStyle(.primary)
-                        Spacer()
-                        Text(formattedBatteryLevel)
-                            .font(.posBodyMediumRegular())
-                            .foregroundStyle(.secondary)
-                    }
-                    .padding()
+                } else {
+                    POSSettingsCardView(title: Localization.cardReaderConnectTitle,
+                                        subtitle: Localization.cardReaderConnectSubtitle,
+                                        action: {
+                        /* TODO: Trigger reader connection*/
+                    })
                 }
+
                 POSSettingsCardView(title: Localization.cardReaderDocumentationTitle,
                                     subtitle: Localization.cardReaderDocumentationSubtitle,
                                     action: { showCardReaderDocumentationModal = true })
-                .padding()
                 .accessibilityAddTraits(.isButton)
                 .listRowSeparator(.hidden)
             }
@@ -436,6 +445,16 @@ private extension PointOfSaleSettingsHardwareDetailView {
             "pointOfSaleSettingsHardwareDetailView.hardwareNavigationBarcodeSubtitle",
             value: "Configure barcode scanner settings",
             comment: "Description of Barcode scanner settings configuration."
+        )
+        static let cardReaderConnectTitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.cardReaderConnectTitle",
+            value: "Connect card reader",
+            comment: "Title for card reader connect button when no reader is connected."
+        )
+        static let cardReaderConnectSubtitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.cardReaderConnectSubtitle",
+            value: "Connect your card reader and start accepting payments",
+            comment: "Subtitle for card reader connect button when no reader is connected."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -463,3 +463,44 @@ private extension PointOfSaleSettingsHardwareDetailView {
     PointOfSaleSettingsHardwareDetailView(settingsController: PointOfSaleSettingsPreviewController())
 }
 #endif
+
+
+struct POSSettingsCardView: View {
+    let title: String
+    let subtitle: String
+    let action: () -> Void
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: POSPadding.xSmall) {
+                Text(title)
+                    .font(.posBodyLargeRegular())
+                    .foregroundStyle(Color.posOnSurface)
+                    .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                Text(subtitle)
+                    .font(.posBodyMediumRegular())
+                    .foregroundStyle(.secondary)
+                    .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.posSurfaceContainerLowest)
+            .posItemCardBorderStyles()
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel("\(title), \(subtitle)")
+    }
+}
+
+#if DEBUG
+#Preview {
+    POSSettingsCardView(
+        title: "Documentation",
+        subtitle: "Learn more about accepting mobile payments",
+        action: { }
+    )
+}
+#endif

--- a/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -182,25 +182,22 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                     VStack(spacing: POSPadding.xSmall) {
                         HStack {
                             Text(Localization.readerModelTitle)
-                                .font(.posBodyMediumRegular())
                                 .foregroundStyle(.primary)
                             Spacer()
                             Text(cardReaderName)
-                                .font(.posBodyMediumRegular())
                                 .foregroundStyle(.secondary)
                         }
                         .padding()
                         HStack {
                             Text(Localization.readerBatteryTitle)
-                                .font(.posBodyMediumRegular())
                                 .foregroundStyle(.primary)
                             Spacer()
                             Text(formattedBatteryLevel)
-                                .font(.posBodyMediumRegular())
                                 .foregroundStyle(.secondary)
                         }
                         .padding()
                     }
+                    .font(.posBodyMediumRegular())
                 } else {
                     POSSettingsCardView(title: Localization.cardReaderConnectTitle,
                                         subtitle: Localization.cardReaderConnectSubtitle,


### PR DESCRIPTION
Partially closes WOOMOB-1570

## Description
This PR starts the work to allow merchants to connect (and disconnect) their card reader directly from POS Settings. As first step we just add a feature flag, create a reusable card component, and allow basic connection without onboarding (it could fail discovery if we have multiple readers found). All changes are behind feature flag.

<img width="942" height="459" alt="Screenshot 2025-10-28 at 16 55 25" src="https://github.com/user-attachments/assets/f511f8a8-ecd4-4cec-b960-23120a943528" />


## Changes
- Add flag `pointOfSaleSettingsCardReaderFlow`.
- Make a copy of existing `cardReadersView` where we can apply the new designs.
- Make a new `POSSettingsCardView` which we'll reuse for other settings.
- Rather than showing the "not connected/unknown" card reader details when disconnected, we show now a new card to connect the reader instead.
- Triggers card reader connection when tapping "Connect card reader" directly in settings.

Presenting the modal connection flow is not implemented yet, this is just the scaffolding.

| Before: Hardware detail view | Before: Card reader view  |
|--------|--------|
| <img width="2266" height="1488" alt="2025-10-28 settings before 1" src="https://github.com/user-attachments/assets/6f203adb-69d7-44c9-a865-339b0a4850df" /> | <img width="2266" height="1488" alt="2025-10-28 settings before 2" src="https://github.com/user-attachments/assets/2a39c95a-74e5-4160-bec2-33ddf6235f52" /> | 

After

https://github.com/user-attachments/assets/4527e010-d3af-4a9d-a775-16fef1be20ac 

## Test Steps
- In POS, with a disconnected reader, go to Settings > Hardware > tap on `Connect card reader`.
- Wait until connection finishes ( you won't see the modal payment flow yet).
- Once connected, you will see model and battery details
