### PR TITLE
Update order status in dashboard card

### DIFF
--- a/Modules/Sources/Yosemite/Tools/EntityListener.swift
+++ b/Modules/Sources/Yosemite/Tools/EntityListener.swift
@@ -47,6 +47,12 @@ public class EntityListener<T: ReadOnlyType> {
         self.init(viewContext: storageManager.persistentContainer.viewContext,
                   readOnlyEntity: readOnlyEntity)
     }
+
+    deinit {
+        if let token = notificationsToken {
+            NotificationCenter.default.removeObserver(token)
+        }
+    }
 }
 
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [Internal] Moved the request for push notification authorization after login [https://github.com/woocommerce/woocommerce-ios/pull/16428]
 - [Internal] Cleaned up logic for push notification token registration [https://github.com/woocommerce/woocommerce-ios/pull/16434]
 - [*] Fixed possible sync issue in POS (https://github.com/woocommerce/woocommerce-ios/pull/16423)
+- [*] Keep order statuses in "Most recent orders" dashboard card up to date (https://github.com/woocommerce/woocommerce-ios/pull/16442)
 
 23.8
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreData
 import Yosemite
 import protocol Storage.StorageManagerType
 import protocol WooFoundation.Analytics
@@ -89,6 +90,8 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
     @Published private(set) var rows: [LastOrderDashboardRowViewModel] = []
     @Published private(set) var allStatuses: [OrderStatusRow] = []
 
+    private var orderEntityListeners: [Int64: EntityListener<Order>] = [:]
+
     var status: String {
         selectedOrderStatus?.description ?? Localization.anyStatusCase
     }
@@ -127,12 +130,15 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
         syncingData = true
         syncingError = nil
         rows = []
+        tearDownOrderEntityListeners()
 
         do {
             async let orders = loadLast3Orders(for: selectedOrderStatus)
             try? await loadOrderStatuses()
-            rows = try await orders
+            let fetchedOrders = try await orders
+            rows = fetchedOrders
                 .map { LastOrderDashboardRowViewModel(order: $0) }
+            setupOrderEntityListeners(for: fetchedOrders)
             analytics.track(event: .DynamicDashboard.cardLoadingCompleted(type: .lastOrders))
         } catch {
             syncingError = error
@@ -238,6 +244,48 @@ private extension LastOrdersDashboardCardViewModel {
                 continuation.resume(returning: OrderStatusEnum(rawValue: rawStatus))
             }))
         }
+    }
+}
+
+// MARK: Orders observing
+//
+private extension LastOrdersDashboardCardViewModel {
+    func setupOrderEntityListeners(for orders: [Order]) {
+        tearDownOrderEntityListeners()
+        guard let viewContext = storageManager.viewStorage as? NSManagedObjectContext else {
+            return
+        }
+
+        for order in orders {
+            let listener = EntityListener(viewContext: viewContext, readOnlyEntity: order)
+            listener.onUpsert = { updatedOrder in
+                Task { @MainActor [weak self] in
+                    self?.updateRow(with: updatedOrder)
+                }
+            }
+            listener.onDelete = {
+                Task { @MainActor [weak self] in
+                    self?.removeRow(with: order.orderID)
+                }
+            }
+            orderEntityListeners[order.orderID] = listener
+        }
+    }
+
+    func tearDownOrderEntityListeners() {
+        orderEntityListeners.removeAll()
+    }
+
+    func updateRow(with order: Order) {
+        guard let index = rows.firstIndex(where: { $0.id == order.orderID }) else {
+            return
+        }
+        rows[index] = LastOrderDashboardRowViewModel(order: order)
+    }
+
+    func removeRow(with orderID: Int64) {
+        rows.removeAll { $0.id == orderID }
+        orderEntityListeners[orderID] = nil
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModelTests.swift
@@ -1,8 +1,8 @@
 import XCTest
+import CoreData
 import Yosemite
+import Storage
 @testable import WooCommerce
-import protocol Storage.StorageManagerType
-import protocol Storage.StorageType
 
 final class LastOrdersDashboardCardViewModelTests: XCTestCase {
     private let sampleSiteID: Int64 = 134
@@ -112,7 +112,7 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
         let viewModel = LastOrdersDashboardCardViewModel(siteID: sampleSiteID,
                                                          stores: stores,
                                                          storageManager: storageManager)
-        insertOrderStatuses(sampleOrderStatuses)
+        await insertOrderStatuses(sampleOrderStatuses)
 
         mockFetchFilteredOrders()
         mockOrderStatuses()
@@ -201,15 +201,59 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
         }
         await viewModel.reloadData()
     }
+
+    @MainActor
+    func test_rows_are_updated_when_storage_order_is_upserted() async throws {
+        // Given
+        let viewModel = LastOrdersDashboardCardViewModel(siteID: sampleSiteID,
+                                                         stores: stores,
+                                                         storageManager: storageManager)
+        mockFetchFilteredOrders()
+        mockOrderStatuses()
+        await viewModel.reloadData()
+        XCTAssertEqual(viewModel.rows.first?.statusDescription, sampleOrders[0].status.description)
+
+        // When
+        let updatedStatus: OrderStatusEnum = .onHold
+        await upsertStorageOrder(sampleOrders[0].copy(status: updatedStatus))
+        try await Task.sleep(nanoseconds: 50_000_000) // allow async Task in listener to run
+
+        // Then
+        XCTAssertEqual(viewModel.rows.first?.statusDescription, updatedStatus.description)
+    }
+
+    @MainActor
+    func test_row_is_removed_when_storage_order_is_deleted() async throws {
+        // Given
+        let viewModel = LastOrdersDashboardCardViewModel(siteID: sampleSiteID,
+                                                         stores: stores,
+                                                         storageManager: storageManager)
+        mockFetchFilteredOrders()
+        mockOrderStatuses()
+        await viewModel.reloadData()
+        XCTAssertEqual(viewModel.rows.count, 3)
+
+        // Ensure order exists in storage so deletion triggers listener
+        await upsertStorageOrder(sampleOrders[0])
+
+        // When
+        await deleteStorageOrder(siteID: sampleSiteID, orderID: sampleOrders[0].orderID)
+        try await Task.sleep(nanoseconds: 50_000_000) // allow async Task in listener to run
+
+        // Then
+        XCTAssertEqual(viewModel.rows.count, 2)
+        XCTAssertFalse(viewModel.rows.contains(where: { $0.id == sampleOrders[0].orderID }))
+    }
 }
 
 private extension LastOrdersDashboardCardViewModelTests {
-    func insertOrderStatuses(_ readOnlyOrderStatuses: [OrderStatus]) {
-        readOnlyOrderStatuses.forEach { orderStatus in
-            let newOrderStatus = storage.insertNewObject(ofType: StorageOrderStatus.self)
-            newOrderStatus.update(with: orderStatus)
-        }
-        storage.saveIfNeeded()
+    func insertOrderStatuses(_ readOnlyOrderStatuses: [Yosemite.OrderStatus]) async {
+        await storageManager.performAndSaveAsync({ storage in
+            readOnlyOrderStatuses.forEach { orderStatus in
+                let newOrderStatus = storage.insertNewObject(ofType: StorageOrderStatus.self)
+                newOrderStatus.update(with: orderStatus)
+            }
+        }, on: .main)
     }
 
     func mockFetchFilteredOrders() {
@@ -232,5 +276,21 @@ private extension LastOrdersDashboardCardViewModelTests {
                 break
             }
         }
+    }
+
+    func upsertStorageOrder(_ order: Yosemite.Order) async {
+        await storageManager.performAndSaveAsync({ storage in
+            let storageOrder = storage.loadOrder(siteID: order.siteID, orderID: order.orderID) ?? storage.insertNewObject(ofType: Storage.Order.self)
+            storageOrder.update(with: order)
+        }, on: .main)
+    }
+
+    func deleteStorageOrder(siteID: Int64, orderID: Int64) async {
+        await storageManager.performAndSaveAsync({ storage in
+            guard let storageOrder = storage.loadOrder(siteID: siteID, orderID: orderID) else {
+                return
+            }
+            storage.deleteObject(storageOrder)
+        }, on: .main)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-47

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Makes "Most recent orders" dashboard card to reflect order status updates. In the original implementation orders were fetched from API bypassing local storage and were presented in card as-is. Thus the presented orders were detached from the local storage state and didn't reflect any changes.

In this branch the `EntityListener` was used to track and reflect order changes in dashboard card following the same approach as in https://github.com/woocommerce/woocommerce-ios/pull/16380. Thx to @itsmeichigo for the suggestion.

- Creates `Order` entity listeners for each order presented in the card.
- Adds/Deletes/Re-creates the corresponding entity listeners in case if the set of displayed orders changes.
- Doesn't track/maintain the collection of orders basing on Core Data state. The orders set presented in dashboard card is still fetched from API directly.
- Additionally unsubscribes the the entity listener on `deinit` for safety.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
- In dashboard display the "Most recent orders" card and make sure there is at least one order.
- Navigate to the order and change the order status to a different one.
- Navigate back to the dashboard card. Make sure there was no pull-to-refresh action on dashboard or any other manual update.
- Make sure the order displays the new selected status in the "Most recent orders" dashboard card.

## Demo
<!-- Include before and after images or gifs when appropriate. -->
https://github.com/user-attachments/assets/9a92888b-7769-4603-bd11-ca23d73898e8

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
