### PR TITLE
Fix request authenticator swap crash

### DIFF
--- a/Modules/.swiftpm/xcode/xcshareddata/xcschemes/Networking.xcscheme
+++ b/Modules/.swiftpm/xcode/xcshareddata/xcschemes/Networking.xcscheme
@@ -33,6 +33,9 @@
             reference = "container:Tests/NetworkingTests/NetworkingTests.xctestplan"
             default = "YES">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:Tests/NetworkingTests/RequestAuthenticatorPressureTests.xctestplan">
+         </TestPlanReference>
       </TestPlans>
    </TestAction>
    <LaunchAction

--- a/Modules/Sources/NetworkingCore/ApplicationPassword/RequestProcessor.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/RequestProcessor.swift
@@ -8,27 +8,20 @@ protocol RequestProcessorDelegate: AnyObject {
 /// Authenticates and retries requests
 ///
 final class RequestProcessor: RequestInterceptor {
-    private var requestsToRetry = [(RetryResult) -> Void]()
-
-    private var isAuthenticating = false
-
-    private var requestAuthenticator: RequestAuthenticator
-
     private let notificationCenter: NotificationCenter
 
-    private var currentSiteID: Int64?
+    private let state: RequestProcessorState
 
     weak var delegate: RequestProcessorDelegate?
 
     init(requestAuthenticator: RequestAuthenticator,
          notificationCenter: NotificationCenter = .default) {
-        self.requestAuthenticator = requestAuthenticator
         self.notificationCenter = notificationCenter
+        self.state = RequestProcessorState(requestAuthenticator: requestAuthenticator)
     }
 
     func updateAuthenticator(_ authenticator: RequestAuthenticator) {
-        requestAuthenticator = authenticator
-        currentSiteID = authenticator.jetpackSiteID
+        state.updateAuthenticator(authenticator)
     }
 }
 
@@ -36,7 +29,8 @@ final class RequestProcessor: RequestInterceptor {
 //
 extension RequestProcessor: RequestAdapter {
     func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
-        let result = Result { try requestAuthenticator.authenticate(urlRequest) }
+        let authenticator = state.authenticator
+        let result = Result { try authenticator.authenticate(urlRequest) }
         completion(result)
     }
 }
@@ -45,18 +39,27 @@ extension RequestProcessor: RequestAdapter {
 //
 extension RequestProcessor: RequestRetrier {
     func retry(_ request: Alamofire.Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
-        guard
-            request.retryCount == 0, // Only retry once
-            let urlRequest = request.request,
-            requestAuthenticator.shouldRetry(urlRequest), // Retry only REST API requests that use application password
-            shouldRetry(error) // Retry only specific errors
-        else {
-            return completion(.doNotRetry)
+        guard request.retryCount == 0, // Only retry once
+              let urlRequest = request.request else {
+            completion(.doNotRetry)
+            return
         }
 
-        requestsToRetry.append(completion)
-        if !isAuthenticating {
-            isAuthenticating = true
+        guard shouldRetry(error) else {
+            completion(.doNotRetry)
+            return
+        }
+
+        let shouldRetryRequest = state.shouldRetry(urlRequest)
+
+        guard shouldRetryRequest else {
+            completion(.doNotRetry)
+            return
+        }
+
+        let shouldStartAuthentication = state.enqueueRetry(completion)
+
+        if shouldStartAuthentication {
             generateApplicationPassword()
         }
     }
@@ -66,28 +69,30 @@ extension RequestProcessor: RequestRetrier {
 //
 private extension RequestProcessor {
     func generateApplicationPassword() {
-        Task(priority: .medium) { @MainActor in
+        Task(priority: .medium) { @MainActor [weak self] in
+            guard let self else { return }
+            let authenticator = self.state.authenticator
             do {
-                let _ = try await requestAuthenticator.generateApplicationPassword()
-                isAuthenticating = false
+                let _ = try await authenticator.generateApplicationPassword()
+                self.state.setAuthenticating(false)
 
                 // Post a notification for tracking
-                notificationCenter.post(name: .ApplicationPasswordsNewPasswordCreated, object: nil, userInfo: nil)
+                self.notificationCenter.post(name: .ApplicationPasswordsNewPasswordCreated, object: nil, userInfo: nil)
 
-                completeRequests(true)
+                self.completeRequests(true)
             } catch {
 
                 // Post a notification for tracking
-                notificationCenter.post(name: .ApplicationPasswordsGenerationFailed, object: error, userInfo: nil)
+                self.notificationCenter.post(name: .ApplicationPasswordsGenerationFailed, object: error, userInfo: nil)
 
-                let shouldRetry = await checkIfRetryingGenerationIsNeeded(for: error)
+                let shouldRetry = await self.checkIfRetryingGenerationIsNeeded(for: error)
                 if shouldRetry {
-                    generateApplicationPassword()
+                    self.generateApplicationPassword()
                 } else {
-                    isAuthenticating = false
-                    completeRequests(false, error: error)
-                    if let currentSiteID {
-                        notifyFailureIfNeeded(error, for: currentSiteID)
+                    self.state.setAuthenticating(false)
+                    self.completeRequests(false, error: error)
+                    if let siteID = self.state.currentSiteID {
+                        self.notifyFailureIfNeeded(error, for: siteID)
                     }
                 }
             }
@@ -98,14 +103,15 @@ private extension RequestProcessor {
     /// Returns whether retry is needed.
     @MainActor
     func checkIfRetryingGenerationIsNeeded(for error: Error) async -> Bool {
-        guard currentSiteID != nil else {
+        guard state.currentSiteID != nil else {
             return false
         }
         switch error {
         case NetworkError.unacceptableStatusCode(let statusCode, _) where statusCode == 409:
             /// Password with the same name already exists. Request deletion remotely and retry.
             do {
-                try await requestAuthenticator.deleteApplicationPassword()
+                let authenticator = state.authenticator
+                try await authenticator.deleteApplicationPassword()
                 return true
             } catch {
                 return false
@@ -156,10 +162,10 @@ private extension RequestProcessor {
                 .doNotRetry
             }
         }()
-        requestsToRetry.forEach { (completion) in
+        let pendingCompletions = state.drainPendingRetries()
+        pendingCompletions.forEach { completion in
             completion(result)
         }
-        requestsToRetry.removeAll()
     }
 }
 
@@ -181,4 +187,69 @@ public extension NSNotification.Name {
     /// Posted when site is detected as eligible for app password authentication
     ///
     static let JetpackSiteEligibleForAppPasswordSupport = NSNotification.Name(rawValue: "JetpackSiteEligibleForAppPasswordSupport")
+}
+
+private extension RequestProcessor {
+    final class RequestProcessorState {
+        private var requestsToRetry: [(RetryResult) -> Void]
+        private var isAuthenticating: Bool
+        private var requestAuthenticator: RequestAuthenticator
+        private var siteID: Int64?
+
+        private let queue = DispatchQueue(
+            label: "com.woocommerce.networking.request-processor.state-queue",
+            qos: .userInitiated
+        )
+
+        init(requestAuthenticator: RequestAuthenticator) {
+            self.requestsToRetry = []
+            self.isAuthenticating = false
+            self.requestAuthenticator = requestAuthenticator
+            self.siteID = requestAuthenticator.jetpackSiteID
+        }
+
+        var authenticator: RequestAuthenticator {
+            queue.sync { requestAuthenticator }
+        }
+
+        var currentSiteID: Int64? {
+            queue.sync { siteID }
+        }
+
+        func shouldRetry(_ request: URLRequest) -> Bool {
+            queue.sync { requestAuthenticator.shouldRetry(request) }
+        }
+
+        func enqueueRetry(_ completion: @escaping (RetryResult) -> Void) -> Bool {
+            queue.sync {
+                requestsToRetry.append(completion)
+                if isAuthenticating {
+                    return false
+                }
+                isAuthenticating = true
+                return true
+            }
+        }
+
+        func setAuthenticating(_ value: Bool) {
+            queue.sync {
+                isAuthenticating = value
+            }
+        }
+
+        func drainPendingRetries() -> [(RetryResult) -> Void] {
+            queue.sync {
+                let completions = requestsToRetry
+                requestsToRetry.removeAll()
+                return completions
+            }
+        }
+
+        func updateAuthenticator(_ authenticator: RequestAuthenticator) {
+            queue.sync {
+                requestAuthenticator = authenticator
+                siteID = authenticator.jetpackSiteID
+            }
+        }
+    }
 }

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
@@ -450,7 +450,7 @@ final class RequestProcessorTests: XCTestCase {
     /// Simulates race condition of multiple `updateAuthenticator` calls from different threads
     /// Should cause a crash on old/non-synchronized `RequestProcessor` implementatoin
     /// Should work fine on synchronized version of `RequestProcessor`
-    func test_concurrentAuthenticatorUpdatesTriggersRaceWhenUnsynchronized() throws {
+    func test_concurrent_authenticator_updates_does_not_trigger_race_condition() throws {
         let credentials = Networking.Credentials.wpcom(
             username: "initial",
             authToken: UUID().uuidString,

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
@@ -445,6 +445,65 @@ final class RequestProcessorTests: XCTestCase {
         XCTAssertTrue(mockRequestAuthenticator.deleteApplicationPasswordCalled)
         XCTAssertFalse(shouldRetry.retryRequired)
     }
+
+    func test_concurrentAuthenticatorUpdatesWhileAdaptingDoesNotCrash() throws {
+        // Given
+        let concurrencyIterations = 2_000
+        let session = Alamofire.Session(configuration: URLSessionConfiguration.default)
+        let urlRequest = URLRequest(url: url)
+        let notificationCenter = MockNotificationCenter()
+
+        let initialCredentials = Networking.Credentials.wpcom(
+            username: "initial-user",
+            authToken: UUID().uuidString,
+            siteAddress: "https://example.com"
+        )
+        let sut = RequestProcessor(
+            requestAuthenticator: DefaultRequestAuthenticator(credentials: initialCredentials),
+            notificationCenter: notificationCenter
+        )
+
+        let adaptExpectation = expectation(description: "adapt completions")
+        adaptExpectation.expectedFulfillmentCount = concurrencyIterations / 2
+
+        let queue = DispatchQueue(
+            label: "com.woocommerce.tests.requestProcessor.concurrent",
+            attributes: .concurrent
+        )
+
+        // When
+        for index in 0..<concurrencyIterations {
+            queue.async {
+                if index.isMultiple(of: 2) {
+                    let credentials = Networking.Credentials.wpcom(
+                        username: "user-\(index)",
+                        authToken: UUID().uuidString,
+                        siteAddress: "https://example.com"
+                    )
+                    let authenticator = DefaultRequestAuthenticator(credentials: credentials)
+                    sut.updateAuthenticator(authenticator)
+                } else {
+                    sut.adapt(urlRequest, for: session) { result in
+                        switch result {
+                        case .success(let request):
+                            let header = request.value(forHTTPHeaderField: "Authorization")
+                            XCTAssertNotNil(header)
+                            if let header {
+                                XCTAssertTrue(header.hasPrefix("Bearer "))
+                            }
+                        case .failure(let error):
+                            XCTFail("Unexpected error while adapting request: \(error)")
+                        }
+                        adaptExpectation.fulfill()
+                    }
+                }
+            }
+        }
+
+        // Then
+        wait(for: [adaptExpectation], timeout: 15)
+        queue.sync(flags: .barrier) { }
+    }
 }
 
 // MARK: Helpers

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
@@ -446,34 +446,33 @@ final class RequestProcessorTests: XCTestCase {
         XCTAssertFalse(shouldRetry.retryRequired)
     }
 
-    func test_concurrentAuthenticatorUpdatesWhileAdaptingDoesNotCrash() throws {
-        // Given
-        let concurrencyIterations = 2_000
-        let session = Alamofire.Session(configuration: URLSessionConfiguration.default)
-        let urlRequest = URLRequest(url: url)
-        let notificationCenter = MockNotificationCenter()
-
-        let initialCredentials = Networking.Credentials.wpcom(
-            username: "initial-user",
+    /// The test is designed for manual local run. It must be excluded from CI pipelines.
+    /// Simulates race condition of multiple `updateAuthenticator` calls from different threads
+    /// Should cause a crash on old/non-synchronized `RequestProcessor` implementatoin
+    /// Should work fine on synchronized version of `RequestProcessor`
+    func test_concurrentAuthenticatorUpdatesTriggersRaceWhenUnsynchronized() throws {
+        let credentials = Networking.Credentials.wpcom(
+            username: "initial",
             authToken: UUID().uuidString,
             siteAddress: "https://example.com"
         )
+        let authenticator = DefaultRequestAuthenticator(credentials: credentials)
         let sut = RequestProcessor(
-            requestAuthenticator: DefaultRequestAuthenticator(credentials: initialCredentials),
-            notificationCenter: notificationCenter
+            requestAuthenticator: authenticator,
+            notificationCenter: MockNotificationCenter()
         )
 
-        let adaptExpectation = expectation(description: "adapt completions")
-        adaptExpectation.expectedFulfillmentCount = concurrencyIterations / 2
-
+        let request = URLRequest(url: url)
+        let iterations = 20000
         let queue = DispatchQueue(
-            label: "com.woocommerce.tests.requestProcessor.concurrent",
+            label: "com.woocommerce.tests.requestProcessor.race",
+            qos: .userInitiated,
             attributes: .concurrent
         )
+        let group = DispatchGroup()
 
-        // When
-        for index in 0..<concurrencyIterations {
-            queue.async {
+        for index in 0..<iterations {
+            queue.async(group: group) {
                 if index.isMultiple(of: 2) {
                     let credentials = Networking.Credentials.wpcom(
                         username: "user-\(index)",
@@ -483,26 +482,13 @@ final class RequestProcessorTests: XCTestCase {
                     let authenticator = DefaultRequestAuthenticator(credentials: credentials)
                     sut.updateAuthenticator(authenticator)
                 } else {
-                    sut.adapt(urlRequest, for: session) { result in
-                        switch result {
-                        case .success(let request):
-                            let header = request.value(forHTTPHeaderField: "Authorization")
-                            XCTAssertNotNil(header)
-                            if let header {
-                                XCTAssertTrue(header.hasPrefix("Bearer "))
-                            }
-                        case .failure(let error):
-                            XCTFail("Unexpected error while adapting request: \(error)")
-                        }
-                        adaptExpectation.fulfill()
-                    }
+                    sut.adapt(request, for: .default) { _ in }
                 }
             }
         }
 
-        // Then
-        wait(for: [adaptExpectation], timeout: 15)
-        queue.sync(flags: .barrier) { }
+        let result = group.wait(timeout: .now() + 20)
+        XCTAssertEqual(result, .success)
     }
 }
 

--- a/Modules/Tests/NetworkingTests/NetworkingTests.xctestplan
+++ b/Modules/Tests/NetworkingTests/NetworkingTests.xctestplan
@@ -14,7 +14,7 @@
   "testTargets" : [
     {
       "skippedTests" : [
-        "RequestProcessorTests\/test_threadSanitizerFlagsRaceInUnsynchronizedImplementation()"
+        "RequestProcessorTests\/test_concurrentAuthenticatorUpdatesTriggersRaceWhenUnsynchronized()"
       ],
       "target" : {
         "containerPath" : "container:",

--- a/Modules/Tests/NetworkingTests/NetworkingTests.xctestplan
+++ b/Modules/Tests/NetworkingTests/NetworkingTests.xctestplan
@@ -13,6 +13,9 @@
   },
   "testTargets" : [
     {
+      "skippedTests" : [
+        "RequestProcessorTests\/test_threadSanitizerFlagsRaceInUnsynchronizedImplementation()"
+      ],
       "target" : {
         "containerPath" : "container:",
         "identifier" : "NetworkingTests",

--- a/Modules/Tests/NetworkingTests/RequestAuthenticatorPressureTests.xctestplan
+++ b/Modules/Tests/NetworkingTests/RequestAuthenticatorPressureTests.xctestplan
@@ -1,0 +1,706 @@
+{
+  "configurations" : [
+    {
+      "id" : "C0023889-182C-4E33-9833-9098BE536CB5",
+      "name" : "Test scheme Action",
+      "options" : {
+        "threadSanitizerEnabled" : true
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : {
+        "suites" : [
+          {
+            "name" : "BackgroundCatalogDownloadCoordinatorTests"
+          },
+          {
+            "name" : "BackgroundDownloadStateTests"
+          },
+          {
+            "name" : "BookingsRemoteTests"
+          },
+          {
+            "name" : "ListMapperTests"
+          },
+          {
+            "name" : "POSCatalogSyncRemoteTests"
+          },
+          {
+            "name" : "POSProductsNetworkingTests"
+          }
+        ],
+        "xctestClasses" : [
+          {
+            "name" : "AccountMapperTests"
+          },
+          {
+            "name" : "AccountRemoteTests"
+          },
+          {
+            "name" : "AccountSettingsMapperTests"
+          },
+          {
+            "name" : "AccountSettingsRemoteTests"
+          },
+          {
+            "name" : "AddOnGroupMapperTests"
+          },
+          {
+            "name" : "AddOnGroupRemoteTests"
+          },
+          {
+            "name" : "AIProductMapperTests"
+          },
+          {
+            "name" : "AlamofireNetworkErrorHandlerTests"
+          },
+          {
+            "name" : "AlamofireNetworkTests"
+          },
+          {
+            "name" : "AnnouncementListMapperTests"
+          },
+          {
+            "name" : "AnnouncementsRemoteTests"
+          },
+          {
+            "name" : "ApplicationPasswordEncoderTests"
+          },
+          {
+            "name" : "ApplicationPasswordMapperTests"
+          },
+          {
+            "name" : "ApplicationPasswordNameAndUUIDMapperTests"
+          },
+          {
+            "name" : "ArrayWooTests"
+          },
+          {
+            "name" : "AuthenticatedDotcomRequestTests"
+          },
+          {
+            "name" : "AuthenticatedRESTRequestTests"
+          },
+          {
+            "name" : "BlazeAISuggestionListMapperTests"
+          },
+          {
+            "name" : "BlazeCampaignListItemsMapperTests"
+          },
+          {
+            "name" : "BlazeCampaignObjectiveListMapperTests"
+          },
+          {
+            "name" : "BlazeForecastedImpressionsInputEncoderTests"
+          },
+          {
+            "name" : "BlazeImpressionsMapperTests"
+          },
+          {
+            "name" : "BlazePaymentInfoMapperTests"
+          },
+          {
+            "name" : "BlazeRemoteTests"
+          },
+          {
+            "name" : "BlazeTargetOptionMapperTests"
+          },
+          {
+            "name" : "BundleWooTests"
+          },
+          {
+            "name" : "CommentRemoteTests"
+          },
+          {
+            "name" : "CommentResultMapperTests"
+          },
+          {
+            "name" : "CookieNonceAuthenticatorTests"
+          },
+          {
+            "name" : "CopiableTests"
+          },
+          {
+            "name" : "CountryListMapperTests"
+          },
+          {
+            "name" : "CouponEncoderTests"
+          },
+          {
+            "name" : "CouponListMapperTests"
+          },
+          {
+            "name" : "CouponMapperTests"
+          },
+          {
+            "name" : "CouponReportListMapperTests"
+          },
+          {
+            "name" : "CouponsRemoteTests"
+          },
+          {
+            "name" : "CreateBlazeCampaignMapperTests"
+          },
+          {
+            "name" : "CreateProductVariationTests"
+          },
+          {
+            "name" : "CustomerMapperTests"
+          },
+          {
+            "name" : "CustomerRemoteTests"
+          },
+          {
+            "name" : "DataRemoteTests"
+          },
+          {
+            "name" : "DateFormatterWooTests"
+          },
+          {
+            "name" : "Decimal_ExtensionsTests"
+          },
+          {
+            "name" : "DecodingError_CodingPathTests"
+          },
+          {
+            "name" : "DefaultApplicationPasswordUseCaseTests"
+          },
+          {
+            "name" : "DefaultRequestAuthenticatorTests"
+          },
+          {
+            "name" : "DevicesRemoteTests"
+          },
+          {
+            "name" : "DotcomDeviceMapperTests"
+          },
+          {
+            "name" : "DotcomRequestTests"
+          },
+          {
+            "name" : "DotcomValidatorTests"
+          },
+          {
+            "name" : "EntityDateModifiedMapperTests"
+          },
+          {
+            "name" : "EntityIDMapperTests"
+          },
+          {
+            "name" : "FeatureFlagRemoteTests"
+          },
+          {
+            "name" : "GenerativeContentRemoteTests"
+          },
+          {
+            "name" : "GiftCardStatsMapperTests"
+          },
+          {
+            "name" : "GiftCardStatsRemoteTests"
+          },
+          {
+            "name" : "GoogleAdsCampaignListMapperTests"
+          },
+          {
+            "name" : "GoogleAdsCampaignStatsMapperTests"
+          },
+          {
+            "name" : "GoogleAdsConnectionMapperTests"
+          },
+          {
+            "name" : "GoogleListingsAndAdsRemoteTests"
+          },
+          {
+            "name" : "IgnoringResponseMapperTests"
+          },
+          {
+            "name" : "InboxNoteListMapperTests"
+          },
+          {
+            "name" : "InboxNoteMapperTests"
+          },
+          {
+            "name" : "InboxNotesRemoteTests"
+          },
+          {
+            "name" : "IPLocationRemoteTests"
+          },
+          {
+            "name" : "JetpackAIQueryResponseMapperTests"
+          },
+          {
+            "name" : "JetpackConnectionDataMapperTests"
+          },
+          {
+            "name" : "JetpackConnectionRemoteTests"
+          },
+          {
+            "name" : "JetpackConnectionURLMapperTests"
+          },
+          {
+            "name" : "JetpackRequestTests"
+          },
+          {
+            "name" : "JetpackSettingsRemoteTests"
+          },
+          {
+            "name" : "JustInTimeMessageListMapperTests"
+          },
+          {
+            "name" : "JustInTimeMessagesRemoteTests"
+          },
+          {
+            "name" : "JWTokenMapperTests"
+          },
+          {
+            "name" : "KeyedDecodingContainer_WooTests"
+          },
+          {
+            "name" : "MediaRemoteTests"
+          },
+          {
+            "name" : "MetaDataEncoderTests"
+          },
+          {
+            "name" : "MetaDataMapperTests"
+          },
+          {
+            "name" : "MetaDataRemoteTests"
+          },
+          {
+            "name" : "NetworkErrorTests"
+          },
+          {
+            "name" : "NewShipmentTrackingMapperTests"
+          },
+          {
+            "name" : "NoteHashListMapperTests"
+          },
+          {
+            "name" : "NoteListMapperTests"
+          },
+          {
+            "name" : "NotificationsRemoteTests"
+          },
+          {
+            "name" : "OneTimeApplicationPasswordUseCaseTests"
+          },
+          {
+            "name" : "OrderEncoderTests"
+          },
+          {
+            "name" : "OrderListMapperTests"
+          },
+          {
+            "name" : "OrderMapperTests"
+          },
+          {
+            "name" : "OrderNotesMapperTests"
+          },
+          {
+            "name" : "OrderShippingLabelListMapperTests"
+          },
+          {
+            "name" : "OrdersRemoteTests"
+          },
+          {
+            "name" : "OrderStatsRemoteV4Tests"
+          },
+          {
+            "name" : "OrderStatsV4MapperTests"
+          },
+          {
+            "name" : "PaymentGatewayListMapperTests"
+          },
+          {
+            "name" : "PaymentGatewayMapperTests"
+          },
+          {
+            "name" : "PaymentRemoteTests"
+          },
+          {
+            "name" : "PaymentsGatewayRemoteTests"
+          },
+          {
+            "name" : "PostMapperTests"
+          },
+          {
+            "name" : "ProductAttributeListMapperTests"
+          },
+          {
+            "name" : "ProductAttributeMapperTests"
+          },
+          {
+            "name" : "ProductAttributesRemoteTests"
+          },
+          {
+            "name" : "ProductAttributeTermListMapperTests"
+          },
+          {
+            "name" : "ProductAttributeTermMapperTests"
+          },
+          {
+            "name" : "ProductAttributeTermRemoteTests"
+          },
+          {
+            "name" : "ProductBundleStatsMapperTests"
+          },
+          {
+            "name" : "ProductBundleStatsRemoteTests"
+          },
+          {
+            "name" : "ProductCategoriesRemoteTests"
+          },
+          {
+            "name" : "ProductCategoryListMapperTests"
+          },
+          {
+            "name" : "ProductCategoryMapperTests"
+          },
+          {
+            "name" : "ProductEncoderTests"
+          },
+          {
+            "name" : "ProductIDMapperTests"
+          },
+          {
+            "name" : "ProductImageAssetTypeCodableTests"
+          },
+          {
+            "name" : "ProductImageStatusCodableTests"
+          },
+          {
+            "name" : "ProductImageStatusStorageTests"
+          },
+          {
+            "name" : "ProductListMapperTests"
+          },
+          {
+            "name" : "ProductMapperTests"
+          },
+          {
+            "name" : "ProductOrVariationIDCodableTests"
+          },
+          {
+            "name" : "ProductReportListMapperTests"
+          },
+          {
+            "name" : "ProductReviewListMapperTests"
+          },
+          {
+            "name" : "ProductReviewsRemoteTests"
+          },
+          {
+            "name" : "ProductShippingClassListMapperTests"
+          },
+          {
+            "name" : "ProductShippingClassMapperTests"
+          },
+          {
+            "name" : "ProductShippingClassRemoteTests"
+          },
+          {
+            "name" : "ProductSkuMapperTests"
+          },
+          {
+            "name" : "ProductsRemoteTests"
+          },
+          {
+            "name" : "ProductsReportMapperTests"
+          },
+          {
+            "name" : "ProductsReportsRemoteTests"
+          },
+          {
+            "name" : "ProductStockListMapperTests"
+          },
+          {
+            "name" : "ProductSubscriptionTests"
+          },
+          {
+            "name" : "ProductTagListMapperTests"
+          },
+          {
+            "name" : "ProductTagsRemoteTests"
+          },
+          {
+            "name" : "ProductVariationEncoderTests"
+          },
+          {
+            "name" : "ProductVariationListMapperTests"
+          },
+          {
+            "name" : "ProductVariationMapperTests"
+          },
+          {
+            "name" : "ProductVariationsBulkCreateMapperTests"
+          },
+          {
+            "name" : "ProductVariationsBulkUpdateMapperTests"
+          },
+          {
+            "name" : "ProductVariationsRemoteTests"
+          },
+          {
+            "name" : "ReceiptRemoteTests"
+          },
+          {
+            "name" : "RefundListMapperTests"
+          },
+          {
+            "name" : "RefundMapperTests"
+          },
+          {
+            "name" : "RemoteTests"
+          },
+          {
+            "name" : "ReportOrderMapperTests"
+          },
+          {
+            "name" : "ReportOrderTotalsMapperTests"
+          },
+          {
+            "name" : "ReportRemoteTests"
+          },
+          {
+            "name" : "RequestConvertorTests"
+          },
+          {
+            "name" : "RequestProcessorTests",
+            "xctestMethods" : [
+              "test_adapt_authenticates_the_urlrequest()",
+              "test_application_password_is_generated_upon_retrying_a_request()",
+              "test_application_password_is_not_generated_when_a_request_is_not_eligible_for_retry()",
+              "test_concurrentAuthenticatorUpdatesWhileAdaptingDoesNotCrash()",
+              "test_delegate_called_when_404_error_occurs_with_wpcom_authentication()",
+              "test_delegate_called_when_application_password_disabled()",
+              "test_delegate_called_when_application_password_disabled_for_user()",
+              "test_notification_is_posted_when_application_password_generation_fails()",
+              "test_notification_is_posted_when_application_password_generation_is_successful()",
+              "test_posted_notification_holds_expected_error_when_application_password_generation_fails()",
+              "test_request_is_not_scheduled_for_retry_when_irrelavant_error_occurs()",
+              "test_request_is_not_scheduled_for_retry_when_request_authenticator_shouldRetry_returns_false()",
+              "test_request_is_scheduled_for_retry_when_401_error_occurs()",
+              "test_request_is_scheduled_for_retry_when_applicationPasswordNotAvailable_error_occurs()",
+              "test_request_is_scheduled_for_retry_when_request_authenticator_shouldRetry_returns_true()",
+              "test_request_is_scheduled_for_retry_when_requestAdaptationFailed_error_occurs()",
+              "test_request_not_retried_when_other_error_occurs_with_wpcom_authentication()",
+              "test_request_not_retried_when_password_deletion_fails_after_409_error_with_wpcom_authentication()",
+              "test_request_with_non_zero_retryCount_is_not_scheduled_for_retry()",
+              "test_request_with_zero_retryCount_is_scheduled_for_retry()"
+            ]
+          },
+          {
+            "name" : "RESTRequestTests"
+          },
+          {
+            "name" : "ShipmentsRemoteTests"
+          },
+          {
+            "name" : "ShipmentTrackingListMapperTests"
+          },
+          {
+            "name" : "ShipmentTrackingProviderListMapperTests"
+          },
+          {
+            "name" : "ShippingLabelAccountSettingsMapperTests"
+          },
+          {
+            "name" : "ShippingLabelCreationEligibilityMapperTests"
+          },
+          {
+            "name" : "ShippingLabelPackagesMapperTests"
+          },
+          {
+            "name" : "ShippingLabelPurchaseMapperTests"
+          },
+          {
+            "name" : "ShippingLabelRemoteTests"
+          },
+          {
+            "name" : "ShippingLabelStatusMapperTests"
+          },
+          {
+            "name" : "ShippingMethodListMapperTests"
+          },
+          {
+            "name" : "ShippingMethodsRemoteTests"
+          },
+          {
+            "name" : "SiteAPIMapperTests"
+          },
+          {
+            "name" : "SiteAPIRemoteTests"
+          },
+          {
+            "name" : "SiteListMapperTests"
+          },
+          {
+            "name" : "SitePluginMapperTests"
+          },
+          {
+            "name" : "SitePluginsMapperTests"
+          },
+          {
+            "name" : "SitePluginsRemoteTests"
+          },
+          {
+            "name" : "SitePostsRemoteTests"
+          },
+          {
+            "name" : "SiteRemoteTests"
+          },
+          {
+            "name" : "SiteSettingMapperTests"
+          },
+          {
+            "name" : "SiteSettingsMapperTests"
+          },
+          {
+            "name" : "SiteSettingsRemoteTests"
+          },
+          {
+            "name" : "SiteStatsRemoteTests"
+          },
+          {
+            "name" : "SiteSummaryStatsMapperTests"
+          },
+          {
+            "name" : "SiteVisitStatsMapperTests"
+          },
+          {
+            "name" : "StoreOnboardingTaskListMapperTests"
+          },
+          {
+            "name" : "StoreOnboardingTasksRemoteTests"
+          },
+          {
+            "name" : "String_HTMLTests"
+          },
+          {
+            "name" : "String_URLTests"
+          },
+          {
+            "name" : "StripeRemoteTests"
+          },
+          {
+            "name" : "SubscriptionListMapperTests"
+          },
+          {
+            "name" : "SubscriptionMapperTests"
+          },
+          {
+            "name" : "SubscriptionsRemoteTests"
+          },
+          {
+            "name" : "SystemPluginMapperTests"
+          },
+          {
+            "name" : "SystemStatusMapperTests"
+          },
+          {
+            "name" : "SystemStatusRemoteTests"
+          },
+          {
+            "name" : "SystemStatusReportMapperTests"
+          },
+          {
+            "name" : "TaxClassListMapperTest"
+          },
+          {
+            "name" : "TaxRemoteTests"
+          },
+          {
+            "name" : "TelemetryRemoteTests"
+          },
+          {
+            "name" : "TopEarnerStatsMapperTests"
+          },
+          {
+            "name" : "TopEarnerStatsRemoteTests"
+          },
+          {
+            "name" : "UnauthenticatedRequestTests"
+          },
+          {
+            "name" : "URLRequestConvertible_PathTests"
+          },
+          {
+            "name" : "UserAgentTests"
+          },
+          {
+            "name" : "UserMapperTests"
+          },
+          {
+            "name" : "UserRemoteTests"
+          },
+          {
+            "name" : "WCAnalyticsCustomerMapperTests"
+          },
+          {
+            "name" : "WCAnalyticsCustomerRemoteTests"
+          },
+          {
+            "name" : "WCPayChargeMapperTests"
+          },
+          {
+            "name" : "WCPayRemoteTests"
+          },
+          {
+            "name" : "WooAPIVersionTests"
+          },
+          {
+            "name" : "WooShippingConfigMapperTests"
+          },
+          {
+            "name" : "WooShippingRemoteTests"
+          },
+          {
+            "name" : "WooShippingShipmentIDFormatterTests"
+          },
+          {
+            "name" : "WooShippingUpdateShipmentMapperTests"
+          },
+          {
+            "name" : "WordPressApiValidatorTests"
+          },
+          {
+            "name" : "WordPressAPIVersionTests"
+          },
+          {
+            "name" : "WordPressMediaMapperTests"
+          },
+          {
+            "name" : "WordPressPageMapperTests"
+          },
+          {
+            "name" : "WordPressSiteMapperTests"
+          },
+          {
+            "name" : "WordPressSiteRemoteTests"
+          },
+          {
+            "name" : "WordPressThemeListMapperTests"
+          },
+          {
+            "name" : "WordPressThemeMapperTests"
+          },
+          {
+            "name" : "WordPressThemeRemoteTests"
+          }
+        ]
+      },
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "NetworkingTests",
+        "name" : "NetworkingTests"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 23.8
 -----
-
+- [*] Crash fix attempt to resolve the race condition in request authenticator swapping [https://github.com/woocommerce/woocommerce-ios/pull/16370]
 
 23.7
 -----

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -3885,6 +3885,7 @@
 		2D05FE952E8D71EA004111FD /* UpdateAttendanceStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAttendanceStatusView.swift; sourceTree = "<group>"; };
 		2D09E0D02E61BC7D005C26F3 /* ApplicationPasswordsExperimentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordsExperimentState.swift; sourceTree = "<group>"; };
 		2D09E0D42E65C9B9005C26F3 /* ApplicationPasswordsExperimentStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordsExperimentStateTests.swift; sourceTree = "<group>"; };
+		2D49A80B2ECDCD4500AF1749 /* RequestAuthenticatorPressureTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = RequestAuthenticatorPressureTests.xctestplan; path = ../Modules/Tests/NetworkingTests/RequestAuthenticatorPressureTests.xctestplan; sourceTree = "<group>"; };
 		2D7A3E222E7891D200C46401 /* CIABEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIABEligibilityCheckerTests.swift; sourceTree = "<group>"; };
 		2D880B482DFB2F3D00A6FB2C /* OptionalBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalBinding.swift; sourceTree = "<group>"; };
 		2D88C1102DF883BD00A6FB2C /* AttributedString+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Helpers.swift"; sourceTree = "<group>"; };
@@ -9617,6 +9618,7 @@
 		B56DB3BD2049BFAA00D4AA8E = {
 			isa = PBXGroup;
 			children = (
+				2D49A80B2ECDCD4500AF1749 /* RequestAuthenticatorPressureTests.xctestplan */,
 				3F3689E22DCB1B470065B48F /* Modules */,
 				D8FBFF1622D4CC2F006E3336 /* docs */,
 				8CA4F6DC220B24EB00A47B5D /* config */,

--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -96,7 +96,7 @@
     },
     {
       "skippedTests" : [
-        "RequestProcessorTests\/test_threadSanitizerFlagsRaceInUnsynchronizedImplementation()"
+        "RequestProcessorTests\/test_concurrentAuthenticatorUpdatesTriggersRaceWhenUnsynchronized()"
       ],
       "target" : {
         "containerPath" : "container:..\/Modules",

--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -95,6 +95,9 @@
       }
     },
     {
+      "skippedTests" : [
+        "RequestProcessorTests\/test_threadSanitizerFlagsRaceInUnsynchronizedImplementation()"
+      ],
       "target" : {
         "containerPath" : "container:..\/Modules",
         "identifier" : "NetworkingTests",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
Part of: WOOMOB-1489

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

#### Crash Analysis
The backtrace stops inside `_StringGuts.append` while evaluating "Bearer " + authToken before the header is written, so the only dynamic input is the token itself.

AuthenticatedDotcomRequest.swiftLines 16-19:
```
authenticated.setValue("Bearer " + authToken, forHTTPHeaderField: "Authorization")
authenticated.setValue("application/json", forHTTPHeaderField: "Accept")
authenticated.setValue(UserAgent.defaultUserAgent, forHTTPHeaderField: "User-Agent")
```

#### Likely Culprit

`RequestProcessor` mutates `requestAuthenticator` from multiple threads (Combine sinks, Alamofire’s adapter/retirer queues, etc.) without any synchronization.

RequestProcessor.swiftLines 10-32:
```
final class RequestProcessor: RequestInterceptor {
    private var requestsToRetry = [(RetryResult) -> Void]()
    private var isAuthenticating = false
    private var requestAuthenticator: RequestAuthenticator
    // ... existing code ...
    func updateAuthenticator(_ authenticator: RequestAuthenticator) {
        requestAuthenticator = authenticator
        currentSiteID = authenticator.jetpackSiteID
    }
}
```

Because `DefaultRequestAuthenticator` is a value type holding several fields (including reference types), a torn write/read here can corrupt its stored Credentials and leave the authToken pointer dangling, which exactly matches an EXC_BAD_ACCESS when the string is read.

#### Solution

`requestsToRetry`, `isAuthenticating`, `requestAuthenticator`, and the current site ID were moved into a private `RequestProcessorState` helper. That helper owns a dedicated serial queue and exposes synchronized accessors that encapsulate every mutation and read. `RequestProcessor` now delegates all state operations through those accessors, so the rest of the logic stays intact while every shared field is serialized consistently. This refactor removes the undefined behavior that previously corrupted credentials and crashed the bearer-token header construction.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
The PR adds the `test_concurrentAuthenticatorUpdatesTriggersRaceWhenUnsynchronized` test that is aimed to cause the race condition and eventually crash. After applying the fix the test should pass.
- Test the crashing condition first:
- Switch to `a766f55e96ec19992ef8aa88c8680f1274aa5b5c` commit.
- Run the `test_concurrentAuthenticatorUpdatesTriggersRaceWhenUnsynchronized` test. It must crash.
- Switch to the latest commit in this branch `4dc03e082e42f6cfe61c63179e632c6ce86fe77d`.
- Run the test again. It should pass.
- Smoke the app networking, specifically the application password experiment toggling and running the app with and without app passwords feature. 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
