### PR TITLE
Fix:  Customer Details Screen Not Scrollable After Selecting Country

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -145,7 +145,6 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                 Spacer(minLength: safeAreaInsets.bottom)
             }
             .disableAutocorrection(true)
-            .scrollDismissesKeyboard(.immediately)
             .background(Color(.listBackground))
             .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         }
@@ -429,6 +428,12 @@ struct SingleAddressForm: View {
         .padding(.horizontal, insets: safeAreaInsets)
         .background(Color(.systemBackground))
         .addingTopAndBottomDividers()
+        .onChange(of: showStateSelector) {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
+        .onChange(of: showCountrySelector) {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
     }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -145,6 +145,7 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                 Spacer(minLength: safeAreaInsets.bottom)
             }
             .disableAutocorrection(true)
+            .scrollDismissesKeyboard(.immediately)
             .background(Color(.listBackground))
             .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
         }


### PR DESCRIPTION
Closes [WOOMOB-1382](https://linear.app/a8c/issue/WOOMOB-1382)

## Description

This PR fixes the linked issue by setting the outer view to dismiss the keyboard when content is scrolled.

## Test Steps

1. Start creating a manual order in the app.
2. Tap Add customer details.
3. Click the + icon.
4. Enter the postcode.
5. Scroll to the Country field.
7. Tap on the Country field and select a country from the list.
8. Note that you can still scroll the Customer Details screen.
9. Also confirm that the keyboard is not missed if you are changing focus from one input to another without scrolling.

## Screenshots
| Before | After |
| --- | --- |
| ![Simulator Screen Recording - iPhone 17 Pro - 2025-10-29 at 10 05 22](https://github.com/user-attachments/assets/2d71652a-0182-4ce5-83bc-a2a403007de5) | ![Simulator Screen Recording - iPhone 17 Pro - 2025-10-29 at 10 07 25](https://github.com/user-attachments/assets/f7c83f8a-7a8f-4c2d-b6b2-75ae5dcf2789) |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
