### PR TITLE
Bookings: Split summary text into 2 lines for booking details header

### DIFF
--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -128,7 +128,7 @@ private extension BookingListView {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .foregroundStyle(Color.primary)
 
-                Text(booking.summaryText(separateLines: false))
+                Text(booking.summaryText)
                     .font(.footnote)
                     .fontWeight(.medium)
                     .foregroundStyle(Color.secondary)

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -128,7 +128,7 @@ private extension BookingListView {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .foregroundStyle(Color.primary)
 
-                Text(booking.summaryText)
+                Text(booking.summaryText(separateLines: false))
                     .font(.footnote)
                     .fontWeight(.medium)
                     .foregroundStyle(Color.secondary)

--- a/WooCommerce/Classes/Extensions/Booking+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Booking+Helpers.swift
@@ -2,17 +2,21 @@ import Foundation
 import struct Yosemite.Booking
 
 extension Booking {
-    func summaryText(separateLines: Bool) -> String {
-        let productName = orderInfo?.productInfo?.name
-        let customerName: String = {
-            guard let name = orderInfo?.customerInfo?.billingAddress.fullName else {
-                return Localization.guest
-            }
-            return name.isEmpty ? Localization.guest : name
-        }()
+    var productName: String? {
+        orderInfo?.productInfo?.name
+    }
+
+    var customerName: String {
+        guard let name = orderInfo?.customerInfo?.billingAddress.fullName else {
+            return Localization.guest
+        }
+        return name.isEmpty ? Localization.guest : name
+    }
+
+    var summaryText: String {
         return [productName, customerName]
             .compactMap { $0 }
-            .joined(separator: separateLines ? "\n" : "  •  ")
+            .joined(separator: "  •  ")
     }
 
     private enum Localization {

--- a/WooCommerce/Classes/Extensions/Booking+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Booking+Helpers.swift
@@ -2,7 +2,7 @@ import Foundation
 import struct Yosemite.Booking
 
 extension Booking {
-    var summaryText: String {
+    func summaryText(separateLines: Bool) -> String {
         let productName = orderInfo?.productInfo?.name
         let customerName: String = {
             guard let name = orderInfo?.customerInfo?.billingAddress.fullName else {
@@ -12,7 +12,7 @@ extension Booking {
         }()
         return [productName, customerName]
             .compactMap { $0 }
-            .joined(separator: "  •  ")
+            .joined(separator: separateLines ? "\n" : "  •  ")
     }
 
     private enum Localization {

--- a/WooCommerce/Classes/ViewModels/Booking Details/HeaderContent.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/HeaderContent.swift
@@ -19,7 +19,7 @@ extension BookingDetailsViewModel {
                 timeStyle: .short,
                 timeZone: BookingListTab.utcTimeZone
             )
-            serviceAndCustomerLine = booking.summaryText
+            serviceAndCustomerLine = booking.summaryText(separateLines: true)
             attendanceStatus = booking.attendanceStatus
             bookingStatus = booking.bookingStatus
         }

--- a/WooCommerce/Classes/ViewModels/Booking Details/HeaderContent.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/HeaderContent.swift
@@ -11,7 +11,8 @@ extension BookingDetailsViewModel {
         @Published private(set) var bookingDate: String = ""
         @Published private(set) var attendanceStatus: BookingAttendanceStatus = .unknown
         @Published private(set) var bookingStatus: BookingStatus = .unknown
-        @Published private(set) var serviceAndCustomerLine: String = ""
+        @Published private(set) var serviceLine: String = ""
+        @Published private(set) var customerLine: String = ""
 
         func update(with booking: Booking) {
             bookingDate = booking.startDate.toString(
@@ -19,7 +20,8 @@ extension BookingDetailsViewModel {
                 timeStyle: .short,
                 timeZone: BookingListTab.utcTimeZone
             )
-            serviceAndCustomerLine = booking.summaryText(separateLines: true)
+            serviceLine = booking.productName ?? ""
+            customerLine = booking.customerName
             attendanceStatus = booking.attendanceStatus
             bookingStatus = booking.bookingStatus
         }

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -14,8 +14,8 @@ struct BookingDetailsView: View {
     enum Layout {
         static let contentSidePadding: CGFloat = 16
         static let contentVerticalPadding: CGFloat = 16
-        static let headerContentVerticalPadding: CGFloat = 6
-        static let headerBadgesAdditionalTopPadding: CGFloat = 4
+        static let headerContentVerticalPadding: CGFloat = 2
+        static let headerBadgesAdditionalTopPadding: CGFloat = 6
         static let sectionFooterTextVerticalPadding: CGFloat = 8
         static let rowTextVerticalPadding: CGFloat = 11
     }

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/HeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/HeaderView.swift
@@ -11,9 +11,14 @@ extension BookingDetailsView {
                         .font(TextFont.bodyMedium)
                         .foregroundColor(.primary)
                 }
-                if !content.serviceAndCustomerLine.isEmpty {
-                    Text(content.serviceAndCustomerLine)
-                        .font(.footnote.weight(.medium))
+                if !content.serviceLine.isEmpty {
+                    Text(content.serviceLine)
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                }
+                if !content.customerLine.isEmpty {
+                    Text(content.customerLine)
+                        .font(.body)
                         .foregroundColor(.secondary)
                 }
                 HStack {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
@@ -159,7 +159,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(headerContent.serviceAndCustomerLine, "Massage Therapy  •  Jane Smith")
+        XCTAssertEqual(headerContent.serviceAndCustomerLine, "Massage Therapy\nJane Smith")
     }
 
     func test_customer_content_populated_from_billing_address() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
@@ -126,7 +126,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
         XCTAssertFalse(hasCustomerSection)
     }
 
-    func test_header_content_uses_booking_summary_text() {
+    func test_header_content_uses_correct_contents() {
         // Given
         let billingAddress = Address.fake().copy(
             firstName: "Jane",
@@ -159,7 +159,8 @@ final class BookingDetailsViewModelTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(headerContent.serviceAndCustomerLine, "Massage Therapy\nJane Smith")
+        XCTAssertEqual(headerContent.serviceLine, "Massage Therapy")
+        XCTAssertEqual(headerContent.customerLine, "Jane Smith")
     }
 
     func test_customer_content_populated_from_billing_address() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1602

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a small update to the header of the booking details screen to keep product and customer names in 2 separate lines.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Log in to a CIAB store with existing bookings.
2. Select a booking with associated order.
3. Confirm in the header that the product name and customer name are in separate lines.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before | After 
--- | ---
<img width="375" height="100" alt="Screenshot 2025-11-07 at 11 34 57" src="https://github.com/user-attachments/assets/c15d73f2-4505-474a-8865-16af60f6b707" /> | <img width="364" height="112" alt="Screenshot 2025-11-07 at 11 37 50" src="https://github.com/user-attachments/assets/d236a92c-b0a0-4d9a-8f04-cdecad08311a" />


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
