### PR TITLE
[Bookings] Make network call to update booking note

### DIFF
--- a/Modules/Sources/Networking/Remote/BookingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/BookingsRemote.swift
@@ -265,6 +265,6 @@ public extension BookingsRemote {
         static let attendanceStatus        = "attendance_status"
         static let paymentStatus           = "booking_status" // to be updated later when payment filtering is supported
         static let status: String          = "status"
-        static let note: String          = "note"
+        static let note: String            = "note"
     }
 }

--- a/Modules/Sources/Networking/Remote/BookingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/BookingsRemote.swift
@@ -20,7 +20,8 @@ public protocol BookingsRemoteProtocol {
         from siteID: Int64,
         bookingID: Int64,
         attendanceStatus: BookingAttendanceStatus?,
-        bookingStatus: BookingStatus?
+        bookingStatus: BookingStatus?,
+        note: String?
     ) async throws -> Booking?
 
     func fetchResource(resourceID: Int64,
@@ -152,7 +153,8 @@ public final class BookingsRemote: Remote, BookingsRemoteProtocol {
         from siteID: Int64,
         bookingID: Int64,
         attendanceStatus: BookingAttendanceStatus?,
-        bookingStatus: BookingStatus?
+        bookingStatus: BookingStatus?,
+        note: String?
     ) async throws -> Booking? {
         let path = "\(Path.bookings)/\(bookingID)"
         var parameters: [String: String] = [:]
@@ -163,6 +165,10 @@ public final class BookingsRemote: Remote, BookingsRemoteProtocol {
 
         if let bookingStatus {
             parameters[ParameterKey.status] = bookingStatus.rawValue
+        }
+
+        if let note {
+            parameters[ParameterKey.note] = note
         }
 
         let request = JetpackRequest(
@@ -259,5 +265,6 @@ public extension BookingsRemote {
         static let attendanceStatus        = "attendance_status"
         static let paymentStatus           = "booking_status" // to be updated later when payment filtering is supported
         static let status: String          = "status"
+        static let note: String          = "note"
     }
 }

--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -617,7 +617,6 @@ public enum WooAnalyticsStat: String {
     case interacRefundCanceled = "interac_refund_cancelled"
 
     // MARK: Push Notifications Events
-    //
     case pushNotificationReceived = "push_notification_received"
     case pushNotificationAlertPressed = "push_notification_alert_pressed"
     case pushNotificationOSAlertAllowed = "push_notification_os_alert_allowed"

--- a/Modules/Sources/Yosemite/Actions/BookingAction.swift
+++ b/Modules/Sources/Yosemite/Actions/BookingAction.swift
@@ -92,7 +92,7 @@ public enum BookingAction: Action {
                            bookingID: Int64,
                            onCompletion: (Error?) -> Void)
 
-    /// Updates a booking attendance status.
+    /// Updates a booking note.
     ///
     /// - Parameter siteID: The site ID of the booking.
     /// - Parameter bookingID: The ID of the booking to be updated.

--- a/Modules/Sources/Yosemite/Actions/BookingAction.swift
+++ b/Modules/Sources/Yosemite/Actions/BookingAction.swift
@@ -91,4 +91,16 @@ public enum BookingAction: Action {
     case markBookingAsPaid(siteID: Int64,
                            bookingID: Int64,
                            onCompletion: (Error?) -> Void)
+
+    /// Updates a booking attendance status.
+    ///
+    /// - Parameter siteID: The site ID of the booking.
+    /// - Parameter bookingID: The ID of the booking to be updated.
+    /// - Parameter note: The new note.
+    /// - Parameter onCompletion: called when update completes, returns an error in case of a failure.
+    ///
+    case updateBookingNote(siteID: Int64,
+                           bookingID: Int64,
+                           note: String,
+                           onCompletion: (Error?) -> Void)
 }

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -82,6 +82,13 @@ public class BookingStore: Store {
                 bookingID: bookingID,
                 onCompletion: onCompletion
             )
+        case .updateBookingNote(let siteID, let bookingID, let note, let onCompletion):
+            updateBookingNote(
+                siteID: siteID,
+                bookingID: bookingID,
+                note: note,
+                onCompletion: onCompletion
+            )
         }
     }
 }
@@ -308,6 +315,7 @@ private extension BookingStore {
                         bookingID: bookingID,
                         attendanceStatus: status,
                         bookingStatus: nil,
+                        note: nil,
                     ) {
                         await self.upsertStoredBookingsInBackground(
                             readOnlyBookings: [remoteBooking],
@@ -325,6 +333,54 @@ private extension BookingStore {
                         siteID: siteID,
                         bookingID: bookingID,
                         statusKey: previousStatusKey
+                    ) { _ in
+                        onCompletion(error)
+                    }
+                }
+            }
+        }
+    }
+
+    func updateBookingNote(
+        siteID: Int64,
+        bookingID: Int64,
+        note: String,
+        onCompletion: @escaping (Error?) -> Void
+    ) {
+        updateBookingNoteLocally(
+            siteID: siteID,
+            bookingID: bookingID,
+            note: note
+        ) { [weak self] previousNote in
+            guard let self else {
+                return onCompletion(UpdateBookingStatusError.undefinedState)
+            }
+
+            Task { @MainActor in
+                do {
+                    if let remoteBooking = try await self.remote.updateBooking(
+                        from: siteID,
+                        bookingID: bookingID,
+                        attendanceStatus: nil,
+                        bookingStatus: nil,
+                        note: note,
+                    ) {
+                        await self.upsertStoredBookingsInBackground(
+                            readOnlyBookings: [remoteBooking],
+                            readOnlyOrders: [],
+                            siteID: siteID
+                        )
+
+                        onCompletion(nil)
+                    } else {
+                        return onCompletion(UpdateBookingStatusError.missingRemoteBooking)
+                    }
+                } catch {
+                    /// Revert Optimistic Update
+                    self.updateBookingNoteLocally(
+                        siteID: siteID,
+                        bookingID: bookingID,
+                        note: note
                     ) { _ in
                         onCompletion(error)
                     }
@@ -361,6 +417,33 @@ private extension BookingStore {
         }, on: .main)
     }
 
+    func updateBookingNoteLocally(
+        siteID: Int64,
+        bookingID: Int64,
+        note: String?,
+        onCompletion: @escaping (String?) -> Void
+    ) {
+        storageManager.performAndSave({ storage -> String? in
+            guard let booking = storage.loadBooking(
+                siteID: siteID,
+                bookingID: bookingID
+            ) else {
+                return note
+            }
+
+            let oldNote = booking.note
+            booking.note = note
+            return oldNote
+        }, completion: { result in
+            switch result {
+            case .success(let status):
+                onCompletion(status)
+            case .failure:
+                onCompletion(note)
+            }
+        }, on: .main)
+    }
+
     /// Cancels a booking by updating its status to cancelled.
     func cancelBooking(
         siteID: Int64,
@@ -373,7 +456,8 @@ private extension BookingStore {
                     from: siteID,
                     bookingID: bookingID,
                     attendanceStatus: nil,
-                    bookingStatus: .cancelled
+                    bookingStatus: .cancelled,
+                    note: nil,
                 ) {
                     await upsertStoredBookingsInBackground(
                         readOnlyBookings: [remoteBooking],
@@ -403,7 +487,8 @@ private extension BookingStore {
                     from: siteID,
                     bookingID: bookingID,
                     attendanceStatus: nil,
-                    bookingStatus: .paid
+                    bookingStatus: .paid,
+                    note: nil,
                 ) {
                     await upsertStoredBookingsInBackground(
                         readOnlyBookings: [remoteBooking],

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -347,44 +347,27 @@ private extension BookingStore {
         note: String,
         onCompletion: @escaping (Error?) -> Void
     ) {
-        updateBookingNoteLocally(
-            siteID: siteID,
-            bookingID: bookingID,
-            note: note
-        ) { [weak self] previousNote in
-            guard let self else {
-                return onCompletion(UpdateBookingStatusError.undefinedState)
-            }
+        Task { @MainActor in
+            do {
+                if let remoteBooking = try await self.remote.updateBooking(
+                    from: siteID,
+                    bookingID: bookingID,
+                    attendanceStatus: nil,
+                    bookingStatus: nil,
+                    note: note,
+                ) {
+                    await self.upsertStoredBookingsInBackground(
+                        readOnlyBookings: [remoteBooking],
+                        readOnlyOrders: [],
+                        siteID: siteID
+                    )
 
-            Task { @MainActor in
-                do {
-                    if let remoteBooking = try await self.remote.updateBooking(
-                        from: siteID,
-                        bookingID: bookingID,
-                        attendanceStatus: nil,
-                        bookingStatus: nil,
-                        note: note,
-                    ) {
-                        await self.upsertStoredBookingsInBackground(
-                            readOnlyBookings: [remoteBooking],
-                            readOnlyOrders: [],
-                            siteID: siteID
-                        )
-
-                        onCompletion(nil)
-                    } else {
-                        return onCompletion(UpdateBookingStatusError.missingRemoteBooking)
-                    }
-                } catch {
-                    /// Revert Optimistic Update
-                    self.updateBookingNoteLocally(
-                        siteID: siteID,
-                        bookingID: bookingID,
-                        note: note
-                    ) { _ in
-                        onCompletion(error)
-                    }
+                    onCompletion(nil)
+                } else {
+                    return onCompletion(UpdateBookingStatusError.missingRemoteBooking)
                 }
+            } catch {
+                return onCompletion(error)
             }
         }
     }
@@ -413,33 +396,6 @@ private extension BookingStore {
                 onCompletion(status)
             case .failure:
                 onCompletion(statusKey)
-            }
-        }, on: .main)
-    }
-
-    func updateBookingNoteLocally(
-        siteID: Int64,
-        bookingID: Int64,
-        note: String?,
-        onCompletion: @escaping (String?) -> Void
-    ) {
-        storageManager.performAndSave({ storage -> String? in
-            guard let booking = storage.loadBooking(
-                siteID: siteID,
-                bookingID: bookingID
-            ) else {
-                return note
-            }
-
-            let oldNote = booking.note
-            booking.note = note
-            return oldNote
-        }, completion: { result in
-            switch result {
-            case .success(let status):
-                onCompletion(status)
-            case .failure:
-                onCompletion(note)
             }
         }, on: .main)
     }

--- a/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
@@ -137,7 +137,8 @@ struct BookingsRemoteTests {
             from: sampleSiteID,
             bookingID: bookingID,
             attendanceStatus: .noShow,
-            bookingStatus: nil
+            bookingStatus: nil,
+            note: nil
         )
 
         // Then
@@ -157,7 +158,8 @@ struct BookingsRemoteTests {
             from: sampleSiteID,
             bookingID: bookingID,
             attendanceStatus: .noShow,
-            bookingStatus: nil
+            bookingStatus: nil,
+            note: nil
         )
 
         // Then
@@ -179,7 +181,8 @@ struct BookingsRemoteTests {
             from: sampleSiteID,
             bookingID: bookingID,
             attendanceStatus: nil,
-            bookingStatus: .confirmed
+            bookingStatus: .confirmed,
+            note: nil
         )
 
         // Then
@@ -201,7 +204,8 @@ struct BookingsRemoteTests {
             from: sampleSiteID,
             bookingID: bookingID,
             attendanceStatus: .booked,
-            bookingStatus: .paid
+            bookingStatus: .paid,
+            note: nil
         )
 
         // Then
@@ -253,5 +257,29 @@ struct BookingsRemoteTests {
 
         #expect((parameters["page"] as? String) == "3")
         #expect((parameters["per_page"] as? String) == "100")
+    }
+
+    @Test func test_updateBookingNote_sends_correct_parameters_for_booking_note() async throws {
+        // Given
+        let remote = BookingsRemote(network: network)
+        let bookingID: Int64 = 206
+        network.simulateResponse(requestUrlSuffix: "bookings/\(bookingID)", filename: "booking-no-create-update-dates")
+
+        // When
+        _ = try await remote.updateBooking(
+            from: sampleSiteID,
+            bookingID: bookingID,
+            attendanceStatus: nil,
+            bookingStatus: nil,
+            note: "hello"
+        )
+
+        // Then
+        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
+        let parameters = request.parameters
+
+        #expect(parameters["attendance_status"] == nil)
+        #expect(parameters["status"] == nil)
+        #expect((parameters["note"] as? String) == "hello")
     }
 }

--- a/Modules/Tests/YosemiteTests/Mocks/MockBookingsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockBookingsRemote.swift
@@ -9,6 +9,7 @@ final class MockBookingsRemote: BookingsRemoteProtocol {
     private var fetchResourceResult: Result<BookingResource?, Error>?
     private var updateBookingResult: Result<Booking?, Error>?
     private var fetchResourcesResult: Result<[BookingResource], Error>?
+    private var updateBookingNote: Result<Booking?, Error>?
 
     func whenLoadingAllBookings(thenReturn result: Result<[Booking], Error>) {
         loadAllBookingsResult = result
@@ -59,7 +60,8 @@ final class MockBookingsRemote: BookingsRemoteProtocol {
     func updateBooking(from siteID: Int64,
                        bookingID: Int64,
                        attendanceStatus: BookingAttendanceStatus?,
-                       bookingStatus: BookingStatus?) async throws -> Booking? {
+                       bookingStatus: BookingStatus?,
+                       note: String?) async throws -> Booking? {
         guard let result = updateBookingResult else {
             throw NetworkError.timeout()
         }

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -252,22 +252,30 @@ extension BookingDetailsViewModel {
         stores.dispatch(action)
     }
 
-    func updateNote(to newNote: String) {
-        let action = BookingAction.updateBookingNote(
-            siteID: booking.siteID,
-            bookingID: booking.bookingID,
-            note: newNote
-        ) { [weak self] error in
-            if let error, let self {
-                DDLogError("⛔️ Error updating booking note: \(error)")
-                displayErrorNotice(
-                    messageFormat: Localization.bookingNoteUpdateFailedMessage
-                ) { [weak self] in
-                    self?.updateNote(to: newNote)
+    @MainActor
+    func updateNote(to newNote: String) async -> MultilineCommitResult {
+        await withCheckedContinuation { continuation in
+            let action = BookingAction.updateBookingNote(
+                siteID: booking.siteID,
+                bookingID: booking.bookingID,
+                note: newNote
+            ) { [booking] error in
+                if let error {
+                    DDLogError("⛔️ Error updating booking note: \(error)")
+                    let message = String.localizedStringWithFormat(
+                        Localization.bookingNoteUpdateFailedMessage,
+                        booking.bookingID
+                    )
+
+                    continuation.resume(returning: .failure(message: message))
+                    return
                 }
+
+                continuation.resume(returning: .success)
             }
+
+            stores.dispatch(action)
         }
-        stores.dispatch(action)
     }
 
     private func displayErrorNotice(
@@ -283,8 +291,7 @@ extension BookingDetailsViewModel {
             message: text,
             feedbackType: .error,
             actionTitle: Localization.retryActionTitle
-        ) { [weak self] in
-            guard let self else { return }
+        ) {
             retry()
         }
     }

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -242,7 +242,11 @@ extension BookingDetailsViewModel {
         ) { [weak self] error in
             if let error, let self {
                 DDLogError("⛔️ Error updating booking attendance status: \(error)")
-                displayAttendanceStatusUpdatedErrorNotice(status: newStatus)
+                displayErrorNotice(
+                    messageFormat: Localization.bookingAttendanceStatusUpdateFailedMessage
+                ) { [weak self] in
+                    self?.updateAttendanceStatus(to: newStatus)
+                }
             }
         }
         stores.dispatch(action)
@@ -256,27 +260,32 @@ extension BookingDetailsViewModel {
         ) { [weak self] error in
             if let error, let self {
                 DDLogError("⛔️ Error updating booking note: \(error)")
-//                displayAttendanceStatusUpdatedErrorNotice(status: newStatus)
+                displayErrorNotice(
+                    messageFormat: Localization.bookingNoteUpdateFailedMessage
+                ) { [weak self] in
+                    self?.updateNote(to: newNote)
+                }
             }
         }
         stores.dispatch(action)
     }
 
-    private func displayAttendanceStatusUpdatedErrorNotice(status: BookingAttendanceStatus) {
+    private func displayErrorNotice(
+        messageFormat: String,
+        retry: @escaping () -> Void
+    ) {
         let text = String.localizedStringWithFormat(
-            Localization.bookingAttendanceStatusUpdateFailedMessage,
+            messageFormat,
             booking.bookingID
         )
-        self.notice = Notice(
+
+        notice = Notice(
             message: text,
             feedbackType: .error,
             actionTitle: Localization.retryActionTitle
         ) { [weak self] in
-            guard let self else {
-                return
-            }
-
-            updateAttendanceStatus(to: status)
+            guard let self else { return }
+            retry()
         }
     }
 }
@@ -486,6 +495,14 @@ private extension BookingDetailsViewModel {
             value: "Unable to change attendance status of Booking #%1$d.",
             comment: "Content of error presented when updating the attendance status of a Booking fails. "
             + "It reads: Unable to change status of Booking #{Booking number}. "
+            + "Parameters: %1$d - Booking number"
+        )
+
+        static let bookingNoteUpdateFailedMessage = NSLocalizedString(
+            "BookingDetailsView.bookingNote.failureMessage.",
+            value: "Unable to update note of Booking #%1$d.",
+            comment: "Content of error presented when updating the not of a Booking fails. "
+            + "It reads: Unable to update note of Booking #{Booking number}. "
             + "Parameters: %1$d - Booking number"
         )
 

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -248,6 +248,20 @@ extension BookingDetailsViewModel {
         stores.dispatch(action)
     }
 
+    func updateNote(to newNote: String) {
+        let action = BookingAction.updateBookingNote(
+            siteID: booking.siteID,
+            bookingID: booking.bookingID,
+            note: newNote
+        ) { [weak self] error in
+            if let error, let self {
+                DDLogError("⛔️ Error updating booking note: \(error)")
+//                displayAttendanceStatusUpdatedErrorNotice(status: newStatus)
+            }
+        }
+        stores.dispatch(action)
+    }
+
     private func displayAttendanceStatusUpdatedErrorNotice(status: BookingAttendanceStatus) {
         let text = String.localizedStringWithFormat(
             Localization.bookingAttendanceStatusUpdateFailedMessage,

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -245,7 +245,7 @@ private extension BookingDetailsView {
         MultilineEditableTextRow(value: viewModel.note,
                                  placeholder: Localization.bookingNotesRowText,
                                  detailTitle: Localization.bookingNoteNavbarText) { newNote in
-            viewModel.updateNote(to: newNote)
+            return await viewModel.updateNote(to: newNote)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -244,7 +244,9 @@ private extension BookingDetailsView {
     func bookingNotesView() -> some View {
         MultilineEditableTextRow(value: viewModel.note,
                                  placeholder: Localization.bookingNotesRowText,
-                                 detailTitle: Localization.bookingNoteNavbarText)
+                                 detailTitle: Localization.bookingNoteNavbarText) { newNote in
+            viewModel.updateNote(to: newNote)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultilineEditableTextRow/MultilineEditableTextDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultilineEditableTextRow/MultilineEditableTextDetailView.swift
@@ -9,11 +9,13 @@ struct MultilineEditableTextDetailView: View {
     @FocusState private var isFocused: Bool
 
     let title: String?
+    let onCommit: ((String) -> Void)?
 
-    init(text: Binding<String>, title: String? = nil) {
+    init(text: Binding<String>, title: String? = nil, onCommit: ((String) -> Void)? = nil) {
         self._text = text
         self._editedText = State(initialValue: text.wrappedValue)
         self.title = title
+        self.onCommit = onCommit
     }
 
     var body: some View {
@@ -54,6 +56,7 @@ struct MultilineEditableTextDetailView: View {
                 ToolbarItem(placement: .primaryAction) {
                     Button(Localization.doneButtonTitle) {
                         text = editedText
+                        onCommit?(editedText)
                         dismiss()
                     }
                     .fontWeight(.medium)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultilineEditableTextRow/MultilineEditableTextDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultilineEditableTextRow/MultilineEditableTextDetailView.swift
@@ -1,5 +1,10 @@
 import SwiftUI
 
+enum MultilineCommitResult {
+    case success
+    case failure(message: String)
+}
+
 struct MultilineEditableTextDetailView: View {
     @Environment(\.dismiss) private var dismiss
 
@@ -7,11 +12,14 @@ struct MultilineEditableTextDetailView: View {
     @State private var editedText: String
     @State private var showDiscardChangesDialog = false
     @FocusState private var isFocused: Bool
+    @State private var notice: Notice?
+    @State private var isSaving = false
+    @State private var errorMessage: String?
 
     let title: String?
-    let onCommit: ((String) -> Void)?
+    let onCommit: (String) async -> MultilineCommitResult
 
-    init(text: Binding<String>, title: String? = nil, onCommit: ((String) -> Void)? = nil) {
+    init(text: Binding<String>, title: String? = nil, onCommit: @escaping (String) async -> MultilineCommitResult) {
         self._text = text
         self._editedText = State(initialValue: text.wrappedValue)
         self.title = title
@@ -31,6 +39,7 @@ struct MultilineEditableTextDetailView: View {
         .toolbar { toolbar }
         .wooNavigationBarStyle()
         .onAppear { isFocused = true }
+        .notice($notice)
     }
 
     private var toolbar: some ToolbarContent {
@@ -54,14 +63,39 @@ struct MultilineEditableTextDetailView: View {
 
             if editedText != text {
                 ToolbarItem(placement: .primaryAction) {
-                    Button(Localization.doneButtonTitle) {
-                        text = editedText
-                        onCommit?(editedText)
-                        dismiss()
+                    if isSaving {
+                        ProgressView()
+                    } else {
+                        Button(Localization.doneButtonTitle) {
+                            Task {
+                                await handleDoneTapped()
+                            }
+                        }
+                        .fontWeight(.medium)
+                        .disabled(isSaving)
                     }
-                    .fontWeight(.medium)
                 }
             }
+        }
+    }
+
+    private func handleDoneTapped() async {
+        guard !isSaving else { return }
+
+        isSaving = true
+        let newText = editedText
+        switch await onCommit(newText) {
+        case .success:
+            text = newText
+            isSaving = false
+            dismiss()
+        case .failure(let message):
+            isSaving = false
+
+            notice = Notice(
+                message: message,
+                feedbackType: .error,
+            )
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultilineEditableTextRow/MultilineEditableTextDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultilineEditableTextRow/MultilineEditableTextDetailView.swift
@@ -14,7 +14,6 @@ struct MultilineEditableTextDetailView: View {
     @FocusState private var isFocused: Bool
     @State private var notice: Notice?
     @State private var isSaving = false
-    @State private var errorMessage: String?
 
     let title: String?
     let onCommit: (String) async -> MultilineCommitResult

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultilineEditableTextRow/MultilineEditableTextRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultilineEditableTextRow/MultilineEditableTextRow.swift
@@ -4,16 +4,22 @@ struct MultilineEditableTextRow: View {
     @State var value: String
     let placeholder: String
     let detailTitle: String?
+    let onCommit: ((String) -> Void)?
 
-    init(value: String, placeholder: String, detailTitle: String? = nil) {
-        self.value = value
+    init(value: String,
+         placeholder: String,
+         detailTitle: String? = nil,
+         onCommit: ((String) -> Void)? = nil
+    ) {
+        self._value = State(initialValue: value)
         self.placeholder = placeholder
         self.detailTitle = detailTitle
+        self.onCommit = onCommit
     }
 
     var body: some View {
         NavigationLink {
-            MultilineEditableTextDetailView(text: $value, title: detailTitle)
+            MultilineEditableTextDetailView(text: $value, title: detailTitle, onCommit: onCommit)
         } label: {
             content
         }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultilineEditableTextRow/MultilineEditableTextRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultilineEditableTextRow/MultilineEditableTextRow.swift
@@ -4,12 +4,12 @@ struct MultilineEditableTextRow: View {
     @State var value: String
     let placeholder: String
     let detailTitle: String?
-    let onCommit: ((String) -> Void)?
+    let onCommit: (String) async -> MultilineCommitResult
 
     init(value: String,
          placeholder: String,
          detailTitle: String? = nil,
-         onCommit: ((String) -> Void)? = nil
+         onCommit: @escaping (String) async -> MultilineCommitResult
     ) {
         self._value = State(initialValue: value)
         self.placeholder = placeholder
@@ -64,7 +64,9 @@ fileprivate extension MultilineEditableTextRow {
     @Previewable @State var text: String = ""
 
     NavigationStack {
-        MultilineEditableTextRow(value: text, placeholder: "Add note")
+        MultilineEditableTextRow(value: text, placeholder: "Add note") { _ in
+            return .success
+        }
             .padding(.horizontal, 16)
     }
     .preferredColorScheme(.dark)


### PR DESCRIPTION
Closes [WOOMOB-1617](https://linear.app/a8c/issue/WOOMOB-1617)

## Description
Adds calling the actual endpoint to update the note.

## Test Steps
1. Download and install the app.
2. Login to a store with bookings.
3. Open the details of a booking.
4. Note what the current text for the note is. It might be just the placeholder.
5. Tap on the note.
6. Edit the note.
7. Tap done.
8. Wait a couple of seconds.
9. Force close the app.
10. Navigate to the same booking and validate that the note is the updated one.

## Screenshots
![Simulator Screen Recording - iPhone 17 Pro - 2025-11-17 at 13 11 12](https://github.com/user-attachments/assets/cd7aaf12-bef1-486e-a784-bd9f23ed8a8c)

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
