### PR TITLE
Bookings: Fix navigation bar collapsing

### DIFF
--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
@@ -16,19 +16,12 @@ struct BookingListContainerView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
+        BookingListView(
+            viewModel: viewModel.listViewModel(for: viewModel.selectedTab),
+            searchViewModel: viewModel.searchViewModel(for: viewModel.selectedTab),
+            selectedBooking: $selectedBooking
+        ) {
             headerView
-            TabView(selection: $viewModel.selectedTab) {
-                ForEach(BookingListTab.allCases, id: \.rawValue) { tab in
-                    BookingListView(
-                        viewModel: viewModel.listViewModel(for: tab),
-                        searchViewModel: viewModel.searchViewModel(for: tab),
-                        selectedBooking: $selectedBooking
-                    )
-                    .tag(tab)
-                }
-            }
-            .tabViewStyle(.page(indexDisplayMode: .never))
         }
         .navigationTitle(Localization.viewTitle)
         .if(isSearching, transform: { view in

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import struct Yosemite.Booking
 
-struct BookingListView: View {
+struct BookingListView<Header: View>: View {
     @ObservedObject private var viewModel: BookingListViewModel
     @ObservedObject private var searchViewModel: BookingSearchViewModel
 
@@ -10,12 +10,16 @@ struct BookingListView: View {
 
     @Binding var selectedBooking: Booking?
 
+    private let header: Header
+
     init(viewModel: BookingListViewModel,
          searchViewModel: BookingSearchViewModel,
-         selectedBooking: Binding<Booking?>) {
+         selectedBooking: Binding<Booking?>,
+         @ViewBuilder header: () -> Header) {
         self.viewModel = viewModel
         self.searchViewModel = searchViewModel
         self._selectedBooking = selectedBooking
+        self.header = header()
     }
 
     var body: some View {
@@ -98,20 +102,25 @@ private extension BookingListView {
                      onNextPage: @escaping () -> Void,
                      onRefresh: @escaping () async -> Void) -> some View {
         List(selection: $selectedBooking) {
-            ForEach(bookings) { item in
-                bookingItem(item)
-                    .tag(item)
-            }
-
-            InfiniteScrollIndicator(showContent: viewModel.shouldShowBottomActivityIndicator)
-                .padding(.top, Layout.viewPadding)
-                .onAppear {
-                    onNextPage()
+            Section {
+                ForEach(bookings) { item in
+                    bookingItem(item)
+                        .tag(item)
                 }
+
+                InfiniteScrollIndicator(showContent: viewModel.shouldShowBottomActivityIndicator)
+                    .padding(.top, BookingListViewLayout.viewPadding)
+                    .onAppear {
+                        onNextPage()
+                    }
+            } header: {
+                header
+                    .listRowInsets(EdgeInsets())
+            }
         }
         .listStyle(.plain)
+        .listSectionSeparator(.hidden, edges: .top)
         .background(Color(.listBackground))
-        .accentColor(Color(.listSelectedBackground))
         .refreshable {
             await onRefresh()
         }
@@ -140,50 +149,56 @@ private extension BookingListView {
                 }
             }
         }
+        .listRowBackground(booking == selectedBooking ? Color(.listSelectedBackground) : Color(.listForeground(modal: false)))
     }
 
     func emptyStateView(isSearching: Bool, onRefresh: @escaping () async -> Void) -> some View {
         GeometryReader { proxy in
             ScrollView {
-                VStack(spacing: Layout.emptyStatePadding) {
-                    Spacer()
-                    Image(uiImage: isSearching ? .magnifyingGlassNotFound : .noBookings)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: Layout.emptyStateImageWidth * scale)
-                        .padding(.bottom, Layout.viewPadding)
-                    if isSearching {
-                        Text(Localization.emptySearchText)
-                            .font(.body)
-                            .foregroundStyle(Color.secondary)
-                    } else {
-                        VStack(spacing: Layout.textVerticalPadding) {
-                            Text(viewModel.emptyStateTitle)
-                                .font(.title2)
-                                .fontWeight(.semibold)
-                                .foregroundStyle(.primary)
-                            Text(viewModel.emptyStateDescription)
-                                .font(.title3)
-                                .foregroundStyle(.secondary)
-                        }
-                        if viewModel.hasFilters {
-                            VStack(spacing: Layout.textVerticalPadding) {
-                                Button("Change filters") {
-                                    // TODO
+                LazyVStack(spacing: 0, pinnedViews: .sectionHeaders) {
+                    Section {
+                        VStack(spacing: BookingListViewLayout.emptyStatePadding) {
+                            Spacer()
+                            Image(uiImage: isSearching ? .magnifyingGlassNotFound : .noBookings)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: BookingListViewLayout.emptyStateImageWidth * scale)
+                                .padding(.bottom, BookingListViewLayout.viewPadding)
+                            if isSearching {
+                                Text(BookingListViewLocalization.emptySearchText)
+                                    .font(.body)
+                                    .foregroundStyle(Color.secondary)
+                            } else {
+                                VStack(spacing: BookingListViewLayout.textVerticalPadding) {
+                                    Text(viewModel.emptyStateTitle)
+                                        .font(.title2)
+                                        .fontWeight(.semibold)
+                                        .foregroundStyle(.primary)
+                                    Text(viewModel.emptyStateDescription)
+                                        .font(.title3)
+                                        .foregroundStyle(.secondary)
                                 }
-                                .buttonStyle(PrimaryButtonStyle())
-                                Button("Clear filters") {
-                                    // TODO
+                                if viewModel.hasFilters {
+                                    VStack(spacing: BookingListViewLayout.textVerticalPadding) {
+                                        Button("Change filters") {
+                                            // TODO
+                                        }
+                                        .buttonStyle(PrimaryButtonStyle())
+                                        Button("Clear filters") {
+                                            // TODO
+                                        }
+                                    }
                                 }
-                                .buttonStyle(SecondaryButtonStyle())
+                                Spacer()
                             }
                         }
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, BookingListViewLayout.emptyStatePadding)
+                        .frame(minWidth: proxy.size.width, minHeight: proxy.size.height)
+                    } header: {
+                        header
                     }
-                    Spacer()
                 }
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, Layout.emptyStatePadding)
-                .frame(minWidth: proxy.size.width, minHeight: proxy.size.height)
             }
             .refreshable {
                 await onRefresh()
@@ -193,40 +208,38 @@ private extension BookingListView {
     }
 
     func errorSnackBar(onTap: @escaping () -> Void) -> some View {
-        Text(Localization.errorMessage)
+        Text(BookingListViewLocalization.errorMessage)
             .foregroundStyle(Color(.listForeground(modal: false)))
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(Layout.viewPadding)
+            .padding(BookingListViewLayout.viewPadding)
             .background {
-                RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                RoundedRectangle(cornerRadius: BookingListViewLayout.cornerRadius)
                     .fill(Color(.text))
             }
-            .padding(Layout.viewPadding)
+            .padding(BookingListViewLayout.viewPadding)
             .padding(.bottom, connectivityMonitor.isOffline ? OfflineBannerView.height : 0)
             .contentShape(Rectangle())
             .onTapGesture { onTap() }
     }
 }
 
-private extension BookingListView {
-    enum Layout {
-        static let textVerticalPadding: CGFloat = 8
-        static let viewPadding: CGFloat = 16
-        static let emptyStatePadding: CGFloat = 24
-        static let emptyStateImageWidth: CGFloat = 67
-        static let cornerRadius: CGFloat = 8
-    }
+private enum BookingListViewLayout {
+    static let textVerticalPadding: CGFloat = 8
+    static let viewPadding: CGFloat = 16
+    static let emptyStatePadding: CGFloat = 24
+    static let emptyStateImageWidth: CGFloat = 67
+    static let cornerRadius: CGFloat = 8
+}
 
-    enum Localization {
-        static let errorMessage = NSLocalizedString(
-            "bookingList.errorMessage",
-            value: "Error fetching bookings",
-            comment: "Error message when fetching bookings fails"
-        )
-        static let emptySearchText = NSLocalizedString(
-            "bookingList.emptySearchText",
-            value: "We couldn’t find any bookings with that name — try adjusting your search term to see more results.",
-            comment: "Message displayed when searching bookings by keyword yields no results."
-        )
-    }
+private enum BookingListViewLocalization {
+    static let errorMessage = NSLocalizedString(
+        "bookingList.errorMessage",
+        value: "Error fetching bookings",
+        comment: "Error message when fetching bookings fails"
+    )
+    static let emptySearchText = NSLocalizedString(
+        "bookingList.emptySearchText",
+        value: "We couldn't find any bookings with that name — try adjusting your search term to see more results.",
+        comment: "Message displayed when searching bookings by keyword yields no results."
+    )
 }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -157,44 +157,8 @@ private extension BookingListView {
             ScrollView {
                 LazyVStack(spacing: 0, pinnedViews: .sectionHeaders) {
                     Section {
-                        VStack(spacing: BookingListViewLayout.emptyStatePadding) {
-                            Spacer()
-                            Image(uiImage: isSearching ? .magnifyingGlassNotFound : .noBookings)
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: BookingListViewLayout.emptyStateImageWidth * scale)
-                                .padding(.bottom, BookingListViewLayout.viewPadding)
-                            if isSearching {
-                                Text(BookingListViewLocalization.emptySearchText)
-                                    .font(.body)
-                                    .foregroundStyle(Color.secondary)
-                            } else {
-                                VStack(spacing: BookingListViewLayout.textVerticalPadding) {
-                                    Text(viewModel.emptyStateTitle)
-                                        .font(.title2)
-                                        .fontWeight(.semibold)
-                                        .foregroundStyle(.primary)
-                                    Text(viewModel.emptyStateDescription)
-                                        .font(.title3)
-                                        .foregroundStyle(.secondary)
-                                }
-                                if viewModel.hasFilters {
-                                    VStack(spacing: BookingListViewLayout.textVerticalPadding) {
-                                        Button("Change filters") {
-                                            // TODO
-                                        }
-                                        .buttonStyle(PrimaryButtonStyle())
-                                        Button("Clear filters") {
-                                            // TODO
-                                        }
-                                    }
-                                }
-                                Spacer()
-                            }
-                        }
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, BookingListViewLayout.emptyStatePadding)
-                        .frame(minWidth: proxy.size.width, minHeight: proxy.size.height)
+                        emptyStateContent(isSearching: isSearching)
+                            .frame(minWidth: proxy.size.width, minHeight: proxy.size.height)
                     } header: {
                         header
                     }
@@ -205,6 +169,46 @@ private extension BookingListView {
             }
         }
         .background(Color(.systemBackground))
+    }
+
+    func emptyStateContent(isSearching: Bool) -> some View {
+        VStack(spacing: BookingListViewLayout.emptyStatePadding) {
+            Spacer()
+            Image(uiImage: isSearching ? .magnifyingGlassNotFound : .noBookings)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: BookingListViewLayout.emptyStateImageWidth * scale)
+                .padding(.bottom, BookingListViewLayout.viewPadding)
+            if isSearching {
+                Text(BookingListViewLocalization.emptySearchText)
+                    .font(.body)
+                    .foregroundStyle(Color.secondary)
+            } else {
+                VStack(spacing: BookingListViewLayout.textVerticalPadding) {
+                    Text(viewModel.emptyStateTitle)
+                        .font(.title2)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.primary)
+                    Text(viewModel.emptyStateDescription)
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                }
+                if viewModel.hasFilters {
+                    VStack(spacing: BookingListViewLayout.textVerticalPadding) {
+                        Button("Change filters") {
+                            // TODO
+                        }
+                        .buttonStyle(PrimaryButtonStyle())
+                        Button("Clear filters") {
+                            // TODO
+                        }
+                    }
+                }
+            }
+            Spacer()
+        }
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, BookingListViewLayout.emptyStatePadding)
     }
 
     func errorSnackBar(onTap: @escaping () -> Void) -> some View {
@@ -223,7 +227,7 @@ private extension BookingListView {
     }
 }
 
-private enum BookingListViewLayout {
+fileprivate enum BookingListViewLayout {
     static let textVerticalPadding: CGFloat = 8
     static let viewPadding: CGFloat = 16
     static let emptyStatePadding: CGFloat = 24
@@ -231,7 +235,7 @@ private enum BookingListViewLayout {
     static let cornerRadius: CGFloat = 8
 }
 
-private enum BookingListViewLocalization {
+fileprivate enum BookingListViewLocalization {
     static let errorMessage = NSLocalizedString(
         "bookingList.errorMessage",
         value: "Error fetching bookings",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1514

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the layout of booking list to fix the issue with collapsing navigation bar when scrolling down.

The cause is the use of `TabView` being the immediate children of the navigation stack, preventing the navigation bar to be collapsed.

The solution is to remove `TabView` and put the header view inside the list view of bookings and the scroll view of the empty screen. The header is now still pinned at the top while the navigation bar is collapsible.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Log in to a CIAB store with existing bookings.
2. Navigate to the Bookings tab.
3. Confirm that both the empty view and the booking list still have the header on the top.
4. Pull to refresh and confirm that the refresh indicator is on top of the navigation title.
5. Scroll down the booking list and confirm that the header is pinned at the top.
6. Confirm that switching tabs, sorting, and filtering still work as before.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/1e77be55-bf74-4baf-8e10-706a2a60af58



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
