### PR TITLE
[Local Catalog] Use variations endpoint for incremental sync

### DIFF
--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -134,7 +134,7 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
         ]
 
         let request = JetpackRequest(
-            wooApiVersion: .wcAnalytics,
+            wooApiVersion: .mark3,
             method: .get,
             siteID: siteID,
             path: path,
@@ -249,7 +249,7 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
         ]
 
         let request = JetpackRequest(
-            wooApiVersion: .wcAnalytics,
+            wooApiVersion: .mark3,
             method: .get,
             siteID: siteID,
             path: path,
@@ -303,7 +303,7 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
         ]
 
         let request = JetpackRequest(
-            wooApiVersion: .wcAnalytics,
+            wooApiVersion: .mark3,
             method: .get,
             siteID: siteID,
             path: path,

--- a/Modules/Sources/Yosemite/Protocols/POSLocalCatalogEligibilityServiceProtocol.swift
+++ b/Modules/Sources/Yosemite/Protocols/POSLocalCatalogEligibilityServiceProtocol.swift
@@ -14,6 +14,7 @@ public enum POSLocalCatalogEligibilityState: Equatable {
 public enum POSLocalCatalogIneligibleReason: Equatable {
     case posTabNotEligible
     case featureFlagDisabled
+    case unsupportedWooCommerceVersion(minimumVersion: String)
     case catalogSizeTooLarge(totalCount: Int, limit: Int)
     case catalogSizeCheckFailed(underlyingError: String)
 }

--- a/Modules/Sources/Yosemite/Tools/POS/POSLocalCatalogEligibilityService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSLocalCatalogEligibilityService.swift
@@ -98,7 +98,8 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
                     reason: .unsupportedWooCommerceVersion(minimumVersion: Constants.wcPluginMinimumVersionForLocalCatalog)
                 )
                 eligibilityStates[siteID] = state
-                DDLogInfo("📋 POSLocalCatalogEligibilityService: WooCommerce version \(wcPlugin.version) below minimum \(Constants.wcPluginMinimumVersionForLocalCatalog) for site \(siteID)")
+                DDLogInfo("📋 POSLocalCatalogEligibilityService: WooCommerce version \(wcPlugin.version) below minimum" +
+                          "\(Constants.wcPluginMinimumVersionForLocalCatalog) for site \(siteID)")
                 return state
             }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSLocalCatalogEligibilityService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSLocalCatalogEligibilityService.swift
@@ -1,8 +1,10 @@
 import Foundation
 import Alamofire
+import WooFoundationCore
 
 public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServiceProtocol {
     private let catalogSizeChecker: POSCatalogSizeCheckerProtocol
+    private let systemStatusService: POSSystemStatusServiceProtocol
     private let catalogSizeLimit: Int
     private let isLocalCatalogFeatureFlagEnabled: Bool
 
@@ -15,14 +17,17 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
     /// Initialize eligibility service
     /// - Parameters:
     ///   - catalogSizeChecker: Service to check catalog size for sites
+    ///   - systemStatusService: Service to check WooCommerce plugin version
     ///   - isLocalCatalogFeatureFlagEnabled: Whether the local catalog feature flag is enabled
     ///   - catalogSizeLimit: Maximum allowed catalog size (products + variations)
     public init(
         catalogSizeChecker: POSCatalogSizeCheckerProtocol,
+        systemStatusService: POSSystemStatusServiceProtocol,
         isLocalCatalogFeatureFlagEnabled: Bool,
         catalogSizeLimit: Int? = nil
     ) {
         self.catalogSizeChecker = catalogSizeChecker
+        self.systemStatusService = systemStatusService
         self.isLocalCatalogFeatureFlagEnabled = isLocalCatalogFeatureFlagEnabled
         self.catalogSizeLimit = catalogSizeLimit ?? Constants.defaultCatalogSizeLimit
     }
@@ -76,6 +81,40 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
             return state
         }
 
