### PR TITLE
[WCiOS17] Update order creation's map picker to use new APIs

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressMapPickerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressMapPickerView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 import Observation
 import struct Yosemite.Country
 
-@available(iOS 17, *)
 struct AddressMapPickerView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel: AddressMapPickerViewModel
@@ -134,7 +133,6 @@ struct AddressMapPickerView: View {
     }
 }
 
-@available(iOS 17, *)
 private extension AddressMapPickerView {
     enum Localization {
         static let close = NSLocalizedString("addressMapPicker.button.close", value: "Close", comment: "Text for the close button in the Edit Address Form.")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressMapPickerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressMapPickerView.swift
@@ -17,12 +17,13 @@ struct AddressMapPickerView: View {
     var body: some View {
         NavigationStack {
             ZStack(alignment: .top) {
-                Map(coordinateRegion: $viewModel.region,
-                    showsUserLocation: true,
-                    annotationItems: viewModel.annotations) { item in
-                    MapMarker(coordinate: item.coordinate)
+                Map(position: $viewModel.position) {
+                    UserAnnotation()
+                    ForEach(viewModel.annotations) { item in
+                        Marker("", coordinate: item.coordinate)
+                    }
                 }
-                    .ignoresSafeArea()
+                .ignoresSafeArea()
 
                 VStack(spacing: 0) {
                     searchBar

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressMapPickerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressMapPickerViewModel.swift
@@ -25,7 +25,6 @@ final class DefaultAddressMapLocalSearchProvider: AddressMapLocalSearchProviding
     }
 }
 
-@available(iOS 17, *)
 @Observable
 final class AddressMapPickerViewModel: NSObject {
     var searchQuery = "" {
@@ -124,7 +123,6 @@ final class AddressMapPickerViewModel: NSObject {
     }
 }
 
-@available(iOS 17, *)
 private extension AddressMapPickerViewModel {
     func configureSearchCompleter() {
         searchCompleter.resultTypes = .address
@@ -196,7 +194,6 @@ private extension AddressMapPickerViewModel {
     }
 }
 
-@available(iOS 17, *)
 extension AddressMapPickerViewModel: MKLocalSearchCompleterDelegate {
     func completerDidUpdateResults(_ completer: MKLocalSearchCompleter) {
         searchResults = completer.results

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressMapPickerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressMapPickerViewModel.swift
@@ -33,9 +33,11 @@ final class AddressMapPickerViewModel: NSObject {
         }
     }
     private(set) var searchResults: [MKLocalSearchCompletion] = []
-    var region = MKCoordinateRegion(
-        center: CLLocationCoordinate2D(latitude: 37.3361, longitude: -122.0380),
-        span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+    var position: MapCameraPosition = .region(
+        MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 37.3361, longitude: -122.0380),
+            span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+        )
     )
     var annotations: [MapAnnotation] = []
     var showsSearchResults: Bool {
@@ -138,9 +140,11 @@ private extension AddressMapPickerViewModel {
                let currentLocation = locationManager.location {
                 DispatchQueue.main.async { [weak self] in
                     guard let self else { return }
-                    region = MKCoordinateRegion(
-                        center: currentLocation.coordinate,
-                        span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+                    position = .region(
+                        MKCoordinateRegion(
+                            center: currentLocation.coordinate,
+                            span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+                        )
                     )
                 }
                 return
@@ -157,9 +161,11 @@ private extension AddressMapPickerViewModel {
                         return
                     }
 
-                    region = MKCoordinateRegion(
-                        center: location.coordinate,
-                        span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+                    position = .region(
+                        MKCoordinateRegion(
+                            center: location.coordinate,
+                            span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+                        )
                     )
                     annotations = [MapAnnotation(coordinate: location.coordinate)]
                 } catch {
@@ -175,9 +181,11 @@ private extension AddressMapPickerViewModel {
             withAnimation { [weak self] in
                 guard let self else { return }
                 searchResults = []
-                region = MKCoordinateRegion(
-                    center: placemark.coordinate,
-                    span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+                position = .region(
+                    MKCoordinateRegion(
+                        center: placemark.coordinate,
+                        span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+                    )
                 )
                 annotations = [MapAnnotation(coordinate: placemark.coordinate)]
                 selectedPlace = placemark

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/AddressMapPickerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/AddressMapPickerViewModelTests.swift
@@ -21,8 +21,6 @@ struct AddressMapPickerViewModelTests {
     }
 
     // MARK: - Initialization Tests
-
-    @available(iOS 17, *)
     @Test func initialization_with_empty_fields_sets_properties_with_default_values() {
         // Given
         let emptyFields = AddressFormFields()
@@ -38,7 +36,6 @@ struct AddressMapPickerViewModelTests {
 
     // MARK: - Selection Tests
 
-    @available(iOS 17, *)
     @Test func selectLocation_updates_annotations_and_hasValidSelection() async {
         // Given
         let fields = AddressFormFields()
@@ -56,7 +53,6 @@ struct AddressMapPickerViewModelTests {
 
     // MARK: - Address Field Updates Tests
 
-    @available(iOS 17, *)
     @Test func updateFields_with_no_selected_place_does_not_modify_fields() {
         // Given
         let sut = AddressMapPickerViewModel(fields: .init(), countryByCode: mockCountryByCode)
@@ -72,7 +68,6 @@ struct AddressMapPickerViewModelTests {
         #expect(updatedFields.city == "Original City")
     }
 
-    @available(iOS 17, *)
     @Test func updateFields_when_country_not_found_in_countryByCode_sets_country_and_state_as_strings() async {
         // Given
         let mockSearchProvider = MockAddressMapLocalSearchProvider.withFrenchAddress()
@@ -95,7 +90,6 @@ struct AddressMapPickerViewModelTests {
         #expect(updatedFields.selectedState == nil)
     }
 
-   @available(iOS 17, *)
    @Test func updateFields_when_country_is_found_in_countryByCode_sets_selected_country_and_state() async {
        // Given
        let mockSearchProvider = MockAddressMapLocalSearchProvider.withUSAddress()


### PR DESCRIPTION
Part of WOOMOB-1003

## Description
This PR addresses the iOS17 warnings of using deprecated APIs when adding shipping address to an order via the map picker.

## Changes
- Replaced `MKCoordinateRegion` with `MapCameraPosition`, which is required for the new `Map` init.
- Replaced `showsUserLocation: true` parameter with `UserAnnotation()` in the content builder. Both do the same, controls whether to display the user's location with the blue pulsing dot.
- Replaced deprecated `MapMarker` with `Marker`. I used an empty string for the marker since before these were unlabeled as well, we can have title/label in here later on.
- In the new "MapContentBuilder" pattern, we cannot seem to pass in `annotationItems` anymore, instead we use a  foreach inside the content builder to iterate over each item.

## Test Steps
- Go to `Orders`  > `Add Shipping Address` > `Find on Map`
- Input an address (this is a bit wonky -at least on my zone, it has a hard time finding the correct address and sends me over to different countries- but is unrelated to the changes as behaves the same on trunk)
- Select one of the options, tap `Use this address`, observe that works normally

https://github.com/user-attachments/assets/ea6c81db-1990-4483-a1df-467f19a4edcf

