### PR TITLE
Bookings: Update date time filter and implement clearing filter

### DIFF
--- a/Modules/Sources/Networking/Remote/BookingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/BookingsRemote.swift
@@ -102,12 +102,18 @@ public final class BookingsRemote: Remote, BookingsRemoteProtocol {
                 parameters[ParameterKey.resource] = filters.resourceIDs.map(String.init)
             }
 
-            if let startDateBefore = filters.startDateBefore {
-                parameters[ParameterKey.startDateBefore] = startDateBefore
+            /// `start_date_before` filter doesn't include the date in the result,
+            /// so move the time forward one second as a workaround.
+            if let startDateBefore = filters.startDateBefore,
+                let adjustedDate = Date.dateWithISO8601String(startDateBefore)?.addingTimeInterval(1) {
+                parameters[ParameterKey.startDateBefore] = adjustedDate.ISO8601Format()
             }
 
-            if let startDateAfter = filters.startDateAfter {
-                parameters[ParameterKey.startDateAfter] = startDateAfter
+            /// `start_date_after` filter doesn't include the date in the result,
+            /// so move the time backward one second as a workaround.
+            if let startDateAfter = filters.startDateAfter,
+               let adjustedDate = Date.dateWithISO8601String(startDateAfter)?.addingTimeInterval(-1) {
+                parameters[ParameterKey.startDateAfter] = adjustedDate.ISO8601Format()
             }
 
             if filters.attendanceStatuses.isNotEmpty {

--- a/Modules/Sources/Yosemite/Tools/Bookings/ResultsController+FilterBookings.swift
+++ b/Modules/Sources/Yosemite/Tools/Bookings/ResultsController+FilterBookings.swift
@@ -12,12 +12,12 @@ extension NSPredicate {
 
         let startDateBeforePredicate = filters.startDateBefore.flatMap { dateString -> NSPredicate? in
             guard let date = ISO8601DateFormatter().date(from: dateString) else { return nil }
-            return NSPredicate(format: "startDate < %@", date as NSDate)
+            return NSPredicate(format: "startDate <= %@", date as NSDate)
         }
 
         let startDateAfterPredicate = filters.startDateAfter.flatMap { dateString -> NSPredicate? in
             guard let date = ISO8601DateFormatter().date(from: dateString) else { return nil }
-            return NSPredicate(format: "startDate > %@", date as NSDate)
+            return NSPredicate(format: "startDate >= %@", date as NSDate)
         }
 
         // TODO: update `statusKey` to paymentStatusKey once available

--- a/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
@@ -64,8 +64,11 @@ struct BookingsRemoteTests {
 
         #expect((parameters["page"] as? String) == "2")
         #expect((parameters["per_page"] as? String) == "50")
-        #expect((parameters["start_date_before"] as? String) == startDateBefore)
-        #expect((parameters["start_date_after"] as? String) == startDateAfter)
+        // Date filters are adjusted to be inclusive:
+        // startDateBefore is adjusted +1 second: 2024-12-31T23:59:59 -> 2025-01-01T00:00:00
+        #expect((parameters["start_date_before"] as? String) == "2025-01-01T00:00:00Z")
+        // startDateAfter is adjusted -1 second: 2024-01-01T00:00:00 -> 2023-12-31T23:59:59
+        #expect((parameters["start_date_after"] as? String) == "2023-12-31T23:59:59Z")
         #expect((parameters["search"] as? String) == searchQuery)
         #expect((parameters["order"] as? String) == "asc")
     }

--- a/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
@@ -41,8 +41,8 @@ struct BookingsRemoteTests {
     @Test func test_loadAllBookings_sends_correct_parameters() async throws {
         // Given
         let remote = BookingsRemote(network: network)
-        let startDateBefore = "2024-12-31T23:59:59"
-        let startDateAfter = "2024-01-01T00:00:00"
+        let startDateBefore = "2024-12-31T23:59:59Z"
+        let startDateAfter = "2024-01-01T00:00:00Z"
         let searchQuery = "test search"
         let filters = BookingFilters(
             startDateBefore: startDateBefore,

--- a/WooCommerce/Classes/Bookings/BookingFilters/BookingDateTimeFilterView.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/BookingDateTimeFilterView.swift
@@ -56,6 +56,7 @@ struct BookingDateTimeFilterView: View {
         .navigationTitle(Localization.title)
         .navigationBarTitleDisplayMode(.inline)
         .background(Color(.listBackground))
+        .environment(\.timeZone, TimeZone(identifier: "UTC")!) // API treats dates as no timezone so use UTC to display and select dates
         .onChange(of: fromDate) { _, newValue in
             selectedFromDate = newValue
         }
@@ -63,22 +64,10 @@ struct BookingDateTimeFilterView: View {
             selectedToDate = newValue
         }
         .onChange(of: selectedFromDate) { _, newValue in
-            guard let newValue else {
-                return onSelection(nil, selectedToDate)
-            }
-            /// Bookings backend treats dates as local time with no time zone.
-            /// Convert the date to keep the selected components but with UTC as time zone.
-            let convertedDate = convertToUTCDate(newValue)
-            onSelection(convertedDate, selectedToDate)
+            onSelection(newValue, selectedToDate)
         }
         .onChange(of: selectedToDate) { _, newValue in
-            guard let newValue else {
-                return onSelection(selectedFromDate, nil)
-            }
-            /// Bookings backend treats dates as local time with no time zone.
-            /// Convert the date to keep the selected components but with UTC as time zone.
-            let convertedDate = convertToUTCDate(newValue)
-            onSelection(selectedFromDate, convertedDate)
+            onSelection(selectedFromDate, newValue)
         }
     }
 }

--- a/WooCommerce/Classes/Bookings/BookingFilters/BookingDateTimeFilterView.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/BookingDateTimeFilterView.swift
@@ -157,19 +157,6 @@ private extension BookingDateTimeFilterView {
             return fromDate...Date.distantFuture
         }
     }
-
-    /// Converts a date by extracting its components in the local timezone
-    /// and reconstructing a new date with those same components in UTC.
-    /// This effectively treats the selected date/time as if it were in UTC.
-    func convertToUTCDate(_ date: Date) -> Date {
-        let localCalendar = Calendar.current
-        let components = localCalendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
-
-        var utcCalendar = Calendar(identifier: .gregorian)
-        utcCalendar.timeZone = TimeZone(identifier: "UTC")!
-
-        return utcCalendar.date(from: components) ?? date
-    }
 }
 
 private extension BookingDateTimeFilterView {

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
@@ -19,10 +19,10 @@ struct BookingListContainerView: View {
         BookingListView(
             viewModel: viewModel.listViewModel(for: viewModel.selectedTab),
             searchViewModel: viewModel.searchViewModel(for: viewModel.selectedTab),
-            selectedBooking: $selectedBooking
-        ) {
-            headerView
-        }
+            selectedBooking: $selectedBooking,
+            header: { headerView },
+            onClearingFilters: { viewModel.clearFilters() }
+        )
         .navigationTitle(Localization.viewTitle)
         .if(isSearching, transform: { view in
             view.searchable(text: $viewModel.searchQuery,

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
@@ -112,6 +112,7 @@ final class BookingListContainerViewModel: ObservableObject {
     }
 
     func updateFilters(_ filters: BookingFiltersViewModel.Filters, shouldPersist: Bool = true) {
+        guard selectedTab == .all else { return }
         self.filters = filters
         self.numberOfActiveFilters = filters.numberOfActiveFilters
         allListViewModel.updateFilters(filters)
@@ -119,6 +120,12 @@ final class BookingListContainerViewModel: ObservableObject {
         if shouldPersist {
             saveFilters(filters)
         }
+    }
+
+    func clearFilters() {
+        guard selectedTab == .all else { return }
+        let filters = BookingFiltersViewModel.Filters()
+        updateFilters(filters)
     }
 }
 
@@ -236,7 +243,7 @@ enum BookingListTab: Int, CaseIterable {
         case .upcoming:
             return Localization.EmptyState.upcomingTitle
         case .all:
-            return Localization.EmptyState.filterTitle
+            return Localization.EmptyState.allTitle
         }
     }
 
@@ -250,7 +257,7 @@ enum BookingListTab: Int, CaseIterable {
         case .upcoming:
             return Localization.EmptyState.upcomingDescription
         case .all:
-            return ""
+            return Localization.EmptyState.allDescription
         }
     }
 
@@ -277,8 +284,8 @@ enum BookingListTab: Int, CaseIterable {
                 comment: "Title for the empty state when no bookings for today is found"
             )
             static let todayDescription = NSLocalizedString(
-                "bookingListView.emptyState.today.description",
-                value: "You don't have any appointments or events scheduled for today.",
+                "bookingListView.emptyState.today.description.i3",
+                value: "Any bookings scheduled for today will appear here.",
                 comment: "Description for the empty state when no bookings for today is found"
             )
             static let upcomingTitle = NSLocalizedString(
@@ -287,19 +294,29 @@ enum BookingListTab: Int, CaseIterable {
                 comment: "Title for the empty state when there's no bookings for today"
             )
             static let upcomingDescription = NSLocalizedString(
-                "bookingListView.emptyState.upcoming.description",
-                value: "You don't have any future appointments or events scheduled yet.",
+                "bookingListView.emptyState.upcoming.description.i3",
+                value: "New bookings will appear here as customers schedule your services or register for events.",
                 comment: "Description for the empty state when there's no upcoming bookings"
             )
+            static let allTitle = NSLocalizedString(
+                "bookingListView.emptyState.all.title",
+                value: "No bookings yet",
+                comment: "Title for the empty state when there's no bookings at all so far"
+            )
+            static let allDescription = NSLocalizedString(
+                "bookingListView.emptyState.all.description",
+                value: "Bookings will appear here once customers start scheduling your services or registering for events.",
+                comment: "Description for the empty state when there's no bookings at all so far"
+            )
             static let filterTitle = NSLocalizedString(
-                "bookingListView.emptyState.filter.title",
+                "bookingListView.emptyState.fo;ter.title",
                 value: "No bookings found",
-                comment: "Title for the empty state when there's no bookings for the given filter"
+                comment: "Title for the empty state when there's no bookings given the filters"
             )
             static let filterDescription = NSLocalizedString(
-                "bookingListView.emptyState.filter.description",
-                value: "No bookings match your filters. Try adjusting them to see more results.",
-                comment: "Description for the empty state when there's no bookings for the given filter"
+                "bookingListView.emptyState.filter.description.i3",
+                value: "Try adjusting or clearing your filters to see more results.",
+                comment: "Description for the empty state when there's no bookings given the filters"
             )
         }
     }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
@@ -309,14 +309,14 @@ enum BookingListTab: Int, CaseIterable {
                 comment: "Description for the empty state when there's no bookings at all so far"
             )
             static let filterTitle = NSLocalizedString(
-                "bookingListView.emptyState.fo;ter.title",
+                "bookingListView.emptyState.filter.title",
                 value: "No bookings found",
-                comment: "Title for the empty state when there's no bookings given the filters"
+                comment: "Title for the empty state when there's no bookings for the given filters"
             )
             static let filterDescription = NSLocalizedString(
                 "bookingListView.emptyState.filter.description.i3",
                 value: "Try adjusting or clearing your filters to see more results.",
-                comment: "Description for the empty state when there's no bookings given the filters"
+                comment: "Description for the empty state when there's no bookings for the given filters"
             )
         }
     }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -11,15 +11,18 @@ struct BookingListView<Header: View>: View {
     @Binding var selectedBooking: Booking?
 
     private let header: Header
+    private let onClearingFilters: (() -> Void)?
 
     init(viewModel: BookingListViewModel,
          searchViewModel: BookingSearchViewModel,
          selectedBooking: Binding<Booking?>,
-         @ViewBuilder header: () -> Header) {
+         @ViewBuilder header: () -> Header,
+         onClearingFilters: (() -> Void)? = nil) {
         self.viewModel = viewModel
         self.searchViewModel = searchViewModel
         self._selectedBooking = selectedBooking
         self.header = header()
+        self.onClearingFilters = onClearingFilters
     }
 
     var body: some View {
@@ -199,13 +202,10 @@ private extension BookingListView {
                 }
                 if viewModel.hasFilters {
                     VStack(spacing: BookingListViewLayout.textVerticalPadding) {
-                        Button("Change filters") {
-                            // TODO
+                        Button(BookingListViewLocalization.clearFilters) {
+                            onClearingFilters?()
                         }
                         .buttonStyle(PrimaryButtonStyle())
-                        Button("Clear filters") {
-                            // TODO
-                        }
                     }
                 }
             }
@@ -250,5 +250,10 @@ fileprivate enum BookingListViewLocalization {
         "bookingList.emptySearchText",
         value: "We couldn't find any bookings with that name — try adjusting your search term to see more results.",
         comment: "Message displayed when searching bookings by keyword yields no results."
+    )
+    static let clearFilters = NSLocalizedString(
+        "bookingList.clearFilters",
+        value: "Clear filters",
+        comment: "Button to clear the filters on booking list"
     )
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
@@ -486,9 +486,12 @@ struct BookingListViewModelTests {
                                              storage: storageManager,
                                              currentDate: testDate)
 
-        // When/Then - should only show bookings within today (startDate > start AND startDate < end)
-        #expect(viewModel.bookings.count == 2)
-        #expect(viewModel.bookings.first?.bookingID == withinTodayBooking.bookingID)
+        // When/Then - should only show bookings within today (startDate >= start AND startDate <= end)
+        #expect(viewModel.bookings.count == 3)
+        let bookingIDs = viewModel.bookings.map({ $0.bookingID })
+        #expect(bookingIDs.contains(withinTodayBooking.bookingID))
+        #expect(bookingIDs.contains(atStartOfDayBooking.bookingID))
+        #expect(bookingIDs.contains(startOfNextDayBooking.bookingID))
     }
 
     @Test func upcoming_tab_results_controller_filters_local_storage_correctly() {
@@ -511,14 +514,14 @@ struct BookingListViewModelTests {
                                              storage: storageManager,
                                              currentDate: testDate)
 
-        // When/Then - should only show bookings after today (startDate > end of today)
-        #expect(viewModel.bookings.count == 2, "Upcoming tab should show bookings after today")
+        // When/Then - should only show bookings after today (startDate >= end of today)
+        #expect(viewModel.bookings.count == 3, "Upcoming tab should show bookings after today")
         let bookingIDs = Set(viewModel.bookings.map { $0.bookingID })
         #expect(bookingIDs.contains(afterTodayBooking1.bookingID), "Should contain booking after today")
         #expect(bookingIDs.contains(afterTodayBooking2.bookingID), "Should contain second booking after today")
         #expect(!bookingIDs.contains(withinTodayBooking.bookingID), "Should not contain booking within today")
         #expect(!bookingIDs.contains(beforeTodayBooking.bookingID), "Should not contain booking before today")
-        #expect(!bookingIDs.contains(atEndOfDayBooking.bookingID), "Should not contain booking exactly at end of day")
+        #expect(bookingIDs.contains(atEndOfDayBooking.bookingID), "Should contain booking exactly at end of day")
     }
 
     @Test func all_tab_results_controller_shows_all_bookings_from_local_storage() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1730

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR addresses a few issues:
- Updated booking date time filter to be inclusive of both start date and end date - both locally and remotely.
- Updated copies of empty state views to match i3 design.
- Updated the empty state view when filters are applied to remove Adjust filter button and implement Clear filter.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Log in to a CIAB store without existing bookings or mock data to return empty lists.
2. Confirm that the empty state views of Today, Upcoming, and All states match i3 design on Figma.
3. Switch to a CIAB store with existing bookings.
4. Select All > Filter > Date and time.
5. Adjust the filter to use the same date for start and end dates. Adjust the time of either start or end date to match exactly a booking (or more if there are bookings of the same time) and select Show bookings.
6. Confirm with Proxyman that the date filters in the GET request are correct with your selected dates - with +/- 1 second to be inclusive and no time zone adjustment. E.g if your time zone is UTC+3 and you select Nov 20 12:00AM, the request should be the exact time with no time zone information.
7. Confirm that after the fetch request succeeds, the list returns the booking with the start date matching either start or end date as you chose.
8. Adjust the filter so that no result is returned.
9. Confirm that the empty state matches i3 design. 
10. Select Clear filters and confirm that the list is refreshed with no filters.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/eeb31751-69ec-44b7-b5bf-86084ff5c661

Query of the filter request in the screencast:

<img width="352" height="234" alt="Screenshot 2025-11-17 at 16 37 42" src="https://github.com/user-attachments/assets/f4c7071d-370f-4643-ba33-92b1307e1eb8" />


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
