### PR TITLE
Use BookingBadgeView radius from latest design

### DIFF
--- a/WooCommerce/Classes/Bookings/BookingBadgeView.swift
+++ b/WooCommerce/Classes/Bookings/BookingBadgeView.swift
@@ -11,7 +11,14 @@ struct BookingBadgeView: View {
                   customizations: .init(textColor: Color(UIColor.label.resolvedColor(with: .init(userInterfaceStyle: .light))),
                                         backgroundColor: color,
                                         bordered: false,
-                                        bold: false))
+                                        bold: false),
+                  backgroundShape: .roundedRectangle(cornerRadius: Layout.cornerRadius))
+    }
+}
+
+private extension BookingBadgeView {
+    enum Layout {
+        static let cornerRadius: CGFloat = 4
     }
 }
 


### PR DESCRIPTION
## Description

Just spotted that the currently used radius is wrong for the booking badge view.

## Test Steps
Just compare the two screenshots below.

## Screenshots
| Before | After |
| --- | --- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-07 at 09 58 59" src="https://github.com/user-attachments/assets/a54105aa-e3cd-466f-b054-29d86d3a59b9" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-07 at 10 14 45" src="https://github.com/user-attachments/assets/87827ca0-761a-438f-b820-effae55f3185" /> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
