### PR TITLE
Split summery text to multiple lines for better readability.

### DIFF
--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -143,16 +143,16 @@ private extension BookingListView {
     }
 
     func bookingItem(_ booking: Booking) -> some View {
-        VStack(alignment: .leading) {
-            Text(booking.startDate.toString(dateStyle: .short,
-                                            timeStyle: .short,
-                                            timeZone: BookingListTab.utcTimeZone))
+        VStack(alignment: .leading, spacing: BookingListViewLayout.bookingSummaryBadgeSpacing) {
+            VStack(alignment: .leading, spacing: BookingListViewLayout.bookingSummarySpacing) {
+                Text(booking.startDate.toString(dateStyle: .short,
+                                                timeStyle: .short,
+                                                timeZone: BookingListTab.utcTimeZone))
                 .font(.body)
                 .fontWeight(.medium)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .foregroundStyle(Color.primary)
 
-            VStack(alignment: .leading) {
                 if let productName = booking.productName {
                     Text(productName)
                         .font(.footnote)
@@ -258,6 +258,8 @@ fileprivate enum BookingListViewLayout {
     static let emptyStateImageWidth: CGFloat = 67
     static let cornerRadius: CGFloat = 8
     static let defaultHeaderHeight: CGFloat = 98
+    static let bookingSummarySpacing: CGFloat = 2
+    static let bookingSummaryBadgeSpacing: CGFloat = 8
 }
 
 fileprivate enum BookingListViewLocalization {

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -152,10 +152,19 @@ private extension BookingListView {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .foregroundStyle(Color.primary)
 
-            Text(booking.summaryText)
-                .font(.footnote)
-                .fontWeight(.medium)
-                .foregroundStyle(Color.secondary)
+            VStack(alignment: .leading) {
+                if let productName = booking.productName {
+                    Text(productName)
+                        .font(.footnote)
+                        .fontWeight(.medium)
+                        .foregroundStyle(Color.secondary)
+                }
+
+                Text(booking.customerName)
+                    .font(.footnote)
+                    .fontWeight(.medium)
+                    .foregroundStyle(Color.secondary)
+            }
 
             HStack {
                 BookingBadgeView(booking.attendanceStatus)

--- a/WooCommerce/Classes/Extensions/Booking+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Booking+Helpers.swift
@@ -13,12 +13,6 @@ extension Booking {
         return name.isEmpty ? Localization.guest : name
     }
 
-    var summaryText: String {
-        return [productName, customerName]
-            .compactMap { $0 }
-            .joined(separator: "  •  ")
-    }
-
     var isEligibleForMarkAsPaid: Bool {
         bookingStatus == .unpaid
     }


### PR DESCRIPTION
Closes [WOOMOB-1655](https://linear.app/a8c/issue/WOOMOB-1655)

## Description

Splits the summary texts into multiple lines to better fit long texts.

## Test Steps
1. Login to a CIAB store.
2. Navigate to bookings
3. Note that the summary text is split to multiple lines.

## Screenshots
| Before | After |
| --- | --- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-27 at 10 46 35" src="https://github.com/user-attachments/assets/03082be0-f94f-4245-b95e-8d8360219412" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-27 at 10 56 36" src="https://github.com/user-attachments/assets/bc8cc6c4-6236-43f3-8de0-2b535b557067" /> |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
