### PR TITLE
[Woo POS][Settings] i2: Payments onboarding flow through POS settings

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -88,6 +88,13 @@ struct POSSettingsHardwareDetailView: View {
                 PointOfSaleCardPresentPaymentAlert(alertType: alertType)
                     .posInteractiveDismissDisabled(alertType.isDismissDisabled)
             })
+            .posModal(item: $posModel.cardPresentPaymentOnboardingViewContainer, onDismiss: {
+                // TODO: Handle dismiss
+            }, content: { viewContainer in
+                PointOfSaleCardPresentPaymentOnboardingView(
+                    viewModel: .init(onboardingViewContainer: viewContainer,
+                                     onDismissTap: { /* TODO: Handle dismiss */ }))
+            })
             .posModal(isPresented: $showBarcodeScanningSetupModal) {
                 POSBarcodeScannerSetup(isPresented: $showBarcodeScanningSetupModal, analytics: analytics)
             }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -89,11 +89,13 @@ struct POSSettingsHardwareDetailView: View {
                     .posInteractiveDismissDisabled(alertType.isDismissDisabled)
             })
             .posModal(item: $posModel.cardPresentPaymentOnboardingViewContainer, onDismiss: {
-                // TODO: Handle dismiss
+                posModel.cancelCardPaymentsOnboarding()
             }, content: { viewContainer in
                 PointOfSaleCardPresentPaymentOnboardingView(
                     viewModel: .init(onboardingViewContainer: viewContainer,
-                                     onDismissTap: { /* TODO: Handle dismiss */ }))
+                                     onDismissTap: {
+                                         posModel.cancelCardPaymentsOnboarding()
+                                     }))
             })
             .posModal(isPresented: $showBarcodeScanningSetupModal) {
                 POSBarcodeScannerSetup(isPresented: $showBarcodeScanningSetupModal, analytics: analytics)

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -96,6 +96,9 @@ struct POSSettingsHardwareDetailView: View {
                                      onDismissTap: {
                                          posModel.cancelCardPaymentsOnboarding()
                                      }))
