### PR TITLE
[Bookings] Add clear option for date filter

### DIFF
--- a/WooCommerce/Classes/Bookings/BookingFilters/BookingDateTimeFilterView.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/BookingDateTimeFilterView.swift
@@ -55,6 +55,14 @@ struct BookingDateTimeFilterView: View {
         .listStyle(.plain)
         .navigationTitle(Localization.title)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(Localization.clear) {
+                    clearDateRange()
+                }
+                .disabled(selectedFromDate == nil && selectedToDate == nil)
+            }
+        }
         .background(Color(.listBackground))
         .environment(\.timeZone, TimeZone(identifier: "UTC")!) // API treats dates as no timezone so use UTC to display and select dates
         .onChange(of: fromDate) { _, newValue in
@@ -157,6 +165,12 @@ private extension BookingDateTimeFilterView {
             return fromDate...Date.distantFuture
         }
     }
+
+    func clearDateRange() {
+        selectedFromDate = nil
+        selectedToDate = nil
+        expandedPicker = nil
+    }
 }
 
 private extension BookingDateTimeFilterView {
@@ -185,6 +199,11 @@ private extension BookingDateTimeFilterView {
             "bookingDateTimeFilterView.time",
             value: "Time",
             comment: "Title of the Time row in the date time picker for booking filter"
+        )
+        static let clear = NSLocalizedString(
+            "bookingDateTimeFilterView.clear",
+            value: "Clear",
+            comment: "Title of the Clear button in the date time picker for booking filter"
         )
     }
 }

--- a/WooCommerce/Classes/Bookings/BookingFilters/BookingDateTimeFilterView.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/BookingDateTimeFilterView.swift
@@ -60,7 +60,7 @@ struct BookingDateTimeFilterView: View {
                 Button(Localization.clear) {
                     clearDateRange()
                 }
-                .disabled(selectedFromDate == nil && selectedToDate == nil)
+                .renderedIf(selectedFromDate != nil || selectedToDate != nil)
             }
         }
         .background(Color(.listBackground))

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -998,6 +998,7 @@
 		2D05FE962E8D71EA004111FD /* UpdateAttendanceStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D05FE952E8D71EA004111FD /* UpdateAttendanceStatusView.swift */; };
 		2D09E0D12E61BC7F005C26F3 /* ApplicationPasswordsExperimentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D09E0D02E61BC7D005C26F3 /* ApplicationPasswordsExperimentState.swift */; };
 		2D09E0D52E65C9B9005C26F3 /* ApplicationPasswordsExperimentStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D09E0D42E65C9B9005C26F3 /* ApplicationPasswordsExperimentStateTests.swift */; };
+		2D200F072ED7245000DD6EBF /* BookingDateTimeFilterViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D200F062ED7245000DD6EBF /* BookingDateTimeFilterViewTests.swift */; };
 		2D7A3E232E7891DB00C46401 /* CIABEligibilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7A3E222E7891D200C46401 /* CIABEligibilityCheckerTests.swift */; };
 		2D880B492DFB2F3F00A6FB2C /* OptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D880B482DFB2F3D00A6FB2C /* OptionalBinding.swift */; };
 		2D88C1112DF883C300A6FB2C /* AttributedString+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D88C1102DF883BD00A6FB2C /* AttributedString+Helpers.swift */; };
