### PR TITLE
[Woo POS][App Listings] Update listing title and subtitle meta

### DIFF
--- a/fastlane/metadata/default/name.txt
+++ b/fastlane/metadata/default/name.txt
@@ -1,1 +1,1 @@
-WooCommerce
+WooCommerce: Store Management & POS

--- a/fastlane/metadata/default/subtitle.txt
+++ b/fastlane/metadata/default/subtitle.txt
@@ -1,1 +1,1 @@
-Your store in your pocket
+All-in-one mobile ecommerce


### PR DESCRIPTION
Continuation of https://github.com/woocommerce/woocommerce-ios/pull/16346
Closes WOOMOB-1641

## Description
This PR updates `name.txt` and `subtitle.txt` that will be used in app store across all languages.

<img width="1241" height="498" alt="Screenshot 2025-11-25 at 11 47 58" src="https://github.com/user-attachments/assets/c253cf88-0e1a-4211-ac9d-c247d9671e40" />

## Changes:
- WooCommerce -> WooCommerce: Store Management & POS
- Your store in your pocket -> All-in-one mobile ecommerce

## Test Steps
- Run `bundle exec fastlane run configure_apply` so that the ASC API key file is present in your machine.
- If they key cannot be found, you might need to copy it over `cp fastlane/env/user.env.example ~/.wcios-env.default`
- Run `bundle exec fastlane update_metadata_on_app_store_connect`
- Once the lane finishes, should automatically open a preview in your browser: `file:///{your machine}/woocommerce-ios/fastlane/screenshots/screenshots.html`
- When the systems prompts you with the following confirmation, answer `no` so it does not actually upload it to ASC.
```
[10:26:00]: Does the Preview on path './fastlane/Preview.html' look okay for you? (y/n)
n
[!] Did not upload the metadata, because the HTML file was rejected by the user
```
- Back in the HTML preview, scroll down to en-US and you should see the updated name and subtitle:

<img width="1000" height="523" alt="Screenshot 2025-11-25 at 11 42 33" src="https://github.com/user-attachments/assets/40aa81cb-8f56-4017-9bc3-d9207fc8ee68" />

