### PR TITLE
[Local catalog] Show errors when syncing in settings

### DIFF
--- a/Modules/Sources/PointOfSale/Models/PointOfSaleErrorState.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleErrorState.swift
@@ -1,9 +1,10 @@
 import Foundation
 import enum Alamofire.AFError
 
-struct PointOfSaleErrorState: Equatable {
+struct PointOfSaleErrorState: Equatable, Identifiable {
     enum ErrorType: Equatable {
         case initialCatalogSyncError
+        case refreshCatalogSyncError
         case productsLoadError
         case variationsLoadError
         case productsNextPageError
@@ -16,6 +17,7 @@ struct PointOfSaleErrorState: Equatable {
         case ordersNextPageError
     }
 
+    let id = UUID()
     let errorType: ErrorType
     let title: String
     let subtitle: String
@@ -117,6 +119,14 @@ struct PointOfSaleErrorState: Equatable {
             buttonText: Constants.retryButtonTitle)
     }
 
+    static func errorOnRefreshingCatalog(error: Error? = nil) -> Self {
+        PointOfSaleErrorState(
+            errorType: .refreshCatalogSyncError,
+            title: Constants.failedToRefreshCatalogTitle,
+            subtitle: subtitle(for: error),
+            buttonText: Constants.retryButtonTitle)
+    }
+
     private static func subtitle(for error: Error?) -> String {
         if let error, error.isConnectivityError {
             return Constants.connectivityErrorSubtitle
@@ -140,6 +150,11 @@ struct PointOfSaleErrorState: Equatable {
             "pos.itemList.syncCatalogErrorTitle",
             value: "Unable to sync catalog",
             comment: "Title appearing on the item list screen when there's an error syncing the catalog for the first time."
+        )
+        static let failedToRefreshCatalogTitle = NSLocalizedString(
+            "pos.catalog.refreshFailedTitle",
+            value: "Unable to refresh catalog",
+            comment: "Title appearing in a modal when there's an error refreshing the catalog."
         )
         static let loadingCouponsErrorTitle = NSLocalizedString(
             "pos.itemList.loadingCouponsErrorTitle.2",

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleErrorState.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleErrorState.swift
@@ -1,7 +1,7 @@
 import Foundation
 import enum Alamofire.AFError
 
-struct PointOfSaleErrorState: Equatable, Identifiable {
+struct PointOfSaleErrorState: Equatable {
     enum ErrorType: Equatable {
         case initialCatalogSyncError
         case refreshCatalogSyncError
@@ -17,7 +17,6 @@ struct PointOfSaleErrorState: Equatable, Identifiable {
         case ordersNextPageError
     }
 
-    let id = UUID()
     let errorType: ErrorType
     let title: String
     let subtitle: String

--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/PointOfSaleEmptyErrorStateViewLayout.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/PointOfSaleEmptyErrorStateViewLayout.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum PointOfSaleEmptyErrorStateViewLayout {
     static let imageAndTextSpacing: CGFloat = POSSpacing.medium
-    static let textAndButtonSpacing: CGFloat = POSSpacing.large
+    static let textAndButtonSpacing: CGFloat = POSSpacing.xxLarge
     static let textSpacing: CGFloat = POSSpacing.small
     static let buttonSpacing: CGFloat = POSSpacing.medium
 }

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -73,6 +73,10 @@ struct PointOfSaleDashboardView: View {
                 .frame(maxWidth: .infinity)
             case .error(let error):
                 PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
+                    if error.errorType == .initialCatalogSyncError {
+                        analytics.track(event: WooAnalyticsEvent.LocalCatalog.splashScreenRetryTapped())
+                    }
+
                     Task {
                         switch viewStateCoordinator.selectedItemListType {
                         case .products(search: false):

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSErrorView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSErrorView.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+import WooFoundation
+
+struct POSErrorView: View {
+    @Environment(\.keyboardObserver) private var keyboard
+
+    let viewModel: POSErrorViewModel
+    @Binding var buttonWidth: CGFloat?
+
+    init(viewModel: POSErrorViewModel, buttonWidth: Binding<CGFloat?>? = nil) {
+        self.viewModel = viewModel
+        if let buttonWidth {
+            self._buttonWidth = buttonWidth
+        } else {
+            self._buttonWidth = Binding<CGFloat?>(
+                get: { nil },
+                set: { _ in })
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .center, spacing: POSSpacing.none) {
+            if !keyboard.isFullSizeKeyboardVisible {
+                if let image = viewModel.imageAsset {
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 88, height: 88)
+                        .foregroundColor(.posOnSurfaceVariantHighest)
+                } else {
+                    POSErrorXMark(size: .large)
+                }
+                Spacer().frame(height: PointOfSaleEmptyErrorStateViewLayout.imageAndTextSpacing)
+            }
+
+            Text(viewModel.title)
+                .accessibilityAddTraits(.isHeader)
+                .foregroundStyle(Color.posOnSurface)
+                .font(.posHeadingBold)
+
+            Spacer().frame(height: PointOfSaleEmptyErrorStateViewLayout.textSpacing)
+
+            Text(viewModel.subtitle)
+                .foregroundStyle(Color.posOnSurface)
+                .font(.posBodyLargeRegular())
+                .padding([.leading, .trailing])
+
+            if viewModel.primaryButton != nil || viewModel.secondaryButton != nil {
+                Spacer().frame(height: PointOfSaleEmptyErrorStateViewLayout.textAndButtonSpacing)
+                VStack(spacing: POSSpacing.medium) {
+                    if let primaryButtonViewModel = viewModel.primaryButton {
+                        POSErrorButton(viewModel: primaryButtonViewModel)
+                    }
+
+                    if let secondaryButtonViewModel = viewModel.secondaryButton {
+                        POSErrorButton(viewModel: secondaryButtonViewModel)
+                    }
+                }
+                .frame(width: buttonWidth)
+            }
+        }
+        .multilineTextAlignment(.center)
+        .dynamicTypeSize(..<DynamicTypeSize.accessibility2)
+    }
+}
+
+struct POSErrorButton: View {
+    let viewModel: POSErrorButtonViewModel
+
+    var body: some View {
+        Button(action: {
+            viewModel.action()
+        }, label: {
+            Text(viewModel.title)
+                .dynamicTypeSize(..<DynamicTypeSize.accessibility2)
+        })
+        .buttonStyle(viewModel.buttonStyle)
+    }
+}
+
+struct POSErrorViewModel {
+    let title: String
+    let subtitle: String
+    let imageAsset: Image?
+    let primaryButton: POSErrorButtonViewModel?
+    let secondaryButton: POSErrorButtonViewModel?
+
+    init(error: PointOfSaleErrorState,
+         primaryButton: POSErrorButtonViewModel? = nil,
+         secondaryButton: POSErrorButtonViewModel? = nil) {
+        self.title = error.title
+        self.subtitle = error.subtitle
+        self.primaryButton = primaryButton
+        self.secondaryButton = secondaryButton
+        switch error.errorType {
+        case .couponsDisabled:
+            self.imageAsset = SharedImageAsset.coupons.decorativeImage
+        default:
+            self.imageAsset = nil
+        }
+    }
+}
+
+struct POSErrorButtonViewModel {
+    let title: String
+    let buttonStyle: AnyButtonStyle
+    let action: () -> Void
+
+    init(title: String, buttonStyle: any ButtonStyle, action: @escaping () -> Void) {
+        self.title = title
+        self.buttonStyle = AnyButtonStyle(buttonStyle)
+        self.action = action
+    }
+}
+
+struct AnyButtonStyle: ButtonStyle {
+    private let _makeBody: (Configuration) -> AnyView
+
+    init<S: ButtonStyle>(_ style: S) {
+        _makeBody = { configuration in
+            AnyView(style.makeBody(configuration: configuration))
+        }
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        _makeBody(configuration)
+    }
+}

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSListErrorView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSListErrorView.swift
@@ -8,110 +8,44 @@ struct POSListErrorView: View {
     @Environment(\.posAnalytics) private var analytics
 
     private let error: PointOfSaleErrorState
-    private let viewModel: POSListErrorViewModel
-    private let onAction: (() -> Void)?
-    private let onExit: (() -> Void)?
-
-    @State private var viewWidth: CGFloat = 0
+    @State private var buttonWidth: CGFloat? = nil
+    private let viewModel: POSErrorViewModel
 
     @Environment(\.keyboardObserver) private var keyboard
 
     init(error: PointOfSaleErrorState, onAction: (() -> Void)? = nil, onExit: (() -> Void)? = nil) {
         self.error = error
-        self.viewModel = POSListErrorViewModel(error: error)
-        self.onAction = onAction
-        self.onExit = onExit
+        let actionButton: POSErrorButtonViewModel? = {
+            guard let onAction else { return nil }
+            return POSErrorButtonViewModel(title: error.buttonText,
+                                           buttonStyle: (POSFilledButtonStyle(size: .normal)),
+                                           action: onAction)
+        }()
+        let exitButton: POSErrorButtonViewModel? = {
+            guard let onExit else { return nil }
+            return POSErrorButtonViewModel(title: Localization.exitButtonText,
+                                           buttonStyle: POSOutlinedButtonStyle(size: .normal),
+                                           action: onExit)
+        }()
+
+        self.viewModel = POSErrorViewModel(error: error, primaryButton: actionButton, secondaryButton: exitButton)
     }
 
     var body: some View {
         ScrollableVStack {
             Spacer()
-            VStack(alignment: .center, spacing: POSSpacing.none) {
-                if !keyboard.isFullSizeKeyboardVisible {
-                    if let image = viewModel.imageAsset {
-                        image
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 88, height: 88)
-                            .foregroundColor(.posOnSurfaceVariantHighest)
-                    } else {
-                        POSErrorXMark(size: .large)
-                    }
-                    Spacer().frame(height: PointOfSaleEmptyErrorStateViewLayout.imageAndTextSpacing)
-                }
-
-                Text(viewModel.title)
-                    .accessibilityAddTraits(.isHeader)
-                    .foregroundStyle(Color.posOnSurface)
-                    .multilineTextAlignment(.center)
-                    .font(.posHeadingBold)
-
-                Spacer().frame(height: PointOfSaleEmptyErrorStateViewLayout.textSpacing)
-
-                Text(viewModel.subtitle)
-                    .foregroundStyle(Color.posOnSurface)
-                    .font(.posBodyLargeRegular())
-                    .multilineTextAlignment(.center)
-                    .padding([.leading, .trailing])
-
-                if let onAction {
-                    Spacer().frame(height: PointOfSaleEmptyErrorStateViewLayout.textAndButtonSpacing)
-                    Button(action: {
-                        // Track retry tapped for splash screen errors (initial catalog sync)
-                        if error.errorType == .initialCatalogSyncError {
-                            analytics.track(event: WooAnalyticsEvent.LocalCatalog.splashScreenRetryTapped())
-                        }
-                        onAction()
-                    }, label: {
-                        Text(viewModel.buttonText)
-                    })
-                    .buttonStyle(POSFilledButtonStyle(size: .normal))
-                    .frame(width: viewWidth / 2)
-                    .padding([.leading, .trailing])
-                }
-
-                if let onExit {
-                    Spacer().frame(height: POSSpacing.medium)
-                    Button(action: {
-                        onExit()
-                    }, label: {
-                        Text(Localization.exitButtonText)
-                    })
-                    .buttonStyle(POSOutlinedButtonStyle(size: .normal))
-                    .frame(width: viewWidth / 2)
-                    .padding([.leading, .trailing])
-                }
-            }
+            POSErrorView(viewModel: viewModel, buttonWidth: $buttonWidth)
             Spacer()
         }
         .padding(.bottom, !keyboard.isFullSizeKeyboardVisible ? floatingControlAreaSize.height : 0)
         .measureWidth { width in
-            viewWidth = width
+            buttonWidth = width / 2
         }
         .onAppear {
             // Track error shown for splash screen errors (initial catalog sync)
             if error.errorType == .initialCatalogSyncError {
                 analytics.track(event: WooAnalyticsEvent.LocalCatalog.splashScreenErrorShown())
             }
-        }
-    }
-}
-
-struct POSListErrorViewModel {
-    let title: String
-    let subtitle: String
-    let buttonText: String
-    let imageAsset: Image?
-
-    init(error: PointOfSaleErrorState) {
-        self.title = error.title
-        self.subtitle = error.subtitle
-        self.buttonText = error.buttonText
-        switch error.errorType {
-        case .couponsDisabled:
-            self.imageAsset = SharedImageAsset.coupons.decorativeImage
-        default:
-            self.imageAsset = nil
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalCloseButton.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalCloseButton.swift
@@ -5,28 +5,37 @@ extension View {
         action: @escaping (() -> Void),
         accessibilityLabel: String = POSModalCloseButton.Localization.defaultAccessibilityLabel) -> some View {
         self.modifier(
-            POSModalCloseButton(
+            POSModalCloseButtonModifier(
                 closeAction: action,
                 accessibilityLabel: accessibilityLabel)
             )
     }
 }
 
-struct POSModalCloseButton: ViewModifier {
+struct POSModalCloseButton: View {
+    let accessibilityLabel: String
+    let closeAction: () -> Void
+
+    var body: some View {
+        HStack {
+            Spacer()
+            Button(action: closeAction, label: {
+                Text(Image(systemName: "xmark"))
+                    .font(.posButtonSymbolMedium)
+            })
+            .foregroundColor(Color.posOnSurface)
+            .accessibilityLabel(accessibilityLabel)
+        }
+    }
+}
+
+struct POSModalCloseButtonModifier: ViewModifier {
     let closeAction: () -> Void
     let accessibilityLabel: String
 
     func body(content: Content) -> some View {
         VStack(spacing: 0) {
-            HStack {
-                Spacer()
-                Button(action: closeAction, label: {
-                    Text(Image(systemName: "xmark"))
-                        .font(.posButtonSymbolMedium)
-                })
-                .foregroundColor(Color.posOnSurface)
-                .accessibilityLabel(accessibilityLabel)
-            }
+            POSModalCloseButton(accessibilityLabel: accessibilityLabel, closeAction: closeAction)
 
             Spacer()
 

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogDetailView.swift
@@ -29,8 +29,8 @@ struct POSSettingsLocalCatalogDetailView: View {
         .task {
             await viewModel.loadCatalogData()
         }
-        .posModal(item: $viewModel.catalogRefreshError) { errorState in
-            errorView(errorState: errorState)
+        .posModal(item: $viewModel.catalogRefreshError) { error in
+            errorView(errorState: error.errorState)
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogDetailView.swift
@@ -30,11 +30,7 @@ struct POSSettingsLocalCatalogDetailView: View {
             await viewModel.loadCatalogData()
         }
         .posModal(item: $viewModel.catalogRefreshError) { errorState in
-            POSListErrorView(error: errorState, onAction: {
-                Task {
-                    await viewModel.refreshCatalog()
-                }
-            })
+            errorView(errorState: errorState)
         }
     }
 }
@@ -99,6 +95,34 @@ private extension POSSettingsLocalCatalogDetailView {
             }
         }
     }
+
+    @ViewBuilder
+    func errorView(errorState: PointOfSaleErrorState) -> some View {
+        VStack(spacing: POSSpacing.xxLarge) {
+            POSModalCloseButton(accessibilityLabel: Localization.errorCancelButtonTitle) {
+                viewModel.catalogRefreshError = nil
+            }
+
+            POSErrorView(viewModel: errorViewModel(errorState: errorState))
+        }
+        .padding(POSPadding.xLarge)
+        .frame(maxWidth: Constants.errorModalMaxWidth)
+    }
+
+    func errorViewModel(errorState: PointOfSaleErrorState) -> POSErrorViewModel {
+        let retryButton = POSErrorButtonViewModel(title: Localization.errorRetryButtonTitle,
+                                                  buttonStyle: POSFilledButtonStyle(size: .normal)) {
+            Task {
+                await viewModel.refreshCatalog()
+            }
+        }
+        let cancelButton = POSErrorButtonViewModel(title: Localization.errorCancelButtonTitle,
+                                                   buttonStyle: POSOutlinedButtonStyle(size: .normal)) {
+            viewModel.catalogRefreshError = nil
+        }
+        return POSErrorViewModel(error: errorState, primaryButton: retryButton, secondaryButton: cancelButton)
+    }
+
 }
 
 private extension POSSettingsLocalCatalogDetailView {
@@ -160,6 +184,22 @@ private extension POSSettingsLocalCatalogDetailView {
             value: "Update catalog",
             comment: "Button text for updating the catalog manually."
         )
+
+        static let errorRetryButtonTitle = NSLocalizedString(
+            "posSettingsLocalCatalogDetailView.catalogRefresh.error.retryButton.title",
+            value: "Retry",
+            comment: "Button text for retrying a refresh after it fails"
+        )
+
+        static let errorCancelButtonTitle = NSLocalizedString(
+            "posSettingsLocalCatalogDetailView.catalogRefresh.error.cancelButton.title",
+            value: "Cancel",
+            comment: "Button text for closing an error after a refresh fails"
+        )
+    }
+
+    enum Constants {
+        static let errorModalMaxWidth: CGFloat = 832
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogDetailView.swift
@@ -8,6 +8,7 @@ struct POSSettingsLocalCatalogDetailView: View {
     }
 
     var body: some View {
+        @Bindable var viewModel = viewModel
         NavigationStack {
             VStack(spacing: POSSpacing.none) {
                 POSPageHeaderView(title: Localization.localCatalogTitle)
@@ -27,6 +28,13 @@ struct POSSettingsLocalCatalogDetailView: View {
         }
         .task {
             await viewModel.loadCatalogData()
+        }
+        .posModal(item: $viewModel.catalogRefreshError) { errorState in
+            POSListErrorView(error: errorState, onAction: {
+                Task {
+                    await viewModel.refreshCatalog()
+                }
+            })
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogViewModel.swift
@@ -12,7 +12,7 @@ final class POSSettingsLocalCatalogViewModel {
     private(set) var isLoading: Bool = false
     private(set) var isRefreshingCatalog: Bool = false
 
-    var catalogRefreshError: PointOfSaleErrorState? = nil
+    var catalogRefreshError: POSIdentifiableErrorState? = nil
 
     private let siteID: Int64
     private let catalogSettingsService: POSCatalogSettingsServiceProtocol
@@ -89,7 +89,7 @@ final class POSSettingsLocalCatalogViewModel {
         } catch {
             DDLogError("⛔️ POSSettingsLocalCatalog: Failed to refresh catalog: \(error)")
             isRefreshingCatalog = false
-            catalogRefreshError = PointOfSaleErrorState.errorOnRefreshingCatalog(error: error)
+            catalogRefreshError = POSIdentifiableErrorState(errorState: .errorOnRefreshingCatalog(error: error))
         }
     }
 
@@ -176,4 +176,9 @@ private extension POSSettingsLocalCatalogViewModel {
             comment: "Text shown when update date cannot be determined."
         )
     }
+}
+
+struct POSIdentifiableErrorState: Identifiable, Equatable {
+    let errorState: PointOfSaleErrorState
+    let id = UUID()
 }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogViewModel.swift
@@ -12,6 +12,8 @@ final class POSSettingsLocalCatalogViewModel {
     private(set) var isLoading: Bool = false
     private(set) var isRefreshingCatalog: Bool = false
 
+    var catalogRefreshError: PointOfSaleErrorState? = nil
+
     private let siteID: Int64
     private let catalogSettingsService: POSCatalogSettingsServiceProtocol
     private let catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol
@@ -78,15 +80,16 @@ final class POSSettingsLocalCatalogViewModel {
     @MainActor
     func refreshCatalog() async {
         isRefreshingCatalog = true
+        catalogRefreshError = nil
 
         do {
             try await catalogSyncCoordinator.performFullSync(for: siteID, regenerateCatalog: true)
-            // Sync completed synchronously - update UI
             isRefreshingCatalog = false
             await loadCatalogData()
         } catch {
             DDLogError("⛔️ POSSettingsLocalCatalog: Failed to refresh catalog: \(error)")
             isRefreshingCatalog = false
+            catalogRefreshError = PointOfSaleErrorState.errorOnRefreshingCatalog(error: error)
         }
     }
 

--- a/Modules/Tests/PointOfSaleTests/Presentation/Settings/POSSettingsLocalCatalogViewModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Presentation/Settings/POSSettingsLocalCatalogViewModelTests.swift
@@ -191,7 +191,7 @@ struct POSSettingsLocalCatalogViewModelTests {
 
         // Then
         let catalogRefreshError = try #require(sut.catalogRefreshError)
-        #expect(catalogRefreshError.errorType == .refreshCatalogSyncError)
+        #expect(catalogRefreshError.errorState.errorType == .refreshCatalogSyncError)
     }
 
     // MARK: - Test Concurrent Operations

--- a/Modules/Tests/PointOfSaleTests/Presentation/Settings/POSSettingsLocalCatalogViewModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Presentation/Settings/POSSettingsLocalCatalogViewModelTests.swift
@@ -32,6 +32,7 @@ struct POSSettingsLocalCatalogViewModelTests {
         #expect(sut.lastIncrementalSyncDate == "")
         #expect(sut.isLoading == false)
         #expect(sut.isRefreshingCatalog == false)
+        #expect(sut.catalogRefreshError == nil)
     }
 
     // MARK: - `loadCatalogData` Tests
@@ -173,6 +174,24 @@ struct POSSettingsLocalCatalogViewModelTests {
         #expect(catalogSyncCoordinator.performFullSyncInvocationCount == 1)
         #expect(sut.catalogSize != "50 products, 25 variations") // `loadCatalogInfo` should not be invoked
         #expect(sut.isRefreshingCatalog == false)
+    }
+
+    @Test func refreshCatalog_sets_refresh_error_state_when_sync_fails() async throws {
+        // Given
+        catalogSettingsService.catalogInfoResult = .success(POSCatalogInfo(
+            productCount: 50,
+            variationCount: 25,
+            lastFullSyncDate: nil,
+            lastIncrementalSyncDate: nil
+        ))
+        catalogSyncCoordinator.performFullSyncResult = .failure(MockError.syncError)
+
+        // When
+        await sut.refreshCatalog()
+
+        // Then
+        let catalogRefreshError = try #require(sut.catalogRefreshError)
+        #expect(catalogRefreshError.errorType == .refreshCatalogSyncError)
     }
 
     // MARK: - Test Concurrent Operations


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR presents modal errors from resyncing the catalog in settings.

I extracted the content from `POSListErrorView` to `POSErrorView`, and reused it for these errors.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Set the version to 23.8
- Launch the app and open POS
- Open POS Settings > Local catalog
- Set a block or breakpoint on `/wc/v3/products*` and abort all the requests from here on out
- Tap `Refresh catalog`
- Observe that the error is shown, and you can retry or cancel it

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/51042589-5669-405f-ab59-15c84be0ed64


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
