### PR TITLE
[Local catalog] Add configurable search debounce strategies

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleCouponsController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleCouponsController.swift
@@ -62,6 +62,14 @@ protocol PointOfSaleCouponsControllerProtocol: PointOfSaleSearchingItemsControll
         fetchStrategy.debounceStrategy
     }
 
+    var searchDebounceStrategy: SearchDebounceStrategy {
+        // Return the debounce strategy that would be used for a search
+        let searchStrategy = fetchStrategyFactory.searchStrategy(searchTerm: "",
+                                                                 analytics: POSItemFetchAnalytics(itemType: .coupon,
+                                                                                                  analytics: analyticsProvider))
+        return searchStrategy.debounceStrategy
+    }
+
     @MainActor
     func loadNextItems(base: ItemListBaseItem) async {
         guard paginationTracker.hasNextPage else {

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleCouponsController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleCouponsController.swift
@@ -7,6 +7,7 @@ import protocol Yosemite.PointOfSaleCouponServiceProtocol
 import struct Yosemite.PointOfSaleCouponFetchStrategyFactory
 import protocol Yosemite.PointOfSaleCouponFetchStrategy
 import class Yosemite.AsyncPaginationTracker
+import enum Yosemite.SearchDebounceStrategy
 
 protocol PointOfSaleCouponsControllerProtocol: PointOfSaleSearchingItemsControllerProtocol {
     /// Enables coupons in store settings
@@ -55,6 +56,10 @@ protocol PointOfSaleCouponsControllerProtocol: PointOfSaleSearchingItemsControll
 
     func clearSearchItems(baseItem: ItemListBaseItem) {
         setSearchingState()
+    }
+
+    var currentDebounceStrategy: SearchDebounceStrategy {
+        fetchStrategy.debounceStrategy
     }
 
     @MainActor

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleItemsController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleItemsController.swift
@@ -10,6 +10,7 @@ import struct Yosemite.POSVariableParentProduct
 import class Yosemite.Store
 import enum Yosemite.POSItemType
 import class Yosemite.AsyncPaginationTracker
+import enum Yosemite.SearchDebounceStrategy
 
 protocol PointOfSaleItemsControllerProtocol {
     ///
@@ -26,6 +27,8 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
     /// Searches for items
     func searchItems(searchTerm: String, baseItem: ItemListBaseItem) async
     func clearSearchItems(baseItem: ItemListBaseItem)
+    /// The debouncing strategy from the current fetch strategy
+    var currentDebounceStrategy: SearchDebounceStrategy { get }
 }
 
 
@@ -69,12 +72,17 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
         fetchStrategy = itemFetchStrategyFactory.searchStrategy(searchTerm: searchTerm,
                                                                 analytics: POSItemFetchAnalytics(itemType: .product,
                                                                                                  analytics: analyticsProvider))
-        setSearchingState(base: baseItem)
+        // Don't set searching state here - let the caller control when to show loading indicators
+        // via clearSearchResults(). This allows for delayed loading indicators for fast queries.
         await loadFirstPage(base: baseItem)
     }
 
     func clearSearchItems(baseItem: ItemListBaseItem) {
         setSearchingState(base: baseItem)
+    }
+
+    var currentDebounceStrategy: SearchDebounceStrategy {
+        fetchStrategy.debounceStrategy
     }
 
     @MainActor

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleItemsController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleItemsController.swift
@@ -74,8 +74,6 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
         fetchStrategy = itemFetchStrategyFactory.searchStrategy(searchTerm: searchTerm,
                                                                 analytics: POSItemFetchAnalytics(itemType: .product,
                                                                                                  analytics: analyticsProvider))
-        // Don't set searching state here - let the caller control when to show loading indicators
-        // via clearSearchResults(). This allows for delayed loading indicators for fast queries.
         await loadFirstPage(base: baseItem)
     }
 

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleItemsController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleItemsController.swift
@@ -29,6 +29,8 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
     func clearSearchItems(baseItem: ItemListBaseItem)
     /// The debouncing strategy from the current fetch strategy
     var currentDebounceStrategy: SearchDebounceStrategy { get }
+    /// The debouncing strategy that will be used when performing a search
+    var searchDebounceStrategy: SearchDebounceStrategy { get }
 }
 
 
@@ -83,6 +85,15 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
 
     var currentDebounceStrategy: SearchDebounceStrategy {
         fetchStrategy.debounceStrategy
+    }
+
+    var searchDebounceStrategy: SearchDebounceStrategy {
+        // Return the debounce strategy that would be used for a search
+        // We create a temporary search strategy to get its debounce settings
+        let searchStrategy = itemFetchStrategyFactory.searchStrategy(searchTerm: "",
+                                                                     analytics: POSItemFetchAnalytics(itemType: .product,
+                                                                                                      analytics: analyticsProvider))
+        return searchStrategy.debounceStrategy
     }
 
     @MainActor

--- a/Modules/Sources/PointOfSale/Presentation/Item Search/POSProductSearchable.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Search/POSProductSearchable.swift
@@ -2,6 +2,7 @@ import Foundation
 import enum Yosemite.POSItemType
 import protocol Yosemite.POSSearchHistoryProviding
 import enum Yosemite.POSItem
