### PR TITLE
[Woo POS][Settings] i2: Card reader management design updates

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -100,8 +100,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .pointOfSaleSurveys:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .pointOfSaleSettingsCardReaderFlow:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .pointOfSaleCatalogAPI:
             return false
         default:

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -208,10 +208,6 @@ public enum FeatureFlag: Int {
     ///
     case pointOfSaleSurveys
 
-    /// Enables card reader connection flow within POS settings
-    ///
-    case pointOfSaleSettingsCardReaderFlow
-
     /// Enables using the catalog API endpoint for Point of Sale catalog full sync
     ///
     case pointOfSaleCatalogAPI

--- a/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentCardReader.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentCardReader.swift
@@ -7,8 +7,12 @@ public struct CardPresentPaymentCardReader: Equatable {
     /// This is an unformatted percentage as a float, e.g. 0.0-1.0
     let batteryLevel: Float?
 
-    public init(name: String, batteryLevel: Float?) {
+    /// The reader's software version, if available.
+    let softwareVersion: String?
+
+    public init(name: String, batteryLevel: Float?, softwareVersion: String? = "Unknown") {
         self.name = name
         self.batteryLevel = batteryLevel
+        self.softwareVersion = softwareVersion
     }
 }

--- a/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentFacade.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentFacade.swift
@@ -1,6 +1,7 @@
 import Foundation
 import enum Yosemite.PaymentChannel
 import struct Yosemite.Order
+import enum Hardware.CardReaderSoftwareUpdateState
 import Combine
 
 public protocol CardPresentPaymentFacade {
@@ -12,6 +13,10 @@ public protocol CardPresentPaymentFacade {
     /// `readerConnectionStatusPublisher` provides the latest connection status for the card reader.
     /// This is a long lasting stream, and will not finish during the life of the façade.
     var readerConnectionStatusPublisher: AnyPublisher<CardPresentPaymentReaderConnectionStatus, Never> { get }
+
+    /// `cardReaderUpdateStatePublisher` provides the latest software update state for the connected card reader.
+    /// This is a long lasting stream, and will not finish during the life of the façade.
+    var cardReaderUpdateStatePublisher: AnyPublisher<CardReaderSoftwareUpdateState, Never> { get }
 
     /// Attempts to a card reader of the specified type.
     /// If another type of reader is already connected, this will be disconnected automatically.

--- a/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentFacade.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentFacade.swift
@@ -26,6 +26,11 @@ public protocol CardPresentPaymentFacade {
     /// Also cancels any in-progress payment, if possible.
     func disconnectReader() async
 
+    /// Starts a software update for the currently connected card reader, if an update is available.
+    /// - Throws: `CardPresentPaymentError` for any failures.
+    /// - Output: publishes intermediate events on the `paymentEventPublisher` as required.
+    func updateCardReaderSoftware() async throws
+
     /// Collects a card present payment for an order.
     /// If the appropriate type of reader is not already connected, this should attempt a connection before the payment.
     /// If another type of reader is already connected, this will be disconnected automatically.

--- a/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentFacade.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentFacade.swift
@@ -1,7 +1,7 @@
 import Foundation
 import enum Yosemite.PaymentChannel
 import struct Yosemite.Order
-import enum Hardware.CardReaderSoftwareUpdateState
+import enum Yosemite.CardReaderSoftwareUpdateState
 import Combine
 
 public protocol CardPresentPaymentFacade {

--- a/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentPreviewService.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentPreviewService.swift
@@ -2,6 +2,7 @@ import Foundation
 import Combine
 import enum Yosemite.PaymentChannel
 import struct Yosemite.Order
+import enum Hardware.CardReaderSoftwareUpdateState
 
 #if DEBUG
 
@@ -12,6 +13,10 @@ final class CardPresentPaymentPreviewService: CardPresentPaymentFacade {
 
     var readerConnectionStatusPublisher: AnyPublisher<CardPresentPaymentReaderConnectionStatus, Never> {
         $readerConnectionStatus.eraseToAnyPublisher()
+    }
+
+    var cardReaderUpdateStatePublisher: AnyPublisher<CardReaderSoftwareUpdateState, Never> {
+        Just(.none).eraseToAnyPublisher()
     }
 
     init(connectionStatus: CardPresentPaymentReaderConnectionStatus = .disconnected) {

--- a/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentPreviewService.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentPreviewService.swift
@@ -2,7 +2,7 @@ import Foundation
 import Combine
 import enum Yosemite.PaymentChannel
 import struct Yosemite.Order
-import enum Hardware.CardReaderSoftwareUpdateState
+import enum Yosemite.CardReaderSoftwareUpdateState
 
 #if DEBUG
 

--- a/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentPreviewService.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentPreviewService.swift
@@ -35,6 +35,10 @@ final class CardPresentPaymentPreviewService: CardPresentPaymentFacade {
     func cancelPayment() {
         // no-op
     }
+
+    func updateCardReaderSoftware() async throws {
+        // no-op
+    }
 }
 
 #endif

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -2,7 +2,6 @@ import CocoaLumberjackSwift
 import Foundation
 import Combine
 import Observation
-import enum Hardware.CardReaderSoftwareUpdateState
 
 import protocol Yosemite.POSOrderableItem
 import protocol WooFoundation.Analytics
@@ -17,6 +16,7 @@ import protocol Yosemite.PointOfSaleBarcodeScanServiceProtocol
 import enum Yosemite.PointOfSaleBarcodeScanError
 import protocol Yosemite.POSCatalogSyncCoordinatorProtocol
 import class Yosemite.POSCatalogSyncCoordinator
+import enum Yosemite.CardReaderSoftwareUpdateState
 
 protocol PointOfSaleAggregateModelProtocol {
     var cart: Cart { get }

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -2,6 +2,7 @@ import CocoaLumberjackSwift
 import Foundation
 import Combine
 import Observation
+import enum Hardware.CardReaderSoftwareUpdateState
 
 import protocol Yosemite.POSOrderableItem
 import protocol WooFoundation.Analytics
@@ -28,11 +29,19 @@ protocol PointOfSaleAggregateModelProtocol {
     private(set) var orderStage: PointOfSaleOrderStage = .building
 
     private(set) var cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus = .disconnected
+    private(set) var cardReaderUpdateState: CardReaderSoftwareUpdateState = .none
     private(set) var paymentState: PointOfSalePaymentState
     var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
     private(set) var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType?
     var cardPresentPaymentOnboardingViewContainer: CardPresentPaymentOnboardingViewContainer?
     private var onOnboardingCancellation: (() -> Void)?
+
+    var isCardReaderUpdateAvailable: Bool {
+        if case .available = cardReaderUpdateState {
+            return true
+        }
+        return false
+    }
 
     private(set) var cart: Cart = .init()
 
@@ -127,6 +136,7 @@ protocol PointOfSaleAggregateModelProtocol {
         self.isLocalCatalogEligible = isLocalCatalogEligible
 
         publishCardReaderConnectionStatus()
+        publishCardReaderUpdateState()
         publishPaymentMessages()
         setupReaderReconnectionObservation()
         setupPaymentSuccessObservation()
@@ -299,6 +309,14 @@ extension PointOfSaleAggregateModel {
         cardPresentPaymentService.readerConnectionStatusPublisher
             .sink(receiveValue: { [weak self] connectionStatus in
                 self?.cardReaderConnectionStatus = connectionStatus
+            })
+            .store(in: &cancellables)
+    }
+
+    private func publishCardReaderUpdateState() {
+        cardPresentPaymentService.cardReaderUpdateStatePublisher
+            .sink(receiveValue: { [weak self] updateState in
+                self?.cardReaderUpdateState = updateState
             })
             .store(in: &cancellables)
     }

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -317,6 +317,13 @@ extension PointOfSaleAggregateModel {
         }
     }
 
+    func updateCardReaderSoftware() {
+        //TODO: analytics.track(.cardReaderUpdateTapped)
+        Task { @MainActor [weak self] in
+            try? await self?.cardPresentPaymentService.updateCardReaderSoftware()
+        }
+    }
+
     /// Starts a payment immediately if a reader is connected.
     /// Otherwise, schedules a payment to start the next time a reader connects.
     /// Note that any scheduled payments are cancelled by `cancelReaderPreparation`

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleSettingsController.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleSettingsController.swift
@@ -75,7 +75,8 @@ protocol POSSettingsControllerProtocol {
 final class POSSettingsPreviewController: POSSettingsControllerProtocol {
     var connectedCardReader: CardPresentPaymentCardReader? = CardPresentPaymentCardReader(
         name: "WisePad 3",
-        batteryLevel: 0.75
+        batteryLevel: 0.75,
+        softwareVersion: "2.0.1.23"
     )
 
     var storeViewModel: POSSettingsStoreViewModel = POSSettingsStoreViewModel(siteID: 123,

--- a/Modules/Sources/PointOfSale/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
@@ -44,9 +44,8 @@ enum PointOfSaleCardPresentPaymentAlertType: Hashable, Identifiable {
             return viewModel.cancelReaderUpdate
         case .optionalReaderUpdateInProgress(let viewModel):
             return viewModel.cancelReaderUpdate
-        case .readerUpdateCompletion:
-            // We only support in-line updates at the moment, and they automatically move on to connecting the reader.
-            return nil
+        case .readerUpdateCompletion(let viewModel):
+            return viewModel.buttonViewModel.actionHandler
         case .updateFailed(let viewModel):
             return viewModel.cancelButtonViewModel.actionHandler
         case .updateFailedNonRetryable(let viewModel):

--- a/Modules/Sources/PointOfSale/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel.swift
@@ -4,19 +4,28 @@ import SwiftUI
 struct PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel {
     let title: String = Localization.title
     let progressTitle: String = .init(format: Localization.percentCompleteFormat, 100.0)
+    let buttonViewModel: CardPresentPaymentsModalButtonViewModel
+
+    init(doneAction: @escaping () -> Void) {
+        self.buttonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: "",
+            actionHandler: doneAction)
+    }
 }
 
 extension PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel: Hashable, Equatable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(title)
         hasher.combine(progressTitle)
+        hasher.combine(buttonViewModel)
     }
 
     /// This can be synthesised – implemented manually to ensure it matches the `hash` function.
     static func ==(lhs: PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel,
                    rhs: PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel) -> Bool {
         return lhs.title == rhs.title &&
-        lhs.progressTitle == rhs.progressTitle
+        lhs.progressTitle == rhs.progressTitle &&
+        lhs.buttonViewModel == rhs.buttonViewModel
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -125,7 +125,8 @@ enum PointOfSaleCardPresentPaymentEventPresentationStyle {
 
         case .updateProgress(let requiredUpdate, let progress, let cancelUpdate):
             if progress == 1.0 {
-                self = .alert(.readerUpdateCompletion(viewModel: .init()))
+                self = .alert(.readerUpdateCompletion(
+                    viewModel: .init(doneAction: dependencies.dismissReaderConnectionModal)))
             } else {
                 self = requiredUpdate ?
                     .alert(.requiredReaderUpdateInProgress(

--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionView.swift
@@ -34,6 +34,7 @@ struct PointOfSaleCardPresentPaymentReaderUpdateCompletionView: View {
         }
         .multilineTextAlignment(.center)
         .accessibilityElement(children: .contain)
+        .posModalCloseButton(action: viewModel.buttonViewModel.actionHandler)
     }
 }
 
@@ -51,7 +52,7 @@ struct PointOfSaleCardPresentPaymentReaderUpdateCompletionPreviewView: View {
         }
         .posSheet(isPresented: $showsSheet) {
             PointOfSaleCardPresentPaymentReaderUpdateCompletionView(
-                viewModel: .init(),
+                viewModel: .init(doneAction: { showsSheet = false }),
                 animation: .init(namespace: namespace)
             )
         }

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/Buttons/POSButtonStyle.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/Buttons/POSButtonStyle.swift
@@ -192,7 +192,6 @@ private struct POSButtonStyleInternal: View {
 
 private extension POSButtonStyleInternal {
     enum Constants {
-        static let cornerRadius: CGFloat = POSCornerRadiusStyle.medium.value
         static let borderStrokeWidth: CGFloat = 2.0
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/Buttons/POSButtonStyle.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/Buttons/POSButtonStyle.swift
@@ -5,6 +5,7 @@ import struct WooFoundation.IndefiniteCircularProgressViewStyle
 enum POSButtonSize {
     case normal
     case extraSmall
+    case compact
 }
 
 /// Button state for different visual presentations
@@ -51,11 +52,37 @@ struct POSOutlinedButtonStyle: ButtonStyle {
     }
 }
 
+/// Info card button style with default and primary variants.
+/// Use with .compact size for info card buttons.
+struct POSInfoCardButtonStyle: ButtonStyle {
+    enum Variant {
+        case `default`
+        case primary
+    }
+
+    private let size: POSButtonSize
+    private let variant: Variant
+    private let state: POSButtonState
+
+    init(size: POSButtonSize, variant: Variant, isLoading: Bool = false) {
+        self.size = size
+        self.variant = variant
+        self.state = isLoading ? .loading : .idle
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        let buttonVariant: POSButtonVariant = variant == .primary ? .filled : .infoCardOutlined
+        return POSButtonStyleInternal(configuration: configuration, variant: buttonVariant, size: size, state: state)
+            .disabled(state != .idle)
+    }
+}
+
 
 /// The visual variant of the POS button.
 fileprivate enum POSButtonVariant {
     case filled
     case outlined
+    case infoCardOutlined
 }
 
 private struct POSButtonStyleInternal: View {
@@ -87,7 +114,7 @@ private struct POSButtonStyleInternal: View {
         .overlay(borderOverlay)
         // Makes the entire area tappable, otherwise the area with clear background is not tappable.
         .contentShape(Rectangle())
-        .cornerRadius(Constants.cornerRadius)
+        .cornerRadius(size.cornerRadius)
         .opacity(configuration.isPressed ? 0.7 : 1.0)
         .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
     }
@@ -101,7 +128,7 @@ private struct POSButtonStyleInternal: View {
                 content()
                 Spacer()
             }
-        case .extraSmall:
+        case .extraSmall, .compact:
             content()
         }
     }
@@ -125,6 +152,8 @@ private struct POSButtonStyleInternal: View {
                 state != .idle ? .posPrimaryContainer : .posDisabledContainer
         case (.outlined, _):
                 .clear
+        case (.infoCardOutlined, _):
+                .posSurfaceContainerLowest
         }
     }
 
@@ -138,14 +167,22 @@ private struct POSButtonStyleInternal: View {
                 .posOnSurface
         case (.outlined, false):
                 .posOnDisabledContainer
+        case (.infoCardOutlined, true):
+                .posOnSurface
+        case (.infoCardOutlined, false):
+                .posOnDisabledContainer
         }
     }
 
     @ViewBuilder
     private var borderOverlay: some View {
         if variant == .outlined {
-            RoundedRectangle(cornerRadius: Constants.cornerRadius)
+            RoundedRectangle(cornerRadius: size.cornerRadius)
                 .strokeBorder(isEnabled ? Color.posInverseSurface : .posDisabledContainer,
+                              lineWidth: Constants.borderStrokeWidth)
+        } else if variant == .infoCardOutlined {
+            RoundedRectangle(cornerRadius: size.cornerRadius)
+                .strokeBorder(isEnabled ? Color.posOnSurface : .posDisabledContainer,
                               lineWidth: Constants.borderStrokeWidth)
         }
     }
@@ -169,6 +206,8 @@ private extension POSButtonSize {
             (vertical: POSPadding.large, horizontal: POSPadding.large)
         case .extraSmall:
             (vertical: POSPadding.small, horizontal: POSPadding.medium)
+        case .compact:
+            (vertical: POSPadding.small, horizontal: POSPadding.medium)
         }
     }
 
@@ -178,6 +217,17 @@ private extension POSButtonSize {
                 .posBodyLargeBold
         case .extraSmall:
                 .posBodyMediumBold
+        case .compact:
+                .posBodySmallBold()
+        }
+    }
+
+    var cornerRadius: CGFloat {
+        switch self {
+        case .normal, .extraSmall:
+            POSCornerRadiusStyle.medium.value
+        case .compact:
+            POSCornerRadiusStyle.small.value
         }
     }
 }
@@ -189,6 +239,8 @@ private extension POSButtonSize {
             (size: 32, lineWidth: 10)
         case .extraSmall:
             (size: 20, lineWidth: 6)
+        case .compact:
+            (size: 16, lineWidth: 4)
         }
     }
 }
@@ -256,6 +308,13 @@ struct POSButtonStyle_Previews: View {
 
                 Button("Disabled Button") {}
                     .buttonStyle(POSOutlinedButtonStyle(size: size))
+                    .disabled(true)
+            case .infoCardOutlined:
+                Button("Enabled Button") {}
+                    .buttonStyle(POSInfoCardButtonStyle(size: size, variant: .default))
+
+                Button("Disabled Button") {}
+                    .buttonStyle(POSInfoCardButtonStyle(size: size, variant: .default))
                     .disabled(true)
             }
         }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSInformationCard.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSInformationCard.swift
@@ -45,7 +45,7 @@ struct POSInformationCardFieldRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: POSPadding.small) {
-            HStack(alignment: .top, spacing: POSSpacing.medium) {
+            HStack(alignment: .center, spacing: POSSpacing.medium) {
                 VStack(alignment: .leading, spacing: POSPadding.small) {
                     Text(label)
                         .font(.posBodyMediumRegular())
@@ -57,26 +57,18 @@ struct POSInformationCardFieldRow: View {
                 Spacer()
 
                 if let buttonTitle, let buttonAction {
-                    VStack {
-                        Spacer()
-                            .frame(height: POSPadding.xSmall)
-
-                        Button(action: buttonAction) {
-                            Text(buttonTitle)
-                                .font(.posBodySmallBold())
-                                .foregroundStyle(buttonStyle == .default ? Color.posOnSurface : Color.posOnPrimaryContainer)
-                        }
-                        .buttonStyle(.plain)
-                        .padding(.horizontal, POSPadding.medium)
-                        .padding(.vertical, POSPadding.small)
-                        .background(buttonStyle == .primary ? Color.posPrimaryContainer : Color.posSurfaceContainerLowest)
-                        .overlay {
-                            RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value)
-                                .stroke(buttonStyle == .default ? Color.posOnSurface : Color.posPrimaryContainer, lineWidth: 2)
-                        }
-
-                        Spacer()
-                            .frame(height: POSPadding.xSmall)
+                    Button(action: buttonAction) {
+                        Text(buttonTitle)
+                            .font(.posBodySmallBold())
+                            .foregroundStyle(buttonStyle == .default ? Color.posOnSurface : Color.posOnPrimaryContainer)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.horizontal, POSPadding.medium)
+                    .padding(.vertical, POSPadding.small)
+                    .background(buttonStyle == .primary ? Color.posPrimaryContainer : Color.posSurfaceContainerLowest)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value)
+                            .stroke(buttonStyle == .default ? Color.posOnSurface : Color.posPrimaryContainer, lineWidth: 2)
                     }
                 }
             }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSInformationCard.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSInformationCard.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct POSInformationCard<Content: View>: View {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .padding()
+            .frame(maxWidth: .infinity)
+            .background(Color.posSurfaceContainerLowest)
+            .posItemCardBorderStyles()
+    }
+}
+
+struct POSInformationCardFieldRow: View {
+    let label: String
+    let value: String
+    let showSeparator: Bool
+
+    init(label: String, value: String, showSeparator: Bool = true) {
+        self.label = label
+        self.value = value
+        self.showSeparator = showSeparator
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: POSPadding.small) {
+            Text(label)
+                .font(.posBodyMediumRegular())
+            Text(value)
+                .font(.posBodyMediumRegular())
+                .foregroundStyle(.secondary)
+
+            if showSeparator {
+                Divider()
+                    .padding(.top, POSPadding.medium)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, POSPadding.medium)
+    }
+}

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSInformationCard.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSInformationCard.swift
@@ -83,7 +83,7 @@ struct POSInformationCardFieldRow: View {
 
             if showSeparator {
                 Divider()
-                    .padding(.top, POSPadding.medium)
+                    .padding(.top, POSPadding.small)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSInformationCard.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSInformationCard.swift
@@ -57,19 +57,11 @@ struct POSInformationCardFieldRow: View {
                 Spacer()
 
                 if let buttonTitle, let buttonAction {
-                    Button(action: buttonAction) {
-                        Text(buttonTitle)
-                            .font(.posBodySmallBold())
-                            .foregroundStyle(buttonStyle == .default ? Color.posOnSurface : Color.posOnPrimaryContainer)
-                    }
-                    .buttonStyle(.plain)
-                    .padding(.horizontal, POSPadding.medium)
-                    .padding(.vertical, POSPadding.small)
-                    .background(buttonStyle == .primary ? Color.posPrimaryContainer : Color.posSurfaceContainerLowest)
-                    .overlay {
-                        RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value)
-                            .stroke(buttonStyle == .default ? Color.posOnSurface : Color.posPrimaryContainer, lineWidth: 2)
-                    }
+                    Button(buttonTitle, action: buttonAction)
+                        .buttonStyle(POSInfoCardButtonStyle(
+                            size: .compact,
+                            variant: buttonStyle == .primary ? .primary : .default
+                        ))
                 }
             }
 

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSInformationCard.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSInformationCard.swift
@@ -20,20 +20,58 @@ struct POSInformationCardFieldRow: View {
     let label: String
     let value: String
     let showSeparator: Bool
+    let buttonTitle: String?
+    let buttonAction: (() -> Void)?
 
-    init(label: String, value: String, showSeparator: Bool = true) {
+    init(label: String,
+         value: String,
+         showSeparator: Bool = true,
+         buttonTitle: String? = nil,
+         buttonAction: (() -> Void)? = nil) {
         self.label = label
         self.value = value
         self.showSeparator = showSeparator
+        self.buttonTitle = buttonTitle
+        self.buttonAction = buttonAction
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: POSPadding.small) {
-            Text(label)
-                .font(.posBodyMediumRegular())
-            Text(value)
-                .font(.posBodyMediumRegular())
-                .foregroundStyle(.secondary)
+            HStack(alignment: .top, spacing: POSSpacing.medium) {
+                VStack(alignment: .leading, spacing: POSPadding.small) {
+                    Text(label)
+                        .font(.posBodyMediumRegular())
+                    Text(value)
+                        .font(.posBodyMediumRegular())
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                if let buttonTitle, let buttonAction {
+                    VStack {
+                        Spacer()
+                            .frame(height: POSPadding.xSmall)
+
+                        Button(action: buttonAction) {
+                            Text(buttonTitle)
+                                .font(.posBodyMediumRegular())
+                                .foregroundStyle(Color.posOnSurface)
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.horizontal, POSPadding.small)
+                        .padding(.vertical, POSPadding.xSmall)
+                        .background(Color.posSurfaceContainerLowest)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value)
+                                .stroke(Color.posOnSurface, lineWidth: 2)
+                        }
+
+                        Spacer()
+                            .frame(height: POSPadding.xSmall)
+                    }
+                }
+            }
 
             if showSeparator {
                 Divider()

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSInformationCard.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSInformationCard.swift
@@ -63,12 +63,12 @@ struct POSInformationCardFieldRow: View {
 
                         Button(action: buttonAction) {
                             Text(buttonTitle)
-                                .font(.posBodyMediumRegular())
+                                .font(.posBodySmallBold())
                                 .foregroundStyle(buttonStyle == .default ? Color.posOnSurface : Color.posOnPrimaryContainer)
                         }
                         .buttonStyle(.plain)
-                        .padding(.horizontal, POSPadding.small)
-                        .padding(.vertical, POSPadding.xSmall)
+                        .padding(.horizontal, POSPadding.medium)
+                        .padding(.vertical, POSPadding.small)
                         .background(buttonStyle == .primary ? Color.posPrimaryContainer : Color.posSurfaceContainerLowest)
                         .overlay {
                             RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value)

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSInformationCard.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSInformationCard.swift
@@ -17,22 +17,30 @@ struct POSInformationCard<Content: View>: View {
 }
 
 struct POSInformationCardFieldRow: View {
+    enum ButtonStyle {
+        case `default`
+        case primary
+    }
+
     let label: String
     let value: String
     let showSeparator: Bool
     let buttonTitle: String?
     let buttonAction: (() -> Void)?
+    let buttonStyle: ButtonStyle
 
     init(label: String,
          value: String,
          showSeparator: Bool = true,
          buttonTitle: String? = nil,
-         buttonAction: (() -> Void)? = nil) {
+         buttonAction: (() -> Void)? = nil,
+         buttonStyle: ButtonStyle = .default) {
         self.label = label
         self.value = value
         self.showSeparator = showSeparator
         self.buttonTitle = buttonTitle
         self.buttonAction = buttonAction
+        self.buttonStyle = buttonStyle
     }
 
     var body: some View {
@@ -56,15 +64,15 @@ struct POSInformationCardFieldRow: View {
                         Button(action: buttonAction) {
                             Text(buttonTitle)
                                 .font(.posBodyMediumRegular())
-                                .foregroundStyle(Color.posOnSurface)
+                                .foregroundStyle(buttonStyle == .default ? Color.posOnSurface : Color.posOnPrimaryContainer)
                         }
                         .buttonStyle(.plain)
                         .padding(.horizontal, POSPadding.small)
                         .padding(.vertical, POSPadding.xSmall)
-                        .background(Color.posSurfaceContainerLowest)
+                        .background(buttonStyle == .primary ? Color.posPrimaryContainer : Color.posSurfaceContainerLowest)
                         .overlay {
                             RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value)
-                                .stroke(Color.posOnSurface, lineWidth: 2)
+                                .stroke(buttonStyle == .default ? Color.posOnSurface : Color.posPrimaryContainer, lineWidth: 2)
                         }
 
                         Spacer()

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSInformationCard.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSInformationCard.swift
@@ -87,6 +87,5 @@ struct POSInformationCardFieldRow: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, POSPadding.medium)
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -448,13 +448,13 @@ private extension POSSettingsHardwareDetailView {
             value: "Update firmware",
             comment: "Title of the button to update firmware in Point of Sale settings."
         )
-        
+
         static let updateFirmwareBannerTitle = NSLocalizedString(
             "pointOfSaleSettingsHardwareDetailView.updateFirmwareBannerTitle",
             value: "Update firmware version",
             comment: "Title for the CTA banner to update firmware in Point of Sale settings."
         )
-        
+
         static let updateFirmwareBannerSubtitle = NSLocalizedString(
             "pointOfSaleSettingsHardwareDetailView.updateFirmwareBannerSubtitle",
             value: "Update the firmware version to continue accepting payments.",

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -149,7 +149,12 @@ private extension POSSettingsHardwareDetailView {
                         POSInformationCard {
                             VStack(spacing: POSSpacing.medium) {
                                 POSInformationCardFieldRow(label: Localization.readerModelTitle,
-                                                           value: cardReaderName)
+                                                           value: cardReaderName,
+                                                           buttonTitle: Localization.cardReaderDisconnectTitle,
+                                                           buttonAction: {
+                                    posModel.disconnectCardReader()
+                                })
+
                                 POSInformationCardFieldRow(label: Localization.readerBatteryTitle,
                                                            value: formattedBatteryLevel,
                                                            showSeparator: false)

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -176,7 +176,8 @@ private extension POSSettingsHardwareDetailView {
                                                            buttonTitle: shouldShowUpdateFirmwareButton ? Localization.updateFirmwareButtontitle : nil,
                                                            buttonAction: shouldShowUpdateFirmwareButton ? {
                                     posModel.updateCardReaderSoftware()
-                                } : nil)
+                                } : nil,
+                                                           buttonStyle: .primary)
                             }
                             .padding(.bottom, POSPadding.medium)
                         }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -158,6 +158,11 @@ private extension POSSettingsHardwareDetailView {
             ScrollView {
                 VStack(spacing: POSSpacing.small) {
                     if case .connected = posModel.cardReaderConnectionStatus {
+                        if shouldShowUpdateFirmwareButton {
+                            POSSettingsCard(title: "Update firmware version",
+                                            subtitle: "Update the firmware version to continue accepting payments.",
+                                            action: { })
+                        }
                         POSInformationCard {
                             VStack(spacing: POSSpacing.medium) {
                                 POSInformationCardFieldRow(label: Localization.readerModelTitle,
@@ -438,7 +443,7 @@ private extension POSSettingsHardwareDetailView {
             value: "Firmware",
             comment: "Title for the card reader firmware section in Point of Sale settings."
         )
-        
+
         static let updateFirmwareButtontitle = NSLocalizedString(
             "pointOfSaleSettingsHardwareDetailView.updateFirmwareButtontitle",
             value: "Update firmware",

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -162,7 +162,7 @@ private extension POSSettingsHardwareDetailView {
                                                     subtitle: Localization.updateFirmwareBannerSubtitle)
                         }
                         POSInformationCard {
-                            VStack(spacing: POSSpacing.medium) {
+                            VStack(spacing: POSSpacing.small) {
                                 POSInformationCardFieldRow(label: Localization.readerModelTitle,
                                                            value: cardReaderName,
                                                            buttonTitle: Localization.cardReaderDisconnectTitle,
@@ -182,7 +182,6 @@ private extension POSSettingsHardwareDetailView {
                                 } : nil,
                                                            buttonStyle: .primary)
                             }
-                            .padding(.bottom, POSPadding.medium)
                         }
                     } else {
                         POSSettingsCard(title: Localization.cardReaderConnectTitle,

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -30,10 +30,13 @@ struct POSSettingsHardwareDetailView: View {
             return Localization.batteryLevelUnknown
         }
     }
-    
-    // TODO
+
     private var formattedCardReaderFirmware: String {
-        "Unknown"
+        if let softwareVersion = settingsController.connectedCardReader?.softwareVersion {
+            return softwareVersion
+        } else {
+            return Localization.firmwareVersionUnknown
+        }
     }
 
     private var backgroundColor: Color {
@@ -321,6 +324,12 @@ private extension POSSettingsHardwareDetailView {
             "pointOfSaleSettingsHardwareDetailView.batteryLevelUnknown",
             value: "Unknown",
             comment: "Text displayed on Point of Sale settings when card reader battery is unknown."
+        )
+
+        static let firmwareVersionUnknown = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.firmwareVersionUnknown",
+            value: "Unknown",
+            comment: "Text displayed on Point of Sale settings when card reader firmware version is unknown."
         )
 
         static let hardwareTitle = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -24,8 +24,7 @@ struct POSSettingsHardwareDetailView: View {
 
     private var formattedBatteryLevel: String {
         if let batteryLevel = settingsController.connectedCardReader?.batteryLevel {
-            let percentage = Int(batteryLevel * 100)
-            return "\(percentage)%"
+            return String(format: Localization.batteryLevelFormat, 100 * batteryLevel)
         } else {
             return Localization.batteryLevelUnknown
         }
@@ -321,6 +320,13 @@ private extension POSSettingsHardwareDetailView {
             "pointOfSaleSettingsHardwareDetailView.readerBatteryTitle",
             value: "Battery",
             comment: "Text displayed on Point of Sale settings pointing to the card reader battery."
+        )
+
+        static let batteryLevelFormat = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.batteryLevelFormat",
+            value: "%.0f%%",
+            comment: "Format string for displaying battery level percentage in Point of Sale settings. " +
+                "Please leave the %.0f%% intact, as it represents the battery percentage."
         )
 
         static let cardReaderNotConnected = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -38,6 +38,10 @@ struct POSSettingsHardwareDetailView: View {
             return Localization.firmwareVersionUnknown
         }
     }
+    
+    private var shouldShowUpdateFirmwareButton: Bool {
+        posModel.isCardReaderUpdateAvailable
+    }
 
     private var backgroundColor: Color {
         Color.posSurface
@@ -169,10 +173,10 @@ private extension POSSettingsHardwareDetailView {
                                 POSInformationCardFieldRow(label: Localization.firmwareTitle,
                                                            value: formattedCardReaderFirmware,
                                                            showSeparator: false,
-                                                           buttonTitle: Localization.updateFirmwareButtontitle,
-                                                           buttonAction: {
+                                                           buttonTitle: shouldShowUpdateFirmwareButton ? Localization.updateFirmwareButtontitle : nil,
+                                                           buttonAction: shouldShowUpdateFirmwareButton ? {
                                     posModel.updateCardReaderSoftware()
-                                })
+                                } : nil)
                             }
                             .padding(.bottom, POSPadding.medium)
                         }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -159,8 +159,8 @@ private extension POSSettingsHardwareDetailView {
                 VStack(spacing: POSSpacing.small) {
                     if case .connected = posModel.cardReaderConnectionStatus {
                         if shouldShowUpdateFirmwareButton {
-                            POSSettingsCardWithIcon(title: "Update firmware version",
-                                                    subtitle: "Update the firmware version to continue accepting payments.")
+                            POSSettingsCardWithIcon(title: Localization.updateFirmwareBannerTitle,
+                                                    subtitle: Localization.updateFirmwareBannerSubtitle)
                         }
                         POSInformationCard {
                             VStack(spacing: POSSpacing.medium) {
@@ -447,6 +447,18 @@ private extension POSSettingsHardwareDetailView {
             "pointOfSaleSettingsHardwareDetailView.updateFirmwareButtontitle",
             value: "Update firmware",
             comment: "Title of the button to update firmware in Point of Sale settings."
+        )
+        
+        static let updateFirmwareBannerTitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.updateFirmwareBannerTitle",
+            value: "Update firmware version",
+            comment: "Title for the CTA banner to update firmware in Point of Sale settings."
+        )
+        
+        static let updateFirmwareBannerSubtitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.updateFirmwareBannerSubtitle",
+            value: "Update the firmware version to continue accepting payments.",
+            comment: "Subtitle for the CTA banner to update firmware in Point of Sale settings."
         )
 
         static let supportCancel = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -30,6 +30,11 @@ struct POSSettingsHardwareDetailView: View {
             return Localization.batteryLevelUnknown
         }
     }
+    
+    // TODO
+    private var formattedCardReaderFirmware: String {
+        "Unknown"
+    }
 
     private var backgroundColor: Color {
         Color.posSurface
@@ -156,8 +161,15 @@ private extension POSSettingsHardwareDetailView {
                                 })
 
                                 POSInformationCardFieldRow(label: Localization.readerBatteryTitle,
-                                                           value: formattedBatteryLevel,
-                                                           showSeparator: false)
+                                                           value: formattedBatteryLevel)
+
+                                POSInformationCardFieldRow(label: Localization.firmwareTitle,
+                                                           value: formattedCardReaderFirmware,
+                                                           showSeparator: false,
+                                                           buttonTitle: Localization.updateFirmwareButtontitle,
+                                                           buttonAction: {
+                                    posModel.updateCardReaderSoftware()
+                                })
                             }
                             .padding(.bottom, POSPadding.medium)
                         }
@@ -388,15 +400,35 @@ private extension POSSettingsHardwareDetailView {
             value: "Configure barcode scanner settings",
             comment: "Description of Barcode scanner settings configuration."
         )
+
         static let cardReaderConnectTitle = NSLocalizedString(
             "pointOfSaleSettingsHardwareDetailView.cardReaderConnectTitle",
             value: "Connect card reader",
             comment: "Title for card reader connect button when no reader is connected."
         )
+
+        static let cardReaderDisconnectTitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.cardReaderDisconnectTitle",
+            value: "Disconnect reader",
+            comment: "Title for card reader disconnect button when reader is already connected."
+        )
+
         static let cardReaderConnectSubtitle = NSLocalizedString(
             "pointOfSaleSettingsHardwareDetailView.cardReaderConnectSubtitle",
             value: "Connect your card reader and start accepting payments",
             comment: "Subtitle for card reader connect button when no reader is connected."
+        )
+
+        static let firmwareTitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.firmwareTitle",
+            value: "Firmware",
+            comment: "Title for the card reader firmware section in Point of Sale settings."
+        )
+        
+        static let updateFirmwareButtontitle = NSLocalizedString(
+            "pointOfSaleSettingsHardwareDetailView.updateFirmwareButtontitle",
+            value: "Update firmware",
+            comment: "Title of the button to update firmware in Point of Sale settings."
         )
 
         static let supportCancel = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -146,25 +146,16 @@ private extension POSSettingsHardwareDetailView {
             ScrollView {
                 VStack(spacing: POSSpacing.small) {
                     if case .connected = posModel.cardReaderConnectionStatus {
-                        VStack(spacing: POSPadding.xSmall) {
-                            HStack {
-                                Text(Localization.readerModelTitle)
-                                    .foregroundStyle(.primary)
-                                Spacer()
-                                Text(cardReaderName)
-                                    .foregroundStyle(.secondary)
+                        POSInformationCard {
+                            VStack(spacing: POSSpacing.medium) {
+                                POSInformationCardFieldRow(label: Localization.readerModelTitle,
+                                                           value: cardReaderName)
+                                POSInformationCardFieldRow(label: Localization.readerBatteryTitle,
+                                                           value: formattedBatteryLevel,
+                                                           showSeparator: false)
                             }
-                            .padding()
-                            HStack {
-                                Text(Localization.readerBatteryTitle)
-                                    .foregroundStyle(.primary)
-                                Spacer()
-                                Text(formattedBatteryLevel)
-                                    .foregroundStyle(.secondary)
-                            }
-                            .padding()
+                            .padding(.bottom, POSPadding.medium)
                         }
-                        .font(.posBodyMediumRegular())
                     } else {
                         POSSettingsCard(title: Localization.cardReaderConnectTitle,
                                             subtitle: Localization.cardReaderConnectSubtitle,
@@ -292,8 +283,8 @@ private extension POSSettingsHardwareDetailView {
 
     enum Localization {
         static let readerModelTitle = NSLocalizedString(
-            "pointOfSaleSettingsHardwareDetailView.readerModelTitle",
-            value: "Model",
+            "pointOfSaleSettingsHardwareDetailView.readerModelTitle.1",
+            value: "Device name",
             comment: "Text displayed on Point of Sale settings pointing to the card reader model."
         )
 

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -38,7 +38,7 @@ struct POSSettingsHardwareDetailView: View {
             return Localization.firmwareVersionUnknown
         }
     }
-    
+
     private var shouldShowUpdateFirmwareButton: Bool {
         posModel.isCardReaderUpdateAvailable
     }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -159,9 +159,8 @@ private extension POSSettingsHardwareDetailView {
                 VStack(spacing: POSSpacing.small) {
                     if case .connected = posModel.cardReaderConnectionStatus {
                         if shouldShowUpdateFirmwareButton {
-                            POSSettingsCard(title: "Update firmware version",
-                                            subtitle: "Update the firmware version to continue accepting payments.",
-                                            action: { })
+                            POSSettingsCardWithIcon(title: "Update firmware version",
+                                                    subtitle: "Update the firmware version to continue accepting payments.")
                         }
                         POSInformationCard {
                             VStack(spacing: POSSpacing.medium) {
@@ -195,8 +194,8 @@ private extension POSSettingsHardwareDetailView {
                     }
 
                     POSSettingsCard(title: Localization.cardReaderDocumentationTitle,
-                                        subtitle: Localization.cardReaderDocumentationSubtitle,
-                                        action: { showCardReaderDocumentationModal = true })
+                                    subtitle: Localization.cardReaderDocumentationSubtitle,
+                                    action: { showCardReaderDocumentationModal = true })
                     .accessibilityAddTraits(.isButton)
                 }
                 .padding(.horizontal, POSPadding.medium)
@@ -455,6 +454,42 @@ private extension POSSettingsHardwareDetailView {
             value: "Cancel",
             comment: "Button to dismiss the support form from POS settings."
         )
+    }
+}
+
+private extension POSSettingsHardwareDetailView {
+    struct POSSettingsCardWithIcon: View {
+        let title: String
+        let subtitle: String
+
+        init(title: String, subtitle: String) {
+            self.title = title
+            self.subtitle = subtitle
+        }
+
+        var body: some View {
+            HStack(alignment: .center, spacing: POSPadding.medium) {
+                Image(systemName: "info.circle")
+                    .font(.posBodyLargeBold)
+                    .foregroundStyle(Color.posOnSurface)
+                    .frame(width: 36, height: 36)
+
+                VStack(alignment: .leading, spacing: POSPadding.xSmall) {
+                    Text(title)
+                        .font(.posBodyLargeBold)
+                        .foregroundStyle(Color.posOnSurface)
+                    Text(subtitle)
+                        .font(.posBodyMediumRegular())
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.posSurfaceContainerLowest)
+            .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+            .posItemCardBorderStyles()
+            .accessibilityLabel("\(title), \(subtitle)")
+        }
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsStoreDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsStoreDetailView.swift
@@ -53,7 +53,6 @@ struct POSSettingsStoreDetailView: View {
                     POSInformationCardFieldRow(label: Localization.storeName, value: viewModel.storeName)
                     POSInformationCardFieldRow(label: Localization.address, value: viewModel.storeAddress, showSeparator: false)
                 }
-                .padding(.bottom, POSPadding.medium)
             }
         }
     }
@@ -99,7 +98,7 @@ struct POSSettingsStoreDetailView: View {
 
             if showSeparator {
                 Divider()
-                    .padding(.top, POSPadding.medium)
+                    .padding(.top, POSPadding.small)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsStoreDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsStoreDetailView.swift
@@ -86,7 +86,6 @@ struct POSSettingsStoreDetailView: View {
                 .font(.posBodyLargeBold)
                 .foregroundColor(.posOnSurface)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, POSPadding.medium)
                 .padding(.vertical, POSPadding.small)
         }
     }
@@ -104,7 +103,6 @@ struct POSSettingsStoreDetailView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, POSPadding.medium)
     }
 
     @ViewBuilder

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsStoreDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsStoreDetailView.swift
@@ -50,8 +50,8 @@ struct POSSettingsStoreDetailView: View {
                 sectionHeaderView(title: Localization.storeInformation)
 
                 VStack(spacing: POSSpacing.medium) {
-                    fieldRowView(label: Localization.storeName, value: viewModel.storeName)
-                    fieldRowView(label: Localization.address, value: viewModel.storeAddress, showSeparator: false)
+                    POSInformationCardFieldRow(label: Localization.storeName, value: viewModel.storeName)
+                    POSInformationCardFieldRow(label: Localization.address, value: viewModel.storeAddress, showSeparator: false)
                 }
                 .padding(.bottom, POSPadding.medium)
             }
@@ -92,24 +92,6 @@ struct POSSettingsStoreDetailView: View {
     }
 
     @ViewBuilder
-    private func fieldRowView(label: String, value: String, showSeparator: Bool = true) -> some View {
-        VStack(alignment: .leading, spacing: POSPadding.small) {
-            Text(label)
-                .font(.posBodyMediumRegular())
-            Text(value)
-                .font(.posBodyMediumRegular())
-                .foregroundStyle(.secondary)
-
-            if showSeparator {
-                Divider()
-                    .padding(.top, POSPadding.medium)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, POSPadding.medium)
-    }
-
-    @ViewBuilder
     private func receiptFieldRowView(label: String, value: String?, showSeparator: Bool = true) -> some View {
         VStack(alignment: .leading, spacing: POSPadding.small) {
             Text(label)
@@ -138,22 +120,6 @@ struct POSSettingsStoreDetailView: View {
                 .font(.posBodyMediumRegular())
                 .foregroundStyle(.secondary)
         }
-    }
-}
-
-private struct POSInformationCard<Content: View>: View {
-    let content: Content
-
-    init(@ViewBuilder content: () -> Content) {
-        self.content = content()
-    }
-
-    var body: some View {
-        content
-            .padding()
-            .frame(maxWidth: .infinity)
-            .background(Color.posSurfaceContainerLowest)
-            .posItemCardBorderStyles()
     }
 }
 

--- a/Modules/Tests/PointOfSaleTests/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests: XCTestCase {
 
     func test_manual_hashable_conformance_number_of_properties_unchanged() {
-        let sut = PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel()
+        let sut = PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel(doneAction: { })
 
         XCTAssertPropertyCount(sut,
                                expectedCount: 2,
@@ -12,7 +12,7 @@ final class PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTes
     }
 
     func test_manual_equatable_conformance_number_of_properties_unchanged() {
-        let sut = PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel()
+        let sut = PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel(doneAction: { })
 
         XCTAssertPropertyCount(sut,
                                expectedCount: 2,

--- a/Modules/Tests/PointOfSaleTests/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift
@@ -7,7 +7,7 @@ final class PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTes
         let sut = PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel(doneAction: { })
 
         XCTAssertPropertyCount(sut,
-                               expectedCount: 2,
+                               expectedCount: 3,
                                messageHint: "Please check that the manual hashable conformance includes new properties.")
     }
 
@@ -15,7 +15,7 @@ final class PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTes
         let sut = PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel(doneAction: { })
 
         XCTAssertPropertyCount(sut,
-                               expectedCount: 2,
+                               expectedCount: 3,
                                messageHint: "Please check that the manual equatable conformance includes new properties.")
     }
 

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockCardPresentPaymentService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockCardPresentPaymentService.swift
@@ -2,6 +2,7 @@ import Foundation
 import Combine
 import enum Yosemite.PaymentChannel
 import struct Yosemite.Order
+import enum Hardware.CardReaderSoftwareUpdateState
 @testable import PointOfSale
 
 final class MockCardPresentPaymentService: CardPresentPaymentFacade {
@@ -57,5 +58,11 @@ final class MockCardPresentPaymentService: CardPresentPaymentFacade {
     func cancelPayment() async throws {
         cancelPaymentCalled = true
         try await onCancelPaymentCalled?()
+    }
+
+    var cardReaderUpdateStatePublisher: AnyPublisher<Hardware.CardReaderSoftwareUpdateState, Never> = Just(.none).eraseToAnyPublisher()
+
+    func updateCardReaderSoftware() async throws {
+        // no-op
     }
 }

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockCardPresentPaymentService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockCardPresentPaymentService.swift
@@ -2,7 +2,7 @@ import Foundation
 import Combine
 import enum Yosemite.PaymentChannel
 import struct Yosemite.Order
-import enum Hardware.CardReaderSoftwareUpdateState
+import enum Yosemite.CardReaderSoftwareUpdateState
 @testable import PointOfSale
 
 final class MockCardPresentPaymentService: CardPresentPaymentFacade {
@@ -60,7 +60,7 @@ final class MockCardPresentPaymentService: CardPresentPaymentFacade {
         try await onCancelPaymentCalled?()
     }
 
-    var cardReaderUpdateStatePublisher: AnyPublisher<Hardware.CardReaderSoftwareUpdateState, Never> = Just(.none).eraseToAnyPublisher()
+    var cardReaderUpdateStatePublisher: AnyPublisher<CardReaderSoftwareUpdateState, Never> = Just(.none).eraseToAnyPublisher()
 
     func updateCardReaderSoftware() async throws {
         // no-op

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentService.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentService.swift
@@ -6,12 +6,15 @@ import struct Yosemite.CardPresentPaymentsConfiguration
 import struct Yosemite.CardReader
 import enum Yosemite.CardPresentPaymentAction
 import enum Yosemite.PaymentChannel
+import enum Hardware.CardReaderSoftwareUpdateState
 import protocol Yosemite.StoresManager
 
 final class CardPresentPaymentService: CardPresentPaymentFacade {
     let paymentEventPublisher: AnyPublisher<CardPresentPaymentEvent, Never>
 
     let readerConnectionStatusPublisher: AnyPublisher<CardPresentPaymentReaderConnectionStatus, Never>
+
+    let cardReaderUpdateStatePublisher: AnyPublisher<CardReaderSoftwareUpdateState, Never>
 
     private let connectedReaderPublisher: AnyPublisher<CardPresentPaymentCardReader?, Never>
 
@@ -75,6 +78,11 @@ final class CardPresentPaymentService: CardPresentPaymentFacade {
             })
             .merge(with: paymentAlertsPresenterAdaptor.readerConnectionStatusPublisher)
             .merge(with: readerConnectionStatusSubject)
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+
+        let updateStatePublisher = await Self.createUpdateStatePublisher(stores: stores)
+        self.cardReaderUpdateStatePublisher = updateStatePublisher
             .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
@@ -213,6 +221,19 @@ private extension CardPresentPaymentService {
                     .eraseToAnyPublisher()
 
                 nillableContinuation?.resume(returning: readerConnectionPublisher)
+                nillableContinuation = nil
+            }
+            stores.dispatch(action)
+        }
+    }
+
+    @MainActor
+    static func createUpdateStatePublisher(stores: StoresManager) async -> AnyPublisher<CardReaderSoftwareUpdateState, Never> {
+        return await withCheckedContinuation { continuation in
+            var nillableContinuation: CheckedContinuation<AnyPublisher<CardReaderSoftwareUpdateState, Never>, Never>? = continuation
+
+            let action = CardPresentPaymentAction.observeCardReaderUpdateState { updateStatePublisher in
+                nillableContinuation?.resume(returning: updateStatePublisher)
                 nillableContinuation = nil
             }
             stores.dispatch(action)

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentService.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentService.swift
@@ -130,6 +130,12 @@ final class CardPresentPaymentService: CardPresentPaymentFacade {
     }
 
     @MainActor
+    func updateCardReaderSoftware() async throws {
+        let action = CardPresentPaymentAction.startCardReaderUpdate
+        stores.dispatch(action)
+    }
+
+    @MainActor
     func collectPayment(for order: Order, using connectionMethod: CardReaderConnectionMethod, channel: PaymentChannel) async throws -> CardPresentPaymentResult {
         paymentTask?.cancel()
 

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentService.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentService.swift
@@ -89,7 +89,8 @@ final class CardPresentPaymentService: CardPresentPaymentFacade {
         switch preflightResult {
         case .completed(let cardReader, _):
             let connectedReader = CardPresentPaymentCardReader(name: cardReader.name ?? cardReader.id,
-                                                               batteryLevel: cardReader.batteryLevel)
+                                                               batteryLevel: cardReader.batteryLevel,
+                                                               softwareVersion: cardReader.softwareVersion)
             paymentEventSubject.send(.show(eventDetails: .connectionSuccess(done: { [weak self] in
                 self?.paymentEventSubject.send(.idle)
             })))
@@ -205,7 +206,8 @@ private extension CardPresentPaymentService {
                             return nil
                         }
                         return CardPresentPaymentCardReader(name: reader.name ?? reader.id,
-                                                            batteryLevel: reader.batteryLevel)
+                                                            batteryLevel: reader.batteryLevel,
+                                                            softwareVersion: reader.softwareVersion)
                     }
                     .receive(on: DispatchQueue.main)
                     .eraseToAnyPublisher()

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -495,6 +495,9 @@ final class MainTabBarControllerTests: XCTestCase {
             if case let .publishCardReaderConnections(completion) = action {
                 completion(Just<[CardReader]>([]).eraseToAnyPublisher())
             }
+            if case let .observeCardReaderUpdateState(completion) = action {
+                completion(Just(.none).eraseToAnyPublisher())
+            }
         }
 
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in


### PR DESCRIPTION
Closes WOOMOB-1646

## Description
This PR updates the card reader "management" section of POS settings by updating the design following qKAWGmvUsvfnW0Z4CssJHe-fi and adding actions for disconnecting the card reader, as well as updating its software.

## Changes
- Updates card reader "management" view to latest designs
- Adds disconnect action from settings
- Adds update firmware action from settings
- Conditionally renders banner when firmware update is needed
- Updates card reader service, facade and reader model to account for firmware status and version
- Update formattedBatteryLevel to account for localization/LTR

## Test Steps
- Navigate to POS Settings
- Play with connecting the reader, disconnecting it, and attempt software updates by updating `Terminal.shared.simulatorConfiguration.availableReaderUpdate`.

## Screenshots

https://github.com/user-attachments/assets/18fc17b5-24c4-4ed0-bda2-051e6d110d6a
