### PR TITLE
[Bookings] Remove dash from empty state text

### DIFF
--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -259,9 +259,9 @@ fileprivate enum BookingListViewLocalization {
         comment: "Error message when fetching bookings fails"
     )
     static let emptySearchText = NSLocalizedString(
-        "bookingList.emptySearchText",
-        value: "We couldn't find any bookings with that name — try adjusting your search term to see more results.",
-        comment: "Message displayed when searching bookings by keyword yields no results."
+        "bookingList.emptySearchText.noDash",
+        value: "We couldn't find any bookings with that name. Try adjusting your search term to see more results.",
+        comment: "Message displayed when searching bookings by keyword yields no results. Version without a dash."
     )
     static let clearFilters = NSLocalizedString(
         "bookingList.clearFilters",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1759

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Removed the dash from empty state localized string. Found only 1 occurrence.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
- Use CIAB store with bookings
- Go to Bookings tab
- Enter search bar and input some nonsense to have 0 search results.
- Make sure the empty state test is correct and doesn't have dashes.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before | After
--- | ---
<img width="277" height="286" alt="Снимок экрана 2025-11-26 в 12 11 03" src="https://github.com/user-attachments/assets/d8ee0afe-c586-497f-b721-5123fbac05dd" /> | <img width="281" height="279" alt="Снимок экрана 2025-11-26 в 12 09 40" src="https://github.com/user-attachments/assets/9cbf392a-687c-4170-a74e-8bab60f09c67" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
