### PR TITLE
[Woo POS][App Listings] POS ASC screenshots 2

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
@@ -40,6 +40,7 @@ struct POSFloatingControlView: View {
                 }
                 .frame(width: Constants.size)
             }
+            .accessibilityIdentifier("pos-menu-button")
             .background(backgroundColor)
             .cornerRadius(Constants.cornerRadius)
             .disabled(posModel.paymentState.card == .processingPayment)
@@ -78,6 +79,7 @@ private extension POSFloatingControlView {
                 icon: { Image(systemName: "rectangle.portrait.and.arrow.forward") }
             )
         }
+        .accessibilityIdentifier("pos-exit-menu-item")
         Button {
             analytics.track(.pointOfSaleSettingsMenuItemTapped)
             showSettings = true

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleExitPosAlertView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleExitPosAlertView.swift
@@ -19,6 +19,7 @@ struct PointOfSaleExitPosAlertView: View {
                     Text(Image(systemName: "xmark"))
                         .font(.posButtonSymbolLarge)
                 }
+                .accessibilityIdentifier("pos-exit-modal-close-button")
                 .foregroundColor(Color.posOnSurfaceVariantLowest)
             }
             Text(Localization.exitTitle)
@@ -33,6 +34,7 @@ struct PointOfSaleExitPosAlertView: View {
             } label: {
                 Text(Localization.exitButton)
             }
+            .accessibilityIdentifier("pos-exit-confirm-button")
             .buttonStyle(POSFilledButtonStyle(size: .normal))
         }
         .padding(Constants.padding)

--- a/Modules/Sources/UITestsFoundation/Screens/POS/POSScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/POS/POSScreen.swift
@@ -122,4 +122,40 @@ public final class POSScreen: ScreenObject {
 
         return self
     }
