### PR TITLE
Login: Support login for sites with captcha plugins

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 23.8
 -----
+- [*] Better support site credential login for sites with captcha plugins [https://github.com/woocommerce/woocommerce-ios/pull/16372]
 - [Internal] Fix broken navigation to a variable product selector [https://github.com/woocommerce/woocommerce-ios/pull/16363]
 
 23.7

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -372,7 +372,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             }
         }()
 
-        // Only show the tutorial if the error can be solved by the app password flow.
+        // Show the tutorial immediately if it's obvious that the error can be solved by the app password flow.
         if isAppPasswordAuthError {
             presentAppPasswordTutorial(error: error, for: siteURL, in: viewController)
         } else {
@@ -798,10 +798,20 @@ private extension AuthenticationManager {
     /// Presents login error alert before redirecting user to the site login using a web view.
     ///
     private func presentAppPasswordAlert(error: Error, for siteURL: String, in viewController: UIViewController) {
-
+        let shouldEnableWebFlow: Bool = {
+            if let siteCredentialError = error as? SiteCredentialLoginError,
+               case .invalidCredentials = siteCredentialError {
+                return true
+            }
+            return false
+        }()
+        let defaultAction = shouldEnableWebFlow ? { [weak self] in
+            guard let self else { return }
+            presentApplicationPasswordWebView(for: siteURL, in: viewController)
+        } : nil
         let alertController = FancyAlertViewController.makeSiteCredentialLoginErrorAlert(
             message: (error as NSError).localizedDescription,
-            defaultAction: nil
+            defaultAction: defaultAction
         )
 
         viewController.present(alertController, animated: true)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -799,6 +799,8 @@ private extension AuthenticationManager {
     ///
     private func presentAppPasswordAlert(error: Error, for siteURL: String, in viewController: UIViewController) {
         let shouldEnableWebFlow: Bool = {
+            /// Since our detection of invalid credentials error might be inaccurate,
+            /// adding the fallback to web flow would unblock users from login.
             if let siteCredentialError = error as? SiteCredentialLoginError,
                case .invalidCredentials = siteCredentialError {
                 return true

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -183,11 +183,14 @@ private extension SiteCredentialLoginUseCase {
             guard let html = String(data: data, encoding: .utf8) else {
                 throw SiteCredentialLoginError.invalidLoginResponse
             }
-            if html.hasInvalidCredentialsPattern() {
+
+            // Extracts error message from the HTML to determine whether there's an authentication issue
+            // otherwise we'll assume it's an invalid response
+            let errorMessage = html.findLoginErrorMessage() ?? ""
+
+            if html.hasInvalidCredentialsPattern(),
+               !errorMessage.lowercased().contains(Constants.captchaText) {
                 throw SiteCredentialLoginError.invalidCredentials
-            }
-            if let errorMessage = html.findLoginErrorMessage() {
-                throw SiteCredentialLoginError.loginFailed(message: errorMessage)
             } else {
                 throw SiteCredentialLoginError.invalidLoginResponse
             }
@@ -227,6 +230,7 @@ extension SiteCredentialLoginUseCase {
         static let loginPath = "/wp-login.php"
         static let adminPath = "/wp-admin"
         static let wporgNoncePath = "/admin-ajax.php?action=rest-nonce"
+        static let captchaText = "captcha"
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-73

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a few improvements to better support site credential login:
- Checks for the keyword "captcha" in the parsed error message to determine invalid response error rather than invalid credentials.
- Restores the option for web login upon invalid credentials. The reason is that our detection of invalid credentials might not be accurate in special cases, so adding this option can work as a fallback to unblock users from login.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

### TC 1:

1. Install this [plugin](https://wordpress.org/plugins/wp-advanced-math-captcha/) to a JN site.
2. Open the app.
3. Sign in using site credentials.
4. Confirm that the app starts the web authorization flow automatically.

https://github.com/user-attachments/assets/27d4768e-c8f8-4afa-abd7-5c1b95c97444

### TC2:

1. Using the same site as TC1, uninstall the captcha plugin.
2. Open the app.
3. Enter some wrong site credentials.
4. Confirm the that the button "Try again with WP Admin page" is available on the error alert.
5. Tap the button and confirm that the web flow is displayed.


https://github.com/user-attachments/assets/e50feebc-92c6-4aeb-908c-03033c22beb0






---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
