### PR TITLE
Add test for card and tap to pay options hiding in CIAB

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
@@ -6,6 +6,7 @@ import WooFoundation
 
 @testable import WooCommerce
 @testable import Yosemite
+@testable import Networking
 
 private typealias Dependencies = PaymentMethodsViewModel.Dependencies
 
@@ -779,6 +780,58 @@ final class PaymentMethodsViewModelTests: XCTestCase {
                                                 flow: .simplePayment,
                                                 channel: .storeManagement,
                                                 dependencies: dependencies)
+
+        // Then
+        XCTAssertFalse(viewModel.showPayWithCardRow)
+        XCTAssertFalse(viewModel.showTapToPayRow)
+    }
+
+    func test_card_rows_are_not_shown_for_ciab_site() {
+        // Given
+        let siteID: Int64 = 1212
+        let orderID: Int64 = 111
+        let ciabSite = Site.fake().copy(siteID: siteID, isGarden: true, gardenName: "commerce")
+        let order = MockOrders()
+            .makeOrder(status: .pending)
+            .copy(
+                siteID: siteID,
+                orderID: orderID,
+                datePaid: .some(nil),
+                total: "100"
+            )
+
+        storage.insertSampleSite(readOnlySite: ciabSite)
+        storage.insertSampleOrder(readOnlyOrder: order)
+
+        let eligibilityStore = OrderCardPresentPaymentEligibilityStore(
+            dispatcher: Dispatcher(),
+            storageManager: storage,
+            network: MockNetwork(),
+            currentSite: { ciabSite }
+        )
+
+        let configuration = CardPresentPaymentsConfiguration(country: .US)
+        stores.whenReceivingAction(ofType: OrderCardPresentPaymentEligibilityAction.self) { action in
+            eligibilityStore.onAction(action)
+        }
+
+        simulate(tapToPayDeviceAvailability: true, on: stores)
+
+        // When
+        let dependencies = Dependencies(
+            stores: stores,
+            storage: storage,
+            cardPresentPaymentsConfiguration: configuration
+        )
+        let viewModel = PaymentMethodsViewModel(
+            siteID: siteID,
+            orderID: orderID,
+            total: "5",
+            formattedTotal: "$5.00",
+            flow: .simplePayment,
+            channel: .storeManagement,
+            dependencies: dependencies
+        )
 
         // Then
         XCTAssertFalse(viewModel.showPayWithCardRow)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1598

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The "Tap to Pay" payment option must be hidden for CIAB sites along with the "Card Reader" option handled in #16270. Since the "Tap to Pay" option is eventually hidden - the test coverage was added in this PR only.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
Not needed - only tests were added. Make sure the CI is green.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A
 
---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
