### PR TITLE
[Local catalog] Animate updates to the item list

### DIFF
--- a/Modules/Sources/Fakes/Yosemite.generated.swift
+++ b/Modules/Sources/Fakes/Yosemite.generated.swift
@@ -35,6 +35,23 @@ extension Yosemite.JustInTimeMessageTemplate {
         .banner
     }
 }
+extension Yosemite.POSItemIdentifier {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Yosemite.POSItemIdentifier {
+        .init(
+            underlyingType: .fake(),
+            itemID: .fake()
+        )
+    }
+}
+extension Yosemite.POSItemIdentifier.UnderlyingType {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Yosemite.POSItemIdentifier.UnderlyingType {
+        .product
+    }
+}
 extension Yosemite.POSSimpleProduct {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
@@ -291,7 +291,7 @@ private extension POSCart {
             guard case let .loaded(item) = purchasableItem.state else { return nil }
             return POSCartItem(item: item, quantity: Decimal(purchasableItem.quantity))
         }
-        let coupons = cart.coupons.map { POSCoupon(id: $0.id, code: $0.code, summary: $0.summary) }
+        let coupons = cart.coupons.map { POSCoupon(id: $0.posItemIdentifier, code: $0.code, summary: $0.summary) }
         self.init(items: items, coupons: coupons)
     }
 }

--- a/Modules/Sources/PointOfSale/Models/Cart.swift
+++ b/Modules/Sources/PointOfSale/Models/Cart.swift
@@ -45,7 +45,7 @@ extension Cart {
             case .loading:
                 return POSItemIdentifier(underlyingType: .loading, itemID: 0)
             case .error:
-                return POSItemIdentifier(underlyingType: .loading, itemID: 0)
+                return POSItemIdentifier(underlyingType: .error, itemID: 0)
             }
         }
 

--- a/Modules/Sources/PointOfSale/Models/Cart.swift
+++ b/Modules/Sources/PointOfSale/Models/Cart.swift
@@ -2,6 +2,7 @@ import Foundation
 import protocol Yosemite.POSOrderableItem
 import enum Yosemite.POSItem
 import enum Yosemite.PointOfSaleBarcodeScanError
