### PR TITLE
[WCiOS17] Update card readers modals to new traits API

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -52,6 +52,7 @@ final class CardPresentPaymentsModalViewController: UIViewController, CardReader
         setButtonsActions()
         styleContent()
         populateContent()
+        observeTraitChanges()
     }
 
     func setViewModel(_ newViewModel: CardPresentPaymentsModalViewModel) {
@@ -62,13 +63,18 @@ final class CardPresentPaymentsModalViewController: UIViewController, CardReader
         }
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        resetHeightAndWidth()
+    private func observeTraitChanges() {
+        let traits: [UITrait] = [
+            UITraitVerticalSizeClass.self,
+            UITraitHorizontalSizeClass.self
+        ]
+        registerForTraitChanges(traits) { (self: Self, _) in
+            self.resetHeightAndWidth()
+        }
     }
 
     private func resetHeightAndWidth() {
-        if traitCollection.containsTraits(in: UITraitCollection(verticalSizeClass: .compact)) {
+        if traitCollection.verticalSizeClass == .compact {
             primaryActionButtonsStackView.axis = .horizontal
             primaryActionButtonsStackView.distribution = .fillProportionally
 
@@ -92,7 +98,7 @@ final class CardPresentPaymentsModalViewController: UIViewController, CardReader
     }
 
     private func updateImageAndLoadingVisibility() {
-        if traitCollection.containsTraits(in: UITraitCollection(verticalSizeClass: .compact)) {
+        if traitCollection.verticalSizeClass == .compact {
             imageView.isHidden = true
             loadingView?.isHidden = true
         } else {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/SeveralReadersFoundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/SeveralReadersFoundViewController.swift
@@ -36,21 +36,18 @@ final class SeveralReadersFoundViewController: UIViewController, UITableViewDele
         configureTable()
         updateViewMargins()
         updateViewAppearances()
+        observeTraitChanges()
     }
 
-    /// Update constraints that vary by size class
-    ///
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        /// Handle size class and orientation
-        ///
-        updateViewMargins()
-
-        /// Handle changes to Light / Dark Appearance
-        ///
-        if let previousTraits = previousTraitCollection, previousTraits.hasDifferentColorAppearance(comparedTo: traitCollection) {
-            updateViewAppearances()
+    private func observeTraitChanges() {
+        let traits: [UITrait] = [
+            UITraitVerticalSizeClass.self,
+            UITraitHorizontalSizeClass.self,
+            UITraitUserInterfaceStyle.self
+        ]
+        registerForTraitChanges(traits) { (self: Self, _) in
+            self.updateViewMargins()
+            self.updateViewAppearances()
         }
     }
 


### PR DESCRIPTION
Closes WOOMOB-1302

## Description
This PR addresses `traitCollectionDidChange' was deprecated in iOS 17.0: Use the trait change registration APIs declared in the UITraitChangeObservable protocol warning` when presenting card reader connection flows.

In the new API (iOS17+), we register the traits we care about when initializing the view and the system will call the handler when traits change, rather than doing a subclass override.

## Changes
- `CardPresentPaymentsModalViewController` traits to be triggered when vertical/horizontal size classes change
- `SeveralReadersFoundViewController` traits to be triggered as well when appearance changes (light/dark mode), which ensures the cancel button styling updates too.

## Test Steps
- On a card present payments-eligible store (the simulator when `-simulate-stripe-card-reader` is enabled should show the "several card readers" option) 
- Go to Settings > Payments > Connect card reader
- Confirm that portrait/landscape/light/dark mode work correctly. Can also add a breakpoint to `observeTraitChanges` to confirm that is triggered

Tested on iPhone 14 iOS 18.6.2

## Screenshots

1. Modals dark mode 

https://github.com/user-attachments/assets/8453bd8b-a874-4549-8aa6-4f2e6bd38929

2. Several readers light mode

https://github.com/user-attachments/assets/aa5fd7b4-d0c8-48fd-9ba5-7fb7db5c29ba

