### PR TITLE
[HACK Week] Attach application logs as attachment for support requests

### DIFF
--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -70,7 +70,7 @@ final class ServiceLocator {
     private static var _fileLogger: Logs = DDFileLogger()
 
     /// Application Log Provider
-    /// 
+    ///
     private static var _applicationLogProvider: ApplicationLogProvider = DefaultApplicationLogProvider()
 
     /// Crash Logging Stack

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -69,6 +69,10 @@ final class ServiceLocator {
     ///
     private static var _fileLogger: Logs = DDFileLogger()
 
+    /// Application Log Provider
+    /// 
+    private static var _applicationLogProvider: ApplicationLogProvider = DefaultApplicationLogProvider()
+
     /// Crash Logging Stack
     ///
     private static var _crashLogging: CrashLoggingStack = WooCrashLoggingStack(
@@ -228,6 +232,10 @@ final class ServiceLocator {
     /// - Returns: An implementation of the Logs protocol. It defaults to DDFileLogger
     static var fileLogger: Logs {
         return _fileLogger
+    }
+
+    static var applicationLogProvider: ApplicationLogProvider {
+        return _applicationLogProvider
     }
 
     /// Provides an instance of `WordPressLoggingDelegate` for logging in WordPress libraries.

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -9,6 +9,23 @@ import SafariServices
 import Yosemite
 import Experiments
 
+/// Represents a Zendesk Attachment
+struct ZendeskAttachment {
+    let data: Data
+    let filename: String
+    let contentType: String
+}
+
+/// Represents a Zendesk Support Request
+struct ZendeskSupportRequest {
+    let formID: Int64
+    let customFields: [Int64: String]
+    let tags: [String]
+    let subject: String
+    let description: String
+    let attachment: ZendeskAttachment?
+}
+
 /// Defines methods for showing Zendesk UI.
 ///
 /// This is primarily used for testability. Not all methods in `ZendeskManager` are defined but
@@ -29,11 +46,7 @@ protocol ZendeskManagerProtocol {
 
     /// Creates a support request using the API-Providers SDK.
     ///
-    func createSupportRequest(formID: Int64,
-                              customFields: [Int64: String],
-                              tags: [String],
-                              subject: String,
-                              description: String,
+    func createSupportRequest(_ request: ZendeskSupportRequest,
                               onCompletion: @escaping (Result<Void, Error>) -> Void)
 
     var zendeskEnabled: Bool { get }
@@ -57,11 +70,7 @@ struct NoZendeskManager: ZendeskManagerProtocol {
         // no-op
     }
 
-    func createSupportRequest(formID: Int64,
-                              customFields: [Int64: String],
-                              tags: [String],
-                              subject: String,
-                              description: String,
+    func createSupportRequest(_ request: ZendeskSupportRequest,
                               onCompletion: @escaping (Result<Void, Error>) -> Void) {
         // no-op
     }
@@ -213,46 +222,40 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
 
     /// Creates a support request using the API-Providers SDK.
     ///
-    func createSupportRequest(formID: Int64,
-                              customFields: [Int64: String],
-                              tags: [String],
-                              subject: String,
-                              description: String,
+    func createSupportRequest(_ request: ZendeskSupportRequest,
                               onCompletion: @escaping (Result<Void, Error>) -> Void) {
 
-        CoreLogger.enabled = true
-        CoreLogger.logLevel = .debug
-        // 1. Upload logs
-        if let logs = customFields[10901699622036] {
-            ZDKUploadProvider().uploadAttachment(logs.data(using: .utf8),
-                                                 withFilename: "application_log.txt",
-                                                 andContentType: "text/plain") { response, error in
-
-
-
-                let requestProvider = ZDKRequestProvider()
-                let request = self.createAPIRequest(formID: formID,
-                                                    customFields: customFields,
-                                                    tags: tags,
-                                                    subject: subject,
-                                                    description: description,
-                                                    attachment: response)
-
-                let req = ZDKRequestProvider()
-
-
-                requestProvider.createRequest(request) { _, error in
-                    // `requestProvider.createRequest` invokes it's completion block on a background thread when the request creation fails.
-                    // Lets make sure we always dispatch the completion block on the main queue.
-                    DispatchQueue.main.async {
-                        if let error {
-                            return onCompletion(.failure(error))
-                        }
-                        onCompletion(.success(()))
+        uploadAttachment(request.attachment) { uploadResponse  in
+            let request = self.createAPIRequest(request: request,
+                                                attachment: uploadResponse)
+            ZDKRequestProvider().createRequest(request) { _, error in
+                // `requestProvider.createRequest` invokes it's completion block on a background thread when the request creation fails.
+                // Lets make sure we always dispatch the completion block on the main queue.
+                DispatchQueue.main.async {
+                    if let error {
+                        return onCompletion(.failure(error))
                     }
+                    onCompletion(.success(()))
                 }
-
             }
+
+        }
+    }
+
+    private func uploadAttachment(_ attachment: ZendeskAttachment?, _ completionHandler: @escaping (ZDKUploadResponse?) -> Void) {
+        guard let attachment else {
+            return completionHandler(nil)
+        }
+
+        let uploadProvider = ZDKUploadProvider()
+        uploadProvider.uploadAttachment(attachment.data,
+                                        withFilename: attachment.filename,
+                                        andContentType: attachment.contentType) { response, error in
+            if let error {
+                DDLogError("Could not uploadt attachment: \(error.localizedDescription)")
+            }
+
+            completionHandler(response)
         }
     }
 
@@ -362,17 +365,18 @@ private extension ZendeskManager {
 
     /// Creates a Zendesk Request to be consumed by a Request Provider.
     ///
-    func createAPIRequest(formID: Int64, customFields: [Int64: String], tags: [String], subject: String, description: String, attachment: ZDKUploadResponse?) -> ZDKCreateRequest {
-        let request = ZDKCreateRequest()
-        request.ticketFormId = formID as NSNumber
-        request.customFields = customFields.map { CustomField(fieldId: $0, value: $1) }
-        request.tags = tags
-        request.subject = subject
-        request.requestDescription = description
+    func createAPIRequest(request: ZendeskSupportRequest,
+                          attachment: ZDKUploadResponse?) -> ZDKCreateRequest {
+        let zdkRequest = ZDKCreateRequest()
+        zdkRequest.ticketFormId = request.formID as NSNumber
+        zdkRequest.customFields = request.customFields.map { CustomField(fieldId: $0, value: $1) }
+        zdkRequest.tags = request.tags
+        zdkRequest.subject = request.subject
+        zdkRequest.requestDescription = request.description
         if let attachment {
-            request.attachments = [attachment]
+            zdkRequest.attachments = [attachment]
         }
-        return request
+        return zdkRequest
     }
 
     // MARK: - User Defaults

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -220,16 +220,38 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
                               description: String,
                               onCompletion: @escaping (Result<Void, Error>) -> Void) {
 
-        let requestProvider = ZDKRequestProvider()
-        let request = createAPIRequest(formID: formID, customFields: customFields, tags: tags, subject: subject, description: description)
-        requestProvider.createRequest(request) { _, error in
-            // `requestProvider.createRequest` invokes it's completion block on a background thread when the request creation fails.
-            // Lets make sure we always dispatch the completion block on the main queue.
-            DispatchQueue.main.async {
-                if let error {
-                    return onCompletion(.failure(error))
+        CoreLogger.enabled = true
+        CoreLogger.logLevel = .debug
+        // 1. Upload logs
+        if let logs = customFields[10901699622036] {
+            ZDKUploadProvider().uploadAttachment(logs.data(using: .utf8),
+                                                 withFilename: "application_log.txt",
+                                                 andContentType: "text/plain") { response, error in
+
+
+
+                let requestProvider = ZDKRequestProvider()
+                let request = self.createAPIRequest(formID: formID,
+                                                    customFields: customFields,
+                                                    tags: tags,
+                                                    subject: subject,
+                                                    description: description,
+                                                    attachment: response)
+
+                let req = ZDKRequestProvider()
+
+
+                requestProvider.createRequest(request) { _, error in
+                    // `requestProvider.createRequest` invokes it's completion block on a background thread when the request creation fails.
+                    // Lets make sure we always dispatch the completion block on the main queue.
+                    DispatchQueue.main.async {
+                        if let error {
+                            return onCompletion(.failure(error))
+                        }
+                        onCompletion(.success(()))
+                    }
                 }
-                onCompletion(.success(()))
+
             }
         }
     }
@@ -340,13 +362,16 @@ private extension ZendeskManager {
 
     /// Creates a Zendesk Request to be consumed by a Request Provider.
     ///
-    func createAPIRequest(formID: Int64, customFields: [Int64: String], tags: [String], subject: String, description: String) -> ZDKCreateRequest {
+    func createAPIRequest(formID: Int64, customFields: [Int64: String], tags: [String], subject: String, description: String, attachment: ZDKUploadResponse?) -> ZDKCreateRequest {
         let request = ZDKCreateRequest()
         request.ticketFormId = formID as NSNumber
         request.customFields = customFields.map { CustomField(fieldId: $0, value: $1) }
         request.tags = tags
         request.subject = subject
         request.requestDescription = description
+        if let attachment {
+            request.attachments = [attachment]
+        }
         return request
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogProvider.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+protocol ApplicationLogProvider {
+    func applicationLogs(cappedTo: Int?) -> String?
+}
+
+extension ApplicationLogProvider {
+    func applicationLogs() -> String? {
+        return applicationLogs(cappedTo: nil)
+    }
+}
+
+class DefaultApplicationLogProvider: ApplicationLogProvider {
+    private let fileLogger: Logs
+
+    init(fileLogger: Logs = ServiceLocator.fileLogger) {
+        self.fileLogger = fileLogger
+    }
+
+    func applicationLogs(cappedTo: Int?) -> String? {
+        guard let logFileInformation = fileLogger.logFileManager.sortedLogFileInfos.first,
+              let logData = try? Data(contentsOf: URL(fileURLWithPath: logFileInformation.filePath)),
+              let logText = String(data: logData, encoding: .utf8) else {
+            return ""
+        }
+
+        // Truncates the log text so it fits in the ticket field.
+        if let cappedTo, logText.count > cappedTo {
+            return String(logText.suffix(cappedTo))
+        }
+
+        return logText
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogProvider.swift
@@ -10,7 +10,7 @@ extension ApplicationLogProvider {
     }
 }
 
-class DefaultApplicationLogProvider: ApplicationLogProvider {
+final class DefaultApplicationLogProvider: ApplicationLogProvider {
     private let fileLogger: Logs
 
     init(fileLogger: Logs = ServiceLocator.fileLogger) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
@@ -10,7 +10,7 @@ import protocol WooFoundation.ConnectivityObserver
 class SupportFormMetadataProvider {
 
     /// Dependencies
-    private let fileLogger: Logs
+    private let applicationLogProvider: ApplicationLogProvider
     private let stores: StoresManager
     private let sessionManager: SessionManagerProtocol
     private let storageManager: StorageManagerType
@@ -24,12 +24,12 @@ class SupportFormMetadataProvider {
     ///
     private let systemStatusReportViewModel: SystemStatusReportViewModel
 
-    internal init(fileLogger: Logs = ServiceLocator.fileLogger,
+    internal init(applicationLogProvider: ApplicationLogProvider = ServiceLocator.applicationLogProvider,
                   stores: StoresManager = ServiceLocator.stores,
                   sessionManager: SessionManagerProtocol = ServiceLocator.stores.sessionManager,
                   storageManager: StorageManagerType = ServiceLocator.storageManager,
                   connectivityObserver: ConnectivityObserver = ServiceLocator.connectivityObserver) {
-        self.fileLogger = fileLogger
+        self.applicationLogProvider = applicationLogProvider
         self.stores = stores
         self.sessionManager = sessionManager
         self.storageManager = storageManager
@@ -167,18 +167,7 @@ private extension SupportFormMetadataProvider {
     /// Gets the content of the main/first log file. Trimmed with a character limit.
     ///
     func getLogFile() -> String {
-        guard let logFileInformation = fileLogger.logFileManager.sortedLogFileInfos.first,
-              let logData = try? Data(contentsOf: URL(fileURLWithPath: logFileInformation.filePath)),
-              let logText = String(data: logData, encoding: .utf8) else {
-            return ""
-        }
-
-        // Truncates the log text so it fits in the ticket field.
-        if logText.count > Constants.logFieldCharacterLimit {
-            return String(logText.suffix(Constants.logFieldCharacterLimit))
-        }
-
-        return logText
+        return applicationLogProvider.applicationLogs(cappedTo: Constants.logFieldCharacterLimit) ?? ""
     }
 
     /// Gets the current site description (site url + site description).

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -56,6 +56,8 @@ public final class SupportFormViewModel: ObservableObject {
     ///
     private let zendeskProvider: ZendeskManagerProtocol
 
+    private let applicationLogsProvider: ApplicationLogProvider
+
     /// Handles the communication with Tracks..
     ///
     private let analyticsProvider: Analytics
@@ -95,11 +97,13 @@ public final class SupportFormViewModel: ObservableObject {
          sourceTag: String? = nil,
          zendeskProvider: ZendeskManagerProtocol = ZendeskProvider.shared,
          analyticsProvider: Analytics = ServiceLocator.analytics,
+         applicationLogsProvider: ApplicationLogProvider = ServiceLocator.applicationLogProvider,
          defaultSite: Site? = nil) {
         self.areas = areas
         self.sourceTag = sourceTag
         self.zendeskProvider = zendeskProvider
         self.analyticsProvider = analyticsProvider
+        self.applicationLogsProvider = applicationLogsProvider
         self.defaultSite = defaultSite
     }
 
@@ -131,11 +135,14 @@ public final class SupportFormViewModel: ObservableObject {
         guard let area else { return }
 
         showLoadingIndicator = true
-        zendeskProvider.createSupportRequest(formID: area.datasource.formID,
-                                             customFields: area.datasource.customFields(siteAddress: siteAddress),
-                                             tags: assembleTags(),
-                                             subject: subject,
-                                             description: description) { [weak self] result in
+
+        let request = ZendeskSupportRequest(formID: area.datasource.formID,
+                                            customFields: area.datasource.customFields(siteAddress: siteAddress),
+                                            tags: assembleTags(),
+                                            subject: subject,
+                                            description: description,
+                                            attachment: attachment())
+        zendeskProvider.createSupportRequest(request) { [weak self] result in
             guard let self else { return }
             self.showLoadingIndicator = false
 
@@ -212,6 +219,15 @@ private extension SupportFormViewModel {
         contactName = identity.name ?? ""
         contactEmailAddress = identity.emailAddress ?? ""
         shouldShowIdentityInput = true
+    }
+
+    func attachment() -> ZendeskAttachment? {
+        guard let applicationLogs = applicationLogsProvider.applicationLogs()?.data(using: .utf8) else {
+            return nil
+        }
+        return ZendeskAttachment(data: applicationLogs,
+                                 filename: "application_log.txt",
+                                 contentType: "text/plain")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -98,7 +98,7 @@ public final class SupportFormViewModel: ObservableObject {
          zendeskProvider: ZendeskManagerProtocol = ZendeskProvider.shared,
          analyticsProvider: Analytics = ServiceLocator.analytics,
          applicationLogsProvider: ApplicationLogProvider = ServiceLocator.applicationLogProvider,
-         defaultSite: Site? = nil) {
+         defaultSite: Site? = ServiceLocator.stores.sessionManager.defaultSite) {
         self.areas = areas
         self.sourceTag = sourceTag
         self.zendeskProvider = zendeskProvider

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1339,6 +1339,7 @@
 		57F2C6CD246DECC10074063B /* SummaryTableViewCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F2C6CC246DECC10074063B /* SummaryTableViewCellViewModelTests.swift */; };
 		57F42E40253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F42E3F253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift */; };
 		640DA3482E97DE4F00317FB2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640DA3472E97DE4F00317FB2 /* SceneDelegate.swift */; };
+		646FEDB82EE827DF00352BFF /* ApplicationLogProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 646FEDB72EE827DF00352BFF /* ApplicationLogProvider.swift */; };
 		647C05FB2ED5D9E800E5FF3F /* NotesContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647C05FA2ED5D9E200E5FF3F /* NotesContent.swift */; };
 		647C05FD2ED5E1C000E5FF3F /* BookingNotesRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647C05FC2ED5E1C000E5FF3F /* BookingNotesRowView.swift */; };
 		6489DFFF2EA78E0D00D96802 /* MockProductDetailCoordinatorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6489DFFE2EA78E0D00D96802 /* MockProductDetailCoordinatorFactory.swift */; };
@@ -4235,6 +4236,7 @@
 		57F2C6CC246DECC10074063B /* SummaryTableViewCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryTableViewCellViewModelTests.swift; sourceTree = "<group>"; };
 		57F42E3F253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndEditableValueTableViewCellViewModelTests.swift; sourceTree = "<group>"; };
 		640DA3472E97DE4F00317FB2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		646FEDB72EE827DF00352BFF /* ApplicationLogProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogProvider.swift; sourceTree = "<group>"; };
 		647C05FA2ED5D9E200E5FF3F /* NotesContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesContent.swift; sourceTree = "<group>"; };
 		647C05FC2ED5E1C000E5FF3F /* BookingNotesRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingNotesRowView.swift; sourceTree = "<group>"; };
 		6489DFFE2EA78E0D00D96802 /* MockProductDetailCoordinatorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductDetailCoordinatorFactory.swift; sourceTree = "<group>"; };
@@ -11091,6 +11093,7 @@
 		CE27257A219249B5002B22EB /* Help */ = {
 			isa = PBXGroup;
 			children = (
+				646FEDB72EE827DF00352BFF /* ApplicationLogProvider.swift */,
 				CE27257B21924A8C002B22EB /* HelpAndSupportViewController.swift */,
 				CE15524921FFB10100EAA690 /* ApplicationLogViewController.swift */,
 				E12FB785266E0CAE0039E9C2 /* ApllicationLogDetailView.swift */,
@@ -15095,6 +15098,7 @@
 				DEE6437826D8DAD900888A75 /* InProgressView.swift in Sources */,
 				016582ED2E7897B3001DBB6F /* String+Helpers.swift in Sources */,
 				0290E275238E4F8100B5C466 /* PaginatedListSelectorViewController.swift in Sources */,
+				646FEDB82EE827DF00352BFF /* ApplicationLogProvider.swift in Sources */,
 				B958A7D628B5310100823EEF /* URLOpener.swift in Sources */,
 				DE2FE5862925DA050018040A /* SiteCredentialLoginView.swift in Sources */,
 				020DD48F232392C9005822B1 /* UIViewController+AppReview.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
+++ b/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
@@ -104,14 +104,10 @@ extension MockZendeskManager {
         // no-op
     }
 
-    func createSupportRequest(formID: Int64,
-                              customFields: [Int64: String],
-                              tags: [String],
-                              subject: String,
-                              description: String,
+    func createSupportRequest(_ request: WooCommerce.ZendeskSupportRequest,
                               onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        latestInvokedTags = tags
-        latestInvokedCustomFields = customFields
+        latestInvokedTags = request.tags
+        latestInvokedCustomFields = request.customFields
         if let stubbedCreateSupportRequestResult {
             onCompletion(stubbedCreateSupportRequestResult)
         }


### PR DESCRIPTION
Resolves [WOOMOB-1800](https://linear.app/a8c/issue/WOOMOB-1800)

## Description
Attaches the full version of the application logs to the Zendesk issue when opening a support request. The trimmed application logs are still added as a custom field.

## Test Steps
⚠️ This is an E2E test. You'll need to resolve the opened issue in Zendesk.

1. Download the app from the build. You need the PR build as it contains the keys for creating the request.
2. Login with any store.
3. Navigate to Settings/Help & Support/Contact Support
4. Fill the required values.
5. Note that site address is prefilled.
6. Tap "Submit Support Request"
7. Open Zendesk and locate the issue.
8. Validate that application logs are visible in the left side bar
9. Validate that logs attached as well.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
