### PR TITLE
[POS Refunds] Order details button

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -33,7 +33,7 @@ struct POSOrderDetailsView: View {
                 title: POSOrderListView.Localization.orderTitle(order.number),
                 backButtonConfiguration: shouldShowBackButton ? .init(state: .enabled, action: onBack) : nil,
                 trailingContent: {
-                    actionsSection(actions: availableActions)
+                    actionsSection(setup: availableActionsSetup)
                 },
                 bottomContent: {
                     headerBottomContent(for: order)
@@ -426,29 +426,33 @@ private extension POSOrderDetailsView {
         }
     }
 
-    var availableActions: [OrderDetailsAction] {
-        OrderDetailsAction.allCases
+    struct OrderDetailsActionsSetup {
+        let primary: OrderDetailsAction?
+        let secondary: [OrderDetailsAction]
+    }
+
+    var availableActionsSetup: OrderDetailsActionsSetup {
+        let available = OrderDetailsAction.allCases
             .filter { $0.isAvailable(for: order, flags: featureFlags) }
             .sorted { $0.priority > $1.priority }
+
+        let primary = available.first
+        let secondary = Array(available.dropFirst())
+
+        return OrderDetailsActionsSetup(primary: primary, secondary: secondary)
     }
 
     @ViewBuilder
-    func actionsSection(actions: [OrderDetailsAction]) -> some View {
-        if actions.isEmpty {
-            EmptyView()
-        } else {
+    func actionsSection(setup: OrderDetailsActionsSetup) -> some View {
+        if let primary = setup.primary {
             HStack(spacing: POSSpacing.large) {
-                let primary = actions[0]
                 Button(primary.title, action: handler(for: primary))
                     .buttonStyle(POSFilledButtonStyle(size: .extraSmall))
                     .accessibilityHint(primary.accessibilityHint)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.5)
 
-                let overflow = actions.dropFirst()
-                if !overflow.isEmpty {
+                if !setup.secondary.isEmpty {
                     Menu {
-                        ForEach(Array(overflow)) { action in
+                        ForEach(setup.secondary) { action in
                             Button(action.title, action: handler(for: action))
                                 .accessibilityHint(action.accessibilityHint)
                         }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -376,7 +376,7 @@ private extension POSOrderDetailsView {
 
 // MARK: - Actions
 private extension POSOrderDetailsView {
-    enum POSAction: Identifiable, CaseIterable {
+    enum OrderDetailsAction: Identifiable, CaseIterable {
         case issueRefund
         case emailReceipt
 
@@ -414,7 +414,7 @@ private extension POSOrderDetailsView {
         }
     }
 
-    func handler(for action: POSAction) -> @MainActor () -> Void {
+    func handler(for action: OrderDetailsAction) -> @MainActor () -> Void {
         switch action {
         case .emailReceipt:
             return {
@@ -426,14 +426,14 @@ private extension POSOrderDetailsView {
         }
     }
 
-    var availableActions: [POSAction] {
-        POSAction.allCases
+    var availableActions: [OrderDetailsAction] {
+        OrderDetailsAction.allCases
             .filter { $0.isAvailable(for: order, flags: featureFlags) }
             .sorted { $0.priority > $1.priority }
     }
 
     @ViewBuilder
-    func actionsSection(actions: [POSAction]) -> some View {
+    func actionsSection(actions: [OrderDetailsAction]) -> some View {
         if actions.isEmpty {
             EmptyView()
         } else {

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -14,6 +14,7 @@ struct POSOrderDetailsView: View {
     @Environment(\.siteTimezone) private var siteTimezone
     @Environment(POSOrderListModel.self) private var orderListModel
     @Environment(\.posAnalytics) private var analytics
+    @Environment(\.posFeatureFlags) private var featureFlags
     @State private var isShowingEmailReceiptView: Bool = false
 
     private var shouldShowBackButton: Bool {
@@ -32,9 +33,7 @@ struct POSOrderDetailsView: View {
                 title: POSOrderListView.Localization.orderTitle(order.number),
                 backButtonConfiguration: shouldShowBackButton ? .init(state: .enabled, action: onBack) : nil,
                 trailingContent: {
-                    if primaryAction != nil || overflowActions.isNotEmpty {
-                        actionsSection(overflowActions)
-                    }
+                    actionsSection(actions: availableActions)
                 },
                 bottomContent: {
                     headerBottomContent(for: order)
@@ -377,86 +376,98 @@ private extension POSOrderDetailsView {
 
 // MARK: - Actions
 private extension POSOrderDetailsView {
-    // Primary action for the header
-    enum POSPrimaryAction {
-        case issueRefund
+    enum POSAction: Identifiable, CaseIterable {
+            case issueRefund
+            case emailReceipt
 
-        var title: String {
-            switch self {
+            var id: String { title }
+
+            var title: String {
+                switch self {
+                case .issueRefund:  Localization.issueRefundActionTitle
+                case .emailReceipt: Localization.emailReceiptActionTitle
+                }
+            }
+
+            var accessibilityHint: String {
+                switch self {
+                case .issueRefund:  Localization.issueRefundAccessibilityHint
+                case .emailReceipt: Localization.emailReceiptAccessibilityHint
+                }
+            }
+
+            var priority: Int {
+                switch self {
+                case .issueRefund:  100
+                case .emailReceipt: 50
+                }
+            }
+
+            func isAvailable(for order: POSOrder, flags: POSFeatureFlagProviding) -> Bool {
+                guard order.status == .completed else { return false }
+                switch self {
+                case .issueRefund:
+                    return flags.isFeatureFlagEnabled(.pointOfSaleRefundsi1)
+                case .emailReceipt:
+                    return true
+                }
+            }
+        }
+
+        func handler(for action: POSAction) -> @MainActor () -> Void {
+            switch action {
+            case .emailReceipt:
+                return {
+                    analytics.track(event: WooAnalyticsEvent.PointOfSale.orderDetailsEmailReceiptTapped())
+                    isShowingEmailReceiptView = true
+                }
             case .issueRefund:
-                Localization.issueRefundActionTitle
+                return { }
             }
         }
 
-        func available(for order: POSOrder) -> Bool {
-            // Adjust the condition as needed
-            return order.status == .completed
+        var availableActions: [POSAction] {
+            POSAction.allCases
+                .filter { $0.isAvailable(for: order, flags: featureFlags) }
+                .sorted { $0.priority > $1.priority }
         }
-    }
-
-    enum POSOverflowAction: Identifiable, CaseIterable {
-        case emailReceipt
-
-        var id: String { title }
-
-        var title: String {
-            switch self {
-            case .emailReceipt:
-                Localization.emailReceiptActionTitle
-            }
-        }
-
-        func available(for order: POSOrder) -> Bool {
-            switch self {
-            case .emailReceipt:
-                return order.status == .completed
-            }
-        }
-    }
-
-    // Primary + overflow actions (formerly `actions`)
-    var primaryAction: POSPrimaryAction? {
-        let candidate: POSPrimaryAction = .issueRefund
-        return candidate.available(for: order) ? candidate : nil
-    }
-
-    var overflowActions: [POSOverflowAction] {
-        POSOverflowAction.allCases.filter { $0.available(for: order) }
-    }
 
     @ViewBuilder
-    func actionsSection(_ actions: [POSOverflowAction]) -> some View {
-        HStack(spacing: POSSpacing.large) {
-            if let primaryAction {
-                Button(primaryAction.title) {}
-                .buttonStyle(POSFilledButtonStyle(size: .extraSmall))
-                .accessibilityHint(Localization.issueRefundAccessibilityHint)
-                .lineLimit(1)
-                .minimumScaleFactor(0.5)
-            }
+    func actionsSection(actions: [POSAction]) -> some View {
+        if actions.isEmpty {
+            EmptyView()
+        } else {
+            HStack(spacing: POSSpacing.large) {
+                let primary = actions[0]
+                Button(primary.title, action: handler(for: primary))
+                    .buttonStyle(POSFilledButtonStyle(size: .extraSmall))
+                    .accessibilityHint(primary.accessibilityHint)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.5)
 
-            if overflowActions.isNotEmpty {
-                Menu {
-                    ForEach(overflowActions) { action in
-                        switch action {
-                        case .emailReceipt:
-                            Button(action.title) {
-                                analytics.track(event: WooAnalyticsEvent.PointOfSale.orderDetailsEmailReceiptTapped())
-                                isShowingEmailReceiptView = true
-                            }
-                            .accessibilityHint(Localization.emailReceiptAccessibilityHint)
+                let overflow = actions.dropFirst()
+                if !overflow.isEmpty {
+                    Menu {
+                        ForEach(Array(overflow)) { action in
+                            Button(action.title, action: handler(for: action))
+                                .accessibilityHint(action.accessibilityHint)
                         }
+                    } label: {
+                        Image(systemName: "ellipsis")
+                            .font(.posBodyLargeBold)
+                            .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                            .foregroundColor(.posOnSurface)
+                            .padding(POSPadding.small)
                     }
-                } label: {
-                    Image(systemName: "ellipsis")
-                        .font(.posBodyLargeBold)
-                        .dynamicTypeSize(...DynamicTypeSize.accessibility2)
-                        .foregroundColor(.posOnSurface)
-                        .padding(POSPadding.small)
+                    .menuIndicator(.hidden)
                 }
-                .menuIndicator(.hidden)
             }
         }
+    }
+
+    func emailReceiptAction() {
+        analytics.track(event: WooAnalyticsEvent.PointOfSale.orderDetailsEmailReceiptTapped())
+        isShowingEmailReceiptView = true
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -377,60 +377,60 @@ private extension POSOrderDetailsView {
 // MARK: - Actions
 private extension POSOrderDetailsView {
     enum POSAction: Identifiable, CaseIterable {
-            case issueRefund
-            case emailReceipt
+        case issueRefund
+        case emailReceipt
 
-            var id: String { title }
+        var id: String { title }
 
-            var title: String {
-                switch self {
-                case .issueRefund:  Localization.issueRefundActionTitle
-                case .emailReceipt: Localization.emailReceiptActionTitle
-                }
-            }
-
-            var accessibilityHint: String {
-                switch self {
-                case .issueRefund:  Localization.issueRefundAccessibilityHint
-                case .emailReceipt: Localization.emailReceiptAccessibilityHint
-                }
-            }
-
-            var priority: Int {
-                switch self {
-                case .issueRefund:  100
-                case .emailReceipt: 50
-                }
-            }
-
-            func isAvailable(for order: POSOrder, flags: POSFeatureFlagProviding) -> Bool {
-                guard order.status == .completed else { return false }
-                switch self {
-                case .issueRefund:
-                    return flags.isFeatureFlagEnabled(.pointOfSaleRefundsi1)
-                case .emailReceipt:
-                    return true
-                }
+        var title: String {
+            switch self {
+            case .issueRefund:  Localization.issueRefundActionTitle
+            case .emailReceipt: Localization.emailReceiptActionTitle
             }
         }
 
-        func handler(for action: POSAction) -> @MainActor () -> Void {
-            switch action {
-            case .emailReceipt:
-                return {
-                    analytics.track(event: WooAnalyticsEvent.PointOfSale.orderDetailsEmailReceiptTapped())
-                    isShowingEmailReceiptView = true
-                }
+        var accessibilityHint: String {
+            switch self {
+            case .issueRefund:  Localization.issueRefundAccessibilityHint
+            case .emailReceipt: Localization.emailReceiptAccessibilityHint
+            }
+        }
+
+        var priority: Int {
+            switch self {
+            case .issueRefund:  100
+            case .emailReceipt: 50
+            }
+        }
+
+        func isAvailable(for order: POSOrder, flags: POSFeatureFlagProviding) -> Bool {
+            guard order.status == .completed else { return false }
+            switch self {
             case .issueRefund:
-                return { }
+                return flags.isFeatureFlagEnabled(.pointOfSaleRefundsi1)
+            case .emailReceipt:
+                return true
             }
         }
+    }
 
-        var availableActions: [POSAction] {
-            POSAction.allCases
-                .filter { $0.isAvailable(for: order, flags: featureFlags) }
-                .sorted { $0.priority > $1.priority }
+    func handler(for action: POSAction) -> @MainActor () -> Void {
+        switch action {
+        case .emailReceipt:
+            return {
+                analytics.track(event: WooAnalyticsEvent.PointOfSale.orderDetailsEmailReceiptTapped())
+                isShowingEmailReceiptView = true
+            }
+        case .issueRefund:
+            return { }
         }
+    }
+
+    var availableActions: [POSAction] {
+        POSAction.allCases
+            .filter { $0.isAvailable(for: order, flags: featureFlags) }
+            .sorted { $0.priority > $1.priority }
+    }
 
     @ViewBuilder
     func actionsSection(actions: [POSAction]) -> some View {

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -32,8 +32,8 @@ struct POSOrderDetailsView: View {
                 title: POSOrderListView.Localization.orderTitle(order.number),
                 backButtonConfiguration: shouldShowBackButton ? .init(state: .enabled, action: onBack) : nil,
                 trailingContent: {
-                    if actions.isNotEmpty {
-                        actionsSection(actions)
+                    if primaryAction != nil || overflowActions.isNotEmpty {
+                        actionsSection(overflowActions)
                     }
                 },
                 bottomContent: {
@@ -377,7 +377,24 @@ private extension POSOrderDetailsView {
 
 // MARK: - Actions
 private extension POSOrderDetailsView {
-    enum POSOrderDetailsAction: Identifiable, CaseIterable {
+    // Primary action for the header
+    enum POSPrimaryAction {
+        case issueRefund
+
+        var title: String {
+            switch self {
+            case .issueRefund:
+                Localization.issueRefundActionTitle
+            }
+        }
+
+        func available(for order: POSOrder) -> Bool {
+            // Adjust the condition as needed
+            return order.status == .completed
+        }
+    }
+
+    enum POSOverflowAction: Identifiable, CaseIterable {
         case emailReceipt
 
         var id: String { title }
@@ -392,43 +409,53 @@ private extension POSOrderDetailsView {
         func available(for order: POSOrder) -> Bool {
             switch self {
             case .emailReceipt:
-                order.status == .completed
+                return order.status == .completed
             }
         }
     }
 
-    var actions: [POSOrderDetailsAction] {
-        POSOrderDetailsAction.allCases.filter { $0.available(for: order) }
+    // Primary + overflow actions (formerly `actions`)
+    var primaryAction: POSPrimaryAction? {
+        let candidate: POSPrimaryAction = .issueRefund
+        return candidate.available(for: order) ? candidate : nil
+    }
+
+    var overflowActions: [POSOverflowAction] {
+        POSOverflowAction.allCases.filter { $0.available(for: order) }
     }
 
     @ViewBuilder
-    func actionsSection(_ actions: [POSOrderDetailsAction]) -> some View {
-        VStack {
-            HStack {
-                ForEach(actions) { action in
-                    Button(action: {
+    func actionsSection(_ actions: [POSOverflowAction]) -> some View {
+        HStack(spacing: POSSpacing.large) {
+            if let primaryAction {
+                Button(primaryAction.title) {}
+                .buttonStyle(POSFilledButtonStyle(size: .extraSmall))
+                .accessibilityHint(Localization.issueRefundAccessibilityHint)
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
+            }
+
+            if overflowActions.isNotEmpty {
+                Menu {
+                    ForEach(overflowActions) { action in
                         switch action {
                         case .emailReceipt:
-                            analytics.track(event: WooAnalyticsEvent.PointOfSale.orderDetailsEmailReceiptTapped())
-                            isShowingEmailReceiptView = true
+                            Button(action.title) {
+                                analytics.track(event: WooAnalyticsEvent.PointOfSale.orderDetailsEmailReceiptTapped())
+                                isShowingEmailReceiptView = true
+                            }
+                            .accessibilityHint(Localization.emailReceiptAccessibilityHint)
                         }
-                    }) {
-                        Text(Localization.emailReceiptActionTitle)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.5)
                     }
-                    .buttonStyle(POSFilledButtonStyle(size: .extraSmall))
-                    .accessibilityHint(accessibilityHint(for: action))
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.posBodyLargeBold)
+                        .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                        .foregroundColor(.posOnSurface)
+                        .padding(POSPadding.small)
                 }
+                .menuIndicator(.hidden)
             }
-            Spacer()
-        }
-    }
-
-    private func accessibilityHint(for action: POSOrderDetailsAction) -> String {
-        switch action {
-        case .emailReceipt:
-            return Localization.emailReceiptAccessibilityHint
         }
     }
 }
@@ -527,6 +554,24 @@ private enum Localization {
         "pos.orderDetailsView.emailReceiptAction.accessibilityHint",
         value: "Tap to send order receipt via email",
         comment: "Accessibility hint for email receipt button on order details view"
+    )
+
+    static let issueRefundActionTitle = NSLocalizedString(
+            "pos.orderDetailsView.issueRefundAction.title",
+            value: "Issue refund",
+            comment: "Primary action button to start issuing a refund on the order details view"
+        )
+
+    static let issueRefundAccessibilityHint = NSLocalizedString(
+        "pos.orderDetailsView.issueRefundAction.accessibilityHint",
+        value: "Start refund flow for this order",
+        comment: "Accessibility hint for issue refund button"
+    )
+
+    static let moreActionsA11yLabel = NSLocalizedString(
+        "pos.orderDetailsView.moreActions.label",
+        value: "More actions",
+        comment: "Accessibility label for the overflow actions menu button (three dots)"
     )
 
     static func headerBottomContentAccessibilityLabel(date: String, email: String?, status: String) -> String {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of WOOMOB-1786

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add the refunds button to the order details and move the email action to the ellipsis menu.

Notes:

- The right logic for showing the refunds button (i.e., not all items are refunded, the order was paid) is coming in a subsequent PR
- I’m following the inner padding of the native Menu element in the iOS SDK, which is slightly narrower than the design. This approach aligns with the Apple Human Interface Guidelines and simplifies the code by relying on the native component.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Go to POS
2. Go to Orders
3. On a completed order, check that the buttons are properly shown.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![My Store 4](https://github.com/user-attachments/assets/f94484d2-2e3b-4049-84b7-6258cd4a4d35)

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
