### PR TITLE
[WCiOS17] Address remaining WPAuth warnings

### DIFF
--- a/WooCommerce/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WooCommerce/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -4,12 +4,16 @@ import Gridicons
 import AuthenticationServices
 
 final class SubheadlineButton: UIButton {
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            titleLabel?.font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
-            setTitleColor(WordPressAuthenticator.shared.style.textButtonColor, for: .normal)
-            setTitleColor(WordPressAuthenticator.shared.style.textButtonHighlightColor, for: .highlighted)
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        observeTraitChanges()
+    }
+
+    private func observeTraitChanges() {
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+            self.titleLabel?.font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
+            self.setTitleColor(WordPressAuthenticator.shared.style.textButtonColor, for: .normal)
+            self.setTitleColor(WordPressAuthenticator.shared.style.textButtonHighlightColor, for: .highlighted)
         }
     }
 }

--- a/WooCommerce/WordPressAuthenticator/NUX/Button/NUXButton.swift
+++ b/WooCommerce/WordPressAuthenticator/NUX/Button/NUXButton.swift
@@ -261,4 +261,3 @@ public struct NUXButtonStyle {
         return isEnabled ? style.normal.titleColor : style.disabled.titleColor
     }
 }
-

--- a/WooCommerce/WordPressAuthenticator/NUX/Button/NUXButton.swift
+++ b/WooCommerce/WordPressAuthenticator/NUX/Button/NUXButton.swift
@@ -131,11 +131,18 @@ public struct NUXButtonStyle {
     open override func didMoveToWindow() {
         super.didMoveToWindow()
         configureAppearance()
+        observeTraitChanges()
     }
 
     open override func awakeFromNib() {
         super.awakeFromNib()
         configureAppearance()
+    }
+
+    private func observeTraitChanges() {
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+            self.didChangePreferredContentSize()
+        }
     }
 
     /// Setup: Everything = [Insets, Backgrounds, titleColor(s), titleLabel]
@@ -255,13 +262,3 @@ public struct NUXButtonStyle {
     }
 }
 
-// MARK: -
-//
-extension NUXButton {
-    override open func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            didChangePreferredContentSize()
-        }
-    }
-}

--- a/WooCommerce/WordPressAuthenticator/NUX/Button/NUXStackedButtonsViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/NUX/Button/NUXStackedButtonsViewController.swift
@@ -104,6 +104,7 @@ open class NUXStackedButtonsViewController: UIViewController {
 
         shadowView?.image = style.buttonViewTopShadowImage
         configureDivider()
+        observeTraitChanges()
     }
 
     override open func viewWillAppear(_ animated: Bool) {
@@ -202,13 +203,10 @@ private extension NUXStackedButtonsViewController {
     func didChangePreferredContentSize() {
         reloadViews()
     }
-}
 
-extension NUXStackedButtonsViewController {
-    override open func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            didChangePreferredContentSize()
+    func observeTraitChanges() {
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+            self.didChangePreferredContentSize()
         }
     }
 }

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -53,6 +53,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         styleNavigationBar(forUnified: true)
         styleBackground()
         styleInstructions()
+        observeTraitChanges()
 
         if let error = errorToPresent {
             displayRemoteError(error)
@@ -349,16 +350,16 @@ extension LoginViewController {
 //
 extension LoginViewController {
 
-    open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        // Update Dynamic Type
-        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            didChangePreferredContentSize()
+    func observeTraitChanges() {
+        // Register for content size category changes
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+            self.didChangePreferredContentSize()
         }
 
-        // Update Table View size
-        setTableViewMargins(forWidth: view.frame.width)
+        // Register for size class changes
+        registerForTraitChanges([UITraitHorizontalSizeClass.self, UITraitVerticalSizeClass.self]) { (self: Self, _) in
+            self.setTableViewMargins(forWidth: self.view.frame.width)
+        }
     }
 
     open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/WooCommerce/WordPressAuthenticator/UI/SiteInfoHeaderView.swift
+++ b/WooCommerce/WordPressAuthenticator/UI/SiteInfoHeaderView.swift
@@ -76,16 +76,13 @@ class SiteInfoHeaderView: UIView {
     override func awakeFromNib() {
         super.awakeFromNib()
         refreshLabelStyles()
+        observeTraitChanges()
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        guard previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory else {
-            return
+    private func observeTraitChanges() {
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+            self.refreshLabelStyles()
         }
-
-        refreshLabelStyles()
     }
 }
 


### PR DESCRIPTION
Part of, closes WOOMOB-1003

## Description
This PR should be the last remaining issue from clearing all iOS17-related warnings. We update the trait observation for the remaining items from the WPAuth library:
- `SiteInfoHeaderView`: Used for login into self-hosted sites (`LoginSelfHostedViewController`, `LoginUsernamePasswordViewController`)
- `NuxButton` and its stacked variant: used all around, but mostly around login/auth flows.
- `SubheadlineButton`: only used for styling `signupTermsButton` (in the button to open our Terms & conditions)

## Test Steps
As with previous ones I tested the login flow for self hosted site, and both the orientation and dark/light switches seem to work correctly, but looping Kiwi since you see those flows much more often. Let me know if anything seems off.
