### PR TITLE
[Woo POS][Settings i2] Update designs for sidebar navigation

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -139,7 +139,7 @@ struct PointOfSaleDashboardView: View {
             documentationView
         }
         .posFullScreenCover(isPresented: $showSettings) {
-            PointOfSaleSettingsView(settingsController: posModel.settingsController)
+            POSSettingsView(settingsController: posModel.settingsController)
         }
         .onChange(of: posModel.entryPointController.eligibilityState) { oldValue, newValue in
             guard newValue == .eligible else { return }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsCardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsCardView.swift
@@ -9,7 +9,7 @@ struct POSSettingsCardView: View {
         Button(action: action) {
             VStack(alignment: .leading, spacing: POSPadding.xSmall) {
                 Text(title)
-                    .font(.posBodyLargeRegular())
+                    .font(.posBodyLargeBold)
                     .foregroundStyle(Color.posOnSurface)
                 Text(subtitle)
                     .font(.posBodyMediumRegular())

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsCardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsCardView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct POSSettingsCardView: View {
     let title: String
     let subtitle: String
+    let isSelected: Bool
     let action: () -> Void
 
     var body: some View {
@@ -20,6 +21,12 @@ struct POSSettingsCardView: View {
             .background(Color.posSurfaceContainerLowest)
             .dynamicTypeSize(...DynamicTypeSize.accessibility2)
             .posItemCardBorderStyles()
+            .overlay {
+                if isSelected {
+                    RoundedRectangle(cornerRadius: POSCornerRadiusStyle.medium.value)
+                        .stroke(Color.posOnSurface, lineWidth: 2)
+                }
+            }
         }
         .buttonStyle(.plain)
         .accessibilityAddTraits(.isButton)
@@ -32,6 +39,7 @@ struct POSSettingsCardView: View {
     POSSettingsCardView(
         title: "Documentation",
         subtitle: "Learn more about accepting mobile payments",
+        isSelected: true,
         action: { }
     )
 }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -243,6 +243,7 @@ private extension POSSettingsHardwareDetailView {
                 } else {
                     POSSettingsCardView(title: Localization.cardReaderConnectTitle,
                                         subtitle: Localization.cardReaderConnectSubtitle,
+                                        isSelected: false, // Temporary. Update with WOOMOB-1571
                                         action: {
                         posModel.connectCardReader()
                     })
@@ -250,6 +251,7 @@ private extension POSSettingsHardwareDetailView {
 
                 POSSettingsCardView(title: Localization.cardReaderDocumentationTitle,
                                     subtitle: Localization.cardReaderDocumentationSubtitle,
+                                    isSelected: false, // Temporary. Update with WOOMOB-1571
                                     action: { showCardReaderDocumentationModal = true })
                 .accessibilityAddTraits(.isButton)
                 .listRowSeparator(.hidden)

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct PointOfSaleSettingsView: View {
+struct POSSettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.posAnalytics) private var analytics
     @State private var selection: SidebarNavigation? = .store
@@ -20,7 +20,7 @@ struct PointOfSaleSettingsView: View {
     }
 }
 
-extension PointOfSaleSettingsView {
+extension POSSettingsView {
     @ViewBuilder
     private var listView: some View {
         VStack(alignment: .leading, spacing: POSSpacing.none) {
@@ -36,23 +36,23 @@ extension PointOfSaleSettingsView {
             .accessibilityAddTraits(.isHeader)
 
             VStack(spacing: POSSpacing.small) {
-                POSSettingsCardView(title: PointOfSaleSettingsView.SidebarNavigation.store.title,
-                                    subtitle: PointOfSaleSettingsView.SidebarNavigation.store.subtitle,
+                POSSettingsCardView(title: POSSettingsView.SidebarNavigation.store.title,
+                                    subtitle: POSSettingsView.SidebarNavigation.store.subtitle,
                                     isSelected: selection == .store,
                                     action: {
                     analytics.track(.pointOfSaleSettingsStoreDetailsTapped)
                     selection = .store
                 })
-                POSSettingsCardView(title: PointOfSaleSettingsView.SidebarNavigation.hardware.title,
-                                    subtitle: PointOfSaleSettingsView.SidebarNavigation.hardware.subtitle,
+                POSSettingsCardView(title: POSSettingsView.SidebarNavigation.hardware.title,
+                                    subtitle: POSSettingsView.SidebarNavigation.hardware.subtitle,
                                     isSelected: selection == .hardware,
                                     action: {
                     analytics.track(.pointOfSaleSettingsHardwareTapped)
                     selection = .hardware
                 })
                 if settingsController.isLocalCatalogEligible {
-                    POSSettingsCardView(title: PointOfSaleSettingsView.SidebarNavigation.localCatalog.title,
-                                        subtitle: PointOfSaleSettingsView.SidebarNavigation.localCatalog.subtitle,
+                    POSSettingsCardView(title: POSSettingsView.SidebarNavigation.localCatalog.title,
+                                        subtitle: POSSettingsView.SidebarNavigation.localCatalog.subtitle,
                                         isSelected: selection == .localCatalog,
                                         action: {
                         selection = .localCatalog
@@ -113,13 +113,13 @@ extension PointOfSaleSettingsView {
     }
 }
 
-extension PointOfSaleSettingsView {
+extension POSSettingsView {
     enum Constants {
         static let sidebarWidthFraction: CGFloat = 0.35
     }
 }
 
-extension PointOfSaleSettingsView {
+extension POSSettingsView {
     enum SidebarNavigation: String, CaseIterable, Identifiable {
         case store
         case hardware
@@ -215,6 +215,6 @@ extension PointOfSaleSettingsView {
 
 #if DEBUG
 #Preview {
-    PointOfSaleSettingsView(settingsController: POSSettingsPreviewController())
+    POSSettingsView(settingsController: POSSettingsPreviewController())
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
@@ -106,6 +106,7 @@ extension POSSettingsView {
             .padding()
             .frame(maxWidth: .infinity, alignment: .leading)
             .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityAddTraits(.isButton)

--- a/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsView.swift
@@ -59,13 +59,28 @@ extension PointOfSaleSettingsView {
                     })
                 }
                 Spacer()
-                POSSettingsCardView(title: PointOfSaleSettingsView.SidebarNavigation.help.title,
-                                    subtitle: PointOfSaleSettingsView.SidebarNavigation.help.subtitle,
-                                    isSelected: selection == .help,
-                                    action: {
+
+                Button {
                     analytics.track(.pointOfSaleSettingsHelpTapped)
                     selection = .help
-                })
+                } label: {
+                    HStack(spacing: POSSpacing.small) {
+                        if let icon = SidebarNavigation.help.icon {
+                            Image(systemName: icon)
+                                .font(.posBodyMediumBold)
+                                .foregroundStyle(Color.posOnSurface)
+                        }
+                        Text(SidebarNavigation.help.title)
+                            .font(.posBodyMediumBold)
+                            .foregroundStyle(Color.posOnSurface)
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                }
+                .buttonStyle(.plain)
+                .accessibilityAddTraits(.isButton)
+                .accessibilityLabel(SidebarNavigation.help.title)
             }
             .padding(.horizontal, POSPadding.medium)
         }
@@ -125,6 +140,15 @@ extension PointOfSaleSettingsView {
             case .help: return Localization.sidebarNavigationHelpSubtitle
             }
         }
+
+        var icon: String? {
+            switch self {
+            case .store, .hardware, .localCatalog:
+                return nil
+            case .help:
+                return "questionmark.circle"
+            }
+        }
     }
 
     enum Localization {
@@ -147,8 +171,8 @@ extension PointOfSaleSettingsView {
         )
 
         static let sidebarNavigationHelpTitle = NSLocalizedString(
-            "pointOfSaleSettingsView.sidebarNavigationHelpTitle",
-            value: "Help",
+            "pointOfSaleSettingsView.sidebarNavigationHelpTitle.1",
+            value: "Get help and support",
             comment: "Title of the Help section within Point of Sale settings."
         )
 

--- a/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsView.swift
@@ -60,27 +60,7 @@ extension PointOfSaleSettingsView {
                 }
                 Spacer()
 
-                Button {
-                    analytics.track(.pointOfSaleSettingsHelpTapped)
-                    selection = .help
-                } label: {
-                    HStack(spacing: POSSpacing.small) {
-                        if let icon = SidebarNavigation.help.icon {
-                            Image(systemName: icon)
-                                .font(.posBodyMediumBold)
-                                .foregroundStyle(Color.posOnSurface)
-                        }
-                        Text(SidebarNavigation.help.title)
-                            .font(.posBodyMediumBold)
-                            .foregroundStyle(Color.posOnSurface)
-                    }
-                    .padding()
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .dynamicTypeSize(...DynamicTypeSize.accessibility2)
-                }
-                .buttonStyle(.plain)
-                .accessibilityAddTraits(.isButton)
-                .accessibilityLabel(SidebarNavigation.help.title)
+                helpView
             }
             .padding(.horizontal, POSPadding.medium)
         }
@@ -105,6 +85,31 @@ extension PointOfSaleSettingsView {
         default:
             EmptyView()
         }
+    }
+
+    @ViewBuilder
+    private var helpView: some View {
+        Button {
+            analytics.track(.pointOfSaleSettingsHelpTapped)
+            selection = .help
+        } label: {
+            HStack(spacing: POSSpacing.small) {
+                if let icon = SidebarNavigation.help.icon {
+                    Image(systemName: icon)
+                        .font(.posBodyMediumBold)
+                        .foregroundStyle(Color.posOnSurface)
+                }
+                Text(SidebarNavigation.help.title)
+                    .font(.posBodyMediumBold)
+                    .foregroundStyle(Color.posOnSurface)
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(SidebarNavigation.help.title)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsView.swift
@@ -31,7 +31,7 @@ extension PointOfSaleSettingsView {
                                                    analytics.track(.pointOfSaleSettingsCloseButtonTapped)
                                                    dismiss()
                                                },
-                                               buttonIcon: "xmark"))
+                                               buttonIcon: "chevron.left"))
             .foregroundColor(.posSurface)
             .accessibilityAddTraits(.isHeader)
 

--- a/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsView.swift
@@ -36,44 +36,32 @@ extension PointOfSaleSettingsView {
             .accessibilityAddTraits(.isHeader)
 
             VStack(spacing: POSSpacing.small) {
-                PointOfSaleSettingsCard(
-                    item: .store,
-                    isSelected: selection == .store,
-                    onTap: {
-                        analytics.track(.pointOfSaleSettingsStoreDetailsTapped)
-                        selection = .store
-                    }
-                )
-
-                PointOfSaleSettingsCard(
-                    item: .hardware,
-                    isSelected: selection == .hardware,
-                    onTap: {
-                        analytics.track(.pointOfSaleSettingsHardwareTapped)
-                        selection = .hardware
-                    }
-                )
-
+                POSSettingsCardView(title: PointOfSaleSettingsView.SidebarNavigation.store.title,
+                                    subtitle: PointOfSaleSettingsView.SidebarNavigation.store.subtitle,
+                                    action: {
+                    analytics.track(.pointOfSaleSettingsStoreDetailsTapped)
+                    selection = .store
+                })
+                POSSettingsCardView(title: PointOfSaleSettingsView.SidebarNavigation.hardware.title,
+                                    subtitle: PointOfSaleSettingsView.SidebarNavigation.hardware.subtitle,
+                                    action: {
+                    analytics.track(.pointOfSaleSettingsHardwareTapped)
+                    selection = .hardware
+                })
                 if settingsController.isLocalCatalogEligible {
-                    PointOfSaleSettingsCard(
-                        item: .localCatalog,
-                        isSelected: selection == .localCatalog,
-                        onTap: {
-                            selection = .localCatalog
-                        }
-                    )
+                    POSSettingsCardView(title: PointOfSaleSettingsView.SidebarNavigation.localCatalog.title,
+                                        subtitle: PointOfSaleSettingsView.SidebarNavigation.localCatalog.subtitle,
+                                        action: {
+                        selection = .localCatalog
+                    })
                 }
-
                 Spacer()
-
-                PointOfSaleSettingsCard(
-                    item: .help,
-                    isSelected: selection == .help,
-                    onTap: {
-                        analytics.track(.pointOfSaleSettingsHelpTapped)
-                        selection = .help
-                    }
-                )
+                POSSettingsCardView(title: PointOfSaleSettingsView.SidebarNavigation.help.title,
+                                    subtitle: PointOfSaleSettingsView.SidebarNavigation.help.subtitle,
+                                    action: {
+                    analytics.track(.pointOfSaleSettingsHelpTapped)
+                    selection = .help
+                })
             }
             .padding(.horizontal, POSPadding.medium)
         }
@@ -107,53 +95,6 @@ extension PointOfSaleSettingsView {
     }
 }
 
-struct PointOfSaleSettingsCard: View {
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    @Environment(\.colorScheme) private var colorScheme
-
-    let item: PointOfSaleSettingsView.SidebarNavigation
-    let isSelected: Bool
-    let onTap: () -> Void
-
-    private var selectionBackgroundColor: Color {
-        guard isSelected else { return Color.clear }
-        return colorScheme == .dark ? Color.posPrimary : Color.posSecondary
-    }
-
-    var body: some View {
-        Button(action: onTap) {
-            HStack(spacing: POSSpacing.medium) {
-                Image(systemName: item.icon)
-                    .font(.posBodyLargeRegular())
-                    .foregroundStyle(Color.posOnSurface)
-                    .accessibilityHidden(true)
-                    .renderedIf(!dynamicTypeSize.isAccessibilitySize)
-
-                VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
-                    Text(item.title)
-                        .font(.posBodyLargeRegular())
-                        .foregroundStyle(Color.posOnSurface)
-                        .dynamicTypeSize(...DynamicTypeSize.accessibility2)
-                    Text(item.subtitle)
-                        .font(.posBodyMediumRegular())
-                        .foregroundStyle(Color.posOnSurface)
-                        .dynamicTypeSize(...DynamicTypeSize.accessibility2)
-                }
-                Spacer()
-            }
-            .padding(.vertical, POSPadding.small)
-            .padding(.horizontal, POSPadding.medium)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityAddTraits(.isButton)
-        .background(
-            RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value, style: .continuous)
-                .fill(selectionBackgroundColor)
-        )
-    }
-}
-
 extension PointOfSaleSettingsView {
     enum SidebarNavigation: String, CaseIterable, Identifiable {
         case store
@@ -178,15 +119,6 @@ extension PointOfSaleSettingsView {
             case .hardware: return Localization.sidebarNavigationHardwareSubtitle
             case .localCatalog: return Localization.sidebarNavigationLocalCatalogSubtitle
             case .help: return Localization.sidebarNavigationHelpSubtitle
-            }
-        }
-
-        var icon: String {
-            switch self {
-            case .store: return "bag"
-            case .hardware: return "wrench.and.screwdriver"
-            case .localCatalog: return "internaldrive"
-            case .help: return "questionmark.circle"
             }
         }
     }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/PointOfSaleSettingsView.swift
@@ -38,12 +38,14 @@ extension PointOfSaleSettingsView {
             VStack(spacing: POSSpacing.small) {
                 POSSettingsCardView(title: PointOfSaleSettingsView.SidebarNavigation.store.title,
                                     subtitle: PointOfSaleSettingsView.SidebarNavigation.store.subtitle,
+                                    isSelected: selection == .store,
                                     action: {
                     analytics.track(.pointOfSaleSettingsStoreDetailsTapped)
                     selection = .store
                 })
                 POSSettingsCardView(title: PointOfSaleSettingsView.SidebarNavigation.hardware.title,
                                     subtitle: PointOfSaleSettingsView.SidebarNavigation.hardware.subtitle,
+                                    isSelected: selection == .hardware,
                                     action: {
                     analytics.track(.pointOfSaleSettingsHardwareTapped)
                     selection = .hardware
@@ -51,6 +53,7 @@ extension PointOfSaleSettingsView {
                 if settingsController.isLocalCatalogEligible {
                     POSSettingsCardView(title: PointOfSaleSettingsView.SidebarNavigation.localCatalog.title,
                                         subtitle: PointOfSaleSettingsView.SidebarNavigation.localCatalog.subtitle,
+                                        isSelected: selection == .localCatalog,
                                         action: {
                         selection = .localCatalog
                     })
@@ -58,6 +61,7 @@ extension PointOfSaleSettingsView {
                 Spacer()
                 POSSettingsCardView(title: PointOfSaleSettingsView.SidebarNavigation.help.title,
                                     subtitle: PointOfSaleSettingsView.SidebarNavigation.help.subtitle,
+                                    isSelected: selection == .help,
                                     action: {
                     analytics.track(.pointOfSaleSettingsHelpTapped)
                     selection = .help


### PR DESCRIPTION
Closes WOOMOB-1571

## Description
This PR updates the sidebar of POS Settings to latest i2 designs qKAWGmvUsvfnW0Z4CssJHe-fi . Updates are not behind feature flag.

## Changes

- Updated the navigation items to use `POSSettingsCardView`, as well as the help section to its separate `helpView`
- Added a border when a card is selected
- Removed icons
- Updated font sizes and weight
- Updated sidebar navigation from `xmark` to `chevron.left`

The general background color for all settings seems to have switched between i1 and i2, will handle this on WOOMOB-1634 once the rest is done for easier testing.

## Test Steps
- Navigate to POS Settings
- Light/Dark mode, colors, font sizes should fit the design for the sidebar
- Tapping the cards should still navigate to their correct place in the sidebar. I've expanded the tappable area in the help section so does not only cover the icon + text

## Screenshots

https://github.com/user-attachments/assets/e1af64c0-d3aa-4920-b5ec-a50a35448dfd
