### PR TITLE
Avoid encoding custom fields when updating products

### DIFF
--- a/Modules/Sources/Networking/Model/Product/Product.swift
+++ b/Modules/Sources/Networking/Model/Product/Product.swift
@@ -766,12 +766,9 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         try container.encode(password, forKey: .password)
 
         // Metadata
-        var metaDataValuePairs = buildMetaDataValuePairs()
-
-        // Add custom fields to metadata
-        let customFields = buildCustomFields()
-        metaDataValuePairs.append(contentsOf: customFields)
-
+        let metaDataValuePairs = buildMetaDataValuePairs()
+        // Custom fields will not be included in metadata - when updating products.
+        // They are saved separately with `MetaDataStore`.
         // Encode metadata if it's not empty
         if metaDataValuePairs.isEmpty == false {
             try container.encode(metaDataValuePairs, forKey: .metadata)
@@ -785,16 +782,6 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         }
         return metaDataArray
     }
-
-    // Function to get the custom fields
-    private func buildCustomFields() -> [[String: String]] {
-        var customFieldsArray: [[String: String]] = []
-        for customField in customFields {
-            customFieldsArray.append(["id": "\(customField.metadataID)", "key": customField.key, "value": customField.value.stringValue])
-        }
-        return customFieldsArray
-    }
-
 }
 
 /// Defines all of the Product CodingKeys

--- a/Modules/Tests/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -489,7 +489,7 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertEqual(product.customFields.first?.value.stringValue, "10")
     }
 
-    /// Test that metadata and subscription are properly encoded.
+    /// Test that only subscription details are encoded for metadata.
     ///
     func test_metadata_and_subscription_are_properly_encoded() throws {
         // Given
@@ -524,7 +524,7 @@ final class ProductMapperTests: XCTestCase {
         // Then
         XCTAssertNotNil(encodedJSON)
         let encodedMetadata = encodedJSON?["meta_data"] as? [[String: Any]]
-        XCTAssertEqual(encodedMetadata?.count, customFields.count + subscription.toKeyValuePairs().count) // Including subscription metadata
+        XCTAssertEqual(encodedMetadata?.count, subscription.toKeyValuePairs().count) // Including only subscription metadata
         XCTAssertEqual(encodedMetadata?[0]["key"] as? String, "_subscription_length")
         XCTAssertEqual(encodedMetadata?[0]["value"] as? String, subscription.length)
         XCTAssertEqual(encodedMetadata?[1]["key"] as? String, "_subscription_period")
@@ -541,12 +541,6 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertEqual(encodedMetadata?[6]["value"] as? String, subscription.trialPeriod.rawValue)
         XCTAssertEqual(encodedMetadata?[7]["key"] as? String, "_subscription_one_time_shipping")
         XCTAssertEqual(encodedMetadata?[7]["value"] as? String, subscription.oneTimeShipping ? "yes" : "no")
-        XCTAssertEqual(Int64(encodedMetadata?[8]["id"] as? String ?? ""), customFields[0].metadataID)
-        XCTAssertEqual(encodedMetadata?[8]["key"] as? String, customFields[0].key)
-        XCTAssertEqual(encodedMetadata?[8]["value"] as? String, customFields[0].value.stringValue)
-        XCTAssertEqual(Int64(encodedMetadata?[9]["id"] as? String ?? ""), customFields[1].metadataID)
-        XCTAssertEqual(encodedMetadata?[9]["key"] as? String, customFields[1].key)
-        XCTAssertEqual(encodedMetadata?[9]["value"] as? String, customFields[1].value.stringValue)
     }
 
     /// Test that attributes are properly encoded.

--- a/Modules/Tests/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -640,6 +640,67 @@ final class ProductsRemoteTests: XCTestCase {
         }
     }
 
