### PR TITLE
Add Buildkite step to optionally trigger FAD build on `trunk`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,6 +31,20 @@ steps:
       - github_commit_status:
           context: Prototype Build
 
+  - group: ":rocket: Prototype Build"
+    if: build.branch == "trunk"
+    steps:
+      - input: Deploy Prototype Build
+        prompt: Share a Prototype Build via Firebase App Distribution?
+        key: prototype_triggered
+      - label: Prototype Build
+        depends: prototype_triggered
+        command: .buildkite/commands/prototype-build.sh
+        plugins: [$CI_TOOLKIT]
+        notify:
+          - github_commit_status:
+              context: Prototype Build From Trunk
+
   #################
   # Run Unit Tests
   #################

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,7 +38,7 @@ steps:
         prompt: Share a Prototype Build via Firebase App Distribution?
         key: prototype_triggered
       - label: Prototype Build
-        depends: prototype_triggered
+        depends_on: prototype_triggered
         command: .buildkite/commands/prototype-build.sh
         plugins: [$CI_TOOLKIT]
         notify:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,7 +34,7 @@ steps:
   - group: ":rocket: Prototype Build"
     if: build.branch == "trunk"
     steps:
-      - input: Deploy Prototype Build
+      - input: Deploy Prototype Build?
         prompt: Share a Prototype Build via Firebase App Distribution?
         key: prototype_triggered
       - label: Prototype Build

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -780,7 +780,7 @@ platform :ios do
       Branch: `#{ENV.fetch('BUILDKITE_BRANCH', 'N/A')}`
       Commit: #{ENV.fetch('BUILDKITE_COMMIT', 'N/A')[0...7]}
     NOTES
-    release_notes += "Pull Request: ##{pull_request_number}" unless pull_request_number.nil?
+    release_notes += "Pull Request: ##{PULL_REQUEST_NUMBER}" unless PULL_REQUEST_NUMBER.nil?
 
     firebase_app_distribution(
       app: FIREBASE_APP_ID,
@@ -796,13 +796,13 @@ platform :ios do
       dsym_path: './build/WooCommerce.app.dSYM.zip'
     )
 
-    next if pull_request_number.nil?
+    next if PULL_REQUEST_NUMBER.nil?
 
     # PR Comment
     comment_body = prototype_build_details_comment(app_display_name: 'WooCommerce iOS Prototype')
     comment_on_pr(
       project: GITHUB_REPO,
-      pr_number: pull_request_number,
+      pr_number: PULL_REQUEST_NUMBER,
       reuse_identifier: 'prototype-build-link',
       body: comment_body
     )
@@ -812,7 +812,7 @@ platform :ios do
   lane :build_for_prototype_build do |fetch_code_signing: true|
     update_certs_and_profiles_enterprise if fetch_code_signing
 
-    pr_prefix = pull_request_number&.then { |num| "pr#{num}" }
+    pr_prefix = PULL_REQUEST_NUMBER&.then { |num| "pr#{num}" }
     commit_short_hash = ENV.fetch('BUILDKITE_COMMIT', '0')[0...7]
     build_number = [pr_prefix, commit_short_hash].compact.join('-')
 
