### PR TITLE
[Bookings] Attendance status update failure notice and retry

### DIFF
--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -233,13 +233,33 @@ extension BookingDetailsViewModel {
             siteID: booking.siteID,
             bookingID: booking.bookingID,
             status: newStatus
-        ) { error in
-            if let error {
+        ) { [weak self] error in
+            if let error, let self {
                 DDLogError("⛔️ Error updating booking attendance status: \(error)")
-                // TODO: Show an error notice to the user
+                displayAttendanceStatusUpdatedErrorNotice(status: newStatus)
             }
         }
         stores.dispatch(action)
+    }
+
+    private func displayAttendanceStatusUpdatedErrorNotice(status: BookingAttendanceStatus) {
+        let title = String.localizedStringWithFormat(
+            Localization.bookingAttendanceStatusUpdateFailedMessage,
+            booking.bookingID
+        )
+        let notice = Notice(
+            title: title,
+            feedbackType: .error,
+            actionTitle: Localization.retryActionTitle
+        ) { [weak self] in
+            guard let self else {
+                return
+            }
+
+            updateAttendanceStatus(to: status)
+        }
+
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 }
 
@@ -361,6 +381,20 @@ private extension BookingDetailsViewModel {
             "BookingDetailsView.cancelation.alert.message",
             value: "%1$@ will no longer be able to attend “%2$@” on %3$@.",
             comment: "Message for the booking cancellation confirmation alert. %1$@ is customer name, %2$@ is product name, %3$@ is booking date."
+        )
+
+        static let bookingAttendanceStatusUpdateFailedMessage = NSLocalizedString(
+            "BookingDetailsView.attendanceStatus.updateFailed.message",
+            value: "Unable to change attendance status of Booking #%1$d",
+            comment: "Content of error presented when updating the attendance status of a Booking fails. "
+            + "It reads: Unable to change status of Booking #{Booking number}. "
+            + "Parameters: %1$d - Booking number"
+        )
+
+        static let retryActionTitle = NSLocalizedString(
+            "BookingDetailsView.retry.action",
+            value: "Retry",
+            comment: "Retry Action"
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -27,6 +27,7 @@ final class BookingDetailsViewModel: ObservableObject {
 
     @Published private(set) var navigationTitle = ""
     @Published private(set) var sections: [Section] = []
+    @Published var notice: Notice?
 
     var bookingAttendanceStatus: BookingAttendanceStatus {
         booking.attendanceStatus
@@ -243,12 +244,12 @@ extension BookingDetailsViewModel {
     }
 
     private func displayAttendanceStatusUpdatedErrorNotice(status: BookingAttendanceStatus) {
-        let title = String.localizedStringWithFormat(
+        let text = String.localizedStringWithFormat(
             Localization.bookingAttendanceStatusUpdateFailedMessage,
             booking.bookingID
         )
-        let notice = Notice(
-            title: title,
+        self.notice = Notice(
+            message: text,
             feedbackType: .error,
             actionTitle: Localization.retryActionTitle
         ) { [weak self] in
@@ -258,8 +259,6 @@ extension BookingDetailsViewModel {
 
             updateAttendanceStatus(to: status)
         }
-
-        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -103,6 +103,7 @@ struct BookingDetailsView: View {
             Text(viewModel.cancellationAlertMessage)
         }
         .notice($notice)
+        .notice($viewModel.notice)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
@@ -247,6 +247,42 @@ final class BookingDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(status, newStatus)
     }
 
+    func test_error_notice_displayed_when_attendance_staus_update_fails() {
+        // Given
+        let booking = Booking.fake()
+        let viewModel = BookingDetailsViewModel(booking: booking, stores: storesManager)
+        let newStatus = BookingAttendanceStatus.checkedIn
+        enum TestError: Error { case generic }
+
+        // When
+        viewModel.updateAttendanceStatus(to: newStatus)
+
+        // Then
+        XCTAssertEqual(storesManager.receivedActions.count, 1)
+        guard let action = storesManager.receivedActions.first as? BookingAction else {
+            XCTFail("Incorrect action type dispatched")
+            return
+        }
+
+        guard case let .updateBookingAttendanceStatus(_, _, _, onCompletion) = action else {
+            XCTFail("Incorrect action case dispatched")
+            return
+        }
+
+        onCompletion(TestError.generic)
+
+        XCTAssertNotNil(viewModel.notice)
+        XCTAssertEqual(viewModel.notice?.feedbackType, .error)
+
+        let messageFormat = NSLocalizedString(
+            "BookingDetailsView.attendanceStatus.updateFailed.message",
+            value: "Unable to change attendance status of Booking #%1$d",
+            comment: ""
+        )
+        let expectedMessage = String(format: messageFormat, booking.bookingID)
+        XCTAssertEqual(viewModel.notice?.message, expectedMessage)
+    }
+
     func test_init_whenBookingHasStatusAndAttendanceStatus_updatesHeaderContentWithCorrectLocalizedStrings() {
         // Given
         let booking = Booking.fake().copy(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1532

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As suggested [here](https://github.com/woocommerce/woocommerce-ios/pull/16280#discussion_r2468003280) - adding an attendance status update failure notice with retry CTA.

- Adds a `notice: Notice?` to view model
- Presents the view model notice in `BookingDetailsView`
- The notice calls the `updateAttendanceStatus(to: _)` on a retry CTA
- Adds tests

## Testing Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Use a CIAB site
- Find a non-cancelled booking and open booking details
- Scroll down to "Attendance" section.
- Turn off internet or make a breakpoint with Proxyman for the `/wc-bookings/v2/bookings/{booking_id}&_method=put`
- Tap on the attendance status row and select a new status
- Make sure the request is failed by emulating 500 error in Proxyman or by keeping the interned disabled.
- Make sure the failure notice is displayed
- Disable the breakpoint / turn on the internet and tap on the retry (make it quick :))
- Make sure the status change is retried and re-applied properly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="676" height="234" alt="Снимок экрана 2025-10-28 в 18 23 38" src="https://github.com/user-attachments/assets/523b2928-a81b-4502-b80d-bc9dc3c5a63e" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
