### PR TITLE
[Local Catalog] Add GRDB to Third-party licenses page

### DIFF
--- a/WooCommerce/Resources/HTML/licenses.html
+++ b/WooCommerce/Resources/HTML/licenses.html
@@ -1,6 +1,7 @@
 <html>
     <head>
         <meta name="viewport" content="initial-scale=1.0" />
+        <meta charset="UTF-8">
         <link rel="stylesheet" type="text/css" href="pure-min.css" />
         <style>
             body {
@@ -47,6 +48,7 @@
             <li><a href="https://github.com/stripe/stripe-terminal-ios">StripeTerminal</a> by <a href="https://github.com/stripe">Stripe</a></li>
             <li><a href="https://github.com/pmusolino/Wormholy">Wormholy</a> by <a href="https://github.com/pmusolino">Paolo Musolino</a></li>
             <li><a href="https://github.com/xmartlabs/XLPagerTabStrip">XLPagerTabStrip</a> by <a href="https://xmartlabs.com/">XMARTLABS</a></li>
+            <li><a href="https://github.com/groue/GRDB.swift/">GRDB</a> by <a href="https://github.com/groue">Gwendal Roué</a>
         </ul>
 
         <h4>The following libraries are licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0">The Apache License, Version 2.0</a>:</h4>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a credit for GRDB to our Third Party Licences screen.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Go to Menu > Settings > About WooCommerce > Legal and more > Third Party Licenses

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![IMG_0031](https://github.com/user-attachments/assets/7bc9f83f-6bd3-48ea-937e-56464665ca9c)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