+    /// Verifies that updateProduct sends only subscription details in metadata and does not send custom fields.
+    ///
+    func test_updateProduct_sends_only_subscription_in_metadata_not_custom_fields() throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)", filename: "product-update")
+
+        // Create a product with both custom fields and a subscription
+        let customFields = [
+            MetaData(metadataID: 1, key: "custom_field_1", value: "value_1"),
+            MetaData(metadataID: 2, key: "custom_field_2", value: "value_2")
+        ]
+        let subscription = ProductSubscription(
+            length: "12",
+            period: .month,
+            periodInterval: "1",
+            price: "9.99",
+            signUpFee: "0",
+            trialLength: "7",
+            trialPeriod: .day,
+            oneTimeShipping: false,
+            paymentSyncDate: "0",
+            paymentSyncMonth: ""
+        )
+        let product = sampleProduct().copy(subscription: subscription, customFields: customFields)
+
+        // When
+        waitForExpectation { expectation in
+            remote.updateProduct(product: product) { _ in
+                expectation.fulfill()
+            }
+        }
+
+        // Then
+        let parametersDictionary = try XCTUnwrap(network.queryParametersDictionary)
+
+        // Verify that metadata contains only subscription details, not custom fields
+        if let metadata = parametersDictionary["meta_data"] as? [[String: Any]] {
+            let metadataKeys = metadata.compactMap { $0["key"] as? String }
+
+            // Verify subscription metadata is present
+            XCTAssertTrue(metadataKeys.contains("_subscription_length"), "Subscription length should be in metadata")
+            XCTAssertTrue(metadataKeys.contains("_subscription_period"), "Subscription period should be in metadata")
+            XCTAssertTrue(metadataKeys.contains("_subscription_period_interval"), "Subscription period interval should be in metadata")
+            XCTAssertTrue(metadataKeys.contains("_subscription_price"), "Subscription price should be in metadata")
+            XCTAssertTrue(metadataKeys.contains("_subscription_sign_up_fee"), "Subscription sign up fee should be in metadata")
+            XCTAssertTrue(metadataKeys.contains("_subscription_trial_length"), "Subscription trial length should be in metadata")
+            XCTAssertTrue(metadataKeys.contains("_subscription_trial_period"), "Subscription trial period should be in metadata")
+            XCTAssertTrue(metadataKeys.contains("_subscription_one_time_shipping"), "Subscription one time shipping should be in metadata")
+
+            // Verify custom fields are NOT in metadata
+            XCTAssertFalse(metadataKeys.contains("custom_field_1"), "Custom field 1 should not be sent in metadata")
+            XCTAssertFalse(metadataKeys.contains("custom_field_2"), "Custom field 2 should not be sent in metadata")
+
+            // Verify metadata contains exactly 8 subscription fields and no custom fields
+            XCTAssertEqual(metadata.count, 8, "Metadata should contain exactly 8 subscription fields")
+        } else {
+            XCTFail("Metadata should be present when product has subscription")
+        }
+    }
+
     // MARK: - Update Product Images
 
     /// Verifies that updateProductImages properly parses the `product-update` sample response.

--- a/Modules/Tests/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -640,67 +640,6 @@ final class ProductsRemoteTests: XCTestCase {
         }
     }
 
