### PR TITLE
Remove extra reference to test plan from project

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -3889,7 +3889,6 @@
 		2D09E0D02E61BC7D005C26F3 /* ApplicationPasswordsExperimentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordsExperimentState.swift; sourceTree = "<group>"; };
 		2D09E0D42E65C9B9005C26F3 /* ApplicationPasswordsExperimentStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordsExperimentStateTests.swift; sourceTree = "<group>"; };
 		2D200F062ED7245000DD6EBF /* BookingDateTimeFilterViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingDateTimeFilterViewTests.swift; sourceTree = "<group>"; };
-		2D49A80B2ECDCD4500AF1749 /* RequestAuthenticatorPressureTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = RequestAuthenticatorPressureTests.xctestplan; path = ../Modules/Tests/NetworkingTests/RequestAuthenticatorPressureTests.xctestplan; sourceTree = "<group>"; };
 		2D7A3E222E7891D200C46401 /* CIABEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIABEligibilityCheckerTests.swift; sourceTree = "<group>"; };
 		2D880B482DFB2F3D00A6FB2C /* OptionalBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalBinding.swift; sourceTree = "<group>"; };
 		2D88C1102DF883BD00A6FB2C /* AttributedString+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Helpers.swift"; sourceTree = "<group>"; };
@@ -9628,7 +9627,6 @@
 		B56DB3BD2049BFAA00D4AA8E = {
 			isa = PBXGroup;
 			children = (
-				2D49A80B2ECDCD4500AF1749 /* RequestAuthenticatorPressureTests.xctestplan */,
 				3F3689E22DCB1B470065B48F /* Modules */,
 				D8FBFF1622D4CC2F006E3336 /* docs */,
 				8CA4F6DC220B24EB00A47B5D /* config */,


### PR DESCRIPTION
@joshheald spotted that there was an extra test plan file reference in project hierarchy: p1764240288217489-slack-C6H8C3G23

Removed the extra reference appeared in project root folder. The correct reference is in place and pointing to the `../Modules/Tests/NetworkingTests/RequestAuthenticatorPressureTests.xctestplan`

Before | After 
--- | ---
<img width="346" height="148" alt="Снимок экрана 2025-11-27 в 13 59 01" src="https://github.com/user-attachments/assets/6d7ee3a4-1eea-4dc8-9527-322fb7a45361" /> | <img width="341" height="129" alt="Снимок экрана 2025-11-27 в 13 58 48" src="https://github.com/user-attachments/assets/130d50e8-1f28-4173-8820-ca1025db0856" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.