### PR TITLE
[Mobile Payments] Enable card payments using Stripe gateway in the UK

### DIFF
--- a/Modules/Sources/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Modules/Sources/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -95,9 +95,12 @@ public struct CardPresentPaymentsConfiguration: Equatable {
                 countryCode: country,
                 paymentMethods: [.cardPresent],
                 currencies: [.GBP],
-                paymentGateways: [WCPayAccount.gatewayID],
+                paymentGateways: [WCPayAccount.gatewayID, StripeAccount.gatewayID],
                 supportedReaders: [.wisepad3, .tapToPay],
-                supportedPluginVersions: [.init(plugin: .wcPay, minimumVersion: "4.4.0")],
+                supportedPluginVersions: [
+                    .init(plugin: .wcPay, minimumVersion: "4.4.0"),
+                    .init(plugin: .stripe, minimumVersion: "6.2.0")
+                ],
                 minimumAllowedChargeAmount: NSDecimalNumber(string: "0.3"),
                 stripeSmallestCurrencyUnitMultiplier: 100,
                 contactlessLimitAmount: 10000,

--- a/Modules/Tests/YosemiteTests/Model/CardPresentConfigurationTests.swift
+++ b/Modules/Tests/YosemiteTests/Model/CardPresentConfigurationTests.swift
@@ -44,7 +44,7 @@ class CardPresentConfigurationTests: XCTestCase {
         let configuration = CardPresentPaymentsConfiguration(country: .GB)
         XCTAssertTrue(configuration.isSupportedCountry)
         XCTAssertEqual(configuration.currencies, [.GBP])
-        XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
+        XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
         XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
         XCTAssertEqual(configuration.purchaseCardReaderUrl(utmProvider: MockUTMParameterProvider()).absoluteString, Constants.PurchaseURL.gb)
         assertEqual([.wisepad3, .tapToPay], configuration.supportedReaders)

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -202,7 +202,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertNotEqual(state, .countryNotSupported(countryCode: .GB))
     }
 
-    func test_onboarding_returns_country_unsupported_with_uk_when_stripe_plugin_installed() {
+    func test_onboarding_returns_etup_not_completed_with_uk_when_stripe_plugin_installed() {
         // Given
         setupCountry(country: .gb)
         setupStripePlugin(status: .active, version: .minimumSupportedVersion)
@@ -214,10 +214,10 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .countryNotSupportedStripe(plugin: .stripe, countryCode: .GB))
+        XCTAssertEqual(state, .pluginSetupNotCompleted(plugin: .stripe))
     }
 
-    func test_onboarding_returns_setup_not_completed_stripe_when_stripe_and_wcPay_plugins_are_installed_in_UK() {
+    func test_onboarding_returns_select_plugin_when_stripe_and_wcPay_plugins_are_installed_in_UK() {
         // Given
         setupCountry(country: .gb)
         setupStripePlugin(status: .active, version: .minimumSupportedVersion)
@@ -230,7 +230,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertEqual(state, .pluginSetupNotCompleted(plugin: .wcPay))
+        XCTAssertEqual(state, .selectPlugin(pluginSelectionWasCleared: false))
     }
 
     func test_onboarding_returns_wcpay_plugin_unsupported_version_for_uk_when_version_unsupported() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -202,7 +202,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertNotEqual(state, .countryNotSupported(countryCode: .GB))
     }
 
-    func test_onboarding_returns_etup_not_completed_with_uk_when_stripe_plugin_installed() {
+    func test_onboarding_returns_setup_not_completed_with_uk_when_stripe_plugin_installed() {
         // Given
         setupCountry(country: .gb)
         setupStripePlugin(status: .active, version: .minimumSupportedVersion)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
# Enable card payments using Stripe gateway in the UK
<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1430

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR enables Stripe Payment Gateway extension in the UK for In-Person Payments and POS.

⚠️ Do not merge label - to ensure we release this feature in the same version across Android and iOS
💡 The public-facing documentation will be updated once the feature is released.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Card-present payment collection should be tested using UK-based store, having Stripe Paymen Gateway plugin activated:
- Test using the WisePad reader with Order Creation (IPP)
- Test using the WisePad reader with Point of Sale
- Test using Tap to Pay with Order Creation (IPP) – this is phone-only, so no need to check POS
- Test onboarding with one and both plugins active on the site — plugin selector should appear.
2. Link to purchase the card reader — should open the GB site and offer WisePad 3
3. "Learn more" links — should point to Stripe-specific site rather than WooPayments

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
