### PR TITLE
Bookings: Fix pull to refresh issue in search mode

### DIFF
--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -109,6 +109,9 @@ private extension BookingListView {
             Section {
                 ForEach(bookings) { item in
                     bookingItem(item)
+                        .if(item == bookings.first) {
+                            $0.listSectionSeparator(.hidden, edges: .top)
+                        }
                         .tag(item)
                 }
 
@@ -131,11 +134,9 @@ private extension BookingListView {
                 $0.listStyle(.plain)
             } else {
                 $0.listStyle(.grouped)
+                    .scrollContentBackground(.hidden)
             }
         }
-        .listStyle(.grouped)
-        .scrollContentBackground(.hidden)
-        .listSectionSeparator(.hidden, edges: .top)
         .background(Color(.listBackground))
         .refreshable {
             await onRefresh()

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -49,6 +49,7 @@ private extension BookingListView {
                 loadingView
             case .results:
                 bookingList(with: viewModel.bookings,
+                            isSearching: false,
                             onNextPage: { viewModel.onLoadNextPageAction() },
                             onRefresh: { await viewModel.onRefreshAction() })
             }
@@ -66,15 +67,18 @@ private extension BookingListView {
     }
 
     var searchContentView: some View {
-        VStack {
+        VStack(spacing: 0) {
             if searchViewModel.isSearching {
                 loadingView
             } else if searchViewModel.searchResults.isEmpty {
+                header
                 emptyStateView(isSearching: true) {
                     await searchViewModel.onRefreshAction()
                 }
             } else {
+                header
                 bookingList(with: searchViewModel.searchResults,
+                            isSearching: true,
                             onNextPage: { searchViewModel.onLoadNextPageAction() },
                             onRefresh: { await searchViewModel.onRefreshAction() })
             }
@@ -103,27 +107,20 @@ private extension BookingListView {
     }
 
     func bookingList(with bookings: [Booking],
+                     isSearching: Bool,
                      onNextPage: @escaping () -> Void,
                      onRefresh: @escaping () async -> Void) -> some View {
         List(selection: $selectedBooking) {
-            Section {
-                ForEach(bookings) { item in
-                    bookingItem(item)
-                        .if(item == bookings.first) {
-                            $0.listSectionSeparator(.hidden, edges: .top)
-                        }
-                        .tag(item)
+            if isSearching {
+                bookingListSection(with: bookings, onNextPage: onNextPage)
+            } else {
+                Section {
+                    bookingListSection(with: bookings, onNextPage: onNextPage)
+                } header: {
+                    header
+                        .listRowInsets(EdgeInsets())
+                        .textCase(nil)
                 }
-
-                InfiniteScrollIndicator(showContent: viewModel.shouldShowBottomActivityIndicator)
-                    .padding(.top, BookingListViewLayout.viewPadding)
-                    .onAppear {
-                        onNextPage()
-                    }
-            } header: {
-                header
-                    .listRowInsets(EdgeInsets())
-                    .textCase(nil)
             }
         }
         .apply {
@@ -141,6 +138,23 @@ private extension BookingListView {
         .refreshable {
             await onRefresh()
         }
+    }
+
+    @ViewBuilder
+    func bookingListSection(with bookings: [Booking], onNextPage: @escaping () -> Void) -> some View {
+        ForEach(bookings) { item in
+            bookingItem(item)
+                .if(item == bookings.first) {
+                    $0.listSectionSeparator(.hidden, edges: .top)
+                }
+                .tag(item)
+        }
+
+        InfiniteScrollIndicator(showContent: viewModel.shouldShowBottomActivityIndicator)
+            .padding(.top, BookingListViewLayout.viewPadding)
+            .onAppear {
+                onNextPage()
+            }
     }
 
     func bookingItem(_ booking: Booking) -> some View {
@@ -182,13 +196,19 @@ private extension BookingListView {
     func emptyStateView(isSearching: Bool, onRefresh: @escaping () async -> Void) -> some View {
         GeometryReader { proxy in
             ScrollView {
-                LazyVStack(spacing: 0, pinnedViews: .sectionHeaders) {
-                    Section {
-                        emptyStateContent(isSearching: isSearching)
-                            .frame(minWidth: proxy.size.width,
-                                   minHeight: proxy.size.height - BookingListViewLayout.defaultHeaderHeight * scale)
-                    } header: {
-                        header
+                if isSearching {
+                    emptyStateContent(isSearching: isSearching)
+                        .frame(minWidth: proxy.size.width,
+                               minHeight: proxy.size.height)
+                } else {
+                    LazyVStack(spacing: 0, pinnedViews: .sectionHeaders) {
+                        Section {
+                            emptyStateContent(isSearching: isSearching)
+                                .frame(minWidth: proxy.size.width,
+                                       minHeight: proxy.size.height - BookingListViewLayout.defaultHeaderHeight * scale)
+                        } header: {
+                            header
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1831

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After the changes in the booking list layout introduced in #16327, the pull-to-refresh feature stopped working when the search bar is in focused.

This PR fixes the issue by updating the layout of the booking list when search is active. The fix is to apply a simple VStack layout to place the header on top instead of keeping it as a section header. The section header implementation is only necessary as a workaround for `refreshable` to work with the navigation bar containing large title.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Log in to a CIAB store with existing bookings.
- Navigate to Bookings tab
- Confirm that pull-to-refresh works with both empty state and list view when search is not active.
- Tap the search icon and type any keyword.
- Confirm that pull-to-refresh works with both empty state and list view when search is active.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before:

https://github.com/user-attachments/assets/7f53bd2e-a321-4729-ba6c-3a9b65924035



After:

https://github.com/user-attachments/assets/38835217-c412-423d-8ba5-30d371bcf96f




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
