### PR TITLE
Fix: Unable to dismiss keyboard when editing Product Title

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 23.6
 -----
 - [*] Handle sites configured with `http` siteAddress.
+- [*] Fix: Unable to dismiss keyboard when editing Product Title. [https://github.com/woocommerce/woocommerce-ios/pull/16288]
 
 23.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -208,7 +208,7 @@ private extension ProductFormTableViewDataSource {
                                                                    productStatus: productStatus,
                                                                    placeholder: placeholder,
                                                                    textViewMinimumHeight: 10.0,
-                                                                   dismissOnReturn: true,
+                                                                   shouldDismissOnReturn: true,
                                                                    isScrollEnabled: false,
                                                                    onNameChange: { [weak self] (newName) in self?.onNameChange?(newName) },
                                                                    style: .headline)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -208,6 +208,7 @@ private extension ProductFormTableViewDataSource {
                                                                    productStatus: productStatus,
                                                                    placeholder: placeholder,
                                                                    textViewMinimumHeight: 10.0,
+                                                                   dismissOnReturn: true,
                                                                    isScrollEnabled: false,
                                                                    onNameChange: { [weak self] (newName) in self?.onNameChange?(newName) },
                                                                    style: .headline)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -645,6 +645,7 @@ private extension ProductFormViewController {
         tableView.delegate = self
         tableView.accessibilityIdentifier = "product-form"
         tableView.cellLayoutMarginsFollowReadableWidth = true
+        tableView.keyboardDismissMode = .onDrag
 
         tableView.backgroundColor = .listForeground(modal: false)
         tableView.removeLastCellSeparator()

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
@@ -6,6 +6,7 @@ final class EnhancedTextView: UITextView {
 
     var onTextChange: ((String) -> Void)?
     var onTextDidBeginEditing: (() -> Void)?
+    var dismissOnReturn: Bool = false
 
     var placeholder: String? {
         didSet {
@@ -83,6 +84,18 @@ private extension EnhancedTextView {
 // MARK: UITextViewDelegate conformance
 //
 extension EnhancedTextView: UITextViewDelegate {
+
+    func textView(_ textView: UITextView,
+                  shouldChangeTextIn range: NSRange,
+                  replacementText text: String) -> Bool {
+
+        if dismissOnReturn && text == "\n" {
+            textView.resignFirstResponder()
+            return false
+        }
+
+        return true
+    }
 
     func textViewDidBeginEditing(_ textView: UITextView) {
         hidePlaceholder()

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
@@ -6,7 +6,7 @@ final class EnhancedTextView: UITextView {
 
     var onTextChange: ((String) -> Void)?
     var onTextDidBeginEditing: (() -> Void)?
-    var dismissOnReturn: Bool = false
+    var shouldDismissOnReturn: Bool = false
 
     var placeholder: String? {
         didSet {
@@ -89,7 +89,7 @@ extension EnhancedTextView: UITextViewDelegate {
                   shouldChangeTextIn range: NSRange,
                   replacementText text: String) -> Bool {
 
-        if dismissOnReturn && text == "\n" {
+        if shouldDismissOnReturn && text == "\n" {
             textView.resignFirstResponder()
             return false
         }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.swift
@@ -8,7 +8,7 @@ final class LabeledTextViewTableViewCell: UITableViewCell {
         var productStatus: ProductStatus
         var placeholder: String? = nil
         var textViewMinimumHeight: CGFloat? = nil
-        var dismissOnReturn: Bool = false
+        var shouldDismissOnReturn: Bool = false
         var isScrollEnabled: Bool = true
         var onNameChange: ((_ text: String) -> Void)? = nil
         var onTextDidBeginEditing: (() -> Void)? = nil
@@ -33,7 +33,7 @@ final class LabeledTextViewTableViewCell: UITableViewCell {
         productTextField.isScrollEnabled = viewModel.isScrollEnabled
         productTextField.onTextChange = viewModel.onNameChange
         productTextField.onTextDidBeginEditing = viewModel.onTextDidBeginEditing
-        productTextField.dismissOnReturn = viewModel.dismissOnReturn
+        productTextField.shouldDismissOnReturn = viewModel.shouldDismissOnReturn
         configureProductStatusLabel(productStatus: viewModel.productStatus)
         applyStyle(style: viewModel.style)
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.swift
@@ -8,8 +8,8 @@ final class LabeledTextViewTableViewCell: UITableViewCell {
         var productStatus: ProductStatus
         var placeholder: String? = nil
         var textViewMinimumHeight: CGFloat? = nil
+        var dismissOnReturn: Bool = false
         var isScrollEnabled: Bool = true
-        var keyboardType: UIKeyboardType = .default
         var onNameChange: ((_ text: String) -> Void)? = nil
         var onTextDidBeginEditing: (() -> Void)? = nil
         var style: Style = .headline
@@ -33,8 +33,7 @@ final class LabeledTextViewTableViewCell: UITableViewCell {
         productTextField.isScrollEnabled = viewModel.isScrollEnabled
         productTextField.onTextChange = viewModel.onNameChange
         productTextField.onTextDidBeginEditing = viewModel.onTextDidBeginEditing
-        productTextField.keyboardType = viewModel.keyboardType
-        productTextField.dismissOnReturn = true
+        productTextField.dismissOnReturn = viewModel.dismissOnReturn
         configureProductStatusLabel(productStatus: viewModel.productStatus)
         applyStyle(style: viewModel.style)
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.swift
@@ -34,6 +34,7 @@ final class LabeledTextViewTableViewCell: UITableViewCell {
         productTextField.onTextChange = viewModel.onNameChange
         productTextField.onTextDidBeginEditing = viewModel.onTextDidBeginEditing
         productTextField.keyboardType = viewModel.keyboardType
+        productTextField.dismissOnReturn = true
         configureProductStatusLabel(productStatus: viewModel.productStatus)
         applyStyle(style: viewModel.style)
     }


### PR DESCRIPTION
Closes [WOOMOB-69](https://linear.app/a8c/issue/WOOMOB-69)

## Description
This PR improves keyboard behavior in the product editor:
  • The keyboard is now dismissed when tapping `return` while editing the product title.
  • Scrolling the product details view also dismisses the keyboard.

## Test Steps
1. Open any product detail.
2. Tap on the title
3. Tap `return`
4. Note that the keyboard is dismiss instead of adding a new line.
5. Tap on the title again.
6. Scroll the view.
7. Note that the keyboard is dismissed now as well.

Tested on iPhone 17 Pro with iOS 26 device and sim.

## Screenshots
| Before | After |
| --- | --- |
| ![Simulator Screen Recording - iPhone 17 Pro - 2025-10-29 at 05 10 56](https://github.com/user-attachments/assets/6e085143-fdb6-4a37-856f-8eeac7dad04a) | ![Simulator Screen Recording - iPhone 17 Pro - 2025-10-29 at 05 12 56](https://github.com/user-attachments/assets/d9491959-791e-4054-8f14-b37e171e5bd4) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
