### PR TITLE
[Woo POS][Surveys] Fix notification when user takes collect payment path. Enable feature flag.

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -99,7 +99,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .ciabBookings:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .pointOfSaleSurveys:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .pointOfSaleCatalogAPI:
             return false
         default:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [**] We added support for collecting in-person payments (including Tap To Pay) using Stripe Payment Gateway extension in the UK. [https://github.com/woocommerce/woocommerce-ios/pull/16287]
 - [*] Improve card payments onboarding error handling to show network errors correctly [https://github.com/woocommerce/woocommerce-ios/pull/16304]
 - [*] Authenticate the admin page automatically for sites with SSO enabled in custom fields, in-person payment setup, and editing tax rates flows. [https://github.com/woocommerce/woocommerce-ios/pull/16318]
+- [*] Show POS feedback surveys for eligible merchants [https://github.com/woocommerce/woocommerce-ios/pull/16325]
 
 23.6
 -----

--- a/WooCommerce/Classes/POS/POSNotificationScheduler.swift
+++ b/WooCommerce/Classes/POS/POSNotificationScheduler.swift
@@ -3,12 +3,10 @@ import UserNotifications
 import Yosemite
 import Experiments
 
-// periphery: ignore - work in progress
 protocol POSNotificationScheduling {
     func scheduleLocalNotificationIfEligible(for merchantType: POSNotificationScheduler.MerchantType) async
 }
 
-// periphery: ignore - work in progress
 final class POSNotificationScheduler: POSNotificationScheduling {
     enum MerchantType {
         case potentialMerchant

--- a/WooCommerce/Classes/POS/POSNotificationScheduler.swift
+++ b/WooCommerce/Classes/POS/POSNotificationScheduler.swift
@@ -62,7 +62,7 @@ final class POSNotificationScheduler: POSNotificationScheduling {
     func scheduleLocalNotificationIfEligible(for merchantType: POSNotificationScheduler.MerchantType) async {
         guard featureFlagService.isFeatureFlagEnabled(.pointOfSaleSurveys) else { return }
 
-        let isScheduled = await isNotificationScheduled(for: merchantType)
+        let isScheduled = await isNotificationAlreadyScheduled(for: merchantType)
         guard !isScheduled else { return }
         guard isCountryEligible() else { return }
 
@@ -84,7 +84,23 @@ final class POSNotificationScheduler: POSNotificationScheduling {
         }
     }
 
-    private func isNotificationScheduled(for merchantType: MerchantType) async -> Bool {
+    private func isNotificationAlreadyScheduled(for merchantType: MerchantType) async -> Bool {
+        // Check if the specific notification type is already scheduled
+        let isCurrentMerchantTypeScheduled = await checkIfScheduled(for: merchantType)
+        if isCurrentMerchantTypeScheduled {
+            return true
+        }
+
+        // Don't schedule notification for potential merchant if the user is already marked as current merchant
+        guard merchantType == .potentialMerchant else {
+            return false
+        }
+
+        let isCurrentMerchantScheduled = await checkIfScheduled(for: .currentMerchant)
+        return isCurrentMerchantScheduled
+    }
+
+    private func checkIfScheduled(for merchantType: MerchantType) async -> Bool {
         await withCheckedContinuation { continuation in
             let action: AppSettingsAction
             switch merchantType {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1044,6 +1044,9 @@ final class EditableOrderViewModel: ObservableObject {
             guard let self else { return }
             self.collectPayment(for: order)
             self.trackCreateOrderSuccess(usesGiftCard: usesGiftCard)
+            Task {
+                await self.posNotificationScheduler.scheduleLocalNotificationIfEligible(for: .potentialMerchant)
+            }
         } onFailure: { [weak self] error, usesGiftCard in
             guard let self else { return }
             self.fixedNotice = NoticeFactory.createOrderErrorNotice(error, order: self.orderSynchronizer.order)

--- a/WooCommerce/WooCommerceTests/POS/POSNotificationSchedulerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSNotificationSchedulerTests.swift
@@ -260,6 +260,46 @@ struct POSNotificationSchedulerTests {
         #expect(mockPushNotesManager.requestedLocalNotifications.isEmpty)
     }
 
+    @Test func scheduleLocalNotificationIfEligible_when_currentMerchant_already_scheduled_then_potentialMerchant_cannot_be_scheduled() async throws {
+        // Given
+        let siteSettings = sampleSiteSettings(countryCode: "US")
+        mockFeatureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleSurveys] = true
+        setupMockStores(isCurrentMerchantScheduled: true)
+
+        let scheduler = POSNotificationScheduler(
+            stores: mockStores,
+            siteSettings: siteSettings,
+            featureFlagService: mockFeatureFlagService,
+            pushNotificationsManager: mockPushNotesManager
+        )
+
+        // When
+        await scheduler.scheduleLocalNotificationIfEligible(for: .potentialMerchant)
+
+        // Then - No notification should be scheduled. Prevents backwards conversion from 'current' to 'potential' merchant.
+        #expect(mockPushNotesManager.requestedLocalNotifications.isEmpty)
+    }
+
+    @Test func scheduleLocalNotificationIfEligible_when_potentialMerchant_already_scheduled_then_does_not_duplicate_notification() async throws {
+        // Given
+        let siteSettings = sampleSiteSettings(countryCode: "US")
+        mockFeatureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleSurveys] = true
+        setupMockStores(isPotentialMerchantScheduled: true)
+
+        let scheduler = POSNotificationScheduler(
+            stores: mockStores,
+            siteSettings: siteSettings,
+            featureFlagService: mockFeatureFlagService,
+            pushNotificationsManager: mockPushNotesManager
+        )
+
+        // When
+        await scheduler.scheduleLocalNotificationIfEligible(for: .potentialMerchant)
+
+        // Then - No duplicate notification should be scheduled
+        #expect(mockPushNotesManager.requestedLocalNotifications.isEmpty)
+    }
+
     private func sampleSiteSettings(countryCode: String) -> [SiteSetting] {
         [
             SiteSetting.fake().copy(


### PR DESCRIPTION
Closes WOOMOB-1636
Closes WOOMOB-1480

## Description
This PR enables the feature flag for POS surveys, and takes care of the 2 issues found in the CFT for POS Surveys:
- https://wp.me/pdfdoF-8k3#comment-9687 Merchants that tap on `Collect Payment` rather than in `Create` were not scheduled for notifications/
- https://wp.me/pdfdoF-8k3#comment-9697 Merchants that are already marked as "current" should not be scheduled for "potential" surveys.

For context, we schedule a "potential merchant" notification when a user creates an order, and we schedule a "current merchant" notification when a user runs the POS at least once (no need to re-enter in POS mode).

We do not present the "potential merchant" notification to "current merchants".

## Test Steps
- On a physical device, with notifications turned on, and in a US/UK store:
- ~~Switch the build configuration to release~~ (we don't have provisioning profiles for release configuration when building to physical device)
- Update `POSNotificationScheduler.timeIntervalInSeconds`  to something like 5 seconds
- In `AppCoordinator.schedulePOSSurveyNotificationIfNeeded` add the following bit to clear any persisted state
```diff
private extension AppCoordinator {
    func schedulePOSSurveyNotificationIfNeeded() {
+        Task { @MainActor in
+          let action = AppSettingsAction.resetPOSSurveyNotificationScheduled { _ in }
+          stores.dispatch(action)
+        }
        Task { @MainActor in
            await POSNotificationScheduler(stores: stores).scheduleLocalNotificationIfEligible(for: .currentMerchant)

            let action = AppSettingsAction.setHasPOSBeenOpenedAtLeastOnce { _ in }
            stores.dispatch(action)
        }
    }
}
```
- Run the app, create an order by tapping in `Create`. Observe the notification is presented. Restart the app, create an order by tapping in `Collect payment`. Observe the notification is presented:

https://indiemelon.mystagingwebsite.com/wp-content/uploads/2025/11/ScreenRecording_11-07-2025-12-03-21_1.mp4

- Enter in POS once.
- Remove the debug code `AppSettingsAction.resetPOSSurveyNotificationScheduled`
- Rerun the app. Observe the "current merchant" notification is presented.
- Navigate back to order creation. Create an order by tapping any button, you should not see any further notification scheduled.

https://indiemelon.mystagingwebsite.com/wp-content/uploads/2025/11/ScreenRecording_11-07-2025-11-56-12_1.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
