### PR TITLE
[Local Catalog] Check remote feature flag for catalog eligibility

### DIFF
--- a/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
+++ b/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
@@ -30,6 +30,7 @@ public enum RemoteFeatureFlag: Decodable {
     case storeCreationCompleteNotification
     case pointOfSale
     case appPasswordsForJetpackSites
+    case posLocalCatalogM1
 
     init?(rawValue: String) {
         switch rawValue {
@@ -39,6 +40,8 @@ public enum RemoteFeatureFlag: Decodable {
             self = .pointOfSale
         case "woo_app_passwords_for_jetpack_sites":
             self = .appPasswordsForJetpackSites
+        case "woo_pos_local_catalog_m1":
+            self = .posLocalCatalogM1
         default:
             return nil
         }

--- a/Modules/Sources/Yosemite/Tools/POS/POSLocalCatalogEligibilityService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSLocalCatalogEligibilityService.swift
@@ -7,6 +7,7 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
     private let systemStatusService: POSSystemStatusServiceProtocol
     private let catalogSizeLimit: Int
     private let isLocalCatalogFeatureFlagEnabled: Bool
+    private let remoteFeatureFlagProvider: @Sendable () async -> Bool
 
     // Eligibility states cached per site
     private var eligibilityStates: [Int64: POSLocalCatalogEligibilityState] = [:]
@@ -14,21 +15,27 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
     // POS eligibility states cached per site
     private var posEligibilityStates: [Int64: Bool] = [:]
 
+    // Cached remote feature flag value
+    private var cachedRemoteFeatureFlag: Bool?
+
     /// Initialize eligibility service
     /// - Parameters:
     ///   - catalogSizeChecker: Service to check catalog size for sites
     ///   - systemStatusService: Service to check WooCommerce plugin version
     ///   - isLocalCatalogFeatureFlagEnabled: Whether the local catalog feature flag is enabled
+    ///   - remoteFeatureFlagProvider: Async closure that fetches the remote feature flag value
     ///   - catalogSizeLimit: Maximum allowed catalog size (products + variations)
     public init(
         catalogSizeChecker: POSCatalogSizeCheckerProtocol,
         systemStatusService: POSSystemStatusServiceProtocol,
         isLocalCatalogFeatureFlagEnabled: Bool,
+        remoteFeatureFlagProvider: @escaping @Sendable () async -> Bool,
         catalogSizeLimit: Int? = nil
     ) {
         self.catalogSizeChecker = catalogSizeChecker
         self.systemStatusService = systemStatusService
         self.isLocalCatalogFeatureFlagEnabled = isLocalCatalogFeatureFlagEnabled
+        self.remoteFeatureFlagProvider = remoteFeatureFlagProvider
         self.catalogSizeLimit = catalogSizeLimit ?? Constants.defaultCatalogSizeLimit
     }
 
@@ -40,6 +47,16 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
         }
         // Not cached yet, refresh and return
         return try await refreshEligibilityState(for: siteID)
+    }
+
+    /// Fetch and cache the remote feature flag value
+    private func isRemoteCatalogFeatureFlagEnabled() async -> Bool {
+        if let cached = cachedRemoteFeatureFlag {
+            return cached
+        }
+        let value = await remoteFeatureFlagProvider()
+        cachedRemoteFeatureFlag = value
+        return value
     }
 
     /// Update POS eligibility and refresh catalog eligibility for the specified site
@@ -73,11 +90,13 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
             return state
         }
 
-        // Check feature flag - if disabled, no need to check catalog size
-        guard isLocalCatalogFeatureFlagEnabled else {
+        // Check feature flags - both local and remote must be enabled
+        let isRemoteEnabled = await isRemoteCatalogFeatureFlagEnabled()
+        guard isLocalCatalogFeatureFlagEnabled && isRemoteEnabled else {
             let state = POSLocalCatalogEligibilityState.ineligible(reason: .featureFlagDisabled)
             eligibilityStates[siteID] = state
-            DDLogInfo("📋 POSLocalCatalogEligibilityService: Local catalog feature flag disabled for site \(siteID)")
+            DDLogInfo("📋 POSLocalCatalogEligibilityService: Local catalog feature flags disabled for site \(siteID) " +
+                      "(local: \(isLocalCatalogFeatureFlagEnabled), remote: \(isRemoteEnabled))")
             return state
         }
 
@@ -143,6 +162,26 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
             eligibilityStates[siteID] = state
             DDLogError("📋 POSLocalCatalogEligibilityService: Failed to check catalog size for site \(siteID): \(error)")
             return state
+        }
+    }
+}
+
+// MARK: - Factory Method
+
+public extension POSLocalCatalogEligibilityService {
+    /// Creates a remote feature flag provider closure for POS local catalog
+    /// - Parameter dispatcher: The dispatcher to use for fetching the remote flag
+    /// - Returns: A closure that fetches the remote feature flag value, defaulting to true if unavailable
+    static func makeRemoteFeatureFlagProvider(dispatcher: Dispatcher) -> @Sendable () async -> Bool {
+        return {
+            await withCheckedContinuation { continuation in
+                Task { @MainActor in
+                    let action = FeatureFlagAction.isRemoteFeatureFlagEnabled(.posLocalCatalogM1, defaultValue: true) { isEnabled in
+                        continuation.resume(returning: isEnabled)
+                    }
+                    dispatcher.dispatch(action)
+                }
+            }
         }
     }
 }