+import enum Yosemite.SearchDebounceStrategy
 
 final class POSProductSearchable: POSSearchable {
     private let itemListType: ItemListType
@@ -22,6 +23,10 @@ final class POSProductSearchable: POSSearchable {
 
     var searchFieldPlaceholder: String {
         itemListType.itemType.searchFieldLabel
+    }
+
+    var debounceStrategy: SearchDebounceStrategy {
+        itemsController.currentDebounceStrategy
     }
 
     func performSearch(term: String) async {

--- a/Modules/Sources/PointOfSale/Presentation/Item Search/POSProductSearchable.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Search/POSProductSearchable.swift
@@ -25,7 +25,7 @@ final class POSProductSearchable: POSSearchable {
         itemListType.itemType.searchFieldLabel
     }
 
-    var debounceStrategy: SearchDebounceStrategy {
+    var currentDebounceStrategy: SearchDebounceStrategy {
         itemsController.currentDebounceStrategy
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Item Search/POSProductSearchable.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Search/POSProductSearchable.swift
@@ -29,6 +29,10 @@ final class POSProductSearchable: POSSearchable {
         itemsController.currentDebounceStrategy
     }
 
+    var searchDebounceStrategy: SearchDebounceStrategy {
+        itemsController.searchDebounceStrategy
+    }
+
     func performSearch(term: String) async {
         await itemsController.searchItems(searchTerm: term, baseItem: .root)
     }

--- a/Modules/Sources/PointOfSale/Presentation/Item Search/POSSearchView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Search/POSSearchView.swift
@@ -10,6 +10,8 @@ protocol POSSearchable {
     var searchHistory: [String] { get }
     /// The debouncing strategy to use for search input
     var debounceStrategy: SearchDebounceStrategy { get }
+    /// The debouncing strategy that will be used when performing a search (may differ from current strategy)
+    var searchDebounceStrategy: SearchDebounceStrategy { get }
 
     /// Called when a search should be performed
     /// - Parameter term: The search term to use
@@ -60,9 +62,14 @@ struct POSSearchField: View {
                 // Cancel any ongoing search
                 searchTask?.cancel()
 
+                // Capture the debounce strategy synchronously BEFORE creating the task.
+                // Use searchDebounceStrategy for non-empty search terms (actual searches),
+                // and debounceStrategy for empty terms (returning to popular products).
+                let debounceStrategy = newValue.isNotEmpty ? searchable.searchDebounceStrategy : searchable.debounceStrategy
+
                 searchTask = Task {
-                    // Apply debouncing based on the strategy from the fetch strategy
-                    switch searchable.debounceStrategy {
+                    // Apply debouncing based on the strategy captured at the start
+                    switch debounceStrategy {
                     case .smart(let duration, let loadingDelayThreshold):
                         // Smart debouncing: Don't debounce first keystroke, but debounce subsequent keystrokes
                         // The loading indicator behavior depends on whether there's a threshold:
@@ -186,7 +193,6 @@ struct POSSearchField: View {
         }
         .onAppear {
             isSearchFieldFocused = true
-            didFinishSearch = true  // Reset state when search view appears
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Item Search/POSSearchView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Search/POSSearchView.swift
@@ -8,8 +8,8 @@ protocol POSSearchable {
     var searchFieldPlaceholder: String { get }
     /// Recent search history for the current item type
     var searchHistory: [String] { get }
-    /// The debouncing strategy to use for search input
-    var debounceStrategy: SearchDebounceStrategy { get }
+    /// The debouncing strategy currently active based on the controller's current state
+    var currentDebounceStrategy: SearchDebounceStrategy { get }
     /// The debouncing strategy that will be used when performing a search (may differ from current strategy)
     var searchDebounceStrategy: SearchDebounceStrategy { get }
 
@@ -64,8 +64,8 @@ struct POSSearchField: View {
 
                 // Capture the debounce strategy synchronously BEFORE creating the task.
                 // Use searchDebounceStrategy for non-empty search terms (actual searches),
-                // and debounceStrategy for empty terms (returning to popular products).
-                let debounceStrategy = newValue.isNotEmpty ? searchable.searchDebounceStrategy : searchable.debounceStrategy
+                // and currentDebounceStrategy for empty terms (returning to popular products).
+                let debounceStrategy = newValue.isNotEmpty ? searchable.searchDebounceStrategy : searchable.currentDebounceStrategy
 
                 searchTask = Task {
                     // Apply debouncing based on the strategy captured at the start

--- a/Modules/Sources/PointOfSale/Presentation/Item Search/POSSearchView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Search/POSSearchView.swift
@@ -63,15 +63,62 @@ struct POSSearchField: View {
                 searchTask = Task {
                     // Apply debouncing based on the strategy from the fetch strategy
                     switch searchable.debounceStrategy {
-                    case .smart(let duration):
-                        // Smart debouncing: Skip debounce on first keystroke after search completes,
-                        // then debounce subsequent keystrokes
-                        let shouldDebounce = !didFinishSearch
-                        if shouldDebounce {
-                            try? await Task.sleep(nanoseconds: duration)
-                        } else {
-                            searchable.clearSearchResults()
+                    case .smart(let duration, let loadingDelayThreshold):
+                        // Smart debouncing: Don't debounce first keystroke, but debounce subsequent keystrokes
+                        // The loading indicator behavior depends on whether there's a threshold:
+                        // - With threshold: Show loading after threshold if search hasn't completed (prevents flicker)
+                        // - Without threshold: Show loading immediately (responsive feel)
+
+                        let shouldDebounceNextSearchRequest = !didFinishSearch
+
+                        // Early exit if search term is empty
+                        guard newValue.isNotEmpty else {
+                            didFinishSearch = true
+                            return
                         }
+
+                        // Start loading indicator task if we have a threshold and this is first keystroke
+                        let loadingTask: Task<Void, Never>?
+                        if !shouldDebounceNextSearchRequest {
+                            // First keystroke - handle loading indicators
+                            if let threshold = loadingDelayThreshold {
+                                // With threshold: delay showing loading to prevent flicker for fast searches
+                                loadingTask = Task { @MainActor in
+                                    try? await Task.sleep(nanoseconds: threshold)
+                                    if !Task.isCancelled {
+                                        searchable.clearSearchResults()
+                                    }
+                                }
+                            } else {
+                                // No threshold - show loading immediately for responsive feel
+                                searchable.clearSearchResults()
+                                loadingTask = nil
+                            }
+                        } else {
+                            // Subsequent keystrokes - loading already showing from previous search
+                            loadingTask = nil
+                        }
+
+                        if shouldDebounceNextSearchRequest {
+                            try? await Task.sleep(nanoseconds: duration)
+                        }
+
+                        // Now perform the search (common code for both and subsequent keystrokes)
+                        guard !Task.isCancelled else {
+                            loadingTask?.cancel()
+                            return
+                        }
+
+                        didFinishSearch = false
+                        await searchable.performSearch(term: newValue)
+
+                        // Cancel loading task if search completed (only relevant for first keystroke with threshold)
+                        loadingTask?.cancel()
+
+                        if !Task.isCancelled {
+                            didFinishSearch = true
+                        }
+                        return
 
                     case .simple(let duration, let loadingDelayThreshold):
                         // Simple debouncing: Always debounce
@@ -139,6 +186,7 @@ struct POSSearchField: View {
         }
         .onAppear {
             isSearchFieldFocused = true
+            didFinishSearch = true  // Reset state when search view appears
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Item Search/POSSearchView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Search/POSSearchView.swift
@@ -59,132 +59,7 @@ struct POSSearchField: View {
             .textInputAutocapitalization(.never)
             .focused($isSearchFieldFocused)
             .onChange(of: searchTerm) { oldValue, newValue in
-                // Cancel any ongoing search
-                searchTask?.cancel()
-
-                // Capture the debounce strategy synchronously BEFORE creating the task.
-                // Use searchDebounceStrategy for non-empty search terms (actual searches),
-                // and currentDebounceStrategy for empty terms (returning to popular products).
-                let debounceStrategy = newValue.isNotEmpty ? searchable.searchDebounceStrategy : searchable.currentDebounceStrategy
-
-                searchTask = Task {
-                    // Apply debouncing based on the strategy captured at the start
-                    switch debounceStrategy {
-                    case .smart(let duration, let loadingDelayThreshold):
-                        // Smart debouncing: Don't debounce first keystroke, but debounce subsequent keystrokes
-                        // The loading indicator behavior depends on whether there's a threshold:
-                        // - With threshold: Show loading after threshold if search hasn't completed (prevents flicker)
-                        // - Without threshold: Show loading immediately (responsive feel)
-
-                        let shouldDebounceNextSearchRequest = !didFinishSearch
-
-                        // Early exit if search term is empty
-                        guard newValue.isNotEmpty else {
-                            didFinishSearch = true
-                            return
-                        }
-
-                        // Start loading indicator task if we have a threshold and this is first keystroke
-                        let loadingTask: Task<Void, Never>?
-                        if !shouldDebounceNextSearchRequest {
-                            // First keystroke - handle loading indicators
-                            if let threshold = loadingDelayThreshold {
-                                // With threshold: delay showing loading to prevent flicker for fast searches
-                                loadingTask = Task { @MainActor in
-                                    try? await Task.sleep(nanoseconds: threshold)
-                                    if !Task.isCancelled {
-                                        searchable.clearSearchResults()
-                                    }
-                                }
-                            } else {
-                                // No threshold - show loading immediately for responsive feel
-                                searchable.clearSearchResults()
-                                loadingTask = nil
-                            }
-                        } else {
-                            // Subsequent keystrokes - loading already showing from previous search
-                            loadingTask = nil
-                        }
-
-                        if shouldDebounceNextSearchRequest {
-                            try? await Task.sleep(nanoseconds: duration)
-                        }
-
-                        // Now perform the search (common code for both and subsequent keystrokes)
-                        guard !Task.isCancelled else {
-                            loadingTask?.cancel()
-                            return
-                        }
-
-                        didFinishSearch = false
-                        await searchable.performSearch(term: newValue)
-
-                        // Cancel loading task if search completed (only relevant for first keystroke with threshold)
-                        loadingTask?.cancel()
-
-                        if !Task.isCancelled {
-                            didFinishSearch = true
-                        }
-                        return
-
-                    case .simple(let duration, let loadingDelayThreshold):
-                        // Simple debouncing: Always debounce
-                        try? await Task.sleep(nanoseconds: duration)
-
-                        guard !Task.isCancelled else { return }
-                        guard newValue.isNotEmpty else {
-                            didFinishSearch = true
-                            return
-                        }
-
-                        didFinishSearch = false
-
-                        if let threshold = loadingDelayThreshold {
-                            // Delay showing loading indicators to avoid flicker for fast queries
-                            // Create a loading task that shows indicators after threshold
-                            let loadingTask = Task { @MainActor in
-                                try? await Task.sleep(nanoseconds: threshold)
-                                // Only show loading if not cancelled
-                                if !Task.isCancelled {
-                                    searchable.clearSearchResults()
-                                }
-                            }
-
-                            // Perform the search
-                            await searchable.performSearch(term: newValue)
-
-                            // Cancel loading task if search completed before threshold
-                            loadingTask.cancel()
-                        } else {
-                            // No loading delay threshold - show loading immediately
-                            searchable.clearSearchResults()
-                            await searchable.performSearch(term: newValue)
-                        }
-
-                        if !Task.isCancelled {
-                            didFinishSearch = true
-                        }
-                        return
-
-                    case .immediate:
-                        // No debouncing
-                        break
-                    }
-
-                    guard !Task.isCancelled else { return }
-
-                    guard newValue.isNotEmpty else {
-                        didFinishSearch = true
-                        return
-                    }
-
-                    didFinishSearch = false
-                    await searchable.performSearch(term: newValue)
-
-                    if !Task.isCancelled {
-                        didFinishSearch = true
-                    }
-                }
+                handleSearchTermChange(newValue)
             }
         }
         .onChange(of: keyboardObserver.isKeyboardVisible) { _, isVisible in
@@ -193,6 +68,142 @@ struct POSSearchField: View {
         }
         .onAppear {
             isSearchFieldFocused = true
+        }
+    }
+}
+
+// MARK: - Search Handling
+private extension POSSearchField {
+    func handleSearchTermChange(_ newValue: String) {
+        searchTask?.cancel()
+
+        let debounceStrategy = selectDebounceStrategy(for: newValue)
+
+        searchTask = Task {
+            await executeSearchWithStrategy(debounceStrategy, searchTerm: newValue)
+        }
+    }
+
+    func selectDebounceStrategy(for searchTerm: String) -> SearchDebounceStrategy {
+        // Use searchDebounceStrategy for non-empty search terms (actual searches),
+        // and currentDebounceStrategy for empty terms (returning to popular products).
+        searchTerm.isNotEmpty ? searchable.searchDebounceStrategy : searchable.currentDebounceStrategy
+    }
+
+    func executeSearchWithStrategy(_ strategy: SearchDebounceStrategy, searchTerm: String) async {
+        switch strategy {
+        case .smart(let duration, let loadingDelayThreshold):
+            await executeSmartDebouncedSearch(duration: duration, loadingDelayThreshold: loadingDelayThreshold, searchTerm: searchTerm)
+        case .simple(let duration, let loadingDelayThreshold):
+            await executeSimpleDebouncedSearch(duration: duration, loadingDelayThreshold: loadingDelayThreshold, searchTerm: searchTerm)
+        case .immediate:
+            await executeImmediateSearch(searchTerm: searchTerm)
+        }
+    }
+
+    func executeSmartDebouncedSearch(duration: UInt64, loadingDelayThreshold: UInt64?, searchTerm: String) async {
+        // Smart debouncing: Don't debounce first keystroke, but debounce subsequent keystrokes
+        // The loading indicator behavior depends on whether there's a threshold:
+        // - With threshold: Show loading after threshold if search hasn't completed (prevents flicker)
+        // - Without threshold: Show loading immediately (responsive feel)
+
+        let isFirstKeystroke = didFinishSearch
+
+        guard searchTerm.isNotEmpty else {
+            didFinishSearch = true
+            return
+        }
+
+        // Handle loading indicators for first keystroke
+        let loadingTask = isFirstKeystroke ? startLoadingIndicatorTask(threshold: loadingDelayThreshold) : nil
+
+        // Debounce subsequent keystrokes
+        if !isFirstKeystroke {
+            try? await Task.sleep(nanoseconds: duration)
+        }
+
+        guard !Task.isCancelled else {
+            loadingTask?.cancel()
+            return
+        }
+
+        await performSearchAndTrackCompletion(searchTerm: searchTerm)
+        loadingTask?.cancel()
+    }
+
+    func executeSimpleDebouncedSearch(duration: UInt64,
+                                      loadingDelayThreshold: UInt64?,
+                                      searchTerm: String) async {
+        // Simple debouncing: Always debounce every keystroke
+        try? await Task.sleep(nanoseconds: duration)
+
+        guard !Task.isCancelled else { return }
+        guard searchTerm.isNotEmpty else {
+            didFinishSearch = true
+            return
+        }
+
+        didFinishSearch = false
+
+        if let threshold = loadingDelayThreshold {
+            await performSearchWithDelayedLoading(searchTerm: searchTerm, threshold: threshold)
+        } else {
+            searchable.clearSearchResults()
+            await searchable.performSearch(term: searchTerm)
+        }
+
+        if !Task.isCancelled {
+            didFinishSearch = true
+        }
+    }
+
+    func executeImmediateSearch(searchTerm: String) async {
+        guard !Task.isCancelled else { return }
+        guard searchTerm.isNotEmpty else {
+            didFinishSearch = true
+            return
+        }
+
+        await performSearchAndTrackCompletion(searchTerm: searchTerm)
+    }
+
+    func startLoadingIndicatorTask(threshold: UInt64?) -> Task<Void, Never>? {
+        if let threshold {
+            // With threshold: delay showing loading to prevent flicker for fast searches
+            return Task { @MainActor in
+                try? await Task.sleep(nanoseconds: threshold)
+                if !Task.isCancelled {
+                    searchable.clearSearchResults()
+                }
+            }
+        } else {
+            // No threshold - show loading immediately for responsive feel
+            searchable.clearSearchResults()
+            return nil
+        }
+    }
+
+    func performSearchWithDelayedLoading(searchTerm: String, threshold: UInt64) async {
+        // Create a loading task that shows indicators after threshold
+        let loadingTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: threshold)
+            if !Task.isCancelled {
+                searchable.clearSearchResults()
+            }
+        }
+
+        await searchable.performSearch(term: searchTerm)
+
+        // Cancel loading task if search completed before threshold
+        loadingTask.cancel()
+    }
+
+    private func performSearchAndTrackCompletion(searchTerm: String) async {
+        didFinishSearch = false
+        await searchable.performSearch(term: searchTerm)
+
+        if !Task.isCancelled {
+            didFinishSearch = true
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Item Search/POSSearchView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Search/POSSearchView.swift
@@ -1,12 +1,15 @@
 import SwiftUI
 import enum Yosemite.POSItemType
 import enum Yosemite.POSItem
+import enum Yosemite.SearchDebounceStrategy
 
 /// Protocol defining search capabilities for POS items
 protocol POSSearchable {
     var searchFieldPlaceholder: String { get }
     /// Recent search history for the current item type
     var searchHistory: [String] { get }
+    /// The debouncing strategy to use for search input
+    var debounceStrategy: SearchDebounceStrategy { get }
 
     /// Called when a search should be performed
     /// - Parameter term: The search term to use
@@ -54,24 +57,64 @@ struct POSSearchField: View {
             .textInputAutocapitalization(.never)
             .focused($isSearchFieldFocused)
             .onChange(of: searchTerm) { oldValue, newValue in
-                // The debouncing logic is a little tricky, because the loading state is held in the controller.
-                // Arguably, we should use view state `isSearching` for this, so the UI is independent of the request timing.
-
-                // As the user types, we don't want to send every keystroke to the remote, so we debounce the requests.
-                // However, we don't want to debounce the first keystroke of a new search, so that the loading
-                // state shows immediately and the UI feels responsive.
-
-                // So, if the last search was finished, we don't debounce the first character. If it didn't
-                // finish i.e. it is still ongoing, we debounce the next keystrokes by 300ms. In either case,
-                // the ongoing search is redundant now there's a new search term, so we cancel it.
-                let shouldDebounceNextSearchRequest = !didFinishSearch
+                // Cancel any ongoing search
                 searchTask?.cancel()
 
                 searchTask = Task {
-                    if shouldDebounceNextSearchRequest {
-                        try? await Task.sleep(nanoseconds: 500 * NSEC_PER_MSEC)
-                    } else {
-                        searchable.clearSearchResults()
+                    // Apply debouncing based on the strategy from the fetch strategy
+                    switch searchable.debounceStrategy {
+                    case .smart(let duration):
+                        // Smart debouncing: Skip debounce on first keystroke after search completes,
+                        // then debounce subsequent keystrokes
+                        let shouldDebounce = !didFinishSearch
+                        if shouldDebounce {
+                            try? await Task.sleep(nanoseconds: duration)
+                        } else {
+                            searchable.clearSearchResults()
+                        }
+
+                    case .simple(let duration, let loadingDelayThreshold):
+                        // Simple debouncing: Always debounce
+                        try? await Task.sleep(nanoseconds: duration)
+
+                        guard !Task.isCancelled else { return }
+                        guard newValue.isNotEmpty else {
+                            didFinishSearch = true
+                            return
+                        }
+
+                        didFinishSearch = false
+
+                        if let threshold = loadingDelayThreshold {
+                            // Delay showing loading indicators to avoid flicker for fast queries
+                            // Create a loading task that shows indicators after threshold
+                            let loadingTask = Task { @MainActor in
+                                try? await Task.sleep(nanoseconds: threshold)
+                                // Only show loading if not cancelled
+                                if !Task.isCancelled {
+                                    searchable.clearSearchResults()
+                                }
+                            }
+
+                            // Perform the search
+                            await searchable.performSearch(term: newValue)
+
+                            // Cancel loading task if search completed before threshold
+                            loadingTask.cancel()
+                        } else {
+                            // No loading delay threshold - show loading immediately
+                            searchable.clearSearchResults()
+                            await searchable.performSearch(term: newValue)
+                        }
+
+                        if !Task.isCancelled {
+                            didFinishSearch = true
+                        }
+                        return
+
+                    case .immediate:
+                        // No debouncing
+                        break
                     }
 
                     guard !Task.isCancelled else { return }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
@@ -372,6 +372,11 @@ final class POSOrderSearchable: POSSearchable {
         .smart(duration: 500 * NSEC_PER_MSEC)
     }
 
+    var searchDebounceStrategy: SearchDebounceStrategy {
+        // Orders use the same strategy for both modes
+        debounceStrategy
+    }
+
     func performSearch(term: String) async {
         await ordersController.searchOrders(searchTerm: term)
     }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import struct WooFoundation.WooAnalyticsEvent
 import struct Yosemite.POSOrder
 import enum Yosemite.OrderPaymentMethod
+import enum Yosemite.SearchDebounceStrategy
 
 struct POSOrderListView: View {
     @Binding var isSearching: Bool
@@ -362,6 +363,13 @@ final class POSOrderSearchable: POSSearchable {
 
     var searchHistory: [String] {
         []
+    }
+
+    var debounceStrategy: SearchDebounceStrategy {
+        // Use smart debouncing for order search to match original behavior:
+        // don't debounce first keystroke to show loading immediately,
+        // then debounce subsequent keystrokes while search is ongoing
+        .smart(duration: 500 * NSEC_PER_MSEC)
     }
 
     func performSearch(term: String) async {

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
@@ -365,7 +365,7 @@ final class POSOrderSearchable: POSSearchable {
         []
     }
 
-    var debounceStrategy: SearchDebounceStrategy {
+    var currentDebounceStrategy: SearchDebounceStrategy {
         // Use smart debouncing for order search to match original behavior:
         // don't debounce first keystroke to show loading immediately,
         // then debounce subsequent keystrokes while search is ongoing
@@ -374,7 +374,7 @@ final class POSOrderSearchable: POSSearchable {
 
     var searchDebounceStrategy: SearchDebounceStrategy {
         // Orders use the same strategy for both modes
-        debounceStrategy
+        currentDebounceStrategy
     }
 
     func performSearch(term: String) async {

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
@@ -369,7 +369,7 @@ final class POSOrderSearchable: POSSearchable {
         // Use smart debouncing for order search to match original behavior:
         // don't debounce first keystroke to show loading immediately,
         // then debounce subsequent keystrokes while search is ongoing
-        .smart(duration: 500 * NSEC_PER_MSEC)
+        .smart()
     }
 
     var searchDebounceStrategy: SearchDebounceStrategy {

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -107,7 +107,7 @@ final class PointOfSalePreviewCouponsController: PointOfSaleCouponsControllerPro
                                                                    itemsStack: ItemsStackState(root: .loading([]),
                                                                                                itemStates: [:]))
     var currentDebounceStrategy: SearchDebounceStrategy { .immediate }
-    var searchDebounceStrategy: SearchDebounceStrategy { .smart(duration: 500 * NSEC_PER_MSEC) }
+    var searchDebounceStrategy: SearchDebounceStrategy { .smart() }
     func enableCoupons() async { }
     func loadItems(base: ItemListBaseItem) async { }
     func refreshItems(base: ItemListBaseItem) async { }
@@ -122,7 +122,7 @@ final class PointOfSalePreviewItemsController: PointOfSaleSearchingItemsControll
                                                                                                itemStates: [:]))
 
     var currentDebounceStrategy: SearchDebounceStrategy { .immediate }
-    var searchDebounceStrategy: SearchDebounceStrategy { .smart(duration: 500 * NSEC_PER_MSEC) }
+    var searchDebounceStrategy: SearchDebounceStrategy { .smart() }
 
     func loadItems(base: ItemListBaseItem) async {
         switch base {

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -107,6 +107,7 @@ final class PointOfSalePreviewCouponsController: PointOfSaleCouponsControllerPro
                                                                    itemsStack: ItemsStackState(root: .loading([]),
                                                                                                itemStates: [:]))
     var currentDebounceStrategy: SearchDebounceStrategy { .immediate }
+    var searchDebounceStrategy: SearchDebounceStrategy { .smart(duration: 500 * NSEC_PER_MSEC) }
     func enableCoupons() async { }
     func loadItems(base: ItemListBaseItem) async { }
     func refreshItems(base: ItemListBaseItem) async { }
@@ -121,6 +122,7 @@ final class PointOfSalePreviewItemsController: PointOfSaleSearchingItemsControll
                                                                                                itemStates: [:]))
 
     var currentDebounceStrategy: SearchDebounceStrategy { .immediate }
+    var searchDebounceStrategy: SearchDebounceStrategy { .smart(duration: 500 * NSEC_PER_MSEC) }
 
     func loadItems(base: ItemListBaseItem) async {
         switch base {

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -18,6 +18,7 @@ import struct Yosemite.POSProduct
 import struct Yosemite.POSProductVariation
 import protocol Yosemite.POSSearchHistoryProviding
 import enum Yosemite.POSItemType
+import enum Yosemite.SearchDebounceStrategy
 import protocol Yosemite.PointOfSaleBarcodeScanServiceProtocol
 import enum Yosemite.PointOfSaleBarcodeScanError
 import Combine
@@ -105,6 +106,7 @@ final class PointOfSalePreviewCouponsController: PointOfSaleCouponsControllerPro
     @Published var itemsViewState: ItemsViewState = ItemsViewState(containerState: .loading(),
                                                                    itemsStack: ItemsStackState(root: .loading([]),
                                                                                                itemStates: [:]))
+    var currentDebounceStrategy: SearchDebounceStrategy { .immediate }
     func enableCoupons() async { }
     func loadItems(base: ItemListBaseItem) async { }
     func refreshItems(base: ItemListBaseItem) async { }
@@ -117,6 +119,8 @@ final class PointOfSalePreviewItemsController: PointOfSaleSearchingItemsControll
     @Published var itemsViewState: ItemsViewState = ItemsViewState(containerState: .loading(),
                                                                    itemsStack: ItemsStackState(root: .loading([]),
                                                                                                itemStates: [:]))
+
+    var currentDebounceStrategy: SearchDebounceStrategy { .immediate }
 
     func loadItems(base: ItemListBaseItem) async {
         switch base {

--- a/Modules/Sources/Storage/GRDB/Model/PersistedProduct.swift
+++ b/Modules/Sources/Storage/GRDB/Model/PersistedProduct.swift
@@ -156,6 +156,7 @@ public extension PersistedProduct {
     /// - Returns: An escaped pattern safe for use in LIKE queries
     private static func escapeSQLLikePattern(_ pattern: String) -> String {
         pattern
+            .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "%", with: "\\%")
             .replacingOccurrences(of: "_", with: "\\_")
     }

--- a/Modules/Sources/Yosemite/PointOfSale/Coupons/PointOfSaleCouponFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Coupons/PointOfSaleCouponFetchStrategy.swift
@@ -102,7 +102,7 @@ struct PointOfSaleSearchCouponFetchStrategy: PointOfSaleCouponFetchStrategy {
     var debounceStrategy: SearchDebounceStrategy {
         // Use smart debouncing for remote coupon search
         // No loading delay threshold - show loading immediately for responsive feel
-        .smart(duration: 500 * NSEC_PER_MSEC)
+        .smart()
     }
 
     func fetchCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {

--- a/Modules/Sources/Yosemite/PointOfSale/Coupons/PointOfSaleCouponFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Coupons/PointOfSaleCouponFetchStrategy.swift
@@ -6,6 +6,16 @@ import protocol Storage.StorageManagerType
 public protocol PointOfSaleCouponFetchStrategy {
     func fetchCoupons(pageNumber: Int) async throws -> PagedItems<POSItem>
     func fetchLocalCoupons() async throws -> [POSItem]
+    /// The debouncing strategy to use for search input.
+    /// Default is `.immediate` (no debouncing) for non-search strategies.
+    var debounceStrategy: SearchDebounceStrategy { get }
+}
+
+public extension PointOfSaleCouponFetchStrategy {
+    /// Default implementation returns `.immediate` for strategies that don't need debouncing
+    var debounceStrategy: SearchDebounceStrategy {
+        .immediate
+    }
 }
 
 struct PointOfSaleDefaultCouponFetchStrategy: PointOfSaleCouponFetchStrategy {
@@ -87,6 +97,11 @@ struct PointOfSaleSearchCouponFetchStrategy: PointOfSaleCouponFetchStrategy {
         self.currencySettings = currencySettings
         self.searchTerm = searchTerm
         self.analytics = analytics
+    }
+
+    var debounceStrategy: SearchDebounceStrategy {
+        // Use smart debouncing for remote coupon search
+        .smart(duration: 500 * NSEC_PER_MSEC)
     }
 
     func fetchCoupons(pageNumber: Int) async throws -> PagedItems<POSItem> {

--- a/Modules/Sources/Yosemite/PointOfSale/Coupons/PointOfSaleCouponFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Coupons/PointOfSaleCouponFetchStrategy.swift
@@ -101,6 +101,7 @@ struct PointOfSaleSearchCouponFetchStrategy: PointOfSaleCouponFetchStrategy {
 
     var debounceStrategy: SearchDebounceStrategy {
         // Use smart debouncing for remote coupon search
+        // No loading delay threshold - show loading immediately for responsive feel
         .smart(duration: 500 * NSEC_PER_MSEC)
     }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemService.swift
@@ -36,7 +36,7 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
             return .init(items: itemMapper.mapProductsToPOSItems(products: products),
                          hasMorePages: pagedProducts.hasMorePages,
                          totalItems: pagedProducts.totalItems)
-        } catch AFError.explicitlyCancelled {
+        } catch AFError.explicitlyCancelled, is CancellationError {
             throw PointOfSaleItemServiceError.requestCancelled
         }
     }
@@ -55,7 +55,7 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
                 hasMorePages: pagedVariations.hasMorePages,
                 totalItems: pagedVariations.totalItems
             )
-        } catch AFError.explicitlyCancelled {
+        } catch AFError.explicitlyCancelled, is CancellationError {
             throw PointOfSaleItemServiceError.requestCancelled
         }
     }

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleLocalSearchPurchasableItemFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleLocalSearchPurchasableItemFetchStrategy.swift
@@ -25,6 +25,13 @@ public struct PointOfSaleLocalSearchPurchasableItemFetchStrategy: PointOfSalePur
         self.pageSize = pageSize
     }
 
+    public var debounceStrategy: SearchDebounceStrategy {
+        // Use simple debouncing for local search: always debounce to prevent excessive queries
+        // even though local searches are fast. 100ms provides responsive feel while preventing
+        // queries on every keystroke. Delay loading indicators by 150ms to avoid flicker for fast queries.
+        .simple(duration: 150 * NSEC_PER_MSEC, loadingDelayThreshold: 300 * NSEC_PER_MSEC)
+    }
+
     public func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct> {
         let startTime = Date()
 

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleLocalSearchPurchasableItemFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleLocalSearchPurchasableItemFetchStrategy.swift
@@ -3,10 +3,11 @@ import protocol Storage.GRDBManagerProtocol
 import protocol Networking.ProductVariationsRemoteProtocol
 
 /// Fetch strategy for searching products in the local GRDB catalog using SQL LIKE queries
-public struct PointOfSaleLocalSearchPurchasableItemFetchStrategy: PointOfSalePurchasableItemFetchStrategy {
+struct PointOfSaleLocalSearchPurchasableItemFetchStrategy: PointOfSalePurchasableItemFetchStrategy {
     private let siteID: Int64
     private let searchTerm: String
     private let grdbManager: GRDBManagerProtocol
+    // periphery:ignore - Reserved for future variation fetching from remote when not in local catalog
     private let variationsRemote: ProductVariationsRemoteProtocol
     private let analytics: POSItemFetchAnalyticsTracking
     private let pageSize: Int
@@ -25,14 +26,14 @@ public struct PointOfSaleLocalSearchPurchasableItemFetchStrategy: PointOfSalePur
         self.pageSize = pageSize
     }
 
-    public var debounceStrategy: SearchDebounceStrategy {
+    var debounceStrategy: SearchDebounceStrategy {
         // Use simple debouncing for local search: always debounce to prevent excessive queries
         // even though local searches are fast. 100ms provides responsive feel while preventing
         // queries on every keystroke. Delay loading indicators by 150ms to avoid flicker for fast queries.
         .simple(duration: 150 * NSEC_PER_MSEC, loadingDelayThreshold: 300 * NSEC_PER_MSEC)
     }
 
-    public func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct> {
+    func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct> {
         let startTime = Date()
 
         // Get total count and persisted products in one transaction
@@ -69,7 +70,7 @@ public struct PointOfSaleLocalSearchPurchasableItemFetchStrategy: PointOfSalePur
                          totalItems: totalCount)
     }
 
-    public func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
+    func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
         // Get total count and persisted variations in one transaction
         let (persistedVariations, totalCount) = try await grdbManager.databaseConnection.read { db in
             let totalCount = try PersistedProductVariation

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
@@ -85,7 +85,7 @@ public struct PointOfSaleSearchPurchasableItemFetchStrategy: PointOfSalePurchasa
         // Use smart debouncing for remote search: don't debounce first keystroke to show loading immediately,
         // then debounce subsequent keystrokes while search is ongoing.
         // No loading delay threshold - show loading immediately for responsive feel.
-        .smart(duration: 500 * NSEC_PER_MSEC)
+        .smart()
     }
 
     public func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct> {

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
@@ -5,6 +5,17 @@ import protocol Networking.ProductVariationsRemoteProtocol
 public protocol PointOfSalePurchasableItemFetchStrategy {
     func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct>
     func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation>
+
+    /// The debouncing strategy to use for search input.
+    /// Default is `.immediate` (no debouncing) for non-search strategies.
+    var debounceStrategy: SearchDebounceStrategy { get }
+}
+
+public extension PointOfSalePurchasableItemFetchStrategy {
+    /// Default implementation returns `.immediate` for strategies that don't need debouncing
+    var debounceStrategy: SearchDebounceStrategy {
+        .immediate
+    }
 }
 
 public struct PointOfSaleDefaultPurchasableItemFetchStrategy: PointOfSalePurchasableItemFetchStrategy {
@@ -67,6 +78,12 @@ public struct PointOfSaleSearchPurchasableItemFetchStrategy: PointOfSalePurchasa
         self.productsRemote = productsRemote
         self.variationsRemote = variationsRemote
         self.analytics = analytics
+    }
+
+    public var debounceStrategy: SearchDebounceStrategy {
+        // Use smart debouncing for remote search: don't debounce first keystroke to show loading immediately,
+        // then debounce subsequent keystrokes while search is ongoing
+        .smart(duration: 500 * NSEC_PER_MSEC)
     }
 
     public func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct> {

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
@@ -82,7 +82,8 @@ public struct PointOfSaleSearchPurchasableItemFetchStrategy: PointOfSalePurchasa
 
     public var debounceStrategy: SearchDebounceStrategy {
         // Use smart debouncing for remote search: don't debounce first keystroke to show loading immediately,
-        // then debounce subsequent keystrokes while search is ongoing
+        // then debounce subsequent keystrokes while search is ongoing.
+        // No loading delay threshold - show loading immediately for responsive feel.
         .smart(duration: 500 * NSEC_PER_MSEC)
     }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
@@ -80,6 +80,7 @@ public struct PointOfSaleSearchPurchasableItemFetchStrategy: PointOfSalePurchasa
         self.analytics = analytics
     }
 
+    // periphery:ignore - Protocol requirement, used via protocol
     public var debounceStrategy: SearchDebounceStrategy {
         // Use smart debouncing for remote search: don't debounce first keystroke to show loading immediately,
         // then debounce subsequent keystrokes while search is ongoing.

--- a/Modules/Sources/Yosemite/PointOfSale/Items/SearchDebounceStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/SearchDebounceStrategy.swift
@@ -3,9 +3,12 @@ import Foundation
 /// Defines the debouncing behavior for search input
 public enum SearchDebounceStrategy: Equatable {
     /// Smart debouncing: Skip debounce on first keystroke after a search completes, then debounce subsequent keystrokes.
+    /// Optionally delays showing loading indicators until a threshold is exceeded.
     /// Optimized for slow network searches where the first keystroke should show loading immediately.
-    /// - Parameter duration: The debounce duration in nanoseconds for subsequent keystrokes
-    case smart(duration: UInt64)
+    /// - Parameters:
+    ///   - duration: The debounce duration in nanoseconds for subsequent keystrokes
+    ///   - loadingDelayThreshold: Optional threshold in nanoseconds before showing loading indicators. If nil, shows loading immediately.
+    case smart(duration: UInt64, loadingDelayThreshold: UInt64? = nil)
 
     /// Simple debouncing: Always debounce every keystroke by the specified duration.
     /// Optionally delays showing loading indicators until a threshold is exceeded.

--- a/Modules/Sources/Yosemite/PointOfSale/Items/SearchDebounceStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/SearchDebounceStrategy.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Defines the debouncing behavior for search input
+public enum SearchDebounceStrategy: Equatable {
+    /// Smart debouncing: Skip debounce on first keystroke after a search completes, then debounce subsequent keystrokes.
+    /// Optimized for slow network searches where the first keystroke should show loading immediately.
+    /// - Parameter duration: The debounce duration in nanoseconds for subsequent keystrokes
+    case smart(duration: UInt64)
+
+    /// Simple debouncing: Always debounce every keystroke by the specified duration.
+    /// Optionally delays showing loading indicators until a threshold is exceeded.
+    /// Optimized for fast local searches to prevent excessive queries and loading flicker.
+    /// - Parameters:
+    ///   - duration: The debounce duration in nanoseconds
+    ///   - loadingDelayThreshold: Optional threshold in nanoseconds before showing loading indicators. If nil, shows loading immediately.
+    case simple(duration: UInt64, loadingDelayThreshold: UInt64? = nil)
+
+    /// Immediate: No debouncing, execute search on every keystroke.
+    /// Use when debouncing is not needed (e.g., non-search operations).
+    case immediate
+}

--- a/Modules/Sources/Yosemite/PointOfSale/Items/SearchDebounceStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/SearchDebounceStrategy.swift
@@ -8,7 +8,7 @@ public enum SearchDebounceStrategy: Equatable {
     /// - Parameters:
     ///   - duration: The debounce duration in nanoseconds for subsequent keystrokes
     ///   - loadingDelayThreshold: Optional threshold in nanoseconds before showing loading indicators. If nil, shows loading immediately.
-    case smart(duration: UInt64, loadingDelayThreshold: UInt64? = nil)
+    case smart(duration: UInt64 = 500 * NSEC_PER_MSEC, loadingDelayThreshold: UInt64? = nil)
 
     /// Simple debouncing: Always debounce every keystroke by the specified duration.
     /// Optionally delays showing loading indicators until a threshold is exceeded.

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleCouponsController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleCouponsController.swift
@@ -9,6 +9,7 @@ final class MockPointOfSaleCouponsController: PointOfSaleCouponsControllerProtoc
                                                itemsStack: .init(root: .empty, itemStates: [:]))
 
     var currentDebounceStrategy: SearchDebounceStrategy = .immediate
+    var searchDebounceStrategy: SearchDebounceStrategy = .smart(duration: 500 * NSEC_PER_MSEC)
 
     func loadItems(base: ItemListBaseItem) async {
         loadItemsCalled = true

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleCouponsController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleCouponsController.swift
@@ -1,5 +1,6 @@
 @testable import PointOfSale
 import Yosemite
+import Foundation
 
 final class MockPointOfSaleCouponsController: PointOfSaleCouponsControllerProtocol {
     var loadItemsCalled = false

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleCouponsController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleCouponsController.swift
@@ -1,4 +1,5 @@
 @testable import PointOfSale
+import Yosemite
 
 final class MockPointOfSaleCouponsController: PointOfSaleCouponsControllerProtocol {
     var loadItemsCalled = false
@@ -6,6 +7,8 @@ final class MockPointOfSaleCouponsController: PointOfSaleCouponsControllerProtoc
 
     var itemsViewState: ItemsViewState = .init(containerState: .content,
                                                itemsStack: .init(root: .empty, itemStates: [:]))
+
+    var currentDebounceStrategy: SearchDebounceStrategy = .immediate
 
     func loadItems(base: ItemListBaseItem) async {
         loadItemsCalled = true

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleCouponsController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleCouponsController.swift
@@ -10,7 +10,7 @@ final class MockPointOfSaleCouponsController: PointOfSaleCouponsControllerProtoc
                                                itemsStack: .init(root: .empty, itemStates: [:]))
 
     var currentDebounceStrategy: SearchDebounceStrategy = .immediate
-    var searchDebounceStrategy: SearchDebounceStrategy = .smart(duration: 500 * NSEC_PER_MSEC)
+    var searchDebounceStrategy: SearchDebounceStrategy = .smart()
 
     func loadItems(base: ItemListBaseItem) async {
         loadItemsCalled = true

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSalePurchasableItemsSearchController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSalePurchasableItemsSearchController.swift
@@ -2,10 +2,13 @@ import Foundation
 import Combine
 @testable import PointOfSale
 import enum Yosemite.POSItem
+import Yosemite
 
 final class MockPointOfSalePurchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol {
     var itemsViewState: ItemsViewState = .init(containerState: .content,
                                                itemsStack: .init(root: .empty, itemStates: [:]))
+
+    var currentDebounceStrategy: SearchDebounceStrategy = .immediate
 
     func searchItems(searchTerm: String, baseItem: ItemListBaseItem) async {}
 

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSalePurchasableItemsSearchController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSalePurchasableItemsSearchController.swift
@@ -9,7 +9,7 @@ final class MockPointOfSalePurchasableItemsSearchController: PointOfSaleSearchin
                                                itemsStack: .init(root: .empty, itemStates: [:]))
 
     var currentDebounceStrategy: SearchDebounceStrategy = .immediate
-    var searchDebounceStrategy: SearchDebounceStrategy = .smart(duration: 500 * NSEC_PER_MSEC)
+    var searchDebounceStrategy: SearchDebounceStrategy = .smart()
 
     func searchItems(searchTerm: String, baseItem: ItemListBaseItem) async {}
 

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSalePurchasableItemsSearchController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSalePurchasableItemsSearchController.swift
@@ -9,6 +9,7 @@ final class MockPointOfSalePurchasableItemsSearchController: PointOfSaleSearchin
                                                itemsStack: .init(root: .empty, itemStates: [:]))
 
     var currentDebounceStrategy: SearchDebounceStrategy = .immediate
+    var searchDebounceStrategy: SearchDebounceStrategy = .smart(duration: 500 * NSEC_PER_MSEC)
 
     func searchItems(searchTerm: String, baseItem: ItemListBaseItem) async {}
 

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSalePurchasableItemsSearchController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSalePurchasableItemsSearchController.swift
@@ -2,7 +2,7 @@ import Foundation
 import Combine
 @testable import PointOfSale
 import enum Yosemite.POSItem
-import Yosemite
+import enum Yosemite.SearchDebounceStrategy
 
 final class MockPointOfSalePurchasableItemsSearchController: PointOfSaleSearchingItemsControllerProtocol {
     var itemsViewState: ItemsViewState = .init(containerState: .content,
@@ -18,5 +18,5 @@ final class MockPointOfSalePurchasableItemsSearchController: PointOfSaleSearchin
 
     func loadNextItems(base: ItemListBaseItem) async { }
 
-    func clearSearchItems(baseItem: PointOfSale.ItemListBaseItem) { }
+    func clearSearchItems(baseItem: ItemListBaseItem) { }
 }

--- a/Modules/Tests/YosemiteTests/PointOfSale/SearchDebounceStrategyTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/SearchDebounceStrategyTests.swift
@@ -172,19 +172,51 @@ private final class MockProductsRemote: ProductsRemoteProtocol {
         ([], false)
     }
 
-    func loadAllProducts(for siteID: Int64, context: String?, pageNumber: Int, pageSize: Int, stockStatus: Networking.ProductStockStatus?, productStatus: Networking.ProductStatus?, productType: Networking.ProductType?, productCategory: Networking.ProductCategoryID?, orderBy: Networking.ProductsRemote.OrderKey, order: Networking.ProductsRemote.Order, excludedProductIDs: [Int64], includedProductIDs: [Int64]) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
+    func loadAllProducts(for siteID: Int64,
+                         context: String?,
+                         pageNumber: Int,
+                         pageSize: Int,
+                         stockStatus: Networking.ProductStockStatus?,
+                         productStatus: Networking.ProductStatus?,
+                         productType: Networking.ProductType?,
+                         productCategory: Networking.ProductCategoryID?,
+                         orderBy: Networking.ProductsRemote.OrderKey,
+                         order: Networking.ProductsRemote.Order,
+                         excludedProductIDs: [Int64],
+                         includedProductIDs: [Int64]) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
         ([], false)
     }
 
-    func loadAllProducts(for siteID: Int64, context: String?, pageNumber: Int, pageSize: Int, stockStatus: Networking.ProductStockStatus?, productStatus: Networking.ProductStatus?, productType: Networking.ProductType?, productCategory: Networking.ProductCategoryID?, orderBy: Networking.ProductsRemote.OrderKey, order: Networking.ProductsRemote.Order, excludedProductIDs: [Int64]) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
+    func loadAllProducts(for siteID: Int64,
+                         context: String?,
+                         pageNumber: Int,
+                         pageSize: Int,
+                         stockStatus: Networking.ProductStockStatus?,
+                         productStatus: Networking.ProductStatus?,
+                         productType: Networking.ProductType?,
+                         productCategory: Networking.ProductCategoryID?,
+                         orderBy: Networking.ProductsRemote.OrderKey,
+                         order: Networking.ProductsRemote.Order,
+                         excludedProductIDs: [Int64]) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
         ([], false)
     }
 
-    func searchProducts(for siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, stockStatus: Networking.ProductStockStatus?, productStatus: Networking.ProductStatus?, productType: Networking.ProductType?, excludedProductIDs: [Int64]) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
+    func searchProducts(for siteID: Int64,
+                        keyword: String,
+                        pageNumber: Int,
+                        pageSize: Int,
+                        stockStatus: Networking.ProductStockStatus?,
+                        productStatus: Networking.ProductStatus?,
+                        productType: Networking.ProductType?,
+                        excludedProductIDs: [Int64]) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
         ([], false)
     }
 
-    func searchProducts(for siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, excludeTypes: [String]) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
+    func searchProducts(for siteID: Int64,
+                        keyword: String,
+                        pageNumber: Int,
+                        pageSize: Int,
+                        excludeTypes: [String]) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
         ([], false)
     }
 
@@ -212,11 +244,20 @@ private final class MockProductsRemote: ProductsRemoteProtocol {
         throw NSError(domain: "test", code: 0)
     }
 
-    func searchProductsForPointOfSale(for siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, stockStatus: Networking.ProductStockStatus?) async throws -> Networking.PagedItems<Networking.POSProduct> {
+    func searchProductsForPointOfSale(for siteID: Int64,
+                                      keyword: String,
+                                      pageNumber: Int,
+                                      pageSize: Int,
+                                      stockStatus: Networking.ProductStockStatus?) async throws
+    -> Networking.PagedItems<Networking.POSProduct> {
         .init(items: [], hasMorePages: false, totalItems: nil)
     }
 
-    func loadProductsForPointOfSale(for siteID: Int64, pageNumber: Int, pageSize: Int, stockStatus: Networking.ProductStockStatus?) async throws -> Networking.PagedItems<Networking.POSProduct> {
+    func loadProductsForPointOfSale(for siteID: Int64,
+                                    pageNumber: Int,
+                                    pageSize: Int,
+                                    stockStatus: Networking.ProductStockStatus?) async throws
+    -> Networking.PagedItems<Networking.POSProduct> {
         .init(items: [], hasMorePages: false, totalItems: nil)
     }
 
@@ -226,7 +267,10 @@ private final class MockProductsRemote: ProductsRemoteProtocol {
 }
 
 private final class MockProductVariationsRemote: ProductVariationsRemoteProtocol {
-    func loadVariationsForPointOfSale(for siteID: Int64, parentProductID: Int64, pageNumber: Int) async throws -> Networking.PagedItems<Networking.POSProductVariation> {
+    func loadVariationsForPointOfSale(for siteID: Int64,
+                                      parentProductID: Int64,
+                                      pageNumber: Int) async throws
+    -> Networking.PagedItems<Networking.POSProductVariation> {
         .init(items: [], hasMorePages: false, totalItems: nil)
     }
 

--- a/Modules/Tests/YosemiteTests/PointOfSale/SearchDebounceStrategyTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/SearchDebounceStrategyTests.swift
@@ -81,12 +81,15 @@ struct SearchDebounceStrategyTests {
 struct FetchStrategyDebouncingTests {
     private let siteID: Int64 = 123
     private let mockAnalytics = MockPOSItemFetchAnalyticsTracking()
+    private let mockProductsRemote = MockProductsRemote()
+    private let mockVariationsRemote = MockProductVariationsRemote()
+    private let mockCouponStoreMethods = MockCouponStoreMethods()
 
     // MARK: - Local Search Strategy Tests
 
     @Test("Local search strategy returns simple debouncing with loading delay threshold")
     func test_local_search_strategy_returns_simple_debouncing_with_threshold() async throws {
-        let grdbManager = try GRDBManager()
+        let grdbManager = try await GRDBManager()
 
         // Initialize site
         try await grdbManager.databaseConnection.write { db in
@@ -97,7 +100,7 @@ struct FetchStrategyDebouncingTests {
             siteID: siteID,
             searchTerm: "test",
             grdbManager: grdbManager,
-            variationsRemote: MockProductVariationsRemote(),
+            variationsRemote: mockVariationsRemote,
             analytics: mockAnalytics
         )
 
@@ -112,8 +115,8 @@ struct FetchStrategyDebouncingTests {
         let strategy = PointOfSaleSearchPurchasableItemFetchStrategy(
             siteID: siteID,
             searchTerm: "test",
-            productsRemote: MockProductsRemote(),
-            variationsRemote: MockProductVariationsRemote(),
+            productsRemote: mockProductsRemote,
+            variationsRemote: mockVariationsRemote,
             analytics: mockAnalytics
         )
 
@@ -127,8 +130,8 @@ struct FetchStrategyDebouncingTests {
     func test_default_purchasable_item_strategy_returns_immediate_debouncing() {
         let strategy = PointOfSaleDefaultPurchasableItemFetchStrategy(
             siteID: siteID,
-            productsRemote: MockProductsRemote(),
-            variationsRemote: MockProductVariationsRemote(),
+            productsRemote: mockProductsRemote,
+            variationsRemote: mockVariationsRemote,
             analytics: mockAnalytics
         )
 
@@ -162,164 +165,5 @@ struct FetchStrategyDebouncingTests {
         )
 
         #expect(strategy.debounceStrategy == .immediate)
-    }
-}
-
-// MARK: - Mock Types
-
-private final class MockProductsRemote: ProductsRemoteProtocol {
-    func loadSimpleProducts(for siteID: Int64, pageNumber: Int, pageSize: Int) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
-        ([], false)
-    }
-
-    func loadAllProducts(for siteID: Int64,
-                         context: String?,
-                         pageNumber: Int,
-                         pageSize: Int,
-                         stockStatus: Networking.ProductStockStatus?,
-                         productStatus: Networking.ProductStatus?,
-                         productType: Networking.ProductType?,
-                         productCategory: Networking.ProductCategoryID?,
-                         orderBy: Networking.ProductsRemote.OrderKey,
-                         order: Networking.ProductsRemote.Order,
-                         excludedProductIDs: [Int64],
-                         includedProductIDs: [Int64]) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
-        ([], false)
-    }
-
-    func loadAllProducts(for siteID: Int64,
-                         context: String?,
-                         pageNumber: Int,
-                         pageSize: Int,
-                         stockStatus: Networking.ProductStockStatus?,
-                         productStatus: Networking.ProductStatus?,
-                         productType: Networking.ProductType?,
-                         productCategory: Networking.ProductCategoryID?,
-                         orderBy: Networking.ProductsRemote.OrderKey,
-                         order: Networking.ProductsRemote.Order,
-                         excludedProductIDs: [Int64]) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
-        ([], false)
-    }
-
-    func searchProducts(for siteID: Int64,
-                        keyword: String,
-                        pageNumber: Int,
-                        pageSize: Int,
-                        stockStatus: Networking.ProductStockStatus?,
-                        productStatus: Networking.ProductStatus?,
-                        productType: Networking.ProductType?,
-                        excludedProductIDs: [Int64]) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
-        ([], false)
-    }
-
-    func searchProducts(for siteID: Int64,
-                        keyword: String,
-                        pageNumber: Int,
-                        pageSize: Int,
-                        excludeTypes: [String]) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
-        ([], false)
-    }
-
-    func searchSku(for siteID: Int64, sku: String, pageNumber: Int, pageSize: Int) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
-        ([], false)
-    }
-
-    func loadProduct(for siteID: Int64, productID: Int64) async throws -> Networking.Product {
-        throw NSError(domain: "test", code: 0)
-    }
-
-    func updateProducts(_ products: [Networking.Product]) async throws -> [Networking.Product] {
-        []
-    }
-
-    func deleteProduct(for siteID: Int64, productID: Int64, forceDelete: Bool) async throws -> Networking.Product {
-        throw NSError(domain: "test", code: 0)
-    }
-
-    func retrieveProductShippingClass(for siteID: Int64, remoteID: Int64) async throws -> Networking.ProductShippingClass {
-        throw NSError(domain: "test", code: 0)
-    }
-
-    func addProduct(product: Networking.Product) async throws -> Networking.Product {
-        throw NSError(domain: "test", code: 0)
-    }
-
-    func searchProductsForPointOfSale(for siteID: Int64,
-                                      keyword: String,
-                                      pageNumber: Int,
-                                      pageSize: Int,
-                                      stockStatus: Networking.ProductStockStatus?) async throws
-    -> Networking.PagedItems<Networking.POSProduct> {
-        .init(items: [], hasMorePages: false, totalItems: nil)
-    }
-
-    func loadProductsForPointOfSale(for siteID: Int64,
-                                    pageNumber: Int,
-                                    pageSize: Int,
-                                    stockStatus: Networking.ProductStockStatus?) async throws
-    -> Networking.PagedItems<Networking.POSProduct> {
-        .init(items: [], hasMorePages: false, totalItems: nil)
-    }
-
-    func loadPopularProductsForPointOfSale(for siteID: Int64) async throws -> [Networking.POSProduct] {
-        []
-    }
-}
-
-private final class MockProductVariationsRemote: ProductVariationsRemoteProtocol {
-    func loadVariationsForPointOfSale(for siteID: Int64,
-                                      parentProductID: Int64,
-                                      pageNumber: Int) async throws
-    -> Networking.PagedItems<Networking.POSProductVariation> {
-        .init(items: [], hasMorePages: false, totalItems: nil)
-    }
-
-    func loadAllVariations(for siteID: Int64, productID: Int64, context: String?) async throws -> [Networking.ProductVariation] {
-        []
-    }
-
-    func loadVariation(for siteID: Int64, productID: Int64, variationID: Int64) async throws -> Networking.ProductVariation {
-        throw NSError(domain: "test", code: 0)
-    }
-
-    func updateVariation(_ variation: Networking.ProductVariation) async throws -> Networking.ProductVariation {
-        throw NSError(domain: "test", code: 0)
-    }
-
-    func createVariation(_ variation: Networking.ProductVariation) async throws -> Networking.ProductVariation {
-        throw NSError(domain: "test", code: 0)
-    }
-
-    func deleteVariation(siteID: Int64, productID: Int64, variationID: Int64) async throws -> Networking.ProductVariation {
-        throw NSError(domain: "test", code: 0)
-    }
-}
-
-private final class MockCouponStoreMethods: CouponStoreMethodsProtocol {
-    func synchronizeCoupons(siteID: Int64, pageNumber: Int, pageSize: Int) async throws -> Bool {
-        false
-    }
-
-    func searchCoupons(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int) async throws {
-    }
-}
-
-private final class MockPOSItemFetchAnalyticsTracking: POSItemFetchAnalyticsTracking {
-    var spyLocalSearchMilliseconds: Int?
-    var spyLocalSearchTotalItems: Int?
-    var spyRemoteSearchMilliseconds: Int?
-    var spyRemoteSearchTotalItems: Int?
-
-    func trackSearchLocalResultsFetchComplete(millisecondsSinceRequestSent: Int, totalItems: Int) {
-        spyLocalSearchMilliseconds = millisecondsSinceRequestSent
-        spyLocalSearchTotalItems = totalItems
-    }
-
-    func trackSearchRemoteResultsFetchComplete(millisecondsSinceRequestSent: Int, totalItems: Int) {
-        spyRemoteSearchMilliseconds = millisecondsSinceRequestSent
-        spyRemoteSearchTotalItems = totalItems
-    }
-
-    func trackFetchComplete(millisecondsSinceRequestSent: Int, totalItems: Int) {
     }
 }

--- a/Modules/Tests/YosemiteTests/PointOfSale/SearchDebounceStrategyTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/SearchDebounceStrategyTests.swift
@@ -1,0 +1,281 @@
+import Foundation
+import Testing
+import Networking
+@testable import Storage
+@testable import Yosemite
+
+@Suite("SearchDebounceStrategy Tests")
+struct SearchDebounceStrategyTests {
+
+    // MARK: - Equatable Tests
+
+    @Test("Smart strategies with same duration are equal")
+    func test_smart_strategies_with_same_duration_are_equal() {
+        let strategy1: SearchDebounceStrategy = .smart(duration: 500 * NSEC_PER_MSEC)
+        let strategy2: SearchDebounceStrategy = .smart(duration: 500 * NSEC_PER_MSEC)
+
+        #expect(strategy1 == strategy2)
+    }
+
+    @Test("Smart strategies with different durations are not equal")
+    func test_smart_strategies_with_different_durations_are_not_equal() {
+        let strategy1: SearchDebounceStrategy = .smart(duration: 500 * NSEC_PER_MSEC)
+        let strategy2: SearchDebounceStrategy = .smart(duration: 300 * NSEC_PER_MSEC)
+
+        #expect(strategy1 != strategy2)
+    }
+
+    @Test("Simple strategies with same duration and no threshold are equal")
+    func test_simple_strategies_with_same_duration_and_no_threshold_are_equal() {
+        let strategy1: SearchDebounceStrategy = .simple(duration: 150 * NSEC_PER_MSEC)
+        let strategy2: SearchDebounceStrategy = .simple(duration: 150 * NSEC_PER_MSEC)
+
+        #expect(strategy1 == strategy2)
+    }
+
+    @Test("Simple strategies with same duration and same threshold are equal")
+    func test_simple_strategies_with_same_duration_and_threshold_are_equal() {
+        let strategy1: SearchDebounceStrategy = .simple(duration: 150 * NSEC_PER_MSEC, loadingDelayThreshold: 300 * NSEC_PER_MSEC)
+        let strategy2: SearchDebounceStrategy = .simple(duration: 150 * NSEC_PER_MSEC, loadingDelayThreshold: 300 * NSEC_PER_MSEC)
+
+        #expect(strategy1 == strategy2)
+    }
+
+    @Test("Simple strategies with different durations are not equal")
+    func test_simple_strategies_with_different_durations_are_not_equal() {
+        let strategy1: SearchDebounceStrategy = .simple(duration: 150 * NSEC_PER_MSEC, loadingDelayThreshold: 300 * NSEC_PER_MSEC)
+        let strategy2: SearchDebounceStrategy = .simple(duration: 200 * NSEC_PER_MSEC, loadingDelayThreshold: 300 * NSEC_PER_MSEC)
+
+        #expect(strategy1 != strategy2)
+    }
+
+    @Test("Simple strategies with different thresholds are not equal")
+    func test_simple_strategies_with_different_thresholds_are_not_equal() {
+        let strategy1: SearchDebounceStrategy = .simple(duration: 150 * NSEC_PER_MSEC, loadingDelayThreshold: 300 * NSEC_PER_MSEC)
+        let strategy2: SearchDebounceStrategy = .simple(duration: 150 * NSEC_PER_MSEC, loadingDelayThreshold: 400 * NSEC_PER_MSEC)
+
+        #expect(strategy1 != strategy2)
+    }
+
+    @Test("Immediate strategies are equal")
+    func test_immediate_strategies_are_equal() {
+        let strategy1: SearchDebounceStrategy = .immediate
+        let strategy2: SearchDebounceStrategy = .immediate
+
+        #expect(strategy1 == strategy2)
+    }
+
+    @Test("Different strategy types are not equal")
+    func test_different_strategy_types_are_not_equal() {
+        let smartStrategy: SearchDebounceStrategy = .smart(duration: 500 * NSEC_PER_MSEC)
+        let simpleStrategy: SearchDebounceStrategy = .simple(duration: 150 * NSEC_PER_MSEC)
+        let immediateStrategy: SearchDebounceStrategy = .immediate
+
+        #expect(smartStrategy != simpleStrategy)
+        #expect(smartStrategy != immediateStrategy)
+        #expect(simpleStrategy != immediateStrategy)
+    }
+}
+
+@Suite("Fetch Strategy Debouncing Tests")
+struct FetchStrategyDebouncingTests {
+    private let siteID: Int64 = 123
+    private let mockAnalytics = MockPOSItemFetchAnalyticsTracking()
+
+    // MARK: - Local Search Strategy Tests
+
+    @Test("Local search strategy returns simple debouncing with loading delay threshold")
+    func test_local_search_strategy_returns_simple_debouncing_with_threshold() async throws {
+        let grdbManager = try GRDBManager()
+
+        // Initialize site
+        try await grdbManager.databaseConnection.write { db in
+            try PersistedSite(id: siteID).insert(db)
+        }
+
+        let strategy = PointOfSaleLocalSearchPurchasableItemFetchStrategy(
+            siteID: siteID,
+            searchTerm: "test",
+            grdbManager: grdbManager,
+            variationsRemote: MockProductVariationsRemote(),
+            analytics: mockAnalytics
+        )
+
+        let expected: SearchDebounceStrategy = .simple(duration: 150 * NSEC_PER_MSEC, loadingDelayThreshold: 300 * NSEC_PER_MSEC)
+        #expect(strategy.debounceStrategy == expected)
+    }
+
+    // MARK: - Remote Search Strategy Tests
+
+    @Test("Remote search strategy returns smart debouncing")
+    func test_remote_search_strategy_returns_smart_debouncing() {
+        let strategy = PointOfSaleSearchPurchasableItemFetchStrategy(
+            siteID: siteID,
+            searchTerm: "test",
+            productsRemote: MockProductsRemote(),
+            variationsRemote: MockProductVariationsRemote(),
+            analytics: mockAnalytics
+        )
+
+        let expected: SearchDebounceStrategy = .smart(duration: 500 * NSEC_PER_MSEC)
+        #expect(strategy.debounceStrategy == expected)
+    }
+
+    // MARK: - Default Strategy Tests
+
+    @Test("Default purchasable item strategy returns immediate debouncing")
+    func test_default_purchasable_item_strategy_returns_immediate_debouncing() {
+        let strategy = PointOfSaleDefaultPurchasableItemFetchStrategy(
+            siteID: siteID,
+            productsRemote: MockProductsRemote(),
+            variationsRemote: MockProductVariationsRemote(),
+            analytics: mockAnalytics
+        )
+
+        #expect(strategy.debounceStrategy == .immediate)
+    }
+
+    // MARK: - Coupon Strategy Tests
+
+    @Test("Search coupon strategy returns smart debouncing")
+    func test_search_coupon_strategy_returns_smart_debouncing() {
+        let strategy = PointOfSaleSearchCouponFetchStrategy(
+            siteID: siteID,
+            currencySettings: .init(),
+            storage: MockStorageManager(),
+            couponStoreMethods: MockCouponStoreMethods(),
+            searchTerm: "test",
+            analytics: mockAnalytics
+        )
+
+        let expected: SearchDebounceStrategy = .smart(duration: 500 * NSEC_PER_MSEC)
+        #expect(strategy.debounceStrategy == expected)
+    }
+
+    @Test("Default coupon strategy returns immediate debouncing")
+    func test_default_coupon_strategy_returns_immediate_debouncing() {
+        let strategy = PointOfSaleDefaultCouponFetchStrategy(
+            siteID: siteID,
+            currencySettings: .init(),
+            storage: MockStorageManager(),
+            couponStoreMethods: MockCouponStoreMethods()
+        )
+
+        #expect(strategy.debounceStrategy == .immediate)
+    }
+}
+
+// MARK: - Mock Types
+
+private final class MockProductsRemote: ProductsRemoteProtocol {
+    func loadSimpleProducts(for siteID: Int64, pageNumber: Int, pageSize: Int) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
+        ([], false)
+    }
+
+    func loadAllProducts(for siteID: Int64, context: String?, pageNumber: Int, pageSize: Int, stockStatus: Networking.ProductStockStatus?, productStatus: Networking.ProductStatus?, productType: Networking.ProductType?, productCategory: Networking.ProductCategoryID?, orderBy: Networking.ProductsRemote.OrderKey, order: Networking.ProductsRemote.Order, excludedProductIDs: [Int64], includedProductIDs: [Int64]) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
+        ([], false)
+    }
+
+    func loadAllProducts(for siteID: Int64, context: String?, pageNumber: Int, pageSize: Int, stockStatus: Networking.ProductStockStatus?, productStatus: Networking.ProductStatus?, productType: Networking.ProductType?, productCategory: Networking.ProductCategoryID?, orderBy: Networking.ProductsRemote.OrderKey, order: Networking.ProductsRemote.Order, excludedProductIDs: [Int64]) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
+        ([], false)
+    }
+
+    func searchProducts(for siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, stockStatus: Networking.ProductStockStatus?, productStatus: Networking.ProductStatus?, productType: Networking.ProductType?, excludedProductIDs: [Int64]) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
+        ([], false)
+    }
+
+    func searchProducts(for siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, excludeTypes: [String]) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
+        ([], false)
+    }
+
+    func searchSku(for siteID: Int64, sku: String, pageNumber: Int, pageSize: Int) async throws -> (products: [Networking.Product], hasNextPage: Bool) {
+        ([], false)
+    }
+
+    func loadProduct(for siteID: Int64, productID: Int64) async throws -> Networking.Product {
+        throw NSError(domain: "test", code: 0)
+    }
+
+    func updateProducts(_ products: [Networking.Product]) async throws -> [Networking.Product] {
+        []
+    }
+
+    func deleteProduct(for siteID: Int64, productID: Int64, forceDelete: Bool) async throws -> Networking.Product {
+        throw NSError(domain: "test", code: 0)
+    }
+
+    func retrieveProductShippingClass(for siteID: Int64, remoteID: Int64) async throws -> Networking.ProductShippingClass {
+        throw NSError(domain: "test", code: 0)
+    }
+
+    func addProduct(product: Networking.Product) async throws -> Networking.Product {
+        throw NSError(domain: "test", code: 0)
+    }
+
+    func searchProductsForPointOfSale(for siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, stockStatus: Networking.ProductStockStatus?) async throws -> Networking.PagedItems<Networking.POSProduct> {
+        .init(items: [], hasMorePages: false, totalItems: nil)
+    }
+
+    func loadProductsForPointOfSale(for siteID: Int64, pageNumber: Int, pageSize: Int, stockStatus: Networking.ProductStockStatus?) async throws -> Networking.PagedItems<Networking.POSProduct> {
+        .init(items: [], hasMorePages: false, totalItems: nil)
+    }
+
+    func loadPopularProductsForPointOfSale(for siteID: Int64) async throws -> [Networking.POSProduct] {
+        []
+    }
+}
+
+private final class MockProductVariationsRemote: ProductVariationsRemoteProtocol {
+    func loadVariationsForPointOfSale(for siteID: Int64, parentProductID: Int64, pageNumber: Int) async throws -> Networking.PagedItems<Networking.POSProductVariation> {
+        .init(items: [], hasMorePages: false, totalItems: nil)
+    }
+
+    func loadAllVariations(for siteID: Int64, productID: Int64, context: String?) async throws -> [Networking.ProductVariation] {
+        []
+    }
+
+    func loadVariation(for siteID: Int64, productID: Int64, variationID: Int64) async throws -> Networking.ProductVariation {
+        throw NSError(domain: "test", code: 0)
+    }
+
+    func updateVariation(_ variation: Networking.ProductVariation) async throws -> Networking.ProductVariation {
+        throw NSError(domain: "test", code: 0)
+    }
+
+    func createVariation(_ variation: Networking.ProductVariation) async throws -> Networking.ProductVariation {
+        throw NSError(domain: "test", code: 0)
+    }
+
+    func deleteVariation(siteID: Int64, productID: Int64, variationID: Int64) async throws -> Networking.ProductVariation {
+        throw NSError(domain: "test", code: 0)
+    }
+}
+
+private final class MockCouponStoreMethods: CouponStoreMethodsProtocol {
+    func synchronizeCoupons(siteID: Int64, pageNumber: Int, pageSize: Int) async throws -> Bool {
+        false
+    }
+
+    func searchCoupons(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int) async throws {
+    }
+}
+
+private final class MockPOSItemFetchAnalyticsTracking: POSItemFetchAnalyticsTracking {
+    var spyLocalSearchMilliseconds: Int?
+    var spyLocalSearchTotalItems: Int?
+    var spyRemoteSearchMilliseconds: Int?
+    var spyRemoteSearchTotalItems: Int?
+
+    func trackSearchLocalResultsFetchComplete(millisecondsSinceRequestSent: Int, totalItems: Int) {
+        spyLocalSearchMilliseconds = millisecondsSinceRequestSent
+        spyLocalSearchTotalItems = totalItems
+    }
+
+    func trackSearchRemoteResultsFetchComplete(millisecondsSinceRequestSent: Int, totalItems: Int) {
+        spyRemoteSearchMilliseconds = millisecondsSinceRequestSent
+        spyRemoteSearchTotalItems = totalItems
+    }
+
+    func trackFetchComplete(millisecondsSinceRequestSent: Int, totalItems: Int) {
+    }
+}

--- a/Modules/Tests/YosemiteTests/PointOfSale/SearchDebounceStrategyTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/SearchDebounceStrategyTests.swift
@@ -89,7 +89,7 @@ struct FetchStrategyDebouncingTests {
 
     @Test("Local search strategy returns simple debouncing with loading delay threshold")
     func test_local_search_strategy_returns_simple_debouncing_with_threshold() async throws {
-        let grdbManager = try await GRDBManager()
+        let grdbManager = try GRDBManager()
 
         // Initialize site
         try await grdbManager.databaseConnection.write { db in


### PR DESCRIPTION
Part of: WOOMOB-1112

## Description
This PR fixes the flickering when we do a local search, while retaining the debounce approach used in existing places

Implements configurable debouncing strategies for search to optimize the user experience for both local and remote searches. Different search types have different performance characteristics and benefit from different debounce behaviors.

Changes include:
- New `SearchDebounceStrategy` enum with three strategies:
  - `.smart`: Skip debounce on first keystroke after search completes, then debounce subsequent keystrokes (optimized for slow network searches)
  - `.simple`: Always debounce every keystroke with optional loading delay threshold (optimized for fast local searches to prevent flicker)
  - `.immediate`: No debouncing, execute search on every keystroke
- Added `debounceStrategy` property to fetch strategy protocols
- Updated search UI to implement strategy-based debouncing logic
- Applied simple debouncing (150ms) to local product search with 300ms loading delay threshold
- Comprehensive test coverage for all three strategies

This ensures responsive UI for fast local searches while preventing loading indicator flicker, and optimized behavior for slower network searches.

This PR is stacked on #16376 and is the fifth and final PR in the series implementing local catalog search.

## Test Steps
N.B. – the remote feature flag now requires WCiOS 23.8 – change it in the project file when you want to use a local catalog store.
<img width="719" height="364" alt="image" src="https://github.com/user-attachments/assets/16731cbd-0095-4290-bcbe-5dafd647446a" />

### Debouncing

- With the feature flag enabled, launch the app and open POS
- Search for an item, typing the term quickly with an external keyboard
- Observe that there aren't intermediate results, when you type quickly
- Observe that there's no flickering, and results update quickly (we'll animate it later, if needed)

Repeat this slower with the software keyboard and observe that there's no flicker (but there will be intermediate results)

Test with the feature flag disabled – observe that loading indicators are still shown and work as expected
Check Coupons and Order History as well.


### General search testing

- Launch the app with the feature flag enabled
- Search for a product by name, SKU, or GTIN
- Observe that results are shown, without a loading state
- Search for a non-matching term
- Observe that the "no results found" screen is shown

### Remaining issues
Note that there are two issues still to tackle in future PRs
 - Occasionally errors show briefly for intermediate results
 - Trashed products aren't filtered, because that PR wasn't in trunk when I branched

## Screenshots


https://github.com/user-attachments/assets/480fe72d-9054-48df-9411-06c8699b60c3



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.