### PR TITLE
[Local catalog] Handle missing products during order creation

### DIFF
--- a/Modules/Sources/NetworkingCore/Network/NetworkError.swift
+++ b/Modules/Sources/NetworkingCore/Network/NetworkError.swift
@@ -51,7 +51,7 @@ public enum NetworkError: Error, Equatable {
     }
 
     /// Content of the `code` field in the response if available
-    var errorCode: String? {
+    public var errorCode: String? {
         guard let response else { return nil }
         let decoder = JSONDecoder()
         guard let decodedResponse = try? decoder.decode(NetworkErrorResponse.self, from: response) else {

--- a/Modules/Sources/NetworkingCore/Network/NetworkError.swift
+++ b/Modules/Sources/NetworkingCore/Network/NetworkError.swift
@@ -59,6 +59,16 @@ public enum NetworkError: Error, Equatable {
         }
         return decodedResponse.code
     }
+
+    /// Content of the `data` field in the response if available
+    public var errorData: [String: AnyDecodable]? {
+        guard let response else { return nil }
+        let decoder = JSONDecoder()
+        guard let decodedResponse = try? decoder.decode(NetworkErrorResponse.self, from: response) else {
+            return nil
+        }
+        return decodedResponse.data
+    }
 }
 
 
@@ -134,6 +144,7 @@ extension NetworkError: CustomStringConvertible {
 
 struct NetworkErrorResponse: Decodable {
     let code: String?
+    let data: [String: AnyDecodable]?
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -144,6 +155,7 @@ struct NetworkErrorResponse: Decodable {
             }
             return try container.decodeIfPresent(String.self, forKey: .code)
         }()
+        self.data = try container.decodeIfPresent([String: AnyDecodable].self, forKey: .data)
     }
 
     /// Coding Keys
@@ -151,5 +163,6 @@ struct NetworkErrorResponse: Decodable {
     private enum CodingKeys: String, CodingKey {
         case error
         case code
+        case data
     }
 }

--- a/Modules/Sources/PointOfSale/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/Modules/Sources/PointOfSale/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -44,6 +44,7 @@ extension WooAnalyticsEvent {
             static let listPosition = "list_position"
             static let daysSinceCreated = "days_since_created"
             static let pageNumber = "page_number"
+            static let syncStrategy = "sync_strategy"
         }
 
         /// Source of the event where the event is triggered
@@ -456,6 +457,49 @@ extension WooAnalyticsEvent {
 
         static func ordersListLoaded() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .ordersListLoaded, properties: [:])
+        }
+    }
+
+    // MARK: - Checkout Outdated Item Detection Events
+
+    public extension PointOfSale {
+        static func checkoutOutdatedItemDetectedScreenShown(
+            reason: String,
+            syncStrategy: String
+        ) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(
+                statName: .pointOfSaleCheckoutOutdatedItemDetectedScreenShown,
+                properties: [
+                    Key.reason: reason,
+                    Key.syncStrategy: syncStrategy
+                ]
+            )
+        }
+
+        static func checkoutOutdatedItemDetectedEditOrderTapped(
+            reason: String,
+            syncStrategy: String
+        ) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(
+                statName: .pointOfSaleCheckoutOutdatedItemDetectedEditOrderTapped,
+                properties: [
+                    Key.reason: reason,
+                    Key.syncStrategy: syncStrategy
+                ]
+            )
+        }
+
+        static func checkoutOutdatedItemDetectedRemoveTapped(
+            reason: String,
+            syncStrategy: String
+        ) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(
+                statName: .pointOfSaleCheckoutOutdatedItemDetectedRemoveTapped,
+                properties: [
+                    Key.reason: reason,
+                    Key.syncStrategy: syncStrategy
+                ]
+            )
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/Modules/Sources/PointOfSale/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -44,6 +44,7 @@ extension WooAnalyticsEvent {
             static let listPosition = "list_position"
             static let daysSinceCreated = "days_since_created"
             static let pageNumber = "page_number"
+            static let reason = "reason"
             static let syncStrategy = "sync_strategy"
         }
 

--- a/Modules/Sources/PointOfSale/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/Modules/Sources/PointOfSale/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -458,11 +458,9 @@ extension WooAnalyticsEvent {
         static func ordersListLoaded() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .ordersListLoaded, properties: [:])
         }
-    }
 
-    // MARK: - Checkout Outdated Item Detection Events
+        // MARK: - Checkout Outdated Item Detection Events
 
-    public extension PointOfSale {
         static func checkoutOutdatedItemDetectedScreenShown(
             reason: String,
             syncStrategy: String

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
@@ -200,8 +200,7 @@ private extension PointOfSaleOrderController {
                 PointOfSaleOrderState.OrderStateError.MissingProductInfo(
                     productID: $0.productID,
                     variationID: $0.variationID,
-                    name: $0.name,
-                    quantity: $0.expectedQuantity
+                    name: $0.name
                 )
             }
             return .missingProducts(missingProductInfo)
@@ -298,8 +297,7 @@ private extension PointOfSaleOrderController {
             PointOfSaleOrderState.OrderStateError.MissingProductInfo(
                 productID: parentProductID,
                 variationID: variationID,
-                name: productName,
-                quantity: 1
+                name: productName
             )
         ]
     }
@@ -322,8 +320,7 @@ private extension PointOfSaleOrderController {
             PointOfSaleOrderState.OrderStateError.MissingProductInfo(
                 productID: 0,
                 variationID: 0,
-                name: Localization.unknownProductName,
-                quantity: 1
+                name: Localization.unknownProductName
             )
         ]
     }

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
@@ -22,10 +22,6 @@ import class WooFoundation.CurrencySettings
 import class Yosemite.PluginsService
 import enum WooFoundation.CurrencyCode
 import protocol WooFoundation.Analytics
-import enum Alamofire.AFError
-import enum Networking.DotcomError
-import enum Networking.NetworkError
-import struct Networking.AnyDecodable
 import class Yosemite.OrderTotalsCalculator
 import struct WooFoundation.WooAnalyticsEvent
 import protocol WooFoundationCore.WooAnalyticsEventPropertyType
@@ -205,137 +201,13 @@ private extension PointOfSaleOrderController {
             }
             return .missingProducts(missingProductInfo)
         }
-        // Check for server-side validation errors about invalid products/variations
-        else if let missingProductInfo = extractMissingProductsFromServerError(error, cart: cart) {
-            return .missingProducts(missingProductInfo)
-        }
         else if let couponsError = CouponsError(underlyingError: error) {
             return .invalidCoupon(couponsError.message)
-        } else if let afErrorDescription = (error as? AFError)?.underlyingError?.localizedDescription {
-            return .other(afErrorDescription)
         } else {
             return .other(error.localizedDescription)
         }
     }
-
-    /// Extracts missing product information from server validation errors
-    /// Handles cases where the server rejects order creation due to invalid product/variation IDs
-    func extractMissingProductsFromServerError(_ error: Error, cart: POSCart) -> [PointOfSaleOrderState.OrderStateError.MissingProductInfo]? {
-        // Check if this is an AFError wrapping a DotcomError or NetworkError
-        let underlyingError: Error? = {
-            if let afError = error as? AFError {
-                return afError.underlyingError
-            }
-            return error
-        }()
-
-        // Check for DotcomError with product/variation validation error codes
-        if case .unknown(let code, _) = underlyingError as? DotcomError {
-            if isProductValidationError(code: code) {
-                // DotcomError doesn't include data field, fall back to generic error
-                return extractMissingProductsFromCart()
-            }
-        }
-
-        // Check for NetworkError with product/variation validation error codes
-        if let networkError = underlyingError as? NetworkError,
-           let errorCode = networkError.errorCode,
-           isProductValidationError(code: errorCode) {
-            // Try to extract variation_id from NetworkError data if available
-            if let variationID = extractVariationID(from: networkError.errorData) {
-                return createMissingProductInfo(forVariationID: variationID, cart: cart)
-            }
-            // Fall back to generic error if no variation_id in data
-            return extractMissingProductsFromCart()
-        }
-
-        return nil
-    }
-
-    /// Extracts variation_id from error data dictionary
-    private func extractVariationID(from data: [String: AnyDecodable]?) -> Int64? {
-        guard let data = data,
-              let variationIDValue = data["variation_id"]?.value else {
-            return nil
-        }
-
-        // Handle different number types
-        if let intValue = variationIDValue as? Int {
-            return Int64(intValue)
-        } else if let int64Value = variationIDValue as? Int64 {
-            return int64Value
-        }
-        return nil
-    }
-
-    /// Creates MissingProductInfo for a specific variation ID
-    /// Searches the cart to find the variation's name and parent product ID
-    private func createMissingProductInfo(forVariationID variationID: Int64, cart: POSCart) -> [PointOfSaleOrderState.OrderStateError.MissingProductInfo] {
-        // Search the cart for the variation to get its name
-        let cartItem = cart.items.first { item in
-            if let variation = item.item as? POSVariation {
-                return variation.productVariationID == variationID
-            }
-            return false
-        }
-
-        let productName: String
-        let parentProductID: Int64
-
-        if let cartItem = cartItem,
-           let variation = cartItem.item as? POSVariation {
-            // Found the variation in the cart - use its parent product name and variation name
-            productName = "\(variation.parentProductName) - \(variation.name)"
-            parentProductID = variation.productID
-        } else {
-            // Couldn't find it in cart, use generic name
-            productName = Localization.unknownProductName
-            parentProductID = 0
-        }
-
-        return [
-            PointOfSaleOrderState.OrderStateError.MissingProductInfo(
-                productID: parentProductID,
-                variationID: variationID,
-                name: productName
-            )
-        ]
-    }
-
-    /// Checks if an error code indicates a product validation error
-    /// Currently only handles the confirmed error code from WooCommerce server responses
-    private func isProductValidationError(code: String) -> Bool {
-        // Only check for the one confirmed error code we've observed
-        // Additional codes can be added as they are discovered through testing
-        return code == "order_item_product_invalid_variation_id"
-    }
-
-    /// Extracts missing products by trying to identify items in cart that might have caused the validation error
-    /// Since server doesn't tell us which specific products failed, we return generic error info
-    private func extractMissingProductsFromCart() -> [PointOfSaleOrderState.OrderStateError.MissingProductInfo]? {
-        // We can't determine which specific products are invalid from the server error
-        // So we return a generic missing product message with 0 for both IDs (meaning unknown)
-        // The user will need to remove all products and retry
-        return [
-            PointOfSaleOrderState.OrderStateError.MissingProductInfo(
-                productID: 0,
-                variationID: 0,
-                name: Localization.unknownProductName
-            )
-        ]
-    }
 }
-
-private extension PointOfSaleOrderController {
-    enum Localization {
-        static let unknownProductName = NSLocalizedString(
-            "pointOfSale.orderController.unknownProduct",
-            value: "One or more products",
-            comment: "Generic product name used when we can't identify which specific product is unavailable"
-        )
-    }
-}
-
 
 // This is named to note that it is for use within the AggregateModel and OrderController.
 // Conversely, PointOfSaleOrderState is available to the Views, as it doesn't include the Order.
@@ -400,8 +272,6 @@ private extension PointOfSaleOrderController {
         if let _ = CouponsError(underlyingError: error) {
             errorType = .invalidCoupon
         } else if case .missingProductsInOrder = error as? POSOrderService.POSOrderServiceError {
-            errorType = .missingProducts
-        } else if extractMissingProductsFromServerError(error, cart: cart) != nil {
             errorType = .missingProducts
         }
 

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
@@ -22,6 +22,8 @@ import class Yosemite.PluginsService
 import enum WooFoundation.CurrencyCode
 import protocol WooFoundation.Analytics
 import enum Alamofire.AFError
+import enum NetworkingCore.DotcomError
+import enum NetworkingCore.NetworkError
 import class Yosemite.OrderTotalsCalculator
 import struct WooFoundation.WooAnalyticsEvent
 import protocol WooFoundationCore.WooAnalyticsEventPropertyType
@@ -195,13 +197,79 @@ private extension PointOfSaleOrderController {
                 PointOfSaleOrderState.OrderStateError.MissingProductInfo(name: $0.name, quantity: $0.expectedQuantity)
             }
             return .missingProducts(missingProductInfo)
-        } else if let couponsError = CouponsError(underlyingError: error) {
+        }
+        // Check for server-side validation errors about invalid products/variations
+        else if let missingProductInfo = extractMissingProductsFromServerError(error) {
+            return .missingProducts(missingProductInfo)
+        }
+        else if let couponsError = CouponsError(underlyingError: error) {
             return .invalidCoupon(couponsError.message)
         } else if let afErrorDescription = (error as? AFError)?.underlyingError?.localizedDescription {
             return .other(afErrorDescription)
         } else {
             return .other(error.localizedDescription)
         }
+    }
+
+    /// Extracts missing product information from server validation errors
+    /// Handles cases where the server rejects order creation due to invalid product/variation IDs
+    func extractMissingProductsFromServerError(_ error: Error) -> [PointOfSaleOrderState.OrderStateError.MissingProductInfo]? {
+        // Check if this is an AFError wrapping a DotcomError or NetworkError
+        let underlyingError: Error? = {
+            if let afError = error as? AFError {
+                return afError.underlyingError
+            }
+            return error
+        }()
+
+        // Check for DotcomError with product/variation validation error codes
+        if case .unknown(let code, let message) = underlyingError as? DotcomError {
+            if isProductValidationError(code: code) {
+                // Try to extract product names from cart since server doesn't return which specific product failed
+                return extractMissingProductsFromCart()
+            }
+        }
+
+        // Check for NetworkError with product/variation validation error codes
+        if let networkError = underlyingError as? NetworkError,
+           let errorCode = networkError.errorCode,
+           isProductValidationError(code: errorCode) {
+            return extractMissingProductsFromCart()
+        }
+
+        return nil
+    }
+
+    /// Checks if an error code indicates a product validation error
+    /// Currently only handles the confirmed error code from WooCommerce server responses
+    private func isProductValidationError(code: String) -> Bool {
+        // Only check for the one confirmed error code we've observed
+        // Additional codes can be added as they are discovered through testing
+        return code == "order_item_product_invalid_variation_id"
+    }
+
+    /// Extracts missing products by trying to identify items in cart that might have caused the validation error
+    /// Since server doesn't tell us which specific products failed, we return generic error info
+    private func extractMissingProductsFromCart() -> [PointOfSaleOrderState.OrderStateError.MissingProductInfo]? {
+        // We can't determine which specific products are invalid from the server error
+        // So we return a generic missing product message
+        // The user will need to remove products and retry to identify the problematic ones
+        return [
+            PointOfSaleOrderState.OrderStateError.MissingProductInfo(
+                name: Localization.unknownProductName,
+                quantity: 1
+            )
+        ]
+    }
+}
+
+private extension PointOfSaleOrderController {
+    enum Localization {
+        static let unknownProductName = NSLocalizedString(
+            "pointOfSale.orderController.unknownProduct",
+            value: "One or more products",
+            comment: "Generic product name used when we can't identify which specific product is unavailable"
+        )
     }
 }
 