--- a/Modules/Sources/Yosemite/Tools/POS/POSLocalCatalogEligibilityService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSLocalCatalogEligibilityService.swift
@@ -37,8 +37,9 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
         self.isLocalCatalogFeatureFlagEnabled = isLocalCatalogFeatureFlagEnabled
         self.remoteFeatureFlagProvider = remoteFeatureFlagProvider
         self.catalogSizeLimit = catalogSizeLimit ?? Constants.defaultCatalogSizeLimit
+        // Eagerly start fetching the remote flag in the background
         Task {
-            _ = await isRemoteCatalogFeatureFlagEnabled()
+            await self.fetchRemoteFlag()
         }
     }
 
@@ -53,22 +54,15 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
     }
 
     /// Fetch and cache the remote feature flag value
-    /// Returns cached value if available, otherwise returns true without waiting for network
+    /// Returns cached value if available, otherwise returns true (assumes eligible)
     private func isRemoteCatalogFeatureFlagEnabled() async -> Bool {
-        if let cached = cachedRemoteFeatureFlag {
-            return cached
-        }
-        // No cached value yet - assume eligible (true) without waiting for network
-        // Kick off the fetch in the background to cache for next time
-        Task { [weak self] in
-            let value = await self?.remoteFeatureFlagProvider() ?? true
-            await self?.cacheRemoteFeatureFlag(value)
-        }
-        return true
+        // Return cached value if we have one
+        return cachedRemoteFeatureFlag ?? true
     }
 
-    /// Cache the remote feature flag value (actor-isolated)
-    private func cacheRemoteFeatureFlag(_ value: Bool) {
+    /// Fetch the remote feature flag value and cache it (actor-isolated)
+    private func fetchRemoteFlag() async {
+        let value = await remoteFeatureFlagProvider()
         cachedRemoteFeatureFlag = value
     }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSLocalCatalogEligibilityService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSLocalCatalogEligibilityService.swift
@@ -50,13 +50,23 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
     }
 
     /// Fetch and cache the remote feature flag value
+    /// Returns cached value if available, otherwise returns true without waiting for network
     private func isRemoteCatalogFeatureFlagEnabled() async -> Bool {
         if let cached = cachedRemoteFeatureFlag {
             return cached
         }
-        let value = await remoteFeatureFlagProvider()
+        // No cached value yet - assume eligible (true) without waiting for network
+        // Kick off the fetch in the background to cache for next time
+        Task { [weak self] in
+            let value = await self?.remoteFeatureFlagProvider() ?? true
+            await self?.cacheRemoteFeatureFlag(value)
+        }
+        return true
+    }
+
+    /// Cache the remote feature flag value (actor-isolated)
+    private func cacheRemoteFeatureFlag(_ value: Bool) {
         cachedRemoteFeatureFlag = value
-        return value
     }
 
     /// Update POS eligibility and refresh catalog eligibility for the specified site

--- a/Modules/Sources/Yosemite/Tools/POS/POSLocalCatalogEligibilityService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSLocalCatalogEligibilityService.swift
@@ -37,6 +37,9 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
         self.isLocalCatalogFeatureFlagEnabled = isLocalCatalogFeatureFlagEnabled
         self.remoteFeatureFlagProvider = remoteFeatureFlagProvider
         self.catalogSizeLimit = catalogSizeLimit ?? Constants.defaultCatalogSizeLimit
+        Task {
+            _ = await isRemoteCatalogFeatureFlagEnabled()
+        }
     }
 
     /// Get catalog eligibility for a specific site

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSLocalCatalogEligibilityServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSLocalCatalogEligibilityServiceTests.swift
@@ -242,7 +242,7 @@ struct POSLocalCatalogEligibilityServiceTests {
         #expect(sizeChecker.checkCatalogSizeCallCount == 0)
     }
 
