### PR TITLE
[WCiOS17] Address deprecations on account and auth flows trait updates

### DIFF
--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/RoleErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/RoleErrorViewController.swift
@@ -61,6 +61,7 @@ class RoleErrorViewController: UIViewController {
         super.viewDidLoad()
 
         configureViews()
+        observeTraitChanges()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -95,6 +96,19 @@ class RoleErrorViewController: UIViewController {
         configureLinkButton()
         configurePrimaryActionButton()
         configureSecondaryActionButton()
+
+        // Set initial image visibility based on vertical size class
+        imageView.isHidden = traitCollection.verticalSizeClass == .compact
+    }
+
+    private func observeTraitChanges() {
+        registerForTraitChanges([UITraitVerticalSizeClass.self, UITraitUserInterfaceStyle.self]) { (self: Self, _) in
+            // Hide image in compact height sizes (e.g. landscape iPhones)
+            // With limited space, text description should have higher priority
+            self.imageView.isHidden = self.traitCollection.verticalSizeClass == .compact
+
+            self.updateViewAppearances()
+        }
     }
 
     func configureDescriptionLabel() {
@@ -128,24 +142,9 @@ class RoleErrorViewController: UIViewController {
         }
     }
 
-    // MARK: Trait Change Adjustments
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        // hide image in compact height sizes (e.g. landscape iphones).
-        // with limited space, text description should have higher priority.
-        imageView.isHidden = traitCollection.verticalSizeClass == .compact
-
-        // handle dynamic color appearance changes.
-        if let previousTrait = previousTraitCollection,
-           previousTrait.hasDifferentColorAppearance(comparedTo: traitCollection) {
-            updateViewAppearances()
-        }
-    }
 
     /// update views that can adjust to color appearance changes.
-    /// this method is called when color appearance changes are detected in `traitCollectionDidChange`.
+    /// this method is called when color appearance changes are detected via trait change registration.
     private func updateViewAppearances() {
         // illustrations
         imageView.image = viewModel.image

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/RoleErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/RoleErrorViewController.swift
@@ -102,11 +102,13 @@ class RoleErrorViewController: UIViewController {
     }
 
     private func observeTraitChanges() {
-        registerForTraitChanges([UITraitVerticalSizeClass.self, UITraitUserInterfaceStyle.self]) { (self: Self, _) in
-            // Hide image in compact height sizes (e.g. landscape iPhones)
-            // With limited space, text description should have higher priority
+        // Image visibility depends on vertical size class only
+        registerForTraitChanges([UITraitVerticalSizeClass.self]) { (self: Self, _) in
             self.imageView.isHidden = self.traitCollection.verticalSizeClass == .compact
+        }
 
+        // Appearance updates only when dark/light mode changes
+        registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: Self, _) in
             self.updateViewAppearances()
         }
     }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
