### PR TITLE
HACK Week: Enable troubleshooting for users authenticated with site credentials

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [Internal] Moved the request for push notification authorization after login [https://github.com/woocommerce/woocommerce-ios/pull/16428]
 - [Internal] Cleaned up logic for push notification token registration [https://github.com/woocommerce/woocommerce-ios/pull/16434]
 - [*] Fixed possible sync issue in POS (https://github.com/woocommerce/woocommerce-ios/pull/16423)
+- [*] Enabled site troubleshooting for users authenticated with site credentials [https://github.com/woocommerce/woocommerce-ios/pull/16441]
 
 23.8
 -----

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -44,7 +44,14 @@ final class ConnectivityToolViewModel {
     ///
     private func startConnectivityTest(sinceTest: ConnectivityTest = .internetConnection) async {
 
-        for (index, testCase) in ConnectivityTest.allCases.enumerated().dropFirst(sinceTest.rawValue) {
+        let supportedTests: [ConnectivityTest] = {
+            if ServiceLocator.stores.isAuthenticatedWithoutWPCom == false {
+                [.internetConnection, .wpComServers, .site, .siteOrders]
+            } else {
+                [.internetConnection, .site, .siteOrders]
+            }
+        }()
+        for (index, testCase) in supportedTests.enumerated().dropFirst(sinceTest.rawValue) {
 
             // Add an inProgress card for the current test.
             cards.append(testCase.inProgressCard)
@@ -265,7 +272,7 @@ private extension ConnectivityToolViewModel {
         case readMore = "arrow.up.forward.app"
     }
 
-    enum ConnectivityTest: Int, CaseIterable {
+    enum ConnectivityTest: Int {
         case internetConnection
         case wpComServers
         case site

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -210,7 +210,6 @@ private extension SettingsViewModel {
             var rows: [Row] = []
 
             if stores.isAuthenticated,
-               stores.isAuthenticatedWithoutWPCom == false,
                stores.sessionManager.defaultSite?.isWordPressComStore == false {
                 rows.append(.connectivity)
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -318,7 +318,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.connectivity) })
     }
 
-    func test_sections_does_not_contain_connectivity_row_if_user_authenticated_without_wpcom() {
+    func test_sections_contains_connectivity_row_if_user_authenticated_without_wpcom() {
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true, isWordPressComStore: false)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false, defaultSite: testSite))
         let viewModel = SettingsViewModel(stores: stores)
@@ -327,7 +327,7 @@ final class SettingsViewModelTests: XCTestCase {
         viewModel.onViewDidLoad()
 
         // Then
-        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.connectivity) })
+        XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.connectivity) })
     }
 
     func test_sections_contains_connectivity_row_if_user_authenticated_with_wpcom_to_non_wpcom_site() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of WOOMOB-1856

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the troubleshooting tool to extend its availability for users authenticated with site credentials. The check for WPCom access is omitted for these users.

In a subsequent PR I'll add more checks to give more useful information for HEs.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Log in to a test store with site credentials.
- Navigate to Menu tab > Settings and confirm that Troubleshoot Connection is available in the Configure section.
- Tap the entry point and confirm that the check for WPCom is omitted.
- Regression check: Repeat the steps by logging in to a self-hosted store with a connected WPCom account.
- Confirm that the entry point is available in Settings and the screen shows the WPCom check.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/c312558f-2cde-4e16-b1a2-4c3dd51d7836



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
