### PR TITLE
Woomob 1674 hide view order for missing orders

### DIFF
--- a/WooCommerce/Classes/Extensions/Booking+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Booking+Helpers.swift
@@ -19,6 +19,10 @@ extension Booking {
             .joined(separator: "  •  ")
     }
 
+    var isOrderValid: Bool {
+        return orderID != 0
+    }
+
     private enum Localization {
         static let guest = NSLocalizedString(
             "bookings.guest",

--- a/WooCommerce/Classes/Extensions/Booking+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Booking+Helpers.swift
@@ -19,8 +19,8 @@ extension Booking {
             .joined(separator: "  •  ")
     }
 
-    var isOrderValid: Bool {
-        return orderID != 0
+    var hasAssociatedOrder: Bool {
+        return orderID > 0
     }
 
     private enum Localization {

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -27,6 +27,7 @@ final class BookingDetailsViewModel: ObservableObject {
 
     @Published private(set) var navigationTitle = ""
     @Published private(set) var sections: [Section] = []
+    @Published private(set) var isViewOrderAvailable = true
     @Published var notice: Notice?
 
     var bookingAttendanceStatus: BookingAttendanceStatus {
@@ -83,6 +84,7 @@ private extension BookingDetailsViewModel {
 
     func updateDisplayProperties(from booking: Booking) {
         navigationTitle = Self.navigationTitle(for: booking)
+        isViewOrderAvailable = booking.isOrderValid
 
         headerContent.update(with: booking)
 

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -84,7 +84,7 @@ private extension BookingDetailsViewModel {
 
     func updateDisplayProperties(from booking: Booking) {
         navigationTitle = Self.navigationTitle(for: booking)
-        isViewOrderAvailable = booking.isOrderValid
+        isViewOrderAvailable = booking.hasAssociatedOrder
 
         headerContent.update(with: booking)
 

--- a/WooCommerce/Classes/ViewModels/Booking Details/PaymentContent.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/PaymentContent.swift
@@ -28,9 +28,8 @@ extension BookingDetailsViewModel {
 
             actions = [
                 .markAsPaid,
-                .issueRefund,
-                .viewOrder
-            ]
+                .issueRefund
+            ] + (booking.isOrderValid ? [.viewOrder] : [])
         }
     }
 }

--- a/WooCommerce/Classes/ViewModels/Booking Details/PaymentContent.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/PaymentContent.swift
@@ -29,7 +29,7 @@ extension BookingDetailsViewModel {
             actions = [
                 .markAsPaid,
                 .issueRefund
-            ] + (booking.isOrderValid ? [.viewOrder] : [])
+            ] + (booking.hasAssociatedOrder ? [.viewOrder] : [])
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -63,8 +63,10 @@ struct BookingDetailsView: View {
                     Button(Localization.markAsPaid) {
                         print("On mark as paid tap")
                     }
-                    Button(Localization.viewOrder) {
-                        viewModel.navigateToOrderDetails()
+                    if viewModel.isViewOrderAvailable {
+                        Button(Localization.viewOrder) {
+                            viewModel.navigateToOrderDetails()
+                        }
                     }
                     Button(Localization.cancelBookingAction, role: .destructive) {
                         print("On cancel booking tap")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
@@ -357,4 +357,31 @@ final class BookingDetailsViewModelTests: XCTestCase {
 
         XCTAssertFalse(containsAttendanceSection)
     }
+
+    func test_view_order_is_hidden_when_booking_order_id_is_invalid() {
+        // Given
+        let booking = Booking.fake().copy(
+            orderID: 0
+        )
+
+        // When
+        let viewModel = BookingDetailsViewModel(booking: booking, stores: storesManager)
+
+        // Then
+        let paymentSection = viewModel.sections.first { section in
+            if case .payment = section.content {
+                return true
+            }
+            return false
+        }
+
+        guard let paymentSection = paymentSection,
+              case let .payment(paymentContent) = paymentSection.content else {
+            XCTFail("Payment section not found")
+            return
+        }
+
+        XCTAssertFalse(viewModel.isViewOrderAvailable)
+        XCTAssertFalse(paymentContent.actions.contains(.viewOrder))
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1674

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Addresses the PR [comment](https://github.com/woocommerce/woocommerce-ios/pull/16331#pullrequestreview-3441260860).

- Hides "View order" option in "Payment" section if an order is absent for a booking (order id is `0`)
- Hides the "View order" option in Booking Details ellipsis menu in the same case as above.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
- Use CIAB site with bookings. Consider using our shared CIAB testing site.
- Find a booking with a missing order. In our testing site that would be booking `302`
- Open booking details
- Make sure the "Payment" section doesn't display the "View order" option
- Tap on ellipsis menu in top right corner.
- Make sure the action sheet doesn't contain the "View order" option
- Regression check - find a booking with a valid order. Open booking details and make sure the "View order" option is presented both in "Payments" section and in ellipsis menu.

## Demo
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/b66b90ad-883a-43ce-aa1b-e70528fc8626

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