@@ -62,13 +62,15 @@ final class ULAccountMismatchViewController: UIViewController {
         configureSecondaryButon()
 
         setUnifiedMargins(forWidth: view.frame.width)
+        observeTraitChanges()
 
         viewModel.viewDidLoad(self)
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        setUnifiedMargins(forWidth: view.frame.width)
+    private func observeTraitChanges() {
+        registerForTraitChanges([UITraitHorizontalSizeClass.self, UITraitVerticalSizeClass.self]) { (self: Self, _) in
+            self.setUnifiedMargins(forWidth: self.view.frame.width)
+        }
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
@@ -72,6 +72,7 @@ final class ULErrorViewController: UIViewController {
         configureButtonLabels()
 
         setUnifiedMargins(forWidth: view.frame.width)
+        observeTraitChanges()
 
         viewModel.viewDidLoad(self)
     }
@@ -81,9 +82,10 @@ final class ULErrorViewController: UIViewController {
         viewDidAppearSubject.send()
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        setUnifiedMargins(forWidth: view.frame.width)
+    private func observeTraitChanges() {
+        registerForTraitChanges([UITraitHorizontalSizeClass.self, UITraitVerticalSizeClass.self]) { (self: Self, _) in
+            self.setUnifiedMargins(forWidth: self.view.frame.width)
+        }
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -501,9 +501,13 @@ private enum Row: CaseIterable {
 }
 
 extension PrivacySettingsViewController: UITextViewDelegate {
-    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-        presentURL(URL)
-        trackURLPresentation(URL)
-        return false
+    func textView(_ textView: UITextView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction? {
+        if case .link(let url) = textItem.content {
+            presentURL(url)
+            trackURLPresentation(url)
+            // Prevent default action
+            return nil
+        }
+        return defaultAction
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -562,10 +562,13 @@ private extension SettingsViewController {
 //
 extension SettingsViewController: UITextViewDelegate {
 
-    func textView(_ textView: UITextView, shouldInteractWith URL: URL,
-                  in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-        weAreHiringWasPressed(url: URL)
-        return false
+    func textView(_ textView: UITextView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction? {
+        if case .link(let url) = textItem.content {
+            weAreHiringWasPressed(url: url)
+            // Prevent default action
+            return nil
+        }
+        return defaultAction
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/FilterTabBar/FilterTabBar.swift
+++ b/WooCommerce/Classes/ViewRelated/FilterTabBar/FilterTabBar.swift
@@ -518,23 +518,23 @@ private class TabBarButton: UIButton {
         super.init(frame: frame)
 
         setFont()
+        observeTraitChanges()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
 
         setFont()
+        observeTraitChanges()
     }
 
     private func setFont() {
         titleLabel?.applySubheadlineStyle()
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            setFont()
+    private func observeTraitChanges() {
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+            self.setFont()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -231,6 +231,13 @@ final class MainTabBarController: UITabBarController {
         startListeningToHubMenuTabBadgeUpdates()
 
         fixTabBarTraitCollectionOnIpadForiOS18()
+        observeTraitChanges()
+    }
+
+    private func observeTraitChanges() {
+        registerForTraitChanges([UITraitHorizontalSizeClass.self, UITraitVerticalSizeClass.self]) { (self: Self, _) in
+            self.fixTabBarTraitCollectionOnIpadForiOS18()
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -309,12 +316,6 @@ final class MainTabBarController: UITabBarController {
     }
 
     // MARK: - iPadOS 18 tabs support
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-         super.traitCollectionDidChange(previousTraitCollection)
-         fixTabBarTraitCollectionOnIpadForiOS18()
-     }
-
 
     /// Force a previous bottom tab bar design on iPadOS 18 when built with Xcode 16
     ///

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AttributedText.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AttributedText.swift
@@ -123,9 +123,13 @@ private struct TextViewWrapper: UIViewRepresentable {
     final class Coordinator: NSObject, UITextViewDelegate {
         var openURL: ((URL) -> Void)?
 
-        func textView(_: UITextView, shouldInteractWith URL: URL, in _: NSRange, interaction _: UITextItemInteraction) -> Bool {
-            openURL?(URL)
-            return false
+        func textView(_ textView: UITextView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction? {
+            if case .link(let url) = textItem.content {
+                openURL?(url)
+                // Prevent default action
+                return nil
+            }
+            return defaultAction
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
@@ -118,12 +118,16 @@ final class TextViewTableViewCell: UITableViewCell {
 }
 
 extension TextViewTableViewCell: UITextViewDelegate {
-    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-        if let onLinkTapped {
-            onLinkTapped(URL)
-            return false
+    func textView(_ textView: UITextView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction? {
+        if case .link(let url) = textItem.content {
+            if let onLinkTapped {
+                onLinkTapped(url)
+                // Prevent default action
+                return nil
+            }
         }
-        return true
+        // Allow default behavior
+        return defaultAction
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveySubmittedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveySubmittedViewController.swift
@@ -67,6 +67,13 @@ final class SurveySubmittedViewController: UIViewController, SurveySubmittedView
         applyStyleToComponents()
         applyLocalizedTextsToComponents()
         configureStackViewsAxis()
+        observeTraitChanges()
+    }
+
+    private func observeTraitChanges() {
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+            self.configureStackViewsAxis()
+        }
     }
 
     @IBAction private func contactUsButtonTapped(_ sender: Any) {
@@ -115,15 +122,6 @@ private extension SurveySubmittedViewController {
     ///
     func configureStackViewsAxis() {
         linkButtonStackView.axis = traitCollection.preferredContentSizeCategory > .extraExtraExtraLarge ? .vertical : .horizontal
-    }
-}
-
-// MARK: Accessibility handling
-//
-extension SurveySubmittedViewController {
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        configureStackViewsAxis()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -74,6 +74,13 @@ final class TopBannerView: UIView {
         actionButtons = viewModel.actionButtons.map { _ in UIButton() }
         super.init(frame: .zero)
         configureSubviews(with: viewModel)
+        observeTraitChanges()
+    }
+
+    private func observeTraitChanges() {
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+            self.updateStackViewsAxis()
+        }
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -309,15 +316,6 @@ private extension TopBannerView {
         self.isExpanded = !isExpanded
         updateExpandCollapseState(isExpanded: isExpanded)
         onTopButtonTapped?()
-    }
-}
-
-// MARK: Accessibility Handling
-//
-extension TopBannerView {
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        updateStackViewsAxis()
     }
 }
 


### PR DESCRIPTION
Closes WOOMOB-1305

<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
This PR addresses iOS17 deprecation warnings in account and authentication flows, as well as settings. We address two types:
- Usage of the one of the textView delegates
- UI updates on trait changes

## Changes
- For trait changes, we just move to the new `UITrait` API
- For the textView delegate, we update it with the recommendation. Looking at the `UIKit.UITextView` interface we've lost URL as a parameter, and the return type is no longer `Bool` but optional `UIAction?`, so we have to return nil to prevent the default action.

```
   @available(iOS, introduced: 10.0, deprecated: 17.0, message: "Replaced by primaryActionForTextItem: and menuConfigurationForTextItem: for additional customization options.")
    optional func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool 

...

    /**
     * Asks the delegate for the action to be performed when interacting with a text item. If a nil action is provided, the text view
     * will request a menu to be presented on primary action if possible.
     *
     * @param textView  The text view requesting the primary action.
     * @param textItem  The text item for performing said action.
     * @param defaultAction The default action for the text item. Return this to perform the default action.
     *
     * @return Return a UIAction to be performed when the text item is interacted with. Return @c nil to prevent the action from being performed.
     */
    @available(iOS 17.0, *)
    optional func textView(_ textView: UITextView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction?
```

## Test Steps
- Unlock the orientation lock in your device
- In the app, observe the main dashboard/tab bar responds normally when the device is set portrait/landscape
- Go to Menu > Settings > Tap Privacy, and the web link. Should work normally.
- Go to Menu > Settings > WooCommerce > Tap Work with us. Should work normally.
- For login cases I wasn't quite sure which flows to test, the affected files for the trait orientations are "role error", "account miss-match", and "error on Unified Login flow". I tried a couple of incorrect logins from the smoke test list and worked fine (ie: incorrect credentials, wrong account)

## Screenshots

https://github.com/user-attachments/assets/b973a831-e2eb-430b-898c-ca68ea7413c2


