### PR TITLE
[Mobile Payments] Show network error when onboarding requests fail

### DIFF
--- a/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -683,6 +683,7 @@ public enum ServerSidePaymentCaptureError: Error, LocalizedError {
     }
 }
 
+//periphery:ignore - logging this error detail in WooCommerce is useful, if it ever happens. It's part of the public API here.
 public enum CardPresentPaymentStoreError: Error {
     case unknownErrorFetchingAccounts
 }

--- a/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -476,8 +476,7 @@ private extension CardPresentPaymentStore {
             case (true, _):
                 // If either succeeds, the load is successful
                 onCompletion(.success(()))
-            case (false, .some(let error)),
-                (.none, .some(let error)):
+            case (_, .some(let error)):
                 // If we have an error, and no success, the load fails
                 onCompletion(.failure(error))
             case (_, .none):

--- a/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -444,6 +444,7 @@ private extension CardPresentPaymentStore {
     ///
     func loadAccounts(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
         var error: Error? = nil
+        var hasSuccess: Bool? = nil
 
         let group = DispatchGroup()
         group.enter()
@@ -453,7 +454,7 @@ private extension CardPresentPaymentStore {
                 DDLogError("⛔️ Error synchronizing WCPay Account: \(loadError)")
                 error = loadError
             case .success:
-                break
+                hasSuccess = true
             }
             group.leave()
         })
@@ -465,17 +466,24 @@ private extension CardPresentPaymentStore {
                 DDLogError("⛔️ Error synchronizing Stripe Account: \(loadError)")
                 error = loadError
             case .success:
-                break
+                hasSuccess = true
             }
             group.leave()
         })
 
         group.notify(queue: .main) {
-            guard let error = error else {
+            switch (hasSuccess, error) {
+            case (true, _):
+                // If either succeeds, the load is successful
                 onCompletion(.success(()))
-                return
+            case (false, .some(let error)),
+                (.none, .some(let error)):
+                // If we have an error, and no success, the load fails
+                onCompletion(.failure(error))
+            case (_, .none):
+                // This... shouldn't really happen.
+                onCompletion(.failure(CardPresentPaymentStoreError.unknownErrorFetchingAccounts))
             }
-            onCompletion(.failure(error))
         }
     }
 
@@ -674,6 +682,10 @@ public enum ServerSidePaymentCaptureError: Error, LocalizedError {
             return error.localizedDescription
         }
     }