+                .onAppear {
+                    posModel.trackCardPaymentsOnboardingShown()
+                }
             })
             .posModal(isPresented: $showBarcodeScanningSetupModal) {
                 POSBarcodeScannerSetup(isPresented: $showBarcodeScanningSetupModal, analytics: analytics)

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -6,6 +6,7 @@ struct POSSettingsHardwareDetailView: View {
     @Environment(\.posFeatureFlags) private var featureFlags
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.posAnalytics) private var analytics
+    @Environment(\.posExternalViews) private var externalViews
 
     let settingsController: POSSettingsControllerProtocol
 
@@ -13,6 +14,7 @@ struct POSSettingsHardwareDetailView: View {
     @State private var showBarcodeScanningSetupModal: Bool = false
     @State private var showBarcodeScanningDocumentationModal: Bool = false
     @State private var showCardReaderDocumentationModal: Bool = false
+    @State private var showSupport: Bool = false
 
     private var cardReaderName: String {
         if let cardReaderName = settingsController.connectedCardReader?.name {
@@ -91,15 +93,12 @@ struct POSSettingsHardwareDetailView: View {
             .posModal(item: $posModel.cardPresentPaymentOnboardingViewContainer, onDismiss: {
                 posModel.cancelCardPaymentsOnboarding()
             }, content: { viewContainer in
-                PointOfSaleCardPresentPaymentOnboardingView(
-                    viewModel: .init(onboardingViewContainer: viewContainer,
-                                     onDismissTap: {
-                                         posModel.cancelCardPaymentsOnboarding()
-                                     }))
-                .onAppear {
-                    posModel.trackCardPaymentsOnboardingShown()
-                }
+                paymentsOnboardingView(from: viewContainer)
             })
+            .posSheet(isPresented: $showSupport) {
+                supportForm
+                    .interactiveDismissDisabled(true)
+            }
             .posModal(isPresented: $showBarcodeScanningSetupModal) {
                 POSBarcodeScannerSetup(isPresented: $showBarcodeScanningSetupModal, analytics: analytics)
             }
@@ -112,6 +111,36 @@ struct POSSettingsHardwareDetailView: View {
 
 // MARK: - Views
 private extension POSSettingsHardwareDetailView {
+    func paymentsOnboardingView(from onboardingViewContainer: CardPresentPaymentOnboardingViewContainer) -> some View {
+        onboardingViewContainer.configuration.showSupport = {
+            posModel.cancelCardPaymentsOnboarding()
+            showSupport = true
+        }
+
+        return PointOfSaleCardPresentPaymentOnboardingView(
+            viewModel: .init(onboardingViewContainer: onboardingViewContainer,
+                             onDismissTap: {
+                                 posModel.cancelCardPaymentsOnboarding()
+                             }))
+        .onAppear {
+            posModel.trackCardPaymentsOnboardingShown()
+        }
+    }
+
+    var supportForm: some View {
+        NavigationView {
+            externalViews.createSupportFormView(isPresented: $showSupport, sourceTag: Constants.supportTag)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.supportCancel) {
+                        showSupport = false
+                    }
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
+    }
+
     var legacyCardReadersView: some View {
         VStack(spacing: POSSpacing.none) {
             POSPageHeaderView(
@@ -366,6 +395,10 @@ private extension POSSettingsHardwareDetailView {
 
 // MARK: - Constants
 private extension POSSettingsHardwareDetailView {
+    enum Constants {
+        static let supportTag = "origin:point-of-sale"
+    }
+
     enum Localization {
         static let readerModelTitle = NSLocalizedString(
             "pointOfSaleSettingsHardwareDetailView.readerModelTitle",
@@ -477,6 +510,12 @@ private extension POSSettingsHardwareDetailView {
             "pointOfSaleSettingsHardwareDetailView.cardReaderConnectSubtitle",
             value: "Connect your card reader and start accepting payments",
             comment: "Subtitle for card reader connect button when no reader is connected."
+        )
+
+        static let supportCancel = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.help.support.cancel",
+            value: "Cancel",
+            comment: "Button to dismiss the support form from POS settings."
         )
     }
 }


### PR DESCRIPTION
Closes WOOMOB-1610

## Description

This PR adds the payments onboarding modal flow through POS settings. For this we copy the existing implementation held in `PointOfSaleDashboardView`.

I'll attempt to reduce the code duplication from both onboarding and card connection in the next PR, some of it is a bit tricky.

## Changes
- Adds new  `.posModal` to the hardware detail view to handle onboarding presentation.
- Adds new `.posSheet` to the hardware detail view to handle support webview presentation from onboarding.

## Test Steps
- If you don't have a store with pending requirements, or that need to be onboarded, hardcode the state by returning `.stripeAccountOverdueRequirement(plugin: .wcPay)` in `CardPresentPaymentsOnboardingUseCase.checkOnboardingState`
- Go to POS > Settings > Hardware > Card readers > Tap `Connect card reader`
- Observe the existing onboarding flow appears, and tapping `dismiss`, `refresh`, `resolve now`, or `contact us` works normally.
- Tapping outside the modal also dismisses the onboarding flow
- Events are logged with the `pos_` decorator:
```
🔵 Tracked pos_card_reader_connection_tapped
🔵 Tracked pos_payments_onboarding_shown
🔵 Tracked pos_card_present_onboarding_not_completed
```

Not necessary to test the full flow, but just for completeness sake: Testing the onboarding is a bit annoying, as is called multiple times through the app lifecycle, the "easier way I found to sort of test from incomplete onboarding to success connection is to add a flag to `CardPresentPaymentsOnboardingUseCase` and wrap `checkOnboardingState()`:
```diff 
final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCaseProtocol, ObservableObject {
+    private var foo: Bool = true

func checkOnboardingState() -> CardPresentPaymentOnboardingState {
+        if foo {
+            return .stripeAccountOverdueRequirement(plugin: .wcPay)
+        }
}
```
Add a breakpoint before `foo` and disable it, navigate to POS Settings, re-enable the breakpoint and once triggers update the value via `expression foo = false` which would bypass the it and continue the normal onboarding flow.

## Screenshots

Onboarding flow

https://github.com/user-attachments/assets/d0c67a80-0eae-4466-a7f8-de6863074349

From incomplete onboarding to card reader connection

https://github.com/user-attachments/assets/242b6b67-2a2d-4669-9633-bd355d5ea8df


