### PR TITLE
Results controller: Notify listeners of changes when updating predicate and sort descriptors

### DIFF
--- a/Modules/Sources/Yosemite/Tools/ResultsController.swift
+++ b/Modules/Sources/Yosemite/Tools/ResultsController.swift
@@ -234,6 +234,7 @@ public class GenericResultsController<T: ResultsControllerMutableType, Output> {
     private func refreshFetchedObjects(predicate: NSPredicate?) {
         controller.fetchRequest.predicate = predicate
         try? controller.performFetch()
+        onDidChangeContent?()
     }
 
     /// Refreshes all of the Fetched Objects, so that the new sort descriptors are applied.
@@ -241,6 +242,7 @@ public class GenericResultsController<T: ResultsControllerMutableType, Output> {
     private func refreshFetchedObjects(sortDescriptors: [NSSortDescriptor]?) {
         controller.fetchRequest.sortDescriptors = sortDescriptors
         try? controller.performFetch()
+        onDidChangeContent?()
     }
 
     /// Initializes the FetchedResultsController

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [*] Fix order details presentation when opened from booking details [https://github.com/woocommerce/woocommerce-ios/pull/16331]
 - [*] Show POS feedback surveys for eligible merchants [https://github.com/woocommerce/woocommerce-ios/pull/16325]
 - [*] Fix product variation selection for order creation [https://github.com/woocommerce/woocommerce-ios/pull/16317]
+- [Internal] Notify listeners immediately after updating predicates or sort descriptors for results controllers. [https://github.com/woocommerce/woocommerce-ios/pull/16350]
 
 23.6
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In #16339 @RafaelKayumov noticed that the results controller was not updated immediately when its predicate and sort descriptors are updated. The list is only updated after syncing finishes.

The reason is that when `performFetch` is triggered directly after changing predicate and sort descriptors, `NSFetchedResultsController` does NOT automatically call its delegate methods. The delegate methods are only triggered when the underlying Core Data store changes, not upon manual refetching.

This PR fixes the issue by manually triggering `onDidChangeContent` at the end of `refreshFetchedObjects` methods in `GenericResultsController`.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Comment out line 123 to prevent the resyncing of data in `BookingListViewModel` when switching filters.
2. Build and run the app.
3. Log in to a CIAB store with existing bookings.
4. Navigate to Bookings tab > All > Filters.
5. Select any filter option and select Show bookings.
6. Confirm that the booking list is reloaded immediately matching the new filters.
7. Repeat the test by tapping Sort and select a different sort option.
8. Confirm that the booking list is reloaded immediately matching the new sort option.


For beta testers, you can also disconnect the Internet connection on your devices and do similar tests as above using the order list or product list.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/363ed928-b243-48e9-9530-8a2666ac97c1



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
