### PR TITLE
Fix product variation selection for order creation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Improve card payments onboarding error handling to show network errors correctly [https://github.com/woocommerce/woocommerce-ios/pull/16304]
 - [*] Authenticate the admin page automatically for sites with SSO enabled in custom fields, in-person payment setup, and editing tax rates flows. [https://github.com/woocommerce/woocommerce-ios/pull/16318]
 - [*] Show POS feedback surveys for eligible merchants [https://github.com/woocommerce/woocommerce-ios/pull/16325]
+- [*] Fix product variation selection for order creation [https://github.com/woocommerce/woocommerce-ios/pull/16317]
 
 23.6
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -139,7 +139,7 @@ struct OrderFormPresentationWrapper: View {
             },
             secondaryView: { isShowingProductSelector in
                 if let productSelectorViewModel = viewModel.productSelectorViewModel {
-                    ProductSelectorView(configuration: .loadConfiguration(for: horizontalSizeClass),
+                    ProductSelectorNavigationView(configuration: .loadConfiguration(for: horizontalSizeClass),
                                         isPresented: isShowingProductSelector,
                                         viewModel: productSelectorViewModel)
                     .sheet(item: $viewModel.productToConfigureViewModel) { viewModel in

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorNavigationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorNavigationView.swift
@@ -15,12 +15,11 @@ struct ProductSelectorNavigationView: View {
     }
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ProductSelectorView(configuration: configuration,
                                 isPresented: $isPresented,
                                 viewModel: viewModel)
         }
-        .navigationViewStyle(.stack)
         .wooNavigationBarStyle()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorView.swift
@@ -15,8 +15,6 @@ struct ProductVariationSelectorView: View {
 
     private let onMultipleSelections: (([Int64]) -> Void)?
 
-    @State private var hasSentSelectionOnDismiss = false
-
     /// Tracks the state for the 'Clear Selection' button
     ///
     private var isClearSelectionDisabled: Bool {
@@ -102,11 +100,6 @@ struct ProductVariationSelectorView: View {
                 }
                 .accessibilityLabel(Localization.backButtonAccessibilityLabel)
             }
-        }
-        .onDisappear {
-            guard !hasSentSelectionOnDismiss else { return }
-            hasSentSelectionOnDismiss = true
-            onMultipleSelections?(viewModel.selectedProductVariationIDs)
         }
         .onAppear {
             viewModel.onLoadTrigger.send()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorView.swift
@@ -15,6 +15,8 @@ struct ProductVariationSelectorView: View {
 
     private let onMultipleSelections: (([Int64]) -> Void)?
 
+    @State private var hasSentSelectionOnDismiss = false
+
     /// Tracks the state for the 'Clear Selection' button
     ///
     private var isClearSelectionDisabled: Bool {
@@ -100,6 +102,11 @@ struct ProductVariationSelectorView: View {
                 }
                 .accessibilityLabel(Localization.backButtonAccessibilityLabel)
             }
+        }
+        .onDisappear {
+            guard !hasSentSelectionOnDismiss else { return }
+            hasSentSelectionOnDismiss = true
+            onMultipleSelections?(viewModel.selectedProductVariationIDs)
         }
         .onAppear {
             viewModel.onLoadTrigger.send()


### PR DESCRIPTION
Closes (WOOMOB-1611)[https://linear.app/a8c/issue/WOOMOB-1611]

## Description
Fixes the linked issue by reusing the ProductSelectorNavigationView, which wraps the selector in a NavigationStack. Interestingly, the problem was sporadic, which I did not notice when I opened the ticket, and even more interestingly, it failed more often in the simulator than on the device. Either way, using the navigation stack, the issue is fixed; it just took me way too long to find the fix.

## Test Steps
1. Start the app.  
2. Open the order tab.  
3. Tap the "+" icon in the nav bar.  
4. Tap on "+ Add Products".  
5. Tap on the product with variations.  
6. Select a variation.  
7. Note that you are **NOT** navigated back to the "Select products" screen.  
8. Note that the variation is marked as selected.  
13. Tap back.  
14. Note that you see the product marked as selected.

## Screenshots

| Before | After |
| --- | --- |
| ![ScreenRecording_10-30-2025 09-09-00_1 (1)](https://github.com/user-attachments/assets/6db874b4-fa56-4a0c-9a92-0218c5109b70) | ![ScreenRecording_11-05-2025 14-01-15_1](https://github.com/user-attachments/assets/43c0e6cb-0006-4c15-bf67-bb4c75194703) |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
