### PR TITLE
Bookings: Implement mark as paid

### DIFF
--- a/Modules/Sources/Yosemite/Actions/BookingAction.swift
+++ b/Modules/Sources/Yosemite/Actions/BookingAction.swift
@@ -81,4 +81,14 @@ public enum BookingAction: Action {
     case cancelBooking(siteID: Int64,
                        bookingID: Int64,
                        onCompletion: (Error?) -> Void)
+
+    /// Marks a booking as paid by updating its status to paid.
+    ///
+    /// - Parameter siteID: The site ID of the booking.
+    /// - Parameter bookingID: The ID of the booking to be marked as paid.
+    /// - Parameter onCompletion: called when the operation completes, returns an error in case of a failure.
+    ///
+    case markBookingAsPaid(siteID: Int64,
+                           bookingID: Int64,
+                           onCompletion: (Error?) -> Void)
 }

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -76,6 +76,12 @@ public class BookingStore: Store {
                 bookingID: bookingID,
                 onCompletion: onCompletion
             )
+        case .markBookingAsPaid(let siteID, let bookingID, let onCompletion):
+            markBookingAsPaid(
+                siteID: siteID,
+                bookingID: bookingID,
+                onCompletion: onCompletion
+            )
         }
     }
 }
@@ -368,6 +374,36 @@ private extension BookingStore {
                     bookingID: bookingID,
                     attendanceStatus: nil,
                     bookingStatus: .cancelled
+                ) {
+                    await upsertStoredBookingsInBackground(
+                        readOnlyBookings: [remoteBooking],
+                        readOnlyOrders: [],
+                        siteID: siteID
+                    )
+
+                    onCompletion(nil)
+                } else {
+                    return onCompletion(UpdateBookingStatusError.missingRemoteBooking)
+                }
+            } catch {
+                onCompletion(error)
+            }
+        }
+    }
+
+    /// Marks a booking as paid by updating its status to paid.
+    func markBookingAsPaid(
+        siteID: Int64,
+        bookingID: Int64,
+        onCompletion: @escaping (Error?) -> Void
+    ) {
+        Task { @MainActor in
+            do {
+                if let remoteBooking = try await remote.updateBooking(
+                    from: siteID,
+                    bookingID: bookingID,
+                    attendanceStatus: nil,
+                    bookingStatus: .paid
                 ) {
                     await upsertStoredBookingsInBackground(
                         readOnlyBookings: [remoteBooking],

--- a/Modules/Tests/YosemiteTests/Stores/BookingStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/BookingStoreTests.swift
@@ -849,6 +849,112 @@ struct BookingStoreTests {
         #expect(error != nil)
     }
 
+    // MARK: - markBookingAsPaid
+
+    @Test func markBookingAsPaid_updates_local_booking_to_paid_status() async throws {
+        // Given
+        let booking = Booking.fake().copy(
+            siteID: sampleSiteID,
+            bookingID: 1,
+            statusKey: "unpaid"
+        )
+        storeBooking(booking)
+
+        let paidBooking = booking.copy(statusKey: "paid")
+        remote.whenUpdatingBooking(thenReturn: .success(paidBooking))
+        let store = BookingStore(dispatcher: Dispatcher(),
+                                 storageManager: storageManager,
+                                 network: network,
+                                 remote: remote,
+                                 ordersRemote: ordersRemote)
+
+        // When
+        let error = await withCheckedContinuation { continuation in
+            store.onAction(
+                BookingAction.markBookingAsPaid(
+                    siteID: sampleSiteID,
+                    bookingID: 1,
+                    onCompletion: { error in
+                        continuation.resume(returning: error)
+                    }
+                )
+            )
+        }
+
+        // Then
+        #expect(error == nil)
+        let storedBooking = try #require(viewStorage.loadBooking(siteID: sampleSiteID, bookingID: 1))
+        #expect(storedBooking.statusKey == "paid")
+    }
+
+    @Test func markBookingAsPaid_returns_error_on_remote_failure() async throws {
+        // Given
+        let booking = Booking.fake().copy(
+            siteID: sampleSiteID,
+            bookingID: 1,
+            statusKey: "unpaid"
+        )
+        storeBooking(booking)
+
+        remote.whenUpdatingBooking(thenReturn: .failure(NetworkError.timeout()))
+        let store = BookingStore(dispatcher: Dispatcher(),
+                                 storageManager: storageManager,
+                                 network: network,
+                                 remote: remote,
+                                 ordersRemote: ordersRemote)
+
+        // When
+        let error = await withCheckedContinuation { continuation in
+            store.onAction(
+                BookingAction.markBookingAsPaid(
+                    siteID: sampleSiteID,
+                    bookingID: 1,
+                    onCompletion: { error in
+                        continuation.resume(returning: error)
+                    }
+                )
+            )
+        }
+
+        // Then
+        #expect(error != nil)
+        let networkError = error as? NetworkError
+        #expect(networkError == .timeout())
+    }
+
+    @Test func markBookingAsPaid_returns_error_when_remote_booking_is_missing() async throws {
+        // Given
+        let booking = Booking.fake().copy(
+            siteID: sampleSiteID,
+            bookingID: 1,
+            statusKey: "unpaid"
+        )
+        storeBooking(booking)
+
+        remote.whenUpdatingBooking(thenReturn: .success(nil))
+        let store = BookingStore(dispatcher: Dispatcher(),
+                                 storageManager: storageManager,
+                                 network: network,
+                                 remote: remote,
+                                 ordersRemote: ordersRemote)
+
+        // When
+        let error = await withCheckedContinuation { continuation in
+            store.onAction(
+                BookingAction.markBookingAsPaid(
+                    siteID: sampleSiteID,
+                    bookingID: 1,
+                    onCompletion: { error in
+                        continuation.resume(returning: error)
+                    }
+                )
+            )
+        }
+
+        // Then
+        #expect(error != nil)
+    }
+
     // MARK: - synchronizeResources
 
     @Test func synchronizeResources_returns_false_for_hasNextPage_when_number_of_retrieved_results_is_zero() async throws {

--- a/WooCommerce/Classes/Extensions/Booking+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Booking+Helpers.swift
@@ -19,6 +19,10 @@ extension Booking {
             .joined(separator: "  •  ")
     }
 
+    var isEligibleForMarkAsPaid: Bool {
+        bookingStatus == .unpaid
+    }
+
     private enum Localization {
         static let guest = NSLocalizedString(
             "bookings.guest",

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -457,8 +457,8 @@ private extension BookingDetailsViewModel {
         )
 
         static let bookingAttendanceStatusUpdateFailedMessage = NSLocalizedString(
-            "BookingDetailsView.attendanceStatus.updateFailed.message",
-            value: "Unable to change attendance status of Booking #%1$d",
+            "BookingDetailsView.attendanceStatus.failureMessage.",
+            value: "Unable to change attendance status of Booking #%1$d.",
             comment: "Content of error presented when updating the attendance status of a Booking fails. "
             + "It reads: Unable to change status of Booking #{Booking number}. "
             + "Parameters: %1$d - Booking number"
@@ -466,7 +466,7 @@ private extension BookingDetailsViewModel {
 
         static let bookingCancellationFailedMessage = NSLocalizedString(
             "BookingDetailsView.cancellation.failureMessage",
-            value: "Unable to cancel Booking #%1$d",
+            value: "Unable to cancel Booking #%1$d.",
             comment: "Content of error presented when cancelling a Booking fails. "
             + "It reads: Unable to cancel Booking #{Booking number}. "
             + "Parameters: %1$d - Booking number"
@@ -474,7 +474,7 @@ private extension BookingDetailsViewModel {
 
         static let bookingMarkAsPaidFailedMessage = NSLocalizedString(
             "BookingDetailsView.markAsPaid.failureMessage",
-            value: "Unable to mark Booking #%1$d as paid",
+            value: "Unable to mark Booking #%1$d as paid.",
             comment: "Content of error presented when cancelling a Booking fails. "
             + "It reads: Unable to mark Booking #{Booking number} as paid. "
             + "Parameters: %1$d - Booking number"

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -295,6 +295,38 @@ extension BookingDetailsViewModel {
     }
 }
 
+/// Mark booking as paid
+extension BookingDetailsViewModel {
+    var shouldShowMarkAsPaid: Bool {
+        booking.isEligibleForMarkAsPaid
+    }
+
+    @MainActor
+    func markBookingAsPaid() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            stores.dispatch(BookingAction.markBookingAsPaid(siteID: booking.siteID, bookingID: booking.bookingID) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            })
+        }
+    }
+
+    func displayMarkingAsPaidErrorNotice(onRetry: @escaping () -> Void) {
+        let text = String.localizedStringWithFormat(
+            Localization.bookingMarkAsPaidFailedMessage,
+            booking.bookingID
+        )
+        self.notice = Notice(
+            message: text,
+            feedbackType: .error,
+            actionTitle: Localization.retryActionTitle
+        ) { onRetry() }
+    }
+}
+
 private extension BookingDetailsViewModel {
     @MainActor
     func fetchResource() async -> BookingResource? {
@@ -436,7 +468,15 @@ private extension BookingDetailsViewModel {
             "BookingDetailsView.cancellation.failureMessage",
             value: "Unable to cancel Booking #%1$d",
             comment: "Content of error presented when cancelling a Booking fails. "
-            + "It reads: Unable cancel Booking #{Booking number}. "
+            + "It reads: Unable to cancel Booking #{Booking number}. "
+            + "Parameters: %1$d - Booking number"
+        )
+
+        static let bookingMarkAsPaidFailedMessage = NSLocalizedString(
+            "BookingDetailsView.markAsPaid.failureMessage",
+            value: "Unable to mark Booking #%1$d as paid",
+            comment: "Content of error presented when cancelling a Booking fails. "
+            + "It reads: Unable to mark Booking #{Booking number} as paid. "
             + "Parameters: %1$d - Booking number"
         )
 

--- a/WooCommerce/Classes/ViewModels/Booking Details/PaymentContent.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/PaymentContent.swift
@@ -27,10 +27,9 @@ extension BookingDetailsViewModel {
             ]
 
             actions = [
-                .markAsPaid,
-                .issueRefund,
+                booking.isEligibleForMarkAsPaid ? .markAsPaid : nil,
                 .viewOrder
-            ]
+            ].compactMap { $0 }
         }
     }
 }
@@ -84,7 +83,6 @@ extension BookingDetailsViewModel.PaymentContent.Amount.AmountType {
 extension BookingDetailsViewModel.PaymentContent {
     enum Action: String, Identifiable {
         case markAsPaid
-        case issueRefund
         case viewOrder
 
         var id: String {
@@ -98,19 +96,8 @@ extension BookingDetailsViewModel.PaymentContent.Action {
         switch self {
         case .markAsPaid:
             return Localization.paymentMarkAsPaidButtonTitle
-        case .issueRefund:
-            return Localization.paymentIssueRefundButtonTitle
         case .viewOrder:
             return Localization.paymentViewOrderButtonTitle
-        }
-    }
-
-    var isEmphasized: Bool {
-        switch self {
-        case .markAsPaid:
-            return true
-        case .issueRefund, .viewOrder:
-            return false
         }
     }
 }
@@ -144,12 +131,6 @@ private enum Localization {
         "BookingDetailsView.payment.markAsPaid.title",
         value: "Mark as paid",
         comment: "Title for 'Mark as paid' button in payment section in booking details view."
-    )
-
-    static let paymentIssueRefundButtonTitle = NSLocalizedString(
-        "BookingDetailsView.payment.issueRefund.title",
-        value: "Issue refund",
-        comment: "Title for 'Issue refund' button in payment section in booking details view."
     )
 
     static let paymentViewOrderButtonTitle = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -8,6 +8,7 @@ struct BookingDetailsView: View {
     @State private var showingStatusSheet = false
     @State private var showingCancelAlert = false
     @State private var cancellingBooking = false
+    @State private var markingAsPaid = false
     @State private var notice: Notice?
 
     @ObservedObject private var viewModel: BookingDetailsViewModel
@@ -62,8 +63,9 @@ struct BookingDetailsView: View {
                 }
                 .confirmationDialog("", isPresented: $showingOptions, titleVisibility: .hidden) {
                     Button(Localization.markAsPaid) {
-                        print("On mark as paid tap")
+                        markBookingAsPaid()
                     }
+                    .renderedIf(viewModel.shouldShowMarkAsPaid)
                     Button(Localization.viewOrder) {
                         viewModel.navigateToOrderDetails()
                     }
@@ -219,20 +221,15 @@ private extension BookingDetailsView {
 
             VStack(alignment: .leading, spacing: Layout.contentVerticalPadding) {
                 ForEach(content.actions) { action in
-                    Button {
-                        if action == .viewOrder {
+                    switch action {
+                    case .viewOrder:
+                        Button(action.buttonTitle) {
                             viewModel.navigateToOrderDetails()
-                        } else {
-                            /// On action tap
                         }
-                    } label: {
-                        Text(action.buttonTitle)
-                    }
-                    .if(action.isEmphasized) {
-                        $0.buttonStyle(PrimaryButtonStyle())
-                    }
-                    .if(!action.isEmphasized) {
-                        $0.buttonStyle(SecondaryButtonStyle())
+                        .buttonStyle(SecondaryButtonStyle())
+                    case .markAsPaid:
+                        Button(action.buttonTitle, action: markBookingAsPaid)
+                            .buttonStyle(PrimaryLoadingButtonStyle(isLoading: markingAsPaid))
                     }
                 }
             }
@@ -267,6 +264,18 @@ extension BookingDetailsView {
                 viewModel.displayBookingCancellationErrorNotice(onRetry: cancelBooking)
             }
             cancellingBooking = false
+        }
+    }
+
+    func markBookingAsPaid() {
+        Task { @MainActor in
+            markingAsPaid = true
+            do {
+                try await viewModel.markBookingAsPaid()
+            } catch {
+                viewModel.displayMarkingAsPaidErrorNotice(onRetry: markBookingAsPaid)
+            }
+            markingAsPaid = false
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
@@ -276,8 +276,8 @@ final class BookingDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.notice?.feedbackType, .error)
 
         let messageFormat = NSLocalizedString(
-            "BookingDetailsView.attendanceStatus.updateFailed.message",
-            value: "Unable to change attendance status of Booking #%1$d",
+            "BookingDetailsView.attendanceStatus.failureMessage",
+            value: "Unable to change attendance status of Booking #%1$d.",
             comment: ""
         )
         let expectedMessage = String(format: messageFormat, booking.bookingID)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1615

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR implements the action for the Mark as paid button. The button is only available for bookings with status `unpaid`. Tapping on it triggers a request to update the booking status to `paid`.

Additionally, the Issue refund button is removed to aligned with the new admin page.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Log in to a CIAB store with existing bookings.
2. Select a booking with status other than `unpaid`. Confirm that neither the Issue refund and Mark as paid buttons are in 
the payment section and ellipsis menu.
3. Select a booking with status `unpaid`. Confirm that the Mark as paid button is available in both payment section and ellipsis menu. Issue refund is not.
4. Put a breakpoint for `PUT /wc-bookings/v2/bookings/*` in Proxyman.
5. Tap Mark as paid and abort the request.
6. Confirm that an error notice is displayed with a Retry button.
7. Tap on Retry and this time allow the request to go through. 
8. After the request succeeds, confirm that the details booking status is updated to Paid and the Mark as paid button is no longer available.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/c1e6a129-d31c-40d6-b8bd-20c97e88bd97



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
