### PR TITLE
Prevent schedule tests from making a plist file

### DIFF
--- a/WooCommerce/WooCommerceTests/Tools/BackgroundTaskScheduleTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/BackgroundTaskScheduleTests.swift
@@ -8,13 +8,9 @@ struct BackgroundTaskScheduleTests {
     private let timeProvider: MockTimeProvider
 
     init() {
-        // Use a unique volatile domain for in-memory storage that doesn't persist to disk
-        let userDefaults = UserDefaults()
-        let volatileDomain = "test.BackgroundTaskSchedule.\(UUID().uuidString)"
-        userDefaults.setVolatileDomain([:], forName: volatileDomain)
-        userDefaults.addSuite(named: volatileDomain)
-
         timeProvider = MockTimeProvider()
+        let userDefaults = InMemoryUserDefaults()
+
         sut = BackgroundTaskSchedule(timeProvider: timeProvider, userDefaults: userDefaults)
     }
 
@@ -224,5 +220,27 @@ private class MockTimeProvider: TimeProvider {
 
     func scheduleTimer(timeInterval: TimeInterval, target: Any, selector: Selector) -> Timer {
         fatalError("not implemented")
+    }
+}
+
+/// In-memory UserDefaults that doesn't persist to disk
+/// Each instance has its own isolated storage
+private class InMemoryUserDefaults: UserDefaults {
+    private var storage: [String: Any] = [:]
+
+    override func set(_ value: Any?, forKey defaultName: String) {
+        storage[defaultName] = value
+    }
+
+    override func data(forKey defaultName: String) -> Data? {
+        storage[defaultName] as? Data
+    }
+
+    override func object(forKey defaultName: String) -> Any? {
+        storage[defaultName]
+    }
+
+    override func removeObject(forKey defaultName: String) {
+        storage.removeValue(forKey: defaultName)
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/BackgroundTaskScheduleTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/BackgroundTaskScheduleTests.swift
@@ -8,8 +8,12 @@ struct BackgroundTaskScheduleTests {
     private let timeProvider: MockTimeProvider
 
     init() {
-        let userDefaults = UserDefaults(suiteName: #file)!
-        userDefaults.removePersistentDomain(forName: #file)
+        // Use a unique volatile domain for in-memory storage that doesn't persist to disk
+        let userDefaults = UserDefaults()
+        let volatileDomain = "test.BackgroundTaskSchedule.\(UUID().uuidString)"
+        userDefaults.setVolatileDomain([:], forName: volatileDomain)
+        userDefaults.addSuite(named: volatileDomain)
+
         timeProvider = MockTimeProvider()
         sut = BackgroundTaskSchedule(timeProvider: timeProvider, userDefaults: userDefaults)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the unit tests to avoid creating `BackgroundTaskScheduleTests.swift.plist` on every test run

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Run unit tests
- Ensure `BackgroundTaskScheduleTests.swift.plist` is not in your working copy when they complete

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