@@ -3885,6 +3886,7 @@
 		2D05FE952E8D71EA004111FD /* UpdateAttendanceStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAttendanceStatusView.swift; sourceTree = "<group>"; };
 		2D09E0D02E61BC7D005C26F3 /* ApplicationPasswordsExperimentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordsExperimentState.swift; sourceTree = "<group>"; };
 		2D09E0D42E65C9B9005C26F3 /* ApplicationPasswordsExperimentStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordsExperimentStateTests.swift; sourceTree = "<group>"; };
+		2D200F062ED7245000DD6EBF /* BookingDateTimeFilterViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingDateTimeFilterViewTests.swift; sourceTree = "<group>"; };
 		2D49A80B2ECDCD4500AF1749 /* RequestAuthenticatorPressureTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = RequestAuthenticatorPressureTests.xctestplan; path = ../Modules/Tests/NetworkingTests/RequestAuthenticatorPressureTests.xctestplan; sourceTree = "<group>"; };
 		2D7A3E222E7891D200C46401 /* CIABEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIABEligibilityCheckerTests.swift; sourceTree = "<group>"; };
 		2D880B482DFB2F3D00A6FB2C /* OptionalBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalBinding.swift; sourceTree = "<group>"; };
@@ -12513,6 +12515,7 @@
 		DED1E3162E8556270089909C /* Bookings */ = {
 			isa = PBXGroup;
 			children = (
+				2D200F062ED7245000DD6EBF /* BookingDateTimeFilterViewTests.swift */,
 				DE8C39FF2EB3527300C69F35 /* SyncableListSelectorViewModelTests.swift */,
 				DE49CD212E966814006DCB07 /* BookingSearchViewModelTests.swift */,
 				DED1E3152E8556270089909C /* BookingListViewModelTests.swift */,
@@ -15954,6 +15957,7 @@
 				FEEB2F61268A215E0075A6E0 /* StorageEligibilityErrorInfoWooTests.swift in Sources */,
 				31F21B02263C8E150035B50A /* CardReaderSettingsSearchingViewModelTests.swift in Sources */,
 				DEACB8852A64F74A00253F0F /* MediaPickingCoordinatorTests.swift in Sources */,
+				2D200F072ED7245000DD6EBF /* BookingDateTimeFilterViewTests.swift in Sources */,
 				45EF798624509B4C00B22BA2 /* ArrayIndexPathTests.swift in Sources */,
 				D8610BDD256F5ABF00A5DF27 /* JetpackErrorViewModelTests.swift in Sources */,
 				746791632108D7C0007CF1DC /* WooAnalyticsTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDateTimeFilterViewTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDateTimeFilterViewTests.swift
@@ -5,20 +5,18 @@ import Combine
 @testable import WooCommerce
 
 final class BookingDateTimeFilterViewTests: XCTestCase {
-    func test_clear_button_is_disabled_initially_when_no_dates_selected() throws {
+    func test_clear_button_is_not_rendered_initially_when_no_dates_selected() throws {
         let sut = BookingDateTimeFilterView(startDate: nil, endDate: nil, onSelection: { _, _ in })
         let view = try sut.inspect()
 
-        let button = try view.find(button: "Clear")
-        XCTAssertTrue(button.isDisabled())
+        XCTAssertThrowsError(try view.find(button: "Clear"))
     }
 
-    func test_clear_button_is_enabled_when_dates_selected() throws {
+    func test_clear_button_is_rendered_when_dates_selected() throws {
         let date = Date()
         let sut = BookingDateTimeFilterView(startDate: date, endDate: date, onSelection: { _, _ in })
         let view = try sut.inspect()
 
-        let button = try view.find(button: "Clear")
-        XCTAssertFalse(button.isDisabled())
+        _ = try view.find(button: "Clear")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDateTimeFilterViewTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDateTimeFilterViewTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+import ViewInspector
+import SwiftUI
+import Combine
+@testable import WooCommerce
+
+final class BookingDateTimeFilterViewTests: XCTestCase {
+    func test_clear_button_is_disabled_initially_when_no_dates_selected() throws {
+        let sut = BookingDateTimeFilterView(startDate: nil, endDate: nil, onSelection: { _, _ in })
+        let view = try sut.inspect()
+
+        let button = try view.find(button: "Clear")
+        XCTAssertTrue(button.isDisabled())
+    }
+
+    func test_clear_button_is_enabled_when_dates_selected() throws {
+        let date = Date()
+        let sut = BookingDateTimeFilterView(startDate: date, endDate: date, onSelection: { _, _ in })
+        let view = try sut.inspect()
+
+        let button = try view.find(button: "Clear")
+        XCTAssertFalse(button.isDisabled())
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1806

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
- Adds clear button in Date & time filter screen for bookings
- Clear button is disabled when no date/time filter options are selected

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Use CIAB site with bookings
- Navigate to bookings list and select "All" tab to reveal bookings filter option
- Tap on "Filter" option
- Tap on "Date & time" option
- While there is no date / time selection yet - make sure the "Clear" button is displayed as disabled
- Make date / time range selection
- Make sure the "Clear" button becomes enabled as soon as there is date / time interval selection.
- Tap on "Clear" button. Make sure date / time selection is cleared.
- Tap on "<" back item in toolbar.
- Make sure that the "Date & time" selection is cleared and presents "Any" in "Filters" screen.
 
## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/2c5bc549-c346-476e-b36c-4d5b6291303f

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