+        // Check WooCommerce version - local catalog requires 10.3.0 or higher
+        do {
+            let pluginInfo = try await systemStatusService.loadWooCommercePluginAndPOSFeatureSwitch(siteID: siteID)
+
+            guard let wcPlugin = pluginInfo.wcPlugin, wcPlugin.active else {
+                let state = POSLocalCatalogEligibilityState.ineligible(reason: .posTabNotEligible)
+                eligibilityStates[siteID] = state
+                DDLogInfo("📋 POSLocalCatalogEligibilityService: WooCommerce plugin not found or inactive for site \(siteID)")
+                return state
+            }
+
+            guard VersionHelpers.isVersionSupported(version: wcPlugin.version,
+                                                    minimumRequired: Constants.wcPluginMinimumVersionForLocalCatalog) else {
+                let state = POSLocalCatalogEligibilityState.ineligible(
+                    reason: .unsupportedWooCommerceVersion(minimumVersion: Constants.wcPluginMinimumVersionForLocalCatalog)
+                )
+                eligibilityStates[siteID] = state
+                DDLogInfo("📋 POSLocalCatalogEligibilityService: WooCommerce version \(wcPlugin.version) below minimum \(Constants.wcPluginMinimumVersionForLocalCatalog) for site \(siteID)")
+                return state
+            }
+
+            DDLogInfo("📋 POSLocalCatalogEligibilityService: WooCommerce version \(wcPlugin.version) meets minimum requirement for site \(siteID)")
+        } catch AFError.explicitlyCancelled, is CancellationError {
+            throw POSCatalogSyncError.requestCancelled
+        } catch {
+            let errorString = String(describing: error)
+            let state = POSLocalCatalogEligibilityState.ineligible(
+                reason: .catalogSizeCheckFailed(underlyingError: errorString)
+            )
+            eligibilityStates[siteID] = state
+            DDLogError("📋 POSLocalCatalogEligibilityService: Failed to check WooCommerce version for site \(siteID): \(error)")
+            return state
+        }
+
         // Fetch remote catalog size and check against limit
         do {
             let size = try await catalogSizeChecker.checkCatalogSize(for: siteID)
@@ -112,5 +151,6 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
 private extension POSLocalCatalogEligibilityService {
     enum Constants {
         static let defaultCatalogSizeLimit = 1000
+        static let wcPluginMinimumVersionForLocalCatalog = "10.3.0-beta"
     }
 }

--- a/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
@@ -584,7 +584,6 @@ struct POSCatalogSyncRemoteTests {
         _ = try? await remote.getProductVariationCount(siteID: sampleSiteID)
 
         // Then - verify API versions match the data endpoints
-        // Products should use .mark3, variations should use .wcAnalytics (based on the load endpoints)
         // This is verified by checking that the correct paths are called
         let requests = network.requestsForResponseData.compactMap { $0 as? JetpackRequest }
         #expect(requests.contains { $0.path.contains("products") })

--- a/Modules/Tests/YosemiteTests/Mocks/MockPOSSystemStatusService.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockPOSSystemStatusService.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Networking
+@testable import Yosemite
+
+final class MockPOSSystemStatusService: POSSystemStatusServiceProtocol {
+    var pluginInfoToReturn: Result<POSPluginAndFeatureInfo, Error>
+    var loadPluginCallCount = 0
+    var lastCheckedSiteID: Int64?
+
+    init(pluginInfoToReturn: Result<POSPluginAndFeatureInfo, Error> = .success(
+        POSPluginAndFeatureInfo(
+            wcPlugin: SystemPlugin(
+                siteID: 123,
+                plugin: "woocommerce/woocommerce.php",
+                name: "WooCommerce",
+                version: "10.3.0",
+                versionLatest: "10.3.0",
+                url: "https://woocommerce.com",
+                authorName: "WooCommerce",
+                authorUrl: "https://woocommerce.com",
+                networkActivated: false,
+                active: true
+            ),
+            featureValue: true
+        )
+    )) {
+        self.pluginInfoToReturn = pluginInfoToReturn
+    }
+
+    func loadWooCommercePluginAndPOSFeatureSwitch(siteID: Int64) async throws -> POSPluginAndFeatureInfo {
+        loadPluginCallCount += 1
+        lastCheckedSiteID = siteID
+        switch pluginInfoToReturn {
+        case .success(let info):
+            return info
+        case .failure(let error):
+            throw error
+        }
+    }
+}

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSLocalCatalogEligibilityServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSLocalCatalogEligibilityServiceTests.swift
@@ -14,8 +14,10 @@ struct POSLocalCatalogEligibilityServiceTests {
         let sizeChecker = MockPOSCatalogSizeChecker(
             sizeToReturn: .success(POSCatalogSize(productCount: 500, variationCount: 400))
         )
+        let systemStatusService = MockPOSSystemStatusService()
         let service = POSLocalCatalogEligibilityService(
             catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
             catalogSizeLimit: 1000
         )
@@ -29,8 +31,10 @@ struct POSLocalCatalogEligibilityServiceTests {
         let sizeChecker = MockPOSCatalogSizeChecker(
             sizeToReturn: .success(POSCatalogSize(productCount: 600, variationCount: 400))
         )
+        let systemStatusService = MockPOSSystemStatusService()
         let service = POSLocalCatalogEligibilityService(
             catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
             catalogSizeLimit: 1000
         )
@@ -46,8 +50,10 @@ struct POSLocalCatalogEligibilityServiceTests {
         let sizeChecker = MockPOSCatalogSizeChecker(
             sizeToReturn: .success(POSCatalogSize(productCount: 501, variationCount: 500))
         )
+        let systemStatusService = MockPOSSystemStatusService()
         let service = POSLocalCatalogEligibilityService(
             catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
             catalogSizeLimit: 1000
         )
@@ -77,8 +83,10 @@ struct POSLocalCatalogEligibilityServiceTests {
         let sizeChecker = MockPOSCatalogSizeChecker(
             sizeToReturn: .failure(expectedError)
         )
+        let systemStatusService = MockPOSSystemStatusService()
         let service = POSLocalCatalogEligibilityService(
             catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
             catalogSizeLimit: 1000
         )
@@ -106,8 +114,10 @@ struct POSLocalCatalogEligibilityServiceTests {
         let sizeChecker = MockPOSCatalogSizeChecker(
             sizeToReturn: .success(POSCatalogSize(productCount: 500, variationCount: 400))
         )
+        let systemStatusService = MockPOSSystemStatusService()
         let service = POSLocalCatalogEligibilityService(
             catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
             catalogSizeLimit: 1000
         )
@@ -129,8 +139,10 @@ struct POSLocalCatalogEligibilityServiceTests {
         let sizeChecker = MockPOSCatalogSizeChecker(
             sizeToReturn: .success(POSCatalogSize(productCount: 500, variationCount: 400))
         )
+        let systemStatusService = MockPOSSystemStatusService()
         let service = POSLocalCatalogEligibilityService(
             catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
             catalogSizeLimit: 1000
         )
@@ -152,8 +164,10 @@ struct POSLocalCatalogEligibilityServiceTests {
         let sizeChecker = MockPOSCatalogSizeChecker(
             sizeToReturn: .success(POSCatalogSize(productCount: 500, variationCount: 400))
         )
+        let systemStatusService = MockPOSSystemStatusService()
         let service = POSLocalCatalogEligibilityService(
             catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
             catalogSizeLimit: 1000
         )
@@ -190,8 +204,10 @@ struct POSLocalCatalogEligibilityServiceTests {
         let sizeChecker = MockPOSCatalogSizeChecker(
             sizeToReturn: .success(POSCatalogSize(productCount: 500, variationCount: 400))
         )
+        let systemStatusService = MockPOSSystemStatusService()
         let service = POSLocalCatalogEligibilityService(
             catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: false,
             catalogSizeLimit: 1000
         )
@@ -220,8 +236,10 @@ struct POSLocalCatalogEligibilityServiceTests {
         let sizeChecker = MockPOSCatalogSizeChecker(
             sizeToReturn: .success(POSCatalogSize(productCount: 100, variationCount: 50))
         )
+        let systemStatusService = MockPOSSystemStatusService()
         let service = POSLocalCatalogEligibilityService(
             catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
             catalogSizeLimit: 100 // Custom lower limit
         )
@@ -250,8 +268,10 @@ struct POSLocalCatalogEligibilityServiceTests {
         let sizeChecker = MockPOSCatalogSizeChecker(
             sizeToReturn: .success(POSCatalogSize(productCount: 500, variationCount: 400))
         )
+        let systemStatusService = MockPOSSystemStatusService()
         let service = POSLocalCatalogEligibilityService(
             catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
             catalogSizeLimit: 1000
         )
@@ -280,8 +300,10 @@ struct POSLocalCatalogEligibilityServiceTests {
         let sizeChecker = MockPOSCatalogSizeChecker(
             sizeToReturn: .success(POSCatalogSize(productCount: 2000, variationCount: 0))
         )
+        let systemStatusService = MockPOSSystemStatusService()
         let service = POSLocalCatalogEligibilityService(
             catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
             catalogSizeLimit: 1000
         )
@@ -309,8 +331,10 @@ struct POSLocalCatalogEligibilityServiceTests {
         let sizeChecker = MockPOSCatalogSizeChecker(
             sizeToReturn: .success(POSCatalogSize(productCount: 500, variationCount: 400))
         )
+        let systemStatusService = MockPOSSystemStatusService()
         let service = POSLocalCatalogEligibilityService(
             catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
             catalogSizeLimit: 1000
         )
@@ -323,5 +347,119 @@ struct POSLocalCatalogEligibilityServiceTests {
 
         // Should have checked catalog size since POS was eligible
         #expect(sizeChecker.checkCatalogSizeCallCount == 1)
+    }
+
+    // MARK: - WooCommerce Version Checking
+
+    @Test("WooCommerce version eligibility",
+          arguments: [
+            ("10.2.0", true, false, 0),         // Below minimum
+            ("10.3.0-beta", true, true, 1),     // At minimum (beta)
+            ("10.3.0", true, true, 1),          // At minimum (stable)
+            ("11.0.0", true, true, 1),          // Above minimum
+          ])
+    func testWooCommerceVersionEligibility(
+        version: String,
+        isActive: Bool,
+        expectEligible: Bool,
+        expectedSizeCheckCount: Int
+    ) async throws {
+        let sizeChecker = MockPOSCatalogSizeChecker(
+            sizeToReturn: .success(POSCatalogSize(productCount: 500, variationCount: 400))
+        )
+        let systemStatusService = MockPOSSystemStatusService(
+            pluginInfoToReturn: .success(
+                POSPluginAndFeatureInfo(
+                    wcPlugin: SystemPlugin(
+                        siteID: siteID,
+                        plugin: "woocommerce/woocommerce.php",
+                        name: "WooCommerce",
+                        version: version,
+                        versionLatest: "11.0.0",
+                        url: "https://woocommerce.com",
+                        authorName: "WooCommerce",
+                        authorUrl: "https://woocommerce.com",
+                        networkActivated: false,
+                        active: isActive
+                    ),
+                    featureValue: true
+                )
+            )
+        )
+        let service = POSLocalCatalogEligibilityService(
+            catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
+            isLocalCatalogFeatureFlagEnabled: true,
+            catalogSizeLimit: 1000
+        )
+        try await service.updatePOSEligibility(isEligible: true, for: siteID)
+
+        let state = try await service.catalogEligibility(for: siteID)
+
+        if expectEligible {
+            #expect(state == .eligible)
+        } else {
+            guard case .ineligible(let reason) = state else {
+                Issue.record("Expected ineligible state for version \(version)")
+                return
+            }
+            guard case .unsupportedWooCommerceVersion(let minimumVersion) = reason else {
+                Issue.record("Expected unsupportedWooCommerceVersion reason for version \(version)")
+                return
+            }
+            #expect(minimumVersion == "10.3.0-beta")
+        }
+        #expect(sizeChecker.checkCatalogSizeCallCount == expectedSizeCheckCount)
+    }
+
+    @Test("WooCommerce plugin states",
+          arguments: [
+            (nil, POSLocalCatalogIneligibleReason.posTabNotEligible),           // Plugin not found
+            (false, POSLocalCatalogIneligibleReason.posTabNotEligible),         // Plugin inactive
+          ])
+    func testWooCommercePluginStates(
+        isActive: Bool?,
+        expectedReason: POSLocalCatalogIneligibleReason
+    ) async throws {
+        let sizeChecker = MockPOSCatalogSizeChecker(
+            sizeToReturn: .success(POSCatalogSize(productCount: 500, variationCount: 400))
+        )
+
+        let wcPlugin: SystemPlugin? = isActive.map { active in
+            SystemPlugin(
+                siteID: siteID,
+                plugin: "woocommerce/woocommerce.php",
+                name: "WooCommerce",
+                version: "10.3.0",
+                versionLatest: "10.3.0",
+                url: "https://woocommerce.com",
+                authorName: "WooCommerce",
+                authorUrl: "https://woocommerce.com",
+                networkActivated: false,
+                active: active
+            )
+        }
+
+        let systemStatusService = MockPOSSystemStatusService(
+            pluginInfoToReturn: .success(
+                POSPluginAndFeatureInfo(wcPlugin: wcPlugin, featureValue: true)
+            )
+        )
+        let service = POSLocalCatalogEligibilityService(
+            catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
+            isLocalCatalogFeatureFlagEnabled: true,
+            catalogSizeLimit: 1000
+        )
+        try await service.updatePOSEligibility(isEligible: true, for: siteID)
+
+        let state = try await service.catalogEligibility(for: siteID)
+
+        guard case .ineligible(let reason) = state else {
+            Issue.record("Expected ineligible state")
+            return
+        }
+        #expect(reason == expectedReason)
+        #expect(sizeChecker.checkCatalogSizeCallCount == 0)
     }
 }

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -189,6 +189,12 @@ class AuthenticatedState: StoresManagerState {
                     selectedSite: site,
                     appPasswordSupportState: appPasswordSupportState.eraseToAnyPublisher()
                 ),
+                systemStatusService: POSSystemStatusService(
+                    credentials: credentials,
+                    selectedSite: site,
+                    appPasswordSupportState: appPasswordSupportState.eraseToAnyPublisher(),
+                    storageManager: ServiceLocator.storageManager
+                ),
                 isLocalCatalogFeatureFlagEnabled: isLocalCatalogFeatureFlagEnabled
             )
             posCatalogEligibilityChecker = eligibilityService


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the local catalog to use the `wc/v3/variations` endpoint, not the analytics version of the endpoint.

This was released in 10.3, so local catalog eligibility now requires that version.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Launch the app using a store with Woo 10.3 and other local catalog requirements
2. Open POS
3. Edit a variation on the web
4. Pull to refresh
5. Observe that the variation is updated. Using a network proxy, observe that the variations requests go to `/wc/v3/variations`, not the analytics endpoint.

Test with a store that has Woo 10.2 or below – the local catalog won't be used.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
