### PR TITLE
Update login and authentication for support sessions

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/ApplicationPasswordsExperimentState.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/ApplicationPasswordsExperimentState.swift
@@ -10,6 +10,14 @@ final class ApplicationPasswordsExperimentState {
 
     private var experimentalFlagSubscription: AnyCancellable?
 
+    private static let isSupportSession: Bool = {
+        #if DEBUG
+        return ProcessInfo.processInfo.arguments.contains("-support-session")
+        #else
+        return false
+        #endif
+    }()
+
     init(
         stores: StoresManager = ServiceLocator.stores,
         availabilityChecker: ApplicationPasswordsExperimentAvailabilityCheckerProtocol = ApplicationPasswordsExperimentAvailabilityChecker(),
@@ -26,6 +34,9 @@ final class ApplicationPasswordsExperimentState {
     @MainActor
     private var isEnabled: Bool {
         get async {
+            guard !Self.isSupportSession else {
+                return false
+            }
             return await withCheckedContinuation { continuation in
                 stores.dispatch(
                     AppSettingsAction.getAppPasswordsExperimentSettingState { isOn in
@@ -65,23 +76,12 @@ final class ApplicationPasswordsExperimentAvailabilityChecker: ApplicationPasswo
     private let userDefaults: UserDefaults
     private let stores: StoresManager
 
-    private static let isSupportSession: Bool = {
-        #if DEBUG
-        return ProcessInfo.processInfo.arguments.contains("-support-session")
-        #else
-        return false
-        #endif
-    }()
-
     init(userDefaults: UserDefaults = .standard, stores: StoresManager = ServiceLocator.stores) {
         self.userDefaults = userDefaults
         self.stores = stores
     }
 
     var isAvailable: Bool {
-        guard !Self.isSupportSession else {
-            return false
-        }
         /// The feature is only available when the user is signed in using WordPress.com account
         let isUserAuthenticatedByWPCom = !stores.isAuthenticatedWithoutWPCom
         return isUserAuthenticatedByWPCom && cachedRemoteFFValue

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/ApplicationPasswordsExperimentState.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/ApplicationPasswordsExperimentState.swift
@@ -65,12 +65,23 @@ final class ApplicationPasswordsExperimentAvailabilityChecker: ApplicationPasswo
     private let userDefaults: UserDefaults
     private let stores: StoresManager
 
+    private static let isSupportSession: Bool = {
+        #if DEBUG
+        return ProcessInfo.processInfo.arguments.contains("-support-session")
+        #else
+        return false
+        #endif
+    }()
+
     init(userDefaults: UserDefaults = .standard, stores: StoresManager = ServiceLocator.stores) {
         self.userDefaults = userDefaults
         self.stores = stores
     }
 
     var isAvailable: Bool {
+        guard !Self.isSupportSession else {
+            return false
+        }
         /// The feature is only available when the user is signed in using WordPress.com account
         let isUserAuthenticatedByWPCom = !stores.isAuthenticatedWithoutWPCom
         return isUserAuthenticatedByWPCom && cachedRemoteFFValue

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
@@ -139,6 +139,10 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "-support-session"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-com.apple.CoreData.ConcurrencyDebug 1"
             isEnabled = "YES">
          </CommandLineArgument>

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -136,6 +136,14 @@ class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
         }
     }
 
+    private static let isSupportSession: Bool = {
+        #if DEBUG
+        return ProcessInfo.processInfo.arguments.contains("-support-session")
+        #else
+        return false
+        #endif
+    }()
+
     // MARK: - View
 
     override func viewDidLoad() {
@@ -517,22 +525,30 @@ private extension GetStartedViewController {
 
         configureViewLoading(true)
         let service = WordPressComAccountService()
-        service.isPasswordlessAccount(username: loginFields.username,
-                                      success: { [weak self] passwordless in
-                                        self?.configureViewLoading(false)
-                                        self?.loginFields.meta.passwordless = passwordless
-                                        passwordless ? self?.requestAuthenticationLink() : self?.showPasswordOrMagicLinkView()
+        service.isPasswordlessAccount(
+            username: loginFields.username,
+            success: { [weak self] passwordless in
+                guard let self else { return }
+                configureViewLoading(false)
+                loginFields.meta.passwordless = passwordless
+                if Self.isSupportSession {
+                    /// Always show password view when running in support session
+                    showPasswordView()
+                } else {
+                    passwordless ? requestAuthenticationLink() : showPasswordOrMagicLinkView()
+                }
             },
-                                      failure: { [weak self] error in
-                                        WordPressAuthenticator.track(.loginFailed, error: error)
-                                        WPAuthenticatorLogError(error.localizedDescription)
-                                        guard let self = self else {
-                                            return
-                                        }
-                                        self.configureViewLoading(false)
-
-                                        self.handleLoginError(error)
-        })
+            failure: { [weak self] error in
+                WordPressAuthenticator.track(.loginFailed, error: error)
+                WPAuthenticatorLogError(error.localizedDescription)
+                guard let self = self else {
+                    return
+                }
+                self.configureViewLoading(false)
+                
+                self.handleLoginError(error)
+            }
+        )
     }
 
     /// Show the Password entry view.
@@ -583,7 +599,11 @@ private extension GetStartedViewController {
             // email address is flagged as suspicious.
             // Take the user to the magic link request screen to verify their email.
             self.tracker.track(failure: error.localizedDescription)
-            self.showMagicLinkRequestScreen()
+            if Self.isSupportSession {
+                showPasswordView()
+            } else {
+                showMagicLinkRequestScreen()
+            }
         } else {
             let signInError = SignInError(error: error, source: source) ?? error
             guard let authenticationDelegate = WordPressAuthenticator.shared.delegate,

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -545,7 +545,6 @@ private extension GetStartedViewController {
                     return
                 }
                 self.configureViewLoading(false)
-                
                 self.handleLoginError(error)
             }
         )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-62

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a new option `-support-session` for the WooCommerce scheme. This is helpful for special settings for login and authentication for support sessions.

More information in p1764067373394239-slack-C03L1NF1EA3.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

TC1: Passwordless login 

- In Xcode, select WooCommerce > Edit Scheme > Enable `-support-session`.
- Follow the guide in P91TBi-bVe-p2 to log in to a passwordless account.
- Confirm that the password screen is displayed instead of the magic link request screen.

TC2: WPCom login
- Ensure that `-support-session` is enabled.
- Log in to a Jetpack store using WPCom credentials.
- Confirm that the app makes requests using Jetpack proxy instead of directly to the remote site.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.