### PR TITLE
HACK Week: Add details for decoding errors in troubleshooting tool

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [Internal] Cleaned up logic for push notification token registration [https://github.com/woocommerce/woocommerce-ios/pull/16434]
 - [*] Fixed possible sync issue in POS (https://github.com/woocommerce/woocommerce-ios/pull/16423)
 - [*] Enabled site troubleshooting for users authenticated with site credentials [https://github.com/woocommerce/woocommerce-ios/pull/16441]
+- [*] Troubleshooting tool: Add step to load products and technical details for decoding errors [https://github.com/woocommerce/woocommerce-ios/pull/16444]
 
 23.8
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ConnectivityTool.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ConnectivityTool.swift
@@ -10,6 +10,7 @@ extension WooAnalyticsEvent {
             case wpCom
             case site
             case orders
+            case products
         }
 
         static func automaticTimeoutRetry() -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -265,7 +265,7 @@ struct ConnectivityToolCard: View {
             }
         }
         .sheet(item: $selectedTechnicalDetails) { item in
-            TechnicalDetailsView(title: title, technicalDetails: item.details)
+            TechnicalDetailsView(technicalDetails: item.details)
                 .presentationDetents([.medium, .large])
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -57,7 +57,7 @@ struct ConnectivityTool: View {
     struct Card {
         let title: String
         let icon: ConnectivityToolCard.Icon
-        let state: ConnectivityToolCard.State
+        let state: ConnectivityToolCard.ConnectivityState
     }
 
     /// Tool cards.
@@ -128,7 +128,7 @@ struct ConnectivityToolCard: View {
 
     /// Represents the state of the card.
     ///
-    enum State {
+    enum ConnectivityState {
 
         /// Represents an action to could be performed when presenting an error.
         ///
@@ -136,6 +136,14 @@ struct ConnectivityToolCard: View {
             let title: String
             let systemImage: String
             let action: () -> ()
+            let technicalDetails: String?
+
+            init(title: String, systemImage: String, action: @escaping () -> Void = {}, technicalDetails: String? = nil) {
+                self.title = title
+                self.systemImage = systemImage
+                self.action = action
+                self.technicalDetails = technicalDetails
+            }
         }
 
         case inProgress
@@ -203,11 +211,19 @@ struct ConnectivityToolCard: View {
 
     /// Card state
     ///
-    let state: State
+    let state: ConnectivityState
 
     /// Internal layout values
     ///
     private static let verticalSpacing = 16.0
+
+    @State private var selectedTechnicalDetails: TechnicalDetailsItem?
+
+    init(icon: Icon, title: String, state: ConnectivityState) {
+        self.icon = icon
+        self.title = title
+        self.state = state
+    }
 
     var body: some View {
         VStack(spacing: Self.verticalSpacing) {
@@ -233,14 +249,24 @@ struct ConnectivityToolCard: View {
                 cardMessage(message)
 
                 ForEach(actions, id: \.title) { action in
-                    Button(action.title, systemImage: action.systemImage, action: action.action)
-                        .foregroundColor(Color(uiColor: .accent))
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Button(action.title, systemImage: action.systemImage) {
+                        if let technicalDetails = action.technicalDetails {
+                            selectedTechnicalDetails = TechnicalDetailsItem(details: technicalDetails)
+                        } else {
+                            action.action()
+                        }
+                    }
+                    .foregroundColor(Color(uiColor: .accent))
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
             default:
                 EmptyView()
             }
+        }
+        .sheet(item: $selectedTechnicalDetails) { item in
+            TechnicalDetailsView(title: title, technicalDetails: item.details)
+                .presentationDetents([.medium, .large])
         }
     }
 
@@ -263,7 +289,7 @@ struct ConnectivityToolCard: View {
                     [.init(title: "Retry connection", systemImage: "arrow.clockwise", action: {}),
                      .init(title: "Read More", systemImage: "arrow.up.forward.app", action: {})])),
             .init(title: "Fetching your site orders", icon: .system("list.clipboard"), state: .inProgress),
-            .init(title: "No connection issues", icon: .empty, state: .empty("If your data still isn’t loading, contact our support team for assistance."))
+            .init(title: "No connection issues", icon: .empty, state: .empty("If your data still isn't loading, contact our support team for assistance."))
         ])
             .navigationTitle("Connectivity Test")
             .navigationBarTitleDisplayMode(.inline)

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -185,7 +185,7 @@ final class ConnectivityToolViewModel {
                     DDLogError("Connectivity Tool: ❌ Site connection\n\(error)")
                 }
 
-                let state = self.stateForSiteResult(result)
+                let state = self.stateForSiteResult(result, operation: .site)
                 continuation.resume(returning: state)
             }
         }
@@ -197,10 +197,10 @@ final class ConnectivityToolViewModel {
         do {
             _ = try await orderRemote.loadAllOrders(for: siteID)
             DDLogInfo("Connectivity Tool: ✅ Site Orders")
-            return stateForSiteResult(Result<[Order], Error>.success([]))
+            return stateForSiteResult(Result<[Order], Error>.success([]), operation: .siteOrders)
         } catch {
             DDLogError("Connectivity Tool: ❌ Site Orders\n\(error)")
-            return stateForSiteResult(Result<[Order], Error>.failure(error))
+            return stateForSiteResult(Result<[Order], Error>.failure(error), operation: .siteOrders)
         }
     }
 
@@ -210,14 +210,14 @@ final class ConnectivityToolViewModel {
         do {
             _ = try await productsRemote.loadAllProducts(for: siteID)
             DDLogInfo("Connectivity Tool: ✅ Retrieving products successfully")
-            return stateForSiteResult(Result<[Product], Error>.success([]))
+            return stateForSiteResult(Result<[Product], Error>.success([]), operation: .loadingProducts)
         } catch {
             DDLogError("Connectivity Tool: ❌ Failed to load products\n\(error)")
-            return stateForSiteResult(Result<[Product], Error>.failure(error))
+            return stateForSiteResult(Result<[Product], Error>.failure(error), operation: .loadingProducts)
         }
     }
 
-    private func stateForSiteResult<T>(_ result: Result<T, Error>) -> ConnectivityToolCard.ConnectivityState {
+    private func stateForSiteResult<T>(_ result: Result<T, Error>, operation: ConnectivityTest) -> ConnectivityToolCard.ConnectivityState {
         guard case let .failure(error) = result else {
             return .success
         }
@@ -241,7 +241,7 @@ final class ConnectivityToolViewModel {
             readMoreAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction)
         case (let decodingError as DecodingError, _):
             message = Localization.ErrorMessage.decodingError
-            let technicalDetails = formatDecodingError(decodingError)
+            let technicalDetails = formatDecodingError(decodingError, operation: operation)
             let viewDetailsTitle = Localization.Action.viewDetails
             let viewDetailsAction = ConnectivityToolCard.ConnectivityState.Action(
                 title: viewDetailsTitle,
@@ -293,9 +293,10 @@ final class ConnectivityToolViewModel {
     /// Extracts detailed technical information from a DecodingError for debugging purposes.
     /// Contents are intentionally not localized for simplicity.
     ///
-    private func formatDecodingError(_ error: DecodingError) -> String {
+    private func formatDecodingError(_ error: DecodingError, operation: ConnectivityTest) -> String {
         var details: [String] = []
 
+        details.append("Operation: \(operation.title)")
         details.append("Error Type: Decoding Error")
         details.append("")
 
@@ -414,8 +415,8 @@ private extension ConnectivityToolViewModel {
             )
             static let retry = NSLocalizedString(
                 "connectivityToolViewModel.action.retry",
-                value: "Retry connection",
-                comment: "Retry connection button in the connectivity tool screen"
+                value: "Retry test",
+                comment: "Retry test button in the connectivity tool screen"
             )
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -94,7 +94,7 @@ final class ConnectivityToolViewModel {
 
     /// Perform the test for a provided test case.
     ///
-    private func runTest(for connectivityTest: ConnectivityTest) async -> ConnectivityToolCard.State {
+    private func runTest(for connectivityTest: ConnectivityTest) async -> ConnectivityToolCard.ConnectivityState {
         switch connectivityTest {
         case .internetConnection:
             return await testInternetConnectivity()
@@ -129,7 +129,7 @@ final class ConnectivityToolViewModel {
 
     /// Perform internet connectivity case using the `connectivityObserver`.
     ///
-    private func testInternetConnectivity() async -> ConnectivityToolCard.State {
+    private func testInternetConnectivity() async -> ConnectivityToolCard.ConnectivityState {
 
         let status = ServiceLocator.connectivityObserver.currentStatus
         let reachable = {
@@ -142,18 +142,16 @@ final class ConnectivityToolViewModel {
             }
         }()
 
-        let state: ConnectivityToolCard.State = reachable ?
+        let state: ConnectivityToolCard.ConnectivityState = reachable ?
             .success :
-            .error(NSLocalizedString("It looks like you're not connected to the internet.\n\n" +
-                                     "Ensure your Wi-Fi is turned on. If you're using mobile data, make sure it's enabled in your device settings.",
-                                     comment: "Message when there is no internet connection in the recovery tool"), [self.retryAction()])
+            .error(Localization.ErrorMessage.noInternet, [self.retryAction()])
 
         return state
     }
 
     /// Test WPCom connectivity by fetching the mobile announcements.
     ///
-    func testWPComServersConnectivity() async -> ConnectivityToolCard.State {
+    func testWPComServersConnectivity() async -> ConnectivityToolCard.ConnectivityState {
         await withCheckedContinuation { continuation in
             announcementsRemote.loadAnnouncements(appVersion: UserAgent.bundleShortVersion, locale: Locale.current.identifier) { result in
 
@@ -164,19 +162,18 @@ final class ConnectivityToolViewModel {
                     DDLogError("Connectivity Tool: ❌ WPCom connection\n\(error)")
                 }
 
-                let state: ConnectivityToolCard.State = result.isSuccess ?
+                let state: ConnectivityToolCard.ConnectivityState = result.isSuccess ?
                     .success :
-                    .error(NSLocalizedString("We can’t connect to WordPress.com right now.\n\n" +
-                                             "Try again in a few minutes, or contact our support team and we will happily assist you.",
-                                             comment: "Message when we can't reach WPCom in the recovery tool"), [self.retryAction()])
-                continuation.resume(returning: state)
+                    .error(Localization.ErrorMessage.wpcomConnection, [self.retryAction()])
+                continuation.resume(returning: state
+                )
             }
         }
     }
 
     /// Test Site connectivity by fetching the status report..
     ///
-    func testSiteConnectivity() async -> ConnectivityToolCard.State {
+    func testSiteConnectivity() async -> ConnectivityToolCard.ConnectivityState {
         await withCheckedContinuation { continuation in
             systemStatusRemote.fetchSystemStatusReport(for: siteID) { [weak self] result in
                 guard let self else { return }
@@ -196,7 +193,7 @@ final class ConnectivityToolViewModel {
 
     /// Test fetching the site orders by actually fetching orders.
     ///
-    func testFetchingOrders() async -> ConnectivityToolCard.State {
+    func testFetchingOrders() async -> ConnectivityToolCard.ConnectivityState {
         do {
             _ = try await orderRemote.loadAllOrders(for: siteID)
             DDLogInfo("Connectivity Tool: ✅ Site Orders")
@@ -209,7 +206,7 @@ final class ConnectivityToolViewModel {
 
     /// Test fetching products.
     ///
-    func testFetchingProducts() async -> ConnectivityToolCard.State {
+    func testFetchingProducts() async -> ConnectivityToolCard.ConnectivityState {
         do {
             _ = try await productsRemote.loadAllProducts(for: siteID)
             DDLogInfo("Connectivity Tool: ✅ Retrieving products successfully")
@@ -220,14 +217,14 @@ final class ConnectivityToolViewModel {
         }
     }
 
-    private func stateForSiteResult<T>(_ result: Result<T, Error>) -> ConnectivityToolCard.State {
+    private func stateForSiteResult<T>(_ result: Result<T, Error>) -> ConnectivityToolCard.ConnectivityState {
         guard case let .failure(error) = result else {
             return .success
         }
 
         let message: String
-        let readMoreAction: ConnectivityToolCard.State.Action
-        let readMore = NSLocalizedString("Read more", comment: "Action button title for a generic error on the connectivity tool")
+        let readMoreAction: ConnectivityToolCard.ConnectivityState.Action
+        let readMore = Localization.Action.readMore
         let generalTroubleshootAction = {
             UIApplication.shared.open(WooConstants.URLs.troubleshootErrorLoadingData.asURL())
             ServiceLocator.analytics.track(event: .ConnectivityTool.readMoreTapped())
@@ -240,30 +237,32 @@ final class ConnectivityToolViewModel {
         // Handle all types of errors but timeouts are specific.
         switch (error, error.isTimeoutError) {
         case (_, true):
-            message = NSLocalizedString("Your site is taking too long to respond.\n\nPlease contact your hosting provider for further assistance.",
-                                        comment: "Message when we there is a timeout error in the recovery tool")
+            message = Localization.ErrorMessage.timeout
             readMoreAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction)
-        case (is DecodingError, _):
-            message = NSLocalizedString("We can't work properly with your site's response.\n\n" +
-                                        "Read more about it or contact our support team and we will happily assist you.",
-                                        comment: "Message when we there is a decoding error in the recovery tool")
+        case (let decodingError as DecodingError, _):
+            message = Localization.ErrorMessage.decodingError
+            let technicalDetails = formatDecodingError(decodingError)
+            let viewDetailsTitle = Localization.Action.viewDetails
+            let viewDetailsAction = ConnectivityToolCard.ConnectivityState.Action(
+                title: viewDetailsTitle,
+                systemImage: SystemImages.viewDetails.rawValue,
+                technicalDetails: technicalDetails
+            )
             readMoreAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction)
+            return .error(message, [viewDetailsAction, readMoreAction, retryAction()])
         case (DotcomError.jetpackNotConnected, _):
-            message = NSLocalizedString("There is problem with your jetpack connection.\n\n" +
-                                        "Read more about it or contact our support team and we will happily assist you.",
-                                        comment: "Message when we there is a jetpack error in the recovery tool")
+            message = Localization.ErrorMessage.noJetpackConnection
             readMoreAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: jetpackTroubleshootAction)
         default:
-            message = NSLocalizedString("There seems to be a problem with your site.\n\nPlease contact your hosting provider for further assistance.",
-                                        comment: "Message when we there is a generic error in the recovery tool")
+            message = Localization.ErrorMessage.generic
             readMoreAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction)
         }
 
         return .error(message, [readMoreAction, retryAction()])
     }
 
-    private func retryAction() -> ConnectivityToolCard.State.Action {
-        let retryText = NSLocalizedString("Retry connection", comment: "Retry connection button in the connectivity tool screen")
+    private func retryAction() -> ConnectivityToolCard.ConnectivityState.Action {
+        let retryText = Localization.Action.retry
         return .init(title: retryText, systemImage: SystemImages.retry.rawValue, action: { [weak self] in
             self?.retryLastTest()
         })
@@ -285,10 +284,140 @@ final class ConnectivityToolViewModel {
     }
 
     private func noConnectionsIssueState() -> ConnectivityTool.Card {
-        .init(title: NSLocalizedString("No connection issues", comment: "Title for when there are no connection issues in the connectivity tool screen"),
+        .init(title: Localization.noIssues,
               icon: .empty,
-              state: .empty(NSLocalizedString("If your data still isn’t loading, contact our support team for assistance.",
-                                              comment: "Info message when there are no connection issues in the connectivity tool screen")))
+              state: .empty(Localization.noIssuesMessage)
+        )
+    }
+
+    /// Extracts detailed technical information from a DecodingError for debugging purposes.
+    /// Contents are intentionally not localized for simplicity.
+    ///
+    private func formatDecodingError(_ error: DecodingError) -> String {
+        var details: [String] = []
+
+        details.append("Error Type: Decoding Error")
+        details.append("")
+
+        switch error {
+        case .typeMismatch(let type, let context):
+            details.append("Issue: Type Mismatch")
+            details.append("Expected Type: \(type)")
+            details.append("Coding Path: \(formatCodingPath(context.codingPath))")
+            details.append("Description: \(context.debugDescription)")
+            if let underlyingError = context.underlyingError {
+                details.append("Underlying Error: \(underlyingError.localizedDescription)")
+            }
+
+        case .valueNotFound(let type, let context):
+            details.append("Issue: Required Value Not Found")
+            details.append("Expected Type: \(type)")
+            details.append("Coding Path: \(formatCodingPath(context.codingPath))")
+            details.append("Description: \(context.debugDescription)")
+            if let underlyingError = context.underlyingError {
+                details.append("Underlying Error: \(underlyingError.localizedDescription)")
+            }
+
+        case .keyNotFound(let key, let context):
+            details.append("Issue: Required Key Not Found")
+            details.append("Missing Key: \(key.stringValue)")
+            details.append("Coding Path: \(formatCodingPath(context.codingPath))")
+            details.append("Description: \(context.debugDescription)")
+            if let underlyingError = context.underlyingError {
+                details.append("Underlying Error: \(underlyingError.localizedDescription)")
+            }
+
+        case .dataCorrupted(let context):
+            details.append("Issue: Data Corrupted")
+            details.append("Coding Path: \(formatCodingPath(context.codingPath))")
+            details.append("Description: \(context.debugDescription)")
+            if let underlyingError = context.underlyingError {
+                details.append("Underlying Error: \(underlyingError.localizedDescription)")
+            }
+
+        @unknown default:
+            details.append("Issue: Unknown Decoding Error")
+            details.append("Description: \(error.localizedDescription)")
+        }
+
+        return details.joined(separator: "\n")
+    }
+
+    /// Formats a coding path into a readable string representation.
+    ///
+    private func formatCodingPath(_ codingPath: [CodingKey]) -> String {
+        guard !codingPath.isEmpty else {
+            return "Root level"
+        }
+        return codingPath.map { $0.stringValue }.joined(separator: " → ")
+    }
+}
+
+private extension ConnectivityToolViewModel {
+    enum Localization {
+        static let noIssues = NSLocalizedString(
+            "connectivityToolViewModel.message.noIssues",
+            value: "No connection issues",
+            comment: "Title for when there are no connection issues in the connectivity tool screen"
+        )
+        static let noIssuesMessage = NSLocalizedString(
+            "connectivityToolViewModel.message.noIssuesMessage",
+            value: "If your data still isn't loading, contact our support team for assistance.",
+            comment: "Info message when there are no connection issues in the connectivity tool screen"
+        )
+        enum ErrorMessage {
+            static let noInternet = NSLocalizedString(
+                "connectivityToolViewModel.errorMessage.noInternet",
+                value: "It looks like you're not connected to the internet.\n\n" +
+                "Ensure your Wi-Fi is turned on. If you're using mobile data, make sure it's enabled in your device settings.",
+                comment: "Message when there is no internet connection in the recovery tool"
+            )
+            static let wpcomConnection = NSLocalizedString(
+                "connectivityToolViewModel.errorMessage.wpcomConnection",
+                value: "We can’t connect to WordPress.com right now.\n\n" +
+                "Try again in a few minutes, or contact our support team and we will happily assist you.",
+                comment: "Message when we can't reach WPCom in the recovery tool"
+            )
+            static let timeout = NSLocalizedString(
+                "connectivityToolViewModel.errorMessage.timeout",
+                value: "Your site is taking too long to respond.\n\nPlease contact your hosting provider for further assistance.",
+                comment: "Message when we there is a timeout error in the recovery tool"
+            )
+            static let decodingError = NSLocalizedString(
+                "connectivityToolViewModel.errorMessage.decodingError",
+                value: "We can't work properly with your site's response.\n\n" +
+                "View technical details below or contact our support team and we will happily assist you.",
+                comment: "Message when we there is a decoding error in the recovery tool"
+            )
+            static let noJetpackConnection = NSLocalizedString(
+                "connectivityToolViewModel.errorMessage.jetpackNotConnected",
+                value: "There is problem with your jetpack connection.\n\n" +
+                "Read more about it or contact our support team and we will happily assist you.",
+                comment: "Message when we there is a jetpack error in the recovery tool"
+            )
+            static let generic = NSLocalizedString(
+                "connectivityToolViewModel.errorMessage.default",
+                value: "There seems to be a problem with your site.\n\nPlease contact your hosting provider for further assistance.",
+                comment: "Message when we there is a generic error in the recovery tool"
+            )
+        }
+        enum Action {
+            static let readMore = NSLocalizedString(
+                "connectivityToolViewModel.action.readMore",
+                value: "Read more",
+                comment: "Action button title for an error on the connectivity tool"
+            )
+            static let viewDetails = NSLocalizedString(
+                "connectivityToolViewModel.action.viewTechnicalDetails",
+                value: "View technical details",
+                comment: "Button to view technical error details in the connectivity tool"
+            )
+            static let retry = NSLocalizedString(
+                "connectivityToolViewModel.action.retry",
+                value: "Retry connection",
+                comment: "Retry connection button in the connectivity tool screen"
+            )
+        }
     }
 }
 
@@ -297,6 +426,7 @@ private extension ConnectivityToolViewModel {
     private enum SystemImages: String {
         case retry = "arrow.clockwise"
         case readMore = "arrow.up.forward.app"
+        case viewDetails = "info.circle"
     }
 
     enum ConnectivityTest: Int {
@@ -309,13 +439,29 @@ private extension ConnectivityToolViewModel {
         var title: String {
             switch self {
             case .internetConnection:
-                NSLocalizedString("Internet Connection", comment: "Title for the internet connection connectivity tool card")
+                NSLocalizedString(
+                    "connectivityToolViewModel.connectivityTest.internetConnection",
+                    value: "Internet Connection",
+                    comment: "Title for the internet connection connectivity tool card"
+                )
             case .wpComServers:
-                NSLocalizedString("Connecting to WordPress.com Servers", comment: "Title for the WPCom servers connectivity tool card")
+                NSLocalizedString(
+                    "connectivityToolViewModel.connectivityTest.wpComServers",
+                    value: "Connecting to WordPress.com Servers",
+                    comment: "Title for the WPCom servers connectivity tool card"
+                )
             case .site:
-                NSLocalizedString("Connecting to your site", comment: "Title for the Your Site connectivity tool card")
+                NSLocalizedString(
+                    "connectivityToolViewModel.connectivityTest.site",
+                    value: "Connecting to your site",
+                    comment: "Title for the Your Site connectivity tool card"
+                )
             case .siteOrders:
-                NSLocalizedString("Fetching your site orders", comment: "Title for the Your Site Orders connectivity tool card")
+                NSLocalizedString(
+                    "connectivityToolViewModel.connectivityTest.siteOrders",
+                    value: "Fetching your site orders",
+                    comment: "Title for the Your Site Orders connectivity tool card"
+                )
             case .loadingProducts:
                 NSLocalizedString(
                     "connectivityToolViewModel.connectivityTest.loadingProducts",
@@ -350,7 +496,7 @@ extension ConnectivityTool.Card {
 
     /// Updates a card state to a new given state.
     ///
-    func updatingState(_ newState: ConnectivityToolCard.State) -> ConnectivityTool.Card {
+    func updatingState(_ newState: ConnectivityToolCard.ConnectivityState) -> ConnectivityTool.Card {
         Self.init(title: title, icon: icon, state: newState)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -1,8 +1,14 @@
 import Foundation
 import Combine
-import Networking
 import UIKit
 import Yosemite
+import enum Networking.DotcomError
+import class Networking.AlamofireNetwork
+import class Networking.AnnouncementsRemote
+import class Networking.SystemStatusRemote
+import class Networking.OrdersRemote
+import class Networking.ProductsRemote
+import class Networking.UserAgent
 
 final class ConnectivityToolViewModel {
 
@@ -20,7 +26,11 @@ final class ConnectivityToolViewModel {
 
     /// Remote used to check the site orders.
     ///
-    private let orderRemote: OrdersRemote?
+    private let orderRemote: OrdersRemote
+
+    /// Remote used to check loading products
+    ///
+    private let productsRemote: ProductsRemote
 
     /// Site to be tested.
     ///
@@ -32,6 +42,7 @@ final class ConnectivityToolViewModel {
         self.announcementsRemote = AnnouncementsRemote(network: network)
         self.systemStatusRemote = SystemStatusRemote(network: network)
         self.orderRemote = OrdersRemote(network: network)
+        self.productsRemote = ProductsRemote(network: network)
         self.siteID = session.defaultStoreID ?? .zero
 
         Task {
@@ -46,9 +57,9 @@ final class ConnectivityToolViewModel {
 
         let supportedTests: [ConnectivityTest] = {
             if ServiceLocator.stores.isAuthenticatedWithoutWPCom == false {
-                [.internetConnection, .wpComServers, .site, .siteOrders]
+                [.internetConnection, .wpComServers, .site, .siteOrders, .loadingProducts]
             } else {
-                [.internetConnection, .site, .siteOrders]
+                [.internetConnection, .site, .siteOrders, .loadingProducts]
             }
         }()
         for (index, testCase) in supportedTests.enumerated().dropFirst(sinceTest.rawValue) {
@@ -93,6 +104,8 @@ final class ConnectivityToolViewModel {
             return await testSiteConnectivity()
         case .siteOrders:
             return await testFetchingOrders()
+        case .loadingProducts:
+            return await testFetchingProducts()
 
         }
     }
@@ -185,12 +198,25 @@ final class ConnectivityToolViewModel {
     ///
     func testFetchingOrders() async -> ConnectivityToolCard.State {
         do {
-            _ = try await orderRemote?.loadAllOrders(for: siteID)
+            _ = try await orderRemote.loadAllOrders(for: siteID)
             DDLogInfo("Connectivity Tool: ✅ Site Orders")
             return stateForSiteResult(Result<[Order], Error>.success([]))
         } catch {
             DDLogError("Connectivity Tool: ❌ Site Orders\n\(error)")
             return stateForSiteResult(Result<[Order], Error>.failure(error))
+        }
+    }
+
+    /// Test fetching products.
+    ///
+    func testFetchingProducts() async -> ConnectivityToolCard.State {
+        do {
+            _ = try await productsRemote.loadAllProducts(for: siteID)
+            DDLogInfo("Connectivity Tool: ✅ Retrieving products successfully")
+            return stateForSiteResult(Result<[Product], Error>.success([]))
+        } catch {
+            DDLogError("Connectivity Tool: ❌ Failed to load products\n\(error)")
+            return stateForSiteResult(Result<[Product], Error>.failure(error))
         }
     }
 
@@ -252,6 +278,7 @@ final class ConnectivityToolViewModel {
             case .wpComServers: return .wpCom
             case .site: return .site
             case .siteOrders: return .orders
+            case .loadingProducts: return .products
             }
         }()
         ServiceLocator.analytics.track(event: .ConnectivityTool.requestResponse(test: eventTest, success: success, timeTaken: timeTaken))
@@ -277,6 +304,7 @@ private extension ConnectivityToolViewModel {
         case wpComServers
         case site
         case siteOrders
+        case loadingProducts
 
         var title: String {
             switch self {
@@ -288,6 +316,12 @@ private extension ConnectivityToolViewModel {
                 NSLocalizedString("Connecting to your site", comment: "Title for the Your Site connectivity tool card")
             case .siteOrders:
                 NSLocalizedString("Fetching your site orders", comment: "Title for the Your Site Orders connectivity tool card")
+            case .loadingProducts:
+                NSLocalizedString(
+                    "connectivityToolViewModel.connectivityTest.loadingProducts",
+                    value: "Fetching products in your store",
+                    comment: "Title for the test to load products in connectivity tool"
+                )
             }
         }
 
@@ -301,6 +335,8 @@ private extension ConnectivityToolViewModel {
                     .system("storefront")
             case .siteOrders:
                     .system("list.clipboard")
+            case .loadingProducts:
+                    .system("cart")
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/TechnicalDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/TechnicalDetailsView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+/// Wrapper for technical details to make them presentable in a sheet
+///
+struct TechnicalDetailsItem: Identifiable {
+    let id = UUID()
+    let details: String
+}
+
+/// View for displaying technical error details with copy functionality
+///
+struct TechnicalDetailsView: View {
+    let title: String
+    let technicalDetails: String
+    @Environment(\.dismiss) var dismiss
+    @State private var showCopiedConfirmation = false
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading) {
+                    Text(technicalDetails)
+                        .font(.system(.body, design: .monospaced))
+                        .textSelection(.enabled)
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Spacer()
+                }
+            }
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.close) {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    Button(Localization.copy) {
+                        UIPasteboard.general.string = technicalDetails
+                        showCopiedConfirmation = true
+                    }
+                }
+            }
+            .alert(Localization.copiedAlertTitle, isPresented: $showCopiedConfirmation) {
+                Button(Localization.ok, role: .cancel) { }
+            } message: {
+                Text(Localization.copiedAlertMessage)
+            }
+        }
+    }
+
+    private enum Localization {
+        static let close = NSLocalizedString(
+            "technicalDetailsView.close",
+            value: "Close",
+            comment: "Button to close technical details screen"
+        )
+        static let copy = NSLocalizedString(
+            "technicalDetailsView.copy",
+            value: "Copy",
+            comment: "Button to copy technical details to clipboard"
+        )
+        static let copiedAlertTitle = NSLocalizedString(
+            "technicalDetailsView.copiedAlert.title",
+            value: "Copied",
+            comment: "Alert title shown when technical details are copied"
+        )
+        static let copiedAlertMessage = NSLocalizedString(
+            "technicalDetailsView.copiedAlert.message",
+            value: "Technical details have been copied to your clipboard.",
+            comment: "Alert message shown when technical details are copied"
+        )
+        static let ok = NSLocalizedString(
+            "technicalDetailsView.ok",
+            value: "OK",
+            comment: "OK button for copied confirmation alert"
+        )
+    }
+}
+
+#Preview("Tool") {
+    NavigationView {
+        TechnicalDetailsView(
+            title: "Loading products",
+            technicalDetails:
+            """
+            Error Type: Decoding Error
+            Issue: Type Mismatch
+            Expected Type: Int
+            Coding Path: test  → id
+            """)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/TechnicalDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/TechnicalDetailsView.swift
@@ -10,10 +10,9 @@ struct TechnicalDetailsItem: Identifiable {
 /// View for displaying technical error details with copy functionality
 ///
 struct TechnicalDetailsView: View {
-    let title: String
     let technicalDetails: String
     @Environment(\.dismiss) var dismiss
-    @State private var showCopiedConfirmation = false
+    @State private var notice: Notice?
 
     var body: some View {
         NavigationView {
@@ -27,7 +26,7 @@ struct TechnicalDetailsView: View {
                     Spacer()
                 }
             }
-            .navigationTitle(title)
+            .navigationTitle(Localization.title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -38,19 +37,20 @@ struct TechnicalDetailsView: View {
                 ToolbarItem(placement: .primaryAction) {
                     Button(Localization.copy) {
                         UIPasteboard.general.string = technicalDetails
-                        showCopiedConfirmation = true
+                        notice = Notice(message: Localization.copiedAlertMessage, feedbackType: .success)
                     }
                 }
             }
-            .alert(Localization.copiedAlertTitle, isPresented: $showCopiedConfirmation) {
-                Button(Localization.ok, role: .cancel) { }
-            } message: {
-                Text(Localization.copiedAlertMessage)
-            }
+            .notice($notice)
         }
     }
 
     private enum Localization {
+        static let title = NSLocalizedString(
+            "technicalDetailsView.title",
+            value: "Technical details",
+            comment: "Title of technical details screen"
+        )
         static let close = NSLocalizedString(
             "technicalDetailsView.close",
             value: "Close",
@@ -60,11 +60,6 @@ struct TechnicalDetailsView: View {
             "technicalDetailsView.copy",
             value: "Copy",
             comment: "Button to copy technical details to clipboard"
-        )
-        static let copiedAlertTitle = NSLocalizedString(
-            "technicalDetailsView.copiedAlert.title",
-            value: "Copied",
-            comment: "Alert title shown when technical details are copied"
         )
         static let copiedAlertMessage = NSLocalizedString(
             "technicalDetailsView.copiedAlert.message",
@@ -82,7 +77,6 @@ struct TechnicalDetailsView: View {
 #Preview("Tool") {
     NavigationView {
         TechnicalDetailsView(
-            title: "Loading products",
             technicalDetails:
             """
             Error Type: Decoding Error

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2461,6 +2461,7 @@
 		DE7E5E8F2B4FD8D2002E28D2 /* BlazeTargetTopicPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E5E8E2B4FD8D2002E28D2 /* BlazeTargetTopicPickerView.swift */; };
 		DE7E5E912B4FD8F0002E28D2 /* BlazeTargetTopicPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E5E902B4FD8F0002E28D2 /* BlazeTargetTopicPickerViewModel.swift */; };
 		DE7E5E932B4FECCA002E28D2 /* BlazeTargetTopicPickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E5E922B4FECCA002E28D2 /* BlazeTargetTopicPickerViewModelTests.swift */; };
+		DE7FF07C2EE809CD00B31E35 /* TechnicalDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7FF07B2EE809CD00B31E35 /* TechnicalDetailsView.swift */; };
 		DE8311C02C6C8D3800A88709 /* BlazeCampaignListItemCustomizationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8311BF2C6C8D3800A88709 /* BlazeCampaignListItemCustomizationsTests.swift */; };
 		DE85E4ED2AB416F5008789E1 /* AddProductWithAIActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE85E4EC2AB416F5008789E1 /* AddProductWithAIActionSheet.swift */; };
 		DE86E9272A4BEA2500A89A5B /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE86E9262A4BEA2500A89A5B /* FeedbackView.swift */; };
@@ -5394,6 +5395,7 @@
 		DE7E5E8E2B4FD8D2002E28D2 /* BlazeTargetTopicPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeTargetTopicPickerView.swift; sourceTree = "<group>"; };
 		DE7E5E902B4FD8F0002E28D2 /* BlazeTargetTopicPickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeTargetTopicPickerViewModel.swift; sourceTree = "<group>"; };
 		DE7E5E922B4FECCA002E28D2 /* BlazeTargetTopicPickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeTargetTopicPickerViewModelTests.swift; sourceTree = "<group>"; };
+		DE7FF07B2EE809CD00B31E35 /* TechnicalDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TechnicalDetailsView.swift; sourceTree = "<group>"; };
 		DE8311BF2C6C8D3800A88709 /* BlazeCampaignListItemCustomizationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignListItemCustomizationsTests.swift; sourceTree = "<group>"; };
 		DE85E4EC2AB416F5008789E1 /* AddProductWithAIActionSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddProductWithAIActionSheet.swift; sourceTree = "<group>"; };
 		DE86E9262A4BEA2500A89A5B /* FeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
@@ -7785,6 +7787,7 @@
 		26CE6F372B7E7198008DB858 /* Connectivity Tool */ = {
 			isa = PBXGroup;
 			children = (
+				DE7FF07B2EE809CD00B31E35 /* TechnicalDetailsView.swift */,
 				26CE6F382B7E71AA008DB858 /* ConnectivityTool.swift */,
 				260520F12B83B1B7005D5D59 /* ConnectivityToolViewModel.swift */,
 			);
@@ -15281,6 +15284,7 @@
 				AE457813275644590092F687 /* OrderStatusSection.swift in Sources */,
 				B57C744E20F56E3800EEFC87 /* UITableViewCell+Helpers.swift in Sources */,
 				0295355B245ADF8100BDC42B /* FilterType+Products.swift in Sources */,
+				DE7FF07C2EE809CD00B31E35 /* TechnicalDetailsView.swift in Sources */,
 				02CA63DA23D1ADD100BBF148 /* CameraCaptureCoordinator.swift in Sources */,
 				2D05D1A52E82D3F6004111FD /* BookingDetailsViewModel+SectionContent.swift in Sources */,
 				260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of WOOMOB-1856

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a few updates to the troubleshooting tool in authenticated state:
- A new testing step for loading products.
- A new screen for technical details of decoding errors. The details would be helpful for HEs to troubleshoot problems when users contact support.

Many of the changes come from the clean up of localized strings.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Create a Jurassic Ninja site with WooCommerce (with or without Jetpack).
2. Install and activate [WP Blog Post Layouts](https://wordpress.org/plugins/wp-blog-post-layouts/) on the site.
3. Log in to the site on the app.
4. Navigate to Menu > Settings > Troubleshooting tool.
5. Confirm that there's a new testing step for loading products after fetching orders.
6. Confirm that loading products step fails and a new action View technical details is available.
7. Tap on View technical details and confirm that a modal is displayed with a user friendly breakdown of the details. The details are not localized for simplicity.
8. Tap on Copy, confirm that a notice is displayed saying the content has been copied. Verify that you can paste the contents somewhere.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/710eae0b-3fe8-4b0d-9f60-3cdb5639198b



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