@@ -269,6 +337,8 @@ private extension PointOfSaleOrderController {
         if let _ = CouponsError(underlyingError: error) {
             errorType = .invalidCoupon
         } else if case .missingProductsInOrder = error as? POSOrderService.POSOrderServiceError {
+            errorType = .missingProducts
+        } else if extractMissingProductsFromServerError(error) != nil {
             errorType = .missingProducts
         }
 

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
@@ -12,6 +12,7 @@ import struct Yosemite.Order
 import struct Yosemite.POSCart
 import struct Yosemite.POSCartItem
 import struct Yosemite.POSCoupon
+import struct Yosemite.POSVariation
 import struct Yosemite.CouponsError
 import enum Yosemite.OrderAction
 import enum Yosemite.OrderUpdateField
@@ -22,8 +23,9 @@ import class Yosemite.PluginsService
 import enum WooFoundation.CurrencyCode
 import protocol WooFoundation.Analytics
 import enum Alamofire.AFError
-import enum NetworkingCore.DotcomError
-import enum NetworkingCore.NetworkError
+import enum Networking.DotcomError
+import enum Networking.NetworkError
+import struct Networking.AnyDecodable
 import class Yosemite.OrderTotalsCalculator
 import struct WooFoundation.WooAnalyticsEvent
 import protocol WooFoundationCore.WooAnalyticsEventPropertyType
@@ -97,15 +99,16 @@ protocol PointOfSaleOrderControllerProtocol {
             return .success(.newOrder)
         } catch {
             self.order = nil
-            trackOrderCreationFailed(error: error)
-            setOrderStateToError(error, retryHandler: retryHandler)
+            trackOrderCreationFailed(error: error, cart: posCart)
+            setOrderStateToError(error, cart: posCart, retryHandler: retryHandler)
             return .failure(SyncOrderStateError.syncFailure)
         }
     }
 
     private func setOrderStateToError(_ error: Error,
+                                      cart: POSCart,
                                       retryHandler: @escaping () async -> Void) {
-        orderState = .error(orderStateError(from: error), {
+        orderState = .error(orderStateError(from: error, cart: cart), {
             Task {
                 await retryHandler()
             }
@@ -190,7 +193,7 @@ private extension PointOfSaleOrderController {
 // MARK: - Error Handling
 
 private extension PointOfSaleOrderController {
-    func orderStateError(from error: Error) -> PointOfSaleOrderState.OrderStateError {
+    func orderStateError(from error: Error, cart: POSCart) -> PointOfSaleOrderState.OrderStateError {
         // Check for missing products error first
         if case .missingProductsInOrder(let missingItems) = error as? POSOrderService.POSOrderServiceError {
             let missingProductInfo = missingItems.map {
@@ -204,7 +207,7 @@ private extension PointOfSaleOrderController {
             return .missingProducts(missingProductInfo)
         }
         // Check for server-side validation errors about invalid products/variations
-        else if let missingProductInfo = extractMissingProductsFromServerError(error) {
+        else if let missingProductInfo = extractMissingProductsFromServerError(error, cart: cart) {
             return .missingProducts(missingProductInfo)
         }
         else if let couponsError = CouponsError(underlyingError: error) {
@@ -218,7 +221,7 @@ private extension PointOfSaleOrderController {
 
     /// Extracts missing product information from server validation errors
     /// Handles cases where the server rejects order creation due to invalid product/variation IDs
-    func extractMissingProductsFromServerError(_ error: Error) -> [PointOfSaleOrderState.OrderStateError.MissingProductInfo]? {
+    func extractMissingProductsFromServerError(_ error: Error, cart: POSCart) -> [PointOfSaleOrderState.OrderStateError.MissingProductInfo]? {
         // Check if this is an AFError wrapping a DotcomError or NetworkError
         let underlyingError: Error? = {
             if let afError = error as? AFError {
@@ -228,9 +231,9 @@ private extension PointOfSaleOrderController {
         }()
 
         // Check for DotcomError with product/variation validation error codes
-        if case .unknown(let code, let message) = underlyingError as? DotcomError {
+        if case .unknown(let code, _) = underlyingError as? DotcomError {
             if isProductValidationError(code: code) {
-                // Try to extract product names from cart since server doesn't return which specific product failed
+                // DotcomError doesn't include data field, fall back to generic error
                 return extractMissingProductsFromCart()
             }
         }
@@ -239,10 +242,66 @@ private extension PointOfSaleOrderController {
         if let networkError = underlyingError as? NetworkError,
            let errorCode = networkError.errorCode,
            isProductValidationError(code: errorCode) {
+            // Try to extract variation_id from NetworkError data if available
+            if let variationID = extractVariationID(from: networkError.errorData) {
+                return createMissingProductInfo(forVariationID: variationID, cart: cart)
+            }
+            // Fall back to generic error if no variation_id in data
             return extractMissingProductsFromCart()
         }
 
         return nil
+    }
+
+    /// Extracts variation_id from error data dictionary
+    private func extractVariationID(from data: [String: AnyDecodable]?) -> Int64? {
+        guard let data = data,
+              let variationIDValue = data["variation_id"]?.value else {
+            return nil
+        }
+
+        // Handle different number types
+        if let intValue = variationIDValue as? Int {
+            return Int64(intValue)
+        } else if let int64Value = variationIDValue as? Int64 {
+            return int64Value
+        }
+        return nil
+    }
+
+    /// Creates MissingProductInfo for a specific variation ID
+    /// Searches the cart to find the variation's name and parent product ID
+    private func createMissingProductInfo(forVariationID variationID: Int64, cart: POSCart) -> [PointOfSaleOrderState.OrderStateError.MissingProductInfo] {
+        // Search the cart for the variation to get its name
+        let cartItem = cart.items.first { item in
+            if let variation = item.item as? POSVariation {
+                return variation.productVariationID == variationID
+            }
+            return false
+        }
+
+        let productName: String
+        let parentProductID: Int64
+
+        if let cartItem = cartItem,
+           let variation = cartItem.item as? POSVariation {
+            // Found the variation in the cart - use its parent product name and variation name
+            productName = "\(variation.parentProductName) - \(variation.name)"
+            parentProductID = variation.productID
+        } else {
+            // Couldn't find it in cart, use generic name
+            productName = Localization.unknownProductName
+            parentProductID = 0
+        }
+
+        return [
+            PointOfSaleOrderState.OrderStateError.MissingProductInfo(
+                productID: parentProductID,
+                variationID: variationID,
+                name: productName,
+                quantity: 1
+            )
+        ]
     }
 
     /// Checks if an error code indicates a product validation error
@@ -338,14 +397,14 @@ extension PointOfSaleOrderController {
 
 
 private extension PointOfSaleOrderController {
-    func trackOrderCreationFailed(error: Error) {
+    func trackOrderCreationFailed(error: Error, cart: POSCart) {
         var errorType: WooAnalyticsEvent.Orders.OrderCreationErrorType?
 
         if let _ = CouponsError(underlyingError: error) {
             errorType = .invalidCoupon
         } else if case .missingProductsInOrder = error as? POSOrderService.POSOrderServiceError {
             errorType = .missingProducts
-        } else if extractMissingProductsFromServerError(error) != nil {
+        } else if extractMissingProductsFromServerError(error, cart: cart) != nil {
             errorType = .missingProducts
         }
 

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
@@ -3,6 +3,7 @@ import Observation
 import protocol Experiments.FeatureFlagService
 import class WooFoundation.VersionHelpers
 import protocol Yosemite.POSOrderServiceProtocol
+import class Yosemite.POSOrderService
 import protocol Yosemite.POSReceiptServiceProtocol
 import protocol Yosemite.PluginsServiceProtocol
 import protocol Yosemite.PaymentCaptureCelebrationProtocol
@@ -188,7 +189,13 @@ private extension PointOfSaleOrderController {
 
 private extension PointOfSaleOrderController {
     func orderStateError(from error: Error) -> PointOfSaleOrderState.OrderStateError {
-        if let couponsError = CouponsError(underlyingError: error) {
+        // Check for missing products error first
+        if case .missingProductsInOrder(let missingItems) = error as? POSOrderService.POSOrderServiceError {
+            let missingProductInfo = missingItems.map {
+                PointOfSaleOrderState.OrderStateError.MissingProductInfo(name: $0.name, quantity: $0.expectedQuantity)
+            }
+            return .missingProducts(missingProductInfo)
+        } else if let couponsError = CouponsError(underlyingError: error) {
             return .invalidCoupon(couponsError.message)
         } else if let afErrorDescription = (error as? AFError)?.underlyingError?.localizedDescription {
             return .other(afErrorDescription)
@@ -261,6 +268,8 @@ private extension PointOfSaleOrderController {
 
         if let _ = CouponsError(underlyingError: error) {
             errorType = .invalidCoupon
+        } else if case .missingProductsInOrder = error as? POSOrderService.POSOrderServiceError {
+            errorType = .missingProducts
         }
 
         analytics.track(event: WooAnalyticsEvent.Orders.orderCreationFailed(
@@ -290,9 +299,9 @@ private extension WooAnalyticsEvent {
         // MARK: - Order Creation Events
 
         /// Matches errors on Android for consistency
-        /// Only coupon tracking is relevant for now
         enum OrderCreationErrorType: String {
             case invalidCoupon = "INVALID_COUPON"
+            case missingProducts = "MISSING_PRODUCTS"
         }
 
         static func orderCreationFailed(

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
@@ -95,16 +95,15 @@ protocol PointOfSaleOrderControllerProtocol {
             return .success(.newOrder)
         } catch {
             self.order = nil
-            trackOrderCreationFailed(error: error, cart: posCart)
-            setOrderStateToError(error, cart: posCart, retryHandler: retryHandler)
+            trackOrderCreationFailed(error: error)
+            setOrderStateToError(error, retryHandler: retryHandler)
             return .failure(SyncOrderStateError.syncFailure)
         }
     }
 
     private func setOrderStateToError(_ error: Error,
-                                      cart: POSCart,
                                       retryHandler: @escaping () async -> Void) {
-        orderState = .error(orderStateError(from: error, cart: cart), {
+        orderState = .error(orderStateError(from: error), {
             Task {
                 await retryHandler()
             }
@@ -189,7 +188,7 @@ private extension PointOfSaleOrderController {
 // MARK: - Error Handling
 
 private extension PointOfSaleOrderController {
-    func orderStateError(from error: Error, cart: POSCart) -> PointOfSaleOrderState.OrderStateError {
+    func orderStateError(from error: Error) -> PointOfSaleOrderState.OrderStateError {
         // Check for missing products error first
         if case .missingProductsInOrder(let missingItems) = error as? POSOrderService.POSOrderServiceError {
             let missingProductInfo = missingItems.map {
@@ -266,7 +265,7 @@ extension PointOfSaleOrderController {
 
 
 private extension PointOfSaleOrderController {
-    func trackOrderCreationFailed(error: Error, cart: POSCart) {
+    func trackOrderCreationFailed(error: Error) {
         var errorType: WooAnalyticsEvent.Orders.OrderCreationErrorType?
 
         if let _ = CouponsError(underlyingError: error) {

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
@@ -194,7 +194,12 @@ private extension PointOfSaleOrderController {
         // Check for missing products error first
         if case .missingProductsInOrder(let missingItems) = error as? POSOrderService.POSOrderServiceError {
             let missingProductInfo = missingItems.map {
-                PointOfSaleOrderState.OrderStateError.MissingProductInfo(id: $0.id, name: $0.name, quantity: $0.expectedQuantity)
+                PointOfSaleOrderState.OrderStateError.MissingProductInfo(
+                    productID: $0.productID,
+                    variationID: $0.variationID,
+                    name: $0.name,
+                    quantity: $0.expectedQuantity
+                )
             }
             return .missingProducts(missingProductInfo)
         }
@@ -252,11 +257,12 @@ private extension PointOfSaleOrderController {
     /// Since server doesn't tell us which specific products failed, we return generic error info
     private func extractMissingProductsFromCart() -> [PointOfSaleOrderState.OrderStateError.MissingProductInfo]? {
         // We can't determine which specific products are invalid from the server error
-        // So we return a generic missing product message with no ID
-        // The user will need to remove products and retry to identify the problematic ones
+        // So we return a generic missing product message with 0 for both IDs (meaning unknown)
+        // The user will need to remove all products and retry
         return [
             PointOfSaleOrderState.OrderStateError.MissingProductInfo(
-                id: nil,
+                productID: 0,
+                variationID: 0,
                 name: Localization.unknownProductName,
                 quantity: 1
             )

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
@@ -194,7 +194,7 @@ private extension PointOfSaleOrderController {
         // Check for missing products error first
         if case .missingProductsInOrder(let missingItems) = error as? POSOrderService.POSOrderServiceError {
             let missingProductInfo = missingItems.map {
-                PointOfSaleOrderState.OrderStateError.MissingProductInfo(name: $0.name, quantity: $0.expectedQuantity)
+                PointOfSaleOrderState.OrderStateError.MissingProductInfo(id: $0.id, name: $0.name, quantity: $0.expectedQuantity)
             }
             return .missingProducts(missingProductInfo)
         }
@@ -252,10 +252,11 @@ private extension PointOfSaleOrderController {
     /// Since server doesn't tell us which specific products failed, we return generic error info
     private func extractMissingProductsFromCart() -> [PointOfSaleOrderState.OrderStateError.MissingProductInfo]? {
         // We can't determine which specific products are invalid from the server error
-        // So we return a generic missing product message
+        // So we return a generic missing product message with no ID
         // The user will need to remove products and retry to identify the problematic ones
         return [
             PointOfSaleOrderState.OrderStateError.MissingProductInfo(
+                id: nil,
                 name: Localization.unknownProductName,
                 quantity: 1
             )

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -219,19 +219,7 @@ extension PointOfSaleAggregateModel {
     /// Removes identified missing products from the catalog only (not from cart)
     /// - Parameter missingProducts: Array of missing product info
     private func removeIdentifiedMissingProductsFromCatalog(_ missingProducts: [PointOfSaleOrderState.OrderStateError.MissingProductInfo]) async {
-        // Extract product and variation IDs from missing products
-        var productIDs = Set<Int64>()
-        var variationIDs = Set<Int64>()
-
-        for missingProduct in missingProducts {
-            // Only process items where we can identify specific products (not 0,0)
-            if missingProduct.variationID != 0 {
-                variationIDs.insert(missingProduct.variationID)
-            } else if missingProduct.productID != 0 {
-                productIDs.insert(missingProduct.productID)
-            }
-            // Skip items with both IDs as 0 (generic errors where we can't identify the product)
-        }
+        let (productIDs, variationIDs) = missingProducts.extractProductAndVariationIDs()
 
         // Remove from local catalog only if we have identifiable products
         guard !productIDs.isEmpty || !variationIDs.isEmpty else { return }
@@ -675,13 +663,13 @@ extension PointOfSaleAggregateModel {
             await self?.checkOut()
         })
         trackOrderSyncState(syncOrderResult)
-        await handlePostSyncCleanup()
+        await removeMissingProductsFromCatalogAfterSync()
         await startPaymentWhenCardReaderConnected()
     }
 
-    /// Handles cleanup operations after order sync, such as removing unavailable products from the catalog
+    /// Removes unavailable products from the local catalog after detecting them during order sync
     @MainActor
-    private func handlePostSyncCleanup() async {
+    private func removeMissingProductsFromCatalogAfterSync() async {
         // If we identified specific missing products, remove them from the catalog immediately
         if case .error(.missingProducts(let missingProducts), _) = orderController.orderState.externalState {
             await removeIdentifiedMissingProductsFromCatalog(missingProducts)

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -17,6 +17,8 @@ import enum Yosemite.PointOfSaleBarcodeScanError
 import protocol Yosemite.POSCatalogSyncCoordinatorProtocol
 import class Yosemite.POSCatalogSyncCoordinator
 import enum Yosemite.CardReaderSoftwareUpdateState
+import struct Yosemite.POSSimpleProduct
+import struct Yosemite.POSVariation
 
 protocol PointOfSaleAggregateModelProtocol {
     var cart: Cart { get }
@@ -192,6 +194,49 @@ extension PointOfSaleAggregateModel {
         orderStage = .building
         paymentState = .idle
         cardPresentPaymentInlineMessage = nil
+    }
+
+    /// Removes missing products from both the cart and the local catalog
+    /// - Parameter missingProductIDs: UUIDs of cart items to remove
+    func removeMissingProductsFromCatalog(missingProductIDs: Set<UUID>) async {
+        // Extract product and variation IDs from cart items before removing them
+        var productIDsToDelete: [Int64] = []
+        var variationIDsToDelete: [Int64] = []
+
+        for item in cart.purchasableItems {
+            guard case .loaded(let orderableItem) = item.state,
+                  missingProductIDs.contains(orderableItem.id) else {
+                continue
+            }
+
+            // Check if it's a simple product or variation by trying to cast
+            if let simpleProduct = orderableItem as? POSSimpleProduct {
+                productIDsToDelete.append(simpleProduct.productID)
+            } else if let variation = orderableItem as? POSVariation {
+                variationIDsToDelete.append(variation.productVariationID)
+            }
+        }
+
+        // Remove items from cart
+        cart.purchasableItems.removeAll { item in
+            guard case .loaded(let orderableItem) = item.state else { return false }
+            return missingProductIDs.contains(orderableItem.id)
+        }
+
+        // Remove from local catalog if we have the coordinator
+        if let catalogSyncCoordinator,
+           !productIDsToDelete.isEmpty || !variationIDsToDelete.isEmpty {
+            do {
+                try await catalogSyncCoordinator.deleteProductsFromCatalog(
+                    productIDsToDelete,
+                    variationIDs: variationIDsToDelete,
+                    siteID: siteID
+                )
+                DDLogInfo("🗑️ Removed \(productIDsToDelete.count) products and \(variationIDsToDelete.count) variations from local catalog")
+            } catch {
+                DDLogError("⚠️ Failed to remove products from local catalog: \(error)")
+            }
+        }
     }
 }
 

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -197,42 +197,35 @@ extension PointOfSaleAggregateModel {
     }
 
     /// Removes missing products from both the cart and the local catalog
-    /// - Parameter missingProductIDs: UUIDs of cart items to remove
-    func removeMissingProductsFromCatalog(missingProductIDs: Set<UUID>) async {
-        // Extract product and variation IDs from cart items before removing them
-        var productIDsToDelete: [Int64] = []
-        var variationIDsToDelete: [Int64] = []
-
-        for item in cart.purchasableItems {
-            guard case .loaded(let orderableItem) = item.state,
-                  missingProductIDs.contains(orderableItem.id) else {
-                continue
-            }
-
-            // Check if it's a simple product or variation by trying to cast
-            if let simpleProduct = orderableItem as? POSSimpleProduct {
-                productIDsToDelete.append(simpleProduct.productID)
-            } else if let variation = orderableItem as? POSVariation {
-                variationIDsToDelete.append(variation.productVariationID)
-            }
-        }
-
-        // Remove items from cart
+    /// - Parameters:
+    ///   - productIDs: Product IDs to remove (for simple products)
+    ///   - variationIDs: Variation IDs to remove (for variations)
+    func removeMissingProductsFromCatalog(productIDs: Set<Int64>, variationIDs: Set<Int64>) async {
+        // Remove items from cart matching these product/variation IDs
         cart.purchasableItems.removeAll { item in
             guard case .loaded(let orderableItem) = item.state else { return false }
-            return missingProductIDs.contains(orderableItem.id)
+
+            // Check if it's a simple product matching the product IDs
+            if let simpleProduct = orderableItem as? POSSimpleProduct {
+                return productIDs.contains(simpleProduct.productID)
+            }
+            // Check if it's a variation matching the variation IDs
+            else if let variation = orderableItem as? POSVariation {
+                return variationIDs.contains(variation.productVariationID)
+            }
+            return false
         }
 
         // Remove from local catalog if we have the coordinator
         if let catalogSyncCoordinator,
-           !productIDsToDelete.isEmpty || !variationIDsToDelete.isEmpty {
+           !productIDs.isEmpty || !variationIDs.isEmpty {
             do {
                 try await catalogSyncCoordinator.deleteProductsFromCatalog(
-                    productIDsToDelete,
-                    variationIDs: variationIDsToDelete,
+                    Array(productIDs),
+                    variationIDs: Array(variationIDs),
                     siteID: siteID
                 )
-                DDLogInfo("🗑️ Removed \(productIDsToDelete.count) products and \(variationIDsToDelete.count) variations from local catalog")
+                DDLogInfo("🗑️ Removed \(productIDs.count) products and \(variationIDs.count) variations from local catalog")
             } catch {
                 DDLogError("⚠️ Failed to remove products from local catalog: \(error)")
             }

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -196,6 +196,26 @@ extension PointOfSaleAggregateModel {
         cardPresentPaymentInlineMessage = nil
     }
 
+    /// Removes missing products from the cart only (catalog is auto-cleaned when errors are detected)
+    /// - Parameters:
+    ///   - productIDs: Product IDs to remove (for simple products)
+    ///   - variationIDs: Variation IDs to remove (for variations)
+    func removeMissingProductsFromCart(productIDs: Set<Int64>, variationIDs: Set<Int64>) {
+        cart.purchasableItems.removeAll { item in
+            guard case .loaded(let orderableItem) = item.state else { return false }
+
+            // Check if it's a simple product matching the product IDs
+            if let simpleProduct = orderableItem as? POSSimpleProduct {
+                return productIDs.contains(simpleProduct.productID)
+            }
+            // Check if it's a variation matching the variation IDs
+            else if let variation = orderableItem as? POSVariation {
+                return variationIDs.contains(variation.productVariationID)
+            }
+            return false
+        }
+    }
+
     /// Removes missing products from both the cart and the local catalog
     /// - Parameters:
     ///   - productIDs: Product IDs to remove (for simple products)
@@ -228,6 +248,40 @@ extension PointOfSaleAggregateModel {
                 DDLogInfo("🗑️ Removed \(productIDs.count) products and \(variationIDs.count) variations from local catalog")
             } catch {
                 DDLogError("⚠️ Failed to remove products from local catalog: \(error)")
+            }
+        }
+    }
+
+    /// Removes identified missing products from the catalog only (not from cart)
+    /// - Parameter missingProducts: Array of missing product info
+    private func removeIdentifiedMissingProductsFromCatalog(_ missingProducts: [PointOfSaleOrderState.OrderStateError.MissingProductInfo]) async {
+        // Extract product and variation IDs from missing products
+        var productIDs = Set<Int64>()
+        var variationIDs = Set<Int64>()
+
+        for missingProduct in missingProducts {
+            // Only process items where we can identify specific products (not 0,0)
+            if missingProduct.variationID != 0 {
+                variationIDs.insert(missingProduct.variationID)
+            } else if missingProduct.productID != 0 {
+                productIDs.insert(missingProduct.productID)
+            }
+            // Skip items with both IDs as 0 (generic errors where we can't identify the product)
+        }
+
+        // Remove from local catalog only if we have identifiable products
+        guard !productIDs.isEmpty || !variationIDs.isEmpty else { return }
+
+        if let catalogSyncCoordinator {
+            do {
+                try await catalogSyncCoordinator.deleteProductsFromCatalog(
+                    Array(productIDs),
+                    variationIDs: Array(variationIDs),
+                    siteID: siteID
+                )
+                DDLogInfo("🗑️ Auto-removed \(productIDs.count) products and \(variationIDs.count) variations from local catalog (unavailable items)")
+            } catch {
+                DDLogError("⚠️ Failed to auto-remove unavailable products from local catalog: \(error)")
             }
         }
     }
@@ -657,6 +711,12 @@ extension PointOfSaleAggregateModel {
             await self?.checkOut()
         })
         trackOrderSyncState(syncOrderResult)
+
+        // If we identified specific missing products, remove them from the catalog immediately
+        if case .error(.missingProducts(let missingProducts), _) = orderController.orderState.externalState {
+            await removeIdentifiedMissingProductsFromCatalog(missingProducts)
+        }
+
         await startPaymentWhenCardReaderConnected()
     }
 }

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -675,13 +675,17 @@ extension PointOfSaleAggregateModel {
             await self?.checkOut()
         })
         trackOrderSyncState(syncOrderResult)
+        await handlePostSyncCleanup()
+        await startPaymentWhenCardReaderConnected()
+    }
 
+    /// Handles cleanup operations after order sync, such as removing unavailable products from the catalog
+    @MainActor
+    private func handlePostSyncCleanup() async {
         // If we identified specific missing products, remove them from the catalog immediately
         if case .error(.missingProducts(let missingProducts), _) = orderController.orderState.externalState {
             await removeIdentifiedMissingProductsFromCatalog(missingProducts)
         }
-
-        await startPaymentWhenCardReaderConnected()
     }
 }
 

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -216,42 +216,6 @@ extension PointOfSaleAggregateModel {
         }
     }
 
-    /// Removes missing products from both the cart and the local catalog
-    /// - Parameters:
-    ///   - productIDs: Product IDs to remove (for simple products)
-    ///   - variationIDs: Variation IDs to remove (for variations)
-    func removeMissingProductsFromCatalog(productIDs: Set<Int64>, variationIDs: Set<Int64>) async {
-        // Remove items from cart matching these product/variation IDs
-        cart.purchasableItems.removeAll { item in
-            guard case .loaded(let orderableItem) = item.state else { return false }
-
-            // Check if it's a simple product matching the product IDs
-            if let simpleProduct = orderableItem as? POSSimpleProduct {
-                return productIDs.contains(simpleProduct.productID)
-            }
-            // Check if it's a variation matching the variation IDs
-            else if let variation = orderableItem as? POSVariation {
-                return variationIDs.contains(variation.productVariationID)
-            }
-            return false
-        }
-
-        // Remove from local catalog if we have the coordinator
-        if let catalogSyncCoordinator,
-           !productIDs.isEmpty || !variationIDs.isEmpty {
-            do {
-                try await catalogSyncCoordinator.deleteProductsFromCatalog(
-                    Array(productIDs),
-                    variationIDs: Array(variationIDs),
-                    siteID: siteID
-                )
-                DDLogInfo("🗑️ Removed \(productIDs.count) products and \(variationIDs.count) variations from local catalog")
-            } catch {
-                DDLogError("⚠️ Failed to remove products from local catalog: \(error)")
-            }
-        }
-    }
-
     /// Removes identified missing products from the catalog only (not from cart)
     /// - Parameter missingProducts: Array of missing product info
     private func removeIdentifiedMissingProductsFromCatalog(_ missingProducts: [PointOfSaleOrderState.OrderStateError.MissingProductInfo]) async {

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
@@ -73,3 +73,27 @@ enum PointOfSaleOrderState: Equatable {
         }
     }
 }
+
+// MARK: - Missing Product Helpers
+extension Array where Element == PointOfSaleOrderState.OrderStateError.MissingProductInfo {
+    /// Extracts product and variation IDs from missing product info
+    /// Returns a tuple of (productIDs, variationIDs) containing only non-zero IDs
+    func extractProductAndVariationIDs() -> (productIDs: Set<Int64>, variationIDs: Set<Int64>) {
+        var productIDs = Set<Int64>()
+        var variationIDs = Set<Int64>()
+
+        for missingProduct in self {
+            // If variationID is non-zero, it's a variation
+            if missingProduct.variationID != 0 {
+                variationIDs.insert(missingProduct.variationID)
+            }
+            // If productID is non-zero (and variationID is zero), it's a simple product
+            else if missingProduct.productID != 0 {
+                productIDs.insert(missingProduct.productID)
+            }
+            // Skip items with both IDs as 0 (generic errors where we can't identify the product)
+        }
+
+        return (productIDs, variationIDs)
+    }
+}

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
@@ -17,7 +17,7 @@ enum PointOfSaleOrderState: Equatable {
             let productID: Int64
             let variationID: Int64
             let name: String
-            let quantity: Decimal // periphery:ignore - Part of public API for future use
+            let quantity: Decimal // periphery:ignore
         }
 
         static func == (lhs: OrderStateError, rhs: OrderStateError) -> Bool {

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
@@ -14,6 +14,7 @@ enum PointOfSaleOrderState: Equatable {
         case missingProducts([MissingProductInfo])
 
         struct MissingProductInfo: Equatable {
+            let id: UUID?
             let name: String
             let quantity: Decimal
         }

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
@@ -11,6 +11,12 @@ enum PointOfSaleOrderState: Equatable {
     enum OrderStateError: Equatable {
         case other(String)
         case invalidCoupon(String)
+        case missingProducts([MissingProductInfo])
+
+        struct MissingProductInfo: Equatable {
+            let name: String
+            let quantity: Decimal
+        }
 
         static func == (lhs: OrderStateError, rhs: OrderStateError) -> Bool {
             switch (lhs, rhs) {
@@ -18,6 +24,8 @@ enum PointOfSaleOrderState: Equatable {
                 return lhsError == rhsError
             case (.invalidCoupon(let lhsCoupon), .invalidCoupon(let rhsCoupon)):
                 return lhsCoupon == rhsCoupon
+            case (.missingProducts(let lhsProducts), .missingProducts(let rhsProducts)):
+                return lhsProducts == rhsProducts
             default:
                 return false
             }

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
@@ -17,8 +17,6 @@ enum PointOfSaleOrderState: Equatable {
             let productID: Int64
             let variationID: Int64
             let name: String
-            // periphery:ignore - part of public API
-            let quantity: Decimal
         }
 
         static func == (lhs: OrderStateError, rhs: OrderStateError) -> Bool {

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
@@ -17,7 +17,7 @@ enum PointOfSaleOrderState: Equatable {
             let productID: Int64
             let variationID: Int64
             let name: String
-            // periphery:ignore
+            // periphery:ignore - part of public API
             let quantity: Decimal
         }
 

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
@@ -17,7 +17,8 @@ enum PointOfSaleOrderState: Equatable {
             let productID: Int64
             let variationID: Int64
             let name: String
-            let quantity: Decimal // periphery:ignore
+            // periphery:ignore
+            let quantity: Decimal
         }
 
         static func == (lhs: OrderStateError, rhs: OrderStateError) -> Bool {

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
@@ -14,7 +14,8 @@ enum PointOfSaleOrderState: Equatable {
         case missingProducts([MissingProductInfo])
 
         struct MissingProductInfo: Equatable {
-            let id: UUID?
+            let productID: Int64
+            let variationID: Int64
             let name: String
             let quantity: Decimal
         }

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
@@ -17,7 +17,7 @@ enum PointOfSaleOrderState: Equatable {
             let productID: Int64
             let variationID: Int64
             let name: String
-            let quantity: Decimal
+            let quantity: Decimal // periphery:ignore - Part of public API for future use
         }
 
         static func == (lhs: OrderStateError, rhs: OrderStateError) -> Bool {

--- a/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
@@ -41,10 +41,8 @@ struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
                                         sourceView: .error,
                                         itemType: .product
                                     ))
-                                Task {
-                                    await removeMissingProductsFromCart()
-                                    retryHandler()
-                                }
+                                removeMissingProductsFromCart()
+                                retryHandler()
                             })
                             .buttonStyle(POSOutlinedButtonStyle(size: .normal))
                         }
@@ -94,7 +92,7 @@ struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
         return !missingProducts.allSatisfy { $0.productID == 0 && $0.variationID == 0 }
     }
 
-    private func removeMissingProductsFromCart() async {
+    private func removeMissingProductsFromCart() {
         // Extract product and variation IDs from missing products
         var productIDs = Set<Int64>()
         var variationIDs = Set<Int64>()
@@ -111,8 +109,8 @@ struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
             // Skip items with both IDs as 0 (shouldn't happen since button is hidden for those)
         }
 
-        // Remove items from cart and local catalog
-        await posModel.removeMissingProductsFromCatalog(productIDs: productIDs, variationIDs: variationIDs)
+        // Remove items from cart only (catalog was already cleaned up when error was detected)
+        posModel.removeMissingProductsFromCart(productIDs: productIDs, variationIDs: variationIDs)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
@@ -1,19 +1,14 @@
 import SwiftUI
 
-public struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
+struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
     let missingProducts: [PointOfSaleOrderState.OrderStateError.MissingProductInfo]
     let retryHandler: () -> Void
-
-    public init(missingProducts: [PointOfSaleOrderState.OrderStateError.MissingProductInfo], retryHandler: @escaping () -> Void) {
-        self.missingProducts = missingProducts
-        self.retryHandler = retryHandler
-    }
 
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
     @Environment(\.posAnalytics) private var analytics
 
-    public var body: some View {
+    var body: some View {
         GeometryReader { geometry in
             HStack(alignment: .center) {
                 Spacer()

--- a/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
@@ -85,18 +85,29 @@ struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
     }
 
     private func removeMissingProductsFromCart() async {
-        // Check if we have IDs available (client-side detection) or generic error (server-side)
-        let missingProductIDs = Set(missingProducts.compactMap { $0.id })
+        // Extract product and variation IDs from missing products
+        var productIDs = Set<Int64>()
+        var variationIDs = Set<Int64>()
 
-        // If we have no IDs (server-side error), remove all purchasable items
-        // since we can't determine which specific product is problematic
-        if missingProductIDs.isEmpty {
-            posModel.removeAllItemsFromCart(types: [.purchasableItem])
-            return
+        for missingProduct in missingProducts {
+            // If both IDs are 0, it's a server-side error and we can't identify specific products
+            if missingProduct.productID == 0 && missingProduct.variationID == 0 {
+                // Remove all purchasable items since we can't determine which specific product is problematic
+                posModel.removeAllItemsFromCart(types: [.purchasableItem])
+                return
+            }
+
+            // If variationID is non-zero, it's a variation
+            if missingProduct.variationID != 0 {
+                variationIDs.insert(missingProduct.variationID)
+            } else {
+                // Otherwise it's a simple product
+                productIDs.insert(missingProduct.productID)
+            }
         }
 
         // Remove items from cart and local catalog
-        await posModel.removeMissingProductsFromCatalog(missingProductIDs: missingProductIDs)
+        await posModel.removeMissingProductsFromCatalog(productIDs: productIDs, variationIDs: variationIDs)
     }
 }
 
@@ -163,7 +174,7 @@ private extension PointOfSaleOrderSyncMissingProductsErrorMessageView {
 #Preview("Single Missing Product") {
     PointOfSaleOrderSyncMissingProductsErrorMessageView(
         missingProducts: [
-            PointOfSaleOrderState.OrderStateError.MissingProductInfo(id: UUID(), name: "Blue T-Shirt", quantity: 2)
+            PointOfSaleOrderState.OrderStateError.MissingProductInfo(productID: 100, variationID: 0, name: "Blue T-Shirt", quantity: 2)
         ],
         retryHandler: {}
     )
@@ -173,8 +184,8 @@ private extension PointOfSaleOrderSyncMissingProductsErrorMessageView {
 #Preview("Multiple Missing Products") {
     PointOfSaleOrderSyncMissingProductsErrorMessageView(
         missingProducts: [
-            PointOfSaleOrderState.OrderStateError.MissingProductInfo(id: UUID(), name: "Blue T-Shirt", quantity: 2),
-            PointOfSaleOrderState.OrderStateError.MissingProductInfo(id: UUID(), name: "Red Hat", quantity: 1)
+            PointOfSaleOrderState.OrderStateError.MissingProductInfo(productID: 100, variationID: 0, name: "Blue T-Shirt", quantity: 2),
+            PointOfSaleOrderState.OrderStateError.MissingProductInfo(productID: 0, variationID: 500, name: "Red Hat", quantity: 1)
         ],
         retryHandler: {}
     )

--- a/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
@@ -39,8 +39,10 @@ struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
                                     sourceView: .error,
                                     itemType: .product
                                 ))
-                            removeMissingProductsFromCart()
-                            retryHandler()
+                            Task {
+                                await removeMissingProductsFromCart()
+                                retryHandler()
+                            }
                         })
                         .buttonStyle(POSOutlinedButtonStyle(size: .normal))
                     }
@@ -82,7 +84,7 @@ struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
         }
     }
 
-    private func removeMissingProductsFromCart() {
+    private func removeMissingProductsFromCart() async {
         // Check if we have IDs available (client-side detection) or generic error (server-side)
         let missingProductIDs = Set(missingProducts.compactMap { $0.id })
 
@@ -93,15 +95,8 @@ struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
             return
         }
 
-        // Find and remove items from cart that match the missing product IDs
-        let itemsToRemove = posModel.cart.purchasableItems.filter { item in
-            guard case .loaded(let orderableItem) = item.state else { return false }
-            return missingProductIDs.contains(orderableItem.id)
-        }
-
-        for item in itemsToRemove {
-            posModel.remove(cartItem: item)
-        }
+        // Remove items from cart and local catalog
+        await posModel.removeMissingProductsFromCatalog(missingProductIDs: missingProductIDs)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
@@ -65,8 +65,10 @@ struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
     }
 
     private var subtitle: String {
-        if missingProducts.count == 1 {
-            return String(format: Localization.subtitleSingular, missingProducts.first?.name ?? "")
+        if missingProducts.count == 1,
+           let productName = missingProducts.first?.name,
+           productName != Localization.unknownProductName {
+            return String(format: Localization.subtitleSingular, productName)
         } else {
             return Localization.subtitlePlural
         }
@@ -82,6 +84,13 @@ struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
 
     private func removeMissingProductsFromCart() {
         let missingProductNames = Set(missingProducts.map { $0.name })
+
+        // If we have a generic error (unknown product), remove all purchasable items
+        // since we can't determine which specific product is problematic
+        if missingProductNames.contains(Localization.unknownProductName) {
+            posModel.removeAllItemsFromCart(types: [.purchasableItem])
+            return
+        }
 
         // Find and remove items from cart that match the missing product names
         let itemsToRemove = posModel.cart.purchasableItems.filter { item in
@@ -144,6 +153,12 @@ private extension PointOfSaleOrderSyncMissingProductsErrorMessageView {
             "pointOfSale.orderSync.missingProductsError.editOrder",
             value: "Edit order",
             comment: "Button to return to order editing when products are no longer available"
+        )
+
+        static let unknownProductName = NSLocalizedString(
+            "pointOfSale.orderSync.missingProductsError.unknownProductName",
+            value: "One or more products",
+            comment: "Generic product name used when we can't identify which specific product is unavailable"
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
@@ -34,17 +34,20 @@ struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
                         })
                         .buttonStyle(POSFilledButtonStyle(size: .normal))
 
-                        Button(removeProductsActionTitle, action: {
-                            analytics.track(event: .PointOfSale.itemRemovedFromCart(
-                                    sourceView: .error,
-                                    itemType: .product
-                                ))
-                            Task {
-                                await removeMissingProductsFromCart()
-                                retryHandler()
-                            }
-                        })
-                        .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+                        // Only show "Remove product" button if we can identify specific products
+                        if canIdentifySpecificProducts {
+                            Button(removeProductsActionTitle, action: {
+                                analytics.track(event: .PointOfSale.itemRemovedFromCart(
+                                        sourceView: .error,
+                                        itemType: .product
+                                    ))
+                                Task {
+                                    await removeMissingProductsFromCart()
+                                    retryHandler()
+                                }
+                            })
+                            .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+                        }
                     }
                     .frame(width: geometry.size.width / 2)
                     .padding([.leading, .trailing], Constants.buttonSidePadding)
@@ -84,26 +87,28 @@ struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
         }
     }
 
+    /// Returns true if we can identify specific products to remove
+    /// Returns false for generic errors where productID=0 and variationID=0
+    private var canIdentifySpecificProducts: Bool {
+        // If all missing products have both IDs as 0, we can't identify them
+        return !missingProducts.allSatisfy { $0.productID == 0 && $0.variationID == 0 }
+    }
+
     private func removeMissingProductsFromCart() async {
         // Extract product and variation IDs from missing products
         var productIDs = Set<Int64>()
         var variationIDs = Set<Int64>()
 
         for missingProduct in missingProducts {
-            // If both IDs are 0, it's a server-side error and we can't identify specific products
-            if missingProduct.productID == 0 && missingProduct.variationID == 0 {
-                // Remove all purchasable items since we can't determine which specific product is problematic
-                posModel.removeAllItemsFromCart(types: [.purchasableItem])
-                return
-            }
-
             // If variationID is non-zero, it's a variation
             if missingProduct.variationID != 0 {
                 variationIDs.insert(missingProduct.variationID)
-            } else {
-                // Otherwise it's a simple product
+            }
+            // If productID is non-zero (and variationID is zero), it's a simple product
+            else if missingProduct.productID != 0 {
                 productIDs.insert(missingProduct.productID)
             }
+            // Skip items with both IDs as 0 (shouldn't happen since button is hidden for those)
         }
 
         // Remove items from cart and local catalog

--- a/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
@@ -83,19 +83,20 @@ struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
     }
 
     private func removeMissingProductsFromCart() {
-        let missingProductNames = Set(missingProducts.map { $0.name })
+        // Check if we have IDs available (client-side detection) or generic error (server-side)
+        let missingProductIDs = Set(missingProducts.compactMap { $0.id })
 
-        // If we have a generic error (unknown product), remove all purchasable items
+        // If we have no IDs (server-side error), remove all purchasable items
         // since we can't determine which specific product is problematic
-        if missingProductNames.contains(Localization.unknownProductName) {
+        if missingProductIDs.isEmpty {
             posModel.removeAllItemsFromCart(types: [.purchasableItem])
             return
         }
 
-        // Find and remove items from cart that match the missing product names
+        // Find and remove items from cart that match the missing product IDs
         let itemsToRemove = posModel.cart.purchasableItems.filter { item in
             guard case .loaded(let orderableItem) = item.state else { return false }
-            return missingProductNames.contains(orderableItem.name)
+            return missingProductIDs.contains(orderableItem.id)
         }
 
         for item in itemsToRemove {
@@ -167,7 +168,7 @@ private extension PointOfSaleOrderSyncMissingProductsErrorMessageView {
 #Preview("Single Missing Product") {
     PointOfSaleOrderSyncMissingProductsErrorMessageView(
         missingProducts: [
-            PointOfSaleOrderState.OrderStateError.MissingProductInfo(name: "Blue T-Shirt", quantity: 2)
+            PointOfSaleOrderState.OrderStateError.MissingProductInfo(id: UUID(), name: "Blue T-Shirt", quantity: 2)
         ],
         retryHandler: {}
     )
@@ -177,8 +178,8 @@ private extension PointOfSaleOrderSyncMissingProductsErrorMessageView {
 #Preview("Multiple Missing Products") {
     PointOfSaleOrderSyncMissingProductsErrorMessageView(
         missingProducts: [
-            PointOfSaleOrderState.OrderStateError.MissingProductInfo(name: "Blue T-Shirt", quantity: 2),
-            PointOfSaleOrderState.OrderStateError.MissingProductInfo(name: "Red Hat", quantity: 1)
+            PointOfSaleOrderState.OrderStateError.MissingProductInfo(id: UUID(), name: "Blue T-Shirt", quantity: 2),
+            PointOfSaleOrderState.OrderStateError.MissingProductInfo(id: UUID(), name: "Red Hat", quantity: 1)
         ],
         retryHandler: {}
     )

--- a/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
@@ -30,6 +30,11 @@ struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
 
                     VStack(spacing: PointOfSaleEmptyErrorStateViewLayout.buttonSpacing) {
                         Button(Localization.editOrderTitle, action: {
+                            let syncStrategy = posModel.isLocalCatalogEligible ? "local_catalog" : "remote"
+                            analytics.track(event: .PointOfSale.checkoutOutdatedItemDetectedEditOrderTapped(
+                                reason: "deleted",
+                                syncStrategy: syncStrategy
+                            ))
                             posModel.addMoreToCart()
                         })
                         .buttonStyle(POSFilledButtonStyle(size: .normal))
@@ -37,10 +42,20 @@ struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
                         // Only show "Remove product" button if we can identify specific products
                         if canIdentifySpecificProducts {
                             Button(removeProductsActionTitle, action: {
+                                let syncStrategy = posModel.isLocalCatalogEligible ? "local_catalog" : "remote"
+
+                                // Track the new specific event
+                                analytics.track(event: .PointOfSale.checkoutOutdatedItemDetectedRemoveTapped(
+                                    reason: "deleted",
+                                    syncStrategy: syncStrategy
+                                ))
+
+                                // Keep existing generic event for backwards compatibility
                                 analytics.track(event: .PointOfSale.itemRemovedFromCart(
-                                        sourceView: .error,
-                                        itemType: .product
-                                    ))
+                                    sourceView: .error,
+                                    itemType: .product
+                                ))
+
                                 removeMissingProductsFromCart()
                                 retryHandler()
                             })
@@ -56,6 +71,13 @@ struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
                 .multilineTextAlignment(.center)
                 Spacer()
             }
+        }
+        .onAppear {
+            let syncStrategy = posModel.isLocalCatalogEligible ? "local_catalog" : "remote"
+            analytics.track(event: .PointOfSale.checkoutOutdatedItemDetectedScreenShown(
+                reason: "deleted",
+                syncStrategy: syncStrategy
+            ))
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
@@ -1,14 +1,19 @@
 import SwiftUI
 
-struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
+public struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
     let missingProducts: [PointOfSaleOrderState.OrderStateError.MissingProductInfo]
     let retryHandler: () -> Void
+
+    public init(missingProducts: [PointOfSaleOrderState.OrderStateError.MissingProductInfo], retryHandler: @escaping () -> Void) {
+        self.missingProducts = missingProducts
+        self.retryHandler = retryHandler
+    }
 
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
     @Environment(\.posAnalytics) private var analytics
 
-    var body: some View {
+    public var body: some View {
         GeometryReader { geometry in
             HStack(alignment: .center) {
                 Spacer()

--- a/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+
+struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
+    let missingProducts: [PointOfSaleOrderState.OrderStateError.MissingProductInfo]
+    let retryHandler: () -> Void
+
+    @Environment(PointOfSaleAggregateModel.self) private var posModel
+    @Environment(\.dynamicTypeSize) var dynamicTypeSize
+    @Environment(\.posAnalytics) private var analytics
+
+    var body: some View {
+        GeometryReader { geometry in
+            HStack(alignment: .center) {
+                Spacer()
+                VStack(alignment: .center, spacing: POSSpacing.none) {
+                    Spacer()
+                    POSErrorXMark()
+                    Spacer().frame(height: PointOfSaleEmptyErrorStateViewLayout.imageAndTextSpacing)
+                    VStack(alignment: .center, spacing: PointOfSaleEmptyErrorStateViewLayout.textSpacing) {
+                        Text(title)
+                            .foregroundStyle(Color.posOnSurface)
+                            .font(.posHeadingBold)
+
+                        Text(subtitle)
+                            .foregroundStyle(Color.posOnSurface)
+                            .font(.posBodyLargeRegular())
+                            .padding([.leading, .trailing])
+                    }
+                    Spacer().frame(height: PointOfSaleEmptyErrorStateViewLayout.textAndButtonSpacing)
+
+                    VStack(spacing: PointOfSaleEmptyErrorStateViewLayout.buttonSpacing) {
+                        Button(Localization.editOrderTitle, action: {
+                            posModel.addMoreToCart()
+                        })
+                        .buttonStyle(POSFilledButtonStyle(size: .normal))
+
+                        Button(removeProductsActionTitle, action: {
+                            analytics.track(event: .PointOfSale.itemRemovedFromCart(
+                                    sourceView: .error,
+                                    itemType: .product
+                                ))
+                            removeMissingProductsFromCart()
+                            retryHandler()
+                        })
+                        .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+                    }
+                    .frame(width: geometry.size.width / 2)
+                    .padding([.leading, .trailing], Constants.buttonSidePadding)
+                    .padding([.bottom], Constants.buttonBottomPadding)
+
+                    Spacer()
+                }
+                .multilineTextAlignment(.center)
+                Spacer()
+            }
+        }
+    }
+
+    private var title: String {
+        if missingProducts.count == 1 {
+            return Localization.titleSingular
+        } else {
+            return Localization.titlePlural
+        }
+    }
+
+    private var subtitle: String {
+        if missingProducts.count == 1 {
+            return String(format: Localization.subtitleSingular, missingProducts.first?.name ?? "")
+        } else {
+            return Localization.subtitlePlural
+        }
+    }
+
+    private var removeProductsActionTitle: String {
+        if missingProducts.count == 1 {
+            return Localization.removeActionTitleSingular
+        } else {
+            return Localization.removeActionTitlePlural
+        }
+    }
+
+    private func removeMissingProductsFromCart() {
+        let missingProductNames = Set(missingProducts.map { $0.name })
+
+        // Find and remove items from cart that match the missing product names
+        let itemsToRemove = posModel.cart.purchasableItems.filter { item in
+            guard case .loaded(let orderableItem) = item.state else { return false }
+            return missingProductNames.contains(orderableItem.name)
+        }
+
+        for item in itemsToRemove {
+            posModel.remove(cartItem: item)
+        }
+    }
+}
+
+private extension PointOfSaleOrderSyncMissingProductsErrorMessageView {
+    enum Constants {
+        static let buttonSidePadding: CGFloat = POSPadding.xxLarge
+        static let buttonBottomPadding: CGFloat = POSPadding.medium
+    }
+}
+
+private extension PointOfSaleOrderSyncMissingProductsErrorMessageView {
+    enum Localization {
+        static let titleSingular = NSLocalizedString(
+            "pointOfSale.orderSync.missingProductsError.titleSingular",
+            value: "Product no longer available",
+            comment: "Title of the error when a single product in the cart is no longer available"
+        )
+
+        static let titlePlural = NSLocalizedString(
+            "pointOfSale.orderSync.missingProductsError.titlePlural",
+            value: "Products no longer available",
+            comment: "Title of the error when multiple products in the cart are no longer available"
+        )
+
+        static let subtitleSingular = NSLocalizedString(
+            "pointOfSale.orderSync.missingProductsError.subtitleSingular",
+            value: "%@ is no longer available and couldn't be added to the order.",
+            comment: "Subtitle of the error when a single product is no longer available. Placeholder is the product name."
+        )
+
+        static let subtitlePlural = NSLocalizedString(
+            "pointOfSale.orderSync.missingProductsError.subtitlePlural",
+            value: "Some products in your cart are no longer available and couldn't be added to the order.",
+            comment: "Subtitle of the error when multiple products are no longer available"
+        )
+
+        static let removeActionTitleSingular = NSLocalizedString(
+            "pointOfSale.orderSync.missingProductsError.removeProductSingular",
+            value: "Remove product",
+            comment: "Button title to remove a single unavailable product and retry creating the order"
+        )
+
+        static let removeActionTitlePlural = NSLocalizedString(
+            "pointOfSale.orderSync.missingProductsError.removeProductsPlural",
+            value: "Remove products",
+            comment: "Button title to remove multiple unavailable products and retry creating the order"
+        )
+
+        static let editOrderTitle =  NSLocalizedString(
+            "pointOfSale.orderSync.missingProductsError.editOrder",
+            value: "Edit order",
+            comment: "Button to return to order editing when products are no longer available"
+        )
+    }
+}
+
+#if DEBUG
+#Preview("Single Missing Product") {
+    PointOfSaleOrderSyncMissingProductsErrorMessageView(
+        missingProducts: [
+            PointOfSaleOrderState.OrderStateError.MissingProductInfo(name: "Blue T-Shirt", quantity: 2)
+        ],
+        retryHandler: {}
+    )
+    .environment(POSPreviewHelpers.makePreviewAggregateModel())
+}
+
+#Preview("Multiple Missing Products") {
+    PointOfSaleOrderSyncMissingProductsErrorMessageView(
+        missingProducts: [
+            PointOfSaleOrderState.OrderStateError.MissingProductInfo(name: "Blue T-Shirt", quantity: 2),
+            PointOfSaleOrderState.OrderStateError.MissingProductInfo(name: "Red Hat", quantity: 1)
+        ],
+        retryHandler: {}
+    )
+    .environment(POSPreviewHelpers.makePreviewAggregateModel())
+}
+#endif

--- a/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
@@ -91,9 +91,12 @@ struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
 
     private var subtitle: String {
         if missingProducts.count == 1,
-           let productName = missingProducts.first?.name,
-           productName != Localization.unknownProductName {
-            return String(format: Localization.subtitleSingular, productName)
+           let productName = missingProducts.first?.name {
+            if productName == Localization.unknownProductName {
+                return Localization.subtitleGenericProduct
+            } else {
+                return String(format: Localization.subtitleSingular, productName)
+            }
         } else {
             return Localization.subtitlePlural
         }
@@ -144,13 +147,19 @@ private extension PointOfSaleOrderSyncMissingProductsErrorMessageView {
 
         static let subtitleSingular = NSLocalizedString(
             "pointOfSale.orderSync.missingProductsError.subtitleSingular",
-            value: "%@ is no longer available and couldn't be added to the order.",
+            value: "%@ is no longer available.",
             comment: "Subtitle of the error when a single product is no longer available. Placeholder is the product name."
+        )
+
+        static let subtitleGenericProduct = NSLocalizedString(
+            "pointOfSale.orderSync.missingProductsError.subtitleGenericProduct",
+            value: "A product in the cart is no longer available.",
+            comment: "Subtitle of the error when we can't identify which specific product is no longer available."
         )
 
         static let subtitlePlural = NSLocalizedString(
             "pointOfSale.orderSync.missingProductsError.subtitlePlural",
-            value: "Some products in your cart are no longer available and couldn't be added to the order.",
+            value: "Some products in your cart are no longer available.",
             comment: "Subtitle of the error when multiple products are no longer available"
         )
 

--- a/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
@@ -199,7 +199,7 @@ private extension PointOfSaleOrderSyncMissingProductsErrorMessageView {
 #Preview("Single Missing Product") {
     PointOfSaleOrderSyncMissingProductsErrorMessageView(
         missingProducts: [
-            PointOfSaleOrderState.OrderStateError.MissingProductInfo(productID: 100, variationID: 0, name: "Blue T-Shirt", quantity: 2)
+            PointOfSaleOrderState.OrderStateError.MissingProductInfo(productID: 100, variationID: 0, name: "Blue T-Shirt")
         ],
         retryHandler: {}
     )
@@ -209,8 +209,8 @@ private extension PointOfSaleOrderSyncMissingProductsErrorMessageView {
 #Preview("Multiple Missing Products") {
     PointOfSaleOrderSyncMissingProductsErrorMessageView(
         missingProducts: [
-            PointOfSaleOrderState.OrderStateError.MissingProductInfo(productID: 100, variationID: 0, name: "Blue T-Shirt", quantity: 2),
-            PointOfSaleOrderState.OrderStateError.MissingProductInfo(productID: 0, variationID: 500, name: "Red Hat", quantity: 1)
+            PointOfSaleOrderState.OrderStateError.MissingProductInfo(productID: 100, variationID: 0, name: "Blue T-Shirt"),
+            PointOfSaleOrderState.OrderStateError.MissingProductInfo(productID: 0, variationID: 500, name: "Red Hat")
         ],
         retryHandler: {}
     )

--- a/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncMissingProductsErrorMessageView.swift
@@ -115,22 +115,7 @@ struct PointOfSaleOrderSyncMissingProductsErrorMessageView: View {
     }
 
     private func removeMissingProductsFromCart() {
-        // Extract product and variation IDs from missing products
-        var productIDs = Set<Int64>()
-        var variationIDs = Set<Int64>()
-
-        for missingProduct in missingProducts {
-            // If variationID is non-zero, it's a variation
-            if missingProduct.variationID != 0 {
-                variationIDs.insert(missingProduct.variationID)
-            }
-            // If productID is non-zero (and variationID is zero), it's a simple product
-            else if missingProduct.productID != 0 {
-                productIDs.insert(missingProduct.productID)
-            }
-            // Skip items with both IDs as 0 (shouldn't happen since button is hidden for those)
-        }
-
+        let (productIDs, variationIDs) = missingProducts.extractProductAndVariationIDs()
         // Remove items from cart only (catalog was already cleaned up when error was detected)
         posModel.removeMissingProductsFromCart(productIDs: productIDs, variationIDs: variationIDs)
     }

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -70,6 +70,9 @@ struct TotalsView: View {
             case .error(.invalidCoupon(let message), let handler):
                 PointOfSaleOrderSyncCouponsErrorMessageView(message: message, retryHandler: handler)
                     .transition(.opacity)
+            case .error(.missingProducts(let missingProducts), let handler):
+                PointOfSaleOrderSyncMissingProductsErrorMessageView(missingProducts: missingProducts, retryHandler: handler)
+                    .transition(.opacity)
             }
         }
         .background(backgroundColor)

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -654,6 +654,10 @@ final class POSPreviewCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol 
     func processBackgroundDownload(fileURL: URL, siteID: Int64) async throws {
         // no-op
     }
+
+    func deleteProductsFromCatalog(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws {
+        // no-op
+    }
 }
 
 #endif

--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -1315,6 +1315,9 @@ public enum WooAnalyticsStat: String {
     case pointOfSaleLocalCatalogSyncCompleted = "local_catalog_sync_completed"
     case pointOfSaleLocalCatalogSyncFailed = "local_catalog_sync_failed"
     case pointOfSaleLocalCatalogSyncSkipped = "local_catalog_sync_skipped"
+    case pointOfSaleCheckoutOutdatedItemDetectedScreenShown = "checkout_outdated_item_detected_screen_shown"
+    case pointOfSaleCheckoutOutdatedItemDetectedEditOrderTapped = "checkout_outdated_item_detected_edit_order_tapped"
+    case pointOfSaleCheckoutOutdatedItemDetectedRemoveTapped = "checkout_outdated_item_detected_remove_tapped"
 
     // MARK: Custom Fields events
     case productDetailCustomFieldsTapped = "product_detail_custom_fields_tapped"

--- a/Modules/Sources/Yosemite/Model/Orders/OrderItem+POSMatching.swift
+++ b/Modules/Sources/Yosemite/Model/Orders/OrderItem+POSMatching.swift
@@ -1,9 +1,0 @@
-import Foundation
-
-extension OrderItem {
-    /// Checks if this OrderItem matches a POSOrderableItem
-    /// Uses the POSOrderableItem's matches method which compares productID and variationID
-    func productMatches(cartItem: POSOrderableItem) -> Bool {
-        return cartItem.matches(orderItem: self)
-    }
-}

--- a/Modules/Sources/Yosemite/Model/Orders/OrderItem+POSMatching.swift
+++ b/Modules/Sources/Yosemite/Model/Orders/OrderItem+POSMatching.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension OrderItem {
+    /// Checks if this OrderItem matches a POSOrderableItem
+    /// Uses the POSOrderableItem's matches method which compares productID and variationID
+    func productMatches(cartItem: POSOrderableItem) -> Bool {
+        return cartItem.matches(orderItem: self)
+    }
+}

--- a/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
@@ -69,11 +69,11 @@ public struct CartOrderComparison {
     /// Represents an item where the quantity doesn't match between cart and order
     public struct QuantityMismatch {
         /// The product or variation name
-        public let name: String
+        public let name: String // periphery:ignore - Part of public API for future use
         /// The quantity in the cart
-        public let expectedQuantity: Decimal
+        public let expectedQuantity: Decimal // periphery:ignore - Part of public API for future use
         /// The quantity in the order
-        public let actualQuantity: Decimal
+        public let actualQuantity: Decimal // periphery:ignore - Part of public API for future use
     }
 }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
@@ -50,6 +50,7 @@ public struct CartOrderComparison {
     }
 
     public struct MissingCartItem {
+        public let id: UUID
         public let name: String
         public let expectedQuantity: Decimal
     }
@@ -103,51 +104,40 @@ extension [POSCartItem] {
         guard let order else {
             // If there's no order but we have items, all items are missing
             let missingItems = self.map {
-                CartOrderComparison.MissingCartItem(name: $0.item.name, expectedQuantity: $0.quantity)
+                CartOrderComparison.MissingCartItem(id: $0.item.id, name: $0.item.name, expectedQuantity: $0.quantity)
             }
             return ItemsComparison(missingItems: missingItems, quantityMismatches: [])
         }
 
-        // Consolidate cart items
-        let consolidatedCartItems = self.reduce(into: [POSCartItem]()) { partialResult, nextItem in
-            if let matchingIndex = partialResult.firstIndex(where: { $0.item.isEqual(to: nextItem.item) }) {
-                let itemToUpdate = partialResult[matchingIndex]
-                partialResult[matchingIndex] = POSCartItem(item: itemToUpdate.item, quantity: itemToUpdate.quantity + nextItem.quantity)
-            } else {
-                partialResult.append(nextItem)
-            }
-        }
-
-        // Consolidate order items
-        let consolidatedOrderItems = order.items.reduce(into: [OrderItem]()) { partialResult, nextItem in
-            if let matchingIndex = partialResult.firstIndex(where: { $0.productID == nextItem.productID && $0.variationID == nextItem.variationID }) {
-                let itemToUpdate = partialResult[matchingIndex]
-                partialResult[matchingIndex] = itemToUpdate.copy(quantity: itemToUpdate.quantity + nextItem.quantity)
-            } else {
-                partialResult.append(nextItem)
-            }
-        }
-
+        // Don't consolidate - check each individual cart item against the order
+        // This preserves UUIDs and allows us to identify specific variations
         var missingItems: [CartOrderComparison.MissingCartItem] = []
         var quantityMismatches: [CartOrderComparison.QuantityMismatch] = []
 
-        // Check each cart item against order items
-        for cartItem in consolidatedCartItems {
-            if let matchingOrderItem = consolidatedOrderItems.first(where: { $0.productMatches(cartItem: cartItem.item) }) {
-                // Item exists in order, check quantity
-                if cartItem.quantity != matchingOrderItem.quantity {
-                    quantityMismatches.append(
-                        CartOrderComparison.QuantityMismatch(
-                            name: cartItem.item.name,
-                            expectedQuantity: cartItem.quantity,
-                            actualQuantity: matchingOrderItem.quantity
-                        )
-                    )
-                }
+        // Group cart items by product/variation for quantity comparison
+        let cartItemsByProduct = Dictionary(grouping: self, by: { $0.item.id })
+
+        // Group order items by product/variation ID
+        let orderQuantities = Dictionary(grouping: order.items, by: { (item: OrderItem) -> String in
+            if item.variationID != 0 {
+                return "variation_\(item.variationID)"
             } else {
+                return "product_\(item.productID)"
+            }
+        }).mapValues { items in
+            items.reduce(Decimal(0)) { $0 + $1.quantity }
+        }
+
+        // Check each cart item
+        for cartItem in self {
+            // Find matching order item
+            let hasMatchInOrder = order.items.contains(where: { $0.productMatches(cartItem: cartItem.item) })
+
+            if !hasMatchInOrder {
                 // Item is in cart but not in order
                 missingItems.append(
                     CartOrderComparison.MissingCartItem(
+                        id: cartItem.item.id,
                         name: cartItem.item.name,
                         expectedQuantity: cartItem.quantity
                     )

--- a/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
@@ -69,11 +69,14 @@ public struct CartOrderComparison {
     /// Represents an item where the quantity doesn't match between cart and order
     public struct QuantityMismatch {
         /// The product or variation name
-        public let name: String // periphery:ignore
+        // periphery:ignore
+        public let name: String
         /// The quantity in the cart
-        public let expectedQuantity: Decimal // periphery:ignore
+        // periphery:ignore
+        public let expectedQuantity: Decimal
         /// The quantity in the order
-        public let actualQuantity: Decimal // periphery:ignore
+        // periphery:ignore
+        public let actualQuantity: Decimal
     }
 }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
@@ -135,6 +135,9 @@ extension [POSCartItem] {
         // Group cart items by product/variation ID to consolidate duplicates
         let cartItemsByProductKey = Dictionary(grouping: self, by: { item -> String in
             guard let (productID, variationID) = extractProductIDs(from: item.item) else {
+                // Use a unique UUID for each invalid item to prevent grouping them together.
+                // This ensures each invalid item is reported separately in error handling
+                // rather than being masked as a single consolidated entry.
                 return "invalid_\(UUID())"
             }
             return variationID != 0 ? "variation_\(variationID)" : "product_\(productID)"

--- a/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
@@ -50,7 +50,8 @@ public struct CartOrderComparison {
     }
 
     public struct MissingCartItem {
-        public let id: UUID
+        public let productID: Int64
+        public let variationID: Int64
         public let name: String
         public let expectedQuantity: Decimal
     }
@@ -103,49 +104,88 @@ extension [POSCartItem] {
     func compareWithOrder(_ order: Order?) -> ItemsComparison {
         guard let order else {
             // If there's no order but we have items, all items are missing
-            let missingItems = self.map {
-                CartOrderComparison.MissingCartItem(id: $0.item.id, name: $0.item.name, expectedQuantity: $0.quantity)
+            let missingItems = self.compactMap { cartItem -> CartOrderComparison.MissingCartItem? in
+                guard let (productID, variationID) = extractProductIDs(from: cartItem.item) else {
+                    return nil
+                }
+                return CartOrderComparison.MissingCartItem(
+                    productID: productID,
+                    variationID: variationID,
+                    name: cartItem.item.name,
+                    expectedQuantity: cartItem.quantity
+                )
             }
             return ItemsComparison(missingItems: missingItems, quantityMismatches: [])
         }
 
-        // Don't consolidate - check each individual cart item against the order
-        // This preserves UUIDs and allows us to identify specific variations
-        var missingItems: [CartOrderComparison.MissingCartItem] = []
-        var quantityMismatches: [CartOrderComparison.QuantityMismatch] = []
+        // Group cart items by product/variation ID to consolidate duplicates
+        let cartItemsByProductKey = Dictionary(grouping: self, by: { item -> String in
+            guard let (productID, variationID) = extractProductIDs(from: item.item) else {
+                return "invalid_\(UUID())"
+            }
+            return variationID != 0 ? "variation_\(variationID)" : "product_\(productID)"
+        })
 
-        // Group cart items by product/variation for quantity comparison
-        let cartItemsByProduct = Dictionary(grouping: self, by: { $0.item.id })
+        // Calculate total quantity for each product/variation in cart
+        let cartQuantities = cartItemsByProductKey.mapValues { items in
+            items.reduce(Decimal(0)) { $0 + $1.quantity }
+        }
 
         // Group order items by product/variation ID
         let orderQuantities = Dictionary(grouping: order.items, by: { (item: OrderItem) -> String in
-            if item.variationID != 0 {
-                return "variation_\(item.variationID)"
-            } else {
-                return "product_\(item.productID)"
-            }
+            item.variationID != 0 ? "variation_\(item.variationID)" : "product_\(item.productID)"
         }).mapValues { items in
             items.reduce(Decimal(0)) { $0 + $1.quantity }
         }
 
-        // Check each cart item
-        for cartItem in self {
-            // Find matching order item
-            let hasMatchInOrder = order.items.contains(where: { $0.productMatches(cartItem: cartItem.item) })
+        var missingItems: [CartOrderComparison.MissingCartItem] = []
+        var quantityMismatches: [CartOrderComparison.QuantityMismatch] = []
 
-            if !hasMatchInOrder {
-                // Item is in cart but not in order
+        // Check each unique product/variation in cart
+        for (key, cartItems) in cartItemsByProductKey {
+            guard let firstItem = cartItems.first,
+                  let (productID, variationID) = extractProductIDs(from: firstItem.item) else {
+                continue
+            }
+
+            let expectedQuantity = cartQuantities[key] ?? 0
+            let actualQuantity = orderQuantities[key] ?? 0
+
+            if actualQuantity == 0 {
+                // Item is in cart but not in order at all
                 missingItems.append(
                     CartOrderComparison.MissingCartItem(
-                        id: cartItem.item.id,
-                        name: cartItem.item.name,
-                        expectedQuantity: cartItem.quantity
+                        productID: productID,
+                        variationID: variationID,
+                        name: firstItem.item.name,
+                        expectedQuantity: expectedQuantity
+                    )
+                )
+            } else if actualQuantity != expectedQuantity {
+                // Item is in both but quantities don't match
+                quantityMismatches.append(
+                    CartOrderComparison.QuantityMismatch(
+                        name: firstItem.item.name,
+                        expectedQuantity: expectedQuantity,
+                        actualQuantity: actualQuantity
                     )
                 )
             }
         }
 
         return ItemsComparison(missingItems: missingItems, quantityMismatches: quantityMismatches)
+    }
+
+    private func extractProductIDs(from item: POSOrderableItem) -> (productID: Int64, variationID: Int64)? {
+        // Check if it's a simple product
+        if let simpleProduct = item as? POSSimpleProduct {
+            return (simpleProduct.productID, 0)
+        }
+        // Check if it's a variation
+        else if let variation = item as? POSVariation {
+            return (variation.productID, variation.productVariationID)
+        }
+        return nil
     }
 
     struct ItemsComparison {

--- a/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
@@ -27,6 +27,38 @@ public extension POSCart {
     func matches(order: Order?) -> Bool {
         return items.matches(order: order) && coupons.matches(order: order)
     }
+
+    func compareWithOrder(_ order: Order?) -> CartOrderComparison {
+        let itemsComparison = items.compareWithOrder(order)
+        let couponsMatch = coupons.matches(order: order)
+
+        return CartOrderComparison(
+            missingItems: itemsComparison.missingItems,
+            quantityMismatches: itemsComparison.quantityMismatches,
+            couponsMatch: couponsMatch
+        )
+    }
+}
+
+public struct CartOrderComparison {
+    public let missingItems: [MissingCartItem]
+    public let quantityMismatches: [QuantityMismatch]
+    public let couponsMatch: Bool
+
+    public var hasDiscrepancies: Bool {
+        return !missingItems.isEmpty || !quantityMismatches.isEmpty || !couponsMatch
+    }
+
+    public struct MissingCartItem {
+        public let name: String
+        public let expectedQuantity: Decimal
+    }
+
+    public struct QuantityMismatch {
+        public let name: String
+        public let expectedQuantity: Decimal
+        public let actualQuantity: Decimal
+    }
 }
 
 extension [POSCartItem] {
@@ -65,6 +97,70 @@ extension [POSCartItem] {
             }
         }
         return true
+    }
+
+    func compareWithOrder(_ order: Order?) -> ItemsComparison {
+        guard let order else {
+            // If there's no order but we have items, all items are missing
+            let missingItems = self.map {
+                CartOrderComparison.MissingCartItem(name: $0.item.name, expectedQuantity: $0.quantity)
+            }
+            return ItemsComparison(missingItems: missingItems, quantityMismatches: [])
+        }
+
+        // Consolidate cart items
+        let consolidatedCartItems = self.reduce(into: [POSCartItem]()) { partialResult, nextItem in
+            if let matchingIndex = partialResult.firstIndex(where: { $0.item.isEqual(to: nextItem.item) }) {
+                let itemToUpdate = partialResult[matchingIndex]
+                partialResult[matchingIndex] = POSCartItem(item: itemToUpdate.item, quantity: itemToUpdate.quantity + nextItem.quantity)
+            } else {
+                partialResult.append(nextItem)
+            }
+        }
+
+        // Consolidate order items
+        let consolidatedOrderItems = order.items.reduce(into: [OrderItem]()) { partialResult, nextItem in
+            if let matchingIndex = partialResult.firstIndex(where: { $0.productID == nextItem.productID && $0.variationID == nextItem.variationID }) {
+                let itemToUpdate = partialResult[matchingIndex]
+                partialResult[matchingIndex] = itemToUpdate.copy(quantity: itemToUpdate.quantity + nextItem.quantity)
+            } else {
+                partialResult.append(nextItem)
+            }
+        }
+
+        var missingItems: [CartOrderComparison.MissingCartItem] = []
+        var quantityMismatches: [CartOrderComparison.QuantityMismatch] = []
+
+        // Check each cart item against order items
+        for cartItem in consolidatedCartItems {
+            if let matchingOrderItem = consolidatedOrderItems.first(where: { $0.productMatches(cartItem: cartItem.item) }) {
+                // Item exists in order, check quantity
+                if cartItem.quantity != matchingOrderItem.quantity {
+                    quantityMismatches.append(
+                        CartOrderComparison.QuantityMismatch(
+                            name: cartItem.item.name,
+                            expectedQuantity: cartItem.quantity,
+                            actualQuantity: matchingOrderItem.quantity
+                        )
+                    )
+                }
+            } else {
+                // Item is in cart but not in order
+                missingItems.append(
+                    CartOrderComparison.MissingCartItem(
+                        name: cartItem.item.name,
+                        expectedQuantity: cartItem.quantity
+                    )
+                )
+            }
+        }
+
+        return ItemsComparison(missingItems: missingItems, quantityMismatches: quantityMismatches)
+    }
+
+    struct ItemsComparison {
+        let missingItems: [CartOrderComparison.MissingCartItem]
+        let quantityMismatches: [CartOrderComparison.QuantityMismatch]
     }
 
     func createGroupedOrderSyncProductInputs() -> [OrderSyncProductInput.ProductType: OrderSyncProductInput] {

--- a/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
@@ -69,11 +69,11 @@ public struct CartOrderComparison {
     /// Represents an item where the quantity doesn't match between cart and order
     public struct QuantityMismatch {
         /// The product or variation name
-        public let name: String // periphery:ignore - Part of public API for future use
+        public let name: String // periphery:ignore
         /// The quantity in the cart
-        public let expectedQuantity: Decimal // periphery:ignore - Part of public API for future use
+        public let expectedQuantity: Decimal // periphery:ignore
         /// The quantity in the order
-        public let actualQuantity: Decimal // periphery:ignore - Part of public API for future use
+        public let actualQuantity: Decimal // periphery:ignore
     }
 }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
@@ -69,13 +69,13 @@ public struct CartOrderComparison {
     /// Represents an item where the quantity doesn't match between cart and order
     public struct QuantityMismatch {
         /// The product or variation name
-        // periphery:ignore
+        // periphery:ignore - part of public API
         public let name: String
         /// The quantity in the cart
-        // periphery:ignore
+        // periphery:ignore - part of public API
         public let expectedQuantity: Decimal
         /// The quantity in the order
-        // periphery:ignore
+        // periphery:ignore - part of public API
         public let actualQuantity: Decimal
     }
 }

--- a/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
@@ -40,25 +40,39 @@ public extension POSCart {
     }
 }
 
+/// Represents the result of comparing a cart with an order to detect discrepancies
 public struct CartOrderComparison {
+    /// Items that were expected in the cart but are missing from the order
     public let missingItems: [MissingCartItem]
+    /// Items where the quantity in the order doesn't match the cart
     public let quantityMismatches: [QuantityMismatch]
+    /// Whether the coupons in the cart match the order
     public let couponsMatch: Bool
 
+    /// Returns true if there are any discrepancies between cart and order
     public var hasDiscrepancies: Bool {
         return !missingItems.isEmpty || !quantityMismatches.isEmpty || !couponsMatch
     }
 
+    /// Represents an item that was expected in the cart but is missing from the order
     public struct MissingCartItem {
+        /// The product ID (for simple products) or parent product ID (for variations)
         public let productID: Int64
+        /// The variation ID (0 for simple products)
         public let variationID: Int64
+        /// The product or variation name
         public let name: String
+        /// The quantity that was expected in the order
         public let expectedQuantity: Decimal
     }
 
+    /// Represents an item where the quantity doesn't match between cart and order
     public struct QuantityMismatch {
+        /// The product or variation name
         public let name: String
+        /// The quantity in the cart
         public let expectedQuantity: Decimal
+        /// The quantity in the order
         public let actualQuantity: Decimal
     }
 }

--- a/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
@@ -62,8 +62,6 @@ public struct CartOrderComparison {
         public let variationID: Int64
         /// The product or variation name
         public let name: String
-        /// The quantity that was expected in the order
-        public let expectedQuantity: Decimal
     }
 
     /// Represents an item where the quantity doesn't match between cart and order
@@ -128,8 +126,7 @@ extension [POSCartItem] {
                 return CartOrderComparison.MissingCartItem(
                     productID: productID,
                     variationID: variationID,
-                    name: cartItem.item.name,
-                    expectedQuantity: cartItem.quantity
+                    name: cartItem.item.name
                 )
             }
             return ItemsComparison(missingItems: missingItems, quantityMismatches: [])
@@ -174,8 +171,7 @@ extension [POSCartItem] {
                     CartOrderComparison.MissingCartItem(
                         productID: productID,
                         variationID: variationID,
-                        name: firstItem.item.name,
-                        expectedQuantity: expectedQuantity
+                        name: firstItem.item.name
                     )
                 )
             } else if actualQuantity != expectedQuantity {

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
@@ -160,26 +160,22 @@ final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
         DDLogInfo("🗑️ Deleting \(productIDs.count) products and \(variationIDs.count) variations from catalog")
 
         try await grdbManager.databaseConnection.write { db in
-            // Delete products
-            for productID in productIDs {
-                if let product = try PersistedProduct
+            // Batch delete products using filter
+            if !productIDs.isEmpty {
+                let deletedProductsCount = try PersistedProduct
                     .filter(PersistedProduct.Columns.siteID == siteID)
-                    .filter(PersistedProduct.Columns.id == productID)
-                    .fetchOne(db) {
-                    try product.delete(db)
-                    DDLogInfo("Deleted product \(productID) from catalog")
-                }
+                    .filter(productIDs.contains(PersistedProduct.Columns.id))
+                    .deleteAll(db)
+                DDLogInfo("Deleted \(deletedProductsCount) products from catalog")
             }
 
-            // Delete variations
-            for variationID in variationIDs {
-                if let variation = try PersistedProductVariation
+            // Batch delete variations using filter
+            if !variationIDs.isEmpty {
+                let deletedVariationsCount = try PersistedProductVariation
                     .filter(PersistedProductVariation.Columns.siteID == siteID)
-                    .filter(PersistedProductVariation.Columns.id == variationID)
-                    .fetchOne(db) {
-                    try variation.delete(db)
-                    DDLogInfo("Deleted variation \(variationID) from catalog")
-                }
+                    .filter(variationIDs.contains(PersistedProductVariation.Columns.id))
+                    .deleteAll(db)
+                DDLogInfo("Deleted \(deletedVariationsCount) variations from catalog")
             }
         }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
@@ -15,6 +15,13 @@ protocol POSCatalogPersistenceServiceProtocol {
     ///   - catalog: The catalog difference to persist
     ///   - siteID: The site ID to associate the catalog with
     func persistIncrementalCatalogData(_ catalog: POSCatalog, siteID: Int64) async throws
+
+    /// Deletes specific products and/or variations from the catalog
+    /// - Parameters:
+    ///   - productIDs: Product IDs to delete
+    ///   - variationIDs: Variation IDs to delete
+    ///   - siteID: The site ID
+    func deleteProducts(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws
 }
 
 final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
@@ -147,6 +154,36 @@ final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
                       "\(productAttributeCount) product attributes, \(variationCount) variations, " +
                       "\(variationImageCount) variation images, \(variationAttributeCount) variation attributes")
         }
+    }
+
+    func deleteProducts(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws {
+        DDLogInfo("🗑️ Deleting \(productIDs.count) products and \(variationIDs.count) variations from catalog")
+
+        try await grdbManager.databaseConnection.write { db in
+            // Delete products
+            for productID in productIDs {
+                if let product = try PersistedProduct
+                    .filter(PersistedProduct.Columns.siteID == siteID)
+                    .filter(PersistedProduct.Columns.id == productID)
+                    .fetchOne(db) {
+                    try product.delete(db)
+                    DDLogInfo("Deleted product \(productID) from catalog")
+                }
+            }
+
+            // Delete variations
+            for variationID in variationIDs {
+                if let variation = try PersistedProductVariation
+                    .filter(PersistedProductVariation.Columns.siteID == siteID)
+                    .filter(PersistedProductVariation.Columns.id == variationID)
+                    .fetchOne(db) {
+                    try variation.delete(db)
+                    DDLogInfo("Deleted variation \(variationID) from catalog")
+                }
+            }
+        }
+
+        DDLogInfo("✅ Catalog deletion complete")
     }
 }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -63,6 +63,13 @@ public protocol POSCatalogSyncCoordinatorProtocol {
     ///   - fileURL: Local file URL of the downloaded catalog
     ///   - siteID: Site ID for this catalog
     func processBackgroundDownload(fileURL: URL, siteID: Int64) async throws
+
+    /// Deletes specific products and/or variations from the local catalog
+    /// - Parameters:
+    ///   - productIDs: Product IDs to delete
+    ///   - variationIDs: Variation IDs to delete
+    ///   - siteID: The site ID
+    func deleteProductsFromCatalog(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws
 }
 
 public extension POSCatalogSyncCoordinatorProtocol {
@@ -761,5 +768,10 @@ private extension POSCatalogSyncCoordinator {
             siteSettings.setFirstPOSCatalogSyncDate(siteID: siteID, date: Date())
             DDLogInfo("📋 POSCatalogSyncCoordinator: Recorded first sync date for site \(siteID)")
         }
+    }
+
+    public func deleteProductsFromCatalog(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws {
+        let persistenceService = POSCatalogPersistenceService(grdbManager: grdbManager)
+        try await persistenceService.deleteProducts(productIDs, variationIDs: variationIDs, siteID: siteID)
     }
 }

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -657,6 +657,11 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
 
         return "unknown_reason"
     }
+
+    public func deleteProductsFromCatalog(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws {
+        let persistenceService = POSCatalogPersistenceService(grdbManager: grdbManager)
+        try await persistenceService.deleteProducts(productIDs, variationIDs: variationIDs, siteID: siteID)
+    }
 }
 
 // MARK: - Syncing State
@@ -768,10 +773,5 @@ private extension POSCatalogSyncCoordinator {
             siteSettings.setFirstPOSCatalogSyncDate(siteID: siteID, date: Date())
             DDLogInfo("📋 POSCatalogSyncCoordinator: Recorded first sync date for site \(siteID)")
         }
-    }
-
-    public func deleteProductsFromCatalog(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws {
-        let persistenceService = POSCatalogPersistenceService(grdbManager: grdbManager)
-        try await persistenceService.deleteProducts(productIDs, variationIDs: variationIDs, siteID: siteID)
     }
 }

--- a/Modules/Sources/Yosemite/Tools/POS/POSOrderService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSOrderService.swift
@@ -258,7 +258,7 @@ private extension POSOrderService {
         )
         static let unknownProductName = NSLocalizedString(
             "pointOfSale.orderController.unknownProduct",
-            value: "Unknown Product",
+            value: "One or more products",
             comment: "Fallback name for a product that couldn't be identified in error handling."
         )
     }

--- a/Modules/Sources/Yosemite/Tools/POS/POSOrderService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSOrderService.swift
@@ -55,7 +55,11 @@ public final class POSOrderService: POSOrderServiceProtocol {
         // Validate that the created order contains all cart items
         let comparison = cart.compareWithOrder(createdOrder)
         if comparison.hasDiscrepancies {
-            DDLogWarn("⚠️ Order created but cart-order mismatch detected. Missing items: \(comparison.missingItems.count), Quantity mismatches: \(comparison.quantityMismatches.count)")
+            DDLogWarn("""
+                ⚠️ Order created but cart-order mismatch detected. \
+                Missing items: \(comparison.missingItems.count), \
+                Quantity mismatches: \(comparison.quantityMismatches.count)
+                """)
 
             if !comparison.missingItems.isEmpty {
                 throw POSOrderServiceError.missingProductsInOrder(comparison.missingItems)

--- a/Modules/Sources/Yosemite/Tools/POS/POSOrderService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSOrderService.swift
@@ -4,6 +4,7 @@ import class WooFoundation.CurrencyFormatter
 import enum WooFoundation.CurrencyCode
 import struct Combine.AnyPublisher
 import struct NetworkingCore.JetpackSite
+import enum Alamofire.AFError
 
 public protocol POSOrderServiceProtocol {
     /// Syncs order based on the cart.
@@ -50,7 +51,20 @@ public final class POSOrderService: POSOrderServiceProtocol {
             .addItems(cart.items)
             .addCoupons(cart.coupons)
 
-        let createdOrder = try await ordersRemote.createPOSOrder(siteID: siteID, order: order, fields: [.items, .status, .currency, .couponLines])
+        let createdOrder: Order
+        do {
+            createdOrder = try await ordersRemote.createPOSOrder(
+                siteID: siteID,
+                order: order,
+                fields: [.items, .status, .currency, .couponLines]
+            )
+        } catch {
+            // Check if this is a server validation error about missing products
+            if let missingItems = extractMissingProductsFromServerError(error, cart: cart) {
+                throw POSOrderServiceError.missingProductsInOrder(missingItems)
+            }
+            throw error
+        }
 
         // Validate that the created order contains all cart items
         let comparison = cart.compareWithOrder(createdOrder)
@@ -123,11 +137,129 @@ public extension POSOrderService {
 }
 
 private extension POSOrderService {
+    /// Extracts missing product information from server validation errors
+    /// Handles cases where the server rejects order creation due to invalid product/variation IDs
+    func extractMissingProductsFromServerError(
+        _ error: Error,
+        cart: POSCart
+    ) -> [CartOrderComparison.MissingCartItem]? {
+        // Check if this is an AFError wrapping a DotcomError or NetworkError
+        let underlyingError: Error? = {
+            if let afError = error as? AFError {
+                return afError.underlyingError
+            }
+            return error
+        }()
+
+        // Check for DotcomError with product/variation validation error codes
+        if case .unknown(let code, _) = underlyingError as? DotcomError {
+            if isProductValidationError(code: code) {
+                // DotcomError doesn't include data field, fall back to generic error
+                return extractMissingProductsFromCart()
+            }
+        }
+
+        // Check for NetworkError with product/variation validation error codes
+        if let networkError = underlyingError as? NetworkError,
+           let errorCode = networkError.errorCode,
+           isProductValidationError(code: errorCode) {
+            // Try to extract variation_id from NetworkError data if available
+            if let variationID = extractVariationID(from: networkError.errorData) {
+                return createMissingProductInfo(forVariationID: variationID, cart: cart)
+            }
+            // Fall back to generic error if no variation_id in data
+            return extractMissingProductsFromCart()
+        }
+
+        return nil
+    }
+
+    /// Extracts variation_id from error data dictionary
+    func extractVariationID(from data: [String: AnyDecodable]?) -> Int64? {
+        guard let data = data,
+              let variationIDValue = data["variation_id"]?.value else {
+            return nil
+        }
+
+        // Handle different number types
+        if let intValue = variationIDValue as? Int {
+            return Int64(intValue)
+        } else if let int64Value = variationIDValue as? Int64 {
+            return int64Value
+        }
+        return nil
+    }
+
+    /// Creates MissingCartItem for a specific variation ID
+    /// Searches the cart to find the variation's name and parent product ID
+    func createMissingProductInfo(
+        forVariationID variationID: Int64,
+        cart: POSCart
+    ) -> [CartOrderComparison.MissingCartItem] {
+        // Search the cart for the variation to get its name
+        let cartItem = cart.items.first { item in
+            if let variation = item.item as? POSVariation {
+                return variation.productVariationID == variationID
+            }
+            return false
+        }
+
+        let productName: String
+        let parentProductID: Int64
+
+        if let cartItem = cartItem,
+           let variation = cartItem.item as? POSVariation {
+            // Found the variation in the cart - use its parent product name and variation name
+            productName = "\(variation.parentProductName) - \(variation.name)"
+            parentProductID = variation.productID
+        } else {
+            // Couldn't find it in cart, use generic name
+            productName = Localization.unknownProductName
+            parentProductID = 0
+        }
+
+        return [
+            CartOrderComparison.MissingCartItem(
+                productID: parentProductID,
+                variationID: variationID,
+                name: productName
+            )
+        ]
+    }
+
+    /// Checks if an error code indicates a product validation error
+    /// Currently only handles the confirmed error code from WooCommerce server responses
+    func isProductValidationError(code: String) -> Bool {
+        // Only check for the one confirmed error code we've observed
+        // Additional codes can be added as they are discovered through testing
+        return code == "order_item_product_invalid_variation_id"
+    }
+
+    /// Extracts missing products by trying to identify items in cart that might have caused the validation error
+    /// Since server doesn't tell us which specific products failed, we return generic error info
+    func extractMissingProductsFromCart() -> [CartOrderComparison.MissingCartItem]? {
+        // We can't determine which specific products are invalid from the server error
+        // So we return a generic missing product message with 0 for both IDs (meaning unknown)
+        // The user will need to remove all products and retry
+        return [
+            CartOrderComparison.MissingCartItem(
+                productID: 0,
+                variationID: 0,
+                name: Localization.unknownProductName
+            )
+        ]
+    }
+
     enum Localization {
         static let cashPaymentMethodTitle = NSLocalizedString(
             "pointOfSaleOrderController.collectCashPayment.paymentMethodTitle",
             value: "Pay in Person",
             comment: "Title for the payment method used when collecting cash payment in Point of Sale."
+        )
+        static let unknownProductName = NSLocalizedString(
+            "pointOfSale.orderController.unknownProduct",
+            value: "Unknown Product",
+            comment: "Fallback name for a product that couldn't be identified in error handling."
         )
     }
 }

--- a/Modules/Sources/Yosemite/Tools/POS/POSOrderService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSOrderService.swift
@@ -50,7 +50,19 @@ public final class POSOrderService: POSOrderServiceProtocol {
             .addItems(cart.items)
             .addCoupons(cart.coupons)
 
-        return try await ordersRemote.createPOSOrder(siteID: siteID, order: order, fields: [.items, .status, .currency, .couponLines])
+        let createdOrder = try await ordersRemote.createPOSOrder(siteID: siteID, order: order, fields: [.items, .status, .currency, .couponLines])
+
+        // Validate that the created order contains all cart items
+        let comparison = cart.compareWithOrder(createdOrder)
+        if comparison.hasDiscrepancies {
+            DDLogWarn("⚠️ Order created but cart-order mismatch detected. Missing items: \(comparison.missingItems.count), Quantity mismatches: \(comparison.quantityMismatches.count)")
+
+            if !comparison.missingItems.isEmpty {
+                throw POSOrderServiceError.missingProductsInOrder(comparison.missingItems)
+            }
+        }
+
+        return createdOrder
     }
 
     public func updatePOSOrder(orderID: Int64, recipientEmail: String) async throws {
@@ -99,9 +111,10 @@ private extension Order {
     }
 }
 
-private extension POSOrderService {
+public extension POSOrderService {
     enum POSOrderServiceError: Error {
         case updateOrderFailed
+        case missingProductsInOrder([CartOrderComparison.MissingCartItem])
     }
 }
 

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSCatalogSyncCoordinator.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSCatalogSyncCoordinator.swift
@@ -100,4 +100,8 @@ final class MockPOSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
             throw error
         }
     }
+
+    func deleteProductsFromCatalog(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws {
+        // no-op
+    }
 }

--- a/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogPersistenceService.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogPersistenceService.swift
@@ -31,4 +31,8 @@ final class MockPOSCatalogPersistenceService: POSCatalogPersistenceServiceProtoc
             throw error
         }
     }
+
+    func deleteProducts(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws {
+        // no-op
+    }
 }

--- a/Modules/Tests/YosemiteTests/Mocks/MockPOSOrdersRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockPOSOrdersRemote.swift
@@ -44,13 +44,26 @@ final class MockPOSOrdersRemote: POSOrdersRemoteProtocol {
     var createPOSOrderCalled: Bool = false
     var spyCreatePOSOrder: Order?
     var spyCreatePOSOrderFields: [OrdersRemote.CreateOrderField]?
+    var createPOSOrderResult: Result<Order, Error>?
     func createPOSOrder(siteID: Int64,
                         order: Networking.Order,
                         fields: [OrdersRemote.CreateOrderField]) async throws -> Order {
         createPOSOrderCalled = true
         spyCreatePOSOrder = order
         spyCreatePOSOrderFields = fields
-        return Order.fake()
+
+        // If a custom result is set, use it
+        if let result = createPOSOrderResult {
+            switch result {
+            case .success(let customOrder):
+                return customOrder
+            case .failure(let error):
+                throw error
+            }
+        }
+
+        // By default, return the order that was passed in (simulating server echo)
+        return order
     }
 
     var mockPagedOrdersResult: Result<PagedItems<Order>, Error> = .success(PagedItems(items: [], hasMorePages: false, totalItems: 0))

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogPersistenceServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogPersistenceServiceTests.swift
@@ -719,7 +719,7 @@ struct POSCatalogPersistenceServiceTests {
         // Then
         try await db.read { db in
             let products = try PersistedProduct
-                .filter(PersistedProduct.Columns.siteID == sampleSiteID)
+                .filter(sql: "\(PersistedProduct.Columns.siteID.name) = \(sampleSiteID)")
                 .fetchAll(db)
             #expect(products.count == 1)
             #expect(products.first?.id == 200)
@@ -747,7 +747,7 @@ struct POSCatalogPersistenceServiceTests {
         // Then
         try await db.read { db in
             let variations = try PersistedProductVariation
-                .filter(PersistedProductVariation.Columns.siteID == sampleSiteID)
+                .filter(sql: "\(PersistedProductVariation.Columns.siteID.name) = \(sampleSiteID)")
                 .fetchAll(db)
             #expect(variations.count == 1)
             #expect(variations.first?.id == 501)
@@ -775,13 +775,13 @@ struct POSCatalogPersistenceServiceTests {
         // Then
         try await db.read { db in
             let products = try PersistedProduct
-                .filter(PersistedProduct.Columns.siteID == sampleSiteID)
+                .filter(sql: "\(PersistedProduct.Columns.siteID.name) = \(sampleSiteID)")
                 .fetchAll(db)
             #expect(products.count == 1)
             #expect(products.first?.id == 200)
 
             let variations = try PersistedProductVariation
-                .filter(PersistedProductVariation.Columns.siteID == sampleSiteID)
+                .filter(sql: "\(PersistedProductVariation.Columns.siteID.name) = \(sampleSiteID)")
                 .fetchAll(db)
             #expect(variations.count == 1)
             #expect(variations.first?.id == 501)
@@ -809,12 +809,12 @@ struct POSCatalogPersistenceServiceTests {
         // Then - Site 100 should have no products, site 200 should still have its product
         try await db.read { db in
             let site1Products = try PersistedProduct
-                .filter(PersistedProduct.Columns.siteID == 100)
+                .filter(sql: "\(PersistedProduct.Columns.siteID.name) = 100")
                 .fetchAll(db)
             #expect(site1Products.isEmpty)
 
             let site2Products = try PersistedProduct
-                .filter(PersistedProduct.Columns.siteID == 200)
+                .filter(sql: "\(PersistedProduct.Columns.siteID.name) = 200")
                 .fetchAll(db)
             #expect(site2Products.count == 1)
         }
@@ -835,7 +835,7 @@ struct POSCatalogPersistenceServiceTests {
         // Then - Should not throw, existing product should remain
         try await db.read { db in
             let products = try PersistedProduct
-                .filter(PersistedProduct.Columns.siteID == sampleSiteID)
+                .filter(sql: "\(PersistedProduct.Columns.siteID.name) = \(sampleSiteID)")
                 .fetchAll(db)
             #expect(products.count == 1)
             #expect(products.first?.id == 100)

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogPersistenceServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogPersistenceServiceTests.swift
@@ -697,6 +697,150 @@ struct POSCatalogPersistenceServiceTests {
             #expect(variationImage?.imageID == 100)
         }
     }
+
+    // MARK: - Delete Products Tests
+
+    @Test func deleteProducts_removes_specified_products_from_catalog() async throws {
+        // Given
+        let catalog = POSCatalog(
+            products: [
+                POSProduct.fake().copy(siteID: sampleSiteID, productID: 100),
+                POSProduct.fake().copy(siteID: sampleSiteID, productID: 200),
+                POSProduct.fake().copy(siteID: sampleSiteID, productID: 300)
+            ],
+            variations: [],
+            syncDate: .now
+        )
+        try await sut.replaceAllCatalogData(catalog, siteID: sampleSiteID)
+
+        // When
+        try await sut.deleteProducts([100, 300], variationIDs: [], siteID: sampleSiteID)
+
+        // Then
+        try await db.read { db in
+            let products = try PersistedProduct
+                .filter(PersistedProduct.Columns.siteID == sampleSiteID)
+                .fetchAll(db)
+            #expect(products.count == 1)
+            #expect(products.first?.id == 200)
+        }
+    }
+
+    @Test func deleteProducts_removes_specified_variations_from_catalog() async throws {
+        // Given
+        let catalog = POSCatalog(
+            products: [
+                POSProduct.fake().copy(siteID: sampleSiteID, productID: 100, productTypeKey: "variable")
+            ],
+            variations: [
+                POSProductVariation.fake().copy(siteID: sampleSiteID, productID: 100, productVariationID: 500),
+                POSProductVariation.fake().copy(siteID: sampleSiteID, productID: 100, productVariationID: 501),
+                POSProductVariation.fake().copy(siteID: sampleSiteID, productID: 100, productVariationID: 502)
+            ],
+            syncDate: .now
+        )
+        try await sut.replaceAllCatalogData(catalog, siteID: sampleSiteID)
+
+        // When
+        try await sut.deleteProducts([], variationIDs: [500, 502], siteID: sampleSiteID)
+
+        // Then
+        try await db.read { db in
+            let variations = try PersistedProductVariation
+                .filter(PersistedProductVariation.Columns.siteID == sampleSiteID)
+                .fetchAll(db)
+            #expect(variations.count == 1)
+            #expect(variations.first?.id == 501)
+        }
+    }
+
+    @Test func deleteProducts_removes_both_products_and_variations() async throws {
+        // Given
+        let catalog = POSCatalog(
+            products: [
+                POSProduct.fake().copy(siteID: sampleSiteID, productID: 100),
+                POSProduct.fake().copy(siteID: sampleSiteID, productID: 200, productTypeKey: "variable")
+            ],
+            variations: [
+                POSProductVariation.fake().copy(siteID: sampleSiteID, productID: 200, productVariationID: 500),
+                POSProductVariation.fake().copy(siteID: sampleSiteID, productID: 200, productVariationID: 501)
+            ],
+            syncDate: .now
+        )
+        try await sut.replaceAllCatalogData(catalog, siteID: sampleSiteID)
+
+        // When - Delete one product and one variation
+        try await sut.deleteProducts([100], variationIDs: [500], siteID: sampleSiteID)
+
+        // Then
+        try await db.read { db in
+            let products = try PersistedProduct
+                .filter(PersistedProduct.Columns.siteID == sampleSiteID)
+                .fetchAll(db)
+            #expect(products.count == 1)
+            #expect(products.first?.id == 200)
+
+            let variations = try PersistedProductVariation
+                .filter(PersistedProductVariation.Columns.siteID == sampleSiteID)
+                .fetchAll(db)
+            #expect(variations.count == 1)
+            #expect(variations.first?.id == 501)
+        }
+    }
+
+    @Test func deleteProducts_only_affects_specified_site() async throws {
+        // Given - Add products for two different sites
+        let site1Catalog = POSCatalog(
+            products: [POSProduct.fake().copy(siteID: 100, productID: 1)],
+            variations: [],
+            syncDate: .now
+        )
+        let site2Catalog = POSCatalog(
+            products: [POSProduct.fake().copy(siteID: 200, productID: 1)],
+            variations: [],
+            syncDate: .now
+        )
+        try await sut.replaceAllCatalogData(site1Catalog, siteID: 100)
+        try await sut.replaceAllCatalogData(site2Catalog, siteID: 200)
+
+        // When - Delete from site 100 only
+        try await sut.deleteProducts([1], variationIDs: [], siteID: 100)
+
+        // Then - Site 100 should have no products, site 200 should still have its product
+        try await db.read { db in
+            let site1Products = try PersistedProduct
+                .filter(PersistedProduct.Columns.siteID == 100)
+                .fetchAll(db)
+            #expect(site1Products.isEmpty)
+
+            let site2Products = try PersistedProduct
+                .filter(PersistedProduct.Columns.siteID == 200)
+                .fetchAll(db)
+            #expect(site2Products.count == 1)
+        }
+    }
+
+    @Test func deleteProducts_succeeds_when_product_not_found() async throws {
+        // Given
+        let catalog = POSCatalog(
+            products: [POSProduct.fake().copy(siteID: sampleSiteID, productID: 100)],
+            variations: [],
+            syncDate: .now
+        )
+        try await sut.replaceAllCatalogData(catalog, siteID: sampleSiteID)
+
+        // When - Try to delete a product that doesn't exist
+        try await sut.deleteProducts([999], variationIDs: [], siteID: sampleSiteID)
+
+        // Then - Should not throw, existing product should remain
+        try await db.read { db in
+            let products = try PersistedProduct
+                .filter(PersistedProduct.Columns.siteID == sampleSiteID)
+                .fetchAll(db)
+            #expect(products.count == 1)
+            #expect(products.first?.id == 100)
+        }
+    }
 }
 
 private extension POSCatalogPersistenceServiceTests {

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
@@ -362,7 +362,7 @@ struct POSOrderServiceTests {
                 #expect(missingItems.count == 1)
                 #expect(missingItems.first?.productID == 0) // Generic error
                 #expect(missingItems.first?.variationID == 0)
-                #expect(missingItems.first?.name == "Unknown Product")
+                #expect(missingItems.first?.name == "One or more products")
                 return true
             }
             return false
@@ -502,7 +502,7 @@ struct POSOrderServiceTests {
                 #expect(missingItems.count == 1)
                 #expect(missingItems.first?.productID == 0)
                 #expect(missingItems.first?.variationID == 999)
-                #expect(missingItems.first?.name == "Unknown Product")
+                #expect(missingItems.first?.name == "One or more products")
                 return true
             }
             return false

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
@@ -254,11 +254,10 @@ struct POSOrderServiceTests {
 
     @Test func syncOrder_throws_error_when_order_missing_variation() async throws {
         // Given
-        let variationUUID = UUID()
         let cart = POSCart(items: [
             POSCartItem(
                 item: POSVariation(
-                    id: variationUUID,
+                    id: UUID(),
                     name: "Large",
                     formattedPrice: "$20",
                     price: "20",
@@ -279,7 +278,8 @@ struct POSOrderServiceTests {
         }, throws: { error in
             if case .missingProductsInOrder(let missingItems) = error as? POSOrderService.POSOrderServiceError {
                 #expect(missingItems.count == 1)
-                #expect(missingItems.first?.id == variationUUID)
+                #expect(missingItems.first?.variationID == 500)
+                #expect(missingItems.first?.productID == 100)
                 return true
             }
             return false
@@ -288,12 +288,10 @@ struct POSOrderServiceTests {
 
     @Test func syncOrder_distinguishes_between_variations_of_same_product() async throws {
         // Given
-        let variation1UUID = UUID()
-        let variation2UUID = UUID()
         let cart = POSCart(items: [
             POSCartItem(
                 item: POSVariation(
-                    id: variation1UUID,
+                    id: UUID(),
                     name: "Small",
                     formattedPrice: "$15",
                     price: "15",
@@ -305,7 +303,7 @@ struct POSOrderServiceTests {
             ),
             POSCartItem(
                 item: POSVariation(
-                    id: variation2UUID,
+                    id: UUID(),
                     name: "Large",
                     formattedPrice: "$20",
                     price: "20",
@@ -335,7 +333,8 @@ struct POSOrderServiceTests {
             if case .missingProductsInOrder(let missingItems) = error as? POSOrderService.POSOrderServiceError {
                 // Should only report the missing variation (variationID 501)
                 #expect(missingItems.count == 1)
-                #expect(missingItems.first?.id == variation2UUID)
+                #expect(missingItems.first?.variationID == 501)
+                #expect(missingItems.first?.productID == 100)
                 return true
             }
             return false

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
@@ -1,6 +1,10 @@
 import Foundation
 import Testing
 @testable import Yosemite
+import enum Networking.DotcomError
+import enum Networking.NetworkError
+import enum Alamofire.AFError
+import struct Networking.AnyDecodable
 
 struct POSOrderServiceTests {
     let sut: POSOrderService
@@ -336,6 +340,169 @@ struct POSOrderServiceTests {
                 #expect(missingItems.count == 1)
                 #expect(missingItems.first?.variationID == 501)
                 #expect(missingItems.first?.productID == 100)
+                return true
+            }
+            return false
+        })
+    }
+
+    // MARK: - Server-side Validation Error Tests
+
+    @Test func syncOrder_throws_missingProducts_error_for_DotcomError_with_invalid_variation_code() async throws {
+        // Given
+        let cart = POSCart(items: [makePOSCartItem(productID: 100, quantity: 1)])
+        let dotcomError = DotcomError.unknown(code: "order_item_product_invalid_variation_id", message: "Invalid variation")
+        mockOrdersRemote.createPOSOrderResult = .failure(dotcomError)
+
+        // When/Then
+        await #expect(performing: {
+            try await sut.syncOrder(cart: cart, currency: .USD)
+        }, throws: { error in
+            if case .missingProductsInOrder(let missingItems) = error as? POSOrderService.POSOrderServiceError {
+                #expect(missingItems.count == 1)
+                #expect(missingItems.first?.productID == 0) // Generic error
+                #expect(missingItems.first?.variationID == 0)
+                #expect(missingItems.first?.name == "Unknown Product")
+                return true
+            }
+            return false
+        })
+    }
+
+    @Test func syncOrder_throws_missingProducts_error_for_NetworkError_with_invalid_variation_code_and_variation_id() async throws {
+        // Given
+        let cart = POSCart(items: [
+            POSCartItem(
+                item: POSVariation(
+                    id: UUID(),
+                    name: "Large",
+                    formattedPrice: "$20",
+                    price: "20",
+                    productID: 100,
+                    variationID: 500,
+                    parentProductName: "T-Shirt"
+                ),
+                quantity: 1
+            )
+        ])
+
+        let errorJSON = """
+        {
+            "code": "order_item_product_invalid_variation_id",
+            "message": "Invalid variation",
+            "data": {
+                "variation_id": 500
+            }
+        }
+        """
+        let errorData = errorJSON.data(using: .utf8)!
+        let networkError = NetworkError.unacceptableStatusCode(statusCode: 400, response: errorData)
+        mockOrdersRemote.createPOSOrderResult = .failure(networkError)
+
+        // When/Then
+        await #expect(performing: {
+            try await sut.syncOrder(cart: cart, currency: .USD)
+        }, throws: { error in
+            if case .missingProductsInOrder(let missingItems) = error as? POSOrderService.POSOrderServiceError {
+                #expect(missingItems.count == 1)
+                #expect(missingItems.first?.productID == 100)
+                #expect(missingItems.first?.variationID == 500)
+                #expect(missingItems.first?.name == "T-Shirt - Large")
+                return true
+            }
+            return false
+        })
+    }
+
+    @Test func syncOrder_throws_missingProducts_error_for_NetworkError_without_variation_id() async throws {
+        // Given
+        let cart = POSCart(items: [makePOSCartItem(productID: 100, quantity: 1)])
+        let errorJSON = """
+        {
+            "code": "order_item_product_invalid_variation_id",
+            "message": "Invalid variation"
+        }
+        """
+        let errorData = errorJSON.data(using: .utf8)!
+        let networkError = NetworkError.unacceptableStatusCode(statusCode: 400, response: errorData)
+        mockOrdersRemote.createPOSOrderResult = .failure(networkError)
+
+        // When/Then
+        await #expect(performing: {
+            try await sut.syncOrder(cart: cart, currency: .USD)
+        }, throws: { error in
+            if case .missingProductsInOrder(let missingItems) = error as? POSOrderService.POSOrderServiceError {
+                #expect(missingItems.count == 1)
+                #expect(missingItems.first?.productID == 0) // Generic error
+                #expect(missingItems.first?.variationID == 0)
+                return true
+            }
+            return false
+        })
+    }
+
+    @Test func syncOrder_throws_missingProducts_error_for_AFError_wrapping_DotcomError() async throws {
+        // Given
+        let cart = POSCart(items: [makePOSCartItem(productID: 100, quantity: 1)])
+        let dotcomError = DotcomError.unknown(code: "order_item_product_invalid_variation_id", message: "Invalid")
+        let afError = AFError.sessionTaskFailed(error: dotcomError)
+        mockOrdersRemote.createPOSOrderResult = .failure(afError)
+
+        // When/Then
+        await #expect(performing: {
+            try await sut.syncOrder(cart: cart, currency: .USD)
+        }, throws: { error in
+            if case .missingProductsInOrder(let missingItems) = error as? POSOrderService.POSOrderServiceError {
+                #expect(missingItems.count == 1)
+                return true
+            }
+            return false
+        })
+    }
+
+    @Test func syncOrder_throws_original_error_for_unrecognized_DotcomError_code() async throws {
+        // Given
+        let cart = POSCart(items: [makePOSCartItem(productID: 100, quantity: 1)])
+        let dotcomError = DotcomError.unknown(code: "some_other_error_code", message: "Different error")
+        mockOrdersRemote.createPOSOrderResult = .failure(dotcomError)
+
+        // When/Then
+        await #expect(performing: {
+            try await sut.syncOrder(cart: cart, currency: .USD)
+        }, throws: { error in
+            // Should throw the original DotcomError, not missingProductsInOrder
+            if case .unknown = error as? DotcomError {
+                return true
+            }
+            return false
+        })
+    }
+
+    @Test func syncOrder_throws_missingProducts_with_generic_name_when_variation_not_in_cart() async throws {
+        // Given
+        let cart = POSCart(items: [makePOSCartItem(productID: 100, quantity: 1)])
+        let errorJSON = """
+        {
+            "code": "order_item_product_invalid_variation_id",
+            "message": "Invalid variation",
+            "data": {
+                "variation_id": 999
+            }
+        }
+        """
+        let errorData = errorJSON.data(using: .utf8)!
+        let networkError = NetworkError.unacceptableStatusCode(statusCode: 400, response: errorData)
+        mockOrdersRemote.createPOSOrderResult = .failure(networkError)
+
+        // When/Then
+        await #expect(performing: {
+            try await sut.syncOrder(cart: cart, currency: .USD)
+        }, throws: { error in
+            if case .missingProductsInOrder(let missingItems) = error as? POSOrderService.POSOrderServiceError {
+                #expect(missingItems.count == 1)
+                #expect(missingItems.first?.productID == 0)
+                #expect(missingItems.first?.variationID == 999)
+                #expect(missingItems.first?.name == "Unknown Product")
                 return true
             }
             return false

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
@@ -222,7 +222,8 @@ struct POSOrderServiceTests {
         }, throws: { error in
             if case .missingProductsInOrder(let missingItems) = error as? POSOrderService.POSOrderServiceError {
                 #expect(missingItems.count == 1)
-                #expect(missingItems.first?.expectedQuantity == 2)
+                #expect(missingItems.first?.productID == 200)
+                #expect(missingItems.first?.name == "")
                 return true
             }
             return false

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
@@ -195,6 +195,152 @@ struct POSOrderServiceTests {
             return true
         })
     }
+
+    // MARK: - Missing Products Tests
+
+    @Test func syncOrder_throws_error_when_order_is_missing_cart_products() async throws {
+        // Given
+        let cart = POSCart(items: [
+            makePOSCartItem(productID: 100, quantity: 1),
+            makePOSCartItem(productID: 200, quantity: 2)
+        ])
+
+        // Mock returns an order with only one of the products
+        let orderWithMissingProduct = OrderFactory.newOrder(currency: .USD)
+            .copy(
+                siteID: 123,
+                status: .autoDraft,
+                items: [
+                    OrderItem.fake().copy(productID: 100, quantity: 1)
+                ]
+            )
+        mockOrdersRemote.createPOSOrderResult = .success(orderWithMissingProduct)
+
+        // When/Then
+        await #expect(performing: {
+            try await sut.syncOrder(cart: cart, currency: .USD)
+        }, throws: { error in
+            if case .missingProductsInOrder(let missingItems) = error as? POSOrderService.POSOrderServiceError {
+                #expect(missingItems.count == 1)
+                #expect(missingItems.first?.expectedQuantity == 2)
+                return true
+            }
+            return false
+        })
+    }
+
+    @Test func syncOrder_succeeds_when_all_cart_items_in_order() async throws {
+        // Given
+        let cart = POSCart(items: [
+            makePOSCartItem(productID: 100, quantity: 1),
+            makePOSCartItem(productID: 200, quantity: 2)
+        ])
+
+        // Mock returns an order with all cart items
+        let completeOrder = OrderFactory.newOrder(currency: .USD)
+            .copy(
+                siteID: 123,
+                status: .autoDraft,
+                items: [
+                    OrderItem.fake().copy(productID: 100, quantity: 1),
+                    OrderItem.fake().copy(productID: 200, quantity: 2)
+                ]
+            )
+        mockOrdersRemote.createPOSOrderResult = .success(completeOrder)
+
+        // When/Then - Should not throw
+        _ = try await sut.syncOrder(cart: cart, currency: .USD)
+    }
+
+    @Test func syncOrder_throws_error_when_order_missing_variation() async throws {
+        // Given
+        let variationUUID = UUID()
+        let cart = POSCart(items: [
+            POSCartItem(
+                item: POSVariation(
+                    id: variationUUID,
+                    name: "Large",
+                    formattedPrice: "$20",
+                    price: "20",
+                    productID: 100,
+                    variationID: 500,
+                    parentProductName: "T-Shirt"
+                ),
+                quantity: 1
+            )
+        ])
+
+        // Mock returns an empty order
+        mockOrdersRemote.createPOSOrderResult = .success(OrderFactory.newOrder(currency: .USD))
+
+        // When/Then
+        await #expect(performing: {
+            try await sut.syncOrder(cart: cart, currency: .USD)
+        }, throws: { error in
+            if case .missingProductsInOrder(let missingItems) = error as? POSOrderService.POSOrderServiceError {
+                #expect(missingItems.count == 1)
+                #expect(missingItems.first?.id == variationUUID)
+                return true
+            }
+            return false
+        })
+    }
+
+    @Test func syncOrder_distinguishes_between_variations_of_same_product() async throws {
+        // Given
+        let variation1UUID = UUID()
+        let variation2UUID = UUID()
+        let cart = POSCart(items: [
+            POSCartItem(
+                item: POSVariation(
+                    id: variation1UUID,
+                    name: "Small",
+                    formattedPrice: "$15",
+                    price: "15",
+                    productID: 100,
+                    variationID: 500,
+                    parentProductName: "T-Shirt"
+                ),
+                quantity: 1
+            ),
+            POSCartItem(
+                item: POSVariation(
+                    id: variation2UUID,
+                    name: "Large",
+                    formattedPrice: "$20",
+                    price: "20",
+                    productID: 100,
+                    variationID: 501,
+                    parentProductName: "T-Shirt"
+                ),
+                quantity: 1
+            )
+        ])
+
+        // Mock returns order with only one variation
+        let orderWithOneVariation = OrderFactory.newOrder(currency: .USD)
+            .copy(
+                siteID: 123,
+                status: .autoDraft,
+                items: [
+                    OrderItem.fake().copy(productID: 100, variationID: 500, quantity: 1)
+                ]
+            )
+        mockOrdersRemote.createPOSOrderResult = .success(orderWithOneVariation)
+
+        // When/Then
+        await #expect(performing: {
+            try await sut.syncOrder(cart: cart, currency: .USD)
+        }, throws: { error in
+            if case .missingProductsInOrder(let missingItems) = error as? POSOrderService.POSOrderServiceError {
+                // Should only report the missing variation (variationID 501)
+                #expect(missingItems.count == 1)
+                #expect(missingItems.first?.id == variation2UUID)
+                return true
+            }
+            return false
+        })
+    }
 }
 
 private func makePOSCartItem(

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -174,6 +174,9 @@ private extension TracksProvider {
             WooAnalyticsStat.pointOfSaleOrdersListSearchResultsFetched,
             WooAnalyticsStat.pointOfSaleOrderDetailsLoaded,
             WooAnalyticsStat.pointOfSaleOrderDetailsEmailReceiptTapped,
+            WooAnalyticsStat.pointOfSaleCheckoutOutdatedItemDetectedScreenShown,
+            WooAnalyticsStat.pointOfSaleCheckoutOutdatedItemDetectedEditOrderTapped,
+            WooAnalyticsStat.pointOfSaleCheckoutOutdatedItemDetectedRemoveTapped,
 
             // Order
             WooAnalyticsStat.ordersListLoaded,

--- a/WooCommerce/WooCommerceTests/Tools/ForegroundPOSCatalogSyncDispatcherTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ForegroundPOSCatalogSyncDispatcherTests.swift
@@ -311,4 +311,8 @@ private final class MockPOSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProt
     func processBackgroundDownload(fileURL: URL, siteID: Int64) async throws {
         // Not used in these tests
     }
+
+    func deleteProductsFromCatalog(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws {
+        // no-op
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Merge after #16345

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR shows merchants issues where a product is no longer available when they check out. 

This can happen when a product or variation hasn't been resynced (i.e. no full sync) since it was deleted. When we create an order with these products, we show an error and prompt the merchant to remove the product, blocking checkout until it's resolved.

We also remove the item from the local catalog, when we can identify it.

There are some difficulties identifying missing variations, as we get different responses for these. That means we have to treat them separately, and when we can't identify the variation we don't give details of the missing items.

If a product is missing, we get the order back missing that line item – so we just compare it to the cart to find missing products.

If a variation is missing, we get an error back. Currently, we don't get the `variation_id` back in the error, and we don't have any line items to compare with.

In a separate backend PR we'll add the `variation_id` to the error, and backend folks are ensuring that'll be passed back through the proxy when using a WPCom connection too. We don't want to require a new version of Woo to use this, so older versions will fall back to a generic error and figuring out the broken product themselves. See `Unknown variation missing` video below.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Launch the app and open POS with a local catalog site
2. Add a product to the cart
3. Delete the product in WP-Admin, and empty the trash
4. Checkout
5. Observe that you're shown the error and can remove or edit the cart
6. Observe that the product is no longer in your local catalog after.
7. Observe that the analytics events are tracked as expected

Repeat with variations... but be aware that you'll only see the generic errors. I can invite you to my test site to see it with the variation ID returned.

### Analytics

Event Identifier | Properties | Description
-- | -- | --
woo_pos_checkout_outdated_item_detected_screen_shown | Reason (deleted), sync_strategy (remote, local_catalog) | Tracked when the user moves to checkout and the app detects an outdated item in the cart.
woo_pos_checkout_outdated_item_detected_edit_order_tapped | Reason (deleted), sync_strategy (remote, local_catalog) | Tracked when the user taps on edit order on the screen.
woo_pos_checkout_outdated_item_detected_remove_tapped | Reason (deleted), sync_strategy (remote, local_catalog) | Tracked when the user taps on remove item from cart on the screen.



## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Unknown variation missing
https://github.com/user-attachments/assets/4766fd30-23ae-4380-a962-31a891788713

### Known missing variations and products
https://github.com/user-attachments/assets/842c1824-c694-4e5e-8da3-ed46055efbc2


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
