### PR TITLE
Remove a couple of unnecessary entries from the user env file

### DIFF
--- a/fastlane/env/user.env.example
+++ b/fastlane/env/user.env.example
@@ -1,4 +1,3 @@
-GHHELPER_ACCESS=<GitHub access token>
 SENTRY_AUTH_TOKEN=<Sentry auth token>
 
 CIRCLE_CI_AUTH_TOKEN=<CircleCI Auth Token>

--- a/fastlane/env/user.env.example
+++ b/fastlane/env/user.env.example
@@ -1,3 +1,1 @@
 SENTRY_AUTH_TOKEN=<Sentry auth token>
-
-CIRCLE_CI_AUTH_TOKEN=<CircleCI Auth Token>


### PR DESCRIPTION
Noticed this looking at an error @iamgabrielma reported internally. Ref p1763011055961849/1762157313.794039-slack-CC7L49W13

I also looked at `project.env` and I think we can remove the entire file because the values are either non-secrets (e.g. the App Store Connect team id) or no longer in use (e.g. `PILOT_API_KEY_PATH` which should be properly superseded by the `ASC_KEY_PATH` const in `Fastfile`). Removing those would require additional time to verify the changes, and given the low comparative return, I simply created a project proposal for doing it across the board: https://linear.app/a8c/project/remove-unused-or-unnecessary-env-vars-from-fastlane-setup-f0feefee0489