### PR TITLE
[Local Catalog] Persist catalog downloads in the background

### DIFF
--- a/Modules/Sources/Networking/Network/BackgroundCatalogDownloadCoordinator.swift
+++ b/Modules/Sources/Networking/Network/BackgroundCatalogDownloadCoordinator.swift
@@ -1,0 +1,58 @@
+import Foundation
+import CocoaLumberjackSwift
+
+/// Coordinates background catalog downloads, including handling app wake events.
+public class BackgroundCatalogDownloadCoordinator {
+    private let backgroundDownloader: BackgroundDownloadProtocol
+    private let fileManager: FileManager
+
+    public init(backgroundDownloader: BackgroundDownloadProtocol = BackgroundDownloadService(),
+                fileManager: FileManager = .default) {
+        self.backgroundDownloader = backgroundDownloader
+        self.fileManager = fileManager
+    }
+
+    /// Handles a background URLSession wake event.
+    /// Called from AppDelegate when iOS wakes the app for a completed download.
+    /// - Parameters:
+    ///   - sessionIdentifier: The session identifier from the callback
+    ///   - completionHandler: Completion handler to call when processing is done
+    ///   - parseHandler: Closure to parse and persist the downloaded file
+    public func handleBackgroundSessionEvent(
+        sessionIdentifier: String,
+        completionHandler: @escaping () -> Void,
+        parseHandler: @escaping (URL, Int64) async throws -> Void
+    ) async {
+        DDLogInfo("🟣 Handling background session event for: \(sessionIdentifier)")
+
+        // Load the saved download state to know which site this is for
+        guard let state = BackgroundDownloadState.load(for: sessionIdentifier) else {
+            DDLogError("⛔️ No saved state found for background download session: \(sessionIdentifier)")
+            completionHandler()
+            return
+        }
+
+        // Reconnect to the background session and get the downloaded file
+        guard let fileURL = await backgroundDownloader.reconnectToSession(identifier: sessionIdentifier,
+                                                                          allowCellular: true,
+                                                                          completionHandler: completionHandler) else {
+            DDLogError("⛔️ Failed to reconnect to background download session")
+            BackgroundDownloadState.clear()
+            return
+        }
+
+        DDLogInfo("🟣 Background download file ready at: \(fileURL.path)")
+
+        // Parse the catalog file in this background window (~30 seconds)
+        // TODO: WOOMOB-1677 - For very large catalogs, consider hybrid approach: try immediate parse, defer if timeout.
+        do {
+            try await parseHandler(fileURL, state.siteID)
+            DDLogInfo("✅ Background catalog processing completed successfully")
+        } catch {
+            DDLogError("⛔️ Failed to process catalog in background: \(error)")
+        }
+
+        // Clean up state
+        BackgroundDownloadState.clear()
+    }
+}

