### PR TITLE
[release/23.7] Fix variable product selector navigation - pull into release

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -116,17 +116,23 @@ struct ProductSelectorView: View {
                     .padding(Constants.defaultPadding)
                     .accessibilityIdentifier(Constants.doneButtonAccessibilityIdentifier)
                     .renderedIf(configuration.multipleSelectionEnabled && viewModel.syncApproach == .onButtonTap)
-
-                    if let variationListViewModel = viewModel.productVariationListViewModel {
-                        LazyNavigationLink(destination: ProductVariationSelectorView(
-                            isPresented: $isPresented,
-                            viewModel: variationListViewModel,
-                            onMultipleSelections: { selectedIDs in
-                                viewModel.updateSelectedVariations(productID: variationListViewModel.productID, selectedVariationIDs: selectedIDs)
-                            }), isActive: $viewModel.isShowingProductVariationList) {
-                                EmptyView()
-                            }
-                            .renderedIf(configuration.treatsAllProductsAsSimple == false)
+                }
+                .if(configuration.treatsAllProductsAsSimple == false) { view in
+                    view.navigationDestination(isPresented: $viewModel.isShowingProductVariationList) {
+                        if let variationListViewModel = viewModel.productVariationListViewModel {
+                            ProductVariationSelectorView(
+                                isPresented: $isPresented,
+                                viewModel: variationListViewModel,
+                                onMultipleSelections: { selectedIDs in
+                                    viewModel.updateSelectedVariations(
+                                        productID: variationListViewModel.productID,
+                                        selectedVariationIDs: selectedIDs
+                                    )
+                                }
+                            )
+                        } else {
+                            EmptyView()
+                        }
                     }
                 }
                 .padding(.horizontal, insets: safeAreaInsets)


### PR DESCRIPTION
This PR pulls and applies same changes from [Fix variable product selector navigation](https://github.com/woocommerce/woocommerce-ios/pull/16363) and applies to 23.7 release.

- Last minute before approved 23.7 distribution we realised that the fix was targeting 23.8. So we decided to also include it into 23.7.
- Release note changes weren't pulled.

For more context check out the discussion thread: p1764685912916129/1763384303.329289-slack-C6H8C3G23

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
- Try to reproduce the actual issue first in the following environment (that happened in latest `trunk` too). Check out the WOOMOB-1734 issue for reproduction video.
- Use `inpersonpayments.wpcomstaging.com` store with the account listed in Smoke Testing flow: P91TBi-bVe-p2
- Navigate to order list and start order creation flow
- Find a variable product in selector list
- Make sure it's tappable and navigates to variations list
- Make sure variations selection works fine and applies to an order that's being created/edited.

## Important note
I noticed that the issue doesn't happen if running from Xcode. I suggest to double check the behaviour in TF build before submitting for App Store review.