### PR TITLE
[Bookings] Navigate to booking order

### DIFF
--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -327,6 +327,14 @@ extension BookingDetailsViewModel {
     }
 }
 
+// MARK: Navigation
+
+extension BookingDetailsViewModel {
+    func navigateToOrderDetails() {
+        MainTabBarController.navigateToOrderDetails(with: booking.orderID, siteID: booking.siteID)
+    }
+}
+
 private extension BookingDetailsViewModel {
     static func navigationTitle(for booking: Booking) -> String {
         let titleFormat = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -223,7 +223,11 @@ private extension BookingDetailsView {
             VStack(alignment: .leading, spacing: Layout.contentVerticalPadding) {
                 ForEach(content.actions) { action in
                     Button {
-                        /// On action tap
+                        if action == .viewOrder {
+                            viewModel.navigateToOrderDetails()
+                        } else {
+                            /// On action tap
+                        }
                     } label: {
                         Text(action.buttonTitle)
                     }

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -70,7 +70,7 @@ struct BookingDetailsView: View {
                         print("On mark as paid tap")
                     }
                     Button(Localization.viewOrder) {
-                        print("On view order tap")
+                        viewModel.navigateToOrderDetails()
                     }
                     Button(Localization.cancelBookingAction, role: .destructive) {
                         print("On cancel booking tap")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1616

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Implements navigation to a booking order from "Booking Details" screen
- Re-uses `MainTabBarController.navigateToOrderDetails(with: , siteID: )` for navigation
- Opens the order in "Orders" tab
- Applies the navigation for "View Order" CTA button and ellipsis action.
- The missing order error fallback is already handled by Order Details screen.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
- Use CIAB sites with existing bookings and corresponding orders
- Navigate to a Booking that has an order (Some booking don't)
- Find and tap "View Order" button in Booking Details screen.
- Make sure the app navigates to "Orders" tab and opens/loads the right order for that booking
- Go back to Booking Details and tap on `...` (ellipsis) button in top rigt. Select "View Order"
- Make sure the right order is opened again in Orders tab.
- Find another booking with existing order and repeat steps to double check
- Find a Booking with missing order.
- Trigger the "View Order" in booking details and make sure the "The Order couldn't be loaded!" + "Retry" error state is displayed in Order details screen.

## Screenshots
https://github.com/user-attachments/assets/a1bcb11a-ce5a-46de-b95b-98444a528f16

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
