### PR TITLE
[Tooling] Use the value from the release tool to update screenshots

### DIFF
--- a/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
+++ b/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
@@ -23,7 +23,7 @@ steps:
       bundle exec fastlane run configure_apply
 
       echo '--- :shipit: Update Release Notes and Other App Store Metadata'
-      bundle exec fastlane update_metadata_on_app_store_connect skip_confirm:true with_screenshots:"$WITH_SCREENSHOTS"
+      bundle exec fastlane update_metadata_on_app_store_connect skip_confirm:true with_screenshots:"${WITH_SCREENSHOTS:-false}"
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
+++ b/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
@@ -23,7 +23,7 @@ steps:
       bundle exec fastlane run configure_apply
 
       echo '--- :shipit: Update Release Notes and Other App Store Metadata'
-      bundle exec fastlane update_metadata_on_app_store_connect skip_confirm:true
+      bundle exec fastlane update_metadata_on_app_store_connect skip_confirm:true with_screenshots:"$WITH_SCREENSHOTS"
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite


### PR DESCRIPTION
Fixes AINFRA-1522
See https://github.a8c.com/Automattic/wpcom/pull/196883

## Description
This PR aims to take the value of the `WITH_SCREENSHOTS` environment variable set by ReleasesV2 and use it in the lane, allowing release managers to control whether they want to update screenshots or not.


⚠️ We need to be careful when merging this PR to make sure it aligns with the changes done on ReleasesV2 ⚠️ 