### PR TITLE
[Bookings] Fix repeating requests on booking details load

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -51,9 +51,6 @@ struct BookingDetailsView: View {
         .refreshable {
             await viewModel.syncData()
         }
-        .task {
-            await viewModel.syncData()
-        }
         .navigationBarTitleDisplayMode(.inline)
         .navigationTitle(viewModel.navigationTitle)
         .background(Color(uiColor: .systemGroupedBackground))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1652

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Fixes the repeating requests. The following code caused duplicated data sync:
- The task in `BookingDetailsView` body
```
.task {
    await viewModel.syncData()
}
```
- Sync triggering in `BookingDetailsView.init`
```
init(_ viewModel: BookingDetailsViewModel) {
    self.viewModel = viewModel

    /// Trigger remote data sync
    Task {
        await viewModel.syncData()
    }
}
```

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Use CIAB site with bookings
- Use Proxyman or any other networking debugging tool
- Navigate to bookings tab
- Clear the Proxyman log for convenience
- Select a booking in bookings list
- Make sure Proxyman displays 3 requests per booking:
    - `/wc-bookings/v2/bookings/315&_method=get` - booking details
    - `wc/v3/orders&_method=get` - booking order details
    - `/wc-bookings/v2/resources/team-members/{member_id}&_method=get` - team member details

## Demo
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/a246aff8-16a8-4eac-883c-ba78334dea22

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
