### PR TITLE
[Local catalog] Hide cellular toggle on non-cellular devices

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogDetailView.swift
@@ -18,7 +18,9 @@ struct POSSettingsLocalCatalogDetailView: View {
                 ScrollView {
                     VStack(spacing: POSSpacing.medium) {
                         catalogStatus
-                        managingDataUsage
+                        if viewModel.deviceHasCellularCapability {
+                            managingDataUsage
+                        }
                         manualCatalogUpdate
                     }
                     .padding(.horizontal, POSPadding.medium)

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogViewModel.swift
@@ -2,6 +2,7 @@ import CocoaLumberjackSwift
 import Yosemite
 import Foundation
 import Storage
+import WooFoundation
 
 @Observable
 final class POSSettingsLocalCatalogViewModel {
@@ -11,6 +12,7 @@ final class POSSettingsLocalCatalogViewModel {
 
     private(set) var isLoading: Bool = false
     private(set) var isRefreshingCatalog: Bool = false
+    let deviceHasCellularCapability: Bool = CellularCapabilityChecker.deviceHasCellularCapability()
 
     var catalogRefreshError: POSIdentifiableErrorState? = nil
 

--- a/Modules/Sources/WooFoundation/Utilities/Connectivity/CellularCapabilityChecker.swift
+++ b/Modules/Sources/WooFoundation/Utilities/Connectivity/CellularCapabilityChecker.swift
@@ -1,0 +1,26 @@
+import Darwin
+
+public struct CellularCapabilityChecker {
+    public static func deviceHasCellularCapability() -> Bool {
+        var addrs: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&addrs) == 0 else { return false }
+        defer { freeifaddrs(addrs) }
+
+        var cursor = addrs
+        while let addr = cursor {
+            guard let namePtr = addr.pointee.ifa_name else {
+                cursor = addr.pointee.ifa_next
+                continue
+            }
+
+            let name = String(cString: namePtr)
+            // This isn't a great check, but the alternatives are deprecated, and apparently it's commonly used.
+            // pdp_ip0 is the first cellular interface – it's not present if there's no cellular hardware.
+            if name == "pdp_ip0" {
+                return true
+            }
+            cursor = addr.pointee.ifa_next
+        }
+        return false
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Many iPads don’t have a cellular connection. It’s a little confusing to show the cellular toggle when it doesn’t apply.

Unfortunately, there’s no good (undeprecated) API for checking this. I’ve used an approach of listing the network interfaces and looking for the cellular one, but it’s undocumented and might not always work.

OTOH, this isn’t a critical feature, so we can keep an eye on it.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Launch the app on a non-cellular iPad
Open POS > Settings > Local catalog
Observe that the cellular toggle isn't shown

Repeat with a cellular iPad, or a phone after commenting out this code in `POSTabVisibilityChecker`

```
        guard userInterfaceIdiom == .pad else {
            return false
        }
```

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
