### PR TITLE
[release/23.7] Revert notify listeners

### DIFF
--- a/Modules/Sources/Yosemite/Tools/ResultsController.swift
+++ b/Modules/Sources/Yosemite/Tools/ResultsController.swift
@@ -234,7 +234,6 @@ public class GenericResultsController<T: ResultsControllerMutableType, Output> {
     private func refreshFetchedObjects(predicate: NSPredicate?) {
         controller.fetchRequest.predicate = predicate
         try? controller.performFetch()
-        onDidChangeContent?()
     }
 
     /// Refreshes all of the Fetched Objects, so that the new sort descriptors are applied.
@@ -242,7 +241,6 @@ public class GenericResultsController<T: ResultsControllerMutableType, Output> {
     private func refreshFetchedObjects(sortDescriptors: [NSSortDescriptor]?) {
         controller.fetchRequest.sortDescriptors = sortDescriptors
         try? controller.performFetch()
-        onDidChangeContent?()
     }
 
     /// Initializes the FetchedResultsController

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,7 +15,6 @@
 - [*] Fix product variation selection for order creation [https://github.com/woocommerce/woocommerce-ios/pull/16317]
 - [internal] Hide non-CIAB product types from filters [https://github.com/woocommerce/woocommerce-ios/pull/16354] 
 - [Internal] Fix warning when displaying offline banner on My Store [https://github.com/woocommerce/woocommerce-ios/pull/16347]
-- [Internal] Notify listeners immediately after updating predicates or sort descriptors for results controllers. [https://github.com/woocommerce/woocommerce-ios/pull/16350]
 
 23.6
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1835

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is a rollback of [#16350](https://github.com/woocommerce/woocommerce-ios/pull/16350/files) for the `23.7` release.

In last minute before 23.7 rollout we discovered a crash that was happening for our results controllers. The first thing that came to my mind was a tweak to actualize the fetched object collection after a predicate / sorting change: [Results controller: Notify listeners of changes when updating predicate and sort descriptors](https://github.com/woocommerce/woocommerce-ios/pull/16350) That's exactly the place where we touched the `ResultsController` behaviour. So let's revert it and revisit as a new task.

Check out the WOOMOB-1835 for crash log reference. 

```
NSInternalInconsistencyException: Invalid update: invalid number of rows in section 0. The number of rows contained in an existing section after the update (10) must be equal to the number of rows contained in that section before the update (0), plus or minus the number of rows inserted or deleted from that section (1 inserted, 0 deleted) and plus or minus the number of rows moved into or out of that section (0 moved in, 0 moved out). Table view: <UITableView: 0x11a2eea00; frame = (0 165; 393 604); clipsToBounds = YES; autoresize = RM+BM; gestureRecognizers = <NSArray: 0x1241f6370>; backgroundColor = <UIDynamicProviderColor: 0x1135c6080; provider = <__NSMallocBlock__: 0x112e76fd0>>; layer = <CALayer: 0x1241f5710>; contentOffset: {0, 0}; contentSize: {393, 45}; adjustedContentInset: {0, 0, 208, 0}; dataSource: <_TtGC11WooCommerce20SearchViewControllerCS_31ProductsTabProductTableViewCellCS_22ProductSearchUICommand_: 0x11a140f00>>
  CoreFoundation      0x198c26964  __exceptionPreprocess
  libobjc.A           0x195b35810  objc_exception_throw
  Foundation          0x196ad2b04  -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:]
  UIKitCore           0x19faff614  -[UITableView _Bug_Detected_In_Client_Of_UITableView_Invalid_Number_Of_Rows_In_Section:]
  UIKitCore           0x19fafedc0  -[UITableView _endCellAnimationsWithContext:]
  UIKitCore           0x19fb11624  -[UITableView _updateRowsAtIndexPaths:withUpdateAction:rowAnimation:usingPresentationValues:]
  UIKitCore           0x19fb1171c  -[UITableView insertRowsAtIndexPaths:withRowAnimation:]
  WooCommerce         0x1050769b8  closure in ResultsController.startForwardingObjectEvents (ResultsController+UIKit.swift:100)
  WooCommerce         0x10507716c  closure in ResultsController.startForwardingObjectEvents (<compiler-generated>)
  WooCommerce         0x10609676c  closure in GenericResultsController.setupEventsForwarding (ResultsController.swift:271)
  WooCommerce         0x1060526d4  FetchedResultsControllerDelegateWrapper.controller (FetchedResultsControllerDelegateWrapper.swift:45)
  WooCommerce         0x1060526d4  FetchedResultsControllerDelegateWrapper.controller (<compiler-generated>:40)
  CoreData            0x19b280574  __82-[NSFetchedResultsController _core_managedObjectContextDidChange:]_block_invoke
  CoreData            0x19b0f3a48  developerSubmittedBlockToNSManagedObjectContextPerform
  CoreData            0x19b21d418  -[NSManagedObjectContext performBlockAndWait:]
  CoreData            0x19b27ef10  -[NSFetchedResultsController _core_managedObjectContextDidChange:]
  CoreFoundation      0x198bb185c  __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__
  CoreFoundation      0x198bb190c  ___CFXRegistrationPost_block_invoke
  CoreFoundation      0x198bb1768  _CFXRegistrationPost
  CoreFoundation      0x198bb1f08  _CFXNotificationPost
  Foundation          0x196b2f2e8  -[NSNotificationCenter postNotificationName:object:userInfo:]
  CoreData            0x19b223014  -[NSManagedObjectContext _createAndPostChangeNotification:deletions:updates:refreshes:deferrals:wasMerge:]
  CoreData            0x19b2130a4  -[NSManagedObjectContext _processRecentChanges:]
  CoreData            0x19b21ce68  -[NSManagedObjectContext _coreMergeChangesFromDidSaveDictionary:usingObjectIDs:withClientQueryGeneration:]
  CoreData            0x19b21d0e0  -[NSManagedObjectContext mergeChangesFromContextDidSaveNotification:]
  CoreData            0x19b0f3a48  developerSubmittedBlockToNSManagedObjectContextPerform
  libdispatch         0x1d16957f8  _dispatch_client_callout
  libdispatch         0x1d16b2b0c  _dispatch_main_queue_drain.cold.5
  libdispatch         0x1d168aec4  _dispatch_main_queue_drain
  libdispatch         0x1d168ae00  _dispatch_main_queue_callback_4CF
  CoreFoundation      0x198bcb2b0  __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__
  CoreFoundation      0x198b7eb38  __CFRunLoopRun
  CoreFoundation      0x198b7da68  _CFRunLoopRunSpecificWithOptions
  GraphicsServices    0x23a77c494  GSEventRunModal
  UIKitCore           0x19e557710  -[UIApplication _run]
  UIKitCore           0x19e4fff74  UIApplicationMain
  WooCommerce         0x1049080e8  main (main.swift:7)
  0x195b8ae28  <redacted>

  CoreFoundation      0x198c26964  __exceptionPreprocess
  libobjc.A           0x195b35810  objc_exception_throw
  Foundation          0x196ad2b04  -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:]
  UIKitCore           0x19faff614  -[UITableView _Bug_Detected_In_Client_Of_UITableView_Invalid_Number_Of_Rows_In_Section:]
  UIKitCore           0x19fafedc0  -[UITableView _endCellAnimationsWithContext:]
  UIKitCore           0x19fb11624  -[UITableView _updateRowsAtIndexPaths:withUpdateAction:rowAnimation:usingPresentationValues:]
  UIKitCore           0x19fb1171c  -[UITableView insertRowsAtIndexPaths:withRowAnimation:]
  WooCommerce         0x1050769b8  closure in ResultsController.startForwardingObjectEvents (ResultsController+UIKit.swift:100)
  WooCommerce         0x10507716c  closure in ResultsController.startForwardingObjectEvents (<compiler-generated>)
  WooCommerce         0x10609676c  closure in GenericResultsController.setupEventsForwarding (ResultsController.swift:271)
  WooCommerce         0x1060526d4  FetchedResultsControllerDelegateWrapper.controller (FetchedResultsControllerDelegateWrapper.swift:45)
  WooCommerce         0x1060526d4  FetchedResultsControllerDelegateWrapper.controller (<compiler-generated>:40)
  CoreData            0x19b280574  __82-[NSFetchedResultsController _core_managedObjectContextDidChange:]_block_invoke
  CoreData            0x19b0f3a48  developerSubmittedBlockToNSManagedObjectContextPerform
  CoreData            0x19b21d418  -[NSManagedObjectContext performBlockAndWait:]
  CoreData            0x19b27ef10  -[NSFetchedResultsController _core_managedObjectContextDidChange:]
  CoreFoundation      0x198bb185c  __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__
  CoreFoundation      0x198bb190c  ___CFXRegistrationPost_block_invoke
  CoreFoundation      0x198bb1768  _CFXRegistrationPost
  CoreFoundation      0x198bb1f08  _CFXNotificationPost
  Foundation          0x196b2f2e8  -[NSNotificationCenter postNotificationName:object:userInfo:]
  CoreData            0x19b223014  -[NSManagedObjectContext _createAndPostChangeNotification:deletions:updates:refreshes:deferrals:wasMerge:]
  CoreData            0x19b2130a4  -[NSManagedObjectContext _processRecentChanges:]
  CoreData            0x19b21ce68  -[NSManagedObjectContext _coreMergeChangesFromDidSaveDictionary:usingObjectIDs:withClientQueryGeneration:]
  CoreData            0x19b21d0e0  -[NSManagedObjectContext mergeChangesFromContextDidSaveNotification:]
  CoreData            0x19b0f3a48  developerSubmittedBlockToNSManagedObjectContextPerform
  libdispatch         0x1d16957f8  _dispatch_client_callout
  libdispatch         0x1d16b2b0c  _dispatch_main_queue_drain.cold.5
  libdispatch         0x1d168aec4  _dispatch_main_queue_drain
  libdispatch         0x1d168ae00  _dispatch_main_queue_callback_4CF
  CoreFoundation      0x198bcb2b0  __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__
  CoreFoundation      0x198b7eb38  __CFRunLoopRun
  CoreFoundation      0x198b7da68  _CFRunLoopRunSpecificWithOptions
  GraphicsServices    0x23a77c494  GSEventRunModal
  UIKitCore           0x19e557710  -[UIApplication _run]
  UIKitCore           0x19e4fff74  UIApplicationMain
  WooCommerce         0x1049080e8  main (main.swift:7)
  0x195b8ae28  <redacted>
```
## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
N/A - Wasn't ever able to reproduce on my side.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