+import struct Yosemite.POSItemIdentifier
 
 struct Cart {
     var purchasableItems: [Cart.PurchasableItem] = []
@@ -12,6 +13,7 @@ struct Cart {
 
 protocol CartItem {
     var id: UUID { get }
+    var posItemIdentifier: POSItemIdentifier { get }
     var type: CartItemType { get }
 }
 
@@ -34,6 +36,17 @@ extension Cart {
             case loaded(POSOrderableItem)
             case loading
             case error
+        }
+
+        var posItemIdentifier: POSItemIdentifier {
+            switch state {
+            case .loaded(let item):
+                return item.id
+            case .loading:
+                return POSItemIdentifier(underlyingType: .loading, itemID: 0)
+            case .error:
+                return POSItemIdentifier(underlyingType: .loading, itemID: 0)
+            }
         }
 
         var formattedPrice: String? {
@@ -76,6 +89,7 @@ extension Cart {
 
     struct CouponItem: CartItem {
         let id: UUID
+        let posItemIdentifier: POSItemIdentifier
         let code: String
         let summary: String
         let type: CartItemType = .coupon
@@ -89,7 +103,7 @@ extension Cart {
         if let purchasableItem = createPurchasableItem(from: posItem) {
             purchasableItems.insert(purchasableItem, at: purchasableItems.startIndex)
         } else if case .coupon(let coupon) = posItem {
-            let couponItem = Cart.CouponItem(id: coupon.id, code: coupon.code, summary: coupon.summary)
+            let couponItem = Cart.CouponItem(id: UUID(), posItemIdentifier: coupon.id, code: coupon.code, summary: coupon.summary)
             coupons.insert(couponItem, at: coupons.startIndex)
         }
     }

--- a/Modules/Sources/PointOfSale/Presentation/CartView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CartView.swift
@@ -479,7 +479,7 @@ private extension CartView {
 
 #Preview("Cart with one item") {
     let posModel = POSPreviewHelpers.makePreviewAggregateModel()
-    posModel.addToCart(.simpleProduct(.init(id: UUID(),
+    posModel.addToCart(.simpleProduct(.init(id: .init(underlyingType: .product, itemID: 6),
                                             name: "Sample Product",
                                             formattedPrice: "$10.00",
                                             productID: 6,

--- a/Modules/Sources/PointOfSale/Presentation/CouponRowView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CouponRowView.swift
@@ -109,6 +109,9 @@ private extension CouponRowView {
 
 #if DEBUG
 #Preview(traits: .sizeThatFitsLayout) {
-    CouponRowView(couponItem: Cart.CouponItem(id: UUID(), code: "10-Discount", summary: "$10 Off · All products"), couponRowState: .idle) {}
+    CouponRowView(couponItem: Cart.CouponItem(id: UUID(),
+                                              posItemIdentifier: .init(underlyingType: .coupon, itemID: 123),
+                                              code: "10-Discount",
+                                              summary: "$10 Off · All products"), couponRowState: .idle) {}
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/Coupons/POSCouponCreationSheet.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Coupons/POSCouponCreationSheet.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import class WooFoundation.CurrencySettings
 import struct Yosemite.Coupon
 import enum Yosemite.POSItem
+import struct Yosemite.POSItemIdentifier
 import struct Yosemite.POSCoupon
 
 extension View {
@@ -31,7 +32,8 @@ private struct POSCouponCreationSheetModifier: ViewModifier {
                     discountType: posDiscountType.discountType,
                     showTypeSelection: $showCouponSelectionSheet,
                     onSuccess: { coupon in
-                        addedCouponItem = .coupon(.init(id: UUID(), code: coupon.code, summary: coupon.summary(currencySettings: currencySettings)))
+                        let id = POSItemIdentifier(underlyingType: .coupon, itemID: coupon.couponID)
+                        addedCouponItem = .coupon(.init(id: id, code: coupon.code, summary: coupon.summary(currencySettings: currencySettings)))
                     },
                     dismissHandler: {
                         selectedType = nil

--- a/Modules/Sources/PointOfSale/Presentation/Item Selector/ChildItemList.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Selector/ChildItemList.swift
@@ -120,7 +120,7 @@ private extension ChildItemList {
 
 #Preview("Variable product child items") {
     let parentProduct = POSVariableParentProduct(
-        id: .init(),
+        id: .init(underlyingType: .product, itemID: 1),
         name: "Variable latte",
         productImageSource: nil,
         productID: 1
@@ -134,7 +134,7 @@ private extension ChildItemList {
                 [
                     .variation(
                         POSVariation(
-                            id: .init(),
+                            id: .init(underlyingType: .variation, itemID: 256),
                             name: "Cinamon chestnut latte",
                             formattedPrice: "$5.75",
                             price: "5.75",
@@ -145,12 +145,12 @@ private extension ChildItemList {
                     ),
                     .variation(
                         POSVariation(
-                            id: .init(),
+                            id: .init(underlyingType: .variation, itemID: 2567),
                             name: "Choco latte",
                             formattedPrice: "$6.5",
                             price: "6.5",
                             productID: 134,
-                            variationID: 256,
+                            variationID: 2567,
                             parentProductName: parentProduct.name
                         )
                     )
@@ -170,7 +170,7 @@ private extension ChildItemList {
 
 #Preview("Variable items load error") {
     let parentProduct = POSVariableParentProduct(
-        id: .init(),
+        id: .init(underlyingType: .product, itemID: 1),
         name: "Variable latte",
         productImageSource: nil,
         productID: 1

--- a/Modules/Sources/PointOfSale/Presentation/Item Selector/CouponCardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Selector/CouponCardView.swift
@@ -90,7 +90,7 @@ private extension CouponCardView {
                 .font(.caption)
                 .foregroundStyle(.secondary)
             CouponCardView(coupon: .init(
-                id: .init(),
+                id: .init(underlyingType: .coupon, itemID: 1),
                 code: "Coupon-123",
                 summary: "10% off - All Products"
             ))
@@ -101,7 +101,7 @@ private extension CouponCardView {
                 .font(.caption)
                 .foregroundStyle(.secondary)
             CouponCardView(coupon: .init(
-                id: .init(),
+                id: .init(underlyingType: .coupon, itemID: 2),
                 code: "Old-Coupon-123",
                 summary: "10% off - All Products",
                 dateExpires: Calendar.current.date(byAdding: .month, value: -1, to: Date())

--- a/Modules/Sources/PointOfSale/Presentation/Item Selector/ItemList.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Selector/ItemList.swift
@@ -68,6 +68,7 @@ struct ItemList<HeaderView: View>: View {
                     .frame(maxWidth: .infinity)
                     .padding(.horizontal, Constants.itemListPadding)
                     .padding(.bottom, keyboardObserver.isFullSizeKeyboardVisible ? Constants.itemListPadding : floatingControlAreaSize.height)
+                    .animation(.default, value: state?.items)
                 }
             )
 

--- a/Modules/Sources/PointOfSale/Presentation/Item Selector/POSItemActionHandler.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Selector/POSItemActionHandler.swift
@@ -58,7 +58,7 @@ extension POSItemActionHandler {
     func shouldSkipDuplicate(_ item: POSItem, posModel: PointOfSaleAggregateModelProtocol) -> Bool {
         switch item {
         case .coupon:
-            return posModel.cart.coupons.contains(where: { $0.id == item.id })
+            return posModel.cart.coupons.contains(where: { $0.posItemIdentifier == item.id })
         default:
             return false
         }

--- a/Modules/Sources/PointOfSale/Presentation/Item Selector/SimpleProductCardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Selector/SimpleProductCardView.swift
@@ -60,7 +60,7 @@ private extension SimpleProductCardView {
 
 #if DEBUG
 #Preview {
-    SimpleProductCardView(product: POSSimpleProduct(id: UUID(),
+    SimpleProductCardView(product: POSSimpleProduct(id: .init(underlyingType: .product, itemID: 123),
                                                     name: "Product name",
                                                     formattedPrice: "$3.00",
                                                     productID: 123,

--- a/Modules/Sources/PointOfSale/Presentation/Item Selector/VariationCardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Selector/VariationCardView.swift
@@ -48,7 +48,7 @@ private extension VariationCardView {
 }
 
 #Preview("Variation without image") {
-    let variation = POSVariation(id: .init(),
+    let variation = POSVariation(id: .init(underlyingType: .variation, itemID: 256),
                                  name: "500ml, double shot",
                                  formattedPrice: "$5.00",
                                  price: "5.00",
@@ -59,13 +59,13 @@ private extension VariationCardView {
 }
 
 #Preview("Variation with image") {
-    let variation = POSVariation(id: .init(),
+    let variation = POSVariation(id: .init(underlyingType: .variation, itemID: 257),
                                  name: "500ml, double shot",
                                  formattedPrice: "$5.00",
                                  price: "5.00",
                                  productImageSource: "https://pd.w.org/2024/12/986762d0d4d4cf17.82435881-scaled.jpeg",
                                  productID: 134,
-                                 variationID: 256,
+                                 variationID: 257,
                                  parentProductName: "Coffee")
     VariationCardView(variation: variation)
 }

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -48,11 +48,12 @@ import protocol Yosemite.POSItemFetchAnalyticsTracking
 import protocol Yosemite.POSOrderListFetchStrategyFactoryProtocol
 import protocol Yosemite.POSOrderListFetchStrategy
 import protocol Yosemite.PointOfSaleCouponFetchStrategyFactoryProtocol
+import struct Yosemite.POSItemIdentifier
 
 // MARK: - PreviewProvider helpers
 //
 struct POSProductPreview: POSOrderableItem, Equatable {
-    let id: UUID
+    let id: POSItemIdentifier
     let name: String
     let formattedPrice: String
     var productImageSource: String?
@@ -86,7 +87,7 @@ final class PointOfSalePreviewItemService: PointOfSaleItemServiceProtocol {
     }
 
     func providePointOfSaleItem() -> POSOrderableItem {
-        POSProductPreview(id: UUID(),
+        POSProductPreview(id: POSItemIdentifier(underlyingType: .product, itemID: 1),
                           name: "Product 1",
                           formattedPrice: "$1.00")
     }
@@ -168,7 +169,7 @@ private var mockItems: [POSItem] {
         mockSimpleProductItem(id: 3, price: "3.00"),
         .variableParentProduct(
             .init(
-                id: .init(),
+                id: POSItemIdentifier(underlyingType: .product, itemID: 5),
                 name: "Variable product 1",
                 productImageSource: nil,
                 productID: 5
@@ -179,7 +180,7 @@ private var mockItems: [POSItem] {
 }
 
 private func mockSimpleProductItem(id: Int, price: String) -> POSItem {
-    .simpleProduct(POSSimpleProduct(id: UUID(),
+    .simpleProduct(POSSimpleProduct(id: POSItemIdentifier(underlyingType: .product, itemID: Int64(id)),
                                     name: "Product \(id)",
                                     formattedPrice: "$\(price)",
                                     productID: Int64(id),
@@ -191,19 +192,19 @@ private func mockSimpleProductItem(id: Int, price: String) -> POSItem {
 
 private var mockVariationItems: [POSItem] {
     [
-        .variation(.init(id: UUID(),
+        .variation(.init(id: POSItemIdentifier(underlyingType: .variation, itemID: 256),
                          name: "Variation 1",
                          formattedPrice: "$1.00",
                          price: "1.00",
                          productID: 134,
                          variationID: 256,
                          parentProductName: "Variable product")),
-        .variation(.init(id: UUID(),
+        .variation(.init(id: POSItemIdentifier(underlyingType: .variation, itemID: 257),
                          name: "Variation 2",
                          formattedPrice: "$2.00",
                          price: "2.00",
                          productID: 134,
-                         variationID: 256,
+                         variationID: 257,
                          parentProductName: "Variable product")),
     ]
 }

--- a/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -5,6 +5,7 @@ import Foundation
 import Networking
 import WooFoundation
 import enum NetworkingCore.OrderStatusEnum
+import struct Networking.PagedItems
 import struct NetworkingCore.Address
 import struct NetworkingCore.MetaData
 import struct NetworkingCore.Order
@@ -54,6 +55,21 @@ extension Yosemite.JustInTimeMessage {
             badgeImageUrl: badgeImageUrl,
             badgeImageDarkUrl: badgeImageDarkUrl,
             template: template
+        )
+    }
+}
+
+extension Yosemite.POSItemIdentifier {
+    public func copy(
+        underlyingType: CopiableProp<POSItemIdentifier.UnderlyingType> = .copy,
+        itemID: CopiableProp<Int64> = .copy
+    ) -> Yosemite.POSItemIdentifier {
+        let underlyingType = underlyingType ?? self.underlyingType
+        let itemID = itemID ?? self.itemID
+
+        return Yosemite.POSItemIdentifier(
+            underlyingType: underlyingType,
+            itemID: itemID
         )
     }
 }

--- a/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -5,7 +5,6 @@ import Foundation
 import Networking
 import WooFoundation
 import enum NetworkingCore.OrderStatusEnum
-import struct Networking.PagedItems
 import struct NetworkingCore.Address
 import struct NetworkingCore.MetaData
 import struct NetworkingCore.Order

--- a/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -111,7 +111,7 @@ extension Yosemite.POSOrder {
 
 extension Yosemite.POSSimpleProduct {
     public func copy(
-        id: CopiableProp<UUID> = .copy,
+        id: CopiableProp<POSItemIdentifier> = .copy,
         name: CopiableProp<String> = .copy,
         formattedPrice: CopiableProp<String> = .copy,
         productImageSource: NullableCopiableProp<String> = .copy,

--- a/Modules/Sources/Yosemite/PointOfSale/Coupons/POSCoupon.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Coupons/POSCoupon.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 public struct POSCoupon: Equatable, Hashable {
-    public let id: UUID
+    public let id: POSItemIdentifier
     public let code: String
     public let summary: String
     public var dateExpires: Date?
 
-    public init(id: UUID, code: String, summary: String = "", dateExpires: Date? = nil) {
+    public init(id: POSItemIdentifier, code: String, summary: String = "", dateExpires: Date? = nil) {
         self.id = id
         self.code = code
         self.summary = summary

--- a/Modules/Sources/Yosemite/PointOfSale/Coupons/PointOfSaleCouponFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Coupons/PointOfSaleCouponFetchStrategy.swift
@@ -169,7 +169,7 @@ private struct CouponResultsControllerAdapter {
     private func mapCouponsToPOSItems(coupons: [Coupon]) -> [POSItem] {
         coupons.compactMap { coupon in
                 .coupon(POSCoupon(
-                    id: UUID(),
+                    id: POSItemIdentifier(underlyingType: .coupon, itemID: coupon.couponID),
                     code: coupon.code,
                     summary: coupon.summary(currencySettings: currencySettings),
                     dateExpires: coupon.dateExpires

--- a/Modules/Sources/Yosemite/PointOfSale/Items/POSItemIdentifier.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/POSItemIdentifier.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Codegen
+
+public struct POSItemIdentifier: Hashable, Sendable, GeneratedCopiable, GeneratedFakeable {
+    public let underlyingType: UnderlyingType
+    public let itemID: Int64
+
+    public init(underlyingType: UnderlyingType, itemID: Int64) {
+        self.underlyingType = underlyingType
+        self.itemID = itemID
+    }
+
+    public enum UnderlyingType: Sendable, GeneratedCopiable, GeneratedFakeable {
+        case product
+        case variation
+        case coupon
+        case loading
+        case error
+    }
+}

--- a/Modules/Sources/Yosemite/PointOfSale/Items/POSSimpleProduct.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/POSSimpleProduct.swift
@@ -5,7 +5,7 @@ import Networking
 
 public struct POSSimpleProduct: POSOrderableItem, OrderSyncProductTypeProtocol {
     // POSOrderableItem
-    public let id: UUID
+    public let id: POSItemIdentifier
     public let name: String
     public let formattedPrice: String
     public var productImageSource: String?
@@ -24,7 +24,7 @@ public struct POSSimpleProduct: POSOrderableItem, OrderSyncProductTypeProtocol {
         return ProductStockStatus(rawValue: stockStatusKey)
     }
 
-    public init(id: UUID,
+    public init(id: POSItemIdentifier,
                 name: String,
                 formattedPrice: String,
                 productImageSource: String? = nil,

--- a/Modules/Sources/Yosemite/PointOfSale/Items/POSVariableParentProduct.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/POSVariableParentProduct.swift
@@ -1,13 +1,16 @@
 import Foundation
 
 public struct POSVariableParentProduct: Equatable, Hashable, Identifiable {
-    public let id: UUID
+    public let id: POSItemIdentifier
     public let name: String
     public let productImageSource: String?
     public let productID: Int64
     let allAttributes: [ProductAttribute]
 
-    init(id: UUID, name: String, productImageSource: String?, productID: Int64, allAttributes: [ProductAttribute]) {
+    init(id: POSItemIdentifier,
+         name: String, productImageSource: String?,
+         productID: Int64,
+         allAttributes: [ProductAttribute]) {
         self.id = id
         self.name = name
         self.productImageSource = productImageSource
@@ -18,7 +21,7 @@ public struct POSVariableParentProduct: Equatable, Hashable, Identifiable {
     #if DEBUG
 
     /// Initializer for SwiftUI previews.
-    public init(id: UUID, name: String, productImageSource: String?, productID: Int64) {
+    public init(id: POSItemIdentifier, name: String, productImageSource: String?, productID: Int64) {
         self.init(id: id, name: name, productImageSource: productImageSource, productID: productID, allAttributes: [])
     }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Items/POSVariation.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/POSVariation.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Hashable, Identifiable {
     // Identifiable & POSOrderableItem
-    public let id: UUID
+    public let id: POSItemIdentifier
 
     // POSOrderableItem
     public let name: String
@@ -17,7 +17,7 @@ public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Ha
     // Variation specific
     public let parentProductName: String
 
-    public init(id: UUID,
+    public init(id: POSItemIdentifier,
                 name: String,
                 formattedPrice: String,
                 price: String,

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemMapper.swift
@@ -20,10 +20,11 @@ final class PointOfSaleItemMapper: PointOfSaleItemMapperProtocol {
     func mapProductsToPOSItems(products: [POSProduct]) -> [POSItem] {
         return products.compactMap { product in
             let thumbnailSource = product.images.first?.src
+            let id = POSItemIdentifier(underlyingType: .product, itemID: product.productID)
 
             switch product.productType {
                 case .simple:
-                    return .simpleProduct(POSSimpleProduct(id: UUID(),
+                return .simpleProduct(POSSimpleProduct(id: id,
                                                            name: product.name,
                                                            formattedPrice: formatPrice(product.price),
                                                            productImageSource: thumbnailSource,
@@ -34,7 +35,7 @@ final class PointOfSaleItemMapper: PointOfSaleItemMapperProtocol {
                                                            stockStatusKey: product.stockStatusKey))
                 case .variable:
                     return .variableParentProduct(POSVariableParentProduct(
-                        id: UUID(),
+                        id: id,
                         name: product.name,
                         productImageSource: thumbnailSource,
                         productID: product.productID,
@@ -48,13 +49,14 @@ final class PointOfSaleItemMapper: PointOfSaleItemMapperProtocol {
 
     func mapVariationsToPOSItems(variations: [POSProductVariation], parentProduct: POSVariableParentProduct) -> [POSItem] {
         return variations.compactMap { variation in
+            let id = POSItemIdentifier(underlyingType: .variation, itemID: variation.productVariationID)
             let variationName = ProductVariationFormatter().generateNameWithAttributeNames(
                 for: variation,
                 from: parentProduct.allAttributes,
                 separator: ", "
             )
             return POSItem
-                .variation(.init(id: UUID(),
+                .variation(.init(id: id,
                                  name: variationName,
                                  formattedPrice: formatPrice(variation.price),
                                  price: variation.price,

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemServiceProtocol.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemServiceProtocol.swift
@@ -1,5 +1,6 @@
 import Foundation
 import struct Networking.PagedItems
+import Codegen
 
 public enum POSItem: Equatable, Identifiable, Hashable {
     case simpleProduct(POSSimpleProduct)
@@ -21,7 +22,7 @@ public enum POSItem: Equatable, Identifiable, Hashable {
     }
 }
 
-public struct POSItemIdentifier: Hashable, Sendable {
+public struct POSItemIdentifier: Hashable, Sendable, GeneratedCopiable, GeneratedFakeable {
     public let underlyingType: UnderlyingType
     public let itemID: Int64
 
@@ -30,7 +31,7 @@ public struct POSItemIdentifier: Hashable, Sendable {
         self.itemID = itemID
     }
 
-    public enum UnderlyingType: Sendable {
+    public enum UnderlyingType: Sendable, GeneratedCopiable, GeneratedFakeable {
         case product
         case variation
         case coupon

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemServiceProtocol.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemServiceProtocol.swift
@@ -1,5 +1,5 @@
 import Foundation
-import struct Networking.PagedItems
+import Networking
 import Codegen
 
 public enum POSItem: Equatable, Identifiable, Hashable {

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemServiceProtocol.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemServiceProtocol.swift
@@ -35,6 +35,7 @@ public struct POSItemIdentifier: Hashable, Sendable {
         case variation
         case coupon
         case loading
+        case error
     }
 }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemServiceProtocol.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemServiceProtocol.swift
@@ -1,6 +1,5 @@
 import Foundation
-import Networking
-import Codegen
+import struct Networking.PagedItems
 
 public enum POSItem: Equatable, Identifiable, Hashable {
     case simpleProduct(POSSimpleProduct)
@@ -19,24 +18,6 @@ public enum POSItem: Equatable, Identifiable, Hashable {
         case .coupon(let coupon):
             return coupon.id
         }
-    }
-}
-
-public struct POSItemIdentifier: Hashable, Sendable, GeneratedCopiable, GeneratedFakeable {
-    public let underlyingType: UnderlyingType
-    public let itemID: Int64
-
-    public init(underlyingType: UnderlyingType, itemID: Int64) {
-        self.underlyingType = underlyingType
-        self.itemID = itemID
-    }
-
-    public enum UnderlyingType: Sendable, GeneratedCopiable, GeneratedFakeable {
-        case product
-        case variation
-        case coupon
-        case loading
-        case error
     }
 }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemServiceProtocol.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemServiceProtocol.swift
@@ -7,7 +7,7 @@ public enum POSItem: Equatable, Identifiable, Hashable {
     case variation(POSVariation)
     case coupon(POSCoupon)
 
-    public var id: UUID {
+    public var id: POSItemIdentifier {
         switch self {
         case .simpleProduct(let product):
             return product.id
@@ -21,12 +21,29 @@ public enum POSItem: Equatable, Identifiable, Hashable {
     }
 }
 
+public struct POSItemIdentifier: Hashable, Sendable {
+    public let underlyingType: UnderlyingType
+    public let itemID: Int64
+
+    public init(underlyingType: UnderlyingType, itemID: Int64) {
+        self.underlyingType = underlyingType
+        self.itemID = itemID
+    }
+
+    public enum UnderlyingType: Sendable {
+        case product
+        case variation
+        case coupon
+        case loading
+    }
+}
+
 /// POSOrderableItem extends a displayable item with the functions required for using it in an order.
 /// This currently includes adding it, and checking whether it's already in an order.
 /// This may need to become less specific in future, e.g. we currently convert it to a product input, but
 /// other order items might be added as fees or similar. at that point, we will need a different function requirement here.
 public protocol POSOrderableItem {
-    var id: UUID { get }
+    var id: POSItemIdentifier { get }
     var name: String { get }
     var productImageSource: String? { get }
     var formattedPrice: String { get }

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleItemsControllerTests.swift
@@ -3,6 +3,7 @@ import Foundation
 @testable import PointOfSale
 import struct Yosemite.POSVariableParentProduct
 import enum Yosemite.POSItem
+import struct Yosemite.POSItemIdentifier
 import enum Yosemite.PointOfSaleItemServiceError
 import class Yosemite.PointOfSaleItemFetchStrategyFactory
 @testable import struct Yosemite.PointOfSaleSearchPurchasableItemFetchStrategy

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleItemsControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleItemsControllerTests.swift
@@ -236,7 +236,7 @@ final class PointOfSaleItemsControllerTests {
             analyticsProvider: MockPOSAnalytics()
         )
 
-        let parentItem = POSItem.variableParentProduct(POSVariableParentProduct(id: UUID(),
+        let parentItem = POSItem.variableParentProduct(POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1),
                                                                                 name: "Fake Parent",
                                                                                 productImageSource: nil,
                                                                                 productID: 12345))
@@ -268,7 +268,7 @@ final class PointOfSaleItemsControllerTests {
             analyticsProvider: MockPOSAnalytics()
         )
 
-        let parentItem = POSItem.variableParentProduct(POSVariableParentProduct(id: UUID(),
+        let parentItem = POSItem.variableParentProduct(POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1),
                                                                                 name: "Fake Parent",
                                                                                 productImageSource: nil,
                                                                                 productID: 12345))
@@ -496,7 +496,7 @@ final class PointOfSaleItemsControllerTests {
             analyticsProvider: MockPOSAnalytics()
         )
 
-        let parentItem = POSItem.variableParentProduct(POSVariableParentProduct(id: UUID(),
+        let parentItem = POSItem.variableParentProduct(POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1),
                                                                                 name: "Parent product",
                                                                                 productImageSource: nil,
                                                                                 productID: 125))
@@ -522,7 +522,7 @@ final class PointOfSaleItemsControllerTests {
             analyticsProvider: MockPOSAnalytics()
         )
 
-        let parentItem = POSItem.variableParentProduct(POSVariableParentProduct(id: UUID(),
+        let parentItem = POSItem.variableParentProduct(POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1),
                                                                                 name: "Parent product",
                                                                                 productImageSource: nil,
                                                                                 productID: 125))

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleObservableItemsControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleObservableItemsControllerTests.swift
@@ -118,7 +118,7 @@ final class PointOfSaleObservableItemsControllerTests {
         let sut = PointOfSaleObservableItemsController(siteID: 123, dataSource: dataSource, catalogSyncCoordinator: coordinator)
 
         let parentProduct = POSVariableParentProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
             name: "Parent",
             productImageSource: nil,
             productID: 100,
@@ -145,7 +145,7 @@ final class PointOfSaleObservableItemsControllerTests {
         let sut = PointOfSaleObservableItemsController(siteID: 123, dataSource: dataSource, catalogSyncCoordinator: coordinator)
 
         let parentProduct = POSVariableParentProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
             name: "Parent",
             productImageSource: nil,
             productID: 100,
@@ -179,7 +179,7 @@ final class PointOfSaleObservableItemsControllerTests {
         let mockVariations = [makeVariation()]
 
         let parentProduct = POSVariableParentProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
             name: "Parent",
             productImageSource: nil,
             productID: 100,
@@ -253,10 +253,10 @@ final class PointOfSaleObservableItemsControllerTests {
         let coordinator = MockPOSCatalogSyncCoordinator()
         let sut = PointOfSaleObservableItemsController(siteID: 123, dataSource: dataSource, catalogSyncCoordinator: coordinator)
 
-        let parent1 = POSVariableParentProduct(id: UUID(), name: "Parent 1", productImageSource: nil, productID: 100, allAttributes: [])
+        let parent1 = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1), name: "Parent 1", productImageSource: nil, productID: 100, allAttributes: [])
         let parentItem1 = POSItem.variableParentProduct(parent1)
 
-        let parent2 = POSVariableParentProduct(id: UUID(), name: "Parent 2", productImageSource: nil, productID: 200, allAttributes: [])
+        let parent2 = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1), name: "Parent 2", productImageSource: nil, productID: 200, allAttributes: [])
         let parentItem2 = POSItem.variableParentProduct(parent2)
 
         // When: Load parent 1 variations
@@ -393,7 +393,7 @@ final class PointOfSaleObservableItemsControllerTests {
         let sut = PointOfSaleObservableItemsController(siteID: 123, dataSource: dataSource, catalogSyncCoordinator: coordinator)
 
         let parentProduct = POSVariableParentProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
             name: "Parent",
             productImageSource: nil,
             productID: 100,
@@ -640,7 +640,7 @@ final class PointOfSaleObservableItemsControllerTests {
         let sut = PointOfSaleObservableItemsController(siteID: siteID, dataSource: dataSource, catalogSyncCoordinator: coordinator)
 
         let parentProduct = POSVariableParentProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
             name: "Parent",
             productImageSource: nil,
             productID: 100,

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleObservableItemsControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleObservableItemsControllerTests.swift
@@ -7,9 +7,9 @@ final class PointOfSaleObservableItemsControllerTests {
 
     // MARK: - Test Helpers
 
-    private func makeSimpleProduct(id: UUID = UUID(), name: String = "Test Product", productID: Int64 = 1) -> POSItem {
+    private func makeSimpleProduct(id: POSItemIdentifier? = nil, name: String = "Test Product", productID: Int64 = 1) -> POSItem {
         .simpleProduct(POSSimpleProduct(
-            id: id,
+            id: id ?? POSItemIdentifier(underlyingType: .product, itemID: productID),
             name: name,
             formattedPrice: "$2.00",
             productID: productID,
@@ -20,9 +20,9 @@ final class PointOfSaleObservableItemsControllerTests {
         ))
     }
 
-    private func makeVariation(id: UUID = UUID(), name: String = "Test Variation", variationID: Int64 = 1) -> POSItem {
+    private func makeVariation(id: POSItemIdentifier? = nil, name: String = "Test Variation", variationID: Int64 = 1) -> POSItem {
         .variation(POSVariation(
-            id: id,
+            id: id ?? POSItemIdentifier(underlyingType: .variation, itemID: variationID),
             name: name,
             formattedPrice: "$2.00",
             price: "2.00",

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleObservableItemsControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleObservableItemsControllerTests.swift
@@ -253,10 +253,22 @@ final class PointOfSaleObservableItemsControllerTests {
         let coordinator = MockPOSCatalogSyncCoordinator()
         let sut = PointOfSaleObservableItemsController(siteID: 123, dataSource: dataSource, catalogSyncCoordinator: coordinator)
 
-        let parent1 = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1), name: "Parent 1", productImageSource: nil, productID: 100, allAttributes: [])
+        let parent1 = POSVariableParentProduct(
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+            name: "Parent 1",
+            productImageSource: nil,
+            productID: 100,
+            allAttributes: []
+        )
         let parentItem1 = POSItem.variableParentProduct(parent1)
 
-        let parent2 = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1), name: "Parent 2", productImageSource: nil, productID: 200, allAttributes: [])
+        let parent2 = POSVariableParentProduct(
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+            name: "Parent 2",
+            productImageSource: nil,
+            productID: 200,
+            allAttributes: []
+        )
         let parentItem2 = POSItem.variableParentProduct(parent2)
 
         // When: Load parent 1 variations

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
@@ -430,12 +430,12 @@ struct PointOfSaleOrderControllerTests {
         mockOrderService.orderToReturn = fakeOrder
 
         // Initial sync to set up the order
-        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: UUID(), code: couponCode, summary: "")]), retryHandler: {})
+        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: couponCode, summary: "")]), retryHandler: {})
 
         mockOrderService.syncOrderWasCalled = false
 
         // When - sync with same items and coupons
-        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: UUID(), code: couponCode, summary: "")]), retryHandler: {})
+        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: couponCode, summary: "")]), retryHandler: {})
 
         // Then
         #expect(mockOrderService.syncOrderWasCalled == false)
@@ -455,12 +455,12 @@ struct PointOfSaleOrderControllerTests {
         mockOrderService.orderToReturn = fakeOrder
 
         // Initial sync
-        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: UUID(), code: initialCouponCode, summary: "")]), retryHandler: {})
+        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: initialCouponCode, summary: "")]), retryHandler: {})
 
         mockOrderService.syncOrderWasCalled = false
 
         // When - sync with same items but different coupon
-        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: UUID(), code: "DIFFERENT20", summary: "")]), retryHandler: {})
+        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "DIFFERENT20", summary: "")]), retryHandler: {})
 
         // Then
         #expect(mockOrderService.syncOrderWasCalled == true)
@@ -480,7 +480,7 @@ struct PointOfSaleOrderControllerTests {
         mockOrderService.orderToReturn = fakeOrder
 
         // Initial sync with coupon
-        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: UUID(), code: couponCode, summary: "")]), retryHandler: {})
+        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: couponCode, summary: "")]), retryHandler: {})
 
         mockOrderService.syncOrderWasCalled = false
 
@@ -518,7 +518,7 @@ struct PointOfSaleOrderControllerTests {
 
             // When
             await sut.syncOrder(for: Cart(purchasableItems: [makeItem()],
-                                           coupons: [.init(id: UUID(), code: "INVALID", summary: "")]),
+                                           coupons: [.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "INVALID", summary: "")]),
                                 retryHandler: {})
         }
 
@@ -566,7 +566,7 @@ struct PointOfSaleOrderControllerTests {
 
             // When
             await sut.syncOrder(for: Cart(purchasableItems: [makeItem()],
-                                           coupons: [.init(id: UUID(), code: "INVALID", summary: "")]),
+                                           coupons: [.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "INVALID", summary: "")]),
                                 retryHandler: {})
         }
 
@@ -700,7 +700,7 @@ private func makeItem(name: String = "",
                       formattedPrice: String = "",
                       quantity: Int = 1,
                       orderItemsToMatch: [OrderItem] = []) -> Cart.PurchasableItem {
-    return .init(id: UUID(),
+    return .init(id: POSItemIdentifier(underlyingType: .product, itemID: 1),
                  item: MockPOSOrderableItem(name: name,
                                             formattedPrice: formattedPrice,
                                             orderItemsToMatch: orderItemsToMatch),

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
@@ -13,6 +13,7 @@ import class WooFoundation.CurrencySettings
 import protocol WooFoundation.Analytics
 import enum Networking.DotcomError
 import enum Networking.NetworkError
+import struct Yosemite.POSItemIdentifier
 
 struct PointOfSaleOrderControllerTests {
     let mockOrderService = MockPOSOrderService()

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
@@ -431,12 +431,24 @@ struct PointOfSaleOrderControllerTests {
         mockOrderService.orderToReturn = fakeOrder
 
         // Initial sync to set up the order
-        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: couponCode, summary: "")]), retryHandler: {})
+        await sut.syncOrder(
+            for: Cart(
+                purchasableItems: [cartItem],
+                coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: couponCode, summary: "")]
+            ),
+            retryHandler: {}
+        )
 
         mockOrderService.syncOrderWasCalled = false
 
         // When - sync with same items and coupons
-        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: couponCode, summary: "")]), retryHandler: {})
+        await sut.syncOrder(
+            for: Cart(
+                purchasableItems: [cartItem],
+                coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: couponCode, summary: "")]
+            ),
+            retryHandler: {}
+        )
 
         // Then
         #expect(mockOrderService.syncOrderWasCalled == false)
@@ -456,12 +468,24 @@ struct PointOfSaleOrderControllerTests {
         mockOrderService.orderToReturn = fakeOrder
 
         // Initial sync
-        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: initialCouponCode, summary: "")]), retryHandler: {})
+        await sut.syncOrder(
+            for: Cart(
+                purchasableItems: [cartItem],
+                coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: initialCouponCode, summary: "")]
+            ),
+            retryHandler: {}
+        )
 
         mockOrderService.syncOrderWasCalled = false
 
         // When - sync with same items but different coupon
-        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 2), code: "DIFFERENT20", summary: "")]), retryHandler: {})
+        await sut.syncOrder(
+            for: Cart(
+                purchasableItems: [cartItem],
+                coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 2), code: "DIFFERENT20", summary: "")]
+            ),
+            retryHandler: {}
+        )
 
         // Then
         #expect(mockOrderService.syncOrderWasCalled == true)
@@ -481,7 +505,13 @@ struct PointOfSaleOrderControllerTests {
         mockOrderService.orderToReturn = fakeOrder
 
         // Initial sync with coupon
-        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: couponCode, summary: "")]), retryHandler: {})
+        await sut.syncOrder(
+            for: Cart(
+                purchasableItems: [cartItem],
+                coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: couponCode, summary: "")]
+            ),
+            retryHandler: {}
+        )
 
         mockOrderService.syncOrderWasCalled = false
 
@@ -518,9 +548,13 @@ struct PointOfSaleOrderControllerTests {
             observeOrderState()
 
             // When
-            await sut.syncOrder(for: Cart(purchasableItems: [makeItem()],
-                                           coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "INVALID", summary: "")]),
-                                retryHandler: {})
+            await sut.syncOrder(
+                for: Cart(
+                    purchasableItems: [makeItem()],
+                    coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "INVALID", summary: "")]
+                ),
+                retryHandler: {}
+            )
         }
 
         await orderStateAppendTask?.value
@@ -566,9 +600,13 @@ struct PointOfSaleOrderControllerTests {
             observeOrderState()
 
             // When
-            await sut.syncOrder(for: Cart(purchasableItems: [makeItem()],
-                                           coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "INVALID", summary: "")]),
-                                retryHandler: {})
+            await sut.syncOrder(
+                for: Cart(
+                    purchasableItems: [makeItem()],
+                    coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "INVALID", summary: "")]
+                ),
+                retryHandler: {}
+            )
         }
 
         await orderStateAppendTask?.value

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
@@ -431,12 +431,12 @@ struct PointOfSaleOrderControllerTests {
         mockOrderService.orderToReturn = fakeOrder
 
         // Initial sync to set up the order
-        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: couponCode, summary: "")]), retryHandler: {})
+        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: couponCode, summary: "")]), retryHandler: {})
 
         mockOrderService.syncOrderWasCalled = false
 
         // When - sync with same items and coupons
-        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: couponCode, summary: "")]), retryHandler: {})
+        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: couponCode, summary: "")]), retryHandler: {})
 
         // Then
         #expect(mockOrderService.syncOrderWasCalled == false)
@@ -456,12 +456,12 @@ struct PointOfSaleOrderControllerTests {
         mockOrderService.orderToReturn = fakeOrder
 
         // Initial sync
-        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: initialCouponCode, summary: "")]), retryHandler: {})
+        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: initialCouponCode, summary: "")]), retryHandler: {})
 
         mockOrderService.syncOrderWasCalled = false
 
         // When - sync with same items but different coupon
-        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "DIFFERENT20", summary: "")]), retryHandler: {})
+        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 2), code: "DIFFERENT20", summary: "")]), retryHandler: {})
 
         // Then
         #expect(mockOrderService.syncOrderWasCalled == true)
