### PR TITLE
Periphery exclude all folders with *Test* in the name

### DIFF
--- a/.periphery.yml
+++ b/.periphery.yml
@@ -58,8 +58,7 @@ index_exclude:
 - Pods/*
 - vendor/**
 - BuildTools/.build/**
-- "**/Tests/*"
-- "**/Test*/*"
+- "**/*Test*/*"
 - "docs/*"
 - "fastlane/*"
 - "config/*"

--- a/Modules/Sources/UITestsFoundation/Screens/Login/GetStartedScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Login/GetStartedScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Login/HelpScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Login/HelpScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Login/LoginOnboardingScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Login/LoginOnboardingScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Login/LoginPasswordScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Login/LoginPasswordScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 import XCUITestHelpers

--- a/Modules/Sources/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Login/PasswordScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Login/PasswordScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Login/PrologueScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Login/PrologueScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Login/TwoFAScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Login/TwoFAScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Menu/MenuScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Menu/MenuScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/MyStore/MyStoreScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/MyStore/MyStoreScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Orders/AddCustomAmountScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Orders/AddCustomAmountScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Orders/AddCustomerDetailsScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Orders/AddCustomerDetailsScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Orders/AddProductScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Orders/AddProductScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Orders/AddShippingScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Orders/AddShippingScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Orders/CardPresentPaymentsModalScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Orders/CardPresentPaymentsModalScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Orders/CustomerDetailsScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Orders/CustomerDetailsScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Orders/CustomerNoteScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Orders/CustomerNoteScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Orders/OrderSearchScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Orders/OrderSearchScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Orders/OrderStatusScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Orders/OrderStatusScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Orders/OrdersScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Orders/OrdersScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Orders/PaymentMethodsScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Orders/PaymentMethodsScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Payments/CardReaderManualsScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Payments/CardReaderManualsScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Products/ProductFilterScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Products/ProductFilterScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Products/ProductSearchScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Products/ProductSearchScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Products/SingleProductScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Products/SingleProductScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 import XCUITestHelpers

--- a/Modules/Sources/UITestsFoundation/Screens/Reviews/ReviewsScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Reviews/ReviewsScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Reviews/SingleReviewScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Reviews/SingleReviewScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Settings/BetaFeaturesScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Settings/BetaFeaturesScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/Settings/SettingsScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Settings/SettingsScreen.swift
@@ -1,4 +1,3 @@
-//periphery:ignore:all
 import ScreenObject
 import XCTest
 

--- a/Modules/Sources/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/TabNavComponent.swift
@@ -2,35 +2,25 @@ import ScreenObject
 import XCTest
 
 public final class TabNavComponent: ScreenObject {
-    // periphery:ignore
     private let myStoreTabButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.tabBars.firstMatch.buttons["tab-bar-my-store-item"]
     }
-    // periphery:ignore
     private let ordersTabButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.tabBars.firstMatch.buttons["tab-bar-orders-item"]
     }
-    // periphery:ignore
     private let productsTabButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.tabBars.firstMatch.buttons["tab-bar-products-item"]
     }
-    // periphery:ignore
     private let posTabButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.tabBars.firstMatch.buttons["tab-bar-pos-item"]
     }
-    // periphery:ignore
     private let menuTabButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.tabBars.firstMatch.buttons["tab-bar-menu-item"]
     }
-    // periphery:ignore
     private var myStoreTabButton: XCUIElement { myStoreTabButtonGetter(app) }
-    // periphery:ignore
     private var ordersTabButton: XCUIElement { ordersTabButtonGetter(app) }
-    // periphery:ignore
     private var menuTabButton: XCUIElement { menuTabButtonGetter(app) }
-    // periphery:ignore
     private var productsTabButton: XCUIElement { productsTabButtonGetter(app) }
-    // periphery:ignore
     private var posTabButton: XCUIElement { posTabButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
@@ -43,47 +33,33 @@ public final class TabNavComponent: ScreenObject {
             app: app
         )
     }
-
-    // periphery:ignore
     @discardableResult
     public func goToMyStoreScreen() throws -> MyStoreScreen {
         myStoreTabButton.tap()
         return try MyStoreScreen()
     }
-
-    // periphery:ignore
     @discardableResult
     public func goToOrdersScreen() throws -> OrdersScreen {
         ordersTabButton.tap()
         return try OrdersScreen()
     }
-
-    // periphery:ignore
     @discardableResult
     public func goToProductsScreen() throws -> ProductsScreen {
         productsTabButton.tap()
         return try ProductsScreen()
     }
-
-    // periphery:ignore
     public func goToPOSScreen() throws -> POSScreen {
         posTabButton.tap()
         return try POSScreen()
     }
-
-    // periphery:ignore
     @discardableResult
     public func goToMenuScreen() throws -> MenuScreen {
         menuTabButton.tap()
         return try MenuScreen()
     }
-
-    // periphery:ignore
     static func isLoaded() -> Bool {
         (try? TabNavComponent().isLoaded) ?? false
     }
-
-    // periphery:ignore
     // TODO: This paradigm is used enough around the test suits that it would be worth extracting to `ScreenObject`.
    static func isVisible() -> Bool {
         guard let tabNavComponent = try? TabNavComponent() else { return false }


### PR DESCRIPTION
This PR updates the periphery config to exclude all folders with *Test* in the name.

## Test Steps
CI should be 🟢 
