### PR TITLE
Push notifications: Clean up logic for register/unregister tokens

### DIFF
--- a/Modules/Sources/Networking/Remote/DevicesRemote.swift
+++ b/Modules/Sources/Networking/Remote/DevicesRemote.swift
@@ -11,13 +11,11 @@ public class DevicesRemote: Remote {
     ///     - device: APNS Device to be registered.
     ///     - applicationId: App ID.
     ///     - applicationVersion: App Version.
-    ///     - defaultStoreID: Active Store ID.
     ///     - completion: Closure to be executed on completion.
     ///
     public func registerDevice(device: APNSDevice,
                                applicationId: String,
                                applicationVersion: String,
-                               defaultStoreID: Int64,
                                completion: @escaping (DotcomDevice?, Error?) -> Void) {
         var parameters = [
             ParameterKeys.applicationId: applicationId,
@@ -27,7 +25,6 @@ public class DevicesRemote: Remote {
             ParameterKeys.deviceModel: device.model,
             ParameterKeys.deviceName: device.name,
             ParameterKeys.deviceOSVersion: device.iOSVersion,
-            ParameterKeys.defaultStoreID: ""
         ]
 
         if let deviceUUID = device.identifierForVendor {
@@ -84,6 +81,5 @@ private extension DevicesRemote {
         static let deviceName = "device_name"
         static let deviceOSVersion = "os_version"
         static let deviceUUID = "device_uuid"
-        static let defaultStoreID = "selected_blog_id"
     }
 }

--- a/Modules/Sources/Yosemite/Actions/NotificationAction.swift
+++ b/Modules/Sources/Yosemite/Actions/NotificationAction.swift
@@ -12,7 +12,6 @@ public enum NotificationAction: Action {
     case registerDevice(device: APNSDevice,
                         applicationId: String,
                         applicationVersion: String,
-                        defaultStoreID: Int64,
                         onCompletion: (DotcomDevice?, Error?) -> Void)
 
     /// Unregisters a device for Push Notifications Delivery.

--- a/Modules/Sources/Yosemite/Stores/NotificationStore.swift
+++ b/Modules/Sources/Yosemite/Stores/NotificationStore.swift
@@ -37,12 +37,10 @@ public class NotificationStore: Store {
         case .registerDevice(let device,
                              let applicationId,
                              let applicationVersion,
-                             let defaultStoreID,
                              let onCompletion):
             registerDevice(device: device,
                            applicationId: applicationId,
                            applicationVersion: applicationVersion,
-                           defaultStoreID: defaultStoreID,
                            onCompletion: onCompletion)
         case .synchronizeNotifications(let onCompletion):
             synchronizeNotifications(onCompletion: onCompletion)
@@ -72,12 +70,10 @@ private extension NotificationStore {
     func registerDevice(device: APNSDevice,
                         applicationId: String,
                         applicationVersion: String,
-                        defaultStoreID: Int64,
                         onCompletion: @escaping (DotcomDevice?, Error?) -> Void) {
         devicesRemote.registerDevice(device: device,
                               applicationId: applicationId,
                               applicationVersion: applicationVersion,
-                              defaultStoreID: defaultStoreID,
                               completion: onCompletion)
     }
 

--- a/Modules/Tests/NetworkingTests/Remote/DevicesRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/DevicesRemoteTests.swift
@@ -29,8 +29,7 @@ final class DevicesRemoteTests: XCTestCase {
 
         remote.registerDevice(device: Parameters.appleDevice,
                               applicationId: Parameters.applicationId,
-                              applicationVersion: Parameters.applicationVersion,
-                              defaultStoreID: Parameters.defaultStoreID) { (settings, error) in
+                              applicationVersion: Parameters.applicationVersion) { (settings, error) in
 
             XCTAssertNil(error)
             XCTAssertNotNil(settings)
@@ -39,24 +38,6 @@ final class DevicesRemoteTests: XCTestCase {
         }
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
-    }
-
-    /// Verifies that registerDevice sets the `selected_blog_id` parameter to empty string.
-    ///
-    func test_registerDevice_sets_selected_blog_id_to_empty_string() throws {
-        // Given
-        let remote = DevicesRemote(network: network)
-
-        // When
-        remote.registerDevice(device: Parameters.appleDevice,
-                              applicationId: Parameters.applicationId,
-                              applicationVersion: Parameters.applicationVersion,
-                              defaultStoreID: Parameters.defaultStoreID) { (_, _) in }
-
-        // Then
-        let queryParameters = try XCTUnwrap(network.queryParameters)
-        let expectedParam = "selected_blog_id="
-        XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
     }
 
     /// Verifies that registerDevice parses a "Failure" Backend Response.
@@ -69,8 +50,7 @@ final class DevicesRemoteTests: XCTestCase {
 
         remote.registerDevice(device: Parameters.appleDevice,
                               applicationId: Parameters.applicationId,
-                              applicationVersion: Parameters.applicationVersion,
-                              defaultStoreID: Parameters.defaultStoreID) { (settings, error) in
+                              applicationVersion: Parameters.applicationVersion) { (settings, error) in
 
             XCTAssertNotNil(error)
             XCTAssertNil(settings)
@@ -124,6 +104,5 @@ private enum Parameters {
                                         identifierForVendor: "1234")
     static let applicationId = "9"
     static let applicationVersion = "99"
-    static let defaultStoreID: Int64 = 1234
     static let dotcomDeviceID = "1234"
 }

--- a/Modules/Tests/YosemiteTests/Stores/NotificationStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/NotificationStoreTests.swift
@@ -364,10 +364,9 @@ class NotificationStoreTests: XCTestCase {
         let (device, error): (DotcomDevice?, Error?) = waitFor { promise in
             let action = NotificationAction.registerDevice(device: self.sampleAPNSDevice(),
                                                            applicationId: self.sampleApplicationID,
-                                                           applicationVersion: self.sampleApplicationVersion,
-                                                           defaultStoreID: self.sampleDefaultStoreID) { (device, error) in
+                                                           applicationVersion: self.sampleApplicationVersion) { (device, error) in
                 promise((device, error))
-            }
+            } 
             noteStore.onAction(action)
         }
 
@@ -389,8 +388,7 @@ class NotificationStoreTests: XCTestCase {
         let (device, error): (DotcomDevice?, Error?) = waitFor { promise in
             let action = NotificationAction.registerDevice(device: self.sampleAPNSDevice(),
                                                            applicationId: self.sampleApplicationID,
-                                                           applicationVersion: self.sampleApplicationVersion,
-                                                           defaultStoreID: self.sampleDefaultStoreID) { (device, error) in
+                                                           applicationVersion: self.sampleApplicationVersion) { (device, error) in
                 promise((device, error))
             }
             noteStore.onAction(action)
@@ -488,12 +486,6 @@ private extension NotificationStoreTests {
     ///
     var sampleDotcomDeviceID: String {
         return "1234"
-    }
-
-    /// Returns a sample Default Store ID
-    ///
-    var sampleDefaultStoreID: Int64 {
-        return 1234
     }
 
     /// Returns a sample Apple Device

--- a/Modules/Tests/YosemiteTests/Stores/NotificationStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/NotificationStoreTests.swift
@@ -366,7 +366,7 @@ class NotificationStoreTests: XCTestCase {
                                                            applicationId: self.sampleApplicationID,
                                                            applicationVersion: self.sampleApplicationVersion) { (device, error) in
                 promise((device, error))
-            } 
+            }
             noteStore.onAction(action)
         }
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 23.9
 -----
 - [Internal] Moved the request for push notification authorization after login [https://github.com/woocommerce/woocommerce-ios/pull/16428]
+- [Internal] Cleaned up logic for push notification token registration [https://github.com/woocommerce/woocommerce-ios/pull/16434]
 - [*] Fixed possible sync issue in POS (https://github.com/woocommerce/woocommerce-ios/pull/16423)
 
 23.8

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -112,11 +112,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        guard let defaultStoreID = ServiceLocator.stores.sessionManager.defaultStoreID else {
-            return
-        }
-
-        ServiceLocator.pushNotesManager.registerDeviceToken(with: deviceToken, defaultStoreID: defaultStoreID)
+        ServiceLocator.pushNotesManager.registerDeviceToken(with: deviceToken)
     }
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -219,7 +219,7 @@ extension PushNotificationsManager {
     ///     - tokenData: APNS's Token Data
     ///     - defaultStoreID: Default WooCommerce Store ID
     ///
-    func registerDeviceToken(with tokenData: Data, defaultStoreID: Int64) {
+    func registerDeviceToken(with tokenData: Data) {
         let newToken = tokenData.hexString
 
         if let _ = deviceToken, deviceToken != newToken {
@@ -231,7 +231,7 @@ extension PushNotificationsManager {
         deviceToken = newToken
 
         // Register in the Dotcom's Infrastructure
-        registerDotcomDevice(with: newToken, defaultStoreID: defaultStoreID) { (device, error) in
+        registerDotcomDevice(with: newToken) { (device, error) in
             guard let deviceID = device?.deviceID else {
                 DDLogError("⛔️ Dotcom Push Notifications Registration Failure: \(error.debugDescription)")
                 return
@@ -556,12 +556,11 @@ private extension PushNotificationsManager {
 
     /// Registers an APNS DeviceToken in the WordPress.com backend.
     ///
-    func registerDotcomDevice(with deviceToken: String, defaultStoreID: Int64, onCompletion: @escaping (DotcomDevice?, Error?) -> Void) {
+    func registerDotcomDevice(with deviceToken: String, onCompletion: @escaping (DotcomDevice?, Error?) -> Void) {
         let device = APNSDevice(deviceToken: deviceToken)
         let action = NotificationAction.registerDevice(device: device,
                                                        applicationId: WooConstants.pushApplicationID,
                                                        applicationVersion: Bundle.main.version,
-                                                       defaultStoreID: defaultStoreID,
                                                        onCompletion: onCompletion)
         stores.dispatch(action)
     }

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -72,9 +72,8 @@ protocol PushNotesManager {
     ///
     /// - Parameters:
     ///     - tokenData: APNS's Token Data
-    ///     - defaultStoreID: Default WooCommerce Store ID
     ///
-    func registerDeviceToken(with tokenData: Data, defaultStoreID: Int64)
+    func registerDeviceToken(with tokenData: Data)
 
     /// Handles a remote push notification payload when the app is in the background.
     /// - Parameter userInfo: Push notification payload.

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -270,7 +270,6 @@ class DefaultStoresManager: StoresManager {
         sessionManager.deleteApplicationPassword(locally: true)
         ServiceLocator.analytics.refreshUserData()
         ZendeskProvider.shared.reset()
-        ServiceLocator.pushNotesManager.unregisterForRemoteNotifications {}
     }
 
     /// Fully deauthenticates the user, if needed.

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -90,7 +90,7 @@ final class MockPushNotificationsManager: PushNotesManager {
 
     }
 
-    func registerDeviceToken(with tokenData: Data, defaultStoreID: Int64) {
+    func registerDeviceToken(with tokenData: Data) {
 
     }
 

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -174,24 +174,6 @@ final class PushNotificationsManagerTests: XCTestCase {
         XCTAssertFalse(defaults.containsObject(forKey: .deviceToken))
     }
 
-    /// Verifies that `registerDevice` effectively dispatches a `registerDevice` Action.
-    ///
-    func testRegisterForRemoteNotificationsDispatchesRegisterDeviceAction() {
-        guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
-            XCTFail()
-            return
-        }
-
-        manager.registerDeviceToken(with: tokenAsData, defaultStoreID: Sample.defaultStoreID)
-
-        guard case let .registerDevice(_, _, _, storeID, _) = storesManager.receivedActions.first as! NotificationAction else {
-            XCTFail()
-            return
-        }
-
-        XCTAssertEqual(storeID, Sample.defaultStoreID)
-    }
-
 
     /// Verifies that `registerDeviceToken` effectively stores the Device Token.
     ///
@@ -202,7 +184,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         }
 
         XCTAssertFalse(defaults.containsObject(forKey: .deviceToken))
-        manager.registerDeviceToken(with: tokenAsData, defaultStoreID: Sample.defaultStoreID)
+        manager.registerDeviceToken(with: tokenAsData)
         XCTAssertTrue(defaults.containsObject(forKey: .deviceToken))
     }
 
@@ -707,10 +689,6 @@ private struct Sample {
     /// Sample DeviceToken
     ///
     static let deviceToken = "4fa963db2cfc824b0d67740ed2b1c0b472cce8eafcb82184905361eb88be55b9"
-
-    /// Sample StoreID
-    ///
-    static let defaultStoreID: Int64 = 9999
 
     /// UserDefaults Suite Name
     ///


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1851

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In a [past project](https://github.com/woocommerce/woocommerce-ios/issues/5032) we added the support the register a single token to get push notifications for all stores. However, in the current codebase we still have some confusing logic:
- Current site ID is sent to the network layer even though it's no longer needed to register PN tokens.
- Unregistration requests are made when switching stores even though the same token is used for all stores.

This PR cleans up the logic:
- Removes the redundant `selected_blog_id` in the request and the related param in methods to avoid confusion. 
- Removes the unregistration request when switching stores.

I'm keeping the registration request when switching stores for simplicity. It's recommended by Apple to re-register often in case tokens are invalidated remotely by Apple, and WPCom server can disregard the request if an existing token is re-registered.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Log in to a test store with a WPCom account that is connected to more than 1 stores in a physical device.
- Put your device to sleep.
- Place an order on the store that you're currently selecting on the app (let's call this store A). Confirm that you get notification about the new order.
- Open the app and switch to another store (store B) and put the device back to sleep.
- Place an order on store B. Confirm that you get notification for this order.
- Placer another order on store A. Confirm that you get notification for this order.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
