### PR TITLE
Ensure push notifications re-register after store switch

### DIFF
--- a/WooCommerce/Classes/System/ProcessConfiguration.swift
+++ b/WooCommerce/Classes/System/ProcessConfiguration.swift
@@ -42,3 +42,10 @@ struct ProcessConfiguration {
         ProcessInfo.processInfo.arguments.contains("use-mocked-card-present-payment")
     }
 }
+
+extension ProcessInfo {
+    /// Indicates whether the current process is executing under XCTest.
+    static var isRunningUnitTests: Bool {
+        NSClassFromString("XCTestCase") != nil
+    }
+}

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -357,6 +357,8 @@ class DefaultStoresManager: StoresManager {
         restoreSessionSiteIfPossible()
         ServiceLocator.pushNotesManager.reloadBadgeCount()
 
+        registerForPushNotificationsIfNeeded()
+
         NotificationCenter.default.post(name: .StoresManagerDidUpdateDefaultSite, object: nil)
     }
 
@@ -401,6 +403,24 @@ class DefaultStoresManager: StoresManager {
 // MARK: - Private Methods
 //
 private extension DefaultStoresManager {
+
+    func registerForPushNotificationsIfNeeded() {
+        #if targetEnvironment(simulator)
+        let shouldRegisterForPushNotifications = ProcessInfo.isRunningUnitTests
+        #else
+        let shouldRegisterForPushNotifications = true
+        #endif
+
+        guard shouldRegisterForPushNotifications else {
+            return
+        }
+
+        DispatchQueue.main.async {
+            let pushNotesManager = ServiceLocator.pushNotesManager
+            pushNotesManager.registerForRemoteNotifications()
+            pushNotesManager.ensureAuthorizationIsRequested(includesProvisionalAuth: false, onCompletion: nil)
+        }
+    }
 
     /// Loads the Default Account into the current Session, if possible.
     ///

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -57,6 +57,10 @@ final class MockPushNotificationsManager: PushNotesManager {
     private(set) var canceledLocalNotificationScenarios: [[LocalNotification.Scenario]] = []
     private(set) var resetBadgeCountKinds: [Note.Kind] = []
     var onRequestLocalNotificationCalled: (() -> Void)?
+    private(set) var registerForRemoteNotificationsCallCount = 0
+    var onRegisterForRemoteNotifications: (() -> Void)?
+    private(set) var ensureAuthorizationIsRequestedCallCount = 0
+    var onEnsureAuthorizationIsRequested: (() -> Void)?
 
     init(mockedDeviceID: String? = nil) {
         self.mockedDeviceID = mockedDeviceID
@@ -75,7 +79,8 @@ final class MockPushNotificationsManager: PushNotesManager {
     }
 
     func registerForRemoteNotifications() {
-
+        registerForRemoteNotificationsCallCount += 1
+        onRegisterForRemoteNotifications?()
     }
 
     func unregisterForRemoteNotifications() {
@@ -83,7 +88,9 @@ final class MockPushNotificationsManager: PushNotesManager {
     }
 
     func ensureAuthorizationIsRequested(includesProvisionalAuth: Bool, onCompletion: ((Bool) -> ())?) {
-
+        ensureAuthorizationIsRequestedCallCount += 1
+        onEnsureAuthorizationIsRequested?()
+        onCompletion?(true)
     }
 
     func registrationDidFail(with error: Error) {

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -246,6 +246,28 @@ final class StoresManagerTests: XCTestCase {
         XCTAssertEqual(siteIDValues, [nil, siteID, nil])
     }
 
+    func test_updateDefaultStore_registersForRemoteNotifications() {
+        // Arrange
+        let pushNotificationsManager = MockPushNotificationsManager()
+        ServiceLocator.setPushNotesManager(pushNotificationsManager)
+        defer {
+            ServiceLocator.setPushNotesManager(PushNotificationsManager())
+        }
+        let manager = DefaultStoresManager.testingInstance
+        let expectation = expectation(description: "register called")
+        pushNotificationsManager.onRegisterForRemoteNotifications = {
+            expectation.fulfill()
+        }
+
+        // Action
+        manager.updateDefaultStore(storeID: 1_234)
+
+        // Assert
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(pushNotificationsManager.registerForRemoteNotificationsCallCount, 1)
+        XCTAssertEqual(pushNotificationsManager.ensureAuthorizationIsRequestedCallCount, 1)
+    }
+
     // MARK: `updateDefaultStore(_ site: Site)`
 
     func test_updateDefaultStore_with_the_same_siteID_updates_site_but_does_not_emit_siteID() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Runtime store switches were leaving the device unsubscribed because `DefaultStoresManager.removeDefaultStore()` always called `unregisterForRemoteNotifications()` while `updateDefaultStore(storeID:)` never re-registered, so users missed pushes until the next cold start. We now invoke a new helper, `registerForPushNotificationsIfNeeded()`, from `updateDefaultStore(storeID:)` to repeat the registration flow immediately (including simulator-friendly test detection via `ProcessInfo.isRunningUnitTests`). The change is covered by an updated `MockPushNotificationsManager` plus a new assertion in `test_updateDefaultStore_registersForRemoteNotifications`.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Sign in with a WordPress.com account that has at least two Jetpack-connected stores and accept the initial push notification permission prompt.
- Trigger a push-worthy event (e.g., place a test order) for Store A and confirm the device receives the notification while that store is selected.
- In the app, switch to Store B via the store picker.
- Trigger the same kind of event for Store B and confirm the device now receives that notification without needing to relaunch the app or re-enable notifications.
- While exercising the flow, note that no extra push-permission prompt appears and that badge counts continue to update normally.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