+}
+
+public enum CardPresentPaymentStoreError: Error {
+    case unknownErrorFetchingAccounts
 }
 
 private extension PaymentGatewayAccount {

--- a/Modules/Tests/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -252,19 +252,20 @@ final class CardPresentPaymentStoreTests: XCTestCase {
     /// Verifies that the PaymentGatewayAccountStore hits the network when loading a WCPay Account and places nothing in storage in case of error.
     ///
     func test_loadAccounts_handles_failure() throws {
-        let expectation = self.expectation(description: "Load Account error response")
         network.simulateResponse(requestUrlSuffix: "payments/accounts",
                                  filename: "generic_error")
         network.simulateResponse(requestUrlSuffix: "wc_stripe/account/summary",
                                  filename: "generic_error")
 
-        let action = CardPresentPaymentAction.loadAccounts(siteID: sampleSiteID, onCompletion: { result in
-            XCTAssertTrue(result.isFailure)
-            expectation.fulfill()
-        })
+        // When
+        let result = waitFor { promise in
+            self.cardPresentStore.onAction(CardPresentPaymentAction.loadAccounts(siteID: self.sampleSiteID, onCompletion: { result in
+                promise(result)
+            }))
+        }
 
-        cardPresentStore.onAction(action)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isFailure)
 
         XCTAssertNil(viewStorage.firstObject(ofType: Storage.PaymentGatewayAccount.self, matching: nil))
     }
@@ -272,18 +273,19 @@ final class CardPresentPaymentStoreTests: XCTestCase {
     /// Verifies that the PaymentGatewayAccountStore hits the network when loading a WCPay Account, propagates success and upserts the account into storage.
     ///
     func test_loadAccounts_returns_expected_data() throws {
-        let expectation = self.expectation(description: "Load Account fetch response")
         network.simulateResponse(requestUrlSuffix: "payments/accounts",
                                  filename: "wcpay-account-complete")
         network.simulateResponse(requestUrlSuffix: "wc_stripe/account/summary",
                                  filename: "stripe-account-complete")
-        let action = CardPresentPaymentAction.loadAccounts(siteID: sampleSiteID, onCompletion: { result in
-            XCTAssertTrue(result.isSuccess)
-            expectation.fulfill()
-        })
+        // When
+        let result = waitFor { promise in
+            self.cardPresentStore.onAction(CardPresentPaymentAction.loadAccounts(siteID: self.sampleSiteID, onCompletion: { result in
+                promise(result)
+            }))
+        }
 
-        cardPresentStore.onAction(action)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isSuccess)
 
         XCTAssert(viewStorage.countObjects(ofType: Storage.PaymentGatewayAccount.self, matching: nil) == 2)
 
@@ -300,19 +302,21 @@ final class CardPresentPaymentStoreTests: XCTestCase {
     /// Verifies that loadAccounts succeeds when only WCPay succeeds and Stripe fails.
     ///
     func test_loadAccounts_succeeds_when_only_wcpay_succeeds() throws {
-        let expectation = self.expectation(description: "Load Account succeeds with WCPay only")
+        // Given
         network.simulateResponse(requestUrlSuffix: "payments/accounts",
                                  filename: "wcpay-account-complete")
         network.simulateResponse(requestUrlSuffix: "wc_stripe/account/summary",
                                  filename: "generic_error")
 
-        let action = CardPresentPaymentAction.loadAccounts(siteID: sampleSiteID, onCompletion: { result in
-            XCTAssertTrue(result.isSuccess)
-            expectation.fulfill()
-        })
+        // When
+        let result = waitFor { promise in
+            self.cardPresentStore.onAction(CardPresentPaymentAction.loadAccounts(siteID: self.sampleSiteID, onCompletion: { result in
+                promise(result)
+            }))
+        }
 
-        cardPresentStore.onAction(action)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isSuccess)
 
         XCTAssert(viewStorage.countObjects(ofType: Storage.PaymentGatewayAccount.self, matching: nil) == 1)
 
@@ -329,19 +333,21 @@ final class CardPresentPaymentStoreTests: XCTestCase {
     /// Verifies that loadAccounts succeeds when only Stripe succeeds and WCPay fails.
     ///
     func test_loadAccounts_succeeds_when_only_stripe_succeeds() throws {
-        let expectation = self.expectation(description: "Load Account succeeds with Stripe only")
+        // Given
         network.simulateResponse(requestUrlSuffix: "payments/accounts",
                                  filename: "generic_error")
         network.simulateResponse(requestUrlSuffix: "wc_stripe/account/summary",
                                  filename: "stripe-account-complete")
 
-        let action = CardPresentPaymentAction.loadAccounts(siteID: sampleSiteID, onCompletion: { result in
-            XCTAssertTrue(result.isSuccess)
-            expectation.fulfill()
-        })
+        // When
+        let result = waitFor { promise in
+            self.cardPresentStore.onAction(CardPresentPaymentAction.loadAccounts(siteID: self.sampleSiteID, onCompletion: { result in
+                promise(result)
+            }))
+        }
 
-        cardPresentStore.onAction(action)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isSuccess)
 
         XCTAssert(viewStorage.countObjects(ofType: Storage.PaymentGatewayAccount.self, matching: nil) == 1)
 
@@ -358,19 +364,20 @@ final class CardPresentPaymentStoreTests: XCTestCase {
     /// Verifies that loadAccounts returns an error when both WCPay and Stripe fail.
     ///
     func test_loadAccounts_fails_when_both_wcpay_and_stripe_fail() throws {
-        let expectation = self.expectation(description: "Load Account fails when both fail")
+        // Given
         network.simulateResponse(requestUrlSuffix: "payments/accounts",
                                  filename: "generic_error")
         network.simulateResponse(requestUrlSuffix: "wc_stripe/account/summary",
                                  filename: "generic_error")
+        // When
+        let result = waitFor { promise in
+            self.cardPresentStore.onAction(CardPresentPaymentAction.loadAccounts(siteID: self.sampleSiteID, onCompletion: { result in
+                promise(result)
+            }))
+        }
 
-        let action = CardPresentPaymentAction.loadAccounts(siteID: sampleSiteID, onCompletion: { result in
-            XCTAssertTrue(result.isFailure)
-            expectation.fulfill()
-        })
-
-        cardPresentStore.onAction(action)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(result.isFailure)
 
         XCTAssertNil(viewStorage.firstObject(ofType: Storage.PaymentGatewayAccount.self, matching: nil))
     }

--- a/Modules/Tests/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -297,6 +297,84 @@ final class CardPresentPaymentStoreTests: XCTestCase {
         XCTAssert(storageAccount?.status == "complete")
     }
 
+    /// Verifies that loadAccounts succeeds when only WCPay succeeds and Stripe fails.
+    ///
+    func test_loadAccounts_succeeds_when_only_wcpay_succeeds() throws {
+        let expectation = self.expectation(description: "Load Account succeeds with WCPay only")
+        network.simulateResponse(requestUrlSuffix: "payments/accounts",
+                                 filename: "wcpay-account-complete")
+        network.simulateResponse(requestUrlSuffix: "wc_stripe/account/summary",
+                                 filename: "generic_error")
+
+        let action = CardPresentPaymentAction.loadAccounts(siteID: sampleSiteID, onCompletion: { result in
+            XCTAssertTrue(result.isSuccess)
+            expectation.fulfill()
+        })
+
+        cardPresentStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        XCTAssert(viewStorage.countObjects(ofType: Storage.PaymentGatewayAccount.self, matching: nil) == 1)
+
+        let storageAccount = viewStorage.loadPaymentGatewayAccount(
+            siteID: sampleSiteID,
+            gatewayID: WCPayAccount.gatewayID
+        )
+
+        XCTAssert(storageAccount?.siteID == sampleSiteID)
+        XCTAssert(storageAccount?.gatewayID == WCPayAccount.gatewayID)
+        XCTAssert(storageAccount?.status == "complete")
+    }
+
+    /// Verifies that loadAccounts succeeds when only Stripe succeeds and WCPay fails.
+    ///
+    func test_loadAccounts_succeeds_when_only_stripe_succeeds() throws {
+        let expectation = self.expectation(description: "Load Account succeeds with Stripe only")
+        network.simulateResponse(requestUrlSuffix: "payments/accounts",
+                                 filename: "generic_error")
+        network.simulateResponse(requestUrlSuffix: "wc_stripe/account/summary",
+                                 filename: "stripe-account-complete")
+
+        let action = CardPresentPaymentAction.loadAccounts(siteID: sampleSiteID, onCompletion: { result in
+            XCTAssertTrue(result.isSuccess)
+            expectation.fulfill()
+        })
+
+        cardPresentStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        XCTAssert(viewStorage.countObjects(ofType: Storage.PaymentGatewayAccount.self, matching: nil) == 1)
+
+        let storageAccount = viewStorage.loadPaymentGatewayAccount(
+            siteID: sampleSiteID,
+            gatewayID: StripeAccount.gatewayID
+        )
+
+        XCTAssert(storageAccount?.siteID == sampleSiteID)
+        XCTAssert(storageAccount?.gatewayID == StripeAccount.gatewayID)
+        XCTAssert(storageAccount?.status == "complete")
+    }
+
+    /// Verifies that loadAccounts returns an error when both WCPay and Stripe fail.
+    ///
+    func test_loadAccounts_fails_when_both_wcpay_and_stripe_fail() throws {
+        let expectation = self.expectation(description: "Load Account fails when both fail")
+        network.simulateResponse(requestUrlSuffix: "payments/accounts",
+                                 filename: "generic_error")
+        network.simulateResponse(requestUrlSuffix: "wc_stripe/account/summary",
+                                 filename: "generic_error")
+
+        let action = CardPresentPaymentAction.loadAccounts(siteID: sampleSiteID, onCompletion: { result in
+            XCTAssertTrue(result.isFailure)
+            expectation.fulfill()
+        })
+
+        cardPresentStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        XCTAssertNil(viewStorage.firstObject(ofType: Storage.PaymentGatewayAccount.self, matching: nil))
+    }
+
     /// Verifies that the store hits the network when fetching a charge, and propagates success.
     ///
     func test_fetchWCPayCharge_returns_expected_data() throws {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 23.7
 -----
-
+- [*] Improve card payments onboarding error handling to show network errors correctly [https://github.com/woocommerce/woocommerce-ios/pull/16304]
 
 23.6
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -4,6 +4,7 @@ import Storage
 import Yosemite
 import Experiments
 import WooFoundation
+import Alamofire
 
 private typealias SystemPlugin = Yosemite.SystemPlugin
 private typealias PaymentGatewayAccount = Yosemite.PaymentGatewayAccount
@@ -180,8 +181,17 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
                 return
             }
 
-            self.updateState()
-            CardPresentPaymentOnboardingStateCache.shared.update(self.state)
+            switch result {
+            case .success:
+                updateState()
+                CardPresentPaymentOnboardingStateCache.shared.update(state)
+            case .failure(let error):
+                if isNetworkError(error) {
+                    state = .noConnectionError
+                } else {
+                    state = .genericError
+                }
+            }
         }
         stores.dispatch(paymentGatewayAccountsAction)
     }
@@ -548,7 +558,11 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     func isNetworkError(_ error: Error) -> Bool {
-        (error as NSError).domain == NSURLErrorDomain
+        if let afError = error as? AFError {
+            return true
+        } else {
+            return (error as NSError).domain == NSURLErrorDomain
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -4,7 +4,7 @@ import Storage
 import Yosemite
 import Experiments
 import WooFoundation
-import Alamofire
+import enum Alamofire.AFError
 
 private typealias SystemPlugin = Yosemite.SystemPlugin
 private typealias PaymentGatewayAccount = Yosemite.PaymentGatewayAccount

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import Fakes
 import Yosemite
+import enum Alamofire.AFError
 @testable import WooCommerce
 
 class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
@@ -1225,6 +1226,62 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(CardPresentPaymentsPlugin.stripe.pluginName, "WooCommerce Stripe Gateway")
         XCTAssertEqual(CardPresentPaymentsPlugin.stripe.plugin, .stripe)
         XCTAssertEqual(CardPresentPaymentsPlugin.stripe.fileNameWithPathExtension, "woocommerce-gateway-stripe/woocommerce-gateway-stripe")
+    }
+
+    // MARK: - loadAccounts error handling tests
+
+    func test_onboarding_handles_network_error_when_loading_accounts() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+
+        // Use AFError.sessionTaskFailed which is what Alamofire returns for network errors
+        let urlError = URLError(.notConnectedToInternet)
+        let networkError = AFError.sessionTaskFailed(error: urlError)
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            switch action {
+            case let .loadAccounts(_, onCompletion):
+                onCompletion(.failure(networkError))
+            default:
+                break
+            }
+        }
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
+                                                           stores: stores,
+                                                           cardPresentPaymentOnboardingStateCache: onboardingStateCache)
+        useCase.updateAccounts()
+
+        // Then - Should show no connection error
+        XCTAssertEqual(useCase.state, .noConnectionError)
+    }
+
+    func test_onboarding_handles_generic_error_when_both_accounts_fail_to_load() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupStripePlugin(status: .active, version: StripePluginVersion.minimumSupportedVersion)
+
+        let genericError = NSError(domain: "test.error", code: 500, userInfo: nil)
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            switch action {
+            case let .loadAccounts(_, onCompletion):
+                // Both accounts fail to load
+                onCompletion(.failure(genericError))
+            default:
+                break
+            }
+        }
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
+                                                           stores: stores,
+                                                           cardPresentPaymentOnboardingStateCache: onboardingStateCache)
+        useCase.updateAccounts()
+
+        // Then - Should show generic error
+        XCTAssertEqual(useCase.state, .genericError)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates our error handling during Card Present Payments Onboarding to show network errors when the gateway account or system status requests fail.