-    @Test("Remote feature flag disabled returns ineligible")
+    @Test("Remote feature flag disabled returns ineligible after refresh")
     func testRemoteFeatureFlagDisabledReturnsIneligible() async throws {
         let sizeChecker = MockPOSCatalogSizeChecker(
             sizeToReturn: .success(POSCatalogSize(productCount: 500, variationCount: 400))
@@ -257,10 +257,14 @@ struct POSLocalCatalogEligibilityServiceTests {
         )
         try await service.updatePOSEligibility(isEligible: true, for: siteID)
 
-        let state = try await service.catalogEligibility(for: siteID)
+        // First refresh might check catalog (using default true before fetch completes)
+        _ = try? await service.refreshEligibilityState(for: siteID)
+
+        // Second refresh should use the fetched remote flag value (false)
+        let state = try await service.refreshEligibilityState(for: siteID)
 
         guard case .ineligible(let reason) = state else {
-            Issue.record("Expected ineligible state")
+            Issue.record("Expected ineligible state after remote flag fetch")
             return
         }
 
@@ -269,8 +273,9 @@ struct POSLocalCatalogEligibilityServiceTests {
             return
         }
 
-        // Should not have checked catalog size
-        #expect(sizeChecker.checkCatalogSizeCallCount == 0)
+        // Second refresh should not have checked catalog size (short-circuited by flag)
+        // First refresh might have checked it (count could be 0 or 1)
+        #expect(sizeChecker.checkCatalogSizeCallCount <= 1)
     }
 
     @Test("Both feature flags required for eligibility")

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSLocalCatalogEligibilityServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSLocalCatalogEligibilityServiceTests.swift
@@ -7,6 +7,11 @@ import Testing
 struct POSLocalCatalogEligibilityServiceTests {
     private let siteID: Int64 = 123
 
+    // Default remote feature flag provider that returns true
+    private func makeRemoteFeatureFlagProvider(returning value: Bool = true) -> @Sendable () async -> Bool {
+        return { value }
+    }
+
     // MARK: - Catalog Size Within Limit
 
     @Test("Catalog size within limit returns eligible")
@@ -19,6 +24,7 @@ struct POSLocalCatalogEligibilityServiceTests {
             catalogSizeChecker: sizeChecker,
             systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
             catalogSizeLimit: 1000
         )
         try await service.updatePOSEligibility(isEligible: true, for: siteID)
@@ -36,6 +42,7 @@ struct POSLocalCatalogEligibilityServiceTests {
             catalogSizeChecker: sizeChecker,
             systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
             catalogSizeLimit: 1000
         )
         try await service.updatePOSEligibility(isEligible: true, for: siteID)
@@ -55,6 +62,7 @@ struct POSLocalCatalogEligibilityServiceTests {
             catalogSizeChecker: sizeChecker,
             systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
             catalogSizeLimit: 1000
         )
         try await service.updatePOSEligibility(isEligible: true, for: siteID)
@@ -88,6 +96,7 @@ struct POSLocalCatalogEligibilityServiceTests {
             catalogSizeChecker: sizeChecker,
             systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
             catalogSizeLimit: 1000
         )
         try await service.updatePOSEligibility(isEligible: true, for: siteID)
@@ -119,6 +128,7 @@ struct POSLocalCatalogEligibilityServiceTests {
             catalogSizeChecker: sizeChecker,
             systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
             catalogSizeLimit: 1000
         )
         try await service.updatePOSEligibility(isEligible: true, for: siteID)
@@ -144,6 +154,7 @@ struct POSLocalCatalogEligibilityServiceTests {
             catalogSizeChecker: sizeChecker,
             systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
             catalogSizeLimit: 1000
         )
         try await service.updatePOSEligibility(isEligible: true, for: siteID)
@@ -169,6 +180,7 @@ struct POSLocalCatalogEligibilityServiceTests {
             catalogSizeChecker: sizeChecker,
             systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
             catalogSizeLimit: 1000
         )
         try await service.updatePOSEligibility(isEligible: true, for: siteID)
@@ -199,8 +211,8 @@ struct POSLocalCatalogEligibilityServiceTests {
 
     // MARK: - Feature Flag
 
-    @Test("Feature flag disabled returns ineligible")
-    func testFeatureFlagDisabledReturnsIneligible() async throws {
+    @Test("Local feature flag disabled returns ineligible")
+    func testLocalFeatureFlagDisabledReturnsIneligible() async throws {
         let sizeChecker = MockPOSCatalogSizeChecker(
             sizeToReturn: .success(POSCatalogSize(productCount: 500, variationCount: 400))
         )
@@ -209,6 +221,7 @@ struct POSLocalCatalogEligibilityServiceTests {
             catalogSizeChecker: sizeChecker,
             systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: false,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
             catalogSizeLimit: 1000
         )
         try await service.updatePOSEligibility(isEligible: true, for: siteID)
@@ -229,6 +242,56 @@ struct POSLocalCatalogEligibilityServiceTests {
         #expect(sizeChecker.checkCatalogSizeCallCount == 0)
     }
 
+    @Test("Remote feature flag disabled returns ineligible")
+    func testRemoteFeatureFlagDisabledReturnsIneligible() async throws {
+        let sizeChecker = MockPOSCatalogSizeChecker(
+            sizeToReturn: .success(POSCatalogSize(productCount: 500, variationCount: 400))
+        )
+        let systemStatusService = MockPOSSystemStatusService()
+        let service = POSLocalCatalogEligibilityService(
+            catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
+            isLocalCatalogFeatureFlagEnabled: true,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(returning: false),
+            catalogSizeLimit: 1000
+        )
+        try await service.updatePOSEligibility(isEligible: true, for: siteID)
+
+        let state = try await service.catalogEligibility(for: siteID)
+
+        guard case .ineligible(let reason) = state else {
+            Issue.record("Expected ineligible state")
+            return
+        }
+
+        guard case .featureFlagDisabled = reason else {
+            Issue.record("Expected featureFlagDisabled reason")
+            return
+        }
+
+        // Should not have checked catalog size
+        #expect(sizeChecker.checkCatalogSizeCallCount == 0)
+    }
+
+    @Test("Both feature flags required for eligibility")
+    func testBothFeatureFlagsRequiredForEligibility() async throws {
+        let sizeChecker = MockPOSCatalogSizeChecker(
+            sizeToReturn: .success(POSCatalogSize(productCount: 500, variationCount: 400))
+        )
+        let systemStatusService = MockPOSSystemStatusService()
+
+        // Test with both flags enabled - should be eligible
+        let serviceWithBothEnabled = POSLocalCatalogEligibilityService(
+            catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
+            isLocalCatalogFeatureFlagEnabled: true,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(returning: true),
+            catalogSizeLimit: 1000
+        )
+        try await serviceWithBothEnabled.updatePOSEligibility(isEligible: true, for: siteID)
+        #expect(try await serviceWithBothEnabled.catalogEligibility(for: siteID) == .eligible)
+    }
+
     // MARK: - Custom Size Limit
 
     @Test("Custom size limit is respected")
@@ -241,6 +304,7 @@ struct POSLocalCatalogEligibilityServiceTests {
             catalogSizeChecker: sizeChecker,
             systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
             catalogSizeLimit: 100 // Custom lower limit
         )
         try await service.updatePOSEligibility(isEligible: true, for: siteID)
@@ -273,6 +337,7 @@ struct POSLocalCatalogEligibilityServiceTests {
             catalogSizeChecker: sizeChecker,
             systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
             catalogSizeLimit: 1000
         )
 
@@ -305,6 +370,7 @@ struct POSLocalCatalogEligibilityServiceTests {
             catalogSizeChecker: sizeChecker,
             systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
             catalogSizeLimit: 1000
         )
 
@@ -336,6 +402,7 @@ struct POSLocalCatalogEligibilityServiceTests {
             catalogSizeChecker: sizeChecker,
             systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
             catalogSizeLimit: 1000
         )
 
@@ -390,6 +457,7 @@ struct POSLocalCatalogEligibilityServiceTests {
             catalogSizeChecker: sizeChecker,
             systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
             catalogSizeLimit: 1000
         )
         try await service.updatePOSEligibility(isEligible: true, for: siteID)
@@ -449,6 +517,7 @@ struct POSLocalCatalogEligibilityServiceTests {
             catalogSizeChecker: sizeChecker,
             systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
             catalogSizeLimit: 1000
         )
         try await service.updatePOSEligibility(isEligible: true, for: siteID)

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -195,7 +195,8 @@ class AuthenticatedState: StoresManagerState {
                     appPasswordSupportState: appPasswordSupportState.eraseToAnyPublisher(),
                     storageManager: ServiceLocator.storageManager
                 ),
-                isLocalCatalogFeatureFlagEnabled: isLocalCatalogFeatureFlagEnabled
+                isLocalCatalogFeatureFlagEnabled: isLocalCatalogFeatureFlagEnabled,
+                remoteFeatureFlagProvider: POSLocalCatalogEligibilityService.makeRemoteFeatureFlagProvider(dispatcher: dispatcher)
             )
             posCatalogEligibilityChecker = eligibilityService
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR integrates the `woo_pos_local_catalog_m1` remote feature flag to decide whether to use the local catalog.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Use a network breakpoint on `wpcom/v2/mobile/feature-flags`, and change the value of `woo_pos_local_catalog_m1` to false in the response.

Launch the app and open POS – observe that it falls back to the network version.

Check the console for log messages showing `Local catalog feature flags disabled for site` with details about local or remote.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="1140" height="218" alt="CleanShot 2025-11-10 at 16 31 15@2x" src="https://github.com/user-attachments/assets/191253ed-e46b-4763-a16f-c0cf0504e955" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