@@ -481,7 +481,7 @@ struct PointOfSaleOrderControllerTests {
         mockOrderService.orderToReturn = fakeOrder
 
         // Initial sync with coupon
-        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: couponCode, summary: "")]), retryHandler: {})
+        await sut.syncOrder(for: Cart(purchasableItems: [cartItem], coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: couponCode, summary: "")]), retryHandler: {})
 
         mockOrderService.syncOrderWasCalled = false
 
@@ -519,7 +519,7 @@ struct PointOfSaleOrderControllerTests {
 
             // When
             await sut.syncOrder(for: Cart(purchasableItems: [makeItem()],
-                                           coupons: [.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "INVALID", summary: "")]),
+                                           coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "INVALID", summary: "")]),
                                 retryHandler: {})
         }
 
@@ -567,7 +567,7 @@ struct PointOfSaleOrderControllerTests {
 
             // When
             await sut.syncOrder(for: Cart(purchasableItems: [makeItem()],
-                                           coupons: [.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "INVALID", summary: "")]),
+                                           coupons: [.init(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "INVALID", summary: "")]),
                                 retryHandler: {})
         }
 
@@ -701,7 +701,7 @@ private func makeItem(name: String = "",
                       formattedPrice: String = "",
                       quantity: Int = 1,
                       orderItemsToMatch: [OrderItem] = []) -> Cart.PurchasableItem {
-    return .init(id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+    return .init(id: UUID(),
                  item: MockPOSOrderableItem(name: name,
                                             formattedPrice: formattedPrice,
                                             orderItemsToMatch: orderItemsToMatch),

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSItemProvider.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSItemProvider.swift
@@ -50,10 +50,7 @@ final class MockPointOfSaleItemService: PointOfSaleItemServiceProtocol {
 
 extension MockPointOfSaleItemService {
     static func makeInitialItems() -> [POSItem] {
-        let fakeUUID1 = UUID(uuidString: "DC55E3B9-9D83-4C07-82A7-4C300A50E84E") ?? UUID()
-        let fakeUUID2 = UUID(uuidString: "DC55E3B8-9D82-4C06-82A5-4C300A50E84A") ?? UUID()
-
-        let product1 = POSSimpleProduct(id: fakeUUID1,
+        let product1 = POSSimpleProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1),
                                         name: "Choco",
                                         formattedPrice: "$2.00",
                                         productID: 1,
@@ -62,11 +59,11 @@ extension MockPointOfSaleItemService {
                                         stockQuantity: nil,
                                         stockStatusKey: "")
 
-        let product2 = POSSimpleProduct(id: fakeUUID2,
+        let product2 = POSSimpleProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 2),
                                         name: "Vanilla",
                                         formattedPrice: "$3.00",
-                                        productID: 1,
-                                        price: "2.00",
+                                        productID: 2,
+                                        price: "3.00",
                                         manageStock: false,
                                         stockQuantity: nil,
                                         stockStatusKey: "")
@@ -74,23 +71,20 @@ extension MockPointOfSaleItemService {
     }
 
     static func makeSecondPageItems() -> [POSItem] {
-        let fakeUUID3 = UUID(uuidString: "DC55E3B9-9D83-4C07-82A7-4C300A50E86D") ?? UUID()
-        let fakeUUID4 = UUID(uuidString: "DC55E3B8-9D82-4C06-82A5-4C300A50E86F") ?? UUID()
-
-        let product3 = POSSimpleProduct(id: fakeUUID3,
+        let product3 = POSSimpleProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 3),
                                         name: "Strawberry",
                                         formattedPrice: "$2.00",
-                                        productID: 1,
+                                        productID: 3,
                                         price: "2.00",
                                         manageStock: false,
                                         stockQuantity: nil,
                                         stockStatusKey: "")
 
-        let product4 = POSSimpleProduct(id: fakeUUID4,
+        let product4 = POSSimpleProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 4),
                                         name: "Pistachio",
                                         formattedPrice: "$3.00",
-                                        productID: 1,
-                                        price: "2.00",
+                                        productID: 4,
+                                        price: "3.00",
                                         manageStock: false,
                                         stockQuantity: nil,
                                         stockStatusKey: "")
@@ -98,10 +92,7 @@ extension MockPointOfSaleItemService {
     }
 
     static func makeInitialVariationItems() -> [POSItem] {
-        let fakeUUID1 = UUID(uuidString: "B04AF636-CF6C-11EF-A45C-FA719FB6C0F0") ?? UUID()
-        let fakeUUID2 = UUID(uuidString: "B04AF727-CF6C-11EF-A45C-FA719FB6C0F0") ?? UUID()
-
-        let variation1 = POSVariation(id: fakeUUID1,
+        let variation1 = POSVariation(id: POSItemIdentifier(underlyingType: .variation, itemID: 1),
                                       name: "Choco",
                                       formattedPrice: "$2.00",
                                       price: "2.00",
@@ -109,7 +100,7 @@ extension MockPointOfSaleItemService {
                                       variationID: 1,
                                       parentProductName: "Ice cream")
 
-        let variation2 = POSVariation(id: fakeUUID2,
+        let variation2 = POSVariation(id: POSItemIdentifier(underlyingType: .variation, itemID: 2),
                                       name: "Vanilla",
                                       formattedPrice: "$2.00",
                                       price: "2.00",
@@ -120,10 +111,7 @@ extension MockPointOfSaleItemService {
     }
 
     static func makeSecondPageVariationItems() -> [POSItem] {
-        let fakeUUID3 = UUID(uuidString: "B04AF758-CF6C-11EF-A45C-FA719FB6C0F0") ?? UUID()
-        let fakeUUID4 = UUID(uuidString: "B04AF78A-CF6C-11EF-A45C-FA719FB6C0F0") ?? UUID()
-
-        let variation3 = POSVariation(id: fakeUUID3,
+        let variation3 = POSVariation(id: POSItemIdentifier(underlyingType: .variation, itemID: 3),
                                       name: "Strawberry",
                                       formattedPrice: "$2.00",
                                       price: "2.00",
@@ -131,10 +119,10 @@ extension MockPointOfSaleItemService {
                                       variationID: 3,
                                       parentProductName: "Ice cream")
 
-        let variation4 = POSVariation(id: fakeUUID4,
+        let variation4 = POSVariation(id: POSItemIdentifier(underlyingType: .variation, itemID: 4),
                                       name: "Pistachio",
                                       formattedPrice: "$3.00",
-                                      price: "2.00",
+                                      price: "3.00",
                                       productID: 1,
                                       variationID: 4,
                                       parentProductName: "Ice cream")

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderableItem.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderableItem.swift
@@ -3,12 +3,12 @@ import Foundation
 
 final class MockPOSOrderableItem: POSOrderableItem, Equatable {
     var name: String
-    var id: UUID
+    var id: POSItemIdentifier
     var formattedPrice: String
     var productImageSource: String?
 
     init(name: String,
-         id: UUID = UUID(),
+         id: POSItemIdentifier = POSItemIdentifier(underlyingType: .product, itemID: 1),
          formattedPrice: String,
          productImageSource: String? = nil,
          orderItemsToMatch: [OrderItem] = [],

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleBarcodeScanService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleBarcodeScanService.swift
@@ -10,7 +10,7 @@ class MockPointOfSaleBarcodeScanService: PointOfSaleBarcodeScanServiceProtocol {
         }
 
         return .simpleProduct(POSSimpleProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
             name: "Scanned Item",
             formattedPrice: "$10.00",
             productID: 1,

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleCouponService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleCouponService.swift
@@ -3,6 +3,7 @@ import protocol Yosemite.PointOfSaleItemServiceProtocol
 import protocol Yosemite.PointOfSaleCouponServiceProtocol
 import enum Yosemite.POSItem
 import struct Yosemite.POSCoupon
+import struct Yosemite.POSItemIdentifier
 import struct Yosemite.PagedItems
 import struct Yosemite.POSVariableParentProduct
 import enum Yosemite.PointOfSaleCouponServiceError
@@ -34,16 +35,16 @@ final class MockPointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
     }
 
     static func makeInitialCoupons() -> [POSItem] {
-        let coupon1 = POSItem.coupon(POSCoupon(id: UUID(uuidString: ("DC55E3B9-9D83-4C07-82A7-4C300A50E84A")) ?? UUID(), code: "VALID1"))
-        let coupon2 = POSItem.coupon(POSCoupon(id: UUID(uuidString: ("DC55E3B9-9D83-4C07-82A7-4C300A50E84B")) ?? UUID(), code: "VALID2"))
-        let coupon3 = POSItem.coupon(POSCoupon(id: UUID(uuidString: ("DC55E3B9-9D83-4C07-82A7-4C300A50E84C")) ?? UUID(), code: "VALID3"))
+        let coupon1 = POSItem.coupon(POSCoupon(id: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "VALID1"))
+        let coupon2 = POSItem.coupon(POSCoupon(id: POSItemIdentifier(underlyingType: .coupon, itemID: 2), code: "VALID2"))
+        let coupon3 = POSItem.coupon(POSCoupon(id: POSItemIdentifier(underlyingType: .coupon, itemID: 3), code: "VALID3"))
         return [coupon1, coupon2, coupon3]
     }
 
     static func makeSecondPageCoupons() -> [POSItem] {
-        let coupon4 = POSItem.coupon(POSCoupon(id: UUID(uuidString: ("DC55E3B9-9D83-4C07-82A7-4C300A50E84D")) ?? UUID(), code: "VALID4"))
-        let coupon5 = POSItem.coupon(POSCoupon(id: UUID(uuidString: ("DC55E3B9-9D83-4C07-82A7-4C300A50E84E")) ?? UUID(), code: "VALID5"))
-        let coupon6 = POSItem.coupon(POSCoupon(id: UUID(uuidString: ("DC55E3B9-9D83-4C07-82A7-4C300A50E84F")) ?? UUID(), code: "VALID6"))
+        let coupon4 = POSItem.coupon(POSCoupon(id: POSItemIdentifier(underlyingType: .coupon, itemID: 4), code: "VALID4"))
+        let coupon5 = POSItem.coupon(POSCoupon(id: POSItemIdentifier(underlyingType: .coupon, itemID: 5), code: "VALID5"))
+        let coupon6 = POSItem.coupon(POSCoupon(id: POSItemIdentifier(underlyingType: .coupon, itemID: 6), code: "VALID6"))
         return [coupon4, coupon5, coupon6]
     }
 

--- a/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
@@ -5,6 +5,7 @@ import protocol WooFoundation.Analytics
 import protocol Yosemite.PointOfSaleBarcodeScanServiceProtocol
 import protocol Yosemite.POSOrderableItem
 import enum Yosemite.POSItem
+import struct Yosemite.POSItemIdentifier
 @testable import struct Yosemite.POSSimpleProduct
 import struct Yosemite.Order
 import protocol Yosemite.POSSearchHistoryProviding

--- a/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
@@ -996,7 +996,7 @@ struct PointOfSaleAggregateModelTests {
 
 private func makePurchasableItem(name: String = "") -> POSItem {
     return .simpleProduct(POSSimpleProduct(
-        id: UUID(),
+        id: POSItemIdentifier(underlyingType: .product, itemID: 1),
         name: name,
         formattedPrice: "",
         productID: 1,
@@ -1007,7 +1007,7 @@ private func makePurchasableItem(name: String = "") -> POSItem {
 }
 
 private func makeCouponItem(code: String = "") -> POSItem {
-    return .coupon(.init(id: UUID(), code: code))
+    return .coupon(.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: code))
 }
 
 private func makeLoadedOrderState(cartTotal: String = "",

--- a/Modules/Tests/PointOfSaleTests/Presentation/POSItemActionHandlerFactoryTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Presentation/POSItemActionHandlerFactoryTests.swift
@@ -3,6 +3,7 @@ import Foundation
 @testable import PointOfSale
 import WooFoundation
 import enum Yosemite.POSItem
+import struct Yosemite.POSItemIdentifier
 
 private enum AnalyticsKeys {
     static let source = "source"

--- a/Modules/Tests/PointOfSaleTests/Presentation/POSItemActionHandlerFactoryTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Presentation/POSItemActionHandlerFactoryTests.swift
@@ -169,12 +169,12 @@ private func makeProductItem() -> POSItem {
 }
 
 private func makeCouponItem() -> POSItem {
-    return .coupon(.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "DISCOUNT!"))
+    return .coupon(.init(id: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "DISCOUNT!"))
 }
 
 private func makeVariationItem() -> POSItem {
     return .variation(.init(
-        id: .init(),
+        id: POSItemIdentifier(underlyingType: .variation, itemID: 1),
         name: "Test",
         formattedPrice: "$2.00",
         price: "2",

--- a/Modules/Tests/PointOfSaleTests/Presentation/POSItemActionHandlerFactoryTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Presentation/POSItemActionHandlerFactoryTests.swift
@@ -158,7 +158,7 @@ struct POSItemActionHandlerFactoryTests {
 }
 
 private func makeProductItem() -> POSItem {
-    return .simpleProduct(.init(id: UUID(),
+    return .simpleProduct(.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1),
                                 name: "Test",
                                 formattedPrice: "$1.00",
                                 productID: 1,
@@ -169,7 +169,7 @@ private func makeProductItem() -> POSItem {
 }
 
 private func makeCouponItem() -> POSItem {
-    return .coupon(.init(id: UUID(), code: "DISCOUNT!"))
+    return .coupon(.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "DISCOUNT!"))
 }
 
 private func makeVariationItem() -> POSItem {

--- a/Modules/Tests/PointOfSaleTests/Presentation/POSItemActionHandlerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Presentation/POSItemActionHandlerTests.swift
@@ -83,11 +83,11 @@ struct POSItemActionHandlerTests {
 }
 
 private func makeCouponItem(code: String = "") -> POSItem {
-    return .coupon(.init(id: UUID(), code: code))
+    return .coupon(.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: code))
 }
 
 private func makeProductItem() -> POSItem {
-    return .simpleProduct(.init(id: UUID(),
+    return .simpleProduct(.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1),
                                 name: "some product name",
                                 formattedPrice: "$10.00",
                                 productID: 123,

--- a/Modules/Tests/PointOfSaleTests/Presentation/POSItemActionHandlerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Presentation/POSItemActionHandlerTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 import enum Yosemite.POSItem
 import enum Yosemite.POSItemType
+import struct Yosemite.POSItemIdentifier
 import protocol Yosemite.PointOfSaleBarcodeScanServiceProtocol
 import protocol Yosemite.POSSearchHistoryProviding
 @testable import PointOfSale

--- a/Modules/Tests/PointOfSaleTests/ViewHelpers/CartViewHelperTests.swift
+++ b/Modules/Tests/PointOfSaleTests/ViewHelpers/CartViewHelperTests.swift
@@ -114,7 +114,7 @@ struct CartViewHelperTests {
 
     @Test func couponRowState_building_stage_returns_idle() async throws {
         // Given
-        let coupon = Cart.CouponItem(id: UUID(), code: "TEST10", summary: "")
+        let coupon = Cart.CouponItem(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "TEST10", summary: "")
         let orderState = PointOfSaleOrderState.loaded(PointOfSaleOrderTotals(
             cartTotal: "$10.00",
             orderTotal: "$12.00",
@@ -129,7 +129,7 @@ struct CartViewHelperTests {
 
     @Test func couponRowState_finalizing_and_syncing_returns_validating() async throws {
         // Given
-        let coupon = Cart.CouponItem(id: UUID(), code: "TEST10", summary: "")
+        let coupon = Cart.CouponItem(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "TEST10", summary: "")
 
         // When, Then
         #expect(sut.couponRowState(orderStage: .finalizing,
@@ -140,7 +140,7 @@ struct CartViewHelperTests {
     @Test func couponRowState_finalizing_and_loaded_with_matching_coupon_returns_valid() async throws {
         // Given
         let couponCode = "TEST10"
-        let coupon = Cart.CouponItem(id: UUID(), code: couponCode, summary: "")
+        let coupon = Cart.CouponItem(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: couponCode, summary: "")
         let couponTotal = PointOfSaleCouponTotal(code: couponCode, total: "10.00")
         let orderTotals = PointOfSaleOrderTotals(
             cartTotal: "$10.00",
@@ -157,7 +157,7 @@ struct CartViewHelperTests {
 
     @Test func couponRowState_finalizing_and_loaded_with_no_matching_coupon_returns_idle() async throws {
         // Given
-        let coupon = Cart.CouponItem(id: UUID(), code: "TEST10", summary: "")
+        let coupon = Cart.CouponItem(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "TEST10", summary: "")
         let orderTotals = PointOfSaleOrderTotals(
             cartTotal: "$10.00",
             orderTotal: "$12.00",
@@ -173,7 +173,7 @@ struct CartViewHelperTests {
 
     @Test func couponRowState_finalizing_and_invalid_coupon_error_returns_invalid() async throws {
         // Given
-        let coupon = Cart.CouponItem(id: UUID(), code: "TEST10", summary: "")
+        let coupon = Cart.CouponItem(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "TEST10", summary: "")
 
         // When, Then
         #expect(sut.couponRowState(orderStage: .finalizing,
@@ -183,7 +183,7 @@ struct CartViewHelperTests {
 
     @Test func couponRowState_finalizing_and_other_error_returns_idle() async throws {
         // Given
-        let coupon = Cart.CouponItem(id: UUID(), code: "TEST10", summary: "")
+        let coupon = Cart.CouponItem(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "TEST10", summary: "")
 
         // When, Then
         #expect(sut.couponRowState(orderStage: .finalizing,
@@ -233,7 +233,7 @@ struct CartViewHelperTests {
 
     @Test func hasUnresolvedItems_when_cart_has_loading_item_returns_true() async throws {
         // Given
-        let loadingItem = Cart.PurchasableItem.loading(id: UUID())
+        let loadingItem = Cart.PurchasableItem.loading(id: POSItemIdentifier(underlyingType: .product, itemID: 1))
         let cart = Cart(purchasableItems: [loadingItem])
 
         // When, Then
@@ -243,7 +243,7 @@ struct CartViewHelperTests {
     @Test func hasUnresolvedItems_when_cart_has_error_item_returns_true() async throws {
         // Given
         let errorItem = Cart.PurchasableItem(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
             title: "",
             subtitle: "",
             quantity: 1,
@@ -257,7 +257,7 @@ struct CartViewHelperTests {
 
     @Test func hasUnresolvedItems_when_cart_has_mixed_items_returns_true() async throws {
         // Given
-        let loadingItem = Cart.PurchasableItem.loading(id: UUID())
+        let loadingItem = Cart.PurchasableItem.loading(id: POSItemIdentifier(underlyingType: .product, itemID: 1))
         let loadedItem = makeItem()
         let cart = Cart(purchasableItems: [loadingItem, loadedItem])
 
@@ -267,7 +267,7 @@ struct CartViewHelperTests {
 }
 
 private func makeItem() -> Cart.PurchasableItem {
-    .init(id: UUID(),
+    .init(id: POSItemIdentifier(underlyingType: .product, itemID: 1),
           item: MockPOSOrderableItem(name: "Item", formattedPrice: "$1.00"),
           title: "Item",
           subtitle: nil,

--- a/Modules/Tests/PointOfSaleTests/ViewHelpers/CartViewHelperTests.swift
+++ b/Modules/Tests/PointOfSaleTests/ViewHelpers/CartViewHelperTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import PointOfSale
+import struct Yosemite.POSItemIdentifier
 
 struct CartViewHelperTests {
     let sut = CartViewHelper()
@@ -114,7 +115,7 @@ struct CartViewHelperTests {
 
     @Test func couponRowState_building_stage_returns_idle() async throws {
         // Given
-        let coupon = Cart.CouponItem(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "TEST10", summary: "")
+        let coupon = Cart.CouponItem(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "TEST10", summary: "")
         let orderState = PointOfSaleOrderState.loaded(PointOfSaleOrderTotals(
             cartTotal: "$10.00",
             orderTotal: "$12.00",
@@ -129,7 +130,7 @@ struct CartViewHelperTests {
 
     @Test func couponRowState_finalizing_and_syncing_returns_validating() async throws {
         // Given
-        let coupon = Cart.CouponItem(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "TEST10", summary: "")
+        let coupon = Cart.CouponItem(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "TEST10", summary: "")
 
         // When, Then
         #expect(sut.couponRowState(orderStage: .finalizing,
@@ -140,7 +141,7 @@ struct CartViewHelperTests {
     @Test func couponRowState_finalizing_and_loaded_with_matching_coupon_returns_valid() async throws {
         // Given
         let couponCode = "TEST10"
-        let coupon = Cart.CouponItem(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: couponCode, summary: "")
+        let coupon = Cart.CouponItem(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: couponCode, summary: "")
         let couponTotal = PointOfSaleCouponTotal(code: couponCode, total: "10.00")
         let orderTotals = PointOfSaleOrderTotals(
             cartTotal: "$10.00",
@@ -157,7 +158,7 @@ struct CartViewHelperTests {
 
     @Test func couponRowState_finalizing_and_loaded_with_no_matching_coupon_returns_idle() async throws {
         // Given
-        let coupon = Cart.CouponItem(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "TEST10", summary: "")
+        let coupon = Cart.CouponItem(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "TEST10", summary: "")
         let orderTotals = PointOfSaleOrderTotals(
             cartTotal: "$10.00",
             orderTotal: "$12.00",
@@ -173,7 +174,7 @@ struct CartViewHelperTests {
 
     @Test func couponRowState_finalizing_and_invalid_coupon_error_returns_invalid() async throws {
         // Given
-        let coupon = Cart.CouponItem(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "TEST10", summary: "")
+        let coupon = Cart.CouponItem(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "TEST10", summary: "")
 
         // When, Then
         #expect(sut.couponRowState(orderStage: .finalizing,
@@ -183,7 +184,7 @@ struct CartViewHelperTests {
 
     @Test func couponRowState_finalizing_and_other_error_returns_idle() async throws {
         // Given
-        let coupon = Cart.CouponItem(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "TEST10", summary: "")
+        let coupon = Cart.CouponItem(id: UUID(), posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "TEST10", summary: "")
 
         // When, Then
         #expect(sut.couponRowState(orderStage: .finalizing,
@@ -233,7 +234,7 @@ struct CartViewHelperTests {
 
     @Test func hasUnresolvedItems_when_cart_has_loading_item_returns_true() async throws {
         // Given
-        let loadingItem = Cart.PurchasableItem.loading(id: POSItemIdentifier(underlyingType: .product, itemID: 1))
+        let loadingItem = Cart.PurchasableItem.loading(id: UUID())
         let cart = Cart(purchasableItems: [loadingItem])
 
         // When, Then
@@ -243,7 +244,7 @@ struct CartViewHelperTests {
     @Test func hasUnresolvedItems_when_cart_has_error_item_returns_true() async throws {
         // Given
         let errorItem = Cart.PurchasableItem(
-            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+            id: UUID(),
             title: "",
             subtitle: "",
             quantity: 1,
@@ -257,7 +258,7 @@ struct CartViewHelperTests {
 
     @Test func hasUnresolvedItems_when_cart_has_mixed_items_returns_true() async throws {
         // Given
-        let loadingItem = Cart.PurchasableItem.loading(id: POSItemIdentifier(underlyingType: .product, itemID: 1))
+        let loadingItem = Cart.PurchasableItem.loading(id: UUID())
         let loadedItem = makeItem()
         let cart = Cart(purchasableItems: [loadingItem, loadedItem])
 
@@ -267,7 +268,7 @@ struct CartViewHelperTests {
 }
 
 private func makeItem() -> Cart.PurchasableItem {
-    .init(id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+    .init(id: UUID(),
           item: MockPOSOrderableItem(name: "Item", formattedPrice: "$1.00"),
           title: "Item",
           subtitle: nil,

--- a/Modules/Tests/PointOfSaleTests/ViewHelpers/TotalsViewHelperTests.swift
+++ b/Modules/Tests/PointOfSaleTests/ViewHelpers/TotalsViewHelperTests.swift
@@ -1,5 +1,6 @@
 import Testing
 @testable import PointOfSale
+import struct Yosemite.POSItemIdentifier
 
 struct TotalsViewHelperTests {
 

--- a/Modules/Tests/PointOfSaleTests/ViewHelpers/TotalsViewHelperTests.swift
+++ b/Modules/Tests/PointOfSaleTests/ViewHelpers/TotalsViewHelperTests.swift
@@ -139,7 +139,7 @@ struct TotalsViewHelperTests {
     @Test
     func test_shouldShowTotalDiscountField_returns_true_when_cart_has_coupons_order_syncing() {
         var cart = Cart()
-        cart.add(.coupon(.init(id: .init(), code: "TEST10", summary: "")))
+        cart.add(.coupon(.init(id: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "TEST10", summary: "")))
 
         #expect(TotalsViewHelper().shouldShowTotalDiscountField(cart: cart, orderTotals: nil))
     }
@@ -147,7 +147,7 @@ struct TotalsViewHelperTests {
     @Test
     func test_shouldShowTotalDiscountField_returns_true_when_cart_has_coupons_and_orderTotals_with_discount() {
         var cart = Cart()
-        cart.add(.coupon(.init(id: .init(), code: "TEST10", summary: "")))
+        cart.add(.coupon(.init(id: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "TEST10", summary: "")))
         let orderTotals = PointOfSaleOrderTotals(cartTotal: "10",
                                                  orderTotal: "8",
                                                  taxTotal: "0",
@@ -160,7 +160,7 @@ struct TotalsViewHelperTests {
     @Test
     func test_shouldShowTotalDiscountField_returns_false_when_cart_has_coupons_and_orderTotals_without_discount() {
         var cart = Cart()
-        cart.add(.coupon(.init(id: .init(), code: "TEST10", summary: "")))
+        cart.add(.coupon(.init(id: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "TEST10", summary: "")))
         let orderTotals = PointOfSaleOrderTotals(cartTotal: "10",
                                                  orderTotal: "10",
                                                  taxTotal: "0",

--- a/Modules/Tests/YosemiteTests/Mocks/MockPOSOrderableItem.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockPOSOrderableItem.swift
@@ -3,12 +3,12 @@ import Foundation
 
 final class MockPOSOrderableItem: POSOrderableItem, Equatable {
     var name: String
-    var id: UUID
+    var id: POSItemIdentifier
     var formattedPrice: String
     var productImageSource: String?
 
     init(name: String,
-         id: UUID = UUID(),
+         id: POSItemIdentifier = POSItemIdentifier(underlyingType: .product, itemID: 1),
          formattedPrice: String,
          productImageSource: String? = nil,
          orderItemsToMatch: [OrderItem] = [],

--- a/Modules/Tests/YosemiteTests/PointOfSale/GRDBObservableDataSourceTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/GRDBObservableDataSourceTests.swift
@@ -184,8 +184,20 @@ struct GRDBObservableDataSourceTests {
         try await insertTestVariations(parentID: 100, count: 2)
         try await insertTestVariations(parentID: 200, count: 3)
 
-        let posParent1 = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1), name: "Parent 1", productImageSource: nil, productID: 100, allAttributes: [])
-        let posParent2 = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1), name: "Parent 2", productImageSource: nil, productID: 200, allAttributes: [])
+        let posParent1 = POSVariableParentProduct(
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+            name: "Parent 1",
+            productImageSource: nil,
+            productID: 100,
+            allAttributes: []
+        )
+        let posParent2 = POSVariableParentProduct(
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+            name: "Parent 2",
+            productImageSource: nil,
+            productID: 200,
+            allAttributes: []
+        )
 
         // When: Load parent 1 variations
         await waitForVariationLoad {
@@ -267,7 +279,13 @@ struct GRDBObservableDataSourceTests {
         #expect(sut.variationItems.isEmpty)
 
         // When: Load variations
-        let posParent = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1), name: "Parent", productImageSource: nil, productID: 100, allAttributes: [])
+        let posParent = POSVariableParentProduct(
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+            name: "Parent",
+            productImageSource: nil,
+            productID: 100,
+            allAttributes: []
+        )
         await waitForVariationLoad {
             sut.loadVariations(for: posParent)
         }
@@ -296,8 +314,20 @@ struct GRDBObservableDataSourceTests {
         // Insert 3 downloadable variations for parent 2 (should be excluded from count)
         try await insertDownloadableVariations(parentID: 200, count: 3, startID: 2000)
 
-        let posParent1 = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1), name: "Parent 1", productImageSource: nil, productID: 100, allAttributes: [])
-        let posParent2 = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1), name: "Parent 2", productImageSource: nil, productID: 200, allAttributes: [])
+        let posParent1 = POSVariableParentProduct(
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+            name: "Parent 1",
+            productImageSource: nil,
+            productID: 100,
+            allAttributes: []
+        )
+        let posParent2 = POSVariableParentProduct(
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+            name: "Parent 2",
+            productImageSource: nil,
+            productID: 200,
+            allAttributes: []
+        )
 
         // When: Load parent 1 variations (first page of 5)
         await waitForVariationLoad {
@@ -349,8 +379,20 @@ struct GRDBObservableDataSourceTests {
         // Parent 2: 8 variations (more than page size of 5)
         try await insertTestVariations(parentID: 200, count: 8)
 
-        let posParent1 = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1), name: "Parent 1", productImageSource: nil, productID: 100, allAttributes: [])
-        let posParent2 = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1), name: "Parent 2", productImageSource: nil, productID: 200, allAttributes: [])
+        let posParent1 = POSVariableParentProduct(
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+            name: "Parent 1",
+            productImageSource: nil,
+            productID: 100,
+            allAttributes: []
+        )
+        let posParent2 = POSVariableParentProduct(
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+            name: "Parent 2",
+            productImageSource: nil,
+            productID: 200,
+            allAttributes: []
+        )
 
         // When: Load parent 1 variations
         await waitForVariationLoad {

--- a/Modules/Tests/YosemiteTests/PointOfSale/GRDBObservableDataSourceTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/GRDBObservableDataSourceTests.swift
@@ -125,7 +125,7 @@ struct GRDBObservableDataSourceTests {
         try await insertTestVariations(parentID: 100, count: 3)
 
         let posParent = POSVariableParentProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
             name: "Parent",
             productImageSource: nil,
             productID: 100,
@@ -151,7 +151,7 @@ struct GRDBObservableDataSourceTests {
         try await insertTestVariations(parentID: 100, count: 2)
 
         let posParent = POSVariableParentProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
             name: "Parent",
             productImageSource: nil,
             productID: 100,
@@ -184,8 +184,8 @@ struct GRDBObservableDataSourceTests {
         try await insertTestVariations(parentID: 100, count: 2)
         try await insertTestVariations(parentID: 200, count: 3)
 
-        let posParent1 = POSVariableParentProduct(id: UUID(), name: "Parent 1", productImageSource: nil, productID: 100, allAttributes: [])
-        let posParent2 = POSVariableParentProduct(id: UUID(), name: "Parent 2", productImageSource: nil, productID: 200, allAttributes: [])
+        let posParent1 = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1), name: "Parent 1", productImageSource: nil, productID: 100, allAttributes: [])
+        let posParent2 = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1), name: "Parent 2", productImageSource: nil, productID: 200, allAttributes: [])
 
         // When: Load parent 1 variations
         await waitForVariationLoad {
@@ -267,7 +267,7 @@ struct GRDBObservableDataSourceTests {
         #expect(sut.variationItems.isEmpty)
 
         // When: Load variations
-        let posParent = POSVariableParentProduct(id: UUID(), name: "Parent", productImageSource: nil, productID: 100, allAttributes: [])
+        let posParent = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1), name: "Parent", productImageSource: nil, productID: 100, allAttributes: [])
         await waitForVariationLoad {
             sut.loadVariations(for: posParent)
         }
@@ -296,8 +296,8 @@ struct GRDBObservableDataSourceTests {
         // Insert 3 downloadable variations for parent 2 (should be excluded from count)
         try await insertDownloadableVariations(parentID: 200, count: 3, startID: 2000)
 
-        let posParent1 = POSVariableParentProduct(id: UUID(), name: "Parent 1", productImageSource: nil, productID: 100, allAttributes: [])
-        let posParent2 = POSVariableParentProduct(id: UUID(), name: "Parent 2", productImageSource: nil, productID: 200, allAttributes: [])
+        let posParent1 = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1), name: "Parent 1", productImageSource: nil, productID: 100, allAttributes: [])
+        let posParent2 = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1), name: "Parent 2", productImageSource: nil, productID: 200, allAttributes: [])
 
         // When: Load parent 1 variations (first page of 5)
         await waitForVariationLoad {
@@ -349,8 +349,8 @@ struct GRDBObservableDataSourceTests {
         // Parent 2: 8 variations (more than page size of 5)
         try await insertTestVariations(parentID: 200, count: 8)
 
-        let posParent1 = POSVariableParentProduct(id: UUID(), name: "Parent 1", productImageSource: nil, productID: 100, allAttributes: [])
-        let posParent2 = POSVariableParentProduct(id: UUID(), name: "Parent 2", productImageSource: nil, productID: 200, allAttributes: [])
+        let posParent1 = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1), name: "Parent 1", productImageSource: nil, productID: 100, allAttributes: [])
+        let posParent2 = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1), name: "Parent 2", productImageSource: nil, productID: 200, allAttributes: [])
 
         // When: Load parent 1 variations
         await waitForVariationLoad {

--- a/Modules/Tests/YosemiteTests/PointOfSale/POSCouponTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/POSCouponTests.swift
@@ -5,7 +5,7 @@ import Testing
 struct POSCouponTests {
     @Test func test_isExpired_when_no_expiration_date_then_returns_false() {
         // Given
-        let coupon = POSCoupon(id: UUID(), code: "valid-forever")
+        let coupon = POSCoupon(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "valid-forever")
 
         // Then
         #expect(coupon.isExpired == false)
@@ -14,7 +14,7 @@ struct POSCouponTests {
     @Test func test_isExpired_when_future_date_then_returns_false() {
         // Given
         let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: Date()) ?? Date()
-        let coupon = POSCoupon(id: UUID(), code: "will-expire-in-the-future", dateExpires: tomorrow)
+        let coupon = POSCoupon(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "will-expire-in-the-future", dateExpires: tomorrow)
 
         // Then
         #expect(coupon.isExpired == false)
@@ -23,7 +23,7 @@ struct POSCouponTests {
     @Test func test_isExpired_when_past_date_then_returns_true() {
         // Given
         let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date()) ?? Date()
-        let coupon = POSCoupon(id: UUID(), code: "expired-yesterday", dateExpires: yesterday)
+        let coupon = POSCoupon(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "expired-yesterday", dateExpires: yesterday)
 
         // Then
         #expect(coupon.isExpired == true)
@@ -32,7 +32,7 @@ struct POSCouponTests {
     @Test func test_isExpired_when_current_date_then_returns_true() {
         // Given
         let now = Date()
-        let coupon = POSCoupon(id: UUID(), code: "expired-now", dateExpires: now)
+        let coupon = POSCoupon(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "expired-now", dateExpires: now)
 
         // Then
         #expect(coupon.isExpired == true, "A coupon expiring at the current time should be considered expired")

--- a/Modules/Tests/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
@@ -29,7 +29,7 @@ struct POSProductOrVariationResolverTests {
             price: "10.00"
         )
         let expectedItem = POSItem.simpleProduct(POSSimpleProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
             name: "Simple Product",
             formattedPrice: "$10.00",
             productID: 123,
@@ -67,14 +67,14 @@ struct POSProductOrVariationResolverTests {
             productTypeKey: "variable"
         )
         let expectedParentItem = POSItem.variableParentProduct(POSVariableParentProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
             name: "Parent Product",
             productImageSource: nil,
             productID: 123,
             allAttributes: []
         ))
         let expectedVariationItem = POSItem.variation(POSVariation(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
             name: "Variation",
             formattedPrice: "$15.00",
             price: "15.00",

--- a/Modules/Tests/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
@@ -49,7 +49,9 @@ struct PointOfSaleCouponServiceTests {
     @Test func provideLocalPointOfSaleCoupons_when_enabled_then_calls_strategy() async throws {
         // Given
         settingStoreMethods.couponsEnabled = true
-        let expectedCoupons = [POSItem.coupon(POSCoupon(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "test", summary: "test", dateExpires: nil))]
+        let expectedCoupons = [POSItem.coupon(
+            POSCoupon(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "test", summary: "test", dateExpires: nil)
+        )]
         mockStrategy.fetchLocalCouponsResult = expectedCoupons
 
         // When

--- a/Modules/Tests/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
@@ -49,7 +49,7 @@ struct PointOfSaleCouponServiceTests {
     @Test func provideLocalPointOfSaleCoupons_when_enabled_then_calls_strategy() async throws {
         // Given
         settingStoreMethods.couponsEnabled = true
-        let expectedCoupons = [POSItem.coupon(POSCoupon(id: UUID(), code: "test", summary: "test", dateExpires: nil))]
+        let expectedCoupons = [POSItem.coupon(POSCoupon(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "test", summary: "test", dateExpires: nil))]
         mockStrategy.fetchLocalCouponsResult = expectedCoupons
 
         // When
@@ -63,7 +63,7 @@ struct PointOfSaleCouponServiceTests {
     @Test func providePointOfSaleCoupons_when_enabled_then_calls_strategy() async throws {
         // Given
         settingStoreMethods.couponsEnabled = true
-        let expectedCoupons = PagedItems(items: [POSItem.coupon(POSCoupon(id: UUID(),
+        let expectedCoupons = PagedItems(items: [POSItem.coupon(POSCoupon(id: POSItemIdentifier(underlyingType: .product, itemID: 1),
                                                                           code: "test",
                                                                           summary: "test",
                                                                           dateExpires: nil))],

--- a/Modules/Tests/YosemiteTests/PointOfSale/PointOfSaleItemMapperTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/PointOfSaleItemMapperTests.swift
@@ -186,7 +186,7 @@ struct PointOfSaleItemMapperTests {
 
     private static func createParentProduct() -> POSVariableParentProduct {
         POSVariableParentProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
             name: "Parent Product",
             productImageSource: nil,
             productID: 125,

--- a/Modules/Tests/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
@@ -79,7 +79,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
                                                                         totalItems: 1))
 
         let expectedItem = POSItem.simpleProduct(POSSimpleProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 208),
             name: "Dymo LabelWriter 4XL",
             formattedPrice: "$216.00",
             productID: 208,
@@ -118,7 +118,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
 
         let mockMappedProducts = mockProducts.map { product in
             POSItem.simpleProduct(POSSimpleProduct(
-                id: UUID(),
+                id: POSItemIdentifier(underlyingType: .product, itemID: product.productID),
                 name: product.name,
                 formattedPrice: "$0.00",
                 productID: product.productID,
@@ -176,7 +176,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         // Given
         let parentProductID: Int64 = 123
         let parentProduct = POSVariableParentProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: parentProductID),
             name: "Tea",
             productImageSource: nil,
             productID: parentProductID,
@@ -196,7 +196,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
                                                                           totalItems: 1))
 
         let expectedVariation = POSItem.variation(POSVariation(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .variation, itemID: 1274),
             name: "Shape: brick, Flavor: nuts, Darkness: 99%, Size: Any",
             formattedPrice: "$0.00",
             price: "",
@@ -226,7 +226,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         // Given
         let parentProductID: Int64 = 123
         let parentProduct = POSVariableParentProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: parentProductID),
             name: "Tea",
             productImageSource: nil,
             productID: parentProductID,
@@ -270,7 +270,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         do {
             _ = try await itemProvider.providePointOfSaleVariationItems(
                 for: .init(
-                    id: UUID(),
+                    id: POSItemIdentifier(underlyingType: .product, itemID: parentProductID),
                     name: "Tea",
                     productImageSource: nil,
                     productID: parentProductID,
@@ -289,7 +289,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         // Given
         let parentProductID: Int64 = 123
         let parentProduct = POSVariableParentProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: parentProductID),
             name: "Tea",
             productImageSource: nil,
             productID: parentProductID,
@@ -302,7 +302,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
                                                                           totalItems: 1))
 
         let expectedVariation = POSItem.variation(POSVariation(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .variation, itemID: 1274),
             name: "Shape: brick, Flavor: nuts, Darkness: 99%, Size: Any",
             formattedPrice: "$0.00",
             price: "",
@@ -347,7 +347,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
                                                                         totalItems: 1))
 
         let expectedItem = POSItem.simpleProduct(POSSimpleProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
             name: "Test Product",
             formattedPrice: "$10.00",
             productID: 1,
@@ -376,7 +376,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
                                                                           totalItems: 1))
 
         let expectedItem = POSItem.variation(POSVariation(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .variation, itemID: 10),
             name: "Test Variation",
             formattedPrice: "$20.00",
             price: "20.00",
@@ -386,7 +386,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         ))
         mockItemMapper.mockMappedVariations = [expectedItem]
 
-        let parentProduct = POSVariableParentProduct.init(id: UUID(),
+        let parentProduct = POSVariableParentProduct.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1),
                                                           name: "Test Variable Product",
                                                           productImageSource: nil,
                                                           productID: 1)
@@ -439,7 +439,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         // Given
         let parentProductID: Int64 = 123
         let parentProduct = POSVariableParentProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: parentProductID),
             name: "Test Variable Product",
             productImageSource: nil,
             productID: parentProductID,

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCartItemTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCartItemTests.swift
@@ -101,7 +101,7 @@ struct POSCartItemTests {
         #expect(sut.matches(order: order) == false)
     }
 
-    private func makeCartItem(id: UUID = UUID(), quantity: Decimal, matching: [OrderItem] = [], matcher: ((OrderItem) -> Bool)? = nil) -> POSCartItem {
+    private func makeCartItem(id: POSItemIdentifier = POSItemIdentifier(underlyingType: .product, itemID: 1), quantity: Decimal, matching: [OrderItem] = [], matcher: ((OrderItem) -> Bool)? = nil) -> POSCartItem {
         return POSCartItem(item: MockPOSOrderableItem(name: "",
                                                       id: id,
                                                       formattedPrice: "",

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCartItemTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCartItemTests.swift
@@ -101,7 +101,12 @@ struct POSCartItemTests {
         #expect(sut.matches(order: order) == false)
     }
 
-    private func makeCartItem(id: POSItemIdentifier = POSItemIdentifier(underlyingType: .product, itemID: 1), quantity: Decimal, matching: [OrderItem] = [], matcher: ((OrderItem) -> Bool)? = nil) -> POSCartItem {
+    private func makeCartItem(
+        id: POSItemIdentifier = POSItemIdentifier(underlyingType: .product, itemID: 1),
+        quantity: Decimal,
+        matching: [OrderItem] = [],
+        matcher: ((OrderItem) -> Bool)? = nil
+    ) -> POSCartItem {
         return POSCartItem(item: MockPOSOrderableItem(name: "",
                                                       id: id,
                                                       formattedPrice: "",

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
@@ -66,7 +66,7 @@ struct POSOrderServiceTests {
         // Given
         let cart = POSCart(
             items: [makePOSCartItem(productID: 100, quantity: 1)],
-            coupons: [.init(id: UUID(), code: "SAVE10")]
+            coupons: [.init(id: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "SAVE10")]
         )
 
         // When
@@ -84,9 +84,9 @@ struct POSOrderServiceTests {
         let cart = POSCart(
             items: [makePOSCartItem(productID: 100, quantity: 1)],
             coupons: [
-                .init(id: UUID(), code: "SAVE10"),
-                .init(id: UUID(), code: "FREESHIP"),
-                .init(id: UUID(), code: "EXTRA5")
+                .init(id: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "SAVE10"),
+                .init(id: POSItemIdentifier(underlyingType: .coupon, itemID: 2), code: "FREESHIP"),
+                .init(id: POSItemIdentifier(underlyingType: .coupon, itemID: 3), code: "EXTRA5")
             ]
         )
 
@@ -262,7 +262,7 @@ struct POSOrderServiceTests {
         let cart = POSCart(items: [
             POSCartItem(
                 item: POSVariation(
-                    id: UUID(),
+                    id: POSItemIdentifier(underlyingType: .variation, itemID: 500),
                     name: "Large",
                     formattedPrice: "$20",
                     price: "20",
@@ -296,7 +296,7 @@ struct POSOrderServiceTests {
         let cart = POSCart(items: [
             POSCartItem(
                 item: POSVariation(
-                    id: UUID(),
+                    id: POSItemIdentifier(underlyingType: .variation, itemID: 500),
                     name: "Small",
                     formattedPrice: "$15",
                     price: "15",
@@ -308,7 +308,7 @@ struct POSOrderServiceTests {
             ),
             POSCartItem(
                 item: POSVariation(
-                    id: UUID(),
+                    id: POSItemIdentifier(underlyingType: .variation, itemID: 501),
                     name: "Large",
                     formattedPrice: "$20",
                     price: "20",
@@ -374,7 +374,7 @@ struct POSOrderServiceTests {
         let cart = POSCart(items: [
             POSCartItem(
                 item: POSVariation(
-                    id: UUID(),
+                    id: POSItemIdentifier(underlyingType: .variation, itemID: 500),
                     name: "Large",
                     formattedPrice: "$20",
                     price: "20",
@@ -514,7 +514,7 @@ private func makePOSCartItem(
     productID: Int64,
     quantity: Decimal) -> POSCartItem {
         return POSCartItem(
-            item: POSSimpleProduct(id: UUID(),
+            item: POSSimpleProduct(id: POSItemIdentifier(underlyingType: .product, itemID: productID),
                                    name: "",
                                    formattedPrice: "",
                                    productID: productID,

--- a/WooCommerce/Classes/POS/Mocks/PointOfSaleItemServiceScreenshotMock.swift
+++ b/WooCommerce/Classes/POS/Mocks/PointOfSaleItemServiceScreenshotMock.swift
@@ -22,7 +22,7 @@ final class PointOfSaleItemServiceScreenshotMock: Yosemite.PointOfSaleItemServic
 
     private static func makeScreenshotMockItems(mockResourceUrlHost: String) -> [Yosemite.POSItem] {
         let product1 = Yosemite.POSSimpleProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
             name: "Rose Gold Shades",
             formattedPrice: "$35.00",
             productImageSource: mockResourceUrlHost + "rose-gold-shades",
@@ -34,7 +34,7 @@ final class PointOfSaleItemServiceScreenshotMock: Yosemite.PointOfSaleItemServic
         )
 
         let product2 = Yosemite.POSSimpleProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 2),
             name: "Black Coral Shades",
             formattedPrice: "$45.00",
             productImageSource: mockResourceUrlHost + "black-coral-shades",
@@ -46,7 +46,7 @@ final class PointOfSaleItemServiceScreenshotMock: Yosemite.PointOfSaleItemServic
         )
 
         let product3 = Yosemite.POSSimpleProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 3),
             name: "Akoya Pearl Shades",
             formattedPrice: "$50.00",
             productImageSource: mockResourceUrlHost + "akoya-pearl-shades",
@@ -58,7 +58,7 @@ final class PointOfSaleItemServiceScreenshotMock: Yosemite.PointOfSaleItemServic
         )
 
         let product4 = Yosemite.POSSimpleProduct(
-            id: UUID(),
+            id: POSItemIdentifier(underlyingType: .product, itemID: 4),
             name: "Malaya Shades",
             formattedPrice: "$40.00",
             productImageSource: mockResourceUrlHost + "malaya-shades",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR animates changes in the item list. This only applies to adding/removing items at present. It's primarily visible using Local Catalog, in search.

The main blocker for this was that we used unstable UUIDs, as they would change when the item state changed. The main work in this PR is to change to use a new `POSItemIdentifier` struct for the `Identifiable` conformance of items in the ItemList. 

We still use `UUID` for `Identifiable` on `CartItem` but we have the item identifier as well. This is because we can have more than one row in the cart for each product, so we can't just use the product/variation/coupon identifier and expect it to be unique.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Launch the app and open POS on a local catalog store.
Add or remove an item in WP-Admin
Pull to refresh
Observe that the item list updates are animated
Open search, and search for a term which will return multiple results.
Observe that the list changes are animated as you type.


Note that the animations aren't always perfect at the moment, but they're a lot better than none.

## Screenshots

https://github.com/user-attachments/assets/fbf6c2fa-f2b5-487b-9b4a-bd25dd222ff2


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
