### PR TITLE
[Local catalog] Specify variation_fields when generating catalog

### DIFF
--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -187,6 +187,7 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
         let path = "products/catalog"
         let parameters: [String: Any] = [
             ParameterKey.fullSyncFields: POSProduct.requestFields,
+            ParameterKey.fullSyncVariationFields: POSProductVariation.requestFields,
             ParameterKey.forceGenerate: forceGeneration
         ]
         let request = JetpackRequest(
@@ -252,12 +253,21 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
             cleanupDownloadedFileIfNeeded(at: fileURL)
         }
 
-        let mapper = ListMapper<POSProduct>(siteID: siteID)
+        let mapper = ListMapper<POSCatalogItem>(siteID: siteID)
         let items = try mapper.map(response: data)
-        let variationProductTypeKey = "variation"
-        let products = items.filter { $0.productTypeKey != variationProductTypeKey }
-        let variations = items.filter { $0.productTypeKey == variationProductTypeKey }
-            .map { $0.toVariation }
+
+        var products: [POSProduct] = []
+        var variations: [POSProductVariation] = []
+
+        for item in items {
+            switch item {
+            case .product(let product):
+                products.append(product)
+            case .variation(let variation):
+                variations.append(variation)
+            }
+        }
+
         return POSCatalogResponse(products: products, variations: variations)
     }
 
@@ -404,6 +414,7 @@ private extension POSCatalogSyncRemote {
         static let perPage = "per_page"
         static let fields = "_fields"
         static let fullSyncFields = "fields"
+        static let fullSyncVariationFields = "variation_fields"
         static let forceGenerate = "force_generate"
         static let includeStatus = "include_status"
     }
@@ -435,6 +446,30 @@ public enum POSCatalogStatus: String, Decodable {
     case processing
     case complete
     case failed
+}
+
+/// Represents a single item in the POS catalog download response.
+/// Decodes the type-tagged wrapper and directly parses the nested data in a single pass.
+public enum POSCatalogItem: Decodable {
+    case product(POSProduct)
+    case variation(POSProductVariation)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case data
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+
+        switch type {
+        case "variation":
+            self = .variation(try container.decode(POSProductVariation.self, forKey: .data))
+        default:
+            self = .product(try container.decode(POSProduct.self, forKey: .data))
+        }
+    }
 }
 
 /// POS catalog from download.

