### PR TITLE
Fix variable product selector navigation 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 23.8
 -----
-
+- [Internal] Fix broken navigation to a variable product selector [https://github.com/woocommerce/woocommerce-ios/pull/16363]
 
 23.7
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -116,17 +116,23 @@ struct ProductSelectorView: View {
                     .padding(Constants.defaultPadding)
                     .accessibilityIdentifier(Constants.doneButtonAccessibilityIdentifier)
                     .renderedIf(configuration.multipleSelectionEnabled && viewModel.syncApproach == .onButtonTap)
-
-                    if let variationListViewModel = viewModel.productVariationListViewModel {
-                        LazyNavigationLink(destination: ProductVariationSelectorView(
-                            isPresented: $isPresented,
-                            viewModel: variationListViewModel,
-                            onMultipleSelections: { selectedIDs in
-                                viewModel.updateSelectedVariations(productID: variationListViewModel.productID, selectedVariationIDs: selectedIDs)
-                            }), isActive: $viewModel.isShowingProductVariationList) {
-                                EmptyView()
-                            }
-                            .renderedIf(configuration.treatsAllProductsAsSimple == false)
+                }
+                .if(configuration.treatsAllProductsAsSimple == false) { view in
+                    view.navigationDestination(isPresented: $viewModel.isShowingProductVariationList) {
+                        if let variationListViewModel = viewModel.productVariationListViewModel {
+                            ProductVariationSelectorView(
+                                isPresented: $isPresented,
+                                viewModel: variationListViewModel,
+                                onMultipleSelections: { selectedIDs in
+                                    viewModel.updateSelectedVariations(
+                                        productID: variationListViewModel.productID,
+                                        selectedVariationIDs: selectedIDs
+                                    )
+                                }
+                            )
+                        } else {
+                            EmptyView()
+                        }
                     }
                 }
                 .padding(.horizontal, insets: safeAreaInsets)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1734

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fixes the issue where a variable product wasn't tappable during product creation. 

I suspect that the culprit was the deprecated `NavigationLink(destination:, isActive:, label:)` call that we used in `LazyNavigationLink`:

```
'init(destination:isActive:label:)' was deprecated in iOS 16.0: use NavigationLink(value:label:), or navigationDestination(isPresented:destination:), inside a NavigationStack or NavigationSplitView
```

To avoid the deprecated call I switched to `navigationDestination(isPresented:)` modifier applied on top of `VStack` while still inside of parent `NavigationStack`.

## Important testing note
The issue is hardly reproducible. It was noticed during 23.6 smoke testing + [https://inpersonpayments.wpcomstaging.com/](https://href.li/?https://inpersonpayments.wpcomstaging.com/) store + iOS 18.4 device. Some folks weren't able to reproduce having the same setup and environment. The issue existed in latest trunk too.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
- Try to reproduce the actual issue first in the following environment (that happened in latest `trunk` too). Check out the WOOMOB-1734 issue for reproduction video.
- Use `inpersonpayments.wpcomstaging.com` store with the account listed in Smoke Testing flow: P91TBi-bVe-p2
- Navigate to order list and start order creation flow
- Find a variable product in selector list
- Make sure it's tappable and navigates to variations list
- Make sure variations selection works fine and applies to an order that's being created/edited.

## Demo iOS 26 + shared testing site

https://github.com/user-attachments/assets/0d4e458b-915d-40d4-9d23-6884529d9323

## Demo iOS 18.4 + inpersonpayments

https://github.com/user-attachments/assets/a9a977a1-a19c-47e9-98c4-eb53a7395798

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.