### PR TITLE
[Local catalog] Skip incremental sync when full sync in progress

### DIFF
--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -105,12 +105,9 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
             throw POSCatalogSyncError.shouldNotSync
         }
 
-        switch fullSyncStateModel.state[siteID] {
-        case .syncStarted, .initialSyncStarted:
+        if await fullSyncInProgress(for: siteID) {
             DDLogInfo("⚠️ POSCatalogSyncCoordinator: Sync already in progress for site \(siteID)")
             throw POSCatalogSyncError.syncAlreadyInProgress(siteID: siteID)
-        default:
-            break
         }
 
         let isFirstSync = await lastFullSyncDate(for: siteID) == nil
@@ -199,6 +196,19 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
         return shouldSync
     }
 
+    private func fullSyncInProgress(for siteID: Int64) async -> Bool {
+        switch fullSyncStateModel.state[siteID] {
+        case .syncStarted, .initialSyncStarted:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func ongoingSyncInProgress(for siteID: Int64) async -> Bool {
+        ongoingIncrementalSyncs.contains(siteID)
+    }
+
     /// Performs an incremental sync if applicable based on sync conditions
     /// - Parameters:
     ///   - siteID: The site ID to sync catalog for
@@ -213,8 +223,13 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
             return
         }
 
-        if ongoingIncrementalSyncs.contains(siteID) {
+        if await ongoingSyncInProgress(for: siteID) {
             DDLogInfo("⚠️ POSCatalogSyncCoordinator: Incremental sync already in progress for site \(siteID)")
+            throw POSCatalogSyncError.syncAlreadyInProgress(siteID: siteID)
+        }
+
+        if await fullSyncInProgress(for: siteID) {
+            DDLogInfo("⚠️ POSCatalogSyncCoordinator: Full sync already in progress for site \(siteID)")
             throw POSCatalogSyncError.syncAlreadyInProgress(siteID: siteID)
         }
 

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
@@ -195,12 +195,8 @@ struct POSCatalogSyncCoordinatorTests {
         try await Task.sleep(nanoseconds: 10_000_000) // 10ms
 
         // When - try to start second sync while first is blocked
-        do {
+        await #expect(throws: POSCatalogSyncError.syncAlreadyInProgress(siteID: sampleSiteID)) {
             _ = try await sut.performFullSync(for: sampleSiteID)
-            #expect(Bool(false), "Should have thrown syncAlreadyInProgress error")
-        } catch let error as POSCatalogSyncError {
-            // Then
-            #expect(error == POSCatalogSyncError.syncAlreadyInProgress(siteID: sampleSiteID))
         }
 
         let currentState = await sut.loadLastFullSyncState(for: sampleSiteID)
@@ -370,12 +366,8 @@ struct POSCatalogSyncCoordinatorTests {
         try await Task.sleep(nanoseconds: 10_000_000) // 10ms
 
         // When - try to start second incremental sync while first is blocked
-        do {
-            _ = try await sut.performIncrementalSyncIfApplicable(for: sampleSiteID, maxAge: sampleMaxAge)
-            #expect(Bool(false), "Should have thrown syncAlreadyInProgress error")
-        } catch let error as POSCatalogSyncError {
-            // Then
-            #expect(error == POSCatalogSyncError.syncAlreadyInProgress(siteID: sampleSiteID))
+        await #expect(throws: POSCatalogSyncError.syncAlreadyInProgress(siteID: sampleSiteID)) {
+            try await sut.performIncrementalSyncIfApplicable(for: sampleSiteID, maxAge: sampleMaxAge)
         }
 
         // Cleanup


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR prevents us starting a pointless incremental sync while we're doing a full sync for a site.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Set `POSLocalCatalogEligibilityService.Constants.defaultCatalogSizeLimit` to 100000

1. Launch the app and connect to a store with a large catalog
2. Open POS and go to POS Settings > Catalog
3. Refresh Catalog
4. Go back to POS and pull to refresh
5. Observe that you see `⚠️ POSCatalogSyncCoordinator: Full sync already in progress for site 247136746` in the logs, and an incremental sync doesn't start.

The `actor` is pretty complex and surprisingly difficult to test. I wasn't able to make a unit test for this behaviour without it hanging. I think this is due to the mixture of isolated and non-isolated variables needed to check it. But, the rest of this is pretty well tested and I think it's an acceptable omission. If this functionality didn't work, it wouldn't be a huge problem, we might just do an extra bit of work we didn't need to from time to time.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
