### PR TITLE
Bookings: Get rid of focus border around selected booking list rows

### DIFF
--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -128,29 +128,31 @@ private extension BookingListView {
     }
 
     func bookingItem(_ booking: Booking) -> some View {
-        VStack(spacing: 0) {
-            VStack(alignment: .leading) {
-                Text(booking.startDate.toString(dateStyle: .short,
-                                                timeStyle: .short,
-                                                timeZone: BookingListTab.utcTimeZone))
-                    .font(.body)
-                    .fontWeight(.medium)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .foregroundStyle(Color.primary)
+        VStack(alignment: .leading) {
+            Text(booking.startDate.toString(dateStyle: .short,
+                                            timeStyle: .short,
+                                            timeZone: BookingListTab.utcTimeZone))
+                .font(.body)
+                .fontWeight(.medium)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .foregroundStyle(Color.primary)
 
-                Text(booking.summaryText)
-                    .font(.footnote)
-                    .fontWeight(.medium)
-                    .foregroundStyle(Color.secondary)
+            Text(booking.summaryText)
+                .font(.footnote)
+                .fontWeight(.medium)
+                .foregroundStyle(Color.secondary)
 
-                HStack {
-                    BookingBadgeView(booking.attendanceStatus)
-                    BookingBadgeView(booking.bookingStatus)
-                    Spacer()
-                }
+            HStack {
+                BookingBadgeView(booking.attendanceStatus)
+                BookingBadgeView(booking.bookingStatus)
+                Spacer()
             }
         }
-        .listRowBackground(booking == selectedBooking ? Color(.listSelectedBackground) : Color(.listForeground(modal: false)))
+        .padding()
+        .background(
+            (booking == selectedBooking ? Color(.listSelectedBackground) : Color(.listForeground(modal: false)))
+        )
+        .listRowInsets(.init())
     }
 
     func emptyStateView(isSearching: Bool, onRefresh: @escaping () async -> Void) -> some View {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously in #16327 I replaced the booking list's accent color with `listRowBackground` modifier since the accent color affects the header's button color.

Turns out, `listRownBackground` also comes with a focus ring that cannot be get rid of even with `focusEffectDisabled` modifier from my testing.

This PR gets rid of the selected border by applying a workaround:
- Set the list row insets to zero and apply paddings around the row contents manually
- Set a background color to the row contents for selected state.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Build and run the app on an iPad simulator.
2. Log in to a CIAB store with existing bookings.
3. Navigate to the Bookings tab and select any booking in the list.
4. Confirm that there is no border around selected items.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before | After
--- | ---
<img width="320" alt="Screenshot 2025-11-12 at 10 22 59" src="https://github.com/user-attachments/assets/f36a2be8-5987-4d99-9507-fc3b419d1a6a" /> | <img width="320" alt="image" src="https://github.com/user-attachments/assets/30bbc70a-d767-4346-9b7c-c435cc2a2220" />




---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
