### PR TITLE
Fix crash on screenshot target due to unhandled action dispatch

### DIFF
--- a/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockAppSettingsActionHandler.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockAppSettingsActionHandler.swift
@@ -57,8 +57,11 @@ struct MockAppSettingsActionHandler: MockActionHandler {
         case .upsertProductsSettings(_, _, _, _, _, _, _, let onCompletion):
             onCompletion(nil)
         case .resetEligibilityErrorInfo,
-                .setTelemetryAvailability
-            :
+                .setTelemetryAvailability,
+                .getAppPasswordsExperimentSettingState,
+                .getPOSSurveyCurrentMerchantNotificationScheduled,
+                .getPOSSurveyPotentialMerchantNotificationScheduled,
+                .getHasPOSBeenOpenedAtLeastOnce:
             break
         default: unimplementedAction(action: action)
         }


### PR DESCRIPTION
Found this one while trying to generate new screenshots for ASC

## Description
WooCommerceScreenshots target crashes when running `testScreenshots()` due to unhandled actions that are dispatched through `MockActionHandler`

One review is enough. No rush to review/merge into 23.7, it's an internal crash only when we run the target, which doesn't run in CI 👍 

## Test Steps
- Switch to `WooCommerceScreenshots`
- Run `WooCommerceScreenshots.testScreenshots()`
- App should not crash. Test should pass*

_* The first time I ran the tests all of them failed due to a Tap to Pay modal appearing in the middle of the screen, which wasn't dismissed automatically so tests couldn't navigate through the app to make screenshots. A second run worked fine. I'm guessing because we only show it once, but I'm unaware of the exact details at this point. If tests fail due to this reason please run them again, we can handle the tap to pay modal separately._

<img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - Tests - 2025-11-13 at 15 38 55" src="https://github.com/user-attachments/assets/f9bb529d-bbe6-49f9-9208-d3c380f113ec" />

