### PR TITLE
[Local catalog] Prevent duplicated attributes in variation names

### DIFF
--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
@@ -95,6 +95,11 @@ final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
 
         try await grdbManager.databaseConnection.write { db in
             for product in catalog.products {
+                // Delete attributes for updated products, the remaining set will be recreated later in the save
+                try PersistedProductAttribute
+                    .filter(PersistedProductAttribute.Columns.productID == product.productID)
+                    .deleteAll(db)
+
                 try PersistedProduct(from: product).save(db)
 
                 // Delete variations that are no longer associated with this product
@@ -129,7 +134,7 @@ final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
             }
 
             for var attribute in catalog.productAttributesToPersist {
-                try attribute.save(db)
+                try attribute.insert(db)
             }
 
             for var attribute in catalog.variationAttributesToPersist {

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogPersistenceServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogPersistenceServiceTests.swift
@@ -275,7 +275,7 @@ struct POSCatalogPersistenceServiceTests {
         }
     }
 
-    @Test func persistIncrementalCatalogData_upserts_attributes_for_updated_product() async throws {
+    @Test func persistIncrementalCatalogData_replaces_attributes_for_updated_product() async throws {
         // Given
         let attribute1 = Yosemite.ProductAttribute.fake().copy(name: "Color", options: ["Indigo", "Blue"])
         let attribute2 = Yosemite.ProductAttribute.fake().copy(name: "Size")
@@ -291,17 +291,40 @@ struct POSCatalogPersistenceServiceTests {
 
         // Then
         try await grdbManager.databaseConnection.read { db in
-            // Should have 4 attributes: original 2 + updated 2 (upsert adds new ones, keeps old ones)
+            // Should have 2 attributes - old ones deleted, new ones added (no duplicates)
             let attributeCount = try PersistedProductAttribute.fetchCount(db)
-            #expect(attributeCount == 4)
+            #expect(attributeCount == 2)
 
             let attributes = try PersistedProductAttribute.fetchAll(db).sorted(by: { $0.name < $1.name })
             #expect(attributes[0].name == "Color")
-            #expect(attributes[0].options == ["Indigo", "Blue"]) // Original unchanged
-            #expect(attributes[1].name == "Color")
-            #expect(attributes[1].options == ["Cardinal", "Blue"]) // Updated version
-            #expect(attributes[2].name == "Material") // New attribute
-            #expect(attributes[3].name == "Size") // Original unchanged
+            #expect(attributes[0].options == ["Cardinal", "Blue"]) // Updated version
+            #expect(attributes[1].name == "Material") // New attribute
+        }
+    }
+
+    @Test func persistIncrementalCatalogData_prevents_duplicate_attributes_on_multiple_syncs() async throws {
+        // Given - product with attributes
+        let attribute1 = Yosemite.ProductAttribute.fake().copy(name: "Color", options: ["Red", "Blue"])
+        let attribute2 = Yosemite.ProductAttribute.fake().copy(name: "Size", options: ["S", "M", "L"])
+        let product = POSProduct.fake().copy(siteID: sampleSiteID, productID: 1, attributes: [attribute1, attribute2])
+        try await insertProduct(product)
+
+        // When - perform multiple incremental syncs with the same product/attributes
+        let catalog = POSCatalog(products: [product], variations: [], syncDate: .now)
+        try await sut.persistIncrementalCatalogData(catalog, siteID: sampleSiteID)
+        try await sut.persistIncrementalCatalogData(catalog, siteID: sampleSiteID)
+        try await sut.persistIncrementalCatalogData(catalog, siteID: sampleSiteID)
+
+        // Then - should have exactly 2 attributes, not duplicates
+        try await grdbManager.databaseConnection.read { db in
+            let attributeCount = try PersistedProductAttribute.fetchCount(db)
+            #expect(attributeCount == 2)
+
+            let attributes = try PersistedProductAttribute.fetchAll(db).sorted(by: { $0.name < $1.name })
+            #expect(attributes[0].name == "Color")
+            #expect(attributes[0].options == ["Red", "Blue"])
+            #expect(attributes[1].name == "Size")
+            #expect(attributes[1].options == ["S", "M", "L"])
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR prevents variations from getting duplicated attributes in their names.

Previously, if a variable product was edited, its attributes would be added to the database again on the next incremental sync. This resulted in its variation's names showing the same components multiple times, making it harder to fit and identify a variation by name.

### Cause
Attributes were duplicated in the database because although we use `save`, which upserts items, they wouldn't update, because they use an auto-incremented primary key. This is due to "local attributes" all having an ID of 0 (local to the product, not related to local catalog.)

GRDB identified the attributes as new, and inserted them instead, which meant that the calculation of the variation's name pulled in all the copies of the attribuet.

### Fix
To fix this, we simply delete all attributes for updated products before inserting them again during incremental syncs. The catalog always includes all attributes, even if they're unchanged, so this is safe (unlike with variations.)

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Open POS and perform a full sync in settings
2. Edit a variable parent product in wp-admin (it doesn't matter what you edit)
3. Pull to refresh to force an incremental sync
4. Exit POS and open it again
5. Open the variable product
6. Observe that all the attributes used for the variation names are not duplicated

N.B. I noticed that changes to attributes don't trigger observation updates for variation names which should change, which is why you need to exit and reopen POS to see the changes. I'll fix that separately.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