@@ -1526,11 +1526,8 @@ TEST_ANALYTICS_ENVIRONMENT = %w[
 # Release Management Utils
 # -----------------------------------------------------------------------------------
 
-def pull_request_number
-  # Buildkite sets this env var to the PR number if on a PR, but to 'false' (and not nil) if not on a PR
-  pr_num = ENV.fetch('BUILDKITE_PULL_REQUEST', 'false')
-  pr_num == 'false' ? nil : Integer(pr_num)
-end
+# Buildkite sets this env var to the PR number if on a PR, but to 'false' (and not nil) if not on a PR
+PULL_REQUEST_NUMBER = ENV['BUILDKITE_PULL_REQUEST']&.then { |n| n == 'false' ? nil : Integer(n) }
 
 def create_backmerge_pr
   version = release_version_current

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -780,7 +780,7 @@ platform :ios do
       Branch: `#{ENV.fetch('BUILDKITE_BRANCH', 'N/A')}`
       Commit: #{ENV.fetch('BUILDKITE_COMMIT', 'N/A')[0...7]}
     NOTES
-    release_notes += "Pull Request: ##{PULL_REQUEST_NUMBER}" unless PULL_REQUEST_NUMBER.nil?
+    release_notes += "Pull Request: ##{pull_request_number}" unless pull_request_number.nil?
 
     firebase_app_distribution(
       app: FIREBASE_APP_ID,
@@ -796,13 +796,13 @@ platform :ios do
       dsym_path: './build/WooCommerce.app.dSYM.zip'
     )
 
-    next if PULL_REQUEST_NUMBER.nil?
+    next if pull_request_number.nil?
 
     # PR Comment
     comment_body = prototype_build_details_comment(app_display_name: 'WooCommerce iOS Prototype')
     comment_on_pr(
       project: GITHUB_REPO,
-      pr_number: PULL_REQUEST_NUMBER,
+      pr_number: pull_request_number,
       reuse_identifier: 'prototype-build-link',
       body: comment_body
     )
@@ -812,7 +812,7 @@ platform :ios do
   lane :build_for_prototype_build do |fetch_code_signing: true|
     update_certs_and_profiles_enterprise if fetch_code_signing
 
-    pr_prefix = PULL_REQUEST_NUMBER&.then { |num| "pr#{num}" }
+    pr_prefix = pull_request_number&.then { |num| "pr#{num}" }
     commit_short_hash = ENV.fetch('BUILDKITE_COMMIT', '0')[0...7]
     build_number = [pr_prefix, commit_short_hash].compact.join('-')
 
@@ -1527,7 +1527,7 @@ TEST_ANALYTICS_ENVIRONMENT = %w[
 # -----------------------------------------------------------------------------------
 
 # Buildkite sets this env var to the PR number if on a PR, but to 'false' (and not nil) if not on a PR
-PULL_REQUEST_NUMBER = ENV['BUILDKITE_PULL_REQUEST']&.then { |n| n == 'false' ? nil : Integer(n) }
+pull_request_number = ENV['BUILDKITE_PULL_REQUEST']&.then { |n| n == 'false' ? nil : Integer(n) }
 
 def create_backmerge_pr
   version = release_version_current

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -777,10 +777,10 @@ platform :ios do
     build_for_prototype_build
 
     release_notes = <<~NOTES
-      Pull Request: ##{pull_request_number || 'N/A'}
       Branch: `#{ENV.fetch('BUILDKITE_BRANCH', 'N/A')}`
       Commit: #{ENV.fetch('BUILDKITE_COMMIT', 'N/A')[0...7]}
     NOTES
+    release_notes += "Pull Request: ##{pull_request_number}" unless pull_request_number.nil?
 
     firebase_app_distribution(
       app: FIREBASE_APP_ID,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,6 +29,9 @@ WORKSPACE_PATH = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce.xcworkspace')
 FIREBASE_APP_ID = '1:124902176124:ios:02259de1e7c42b291620f9'
 FIREBASE_TESTERS_GROUP = 'woocommerce-ios---prototype-builds'
 
+# Buildkite sets this env var to the PR number if on a PR, but to 'false' (and not nil) if not on a PR
+pull_request_number = ENV['BUILDKITE_PULL_REQUEST']&.then { |n| n == 'false' ? nil : Integer(n) }
+
 BUILDKITE_RELEASE_PIPELINE = 'release-builds.yml'
 IOS_LOCALES = %w[ar-SA de-DE en-US es-ES fr-FR he id it ja ko nl-NL pt-BR ru sv tr zh-Hans zh-Hant].freeze
 SIMULATOR_VERSION = '18.5' # For screenshots
@@ -1525,9 +1528,6 @@ TEST_ANALYTICS_ENVIRONMENT = %w[
 # -----------------------------------------------------------------------------------
 # Release Management Utils
 # -----------------------------------------------------------------------------------
-
-# Buildkite sets this env var to the PR number if on a PR, but to 'false' (and not nil) if not on a PR
-pull_request_number = ENV['BUILDKITE_PULL_REQUEST']&.then { |n| n == 'false' ? nil : Integer(n) }
 
 def create_backmerge_pr
   version = release_version_current


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
Closes [AINFRA-1614](https://linear.app/a8c/issue/AINFRA-1614/build-wc-ios-prototypes-from-trunk).

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Similar to https://github.com/woocommerce/woocommerce-android/pull/15027, this PR adds an optional step that will appear on CI builds from `trunk` to deploy to Firebase App Distribution.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
Given the step will appear only on `trunk` we can only test once this is merged... However, you can see an hacked version here https://github.com/woocommerce/woocommerce-ios/pull/16431

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/2c34fdcd-429b-44ea-94de-2645be3ba4d3

<img width="769" height="264" alt="image" src="https://github.com/user-attachments/assets/cd1d9c32-f4b3-40ef-bd6a-c92947dd33b5" />

<img alt="IMG_5772" src="https://github.com/user-attachments/assets/b289d865-0d20-49c7-811f-c3e4782584d7" width=300/>

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. - N.A.