-    /// Verifies that updateProduct sends only subscription details in metadata and does not send custom fields.
-    ///
-    func test_updateProduct_sends_only_subscription_in_metadata_not_custom_fields() throws {
-        // Given
-        let remote = ProductsRemote(network: network)
-        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)", filename: "product-update")
-
-        // Create a product with both custom fields and a subscription
-        let customFields = [
-            MetaData(metadataID: 1, key: "custom_field_1", value: "value_1"),
-            MetaData(metadataID: 2, key: "custom_field_2", value: "value_2")
-        ]
-        let subscription = ProductSubscription(
-            length: "12",
-            period: .month,
-            periodInterval: "1",
-            price: "9.99",
-            signUpFee: "0",
-            trialLength: "7",
-            trialPeriod: .day,
-            oneTimeShipping: false,
-            paymentSyncDate: "0",
-            paymentSyncMonth: ""
-        )
-        let product = sampleProduct().copy(subscription: subscription, customFields: customFields)
-
-        // When
-        waitForExpectation { expectation in
-            remote.updateProduct(product: product) { _ in
-                expectation.fulfill()
-            }
-        }
-
-        // Then
-        let parametersDictionary = try XCTUnwrap(network.queryParametersDictionary)
-
-        // Verify that metadata contains only subscription details, not custom fields
-        if let metadata = parametersDictionary["meta_data"] as? [[String: Any]] {
-            let metadataKeys = metadata.compactMap { $0["key"] as? String }
-
-            // Verify subscription metadata is present
-            XCTAssertTrue(metadataKeys.contains("_subscription_length"), "Subscription length should be in metadata")
-            XCTAssertTrue(metadataKeys.contains("_subscription_period"), "Subscription period should be in metadata")
-            XCTAssertTrue(metadataKeys.contains("_subscription_period_interval"), "Subscription period interval should be in metadata")
-            XCTAssertTrue(metadataKeys.contains("_subscription_price"), "Subscription price should be in metadata")
-            XCTAssertTrue(metadataKeys.contains("_subscription_sign_up_fee"), "Subscription sign up fee should be in metadata")
-            XCTAssertTrue(metadataKeys.contains("_subscription_trial_length"), "Subscription trial length should be in metadata")
-            XCTAssertTrue(metadataKeys.contains("_subscription_trial_period"), "Subscription trial period should be in metadata")
-            XCTAssertTrue(metadataKeys.contains("_subscription_one_time_shipping"), "Subscription one time shipping should be in metadata")
-
-            // Verify custom fields are NOT in metadata
-            XCTAssertFalse(metadataKeys.contains("custom_field_1"), "Custom field 1 should not be sent in metadata")
-            XCTAssertFalse(metadataKeys.contains("custom_field_2"), "Custom field 2 should not be sent in metadata")
-
-            // Verify metadata contains exactly 8 subscription fields and no custom fields
-            XCTAssertEqual(metadata.count, 8, "Metadata should contain exactly 8 subscription fields")
-        } else {
-            XCTFail("Metadata should be present when product has subscription")
-        }
-    }
-
     // MARK: - Update Product Images
 
     /// Verifies that updateProductImages properly parses the `product-update` sample response.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1633

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

**Problem**
Upon saving products, custom fields are merged with subscription details to the `metadata` field. Custom field values are encoded as string disregard of their actual types. When there are fields with non-string values, saving products sends custom fields as string, causing corrupted data.

**Solution**
The way product saving works: any fields sent to the `metadata` field are updated, the existing ones stay intact. So there's no need to send custom fields when saving products on the product form. Custom fields are updated separately on Custom Fields screen through `MetaDataStore`.

This PR fixes the issue by not encoding custom fields into `metadata` when saving product on the product form.


## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Use API to create custom fields for a product with values being JSON.
<details>
<summary>cURL request</summary>
```
curl --location 'https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/{site_id}/rest-api' \
--header 'Authorization: Bearer {auth_token}' \
--header 'Accept: application/json' \
--header 'User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 wc-ios/6.5' \
--form 'path="wc/v3/products/{product_id}"' \
--form 'json="true"' \
--form '_method="put"' \
--form 'body="{
    \"meta_data\": [
        {
            \"key\": \"json_object\",
            \"value\": {
                \"Key\": \"Value\"
            }
        },
        {
            \"key\": \"json_array\",
            \"value\": [
                {
                    \"Key\": \"Value\"
                }
            ]
        }
    ]
}"'
```

</details>

2. Log in to the same test store on the app.
3. Navigate to Products tab > open the product with the custom fields in step 1.
4. Update any other details: name/description/price/etc.
5. Check with Proxyman or API `GET wc/v3/products/{product_id}` to confirm that the custom fields with JSON values are still correct. Values should not be updated to string. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