--- a/Modules/Sources/Networking/Network/BackgroundCatalogDownloadCoordinator.swift
+++ b/Modules/Sources/Networking/Network/BackgroundCatalogDownloadCoordinator.swift
@@ -4,12 +4,9 @@ import CocoaLumberjackSwift
 /// Coordinates background catalog downloads, including handling app wake events.
 public class BackgroundCatalogDownloadCoordinator {
     private let backgroundDownloader: BackgroundDownloadProtocol
-    private let fileManager: FileManager
 
-    public init(backgroundDownloader: BackgroundDownloadProtocol = BackgroundDownloadService(),
-                fileManager: FileManager = .default) {
+    public init(backgroundDownloader: BackgroundDownloadProtocol = BackgroundDownloadService()) {
         self.backgroundDownloader = backgroundDownloader
-        self.fileManager = fileManager
     }
 
     /// Handles a background URLSession wake event.

--- a/Modules/Sources/Networking/Network/BackgroundDownloadProtocol.swift
+++ b/Modules/Sources/Networking/Network/BackgroundDownloadProtocol.swift
@@ -15,6 +15,17 @@ public protocol BackgroundDownloadProtocol {
     /// - Parameter completionHandler: Handler to call when background download completes.
     func setBackgroundCompletionHandler(_ completionHandler: @escaping () -> Void)
 
+    /// Reconnects to an existing background session after app wake.
+    /// Call this from AppDelegate when iOS wakes the app for background URLSession events.
+    /// - Parameters:
+    ///   - sessionIdentifier: The session identifier from the callback
+    ///   - allowCellular: Whether cellular data should be allowed
+    ///   - completionHandler: Completion handler to call when all events are processed
+    /// - Returns: Downloaded file URL if download completed, nil if still in progress
+    func reconnectToSession(identifier sessionIdentifier: String,
+                           allowCellular: Bool,
+                           completionHandler: @escaping () -> Void) async -> URL?
+
     /// Cancels all active downloads for the session.
     /// - Parameter sessionIdentifier: The session identifier to cancel.
     func cancelDownloads(for sessionIdentifier: String) async

--- a/Modules/Sources/Networking/Network/BackgroundDownloadService.swift
+++ b/Modules/Sources/Networking/Network/BackgroundDownloadService.swift
@@ -36,6 +36,28 @@ extension BackgroundDownloadService: BackgroundDownloadProtocol {
         backgroundCompletionHandler = completionHandler
     }
 
+    /// Reconnects to an existing background session after app wake.
+    /// Call this from AppDelegate when iOS wakes the app for background URLSession events.
+    /// - Parameters:
+    ///   - sessionIdentifier: The session identifier from the callback
+    ///   - completionHandler: Completion handler to call when all events are processed
+    /// - Returns: Downloaded file URL if download completed, nil if still in progress
+    public func reconnectToSession(identifier sessionIdentifier: String,
+                                   allowCellular: Bool,
+                                   completionHandler: @escaping () -> Void) async -> URL? {
+        DDLogInfo("🟣 Reconnecting to background session: \(sessionIdentifier)")
+
+        setBackgroundCompletionHandler(completionHandler)
+
+        // Create session with same identifier - this reconnects to the existing download
+        let session = createBackgroundSession(identifier: sessionIdentifier, allowCellular: allowCellular)
+
+        // Wait for delegate callbacks to complete
+        return try? await withCheckedThrowingContinuation { continuation in
+            downloadContinuations[sessionIdentifier] = continuation
+        }
+    }
+
     public func cancelDownloads(for sessionIdentifier: String) async {
         if let task = downloadTasks[sessionIdentifier] {
             task.cancel()

--- a/Modules/Sources/Networking/Network/BackgroundDownloadState.swift
+++ b/Modules/Sources/Networking/Network/BackgroundDownloadState.swift
@@ -5,7 +5,6 @@ import Foundation
 public struct BackgroundDownloadState: Codable {
     let sessionIdentifier: String
     let siteID: Int64
-    let startedAt: Date
 
     private static let userDefaultsKey = "com.woocommerce.pos.backgroundDownloadState"
 

--- a/Modules/Sources/Networking/Network/BackgroundDownloadState.swift
+++ b/Modules/Sources/Networking/Network/BackgroundDownloadState.swift
@@ -7,18 +7,25 @@ public struct BackgroundDownloadState: Codable {
     let siteID: Int64
 
     private static let userDefaultsKey = "com.woocommerce.pos.backgroundDownloadState"
+    private static var userDefaults: UserDefaults = .standard
+
+    /// Configure UserDefaults instance for testing.
+    /// - Parameter userDefaults: The UserDefaults instance to use for persistence.
+    public static func configure(userDefaults: UserDefaults) {
+        self.userDefaults = userDefaults
+    }
 
     /// Saves download state for later retrieval.
     public static func save(_ state: BackgroundDownloadState) {
         let encoder = JSONEncoder()
         if let encoded = try? encoder.encode(state) {
-            UserDefaults.standard.set(encoded, forKey: userDefaultsKey)
+            userDefaults.set(encoded, forKey: userDefaultsKey)
         }
     }
 
     /// Loads saved download state for a specific session identifier.
     public static func load(for sessionIdentifier: String) -> BackgroundDownloadState? {
-        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
+        guard let data = userDefaults.data(forKey: userDefaultsKey),
               let state = try? JSONDecoder().decode(BackgroundDownloadState.self, from: data),
               state.sessionIdentifier == sessionIdentifier else {
             return nil
@@ -28,6 +35,6 @@ public struct BackgroundDownloadState: Codable {
 
     /// Clears saved download state.
     public static func clear() {
-        UserDefaults.standard.removeObject(forKey: userDefaultsKey)
+        userDefaults.removeObject(forKey: userDefaultsKey)
     }
 }

--- a/Modules/Sources/Networking/Network/BackgroundDownloadState.swift
+++ b/Modules/Sources/Networking/Network/BackgroundDownloadState.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Persisted state for background catalog downloads.
+/// Allows the app to resume processing downloads after being terminated.
+public struct BackgroundDownloadState: Codable {
+    let sessionIdentifier: String
+    let siteID: Int64
+    let startedAt: Date
+
+    private static let userDefaultsKey = "com.woocommerce.pos.backgroundDownloadState"
+
+    /// Saves download state for later retrieval.
+    public static func save(_ state: BackgroundDownloadState) {
+        let encoder = JSONEncoder()
+        if let encoded = try? encoder.encode(state) {
+            UserDefaults.standard.set(encoded, forKey: userDefaultsKey)
+        }
+    }
+
+    /// Loads saved download state for a specific session identifier.
+    public static func load(for sessionIdentifier: String) -> BackgroundDownloadState? {
+        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
+              let state = try? JSONDecoder().decode(BackgroundDownloadState.self, from: data),
+              state.sessionIdentifier == sessionIdentifier else {
+            return nil
+        }
+        return state
+    }
+
+    /// Clears saved download state.
+    public static func clear() {
+        UserDefaults.standard.removeObject(forKey: userDefaultsKey)
+    }
+}

--- a/Modules/Sources/Networking/Network/BackgroundDownloadState.swift
+++ b/Modules/Sources/Networking/Network/BackgroundDownloadState.swift
@@ -11,6 +11,7 @@ public struct BackgroundDownloadState: Codable {
 
     /// Configure UserDefaults instance for testing.
     /// - Parameter userDefaults: The UserDefaults instance to use for persistence.
+    // periphery:ignore - required by tests
     public static func configure(userDefaults: UserDefaults) {
         self.userDefaults = userDefaults
     }

--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -215,8 +215,7 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
         // Save download state so we can resume if app is terminated
         let downloadState = BackgroundDownloadState(
             sessionIdentifier: sessionIdentifier,
-            siteID: siteID,
-            startedAt: Date()
+            siteID: siteID
         )
         BackgroundDownloadState.save(downloadState)
 

--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -47,6 +47,14 @@ public protocol POSCatalogSyncRemoteProtocol {
                          downloadURL: String,
                          allowCellular: Bool) async throws -> POSCatalogResponse
 
+    /// Parses a downloaded catalog file.
+    /// Used for processing background downloads after app wake.
+    /// - Parameters:
+    ///   - fileURL: Local file URL of the downloaded catalog.
+    ///   - siteID: Site ID for proper mapping.
+    /// - Returns: Parsed POS catalog response.
+    func parseDownloadedCatalog(from fileURL: URL, siteID: Int64) async throws -> POSCatalogResponse
+
     /// Loads POS products for full sync.
     ///
     /// - Parameters:
@@ -203,10 +211,26 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
         }
 
         let sessionIdentifier = "\(POSCatalogSyncConstants.backgroundDownloadSessionPrefix).\(siteID).\(UUID().uuidString)"
+
+        // Save download state so we can resume if app is terminated
+        let downloadState = BackgroundDownloadState(
+            sessionIdentifier: sessionIdentifier,
+            siteID: siteID,
+            startedAt: Date()
+        )
+        BackgroundDownloadState.save(downloadState)
+
         let fileURL = try await backgroundDownloader.downloadFile(from: url,
                                                                    sessionIdentifier: sessionIdentifier,
                                                                    allowCellular: allowCellular)
-        return try await parseDownloadedCatalog(from: fileURL, siteID: siteID)
+
+        // Download completed - parse the file
+        let catalogResponse = try await parseDownloadedCatalog(from: fileURL, siteID: siteID)
+
+        // Clear the saved state since we successfully completed
+        BackgroundDownloadState.clear()
+
+        return catalogResponse
     }
 
     /// Parses the downloaded catalog file.
@@ -214,7 +238,7 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     ///   - fileURL: Local file URL of the downloaded catalog.
     ///   - siteID: Site ID for proper mapping.
     /// - Returns: Parsed POS catalog.
-    private func parseDownloadedCatalog(from fileURL: URL, siteID: Int64) async throws -> POSCatalogResponse {
+    public func parseDownloadedCatalog(from fileURL: URL, siteID: Int64) async throws -> POSCatalogResponse {
         let data = try Data(contentsOf: fileURL)
 
         // Clean up the downloaded file after reading.

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogViewModel.swift
@@ -96,37 +96,44 @@ final class POSSettingsLocalCatalogViewModel {
             var previousState = currentSyncState
 
             while !Task.isCancelled {
-                // Use withObservationTracking to detect changes
-                await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                    withObservationTracking {
-                        // Access the observed property to register observation
-                        _ = currentSyncState
-                    } onChange: {
-                        // When state changes, resume the continuation
-                        continuation.resume()
-                    }
-                }
+                // Wait for the next state change
+                await observeNextStateChange()
 
-                // Check if state actually changed
+                // Read the new state after change is detected
                 let newState = currentSyncState
-                if newState != previousState {
-                    switch newState {
-                    case .syncCompleted, .syncFailed, .initialSyncFailed:
-                        // Sync finished - clear the refreshing state if it was set
-                        if isRefreshingCatalog {
-                            isRefreshingCatalog = false
-                            // Reload catalog data to show updated info
-                            await loadCatalogData()
-                        }
-                    case .syncStarted, .initialSyncStarted:
-                        // Sync is running - keep spinner active
-                        break
-                    case .syncNeverDone:
-                        // No sync has been done
-                        break
+                guard newState != previousState else { continue }
+
+                // Handle terminal states when user initiated refresh
+                switch newState {
+                case .syncCompleted, .syncFailed, .initialSyncFailed:
+                    // Sync finished - clear the refreshing state if it was set
+                    if isRefreshingCatalog {
+                        isRefreshingCatalog = false
+                        // Reload catalog data to show updated info
+                        await loadCatalogData()
                     }
-                    previousState = newState
+                case .syncStarted, .initialSyncStarted:
+                    // Sync is running - keep spinner active
+                    break
+                case .syncNeverDone:
+                    // No sync has been done
+                    break
                 }
+                previousState = newState
+            }
+        }
+    }
+
+    /// Waits for the next change to the observed sync state.
+    /// Re-registers observation each time it's called.
+    private func observeNextStateChange() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            withObservationTracking {
+                // Access the observed property to register observation
+                _ = currentSyncState
+            } onChange: {
+                // When state changes, resume the continuation
+                continuation.resume()
             }
         }
     }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogViewModel.swift
@@ -16,12 +16,19 @@ final class POSSettingsLocalCatalogViewModel {
     private let catalogSettingsService: POSCatalogSettingsServiceProtocol
     private let catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol
     private let siteSettings: SiteSpecificAppSettingsStoreMethodsProtocol
+    private let syncStateModel: POSCatalogSyncStateModel
     private let dateFormatter: RelativeDateTimeFormatter = {
         let formatter = RelativeDateTimeFormatter()
         formatter.dateTimeStyle = .named
         formatter.unitsStyle = .full
         return formatter
     }()
+
+    private var syncStateObservationTask: Task<Void, Never>?
+
+    private var currentSyncState: POSCatalogSyncState {
+        syncStateModel.state[siteID] ?? .syncNeverDone(siteID: siteID)
+    }
 
     var allowFullSyncOnCellular: Bool {
         get {
@@ -39,7 +46,15 @@ final class POSSettingsLocalCatalogViewModel {
         self.siteID = siteID
         self.catalogSettingsService = catalogSettingsService
         self.catalogSyncCoordinator = catalogSyncCoordinator
+        self.syncStateModel = catalogSyncCoordinator.fullSyncStateModel
         self.siteSettings = siteSettings ?? SiteSpecificAppSettingsStoreMethods(fileStorage: PListFileStorage())
+
+        // Observe sync state changes to update UI when sync completes in background
+        startObservingSyncState()
+    }
+
+    deinit {
+        syncStateObservationTask?.cancel()
     }
 
     @MainActor
@@ -63,13 +78,56 @@ final class POSSettingsLocalCatalogViewModel {
     @MainActor
     func refreshCatalog() async {
         isRefreshingCatalog = true
-        defer { isRefreshingCatalog = false }
 
         do {
             try await catalogSyncCoordinator.performFullSync(for: siteID, regenerateCatalog: true)
+            // Sync completed synchronously - update UI
+            isRefreshingCatalog = false
             await loadCatalogData()
         } catch {
             DDLogError("⛔️ POSSettingsLocalCatalog: Failed to refresh catalog: \(error)")
+            isRefreshingCatalog = false
+        }
+    }
+
+    /// Starts observing sync state changes to update UI when sync completes in background
+    private func startObservingSyncState() {
+        syncStateObservationTask = Task { @MainActor in
+            var previousState = currentSyncState
+
+            while !Task.isCancelled {
+                // Use withObservationTracking to detect changes
+                await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                    withObservationTracking {
+                        // Access the observed property to register observation
+                        _ = currentSyncState
+                    } onChange: {
+                        // When state changes, resume the continuation
+                        continuation.resume()
+                    }
+                }
+
+                // Check if state actually changed
+                let newState = currentSyncState
+                if newState != previousState {
+                    switch newState {
+                    case .syncCompleted, .syncFailed, .initialSyncFailed:
+                        // Sync finished - clear the refreshing state if it was set
+                        if isRefreshingCatalog {
+                            isRefreshingCatalog = false
+                            // Reload catalog data to show updated info
+                            await loadCatalogData()
+                        }
+                    case .syncStarted, .initialSyncStarted:
+                        // Sync is running - keep spinner active
+                        break
+                    case .syncNeverDone:
+                        // No sync has been done
+                        break
+                    }
+                    previousState = newState
+                }
+            }
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -645,6 +645,10 @@ final class POSPreviewCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol 
     func stopOngoingSyncs(for siteID: Int64) async {
         // Preview implementation - no-op
     }
+
+    func processBackgroundDownload(fileURL: URL, siteID: Int64) async throws {
+        // no-op
+    }
 }
 
 #endif

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
@@ -105,6 +105,27 @@ public final class POSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol 
             throw error
         }
     }
+
+    public func parseAndPersistBackgroundDownload(fileURL: URL, siteID: Int64) async throws -> POSCatalog {
+        DDLogInfo("🟣 Parsing background catalog download for site \(siteID)")
+
+        let syncStartDate = Date.now
+        let catalogResponse = try await syncRemote.parseDownloadedCatalog(from: fileURL, siteID: siteID)
+
+        let catalog = POSCatalog(
+            products: catalogResponse.products,
+            variations: catalogResponse.variations,
+            syncDate: syncStartDate
+        )
+
+        DDLogInfo("✅ Loaded \(catalog.products.count) products and \(catalog.variations.count) variations for siteID \(siteID)")
+
+        // Persist to database
+        try await persistenceService.replaceAllCatalogData(catalog, siteID: siteID)
+        DDLogInfo("✅ Persisted \(catalog.products.count) products and \(catalog.variations.count) variations to database for siteID \(siteID)")
+
+        return catalog
+    }
 }
 
 // MARK: - Remote Loading
@@ -206,26 +227,5 @@ private extension POSCatalogFullSyncService {
         }
 
         throw POSCatalogSyncError.timeout
-    }
-
-    public func parseAndPersistBackgroundDownload(fileURL: URL, siteID: Int64) async throws -> POSCatalog {
-        DDLogInfo("🟣 Parsing background catalog download for site \(siteID)")
-
-        let syncStartDate = Date.now
-        let catalogResponse = try await syncRemote.parseDownloadedCatalog(from: fileURL, siteID: siteID)
-
-        let catalog = POSCatalog(
-            products: catalogResponse.products,
-            variations: catalogResponse.variations,
-            syncDate: syncStartDate
-        )
-
-        DDLogInfo("✅ Loaded \(catalog.products.count) products and \(catalog.variations.count) variations for siteID \(siteID)")
-
-        // Persist to database
-        try await persistenceService.replaceAllCatalogData(catalog, siteID: siteID)
-        DDLogInfo("✅ Persisted \(catalog.products.count) products and \(catalog.variations.count) variations to database for siteID \(siteID)")
-
-        return catalog
     }
 }

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
@@ -17,6 +17,13 @@ public protocol POSCatalogFullSyncServiceProtocol {
     ///   - allowCellular: Should cellular data be used if required.
     /// - Returns: The synced catalog containing products and variations
     func startFullSync(for siteID: Int64, regenerateCatalog: Bool, allowCellular: Bool) async throws -> POSCatalog
+
+    /// Parses and persists a downloaded catalog file from a background download.
+    /// - Parameters:
+    ///   - fileURL: Local file URL of the downloaded catalog
+    ///   - siteID: Site ID for this catalog
+    /// - Returns: The parsed catalog
+    func parseAndPersistBackgroundDownload(fileURL: URL, siteID: Int64) async throws -> POSCatalog
 }
 
 /// POS catalog from full sync.
@@ -199,5 +206,26 @@ private extension POSCatalogFullSyncService {
         }
 
         throw POSCatalogSyncError.timeout
+    }
+
+    public func parseAndPersistBackgroundDownload(fileURL: URL, siteID: Int64) async throws -> POSCatalog {
+        DDLogInfo("🟣 Parsing background catalog download for site \(siteID)")
+
+        let syncStartDate = Date.now
+        let catalogResponse = try await syncRemote.parseDownloadedCatalog(from: fileURL, siteID: siteID)
+
+        let catalog = POSCatalog(
+            products: catalogResponse.products,
+            variations: catalogResponse.variations,
+            syncDate: syncStartDate
+        )
+
+        DDLogInfo("✅ Loaded \(catalog.products.count) products and \(catalog.variations.count) variations for siteID \(siteID)")
+
+        // Persist to database
+        try await persistenceService.replaceAllCatalogData(catalog, siteID: siteID)
+        DDLogInfo("✅ Persisted \(catalog.products.count) products and \(catalog.variations.count) variations to database for siteID \(siteID)")
+
+        return catalog
     }
 }

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -46,6 +46,14 @@ public protocol POSCatalogSyncCoordinatorProtocol {
     /// Stops all ongoing sync tasks for the specified site
     /// - Parameter siteID: The site ID to stop syncs for
     func stopOngoingSyncs(for siteID: Int64) async
+
+    /// Processes a completed background catalog download.
+    /// Called when the app is woken by iOS for a background URLSession completion.
+    /// Parses and persists the catalog, then updates sync state.
+    /// - Parameters:
+    ///   - fileURL: Local file URL of the downloaded catalog
+    ///   - siteID: Site ID for this catalog
+    func processBackgroundDownload(fileURL: URL, siteID: Int64) async throws
 }
 
 public extension POSCatalogSyncCoordinatorProtocol {
@@ -422,6 +430,21 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
                 break
             }
         }
+    }
+
+    public func processBackgroundDownload(fileURL: URL, siteID: Int64) async throws {
+        DDLogInfo("🟣 POSCatalogSyncCoordinator: Processing background download for site \(siteID)")
+
+        // Parse and persist using the full sync service
+        let catalog = try await fullSyncService.parseAndPersistBackgroundDownload(fileURL: fileURL, siteID: siteID)
+
+        DDLogInfo("✅ Background catalog processed: \(catalog.products.count) products, \(catalog.variations.count) variations")
+
+        // Update sync state to completed
+        emitSyncState(.syncCompleted(siteID: siteID))
+
+        // Record first sync date if needed
+        recordFirstSyncIfNeeded(for: siteID)
     }
 }
 

--- a/Modules/Tests/NetworkingTests/Mocks/MockBackgroundDownloader.swift
+++ b/Modules/Tests/NetworkingTests/Mocks/MockBackgroundDownloader.swift
@@ -12,6 +12,9 @@ final class MockBackgroundDownloader: BackgroundDownloadProtocol {
     var backgroundCompletionHandler: (() -> Void)?
     var cancelCallCount = 0
     var lastCancelledSessionIdentifier: String?
+    var reconnectSessionCallCount = 0
+    var lastReconnectSessionIdentifier: String?
+    var mockFileURL: URL?
 
     private let fileManager: FileManager
 
@@ -40,6 +43,15 @@ final class MockBackgroundDownloader: BackgroundDownloadProtocol {
 
     func setBackgroundCompletionHandler(_ completionHandler: @escaping () -> Void) {
         backgroundCompletionHandler = completionHandler
+    }
+
+    func reconnectToSession(identifier sessionIdentifier: String,
+                           allowCellular: Bool,
+                           completionHandler: @escaping () -> Void) async -> URL? {
+        reconnectSessionCallCount += 1
+        lastReconnectSessionIdentifier = sessionIdentifier
+        setBackgroundCompletionHandler(completionHandler)
+        return mockFileURL
     }
 
     func cancelDownloads(for sessionIdentifier: String) async {
@@ -71,6 +83,9 @@ extension MockBackgroundDownloader {
         backgroundCompletionHandler = nil
         cancelCallCount = 0
         lastCancelledSessionIdentifier = nil
+        reconnectSessionCallCount = 0
+        lastReconnectSessionIdentifier = nil
+        mockFileURL = nil
     }
 
     /// Simulate calling the background completion handler

--- a/Modules/Tests/NetworkingTests/Mocks/MockBackgroundDownloader.swift
+++ b/Modules/Tests/NetworkingTests/Mocks/MockBackgroundDownloader.swift
@@ -15,6 +15,7 @@ final class MockBackgroundDownloader: BackgroundDownloadProtocol {
     var reconnectSessionCallCount = 0
     var lastReconnectSessionIdentifier: String?
     var mockFileURL: URL?
+    var onDownloadStarted: (() -> Void)?
 
     private let fileManager: FileManager
 
@@ -30,8 +31,8 @@ final class MockBackgroundDownloader: BackgroundDownloadProtocol {
         lastSessionIdentifier = sessionIdentifier
         lastAllowCellular = allowCellular
 
-        // Simulates async behavior
-        try await Task.sleep(nanoseconds: 1_000_000) // 1ms
+        // Notify test that download has started
+        onDownloadStarted?()
 
         switch downloadResult {
         case .success(let fileURL):
@@ -86,6 +87,7 @@ extension MockBackgroundDownloader {
         reconnectSessionCallCount = 0
         lastReconnectSessionIdentifier = nil
         mockFileURL = nil
+        onDownloadStarted = nil
     }
 
     /// Simulate calling the background completion handler

--- a/Modules/Tests/NetworkingTests/Network/BackgroundCatalogDownloadCoordinatorTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/BackgroundCatalogDownloadCoordinatorTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+@testable import Networking
+
+struct BackgroundCatalogDownloadCoordinatorTests {
+
+    @Test func handleBackgroundSessionEvent_loads_saved_state() async {
+        // Given
+        let sessionIdentifier = "com.woocommerce.pos.catalog.download.123"
+        let siteID: Int64 = 456
+        let state = BackgroundDownloadState(
+            sessionIdentifier: sessionIdentifier,
+            siteID: siteID,
+            startedAt: Date()
+        )
+        BackgroundDownloadState.save(state)
+
+        let mockDownloader = MockBackgroundDownloader()
+        mockDownloader.mockFileURL = URL(fileURLWithPath: "/tmp/test.json")
+        let coordinator = BackgroundCatalogDownloadCoordinator(backgroundDownloader: mockDownloader)
+
+        var parsedSiteID: Int64?
+        var parsedFileURL: URL?
+
+        // When
+        await coordinator.handleBackgroundSessionEvent(
+            sessionIdentifier: sessionIdentifier,
+            completionHandler: { },
+            parseHandler: { fileURL, siteID in
+                parsedFileURL = fileURL
+                parsedSiteID = siteID
+            }
+        )
+
+        // Then
+        #expect(parsedSiteID == siteID)
+        #expect(parsedFileURL?.path == "/tmp/test.json")
+
+        // Cleanup
+        BackgroundDownloadState.clear()
+    }
+
+    @Test func handleBackgroundSessionEvent_calls_completion_handler_when_no_state() async {
+        // Given
+        BackgroundDownloadState.clear() // Ensure no saved state
+        let sessionIdentifier = "com.woocommerce.pos.catalog.download.999"
+        let mockDownloader = MockBackgroundDownloader()
+        let coordinator = BackgroundCatalogDownloadCoordinator(backgroundDownloader: mockDownloader)
+
+        var completionCalled = false
+        var parseCalled = false
+
+        // When
+        await coordinator.handleBackgroundSessionEvent(
+            sessionIdentifier: sessionIdentifier,
+            completionHandler: {
+                completionCalled = true
+            },
+            parseHandler: { _, _ in
+                parseCalled = true
+            }
+        )
+
+        // Then
+        #expect(completionCalled == true)
+        #expect(parseCalled == false) // Should not parse without state
+    }
+
+    @Test func handleBackgroundSessionEvent_clears_state_after_processing() async {
+        // Given
+        let sessionIdentifier = "com.woocommerce.pos.catalog.download.789"
+        let state = BackgroundDownloadState(
+            sessionIdentifier: sessionIdentifier,
+            siteID: 111,
+            startedAt: Date()
+        )
+        BackgroundDownloadState.save(state)
+
+        let mockDownloader = MockBackgroundDownloader()
+        mockDownloader.mockFileURL = URL(fileURLWithPath: "/tmp/test.json")
+        let coordinator = BackgroundCatalogDownloadCoordinator(backgroundDownloader: mockDownloader)
+
+        // When
+        await coordinator.handleBackgroundSessionEvent(
+            sessionIdentifier: sessionIdentifier,
+            completionHandler: { },
+            parseHandler: { _, _ in }
+        )
+
+        // Then - state should be cleared
+        let loadedState = BackgroundDownloadState.load(for: sessionIdentifier)
+        #expect(loadedState == nil)
+    }
+
+    @Test func handleBackgroundSessionEvent_reconnects_to_session() async {
+        // Given
+        let sessionIdentifier = "com.woocommerce.pos.catalog.download.reconnect"
+        let state = BackgroundDownloadState(
+            sessionIdentifier: sessionIdentifier,
+            siteID: 222,
+            startedAt: Date()
+        )
+        BackgroundDownloadState.save(state)
+
+        let mockDownloader = MockBackgroundDownloader()
+        mockDownloader.mockFileURL = URL(fileURLWithPath: "/tmp/catalog.json")
+        let coordinator = BackgroundCatalogDownloadCoordinator(backgroundDownloader: mockDownloader)
+
+        // When
+        await coordinator.handleBackgroundSessionEvent(
+            sessionIdentifier: sessionIdentifier,
+            completionHandler: { },
+            parseHandler: { _, _ in }
+        )
+
+        // Then
+        #expect(mockDownloader.reconnectSessionCallCount == 1)
+        #expect(mockDownloader.lastReconnectSessionIdentifier == sessionIdentifier)
+
+        // Cleanup
+        BackgroundDownloadState.clear()
+    }
+}

--- a/Modules/Tests/NetworkingTests/Network/BackgroundCatalogDownloadCoordinatorTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/BackgroundCatalogDownloadCoordinatorTests.swift
@@ -10,8 +10,7 @@ struct BackgroundCatalogDownloadCoordinatorTests {
         let siteID: Int64 = 456
         let state = BackgroundDownloadState(
             sessionIdentifier: sessionIdentifier,
-            siteID: siteID,
-            startedAt: Date()
+            siteID: siteID
         )
         BackgroundDownloadState.save(state)
 
@@ -71,8 +70,7 @@ struct BackgroundCatalogDownloadCoordinatorTests {
         let sessionIdentifier = "com.woocommerce.pos.catalog.download.789"
         let state = BackgroundDownloadState(
             sessionIdentifier: sessionIdentifier,
-            siteID: 111,
-            startedAt: Date()
+            siteID: 111
         )
         BackgroundDownloadState.save(state)
 
@@ -97,8 +95,7 @@ struct BackgroundCatalogDownloadCoordinatorTests {
         let sessionIdentifier = "com.woocommerce.pos.catalog.download.reconnect"
         let state = BackgroundDownloadState(
             sessionIdentifier: sessionIdentifier,
-            siteID: 222,
-            startedAt: Date()
+            siteID: 222
         )
         BackgroundDownloadState.save(state)
 

--- a/Modules/Tests/NetworkingTests/Network/BackgroundCatalogDownloadCoordinatorTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/BackgroundCatalogDownloadCoordinatorTests.swift
@@ -34,9 +34,6 @@ struct BackgroundCatalogDownloadCoordinatorTests {
         // Then
         #expect(parsedSiteID == siteID)
         #expect(parsedFileURL?.path == "/tmp/test.json")
-
-        // Cleanup
-        BackgroundDownloadState.clear()
     }
 
     @Test func handleBackgroundSessionEvent_calls_completion_handler_when_no_state() async {
@@ -113,8 +110,5 @@ struct BackgroundCatalogDownloadCoordinatorTests {
         // Then
         #expect(mockDownloader.reconnectSessionCallCount == 1)
         #expect(mockDownloader.lastReconnectSessionIdentifier == sessionIdentifier)
-
-        // Cleanup
-        BackgroundDownloadState.clear()
     }
 }

--- a/Modules/Tests/NetworkingTests/Network/BackgroundCatalogDownloadCoordinatorTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/BackgroundCatalogDownloadCoordinatorTests.swift
@@ -45,7 +45,6 @@ struct BackgroundCatalogDownloadCoordinatorTests {
 
     @Test func handleBackgroundSessionEvent_calls_completion_handler_when_no_state() async {
         // Given
-        BackgroundDownloadState.clear() // Ensure no saved state
         let sessionIdentifier = "com.woocommerce.pos.catalog.download.999"
         let mockDownloader = MockBackgroundDownloader()
         let coordinator = BackgroundCatalogDownloadCoordinator(backgroundDownloader: mockDownloader)

--- a/Modules/Tests/NetworkingTests/Network/BackgroundCatalogDownloadCoordinatorTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/BackgroundCatalogDownloadCoordinatorTests.swift
@@ -3,6 +3,13 @@ import Testing
 @testable import Networking
 
 struct BackgroundCatalogDownloadCoordinatorTests {
+    private let testDefaults: UserDefaults
+
+    init() {
+        // Create isolated UserDefaults suite for this test
+        testDefaults = UserDefaults(suiteName: "BackgroundCatalogDownloadCoordinatorTests.\(UUID().uuidString)")!
+        BackgroundDownloadState.configure(userDefaults: testDefaults)
+    }
 
     @Test func handleBackgroundSessionEvent_loads_saved_state() async {
         // Given

--- a/Modules/Tests/NetworkingTests/Network/BackgroundDownloadStateTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/BackgroundDownloadStateTests.swift
@@ -25,15 +25,9 @@ struct BackgroundDownloadStateTests {
         let loaded = BackgroundDownloadState.load(for: "test.session.123")
         #expect(loaded?.sessionIdentifier == "test.session.123")
         #expect(loaded?.siteID == 456)
-
-        // Cleanup
-        BackgroundDownloadState.clear()
     }
 
     @Test func load_returns_nil_for_nonexistent_session() {
-        // Given
-        BackgroundDownloadState.clear()
-
         // When
         let loaded = BackgroundDownloadState.load(for: "nonexistent.session")
 
@@ -54,9 +48,6 @@ struct BackgroundDownloadStateTests {
 
         // Then
         #expect(loaded == nil)
-
-        // Cleanup
-        BackgroundDownloadState.clear()
     }
 
     @Test func clear_removes_saved_state() {
@@ -98,8 +89,5 @@ struct BackgroundDownloadStateTests {
         #expect(loadedFirst == nil) // First session is overwritten
         #expect(loadedSecond?.sessionIdentifier == "session.2")
         #expect(loadedSecond?.siteID == 200)
-
-        // Cleanup
-        BackgroundDownloadState.clear()
     }
 }

--- a/Modules/Tests/NetworkingTests/Network/BackgroundDownloadStateTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/BackgroundDownloadStateTests.swift
@@ -3,6 +3,13 @@ import Testing
 @testable import Networking
 
 struct BackgroundDownloadStateTests {
+    private let testDefaults: UserDefaults
+
+    init() {
+        // Create isolated UserDefaults suite for this test
+        testDefaults = UserDefaults(suiteName: "BackgroundDownloadStateTests.\(UUID().uuidString)")!
+        BackgroundDownloadState.configure(userDefaults: testDefaults)
+    }
 
     @Test func save_persists_state_to_userdefaults() {
         // Given

--- a/Modules/Tests/NetworkingTests/Network/BackgroundDownloadStateTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/BackgroundDownloadStateTests.swift
@@ -8,8 +8,7 @@ struct BackgroundDownloadStateTests {
         // Given
         let state = BackgroundDownloadState(
             sessionIdentifier: "test.session.123",
-            siteID: 456,
-            startedAt: Date()
+            siteID: 456
         )
 
         // When
@@ -19,7 +18,6 @@ struct BackgroundDownloadStateTests {
         let loaded = BackgroundDownloadState.load(for: "test.session.123")
         #expect(loaded?.sessionIdentifier == "test.session.123")
         #expect(loaded?.siteID == 456)
-        #expect(loaded?.startedAt != nil)
 
         // Cleanup
         BackgroundDownloadState.clear()
@@ -40,8 +38,7 @@ struct BackgroundDownloadStateTests {
         // Given
         let state = BackgroundDownloadState(
             sessionIdentifier: "session.A",
-            siteID: 123,
-            startedAt: Date()
+            siteID: 123
         )
         BackgroundDownloadState.save(state)
 
@@ -59,8 +56,7 @@ struct BackgroundDownloadStateTests {
         // Given
         let state = BackgroundDownloadState(
             sessionIdentifier: "test.session",
-            siteID: 789,
-            startedAt: Date()
+            siteID: 789
         )
         BackgroundDownloadState.save(state)
 
@@ -76,15 +72,13 @@ struct BackgroundDownloadStateTests {
         // Given
         let firstState = BackgroundDownloadState(
             sessionIdentifier: "session.1",
-            siteID: 100,
-            startedAt: Date()
+            siteID: 100
         )
         BackgroundDownloadState.save(firstState)
 
         let secondState = BackgroundDownloadState(
             sessionIdentifier: "session.2",
-            siteID: 200,
-            startedAt: Date()
+            siteID: 200
         )
 
         // When

--- a/Modules/Tests/NetworkingTests/Network/BackgroundDownloadStateTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/BackgroundDownloadStateTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+@testable import Networking
+
+struct BackgroundDownloadStateTests {
+
+    @Test func save_persists_state_to_userdefaults() {
+        // Given
+        let state = BackgroundDownloadState(
+            sessionIdentifier: "test.session.123",
+            siteID: 456,
+            startedAt: Date()
+        )
+
+        // When
+        BackgroundDownloadState.save(state)
+
+        // Then
+        let loaded = BackgroundDownloadState.load(for: "test.session.123")
+        #expect(loaded?.sessionIdentifier == "test.session.123")
+        #expect(loaded?.siteID == 456)
+        #expect(loaded?.startedAt != nil)
+
+        // Cleanup
+        BackgroundDownloadState.clear()
+    }
+
+    @Test func load_returns_nil_for_nonexistent_session() {
+        // Given
+        BackgroundDownloadState.clear()
+
+        // When
+        let loaded = BackgroundDownloadState.load(for: "nonexistent.session")
+
+        // Then
+        #expect(loaded == nil)
+    }
+
+    @Test func load_returns_nil_for_different_session_identifier() {
+        // Given
+        let state = BackgroundDownloadState(
+            sessionIdentifier: "session.A",
+            siteID: 123,
+            startedAt: Date()
+        )
+        BackgroundDownloadState.save(state)
+
+        // When
+        let loaded = BackgroundDownloadState.load(for: "session.B")
+
+        // Then
+        #expect(loaded == nil)
+
+        // Cleanup
+        BackgroundDownloadState.clear()
+    }
+
+    @Test func clear_removes_saved_state() {
+        // Given
+        let state = BackgroundDownloadState(
+            sessionIdentifier: "test.session",
+            siteID: 789,
+            startedAt: Date()
+        )
+        BackgroundDownloadState.save(state)
+
+        // When
+        BackgroundDownloadState.clear()
+
+        // Then
+        let loaded = BackgroundDownloadState.load(for: "test.session")
+        #expect(loaded == nil)
+    }
+
+    @Test func save_overwrites_previous_state() {
+        // Given
+        let firstState = BackgroundDownloadState(
+            sessionIdentifier: "session.1",
+            siteID: 100,
+            startedAt: Date()
+        )
+        BackgroundDownloadState.save(firstState)
+
+        let secondState = BackgroundDownloadState(
+            sessionIdentifier: "session.2",
+            siteID: 200,
+            startedAt: Date()
+        )
+
+        // When
+        BackgroundDownloadState.save(secondState)
+
+        // Then
+        let loadedFirst = BackgroundDownloadState.load(for: "session.1")
+        let loadedSecond = BackgroundDownloadState.load(for: "session.2")
+
+        #expect(loadedFirst == nil) // First session is overwritten
+        #expect(loadedSecond?.sessionIdentifier == "session.2")
+        #expect(loadedSecond?.siteID == 200)
+
+        // Cleanup
+        BackgroundDownloadState.clear()
+    }
+}

--- a/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
@@ -993,7 +993,6 @@ extension POSCatalogSyncRemoteTests {
         // Given
         let remote = createRemote()
         let downloadURL = "https://example.com/catalog.json"
-        BackgroundDownloadState.clear() // Start clean
 
         let mockFileURL = mockBackgroundDownloader.createMockDownloadFile(withContent: "[]")
         mockBackgroundDownloader.mockSuccessfulDownload(fileURL: mockFileURL)
@@ -1023,14 +1022,12 @@ extension POSCatalogSyncRemoteTests {
 
         // Cleanup
         try? FileManager.default.removeItem(at: mockFileURL)
-        BackgroundDownloadState.clear()
     }
 
     @Test func downloadCatalog_clears_state_on_success() async throws {
         // Given
         let remote = createRemote()
         let downloadURL = "https://example.com/catalog.json"
-        BackgroundDownloadState.clear() // Start clean
 
         // When
         let mockFileURL = mockBackgroundDownloader.createMockDownloadFile(withContent: "[]")

--- a/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
@@ -8,6 +8,13 @@ struct POSCatalogSyncRemoteTests {
     private let mockBackgroundDownloader = MockBackgroundDownloader()
     private let mockFileManager = MockFileManager()
     private let sampleSiteID: Int64 = 1234
+    private let testDefaults: UserDefaults
+
+    init() {
+        // Create isolated UserDefaults suite for this test
+        testDefaults = UserDefaults(suiteName: "POSCatalogSyncRemoteTests.\(UUID().uuidString)")!
+        BackgroundDownloadState.configure(userDefaults: testDefaults)
+    }
 
     @Test func loadProducts_sets_correct_parameters() async throws {
         // Given

--- a/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
@@ -978,3 +978,65 @@ private class MockFileManager: FileManager {
         lastRemovedURL = URL
     }
 }
+
+// MARK: - Background Download State Tests
+
+extension POSCatalogSyncRemoteTests {
+    @Test func downloadCatalog_saves_background_state() async throws {
+        // Given
+        let remote = createRemote()
+        let downloadURL = "https://example.com/catalog.json"
+        BackgroundDownloadState.clear() // Start clean
+
+        // When
+        mockBackgroundDownloader.mockFileURL = URL(fileURLWithPath: "/tmp/catalog.json")
+        network.simulateResponse(requestUrlSuffix: "catalog", filename: "pos-catalog-download")
+        _ = try? await remote.downloadCatalog(for: sampleSiteID, downloadURL: downloadURL, allowCellular: true)
+
+        // Then - state should be saved with session identifier
+        let savedState = BackgroundDownloadState.load(for: mockBackgroundDownloader.lastSessionIdentifier ?? "")
+        #expect(savedState?.siteID == sampleSiteID)
+        #expect(savedState?.sessionIdentifier == mockBackgroundDownloader.lastSessionIdentifier)
+
+        // Cleanup
+        BackgroundDownloadState.clear()
+    }
+
+    @Test func downloadCatalog_clears_state_on_success() async throws {
+        // Given
+        let remote = createRemote()
+        let downloadURL = "https://example.com/catalog.json"
+
+        // When
+        mockBackgroundDownloader.mockFileURL = URL(fileURLWithPath: "/tmp/catalog.json")
+        network.simulateResponse(requestUrlSuffix: "catalog", filename: "pos-catalog-download")
+        _ = try? await remote.downloadCatalog(for: sampleSiteID, downloadURL: downloadURL, allowCellular: true)
+
+        // Then - state should be cleared after successful completion
+        let savedState = BackgroundDownloadState.load(for: mockBackgroundDownloader.lastSessionIdentifier ?? "")
+        #expect(savedState == nil)
+    }
+
+    @Test func downloadCatalog_creates_unique_session_identifiers() async throws {
+        // Given
+        let remote = createRemote()
+        let downloadURL = "https://example.com/catalog.json"
+        mockBackgroundDownloader.mockFileURL = URL(fileURLWithPath: "/tmp/catalog.json")
+        network.simulateResponse(requestUrlSuffix: "catalog", filename: "pos-catalog-download")
+
+        // When - download twice
+        _ = try? await remote.downloadCatalog(for: sampleSiteID, downloadURL: downloadURL, allowCellular: true)
+        let firstSessionID = mockBackgroundDownloader.lastSessionIdentifier
+
+        _ = try? await remote.downloadCatalog(for: sampleSiteID, downloadURL: downloadURL, allowCellular: true)
+        let secondSessionID = mockBackgroundDownloader.lastSessionIdentifier
+
+        // Then - session IDs should be different
+        #expect(firstSessionID != secondSessionID)
+        #expect(firstSessionID?.hasPrefix("com.woocommerce.pos.catalog.download") == true)
+        #expect(secondSessionID?.hasPrefix("com.woocommerce.pos.catalog.download") == true)
+
+        // Cleanup
+        BackgroundDownloadState.clear()
+    }
+}

--- a/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
@@ -988,17 +988,34 @@ extension POSCatalogSyncRemoteTests {
         let downloadURL = "https://example.com/catalog.json"
         BackgroundDownloadState.clear() // Start clean
 
-        // When
-        mockBackgroundDownloader.mockFileURL = URL(fileURLWithPath: "/tmp/catalog.json")
+        let mockFileURL = mockBackgroundDownloader.createMockDownloadFile(withContent: "[]")
+        mockBackgroundDownloader.mockSuccessfulDownload(fileURL: mockFileURL)
         network.simulateResponse(requestUrlSuffix: "catalog", filename: "pos-catalog-download")
-        _ = try? await remote.downloadCatalog(for: sampleSiteID, downloadURL: downloadURL, allowCellular: true)
 
-        // Then - state should be saved with session identifier
-        let savedState = BackgroundDownloadState.load(for: mockBackgroundDownloader.lastSessionIdentifier ?? "")
+        // When - use continuation to capture state when download starts
+        let savedState: BackgroundDownloadState? = await withCheckedContinuation { continuation in
+            mockBackgroundDownloader.onDownloadStarted = {
+                // Download has started, state should be saved now
+                if let sessionIdentifier = mockBackgroundDownloader.lastSessionIdentifier {
+                    let state = BackgroundDownloadState.load(for: sessionIdentifier)
+                    continuation.resume(returning: state)
+                } else {
+                    continuation.resume(returning: nil)
+                }
+            }
+
+            Task {
+                _ = try? await remote.downloadCatalog(for: sampleSiteID, downloadURL: downloadURL, allowCellular: true)
+            }
+        }
+
+        // Then - state should have been saved during download
+        #expect(savedState != nil)
         #expect(savedState?.siteID == sampleSiteID)
         #expect(savedState?.sessionIdentifier == mockBackgroundDownloader.lastSessionIdentifier)
 
         // Cleanup
+        try? FileManager.default.removeItem(at: mockFileURL)
         BackgroundDownloadState.clear()
     }
 
@@ -1006,15 +1023,20 @@ extension POSCatalogSyncRemoteTests {
         // Given
         let remote = createRemote()
         let downloadURL = "https://example.com/catalog.json"
+        BackgroundDownloadState.clear() // Start clean
 
         // When
-        mockBackgroundDownloader.mockFileURL = URL(fileURLWithPath: "/tmp/catalog.json")
+        let mockFileURL = mockBackgroundDownloader.createMockDownloadFile(withContent: "[]")
+        mockBackgroundDownloader.mockSuccessfulDownload(fileURL: mockFileURL)
         network.simulateResponse(requestUrlSuffix: "catalog", filename: "pos-catalog-download")
         _ = try? await remote.downloadCatalog(for: sampleSiteID, downloadURL: downloadURL, allowCellular: true)
 
         // Then - state should be cleared after successful completion
         let savedState = BackgroundDownloadState.load(for: mockBackgroundDownloader.lastSessionIdentifier ?? "")
         #expect(savedState == nil)
+
+        // Cleanup
+        try? FileManager.default.removeItem(at: mockFileURL)
     }
 
     @Test func downloadCatalog_creates_unique_session_identifiers() async throws {

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSCatalogSyncCoordinator.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSCatalogSyncCoordinator.swift
@@ -76,4 +76,22 @@ final class MockPOSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
     }
 
     func stopOngoingSyncs(for siteID: Int64) async {}
+
+    var processBackgroundDownloadResult: Result<Void, Error> = .success(())
+    private(set) var processBackgroundDownloadCallCount = 0
+    private(set) var lastProcessedFileURL: URL?
+    private(set) var lastProcessedSiteID: Int64?
+
+    func processBackgroundDownload(fileURL: URL, siteID: Int64) async throws {
+        processBackgroundDownloadCallCount += 1
+        lastProcessedFileURL = fileURL
+        lastProcessedSiteID = siteID
+
+        switch processBackgroundDownloadResult {
+        case .success:
+            return
+        case .failure(let error):
+            throw error
+        }
+    }
 }

--- a/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogSyncRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogSyncRemote.swift
@@ -154,6 +154,24 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
         }
     }
 
+    var parseDownloadedCatalogResult: Result<POSCatalogResponse, Error> = .success(.init(products: [], variations: []))
+    private(set) var parseDownloadedCatalogCallCount = 0
+    private(set) var lastParsedFileURL: URL?
+    private(set) var lastParsedSiteID: Int64?
+
+    func parseDownloadedCatalog(from fileURL: URL, siteID: Int64) async throws -> POSCatalogResponse {
+        parseDownloadedCatalogCallCount += 1
+        lastParsedFileURL = fileURL
+        lastParsedSiteID = siteID
+
+        switch parseDownloadedCatalogResult {
+        case .success(let response):
+            return response
+        case .failure(let error):
+            throw error
+        }
+    }
+
     // MARK: - Protocol Methods - Catalog size
 
     // MARK: - getProductCount tracking

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
@@ -618,6 +618,24 @@ final class MockPOSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol {
         }
     }
 
+    var parseAndPersistBackgroundDownloadResult: Result<POSCatalog, Error> = .success(POSCatalog(products: [], variations: [], syncDate: .now))
+    private(set) var parseAndPersistBackgroundDownloadCallCount = 0
+    private(set) var lastBackgroundDownloadFileURL: URL?
+    private(set) var lastBackgroundDownloadSiteID: Int64?
+
+    func parseAndPersistBackgroundDownload(fileURL: URL, siteID: Int64) async throws -> POSCatalog {
+        parseAndPersistBackgroundDownloadCallCount += 1
+        lastBackgroundDownloadFileURL = fileURL
+        lastBackgroundDownloadSiteID = siteID
+
+        switch parseAndPersistBackgroundDownloadResult {
+        case .success(let catalog):
+            return catalog
+        case .failure(let error):
+            throw error
+        }
+    }
+
     func blockNextSync() {
         shouldBlockSync = true
     }

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -2,6 +2,7 @@ import UIKit
 import Combine
 import Storage
 import class Networking.UserAgent
+import class Networking.BackgroundCatalogDownloadCoordinator
 import Experiments
 import protocol WooFoundation.Analytics
 import protocol Yosemite.StoresManager
@@ -149,16 +150,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                      completionHandler: @escaping () -> Void) {
         DDLogInfo("🟣 Handling background URLSession events for identifier: \(identifier)")
 
-        // Store the completion handler for the background session
-        // The BackgroundDownloadService will invoke this when all events are processed
         if identifier.hasPrefix("com.woocommerce.pos.catalog.download") {
-            // In a production implementation, this would be passed to the BackgroundDownloadService
-            // For now, we store it and the service will need to retrieve it
-            // TODO: WOOMOB-1173 - Wire this to BackgroundDownloadService.setBackgroundCompletionHandler
-            // TODO: WOOMOB-1677 - Catalog parsing happens in the ~30s window after download completes.
-            // For very large catalogs, consider hybrid approach: try immediate parse, defer if timeout.
-            DDLogInfo("🟣 Background catalog download session completion handler stored")
-            completionHandler()
+            // Handle POS catalog download completion in background
+            Task {
+                let downloadCoordinator = BackgroundCatalogDownloadCoordinator()
+                await downloadCoordinator.handleBackgroundSessionEvent(
+                    sessionIdentifier: identifier,
+                    completionHandler: completionHandler,
+                    parseHandler: { fileURL, siteID in
+                        // Use the POS catalog sync coordinator to parse and persist
+                        guard let coordinator = ServiceLocator.stores.posCatalogSyncCoordinator else {
+                            throw NSError(domain: "com.woocommerce.pos", code: -1,
+                                         userInfo: [NSLocalizedDescriptionKey: "POS catalog coordinator not available"])
+                        }
+                        try await coordinator.processBackgroundDownload(fileURL: fileURL, siteID: siteID)
+                    }
+                )
+            }
         } else {
             // Unknown session identifier - call completion handler immediately
             DDLogWarn("🟣 Unknown background URLSession identifier: \(identifier)")

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -3,7 +3,6 @@ import Combine
 import Storage
 import class Networking.UserAgent
 import class Networking.BackgroundCatalogDownloadCoordinator
-import Experiments
 import protocol WooFoundation.Analytics
 import protocol Yosemite.StoresManager
 import struct Yosemite.Site

--- a/WooCommerce/WooCommerceTests/Tools/ForegroundPOSCatalogSyncDispatcherTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ForegroundPOSCatalogSyncDispatcherTests.swift
@@ -303,4 +303,8 @@ private final class MockPOSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProt
     }
 
     func stopOngoingSyncs(for siteID: Int64) async {}
+
+    func processBackgroundDownload(fileURL: URL, siteID: Int64) async throws {
+        // Not used in these tests
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Merge after: #16337

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR moves the handling (parsing and persistence) of background full catalog sync downloads, to be completed in the background. This happens in the 30s that Apple give us after the background completes.

Note than none of this will be live for a while, because we need the Catalog endpoints in Core first.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->


Backgrounded testing is tricky, and you can't really do it with the debugger attached. I've found network breakpoints are useful.

- Use a large catalog store with the catalog generation/file endpoints, e.g. largefuntesting.mystagingwebsite.com
- Turn on the `pointOfSaleCatalogAPI` feature flag
- Set `POSLocalCatalogEligibilityService.Constants.defaultCatalogSizeLimit` to 100000
- Set network conditions to something slow, like 3g or 2g. In Proxyman, it's `Tools > Network conditions > +` then set the host to `largefuntesting.mystagingwebsite.com` and use the preset profile. Note that this is only wanted for the file download, so no need to do it on public-api.wordpress.com. For these settings, 3g takes about 30s to download, and 2g takes about 2 minutes.

1. Run the app, then stop it.
2. Launch the app from the device, not Xcode.
3. Go to `POS > Settings` and tap refresh catalog
4. Watch the requests to `/wc/v3/products/catalog`, wait for the `completed` status response with a download URL (this takes a few minutes)
5. As soon as you see that, background the app
6. Wait for the download to complete (see Proxyman to check that it has)
7. Wait another 3-5 minutes to give time for the persistence and parsing to complete
8. Open the app again and go to `Menu > Settings > Help and Support > Application logs > Current`
9. Observe that the download completed and was persisted when we opened the app again. Note that it's fine to only see `Clearing catalog data for site 247136746` in the background. It's possible to run out of time with this approach to handling downloads, but they get completed when you open the app again.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

```
2025/11/11 12:55:15:570  🔵 Tracked pos_settings_open, properties: [site_url: https://largefuntesting.mystagingwebsite.com, blog_id: 247136746, store_id: 5127f96a-6b26-4aca-bdf3-7f92defeb6ce, is_wpcom_store: false, plan: jetpack_security_t1_yearly, was_ecommerce_trial: false]
2025/11/11 12:55:21:478  📋 POSCatalogSyncCoordinator: Site 247136746 eligible (within grace period: 0 days since first sync)
2025/11/11 12:55:21:481  📋 POSCatalogSyncCoordinator: Last sync for site 247136746 was 2408s ago (max: 0s), sync needed
2025/11/11 12:55:21:491  🔄 POSCatalogSyncCoordinator starting full sync for site 247136746
2025/11/11 12:55:21:492  🔄 Starting full catalog sync for site ID: 247136746 with regenerateCatalog: true and allowCellular: true
2025/11/11 12:55:21:492  🟣 Starting catalog request...
2025/11/11 12:55:23:918  🟣 Catalog request pending... (attempt 1/1000)
2025/11/11 13:00:22:596  🟣 Catalog request processing... (attempt 141/1000)
2025/11/11 13:00:24:749  🟣 Catalog ready for download: https://largefuntesting.mystagingwebsite.com/wp-content/uploads/wc-product-catalog/pos-catalog-feed.json
2025/11/11 13:01:07:064  Scheduling background refresh task ordersAndDashboardSync in 1799s
2025/11/11 13:01:07:073  🔵 Tracked application_closed, properties: [plan: jetpack_security_t1_yearly, blog_id: 247136746, is_wpcom_store: false, store_id: 5127f96a-6b26-4aca-bdf3-7f92defeb6ce, site_url: https://largefuntesting.mystagingwebsite.com, time_in_app: 363.0, was_ecommerce_trial: false]
2025/11/11 13:01:07:074  ⏱️ ForegroundPOSCatalogSyncDispatcher: Stopping timer
2025/11/11 13:02:21:601  🟣 Handling background URLSession events for identifier: com.woocommerce.pos.catalog.download.247136746.8BB90F4D-65B6-4E07-A82F-1EB22314BA04
2025/11/11 13:02:21:603  🟣 Handling background session event for: com.woocommerce.pos.catalog.download.247136746.8BB90F4D-65B6-4E07-A82F-1EB22314BA04
2025/11/11 13:02:21:605  🟣 Reconnecting to background session: com.woocommerce.pos.catalog.download.247136746.8BB90F4D-65B6-4E07-A82F-1EB22314BA04
2025/11/11 13:02:21:620  🟣 Background download completed, file moved to: /private/var/mobile/Containers/Data/Application/12167735-BF6A-4EBA-A4C5-0619BE4432E6/tmp/pos-catalog-feed.json
2025/11/11 13:02:36:575  🟣 Catalog download completed - Time: 435.08s
2025/11/11 13:02:36:575  ✅ Loaded 4977 products and 12458 variations for siteID 247136746
2025/11/11 13:02:36:575  💾 Persisting catalog with 4977 products and 12458 variations
2025/11/11 13:02:53:010  🗑️ Clearing catalog data for site 247136746
2025/11/11 13:07:01:056  🔵 Tracked application_opened, properties: [widgets: , is_wpcom_store: false, store_id: 5127f96a-6b26-4aca-bdf3-7f92defeb6ce, was_ecommerce_trial: false, site_url: https://largefuntesting.mystagingwebsite.com, blog_id: 247136746, plan: jetpack_security_t1_yearly]
2025/11/11 13:07:15:013  ✅ Database write complete for site 247136746
2025/11/11 13:07:15:048  ✅ Catalog persistence complete
2025/11/11 13:07:15:050  📋 POSCatalogSyncCoordinator: Site 247136746 eligible (within grace period: 0 days since first sync)
2025/11/11 13:07:15:051  Persisted 4960 products, 5694 product images, 1992 product attributes, 12288 variations, 12288 variation images, 32023 variation attributes
2025/11/11 13:07:15:052  ✅ Persisted 4977 products and 12458 variations to database for siteID 247136746
2025/11/11 13:07:15:079  ✅ POSCatalogSyncCoordinator completed full sync for site 247136746
```

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
