### PR TITLE
[Tooling] Use ReleasesV2 version as the source of truth during Code Freeze

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1429,15 +1429,15 @@ def build_code_current
   BUILD_CODE_FORMATTER.build_code(version: version)
 end
 
-# Returns the build code of the app for the code freeze. It is the release version name plus sets the build number to 0
+# Returns the initial build code for a code freeze (e.g., "1.2.3.0" for release version "1.2.3")
+# Takes the release version and formats it as a four-part build code with the build number set to 0
 #
 def build_code_code_freeze(version_short: nil)
+  # Use provided version or read the current release version from the .xcconfig file
   version_short ||= VERSION_FILE.read_release_version
-  # Read the current build code from the .xcconfig file and parse it into an AppVersion object
-  # The AppVersion is used because WCiOS uses the four part (1.2.3.4) build code format, so the version
-  # calculator can be used to calculate the next four-part version
+  # Parse the release version string (e.g., "1.2.3") into an AppVersion object
   release_version_current = VERSION_FORMATTER.parse(version_short)
-  # Return the formatted build code
+  # Format as four-part build code (e.g., "1.2.3.0")
   BUILD_CODE_FORMATTER.build_code(version: release_version_current)
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -201,15 +201,17 @@ platform :ios do
     computed_version = release_version_next
     new_version = version || computed_version
 
-    # Warn if provided version differs from computed version
+    # Fail if provided version differs from computed version
     if version && version != computed_version
-      warning_message = <<~WARNING
-        ⚠️ Version mismatch: The explicitly-provided version was '#{version}' while new computed version would have been '#{computed_version}'.
-        If this is unexpected, you might want to investigate the discrepency.
-        Continuing with the explicitly-provided verison '#{version}'.
-      WARNING
-      UI.important(warning_message)
-      buildkite_annotate(style: 'warning', context: 'start-code-freeze-version-mismatch', message: warning_message) if is_ci
+      error_message = <<~ERROR
+        ❌ Version mismatch detected!
+
+        The explicitly-provided version from the release tool is '#{version}' but the computed version from the codebase is '#{computed_version}'.
+
+        This mismatch must be resolved before proceeding with the code freeze. Please investigate and ensure the versions are aligned.
+      ERROR
+      buildkite_annotate(style: 'error', context: 'start-code-freeze-version-mismatch', message: error_message) if is_ci
+      UI.user_error!(error_message)
     end
 
     UI.important <<-MESSAGE

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -197,35 +197,23 @@ platform :ios do
     # Check out the up-to-date default branch, the designated starting point for the code freeze
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
-    # Use provided version from release tool, or fall back to computed version
-    computed_version = release_version_next
-    new_version = version || computed_version
-
-    # Fail if provided version differs from computed version
-    if version && version != computed_version
-      error_message = <<~ERROR
-        ❌ Version mismatch detected!
-
-        The explicitly-provided version from the release tool is '#{version}' but the computed version from the codebase is '#{computed_version}'.
-
-        This mismatch must be resolved before proceeding with the code freeze. Please investigate and ensure the versions are aligned.
-      ERROR
-      buildkite_annotate(style: 'error', context: 'start-code-freeze-version-mismatch', message: error_message) if is_ci
-      UI.user_error!(error_message)
-    end
+    # If a new version is passed, use it as source of truth from now on
+    new_version = version || release_version_next
+    new_release_branch = "release/#{new_version}"
+    new_build_code = build_code_code_freeze(version_short: new_version)
 
     UI.important <<-MESSAGE
 
       Code Freeze:
-      • New release branch from #{DEFAULT_BRANCH}: release/#{new_version}
+      • New release branch from #{DEFAULT_BRANCH}: #{new_release_branch}
+
       • Current release version and build code: #{release_version_current} (#{build_code_current}).
-      • New release version and build code: #{new_version} (#{build_code_code_freeze}).
+      • New release version and build code: #{new_version} (#{new_build_code}).
 
     MESSAGE
     UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
 
     # Create the release branch
-    new_release_branch = "release/#{new_version}"
     ensure_branch_does_not_exist!(new_release_branch)
 
     UI.message('Creating release branch...')
@@ -235,8 +223,8 @@ platform :ios do
     # Bump the release version and build code and write it to the `xcconfig` file
     UI.message('Bumping release version and build code...')
     VERSION_FILE.write(
-      version_short: release_version_next,
-      version_long: build_code_code_freeze
+      version_short: new_version,
+      version_long: new_build_code
     )
     commit_version_bump
     UI.success("Done! New Release Version: #{release_version_current}. New Build Code: #{build_code_current}")
@@ -260,7 +248,7 @@ platform :ios do
     copy_branch_protection(
       repository: GITHUB_REPO,
       from_branch: DEFAULT_BRANCH,
-      to_branch: "release/#{new_version}"
+      to_branch: new_release_branch
     )
 
     begin
@@ -1443,15 +1431,14 @@ end
 
 # Returns the build code of the app for the code freeze. It is the release version name plus sets the build number to 0
 #
-def build_code_code_freeze
+def build_code_code_freeze(version_short: nil)
+  version_short ||= VERSION_FILE.read_release_version
   # Read the current build code from the .xcconfig file and parse it into an AppVersion object
   # The AppVersion is used because WCiOS uses the four part (1.2.3.4) build code format, so the version
   # calculator can be used to calculate the next four-part version
-  release_version_current = VERSION_FORMATTER.parse(VERSION_FILE.read_release_version)
-  # Calculate the next release version, which will be used as the basis of the new build code
-  build_code_code_freeze = VERSION_CALCULATOR.next_release_version(version: release_version_current)
+  release_version_current = VERSION_FORMATTER.parse(version_short)
   # Return the formatted build code
-  BUILD_CODE_FORMATTER.build_code(version: build_code_code_freeze)
+  BUILD_CODE_FORMATTER.build_code(version: release_version_current)
 end
 
 # Returns the next build code of the app


### PR DESCRIPTION
See AINFRA-1478

## Description

This PR enhances the version handling added in the previous iteration to assume the version received by the code freeze lane as the source of truth, ignoring potential mismatches between the ReleasesV2 version and the project's computed version.

## Testing

You can make sure the calculated release branch, current version and the next version are correctly shown in the "Continue" prompt, **remembering to answer `N` when asked to continue to cancel the code freeze**.

To avoid unexpected results, comment out the lines doing `ensure_git_status_clean` and `Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)` at the beginning of the lane.

You can run the `start_code_freeze` lane, with and without the version parameters:
- Run `bundle exec fastlane start_code_freeze` 
- Run `bundle exec fastlane start_code_freeze version:30.6`

This will be fully tested in the next release cycle during code freeze.