### PR TITLE
Bookings: Update service/event filter to search by name only

### DIFF
--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -23,6 +23,7 @@ public protocol ProductsRemoteProtocol {
                          excludedProductIDs: [Int64]) async throws -> [Product]
     func searchProducts(for siteID: Int64,
                         keyword: String,
+                        searchFields: [ProductSearchField],
                         pageNumber: Int,
                         pageSize: Int,
                         stockStatus: ProductStockStatus?,
@@ -313,7 +314,11 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         parameters.updateValue(query, forKey: ParameterKey.searchNameOrSKU)
 
         // Takes precedence over `search_name_or_sku` from WC 10.1+ and is combined with `search` value
-        parameters.updateValue([SearchField.name, SearchField.sku, SearchField.globalUniqueID], forKey: ParameterKey.searchFields)
+        parameters.updateValue([
+            ProductSearchField.name.rawValue,
+            ProductSearchField.sku.rawValue,
+            ProductSearchField.globalUniqueID.rawValue
+        ], forKey: ParameterKey.searchFields)
 
         return try await makePagedPointOfSaleProductsRequest(
             for: siteID,
@@ -429,6 +434,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     ///
     public func searchProducts(for siteID: Int64,
                                keyword: String,
+                               searchFields: [ProductSearchField],
                                pageNumber: Int,
                                pageSize: Int,
                                stockStatus: ProductStockStatus? = nil,
@@ -447,10 +453,11 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.exclude: stringOfExcludedProductIDs
             ].filter({ $0.value.isEmpty == false })
 
-        let parameters = [
+        let parameters: [String: Any] = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),
             ParameterKey.search: keyword,
+            ParameterKey.searchFields: searchFields.map { $0.rawValue },
             ParameterKey.exclude: stringOfExcludedProductIDs,
             ParameterKey.contextKey: Default.context
         ].merging(filterParameters, uniquingKeysWith: { (first, _) in first })
@@ -774,12 +781,12 @@ public extension ProductsRemote {
         static let productSegment = "product"
         static let itemsSold = "items_sold"
     }
+}
 
-    private enum SearchField {
-        static let name = "name"
-        static let sku = "sku"
-        static let globalUniqueID = "global_unique_id"
-    }
+public enum ProductSearchField: String {
+    case name
+    case sku
+    case globalUniqueID = "global_unique_id"
 }
 
 private extension ProductsRemote {

--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -292,7 +292,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     }
 
     /// Remote search of products for the Point of Sale. Simple and variable products are loaded for WC version 9.6+, otherwise only simple products are loaded.
-    /// `search` is used, which searches in `name`, `description`, `short_description` fields.
+    /// `search` is used, which searches in `name`, `sku`, `globalUniqueID` fields.
     /// We also send `search_name_or_sku`, which will be used in preference to `search` when implemented on a site (in future.)
     ///
     /// - Parameter siteID: Site for which we'll fetch remote products.

--- a/Modules/Sources/Yosemite/Model/Products/ProductSearchFilter.swift
+++ b/Modules/Sources/Yosemite/Model/Products/ProductSearchFilter.swift
@@ -4,6 +4,14 @@
 public enum ProductSearchFilter: String, Equatable, CaseIterable {
     /// Search for all products based on the keyword.
     case all
+    /// Search for products that match the name field.
+    case name
     /// Search for products that match the SKU field.
     case sku
+
+    /// Options for searching in product selector view.
+    /// `name` is omitted as it's used for bookable product filters only so far.
+    public static var productSelectorOptions: [ProductSearchFilter] {
+        [.all, .sku]
+    }
 }