+
+    @discardableResult
+    public func tapMenuButton() -> Self {
+        let menuButton = app.buttons["pos-menu-button"]
+
+        guard menuButton.waitForExistence(timeout: 3) else {
+            return self
+        }
+
+        menuButton.tap()
+        return self
+    }
+
+    @discardableResult
+    public func tapExitMenuItem() -> Self {
+        let exitMenuItem = app.buttons["pos-exit-menu-item"]
+
+        guard exitMenuItem.waitForExistence(timeout: 3) else {
+            return self
+        }
+
+        exitMenuItem.tap()
+        return self
+    }
+
+    @discardableResult
+    public func confirmExitPOS() throws -> TabNavComponent {
+        let exitButton = app.buttons["pos-exit-confirm-button"]
+
+        guard exitButton.waitForExistence(timeout: 3) else {
+            return try TabNavComponent()
+        }
+
+        exitButton.tap()
+        return try TabNavComponent()
+    }
 }

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -50,23 +50,6 @@ class WooCommerceScreenshots: XCTestCase {
         // The interruption monitor above only activates when the app receives user interaction.
         app.tap()
 
-        // POS
-        try TabNavComponent()
-            .goToPOSScreen()
-            .tapAddProduct(productID: 1)
-            .tapAddProduct(productID: 2)
-            .thenTakeScreenshot(named: "test-pos-screenshot", orientation: .landscapeLeft)
-            .tapConnectReader()
-            .waitForReaderConnected()
-            .tapCheckout()
-            .waitForTotalsLoaded()
-            .waitForCardPaymentReady()
-            .thenTakeScreenshot(named: "test-pos-screenshot-2", orientation: .landscapeLeft)
-            .tapCashPayment()
-            .tapMarkPaymentComplete()
-            .waitForPaymentSuccess()
-            .thenTakeScreenshot(named: "test-pos-screenshot-3", orientation: .landscapeLeft)
-
         // My Store
         try TabNavComponent()
             .goToMyStoreScreen()
@@ -90,6 +73,26 @@ class WooCommerceScreenshots: XCTestCase {
         .goBackToPaymentMethodsScreen()
         .goBackToOrderScreen()
         .goBackToOrdersScreen()
+
+        // POS
+        try TabNavComponent()
+            .goToPOSScreen()
+            .tapAddProduct(productID: 1)
+            .tapAddProduct(productID: 2)
+            .thenTakeScreenshot(named: "pos-dashboard", orientation: .landscapeLeft)
+            .tapConnectReader()
+            .waitForReaderConnected()
+            .tapCheckout()
+            .waitForTotalsLoaded()
+            .waitForCardPaymentReady()
+            .thenTakeScreenshot(named: "pos-payment", orientation: .landscapeLeft)
+            .tapCashPayment()
+            .tapMarkPaymentComplete()
+            .waitForPaymentSuccess()
+            .thenTakeScreenshot(named: "pos-success", orientation: .landscapeLeft)
+            .tapMenuButton()
+            .tapExitMenuItem()
+            .confirmExitPOS()
 
         // Products
         try TabNavComponent()

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,10 +30,10 @@ FIREBASE_APP_ID = '1:124902176124:ios:02259de1e7c42b291620f9'
 FIREBASE_TESTERS_GROUP = 'woocommerce-ios---prototype-builds'
 
 BUILDKITE_RELEASE_PIPELINE = 'release-builds.yml'
-IOS_LOCALES = %w[ar-SA de-DE en-US es-ES fr-FR he id it ja ko nl-NL pt-BR ru sv tr zh-Hans zh-Hant].freeze
 SIMULATOR_VERSION = '18.5' # For screenshots
+SCREENSHOTS_LOCALES = %w[ar-SA de-DE en-US en-GB es-ES fr-FR he id it ja ko nl-NL pt-BR ru sv tr zh-Hans zh-Hant].freeze
 SCREENSHOTS_SCHEME = 'WooCommerceScreenshots'
-SCREENSHOT_DEVICES = [
+SCREENSHOTS_DEVICES = [
   'iPhone 16 Plus',
   'iPad Pro 13-inch (M4)'
 ].freeze
@@ -882,15 +882,17 @@ platform :ios do
     xcversion
 
     # By default, clear previous screenshots
-    languages = IOS_LOCALES
+    languages = SCREENSHOTS_LOCALES
+    languages &= options[:languages].split(',')
+    if languages.empty?
+      UI.user_error!("List of languages provided (`#{options[:languages]}`) don't intersect with the known list of locales (`#{SCREENSHOTS_LOCALES}`).")
+    end
 
-    languages &= options[:languages].split(',') unless options[:languages].nil?
-
-    devices = SCREENSHOT_DEVICES
-
+    devices = SCREENSHOTS_DEVICES
     devices &= options[:devices].split(',') unless options[:devices].nil?
-
-    UI.user_error!("Unable to run on devices: \"#{devices}\"") if devices.empty?
+    if devices.empty?
+      UI.user_error!("List of devices provided (`#{devices}`) don't intersect with the known list of devices (`#{SCREENSHOTS_DEVICES}`).")
+    end
 
     puts "Creating screenshots for #{languages} on #{devices}"
 
@@ -954,13 +956,13 @@ platform :ios do
     require 'simctl'
 
     SimCtl.list_devices.each do |device|
-      next unless SCREENSHOT_DEVICES.include? device.name
+      next unless SCREENSHOTS_DEVICES.include? device.name
 
       puts "Deleting #{device.name} because it already exists."
       device.delete
     end
 
-    SCREENSHOT_DEVICES.each do |device|
+    SCREENSHOTS_DEVICES.each do |device|
       runtime = SimCtl.runtime(name: "iOS #{SIMULATOR_VERSION}")
       devicetype = SimCtl.devicetype(name: device)
 


### PR DESCRIPTION
tests will fail depending on the order: If triggered after products tests, we lock screen for notifications. If triggered before, we need to exit POS mode to continue the rest of tests

<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
