### PR TITLE
Bookings: Hide payment status and canceled attendance status

### DIFF
--- a/WooCommerce/Classes/Bookings/BookingFilters/BookingFiltersViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/BookingFiltersViewModel.swift
@@ -342,6 +342,7 @@ private extension BookingFiltersViewModel.BookingListFilter {
             value: "Attendance Status",
             comment: "Row title for filtering bookings by attendance status.")
 
+        // periphery: ignore - to be used again later when payment status filter is restored.
         static let rowTitlePaymentStatus = NSLocalizedString(
             "bookingFilters.rowTitlePaymentStatus",
             value: "Payment Status",

--- a/WooCommerce/Classes/Bookings/BookingFilters/BookingFiltersViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/BookingFiltersViewModel.swift
@@ -11,7 +11,7 @@ final class BookingFiltersViewModel: FilterListViewModel {
     private let productFilterViewModel: FilterTypeViewModel
     private let customerFilterViewModel: FilterTypeViewModel
     private let attendanceStatusFilterViewModel: FilterTypeViewModel
-    private let paymentStatusFilterViewModel: FilterTypeViewModel
+//    private let paymentStatusFilterViewModel: FilterTypeViewModel
     private let dateTimeFilterViewModel: FilterTypeViewModel
 
 
@@ -21,14 +21,14 @@ final class BookingFiltersViewModel: FilterListViewModel {
         productFilterViewModel = BookingListFilter.product(siteID: siteID).createViewModel(filters: filter)
         customerFilterViewModel = BookingListFilter.customer(siteID: siteID).createViewModel(filters: filter)
         attendanceStatusFilterViewModel = BookingListFilter.attendanceStatus.createViewModel(filters: filter)
-        paymentStatusFilterViewModel = BookingListFilter.paymentStatus.createViewModel(filters: filter)
+//        paymentStatusFilterViewModel = BookingListFilter.paymentStatus.createViewModel(filters: filter)
         dateTimeFilterViewModel = BookingListFilter.dateTime.createViewModel(filters: filter)
 
         filterTypeViewModels = [
             teamMemberFilterViewModel,
             productFilterViewModel,
             attendanceStatusFilterViewModel,
-            paymentStatusFilterViewModel,
+//            paymentStatusFilterViewModel,
             customerFilterViewModel,
             dateTimeFilterViewModel
         ]
@@ -39,14 +39,14 @@ final class BookingFiltersViewModel: FilterListViewModel {
         let products = (productFilterViewModel.selectedValue as? MultipleFilterSelection)?.items as? [BookingProductFilter] ?? []
         let customers = (customerFilterViewModel.selectedValue as? MultipleFilterSelection)?.items as? [BookingCustomerFilter] ?? []
         let attendanceStatuses = (attendanceStatusFilterViewModel.selectedValue as? MultipleFilterSelection)?.items as? [BookingAttendanceStatus] ?? []
-        let paymentStatuses = (paymentStatusFilterViewModel.selectedValue as? MultipleFilterSelection)?.items as? [BookingPaymentStatus] ?? []
+//        let paymentStatuses = (paymentStatusFilterViewModel.selectedValue as? MultipleFilterSelection)?.items as? [BookingPaymentStatus] ?? []
         let dateRange = dateTimeFilterViewModel.selectedValue as? BookingDateRangeFilter
         let numberOfActiveFilters = filterTypeViewModels.numberOfActiveFilters
 
         return Filters(teamMembers: teamMembers,
                        products: products,
                        attendanceStatuses: attendanceStatuses,
-                       paymentStatuses: paymentStatuses,
+                       paymentStatuses: /*paymentStatuses*/ [],
                        customers: customers,
                        dateRange: dateRange,
                        numberOfActiveFilters: numberOfActiveFilters)
@@ -78,7 +78,7 @@ final class BookingFiltersViewModel: FilterListViewModel {
         productFilterViewModel.selectedValue = BookingProductFilter?.none
         customerFilterViewModel.selectedValue = CustomerFilter?.none
         attendanceStatusFilterViewModel.selectedValue = BookingAttendanceStatus?.none
-        paymentStatusFilterViewModel.selectedValue = BookingPaymentStatus?.none
+//        paymentStatusFilterViewModel.selectedValue = BookingPaymentStatus?.none
         dateTimeFilterViewModel.selectedValue = BookingDateRangeFilter?.none
     }
 
@@ -157,7 +157,7 @@ extension BookingFiltersViewModel {
         case teamMember(siteID: Int64)
         case product(siteID: Int64)
         case attendanceStatus
-        case paymentStatus
+//        case paymentStatus
         case customer(siteID: Int64)
         case dateTime
     }
@@ -174,8 +174,8 @@ private extension BookingFiltersViewModel.BookingListFilter {
             return Localization.rowTitleCustomer
         case .attendanceStatus:
             return Localization.rowTitleAttendanceStatus
-        case .paymentStatus:
-            return Localization.rowTitlePaymentStatus
+//        case .paymentStatus:
+//            return Localization.rowTitlePaymentStatus
         case .dateTime:
             return Localization.rowTitleDateTime
         }
@@ -198,15 +198,15 @@ extension BookingFiltersViewModel.BookingListFilter {
                                        listSelectorConfig: .bookingCustomers(siteID: siteID),
                                        selectedValue: MultipleFilterSelection(items: filters.customers))
         case .attendanceStatus:
-            let options: [BookingAttendanceStatus?] = [.booked, .checkedIn, .noShow, .cancelled]
+            let options: [BookingAttendanceStatus?] = [.booked, .checkedIn, .noShow/*, .cancelled*/]
             return FilterTypeViewModel(title: title,
                                        listSelectorConfig: .multiSelectStaticOptions(options: options),
                                        selectedValue: MultipleFilterSelection(items: filters.attendanceStatuses))
-        case .paymentStatus:
-            let options: [BookingPaymentStatus?] = [.paid, .unpaid, .refunded]
-            return FilterTypeViewModel(title: title,
-                                       listSelectorConfig: .multiSelectStaticOptions(options: options),
-                                       selectedValue: MultipleFilterSelection(items: filters.paymentStatuses))
+//        case .paymentStatus:
+//            let options: [BookingPaymentStatus?] = [.paid, .unpaid, .refunded]
+//            return FilterTypeViewModel(title: title,
+//                                       listSelectorConfig: .multiSelectStaticOptions(options: options),
+//                                       selectedValue: MultipleFilterSelection(items: filters.paymentStatuses))
         case .dateTime:
             return FilterTypeViewModel(title: title,
                                        listSelectorConfig: .bookingDateTime,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-1711

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

There are some parts of booking filters that aren't working currently due to pending work on the API:
- Attendance status: Selecting the Canceled option would cause the fetch request to fail.
- Payment status: this hasn't been implemented for the API yet.

This PR hides these parts to ensure everything works for the demo of CIAB Alpha 2. Since we'll need to restore the functionalities in the future, I simply commented out the not-ready parts.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Log in to a CIAB store with existing bookings.
2. Navigates to Bookings tab > All > Filters.
3. Confirm that the Payment status filter is no longer available.
4. Select Attendance status and confirm that the Canceled option is no longer available.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/7d765623-52c4-406a-8455-972447a5a924



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
