### PR TITLE
Speculative fix for flaky order sync test

### DIFF
--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
@@ -60,18 +60,44 @@ struct PointOfSaleOrderControllerTests {
                                              currencySettingsProvider: MockCurrencySettingsProvider(),
                                              analytics: MockPOSAnalytics())
         mockOrderService.simulateSyncing = true
-        Task {
-            await sut.syncOrder(for: Cart(purchasableItems: [makeItem(quantity: 1)]), retryHandler: {})
+
+        // Use a continuation to wait until the first sync has definitely started
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            Task { @MainActor in
+                // Start observing state changes
+                @Sendable func observeOrderState() {
+                    withObservationTracking {
+                        _ = sut.orderState
+                    } onChange: {
+                        Task { @MainActor in
+                            if sut.orderState.isSyncing {
+                                // State is now syncing, resume the test
+                                continuation.resume()
+                            } else {
+                                // Keep observing
+                                observeOrderState()
+                            }
+                        }
+                    }
+                }
+                observeOrderState()
+
+                // Start the first sync in a background task
+                Task {
+                    await sut.syncOrder(for: Cart(purchasableItems: [makeItem(quantity: 1)]), retryHandler: {})
+                }
+            }
         }
-        try await Task.sleep(nanoseconds: UInt64(100 * Double(NSEC_PER_MSEC)))
+
+        // Reset the flag after confirming the sync has started
         mockOrderService.syncOrderWasCalled = false
 
-        // When
+        // When - try to sync while already syncing
         await sut.syncOrder(for: Cart(purchasableItems: [makeItem(quantity: 2),
                                                           makeItem(quantity: 5)]),
                             retryHandler: {})
 
-        // Then
+        // Then - the second sync should have been skipped
         #expect(mockOrderService.syncOrderWasCalled == false)
     }
 

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
@@ -53,52 +53,57 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockOrderService.syncOrderWasCalled == false)
     }
 
-    @Test func syncOrder_when_already_syncing_doesnt_call_orderService() async throws {
+    @Test @MainActor func syncOrder_when_already_syncing_doesnt_call_orderService() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
                                              receiptSender: mockReceiptSender,
                                              currencySettingsProvider: MockCurrencySettingsProvider(),
                                              analytics: MockPOSAnalytics())
-        mockOrderService.simulateSyncing = true
 
-        // Use a continuation to wait until the first sync has definitely started
+        // Block the sync so it doesn't complete until we manually resume it
+        mockOrderService.blockNextSync()
+
+        // Start the first sync in a detached task so it runs concurrently
+        let firstSyncTask = Task.detached {
+            await sut.syncOrder(for: Cart(purchasableItems: [makeItem(quantity: 1)]), retryHandler: {})
+        }
+
+        // Wait for the order state to actually become syncing
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            Task { @MainActor in
-                // Start observing state changes
-                @Sendable func observeOrderState() {
-                    withObservationTracking {
-                        _ = sut.orderState
-                    } onChange: {
-                        Task { @MainActor in
-                            if sut.orderState.isSyncing {
-                                // State is now syncing, resume the test
-                                continuation.resume()
-                            } else {
-                                // Keep observing
-                                observeOrderState()
-                            }
+            @Sendable func observeOrderState() {
+                withObservationTracking {
+                    _ = sut.orderState
+                } onChange: {
+                    Task { @MainActor in
+                        if sut.orderState.isSyncing {
+                            continuation.resume()
+                        } else {
+                            observeOrderState()
                         }
                     }
                 }
-                observeOrderState()
-
-                // Start the first sync in a background task
-                Task {
-                    await sut.syncOrder(for: Cart(purchasableItems: [makeItem(quantity: 1)]), retryHandler: {})
-                }
             }
+            observeOrderState()
         }
+
+        // Verify the state is actually syncing
+        #expect(sut.orderState.isSyncing == true)
+        #expect(mockOrderService.syncOrderWasCalled == true)
 
         // Reset the flag after confirming the sync has started
         mockOrderService.syncOrderWasCalled = false
 
-        // When - try to sync while already syncing
+        // When - try to sync while the first sync is still in progress
         await sut.syncOrder(for: Cart(purchasableItems: [makeItem(quantity: 2),
                                                           makeItem(quantity: 5)]),
                             retryHandler: {})
 
         // Then - the second sync should have been skipped
         #expect(mockOrderService.syncOrderWasCalled == false)
+
+        // Cleanup - allow the first sync to complete
+        mockOrderService.resumeBlockedSync()
+        _ = await firstSyncTask.result
     }
 
     @Test func syncOrder_with_no_previous_order_calls_orderService() async throws {

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderService.swift
@@ -14,12 +14,33 @@ class MockPOSOrderService: POSOrderServiceProtocol {
     var spySyncOrderCurrency: CurrencyCode?
     var spyCashPaymentChangeDueAmount: String?
 
+    // For controlling sync timing in tests
+    private var syncContinuation: CheckedContinuation<Void, Never>?
+    private var shouldBlockSync = false
+
+    /// Blocks the next sync operation until `resumeBlockedSync()` is called
+    func blockNextSync() {
+        shouldBlockSync = true
+    }
+
+    /// Resumes a blocked sync operation
+    func resumeBlockedSync() {
+        syncContinuation?.resume()
+        syncContinuation = nil
+        shouldBlockSync = false
+    }
+
     func syncOrder(cart: Yosemite.POSCart,
                    currency: CurrencyCode) async throws -> Yosemite.Order {
         syncOrderWasCalled = true
         spySyncOrderCurrency = currency
 
-        if simulateSyncing {
+        if shouldBlockSync {
+            shouldBlockSync = false // Only block the first call
+            await withCheckedContinuation { continuation in
+                syncContinuation = continuation
+            }
+        } else if simulateSyncing {
             try await Task.sleep(nanoseconds: UInt64(1 * Double(NSEC_PER_SEC)))
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This test has been around for about a year, and there's no recent changes in the area, so I'm not really sure why it's started getting flaky... I also couldn't reproduce it reliably even running the tests thousands of times.

I couldn't see anything obvious, so this is a fairly speculative improvement, but removing the sleep should help.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

In Xcode, right click the test suite diamond and select `Run Tests repeatedly` and run them 1000 times. I tried 5000 with no failures.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="1028" height="176" alt="CleanShot 2025-11-07 at 12 40 25@2x" src="https://github.com/user-attachments/assets/1b5f74b9-e678-4265-9804-65e6ff70aa10" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