--- a/Modules/Sources/Yosemite/Stores/ProductStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductStore.swift
@@ -231,27 +231,27 @@ private extension ProductStore {
                         productCategory: ProductCategory?,
                         excludedProductIDs: [Int64],
                         onCompletion: @escaping (Result<Bool, Error>) -> Void) {
+        /// internal helper search method
+        func searchProductsByKeyword(searchFields: [ProductSearchField]) async throws -> [Product] {
+            try await remote.searchProducts(for: siteID,
+                                            keyword: keyword,
+                                            searchFields: searchFields,
+                                            pageNumber: pageNumber,
+                                            pageSize: pageSize,
+                                            stockStatus: stockStatus,
+                                            productStatus: productStatus,
+                                            productType: productType,
+                                            productCategory: productCategory,
+                                            excludedProductIDs: excludedProductIDs)
+        }
         Task { @MainActor in
             do {
                 let products: [Product]
                 switch filter {
-                case .all, .name:
-                    let searchFields: [ProductSearchField] = {
-                        if filter == .name {
-                            return [.name]
-                        }
-                        return []
-                    }()
-                    products = try await remote.searchProducts(for: siteID,
-                                                               keyword: keyword,
-                                                               searchFields: searchFields,
-                                                               pageNumber: pageNumber,
-                                                               pageSize: pageSize,
-                                                               stockStatus: stockStatus,
-                                                               productStatus: productStatus,
-                                                               productType: productType,
-                                                               productCategory: productCategory,
-                                                               excludedProductIDs: excludedProductIDs)
+                case .all:
+                    products = try await searchProductsByKeyword(searchFields: [])
+                case .name:
+                    products = try await searchProductsByKeyword(searchFields: [.name])
                 case .sku:
                     products = try await remote.searchProductsBySKU(for: siteID,
                                                                     keyword: keyword,

--- a/Modules/Sources/Yosemite/Stores/ProductStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductStore.swift
@@ -235,9 +235,16 @@ private extension ProductStore {
             do {
                 let products: [Product]
                 switch filter {
-                case .all:
+                case .all, .name:
+                    let searchFields: [ProductSearchField] = {
+                        if filter == .name {
+                            return [.name]
+                        }
+                        return []
+                    }()
                     products = try await remote.searchProducts(for: siteID,
                                                                keyword: keyword,
+                                                               searchFields: searchFields,
                                                                pageNumber: pageNumber,
                                                                pageSize: pageSize,
                                                                stockStatus: stockStatus,

--- a/Modules/Tests/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -458,6 +458,7 @@ final class ProductsRemoteTests: XCTestCase {
         // When
         let products = try await remote.searchProducts(for: sampleSiteID,
                                                        keyword: "photo",
+                                                       searchFields: [],
                                                        pageNumber: 0,
                                                        pageSize: 100)
 
@@ -475,12 +476,33 @@ final class ProductsRemoteTests: XCTestCase {
         do {
             _ = try await remote.searchProducts(for: sampleSiteID,
                                                 keyword: String(),
+                                                searchFields: [],
                                                 pageNumber: 0,
                                                 pageSize: 100)
             XCTFail("Expected error to be thrown")
         } catch {
             // Expected error
         }
+    }
+
+    /// Verifies that searchProducts with name search field includes the search_fields param in network request.
+    ///
+    func test_searchProducts_with_name_search_field_includes_search_fields_param_in_network_request() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-search-photo")
+
+        // When
+        _ = try await remote.searchProducts(for: sampleSiteID,
+                                            keyword: "test",
+                                            searchFields: [.name],
+                                            pageNumber: 0,
+                                            pageSize: 100)
+
+        // Then
+        let queryParameters = try XCTUnwrap(network.queryParameters)
+        let expectedParam = "search_fields=[\"name\"]"
+        XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
     }
 
     // MARK: - Search Products by SKU

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -286,6 +286,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
 
     func searchProducts(for siteID: Int64,
                         keyword: String,
+                        searchFields: [ProductSearchField],
                         pageNumber: Int,
                         pageSize: Int,
                         stockStatus: ProductStockStatus?,

--- a/WooCommerce/Classes/Bookings/BookingFilters/BookableProductListSyncable.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/BookableProductListSyncable.swift
@@ -60,6 +60,7 @@ struct BookableProductListSyncable: ListSyncable {
         ProductAction.searchProducts(
             siteID: siteID,
             keyword: keyword,
+            filter: .name,
             pageNumber: pageNumber,
             pageSize: pageSize,
             productType: .booking,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -336,7 +336,7 @@ private extension ProductSelectorView {
                 .submitLabel(.done)
                 .accessibilityIdentifier("product-selector-search-bar")
                 Picker(selection: $viewModel.productSearchFilter, label: EmptyView()) {
-                    ForEach(ProductSearchFilter.allCases, id: \.self) { option in Text(option.title) }
+                    ForEach(ProductSearchFilter.productSelectorOptions, id: \.self) { option in Text(option.title) }
                 }
                 .if(geometry.size.width <= Constants.headerSearchRowWidth) { $0.pickerStyle(.menu) }
                 .if(geometry.size.width > Constants.headerSearchRowWidth) { $0.pickerStyle(.segmented) }

--- a/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
@@ -200,22 +200,27 @@ private extension ProductSearchUICommand {
 }
 
 extension ProductSearchFilter {
+    /// The title of the option on the picker of product selector view.
     var title: String {
         switch self {
         case .all:
             return NSLocalizedString("All Products", comment: "Title of the product search filter to search for all products.")
         case .sku:
             return NSLocalizedString("SKU", comment: "Title of the product search filter to search for products that match the SKU.")
+        case .name:
+            fatalError("This option is not supported on the product selector UI")
         }
     }
 
-    /// The value that is set in the analytics event property.
+    /// The value that is set in the analytics event property when selecting the option on the product selector view.
     var analyticsValue: String {
         switch self {
         case .all:
             return "all"
         case .sku:
             return "sku"
+        case .name:
+            fatalError("This option is not supported on the product selector UI")
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of WOOMOB-1240

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR improves the search experience on Bookings' Service/Event filter.

Previously in #16294 I got a feedback regarding the search behavior of Service/Event:

> For example if testing in our shared CIAB site and entering the "Ro" search term I can see both "Room Rental" and "Hair Salon Appointment". Entering "P" also reveals both results. "Re" also both results.

The reason for this is that currently we're searching products without defining which fields to search. By default, this would mean matching keywords with product names, descriptions, short descriptions, SKUs, and global unique identifiers. On the Service/Event filter view, the only visible detail is product name, so returning results matching other fields might make it look like the search results are incorrect.

This PR improves the experience by asking the remote to search only by product names when filtering booking service/events. This comes with updates to the Networking and Yosemite layers to include the `search_fields` in the network requests.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Log in to a CIAB store with existing bookings.
2. Navigate to the Bookings tab > All > Filter > Service/Event.
3. In the search bar, enter short keywords and ensure that only items with matching names are displayed in the search results.

Regression test: Since I updated the search request for POS in `ProductsRemote`, we need to ensure that I didn't cause any regression.
1. Log in to a non-CIAB store on tablet.
2. Navigate to the POS tab.
3. Tap the Search icon for products.
4. Enter any keywords and ensure that the results are correct.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/79257cb8-049f-4dfa-b256-7b4d9bd883c6



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