--- a/Modules/Tests/NetworkingTests/Responses/pos-catalog-download-mixed.json
+++ b/Modules/Tests/NetworkingTests/Responses/pos-catalog-download-mixed.json
@@ -1,119 +1,125 @@
 [
   {
-    "id": 48,
     "type": "simple",
-    "sku": "synergistic-copper-clock-61732018",
-    "global_unique_id": "61732018",
-    "name": "Synergistic Copper Clock",
-    "short_description": "Aut nulla accusantium mollitia aut dolor. Nesciunt dolor eligendi enim voluptas.",
-    "description": "Assumenda id quidem iste incidunt velit. Illo quae voluptatem voluptatum tempore in fuga.",
-    "stock_status": "instock",
-    "manage_stock": false,
-    "stock_quantity": null,
-    "price": 220,
-    "images": [
-      {
-        "id": 77,
-        "date_created": "2025-08-06T02:37:12",
-        "date_created_gmt": "2025-08-06T02:37:12",
-        "date_modified": "2025-08-06T02:37:12",
-        "date_modified_gmt": "2025-08-06T02:37:12",
-        "src": "https://example.com/wp-content/uploads/2025/08/img-ad.png",
-        "name": "img-ad.png",
-        "alt": "",
-        "srcset": "https://example.com/wp-content/uploads/2025/08/img-ad.png 700w, https://example.com/wp-content/uploads/2025/08/img-ad-300x300.png 300w, https://example.com/wp-content/uploads/2025/08/img-ad-150x150.png 150w, https://example.com/wp-content/uploads/2025/08/img-ad-600x600.png 600w, https://example.com/wp-content/uploads/2025/08/img-ad-100x100.png 100w",
-        "sizes": "(max-width: 700px) 100vw, 700px",
-        "thumbnail": "https://example.com/wp-content/uploads/2025/08/img-ad-300x300.png"
-      }
-    ],
-    "parent_id": 0,
-    "attributes": [],
-    "downloadable": false,
-    "status": "publish"
+    "data": {
+      "id": 48,
+      "sku": "synergistic-copper-clock-61732018",
+      "global_unique_id": "61732018",
+      "name": "Synergistic Copper Clock",
+      "short_description": "Aut nulla accusantium mollitia aut dolor. Nesciunt dolor eligendi enim voluptas.",
+      "description": "Assumenda id quidem iste incidunt velit. Illo quae voluptatem voluptatum tempore in fuga.",
+      "stock_status": "instock",
+      "manage_stock": false,
+      "stock_quantity": null,
+      "price": 220,
+      "images": [
+        {
+          "id": 77,
+          "date_created": "2025-08-06T02:37:12",
+          "date_created_gmt": "2025-08-06T02:37:12",
+          "date_modified": "2025-08-06T02:37:12",
+          "date_modified_gmt": "2025-08-06T02:37:12",
+          "src": "https://example.com/wp-content/uploads/2025/08/img-ad.png",
+          "name": "img-ad.png",
+          "alt": "",
+          "srcset": "https://example.com/wp-content/uploads/2025/08/img-ad.png 700w, https://example.com/wp-content/uploads/2025/08/img-ad-300x300.png 300w, https://example.com/wp-content/uploads/2025/08/img-ad-150x150.png 150w, https://example.com/wp-content/uploads/2025/08/img-ad-600x600.png 600w, https://example.com/wp-content/uploads/2025/08/img-ad-100x100.png 100w",
+          "sizes": "(max-width: 700px) 100vw, 700px",
+          "thumbnail": "https://example.com/wp-content/uploads/2025/08/img-ad-300x300.png"
+        }
+      ],
+      "parent_id": 0,
+      "attributes": [],
+      "downloadable": false,
+      "status": "publish",
+      "type": "simple"
+    }
   },
   {
-    "id": 31,
     "type": "variable",
-    "sku": "incredible-silk-chair-13060312",
-    "global_unique_id": "",
-    "name": "Incredible Silk Chair",
-    "short_description": "",
-    "description": "",
-    "stock_status": "onbackorder",
-    "manage_stock": true,
-    "stock_quantity": -83,
-    "price": 134.58,
-    "images": [
-      {
-        "id": 61,
-        "date_created": "2025-08-06T02:37:03",
-        "date_created_gmt": "2025-08-06T02:37:03",
-        "date_modified": "2025-08-06T02:37:03",
-        "date_modified_gmt": "2025-08-06T02:37:03",
-        "src": "https://example.com/wp-content/uploads/2025/08/img-harum.png",
-        "name": "img-harum.png",
-        "alt": "",
-        "srcset": "https://example.com/wp-content/uploads/2025/08/img-harum.png 700w, https://example.com/wp-content/uploads/2025/08/img-harum-300x300.png 300w, https://example.com/wp-content/uploads/2025/08/img-harum-150x150.png 150w, https://example.com/wp-content/uploads/2025/08/img-harum-600x600.png 600w, https://example.com/wp-content/uploads/2025/08/img-harum-100x100.png 100w",
-        "sizes": "(max-width: 700px) 100vw, 700px",
-        "thumbnail": "https://example.com/wp-content/uploads/2025/08/img-harum-300x300.png"
-      }
-    ],
-    "parent_id": 0,
-    "attributes": [
-      {
-        "id": 1,
-        "name": "Size",
-        "position": 0,
-        "visible": true,
-        "variation": true,
-        "options": [
-          "Earum"
-        ]
-      },
-      {
-        "id": 0,
-        "name": "Ab",
-        "position": 1,
-        "visible": true,
-        "variation": true,
-        "options": [
-          "deserunt",
-          "ea",
-          "ut"
-        ]
-      },
-      {
-        "id": 2,
-        "name": "Numeric Size",
-        "position": 2,
-        "visible": true,
-        "variation": true,
-        "options": [
-          "19",
-          "8",
-          "9",
-          "At",
-          "Reiciendis"
-        ]
-      }
-    ],
-    "downloadable": false,
-    "status": "publish"
+    "data": {
+      "id": 31,
+      "sku": "incredible-silk-chair-13060312",
+      "global_unique_id": "",
+      "name": "Incredible Silk Chair",
+      "short_description": "",
+      "description": "",
+      "stock_status": "onbackorder",
+      "manage_stock": true,
+      "stock_quantity": -83,
+      "price": 134.58,
+      "images": [
+        {
+          "id": 61,
+          "date_created": "2025-08-06T02:37:03",
+          "date_created_gmt": "2025-08-06T02:37:03",
+          "date_modified": "2025-08-06T02:37:03",
+          "date_modified_gmt": "2025-08-06T02:37:03",
+          "src": "https://example.com/wp-content/uploads/2025/08/img-harum.png",
+          "name": "img-harum.png",
+          "alt": "",
+          "srcset": "https://example.com/wp-content/uploads/2025/08/img-harum.png 700w, https://example.com/wp-content/uploads/2025/08/img-harum-300x300.png 300w, https://example.com/wp-content/uploads/2025/08/img-harum-150x150.png 150w, https://example.com/wp-content/uploads/2025/08/img-harum-600x600.png 600w, https://example.com/wp-content/uploads/2025/08/img-harum-100x100.png 100w",
+          "sizes": "(max-width: 700px) 100vw, 700px",
+          "thumbnail": "https://example.com/wp-content/uploads/2025/08/img-harum-300x300.png"
+        }
+      ],
+      "parent_id": 0,
+      "attributes": [
+        {
+          "id": 1,
+          "name": "Size",
+          "position": 0,
+          "visible": true,
+          "variation": true,
+          "options": [
+            "Earum"
+          ]
+        },
+        {
+          "id": 0,
+          "name": "Ab",
+          "position": 1,
+          "visible": true,
+          "variation": true,
+          "options": [
+            "deserunt",
+            "ea",
+            "ut"
+          ]
+        },
+        {
+          "id": 2,
+          "name": "Numeric Size",
+          "position": 2,
+          "visible": true,
+          "variation": true,
+          "options": [
+            "19",
+            "8",
+            "9",
+            "At",
+            "Reiciendis"
+          ]
+        }
+      ],
+      "downloadable": false,
+      "status": "publish",
+      "type": "variable"
+    }
   },
   {
-    "id": 32,
     "type": "variation",
-    "sku": "",
-    "global_unique_id": "",
-    "name": "Incredible Silk Chair",
-    "short_description": "",
-    "description": "",
-    "stock_status": "instock",
-    "manage_stock": true,
-    "stock_quantity": 69,
-    "price": 330.34,
-    "images": [
-      {
+    "data": {
+      "id": 32,
+      "sku": "",
+      "global_unique_id": "",
+      "name": "Incredible Silk Chair",
+      "short_description": "",
+      "description": "",
+      "stock_status": "instock",
+      "manage_stock": true,
+      "stock_quantity": 69,
+      "price": 330.34,
+      "image": {
         "id": 62,
         "date_created": "2025-08-06T02:37:04",
         "date_created_gmt": "2025-08-06T02:37:04",
@@ -125,43 +131,42 @@
         "srcset": "https://example.com/wp-content/uploads/2025/08/img-quae.png 700w, https://example.com/wp-content/uploads/2025/08/img-quae-300x300.png 300w, https://example.com/wp-content/uploads/2025/08/img-quae-150x150.png 150w, https://example.com/wp-content/uploads/2025/08/img-quae-600x600.png 600w, https://example.com/wp-content/uploads/2025/08/img-quae-100x100.png 100w",
         "sizes": "(max-width: 700px) 100vw, 700px",
         "thumbnail": "https://example.com/wp-content/uploads/2025/08/img-quae-300x300.png"
-      }
-    ],
-    "parent_id": 31,
-    "attributes": [
-      {
-        "id": 1,
-        "name": "Size",
-        "option": "Earum"
       },
-      {
-        "id": 0,
-        "name": "ab",
-        "option": "deserunt"
-      },
-      {
-        "id": 2,
-        "name": "Numeric Size",
-        "option": "19"
-      }
-    ],
-    "downloadable": false,
-    "status": "publish"
+      "parent_id": 31,
+      "attributes": [
+        {
+          "id": 1,
+          "name": "Size",
+          "option": "Earum"
+        },
+        {
+          "id": 0,
+          "name": "ab",
+          "option": "deserunt"
+        },
+        {
+          "id": 2,
+          "name": "Numeric Size",
+          "option": "19"
+        }
+      ],
+      "downloadable": false
+    }
   },
   {
-    "id": 33,
     "type": "variation",
-    "sku": "",
-    "global_unique_id": "",
-    "name": "Incredible Silk Chair",
-    "short_description": "",
-    "description": "",
-    "stock_status": "instock",
-    "manage_stock": true,
-    "stock_quantity": 64,
-    "price": 580.05,
-    "images": [
-      {
+    "data": {
+      "id": 33,
+      "sku": "",
+      "global_unique_id": "",
+      "name": "Incredible Silk Chair",
+      "short_description": "",
+      "description": "",
+      "stock_status": "instock",
+      "manage_stock": true,
+      "stock_quantity": 64,
+      "price": 580.05,
+      "image": {
         "id": 63,
         "date_created": "2025-08-06T02:37:05",
         "date_created_gmt": "2025-08-06T02:37:05",
@@ -173,27 +178,26 @@
         "srcset": "https://example.com/wp-content/uploads/2025/08/img-delectus-1.png 700w, https://example.com/wp-content/uploads/2025/08/img-delectus-1-300x300.png 300w, https://example.com/wp-content/uploads/2025/08/img-delectus-1-150x150.png 150w, https://example.com/wp-content/uploads/2025/08/img-delectus-1-600x600.png 600w, https://example.com/wp-content/uploads/2025/08/img-delectus-1-100x100.png 100w",
         "sizes": "(max-width: 700px) 100vw, 700px",
         "thumbnail": "https://example.com/wp-content/uploads/2025/08/img-delectus-1-300x300.png"
-      }
-    ],
-    "parent_id": 31,
-    "attributes": [
-      {
-        "id": 1,
-        "name": "Size",
-        "option": "Earum"
       },
-      {
-        "id": 0,
-        "name": "ab",
-        "option": "deserunt"
-      },
-      {
-        "id": 2,
-        "name": "Numeric Size",
-        "option": "8"
-      }
-    ],
-    "downloadable": false,
-    "status": "publish"
-  },
+      "parent_id": 31,
+      "attributes": [
+        {
+          "id": 1,
+          "name": "Size",
+          "option": "Earum"
+        },
+        {
+          "id": 0,
+          "name": "ab",
+          "option": "deserunt"
+        },
+        {
+          "id": 2,
+          "name": "Numeric Size",
+          "option": "8"
+        }
+      ],
+      "downloadable": false
+    }
+  }
 ]


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR evolves the file-download full catalog sync approach to match the current state of the API.

This is feature-flagged, and will probably evolve further.

There’s now a separation between product fields and variation fields, so we can fetch what we need and have more specificity about what’s in the response.

With this shift, the file format has changed to return products/variations wrapped with their type, so I’ve updated the JSON parsing to match that here.


## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Pre-requisites – POS site running:
- WooCommerce built from this PR: https://github.com/woocommerce/woocommerce/pull/61763
- woocommerce-product-feed-for-openai from this PR: https://github.com/woocommerce/woocommerce-product-feed-for-openai/pull/37
- You can use largefuntesting.mystagingwebsite.com which already has those.
- Enable the `pointOfSaleCatalogAPI` feature flag
- Increase the catalog limit to 100000 in `POSLocalCatalogEligibilityService.Constants`

1. Log out of the app, then log in to the site
2. Open POS – observe that it shows the syncing screen for a while then shows the items.
3. Log out and back in again
4. Open POS – observe that the syncing screen is shown for much shorter, or not at all.

Observe the logs and sync details on the catalog settings to make sure they make sense.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/345bdf6a-ff09-4db1-8a3e-59a3ea152ddd

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
