### PR TITLE
Fix Order Details presentation on phone

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [**] We added support for collecting in-person payments (including Tap To Pay) using Stripe Payment Gateway extension in the UK. [https://github.com/woocommerce/woocommerce-ios/pull/16287]
 - [*] Improve card payments onboarding error handling to show network errors correctly [https://github.com/woocommerce/woocommerce-ios/pull/16304]
 - [*] Authenticate the admin page automatically for sites with SSO enabled in custom fields, in-person payment setup, and editing tax rates flows. [https://github.com/woocommerce/woocommerce-ios/pull/16318]
+- [*] Fix order details presentation when opened from booking details [https://github.com/woocommerce/woocommerce-ios/pull/16331]
 
 23.6
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -110,6 +110,14 @@ final class OrderDetailsViewController: UIViewController {
     override var shouldShowOfflineBanner: Bool {
         true
     }
+
+    func isPresentingViewModelOrder(_ viewModel: OrderDetailsViewModel) -> Bool {
+        return self.viewModel.order.orderID == viewModel.order.orderID
+    }
+
+    func isQuickOrderNavigationSupported() -> Bool {
+        viewModels.count > 1
+    }
 }
 
 // MARK: - TableView Configuration

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -626,8 +626,13 @@ extension OrderListViewController {
     /// Adds ability to select any order
     /// Used when opening an order with deep link
     /// - Parameter orderID: ID of the order to select in the list.
+    /// - Parameter isTriggeredByUserAction: Reflects if the order selection was triggered by a manual user action and not a view lifecycle update
+    /// Practically if the `isTriggeredByUserAction` is true, then the order details will be force presented even if `selectedOrderID` is the same as the new `orderID`
     /// - Returns: Whether the order to select is in the list already (i.e. the order has been fetched and exists locally).
-    func selectOrderFromListIfPossible(for orderID: Int64) -> Bool {
+    func selectOrderFromListIfPossible(
+        for orderID: Int64,
+        isTriggeredByUserAction: Bool = false,
+    ) -> Bool {
         guard let dataSource else {
             return false
         }
@@ -637,7 +642,7 @@ extension OrderListViewController {
                 let orderNotAlreadySelected = selectedOrderID != orderID
                 let indexPath = dataSource.indexPath(for: identifier)
                 let indexPathNotAlreadySelected = selectedIndexPath != indexPath
-                let shouldSwitchDetails = orderNotAlreadySelected || indexPathNotAlreadySelected
+                let shouldSwitchDetails = orderNotAlreadySelected || indexPathNotAlreadySelected || isTriggeredByUserAction
                 if shouldSwitchDetails {
                     showOrderDetails(detailsViewModel.order)
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -627,7 +627,8 @@ extension OrderListViewController {
     /// Used when opening an order with deep link
     /// - Parameter orderID: ID of the order to select in the list.
     /// - Parameter isTriggeredByUserAction: Reflects if the order selection was triggered by a manual user action and not a view lifecycle update
-    /// Practically if the `isTriggeredByUserAction` is true, then the order details will be force presented even if `selectedOrderID` is the same as the new `orderID`
+    /// Practically if the `isTriggeredByUserAction` is true, then the order details will be force presented
+    /// even if `selectedOrderID` is the same as the new `orderID`
     /// - Returns: Whether the order to select is in the list already (i.e. the order has been fetched and exists locally).
     func selectOrderFromListIfPossible(
         for orderID: Int64,

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -165,7 +165,10 @@ final class OrdersRootViewController: UIViewController {
     /// - Returns: Whether the order to select is in the list already (i.e. the order has been fetched and exists locally).
     @discardableResult
     func selectOrderFromListIfPossible(for orderID: Int64) -> Bool {
-        ordersViewController.selectOrderFromListIfPossible(for: orderID)
+        ordersViewController.selectOrderFromListIfPossible(
+            for: orderID,
+            isTriggeredByUserAction: true
+        )
     }
 
     /// Called when an order is shown externally (outside of `OrderListViewController`) and the order should be

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -129,10 +129,12 @@ private extension OrdersSplitViewWrapperController {
         // shown should replace the topViewController, to avoid having to tap back through several Order Details
         // screens in the navigation stack. The back button should always go to the Order List.
         // The up and down arrows are enabled when there is more than one item in `viewModels`.
-        guard isQuickOrderNavigationSupported(viewModels: viewModels),
-              let viewModel = viewModels[safe: currentIndex],
-              let secondaryNavigationController = ordersSplitViewController.viewController(for: .secondary) as? UINavigationController,
-              secondaryNavigationController.topViewController is OrderDetailsViewController else {
+        guard
+            let viewModel = viewModels[safe: currentIndex],
+            let secondaryNavigationController = ordersSplitViewController.viewController(for: .secondary) as? UINavigationController,
+            let existingOrderDetailsViewController = secondaryNavigationController.topViewController as? OrderDetailsViewController,
+            existingOrderDetailsViewController.isQuickOrderNavigationSupported() == orderDetailsViewController.isQuickOrderNavigationSupported()
+        else {
             // When showing an order without quick navigation, it simply sets the order details to the secondary view.
             let orderDetailsNavigationController = WooNavigationController(rootViewController: orderDetailsViewController)
             showSecondaryView(orderDetailsNavigationController)
@@ -140,14 +142,16 @@ private extension OrdersSplitViewWrapperController {
             return
         }
 
-        secondaryNavigationController.replaceTopViewController(with: orderDetailsViewController, animated: false)
-        ordersViewController.onOrderSelected(id: viewModel.order.orderID)
+        if !existingOrderDetailsViewController.isPresentingViewModelOrder(viewModel) {
+            secondaryNavigationController.replaceTopViewController(
+                with: orderDetailsViewController,
+                animated: false
+            )
+            ordersViewController.onOrderSelected(id: viewModel.order.orderID)
+        }
+
         ordersSplitViewController.show(.secondary)
         onCompletion?(true)
-    }
-
-    func isQuickOrderNavigationSupported(viewModels: [OrderDetailsViewModel]) -> Bool {
-        viewModels.count > 1
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1653

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Repetitive order details presentation from booking was broken on iPhone. If a booking order was presented by tapping on "View Order" in booking details, dismissed and then triggered to be presented again - the order details won't be opened the second time.

The issue is happening because `selectedOrderID` and `selectedIndexPath` keep their value even when order details get dismissed on iPhone. The following logic prevented the details presentation:
```
let orderNotAlreadySelected = selectedOrderID != orderID
let indexPath = dataSource.indexPath(for: identifier)
let indexPathNotAlreadySelected = selectedIndexPath != indexPath
let shouldSwitchDetails = orderNotAlreadySelected || indexPathNotAlreadySelected
```

To resolve the above issue the `isTriggeredByUserAction` attribute was added to force order details presentation if the navigation was manually triggered by the user action. Also the derails presentation logic was changed in OrdersSplitViewWrapperController - the new details VC wasn't re-created and applied in case if the new order has the same id. In that case the existing details VC was obtained and re-presented.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

### TC1: Basic scenario
- Run on iPhone and iPad at the same time to compare behaviour.
- Use CIAB site with existing bookings and corresponding orders.
- Navigate to a booking that has an order.
- In booking details tap on "View Order" CTA
- Make sure the "Orders" tab is opened and the corresponding order is selected in orders list and also presented in Order Details screen.
- Dismiss the booking details (on iPhone)
- Go back to the Bookings tab where the same booking is opened.
- Tap on the "View Order" CTA again.
- Make sure the Order Details correctly re-opened in Orders tab.

https://github.com/user-attachments/assets/892b21bb-5af9-41d7-92b5-273a1ae10bb6

### TC2: don't dismiss the order details
- Repeat the steps from the TC1 but skip the "Dismiss the booking details"
- Make sure when the order details are opened for the 2nd time - there is no screen re-creation. The same screen should be just re-opened.

https://github.com/user-attachments/assets/c5b752e4-58cd-4ed5-993b-07897c98a6ae

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