Previously, errors in these requests would result in us showing a "Finish Setup" message, suggesting there was more for the user to do on the web before they could take payments. This was confusing, because they may well have been fully setup and onboarded – the app just couldn't tell because it couldn't fetch their payments account.

![finish setup](https://github.com/user-attachments/assets/22595162-6d3d-47ae-8c16-45e9ecb7e84c)

Generally speaking, people won't hit these issues because of having no internet connection, but there could be other issues with them making a particular call.

## Changes
There was already some code to handle `noConnectionError`, but it didn't work because it was too picky about the types of errors which would be considered. Network errors tend to be AlamofireErrors, so we now consider these as "connection" errors when we encounter them during onboarding.

The payment gateway account request was a little different, as errors were never sent to the view. Ironically, it would almost always error, because we check both Stripe and WooPayments to see whether there's an account or not. I've changed that behaviour:

 - If one or both of the account requests succeed, we return success
 - If both account requests fail, we return the error
 - If they don't do either... we return a new error! Generally this shouldn't happen, but we've removed a no-completion call from the flow here.

Back in CardPresentPaymentsOnboardingUseCase, when we get an error from these (i.e. there's **no account**) we show the connection error.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Network breakpoints are your friend. Aborting a bunch of requests is the way to reproduce this.

- `wc/v3/system_status`
- `wc/v3/payments/accounts`
- `wc/v3/wc_stripe/account/summary`

Set your breakpoints on the request, and abort them before they go out to the server.

It's worth testing with both WordPress.com credentials and site credentials, as errors can be affected by that.

1. Leaving your breakpoints turned off, log out, and back in again.
2. Go to an order and turn your breakpoints on 
3. Start taking payment, select card reader
4. Onboarding should start with the loading screen 
5. Abort the system status request
6. Observe that the no connection error is shown
7. Tap `Retry`
8. Allow the system status request, then abort the accounts request
9. Observe that the no connection error is shown again
10. Tap `Retry` and allow all the requests
11. Observe that onboarding completes.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/fb5ee795-98e2-4e84-99a5-ceaf2dc15146


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
