### PR TITLE
[Woo POS][Settings] i2: Reader connection modal flow (2)

### DIFF
--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -43,7 +43,7 @@ protocol PointOfSaleAggregateModelProtocol {
     let popularPurchasableItemsController: PointOfSaleItemsControllerProtocol
     let couponsController: PointOfSaleCouponsControllerProtocol
     let couponsSearchController: PointOfSaleSearchingItemsControllerProtocol
-    let settingsController: PointOfSaleSettingsControllerProtocol
+    let settingsController: POSSettingsControllerProtocol
 
     private let cardPresentPaymentService: CardPresentPaymentFacade
     private let orderController: PointOfSaleOrderControllerProtocol
@@ -79,7 +79,7 @@ protocol PointOfSaleAggregateModelProtocol {
          couponsSearchController: PointOfSaleSearchingItemsControllerProtocol,
          cardPresentPaymentService: CardPresentPaymentFacade,
          orderController: PointOfSaleOrderControllerProtocol,
-         settingsController: PointOfSaleSettingsControllerProtocol,
+         settingsController: POSSettingsControllerProtocol,
          analytics: POSAnalyticsProviding,
          collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking,
          searchHistoryService: POSSearchHistoryProviding,

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleSettingsController.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleSettingsController.swift
@@ -11,14 +11,14 @@ import protocol Storage.GRDBManagerProtocol
 import protocol Yosemite.POSCatalogSyncCoordinatorProtocol
 import class Yosemite.POSCatalogSettingsService
 
-protocol PointOfSaleSettingsControllerProtocol {
+protocol POSSettingsControllerProtocol {
     var connectedCardReader: CardPresentPaymentCardReader? { get }
     var storeViewModel: POSSettingsStoreViewModel { get }
     var localCatalogViewModel: POSSettingsLocalCatalogViewModel? { get }
     var isLocalCatalogEligible: Bool { get }
 }
 
-@Observable final class PointOfSaleSettingsController: PointOfSaleSettingsControllerProtocol {
+@Observable final class PointOfSaleSettingsController: POSSettingsControllerProtocol {
     private(set) var connectedCardReader: CardPresentPaymentCardReader?
     private var cancellables: AnyCancellable?
 
@@ -72,7 +72,7 @@ protocol PointOfSaleSettingsControllerProtocol {
 }
 
 #if DEBUG
-final class PointOfSaleSettingsPreviewController: PointOfSaleSettingsControllerProtocol {
+final class POSSettingsPreviewController: POSSettingsControllerProtocol {
     var connectedCardReader: CardPresentPaymentCardReader? = CardPresentPaymentCardReader(
         name: "WisePad 3",
         batteryLevel: 0.75

--- a/Modules/Sources/PointOfSale/Presentation/Barcode Scanner Setup/POSBarcodeScannerSetup.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Barcode Scanner Setup/POSBarcodeScannerSetup.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct PointOfSaleBarcodeScannerSetup: View {
+struct POSBarcodeScannerSetup: View {
     @Binding var isPresented: Bool
     @State private var flowManager: PointOfSaleBarcodeScannerSetupFlowManager
     @Environment(\.posModalParentSize) var parentSize
@@ -91,7 +91,7 @@ private enum Constants {
 }
 
 // MARK: - Private Localization Extension
-private extension PointOfSaleBarcodeScannerSetup {
+private extension POSBarcodeScannerSetup {
     enum Localization {
         static let starBSH20BTitle = NSLocalizedString(
             "pos.barcodeScannerSetup.starBSH20B.title",
@@ -120,7 +120,7 @@ private extension PointOfSaleBarcodeScannerSetup {
 
 #if DEBUG
 #Preview {
-    PointOfSaleBarcodeScannerSetup(isPresented: .constant(true), analytics: EmptyPOSAnalytics())
+    POSBarcodeScannerSetup(isPresented: .constant(true), analytics: EmptyPOSAnalytics())
 }
 #endif
 

--- a/Modules/Sources/PointOfSale/Presentation/CartView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CartView.swift
@@ -69,7 +69,7 @@ struct CartView: View {
                 }
             }
             .posModal(isPresented: $showBarcodeScanningModal) {
-                PointOfSaleBarcodeScannerSetup(isPresented: $showBarcodeScanningModal, analytics: analytics)
+                POSBarcodeScannerSetup(isPresented: $showBarcodeScanningModal, analytics: analytics)
             }
             .animation(Constants.cartAnimation, value: posModel.cart.isEmpty)
             .frame(maxWidth: .infinity)

--- a/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
@@ -55,7 +55,7 @@ struct POSFloatingControlView: View {
             SimpleProductsOnlyInformation(isPresented: $showProductRestrictionsModal)
         }
         .posModal(isPresented: $showBarcodeScanningModal) {
-            PointOfSaleBarcodeScannerSetup(isPresented: $showBarcodeScanningModal, analytics: analytics)
+            POSBarcodeScannerSetup(isPresented: $showBarcodeScanningModal, analytics: analytics)
         }
         .posFullScreenCover(isPresented: $showOrders) {
             POSOrdersView(isPresented: $showOrders)

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -33,7 +33,7 @@ public struct PointOfSaleEntryPointView: View {
     private let couponsSearchController: PointOfSaleSearchingItemsControllerProtocol
     private let cardPresentPaymentService: CardPresentPaymentFacade
     private let orderController: PointOfSaleOrderControllerProtocol
-    private let settingsController: PointOfSaleSettingsControllerProtocol
+    private let settingsController: POSSettingsControllerProtocol
     private let collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking
     private let searchHistoryService: POSSearchHistoryProviding
     private let popularPurchasableItemsController: PointOfSaleItemsControllerProtocol

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -251,7 +251,7 @@ extension EnvironmentValues {
         }
     }
     .posModal(isPresented: $showModal) {
-        PointOfSaleBarcodeScannerSetup(isPresented: $showModal, analytics: EmptyPOSAnalytics())
+        POSBarcodeScannerSetup(isPresented: $showModal, analytics: EmptyPOSAnalytics())
     }
     .posRootModal()
     .environmentObject(modalManager)

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -82,11 +82,6 @@ struct POSSettingsHardwareDetailView: View {
                     scannersView
                 }
             }
-            .posModal(item: $posModel.cardPresentPaymentOnboardingViewContainer, onDismiss: {
-                // TODO: Dismissal
-            }, content: { onboardingViewContainer in
-                paymentsOnboardingView(onboardingViewContainer)
-            })
             .posModal(item: $posModel.cardPresentPaymentAlertViewModel, onDismiss: {
                 // TODO: Dismissal
             }, content: { alertType in
@@ -272,21 +267,6 @@ private extension POSSettingsHardwareDetailView {
         .navigationBarBackButtonHidden(true)
     }
 }
-
-// MARK: - Reader connection
-private extension POSSettingsHardwareDetailView {
-    func paymentsOnboardingView(_ onboardingViewContainer: CardPresentPaymentOnboardingViewContainer) -> some View {
-        let viewModel = PointOfSaleCardPresentPaymentOnboardingViewModel(onboardingViewContainer: onboardingViewContainer, onDismissTap: {
-            // TODO: Handle dismissal
-        })
-        return PointOfSaleCardPresentPaymentOnboardingView(viewModel: viewModel)
-            .onAppear {
-                // TODO: Do we need to distinguish here for tracking?
-                // posModel.trackCardPaymentsOnboardingShown()
-            }
-    }
-}
-
 
 // MARK: - Navigation
 private extension POSSettingsHardwareDetailView {

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -36,6 +36,7 @@ struct POSSettingsHardwareDetailView: View {
     }
 
     var body: some View {
+        @Bindable var posModel = posModel
         NavigationStack(path: $navigationPath) {
             POSPageHeaderView(title: Localization.hardwareTitle)
             .foregroundColor(.posSurface)
@@ -81,6 +82,17 @@ struct POSSettingsHardwareDetailView: View {
                     scannersView
                 }
             }
+            .posModal(item: $posModel.cardPresentPaymentOnboardingViewContainer, onDismiss: {
+                // TODO: Dismissal
+            }, content: { onboardingViewContainer in
+                paymentsOnboardingView(onboardingViewContainer)
+            })
+            .posModal(item: $posModel.cardPresentPaymentAlertViewModel, onDismiss: {
+                // TODO: Dismissal
+            }, content: { alertType in
+                PointOfSaleCardPresentPaymentAlert(alertType: alertType)
+                    .posInteractiveDismissDisabled(alertType.isDismissDisabled)
+            })
             .posModal(isPresented: $showBarcodeScanningSetupModal) {
                 POSBarcodeScannerSetup(isPresented: $showBarcodeScanningSetupModal, analytics: analytics)
             }
@@ -260,6 +272,21 @@ private extension POSSettingsHardwareDetailView {
         .navigationBarBackButtonHidden(true)
     }
 }
+
+// MARK: - Reader connection
+private extension POSSettingsHardwareDetailView {
+    func paymentsOnboardingView(_ onboardingViewContainer: CardPresentPaymentOnboardingViewContainer) -> some View {
+        let viewModel = PointOfSaleCardPresentPaymentOnboardingViewModel(onboardingViewContainer: onboardingViewContainer, onDismissTap: {
+            // TODO: Handle dismissal
+        })
+        return PointOfSaleCardPresentPaymentOnboardingView(viewModel: viewModel)
+            .onAppear {
+                // TODO: Do we need to distinguish here for tracking?
+                // posModel.trackCardPaymentsOnboardingShown()
+            }
+    }
+}
+
 
 // MARK: - Navigation
 private extension POSSettingsHardwareDetailView {

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 import struct WooFoundation.SafariView
 
-struct PointOfSaleSettingsHardwareDetailView: View {
+struct POSSettingsHardwareDetailView: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.posFeatureFlags) private var featureFlags
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.posAnalytics) private var analytics
 
-    let settingsController: PointOfSaleSettingsControllerProtocol
+    let settingsController: POSSettingsControllerProtocol
 
     @State private var navigationPath: [NavigationDestination] = []
     @State private var showBarcodeScanningSetupModal: Bool = false
@@ -82,7 +82,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
                 }
             }
             .posModal(isPresented: $showBarcodeScanningSetupModal) {
-                PointOfSaleBarcodeScannerSetup(isPresented: $showBarcodeScanningSetupModal, analytics: analytics)
+                POSBarcodeScannerSetup(isPresented: $showBarcodeScanningSetupModal, analytics: analytics)
             }
             .posFullScreenCover(isPresented: $showBarcodeScanningDocumentationModal) {
                 SafariView(url: POSConstants.URLs.pointOfSaleBarcodeScannerDocumentation.asURL())
@@ -92,7 +92,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
 }
 
 // MARK: - Views
-private extension PointOfSaleSettingsHardwareDetailView {
+private extension POSSettingsHardwareDetailView {
     var legacyCardReadersView: some View {
         VStack(spacing: POSSpacing.none) {
             POSPageHeaderView(
@@ -262,7 +262,7 @@ private extension PointOfSaleSettingsHardwareDetailView {
 }
 
 // MARK: - Navigation
-private extension PointOfSaleSettingsHardwareDetailView {
+private extension POSSettingsHardwareDetailView {
     enum HardwareDestination: Identifiable, CaseIterable {
         case cardReaders
         case scanners
@@ -346,7 +346,7 @@ private extension PointOfSaleSettingsHardwareDetailView {
 }
 
 // MARK: - Constants
-private extension PointOfSaleSettingsHardwareDetailView {
+private extension POSSettingsHardwareDetailView {
     enum Localization {
         static let readerModelTitle = NSLocalizedString(
             "pointOfSaleSettingsHardwareDetailView.readerModelTitle",
@@ -464,6 +464,6 @@ private extension PointOfSaleSettingsHardwareDetailView {
 
 #if DEBUG
 #Preview {
-    PointOfSaleSettingsHardwareDetailView(settingsController: PointOfSaleSettingsPreviewController())
+    POSSettingsHardwareDetailView(settingsController: POSSettingsPreviewController())
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -342,7 +342,7 @@ private extension POSSettingsHardwareDetailView {
         }
     }
 
-    private func handleScannerDestination(_ destination: ScannerDestination) {
+    func handleScannerDestination(_ destination: ScannerDestination) {
         switch destination {
         case .setup:
             showBarcodeScanningSetupModal = true

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -83,7 +83,7 @@ struct POSSettingsHardwareDetailView: View {
                 }
             }
             .posModal(item: $posModel.cardPresentPaymentAlertViewModel, onDismiss: {
-                // TODO: Dismissal
+                posModel.cardPresentPaymentAlertViewModel?.onDismiss?()
             }, content: { alertType in
                 PointOfSaleCardPresentPaymentAlert(alertType: alertType)
                     .posInteractiveDismissDisabled(alertType.isDismissDisabled)

--- a/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsHardwareDetailView.swift
@@ -89,17 +89,11 @@ struct PointOfSaleSettingsHardwareDetailView: View {
             }
         }
     }
+}
 
-    private func handleScannerDestination(_ destination: ScannerDestination) {
-        switch destination {
-        case .setup:
-            showBarcodeScanningSetupModal = true
-        case .documentation:
-            showBarcodeScanningDocumentationModal = true
-        }
-    }
-
-    private var legacyCardReadersView: some View {
+// MARK: - Views
+private extension PointOfSaleSettingsHardwareDetailView {
+    var legacyCardReadersView: some View {
         VStack(spacing: POSSpacing.none) {
             POSPageHeaderView(
                 title: Localization.cardReadersTitle,
@@ -168,7 +162,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
         }
     }
 
-    private var cardReadersView: some View {
+    var cardReadersView: some View {
         VStack(spacing: POSSpacing.none) {
             POSPageHeaderView(
                 title: Localization.cardReadersTitle,
@@ -224,7 +218,7 @@ struct PointOfSaleSettingsHardwareDetailView: View {
         }
     }
 
-    private var scannersView: some View {
+    var scannersView: some View {
         VStack(spacing: POSSpacing.none) {
             POSPageHeaderView(
                 title: Localization.scannersTitle,
@@ -340,8 +334,18 @@ private extension PointOfSaleSettingsHardwareDetailView {
             }
         }
     }
+
+    private func handleScannerDestination(_ destination: ScannerDestination) {
+        switch destination {
+        case .setup:
+            showBarcodeScanningSetupModal = true
+        case .documentation:
+            showBarcodeScanningDocumentationModal = true
+        }
+    }
 }
 
+// MARK: - Constants
 private extension PointOfSaleSettingsHardwareDetailView {
     enum Localization {
         static let readerModelTitle = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsStoreDetailView.swift
@@ -198,7 +198,7 @@ private extension PointOfSaleSettingsStoreDetailView {
 
 #if DEBUG
 #Preview {
-    let controller = PointOfSaleSettingsPreviewController()
+    let controller = POSSettingsPreviewController()
     PointOfSaleSettingsStoreDetailView(viewModel: controller.storeViewModel)
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsView.swift
@@ -5,7 +5,7 @@ struct PointOfSaleSettingsView: View {
     @Environment(\.posAnalytics) private var analytics
     @State private var selection: SidebarNavigation? = .store
 
-    let settingsController: PointOfSaleSettingsControllerProtocol
+    let settingsController: POSSettingsControllerProtocol
 
     var body: some View {
         GeometryReader { geometry in
@@ -86,7 +86,7 @@ extension PointOfSaleSettingsView {
         case .store:
             PointOfSaleSettingsStoreDetailView(viewModel: settingsController.storeViewModel)
         case .hardware:
-            PointOfSaleSettingsHardwareDetailView(settingsController: settingsController)
+            POSSettingsHardwareDetailView(settingsController: settingsController)
         case .localCatalog:
             if let viewModel = settingsController.localCatalogViewModel {
                 POSSettingsLocalCatalogDetailView(viewModel: viewModel)
@@ -250,6 +250,6 @@ extension PointOfSaleSettingsView {
 
 #if DEBUG
 #Preview {
-    PointOfSaleSettingsView(settingsController: PointOfSaleSettingsPreviewController())
+    PointOfSaleSettingsView(settingsController: POSSettingsPreviewController())
 }
 #endif

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -208,7 +208,7 @@ struct POSPreviewHelpers {
         couponsSearchController: PointOfSaleCouponsControllerProtocol = PointOfSalePreviewCouponsController(),
         cardPresentPaymentService: CardPresentPaymentFacade = CardPresentPaymentPreviewService(),
         orderController: PointOfSaleOrderControllerProtocol = PointOfSalePreviewOrderController(),
-        settingsController: PointOfSaleSettingsControllerProtocol = PointOfSaleSettingsPreviewController(),
+        settingsController: POSSettingsControllerProtocol = POSSettingsPreviewController(),
         collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking = POSCollectOrderPaymentPreviewAnalytics(),
         searchHistoryService: POSSearchHistoryProviding = PointOfSalePreviewHistoryService(),
         popularItemsController: PointOfSaleItemsControllerProtocol = PointOfSalePreviewItemsController(),

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSSettingsControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSSettingsControllerTests.swift
@@ -5,7 +5,7 @@ import Foundation
 import Storage
 
 @MainActor
-struct PointOfSaleSettingsControllerTests {
+struct POSSettingsControllerTests {
     private let mockSettingsService = MockPointOfSaleSettingsService()
     private let mockCardPresentPaymentService = MockCardPresentPaymentService()
     private let mockPluginService = MockPluginsService()
@@ -75,7 +75,7 @@ private final class MockPointOfSaleSettingsService: PointOfSaleSettingsServicePr
     }
 }
 
-final class MockPointOfSaleSettingsController: PointOfSaleSettingsControllerProtocol {
+final class MockPOSSettingsController: POSSettingsControllerProtocol {
     var connectedCardReader: CardPresentPaymentCardReader? = nil
     var storeViewModel: POSSettingsStoreViewModel = POSSettingsStoreViewModel(siteID: 123,
                                                                               settingsService: MockPointOfSaleSettingsService(),

--- a/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
@@ -974,7 +974,7 @@ private func makePointOfSaleAggregateModel(
     couponsSearchController: PointOfSaleSearchingItemsControllerProtocol = MockPointOfSaleCouponsController(),
     cardPresentPaymentService: CardPresentPaymentFacade = MockCardPresentPaymentService(),
     orderController: PointOfSaleOrderControllerProtocol = MockPointOfSaleOrderController(),
-    settingsController: PointOfSaleSettingsControllerProtocol = MockPointOfSaleSettingsController(),
+    settingsController: POSSettingsControllerProtocol = MockPOSSettingsController(),
     analytics: POSAnalyticsProviding = MockPOSAnalytics(),
     collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking = MockPOSCollectOrderPaymentAnalyticsTracker(),
     searchHistoryService: POSSearchHistoryProviding = MockPOSSearchHistoryService(),

--- a/Modules/Tests/PointOfSaleTests/Presentation/POSItemActionHandlerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Presentation/POSItemActionHandlerTests.swift
@@ -105,7 +105,7 @@ private func makePointOfSaleAggregateModel(
     couponsSearchController: PointOfSaleSearchingItemsControllerProtocol = MockPointOfSaleCouponsController(),
     cardPresentPaymentService: CardPresentPaymentFacade = MockCardPresentPaymentService(),
     orderController: PointOfSaleOrderControllerProtocol = MockPointOfSaleOrderController(),
-    settingsController: PointOfSaleSettingsControllerProtocol = MockPointOfSaleSettingsController(),
+    settingsController: POSSettingsControllerProtocol = MockPOSSettingsController(),
     analytics: POSAnalyticsProviding = MockPOSAnalytics(),
     collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking = MockPOSCollectOrderPaymentAnalyticsTracker(),
     searchHistoryService: POSSearchHistoryProviding = MockPOSSearchHistoryService(),


### PR DESCRIPTION
Continuation of https://github.com/woocommerce/woocommerce-ios/pull/16283
Closes WOOMOB-1570

## Description
This PR adds the card reader connection modal flow through POS settings. For this we copy the existing implementation held in `PointOfSaleDashboardView`, except the onboarding part (this will come in the next PR), so the merchant already has to be onboarded.

I kept onboarding out of scope of the PR for now, so we can test it separately.

## Changes
- Renamed some of the affected files to use the `POS` prefix 
- `POSSettingsHardwareDetailView` contains 1 new modal, triggering `PointOfSaleCardPresentPaymentAlert`, which listens to `cardPresentPaymentAlertViewModel`  and triggers the alert presentation for the card reader connection flow depending on the current reader state.

## Test Steps
- In POS > Settings, try the connection flow both starting disconnected, as well as connected. Connect, dismiss, move forward with a payment. It should work normally.
- When disconnected, we show the "Connect card reader" card, while when connected we show the reader details. UI to be updated soon.

https://github.com/user-attachments/assets/6bfaf0b4-d0d9-4ee0-a2af-d93b55debbc4
