### PR TITLE
Bookings: Fix styling for booking list on iOS 18

### DIFF
--- a/Modules/Sources/WooFoundation/ViewModifiers/View+Conditionals.swift
+++ b/Modules/Sources/WooFoundation/ViewModifiers/View+Conditionals.swift
@@ -11,6 +11,13 @@ public extension View {
         return self
     }
 
+    /// Applies modifiers within a closure.
+    /// Helpful for setting different modifiers conditionally (e.g. OS versions).
+    ///
+    func apply<V: View>(@ViewBuilder _ block: (Self) -> V) -> V {
+        block(self)
+    }
+
     /// Applies the given transform if the given condition evaluates to `true`.
     /// - Parameters:
     ///   - condition: The condition to evaluate.

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -120,9 +120,11 @@ private extension BookingListView {
             } header: {
                 header
                     .listRowInsets(EdgeInsets())
+                    .textCase(nil)
             }
         }
-        .listStyle(.plain)
+        .listStyle(.grouped)
+        .scrollContentBackground(.hidden)
         .listSectionSeparator(.hidden, edges: .top)
         .background(Color(.listBackground))
         .refreshable {

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -123,6 +123,16 @@ private extension BookingListView {
                     .textCase(nil)
             }
         }
+        .apply {
+            /// Plain list style in iOS prior to 26.0 comes with extra spacing at the top of header.
+            /// Use grouped style for these versions instead.
+            /// Grouped list style doesn't pin header at the top, we have to accept this.
+            if #available(iOS 26.0, *) {
+                $0.listStyle(.plain)
+            } else {
+                $0.listStyle(.grouped)
+            }
+        }
         .listStyle(.grouped)
         .scrollContentBackground(.hidden)
         .listSectionSeparator(.hidden, edges: .top)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1718

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

There was a report about the extra spacing on top of the header in booking list in iOS 18. Looks like headers comes with this extra spacing when plain style is applied to list view.

I tried switching to scroll view to avoid the unwanted styling but this breaks the selection of items in the split view, i.e., the booking details screen can only be presented when using list selection.

Another solution is to move the header to the list content, but then we'd lose the capability to pin the header to the top of the list when scrolling down.

My solution is accepting the trade off for iOS below 26:
- Introduce a new modifier to set modifiers conditionally.
- Set the list style to grouped for iOS below 26 and plain otherwise. Headers in grouped list are not pinned to the top, so we have to accept this.

Any suggestion for a better solution is very much appreciated. 

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Build and run the app on iOS 18.x simulator.
2. Log in to a CIAB store with existing bookings.
3. Confirm that the booking list no longer has a spacing at the top of the header. 
4. Repeat the test on iOS 26. Confirm that the header can be pinned at the top when scrolling down.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

iOS 18.5:


https://github.com/user-attachments/assets/be68ef5f-0f91-48ed-8a98-b82bd7d1bacb

iOS 26:


https://github.com/user-attachments/assets/3568ab7b-35e4-4222-8c09-e335d2ca6978



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
