### PR TITLE
Store onboarding: Fix issue showing tasks in full view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -25,7 +25,7 @@ struct DashboardView: View {
     /// Set externally in the hosting controller.
     var onboardingTaskTapped: ((Site, StoreOnboardingTask) -> Void)?
     /// Set externally in the hosting controller.
-    var viewAllOnboardingTasksTapped: ((Site) -> Void)?
+    var viewAllOnboardingTasksTapped: ((Site, [StoreOnboardingTaskViewModel]) -> Void)?
 
     /// Set externally in the hosting controller.
     var showAllBlazeCampaignsTapped: (() -> Void)?
@@ -215,9 +215,9 @@ private extension DashboardView {
                                             onTaskTapped: { task in
                             guard let currentSite else { return }
                             onboardingTaskTapped?(currentSite, task)
-                        }, onViewAllTapped: {
+                        }, onViewAllTapped: { tasks in
                             guard let currentSite else { return }
-                            viewAllOnboardingTasksTapped?(currentSite)
+                            viewAllOnboardingTasksTapped?(currentSite, tasks)
                         })
                     case .blaze:
                         BlazeCampaignDashboardView(viewModel: viewModel.blazeCampaignDashboardViewModel,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -175,11 +175,11 @@ private extension DashboardViewHostingController {
             storeOnboardingCoordinator?.start(task: task)
         }
 
-        rootView.viewAllOnboardingTasksTapped = { [weak self] site in
+        rootView.viewAllOnboardingTasksTapped = { [weak self] site, tasks in
             guard let self else { return }
             ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .onboarding))
             updateStoreOnboardingCoordinatorIfNeeded(with: site)
-            storeOnboardingCoordinator?.start()
+            storeOnboardingCoordinator?.start(tasks: tasks)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -5,7 +5,7 @@ import struct Yosemite.Site
 import struct Yosemite.StoreOnboardingTask
 
 /// Coordinates navigation for store onboarding.
-final class StoreOnboardingCoordinator: Coordinator {
+final class StoreOnboardingCoordinator {
     typealias TaskType = StoreOnboardingTask.TaskType
 
     let navigationController: UINavigationController
@@ -31,11 +31,15 @@ final class StoreOnboardingCoordinator: Coordinator {
     }
 
     /// Navigates to the fullscreen store onboarding view.
-    func start() {
+    func start(tasks: [StoreOnboardingTaskViewModel]) {
         Task { @MainActor in
+            let viewModel = StoreOnboardingViewModel(
+                siteID: site.siteID,
+                isExpanded: true,
+                taskViewModels: tasks
+            )
             let onboardingNavigationController = UINavigationController()
-            let onboardingViewController = StoreOnboardingViewHostingController(viewModel: .init(siteID: site.siteID,
-                                                                                                 isExpanded: true),
+            let onboardingViewController = StoreOnboardingViewHostingController(viewModel: viewModel,
                                                                                 navigationController: onboardingNavigationController,
                                                                                 site: site)
             onboardingNavigationController.pushViewController(onboardingViewController, animated: false)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -42,9 +42,9 @@ final class StoreOnboardingViewHostingController: SelfSizingHostingController<St
         }
 
         if !viewModel.isExpanded {
-            rootView.viewAllTapped = { [weak self] in
+            rootView.viewAllTapped = { [weak self] tasks in
                 guard let self else { return }
-                self.coordinator.start()
+                self.coordinator.start(tasks: tasks)
             }
         }
     }
@@ -93,13 +93,13 @@ struct StoreOnboardingView: View {
     /// Set externally in the hosting controller.
     var taskTapped: ((StoreOnboardingTask) -> Void)?
     /// Set externally in the hosting controller.
-    var viewAllTapped: (() -> Void)?
+    var viewAllTapped: (([StoreOnboardingTaskViewModel]) -> Void)?
 
     @ObservedObject private var viewModel: StoreOnboardingViewModel
 
     init(viewModel: StoreOnboardingViewModel,
          onTaskTapped: ((StoreOnboardingTask) -> Void)? = nil,
-         onViewAllTapped: (() -> Void)? = nil) {
+         onViewAllTapped: (([StoreOnboardingTaskViewModel]) -> Void)? = nil) {
         self.viewModel = viewModel
         self.taskTapped = onTaskTapped
         self.viewAllTapped = onViewAllTapped
@@ -159,7 +159,9 @@ struct StoreOnboardingView: View {
                         .padding(.leading, Layout.padding)
 
                     // View all button
-                    viewAllButton(action: viewAllTapped, text: String(format: Localization.viewAll, viewModel.taskViewModels.count))
+                    viewAllButton(action: {
+                        viewAllTapped?(viewModel.taskViewModels)
+                    }, text: String(format: Localization.viewAll, viewModel.taskViewModels.count))
                         .renderedIf(viewModel.shouldShowViewAllButton)
                         .padding(.horizontal, Layout.padding)
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -83,6 +83,7 @@ class StoreOnboardingViewModel: ObservableObject {
     ///   - defaults: UserDefaults for storing when all onboarding tasks are completed
     init(siteID: Int64,
          isExpanded: Bool,
+         taskViewModels: [StoreOnboardingTaskViewModel] = [],
          stores: StoresManager = ServiceLocator.stores,
          defaults: UserDefaults = .standard,
          analytics: Analytics = ServiceLocator.analytics,
@@ -94,6 +95,7 @@ class StoreOnboardingViewModel: ObservableObject {
         self.defaults = defaults
         self.analytics = analytics
         self.waitingTimeTracker = waitingTimeTracker
+        self.taskViewModels = taskViewModels
 
         $noTasksAvailableForDisplay
             .combineLatest(defaults.publisher(for: \.completedAllStoreOnboardingTasks))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -119,7 +119,11 @@ class StoreOnboardingViewModel: ObservableObject {
         }
 
         analytics.track(event: .DynamicDashboard.cardLoadingStarted(type: .onboarding))
-        update(state: .loading)
+        if taskViewModels.isEmpty {
+            update(state: .loading)
+        } else {
+            update(state: .loaded(rows: taskViewModels))
+        }
 
         let tasks: [StoreOnboardingTaskViewModel]
         var syncingError: Error?


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1733

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

**Context**
Recently we added the functionality to switch to direct requests with remote sites for Jetpack sites that support application passwords.

Upon logging to the app or first switching to a store, the app would need to check if the site supports application passwords first. While that is in progress, all requests are made with Jetpack proxy by default.

**Problem**

There's an issue with the `GET /wc-admin/onboarding/tasks` API: 
- When triggered with Jetpack proxy, it would return a list of tasks including completed and incomplete ones.
- When triggered directly with the remote site, it would just return an empty array.

On the app, we load the store onboarding card early upon logging in or switching stores. When this happens before the app could finish determining application password support in the site, the onboarding cards are loaded with Jetpack proxy.

When the user taps on view all tasks, the onboarding cards are loaded again. When this happens after the app determines that application password is supported and network switching is eligible, onboarding cards are loaded directly with the remote sites.

The inconsistent data causes a glitch: one can see 2 incomplete tasks on the dashboard screen but then sees an empty view on the full list.

**Solution**

To fix the above issue, I'm sending the loaded tasks from the dashboard card to the full view. I'm keeping the original logic in #9185 to fall back to loaded tasks when reloading tasks returns an empty list.

We'll need to contact someone on the backend side to look into the empty list returned from direct requests.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Log out of the app if you haven't already.
2. Log in to a store with incomplete tasks using WPCom credentials. For simplicity, use our shared CIAB store or a JN store with Jetpack connected.
3. Once the dashboard completes loading, confirm that the Store setup dashboard card shows that there are 2 tasks.
4. Tap on View all tasks and confirm that the full view shows the tasks instantly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->



https://github.com/user-attachments/assets/450d1d45-98e8-4d48-aa56-0fe008fdcbec




---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
