### PR TITLE
Log out: Ensure that unregistering push notifications completes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Better support site credential login for sites with captcha plugins [https://github.com/woocommerce/woocommerce-ios/pull/16372]
 - [*] Crash fix attempt to resolve the race condition in request authenticator swapping [https://github.com/woocommerce/woocommerce-ios/pull/16370]
 - [*] Update products on the Top Performers card when there are changes made to displayed products [https://github.com/woocommerce/woocommerce-ios/pull/16380]
+- [*] Fixed issue unregistering device from push notifications [https://github.com/woocommerce/woocommerce-ios/pull/16386]
 - [Internal] Fix broken navigation to a variable product selector [https://github.com/woocommerce/woocommerce-ios/pull/16363]
 
 23.7

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -167,18 +167,19 @@ extension PushNotificationsManager {
 
     /// Unregisters the Application from WordPress.com Push Notifications Service.
     ///
-    func unregisterForRemoteNotifications() {
+    func unregisterForRemoteNotifications(onCompletion: @escaping () -> Void) {
         DDLogInfo("📱 Unregistering For Remote Notifications...")
 
         unregisterDotcomDeviceIfPossible() { error in
             if let error = error {
                 DDLogError("⛔️ Unable to unregister from WordPress.com Push Notifications: \(error)")
-                return
+            } else {
+                DDLogInfo("📱 Successfully unregistered from WordPress.com Push Notifications!")
+                self.deviceID = nil
+                self.deviceToken = nil
             }
-
-            DDLogInfo("📱 Successfully unregistered from WordPress.com Push Notifications!")
-            self.deviceID = nil
-            self.deviceToken = nil
+            // Always call completion, even on error
+            onCompletion()
         }
     }
 
@@ -249,7 +250,7 @@ extension PushNotificationsManager {
     ///
     func registrationDidFail(with error: Error) {
         DDLogError("⛔️ Push Notifications Registration Failure: \(error)")
-        unregisterForRemoteNotifications()
+        unregisterForRemoteNotifications {}
     }
 
     /// Handles a notification while the app is in foreground

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -50,6 +50,7 @@ protocol PushNotesManager {
     func registerForRemoteNotifications()
 
     /// Unregisters the Application from WordPress.com Push Notifications Service.
+    /// - Parameter onCompletion: Closure to be executed on completion.
     ///
     func unregisterForRemoteNotifications(onCompletion: @escaping () -> Void)
 

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -51,7 +51,7 @@ protocol PushNotesManager {
 
     /// Unregisters the Application from WordPress.com Push Notifications Service.
     ///
-    func unregisterForRemoteNotifications()
+    func unregisterForRemoteNotifications(onCompletion: @escaping () -> Void)
 
     /// Requests Authorization to receive Push Notifications, *only* when the current Status is not determined.
     ///

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -237,11 +237,6 @@ class AuthenticatedState: StoresManagerState {
     /// Executed before the current state is deactivated.
     ///
     func willLeave() {
-        let pushNotesManager = ServiceLocator.pushNotesManager
-
-        pushNotesManager.unregisterForRemoteNotifications()
-        pushNotesManager.resetBadgeCountForAllStores(onCompletion: {})
-
         resetServices()
     }
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -299,7 +299,8 @@ class DefaultStoresManager: StoresManager {
 
         // Unregister from remote notifications asynchronously
         pushNotesManager.unregisterForRemoteNotifications {
-            // Release the strong reference to allow state cleanup
+            DDLogInfo("📱 Push notification unregistration completed after logout")
+            // Keep `currentState` until the end of the closure
             _ = currentState
         }
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -270,7 +270,7 @@ class DefaultStoresManager: StoresManager {
         sessionManager.deleteApplicationPassword(locally: true)
         ServiceLocator.analytics.refreshUserData()
         ZendeskProvider.shared.reset()
-        ServiceLocator.pushNotesManager.unregisterForRemoteNotifications()
+        ServiceLocator.pushNotesManager.unregisterForRemoteNotifications {}
     }
 
     /// Fully deauthenticates the user, if needed.
@@ -290,6 +290,19 @@ class DefaultStoresManager: StoresManager {
     ///
     @discardableResult
     func deauthenticate() -> StoresManager {
+        let pushNotesManager = ServiceLocator.pushNotesManager
+        pushNotesManager.resetBadgeCountForAllStores(onCompletion: {})
+
+        // Keep a strong reference to the current state to prevent it from being deallocated
+        // until the unregister completes
+        let currentState = state
+
+        // Unregister from remote notifications asynchronously
+        pushNotesManager.unregisterForRemoteNotifications {
+            // Release the strong reference to allow state cleanup
+            _ = currentState
+        }
+
         applicationPasswordGenerationFailureObserver = nil
         invalidWPCOMTokenNotificationObserver = nil
         stopObservingNetworkNotifications()

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -78,7 +78,7 @@ final class MockPushNotificationsManager: PushNotesManager {
 
     }
 
-    func unregisterForRemoteNotifications() {
+    func unregisterForRemoteNotifications(onCompletion: @escaping () -> Void) {
 
     }
 

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -134,7 +134,7 @@ final class PushNotificationsManagerTests: XCTestCase {
     ///
     func testUnregisterForRemoteNotificationsDoesNothingWhenThereIsNoDeviceIdStored() {
         XCTAssert(storesManager.receivedActions.isEmpty)
-        manager.unregisterForRemoteNotifications()
+        manager.unregisterForRemoteNotifications {}
         XCTAssert(storesManager.receivedActions.isEmpty)
     }
 
@@ -143,7 +143,7 @@ final class PushNotificationsManagerTests: XCTestCase {
     ///
     func testUnregisterForRemoteNotificationsEffectivelyDispatchesUnregisterDeviceAction() {
         defaults.set(Sample.deviceID, forKey: .deviceID)
-        manager.unregisterForRemoteNotifications()
+        manager.unregisterForRemoteNotifications {}
 
         guard case let .unregisterDevice(deviceID, _) = storesManager.receivedActions.first as! NotificationAction else {
             XCTFail()
@@ -161,7 +161,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         defaults.set(Sample.deviceID, forKey: .deviceID)
         defaults.set(Sample.deviceToken, forKey: .deviceToken)
 
-        manager.unregisterForRemoteNotifications()
+        manager.unregisterForRemoteNotifications {}
 
         guard case let .unregisterDevice(_, onCompletion) = storesManager.receivedActions.first as! NotificationAction else {
             XCTFail()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of WOOMOB-1755

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We got reports about some devices still get push notifications even after logging out. While testing, I notice that very often I don't see `📱 Successfully unregistered from WordPress.com Push Notifications!` in my logs after logging out.

This PR adds updates to ensure that push notifications are unregistered completely upon logout. The solution is to keep a strong reference of the authenticated state until unregisteration is finished.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Build and run the app on a device.
- Log in to a test store with a WPCom account if you haven't already.
- Log out of the app.
- Tap Log in > Help > View application Log > Current.
- Scroll to the bottom of the log.
- Confirm that you see `📱 Successfully unregistered from WordPress.com Push Notifications!` near the bottom.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
