### PR TITLE
[POS - Empty copies] Remove em dashes after feedback and update copy.

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListEmptyViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListEmptyViewModel.swift
@@ -51,7 +51,7 @@ private enum Localization {
     )
 
     static let emptyOrdersSearchSubtitle = NSLocalizedString(
-        "pos.orderListView.emptyOrdersSearchSubtitle",
+        "pos.orderListView.emptyOrdersSearchSubtitle.1",
         value: "We couldn't find any orders with that name.",
         comment: "Subtitle appearing when order search returns no results."
     )

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListEmptyViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListEmptyViewModel.swift
@@ -52,7 +52,7 @@ private enum Localization {
 
     static let emptyOrdersSearchSubtitle = NSLocalizedString(
         "pos.orderListView.emptyOrdersSearchSubtitle",
-        value: "We couldn't find any orders matching your search.",
+        value: "We couldn't find any orders with that name.",
         comment: "Subtitle appearing when order search returns no results."
     )
 

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSListEmptyView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSListEmptyView.swift
@@ -237,7 +237,7 @@ struct POSListEmptyViewModel: POSListEmptyViewModelProtocol {
             comment: "Text for the button appearing on the coupons list screen when there's no coupons found."
         )
         static let emptyCouponSearchSubtitle = NSLocalizedString(
-            "pos.pointOfSaleItemListEmptyView.emptyCouponSearchSubtitle.2",
+            "pos.pointOfSaleItemListEmptyView.emptyCouponSearchSubtitle.3",
             value: "We couldn’t find any coupons with that name. Try adjusting your search term.",
             comment: "Text appearing on the coupons list screen as subtitle when there's no coupons found."
         )

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSListEmptyView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSListEmptyView.swift
@@ -198,7 +198,7 @@ struct POSListEmptyViewModel: POSListEmptyViewModelProtocol {
         )
         static let emptyProductsSearchSubtitle = NSLocalizedString(
             "pos.pointOfSaleItemListEmptyView.emptyProductsSearchSubtitle.2",
-            value: "We couldn't find any matching products — try adjusting your search term.",
+            value: "We couldn't find any matching products. Try adjusting your search term.",
             comment: "Subtitle text suggesting to modify search terms when no products are found in the POS product search."
         )
         static let emptyProductsSearchHint = NSLocalizedString(
@@ -238,7 +238,7 @@ struct POSListEmptyViewModel: POSListEmptyViewModelProtocol {
         )
         static let emptyCouponSearchSubtitle = NSLocalizedString(
             "pos.pointOfSaleItemListEmptyView.emptyCouponSearchSubtitle.2",
-            value: "We couldn’t find any coupons with that name — try adjusting your search term.",
+            value: "We couldn’t find any coupons with that name. Try adjusting your search term.",
             comment: "Text appearing on the coupons list screen as subtitle when there's no coupons found."
         )
         static let emptyProductsButtonTitle = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSListEmptyView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSListEmptyView.swift
@@ -197,7 +197,7 @@ struct POSListEmptyViewModel: POSListEmptyViewModelProtocol {
             comment: "Text appearing on screen when a POS product search returns no results."
         )
         static let emptyProductsSearchSubtitle = NSLocalizedString(
-            "pos.pointOfSaleItemListEmptyView.emptyProductsSearchSubtitle.2",
+            "pos.pointOfSaleItemListEmptyView.emptyProductsSearchSubtitle.3",
             value: "We couldn't find any matching products. Try adjusting your search term.",
             comment: "Subtitle text suggesting to modify search terms when no products are found in the POS product search."
         )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
After the feedback received here, pdfdoF-8lY-p2 we proceed to remove the em dashes from the empty search copy. Other than that, we adjust the copy to the latest designs. NFWCJetWSgHq2jPLKjpKYw-fi-8160_5862

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
Go to POS and enter terms that don't provide a result in Products, Coupons, and Orders. Check that the empty search copy doesn't show em dashes.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

#### Products
<img width="2360" height="1640" alt="IMG_0018" src="https://github.com/user-attachments/assets/d1ae3b10-99ff-4b21-84bf-65cd3d56cc66" />


#### Coupons
<img width="2360" height="1640" alt="IMG_0019" src="https://github.com/user-attachments/assets/f898efe3-81a5-4de2-af64-8d8702a51559" />

#### Orders
<img width="2360" height="1640" alt="IMG_0020" src="https://github.com/user-attachments/assets/ebc4c62a-0d7e-4680-8437-588312568673" />


- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->