### PR TITLE
Login: Show error when site credential login is blocked by basic auth

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [Internal] Moved the request for push notification authorization after login [https://github.com/woocommerce/woocommerce-ios/pull/16428]
 - [Internal] Cleaned up logic for push notification token registration [https://github.com/woocommerce/woocommerce-ios/pull/16434]
 - [*] Fixed possible sync issue in POS (https://github.com/woocommerce/woocommerce-ios/pull/16423)
+- [*] Login: Show error alert when login with site credentials fails due to basic auth [https://github.com/woocommerce/woocommerce-ios/pull/16446]
 - [*] Enabled site troubleshooting for users authenticated with site credentials [https://github.com/woocommerce/woocommerce-ios/pull/16441]
 
 23.8

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordTutorialViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordTutorialViewModel.swift
@@ -23,6 +23,8 @@ struct ApplicationPasswordTutorialViewModel {
                                      comment: "Reason for why the user could not login tin the application password tutorial screen")
         case .invalidCredentials:
             return error.localizedDescription
+        case .failedAuthenticationChallenge:
+            fatalError("Failure to handle authentication challenge is not eligible for application password flow.")
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -363,7 +363,9 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
 
         let isAppPasswordAuthError = {
             switch error {
-            case SiteCredentialLoginError.genericFailure, SiteCredentialLoginError.invalidCredentials:
+            case SiteCredentialLoginError.genericFailure,
+                SiteCredentialLoginError.invalidCredentials,
+                SiteCredentialLoginError.failedAuthenticationChallenge:
                 return false
             case is SiteCredentialLoginError:
                 return true

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -162,8 +162,9 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol, U
             } catch let error as SiteCredentialLoginError {
                 errorHandler?(error)
             } catch {
-                if receivedAuthChallengeMethod != nil {
+                if let receivedAuthChallengeMethod {
                     errorHandler?(.failedAuthenticationChallenge)
+                    DDLogError("⛔️ Authentication Error: Nonce retrieval blocked by authentication challenge \(receivedAuthChallengeMethod)")
                 } else {
                     errorHandler?(.genericFailure(underlyingError: error as NSError))
                 }

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -333,6 +333,6 @@ extension SiteCredentialLoginUseCase {
         let authMethod = challenge.protectionSpace.authenticationMethod
         receivedAuthChallengeMethod = authMethod
         DDLogWarn("⚠️ An authentication challenge is required for login: \(authMethod)")
-        completionHandler(.performDefaultHandling, nil)
+        completionHandler(.cancelAuthenticationChallenge, nil)
     }
 }

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -15,6 +15,7 @@ enum SiteCredentialLoginError: LocalizedError {
     case inaccessibleLoginPage
     case inaccessibleAdminPage
     case unacceptableStatusCode(code: Int)
+    case failedAuthenticationChallenge
     case genericFailure(underlyingError: Error)
 
     /// Used for tracking error code
@@ -26,7 +27,8 @@ enum SiteCredentialLoginError: LocalizedError {
              .invalidLoginResponse,
              .invalidCredentials,
              .loginFailed,
-             .unacceptableStatusCode:
+             .unacceptableStatusCode,
+             .failedAuthenticationChallenge:
             return NSError(domain: Self.errorDomain, code: errorCode, userInfo: [NSLocalizedDescriptionKey: errorMessage])
         case .genericFailure(let underlyingError):
             return underlyingError as NSError
@@ -45,6 +47,8 @@ enum SiteCredentialLoginError: LocalizedError {
             return 401
         case .unacceptableStatusCode(let code):
             return code
+        case .failedAuthenticationChallenge:
+            return -2
         case .genericFailure(let underlyingError):
             return (underlyingError as NSError).code
         }
@@ -64,6 +68,8 @@ enum SiteCredentialLoginError: LocalizedError {
             return message
         case .unacceptableStatusCode(let code):
             return String(format: Localization.unacceptableStatusCode, code)
+        case .failedAuthenticationChallenge:
+            return Localization.failedAuthenticationChallenge
         case .genericFailure:
             return ""
         }
@@ -83,7 +89,8 @@ enum SiteCredentialLoginError: LocalizedError {
             comment: "Error message explaining login failure due to blocked WP Admin page"
         )
         static let invalidLoginResponse = NSLocalizedString(
-            "Unable to login due to an unexpected response from your site. We are working on fixing this issue.",
+            "siteCredentialLoginError.invalidLoginResponse.message",
+            value: "Unable to login due to an unexpected response from your site.",
             comment: "Error message explaining login failure due to unexpected response."
         )
         static let unacceptableStatusCode = NSLocalizedString(
@@ -93,6 +100,11 @@ enum SiteCredentialLoginError: LocalizedError {
         static let invalidCredentials = NSLocalizedString(
             "It seems the username or password you entered doesn't quite match. Double-check your credentials and try again.",
             comment: "Error message explaining login failure due to invalid credentials."
+        )
+        static let failedAuthenticationChallenge = NSLocalizedString(
+            "siteCredentialLoginError.failedAuthenticationChallenge.message",
+            value: "Unable to log in due to an unexpected security measure on your store. Please contact support for troubleshooting.",
+            comment: "Error message explaining login failure due to an unexpected authentication challenge."
         )
     }
 }
@@ -104,12 +116,24 @@ enum SiteCredentialLoginError: LocalizedError {
 /// - If the request does not redirect or the redirect fails, login fails.
 /// Ref: pe5sF9-1iQ-p2
 ///
-final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
+final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol, URLSessionTaskDelegate {
     private let siteURL: String
     private let cookieJar: HTTPCookieStorage
     private var successHandler: (() -> Void)?
     private var errorHandler: ((SiteCredentialLoginError) -> Void)?
-    private lazy var session = URLSession(configuration: .default)
+
+    private var receivedAuthChallengeMethod: String?
+
+    private lazy var session = {
+        var configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForResource = 60
+        return URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+    }()
+
+    static let supportedAuthChallengeMethods = [
+        NSURLAuthenticationMethodServerTrust,
+        NSURLAuthenticationMethodHTTPBasic
+    ]
 
     init(siteURL: String,
          cookieJar: HTTPCookieStorage = HTTPCookieStorage.shared) {
@@ -128,10 +152,14 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
         // Old cookies can make the login succeeds even with incorrect credentials
         // So we need to clear all cookies before login.
         clearAllCookies()
+
+        receivedAuthChallengeMethod = nil
+
         guard let loginRequest = buildLoginRequest(username: username, password: password) else {
             DDLogError("⛔️ Error constructing login requests")
             return
         }
+
         Task { @MainActor in
             do {
                 try await startLogin(with: loginRequest)
@@ -139,7 +167,11 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
             } catch let error as SiteCredentialLoginError {
                 errorHandler?(error)
             } catch {
-                errorHandler?(.genericFailure(underlyingError: error as NSError))
+                if receivedAuthChallengeMethod != nil {
+                    errorHandler?(.failedAuthenticationChallenge)
+                } else {
+                    errorHandler?(.genericFailure(underlyingError: error as NSError))
+                }
             }
         }
     }
@@ -295,5 +327,16 @@ private extension String {
             return false
         }
         return wholeMatch(of: regex) != nil
+    }
+}
+
+// MARK: - URLSessionTaskDelegate
+extension SiteCredentialLoginUseCase {
+    func urlSession(_ session: URLSession,
+                    didReceive challenge: URLAuthenticationChallenge,
+                    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        let authMethod = challenge.protectionSpace.authenticationMethod
+        receivedAuthChallengeMethod = authMethod
+        completionHandler(.performDefaultHandling, nil)
     }
 }

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -337,6 +337,7 @@ extension SiteCredentialLoginUseCase {
                     completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         let authMethod = challenge.protectionSpace.authenticationMethod
         receivedAuthChallengeMethod = authMethod
+        DDLogWarn("⚠️ An authentication challenge is required for login: \(authMethod)")
         completionHandler(.performDefaultHandling, nil)
     }
 }

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -333,7 +333,6 @@ extension SiteCredentialLoginUseCase {
                     completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         let authMethod = challenge.protectionSpace.authenticationMethod
         receivedAuthChallengeMethod = authMethod
-        DDLogWarn("⚠️ An authentication challenge is required for login: \(authMethod)")
         completionHandler(.cancelAuthenticationChallenge, nil)
     }
 }

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -130,11 +130,6 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol, U
         return URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
     }()
 
-    static let supportedAuthChallengeMethods = [
-        NSURLAuthenticationMethodServerTrust,
-        NSURLAuthenticationMethodHTTPBasic
-    ]
-
     init(siteURL: String,
          cookieJar: HTTPCookieStorage = HTTPCookieStorage.shared) {
         self.siteURL = siteURL


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-1703

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR implements updates as proposed in pe5sF9-4LP-p2:
- Catches when an authentication challenge is required for nonce retrieval to cancel the request.
- Throws an error for unhandled authentication challenge and logs the required authentication challenge method.
- Displays an alert for the failure

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Ensure that you have a Pressable site. Check for "Live & Test Environments: Pressable" in the field guide if you don't have one yet.
- Enable basic auth on your site by logging in to Pressable > select the site > Settings > Advanced > Basic auth.
- Build the app and log in to your site with site credentials.
- Confirm that login fails with an alert mentioning security measure. There should be no entry point to application password login.
- Check Xcode console and confirm that the failure is tracked: `login_site_credentials_login_failed` with error_code: -2 and error_domain: SiteCredentialLogin.
- Also confirm that the failure is logged: `⛔️ Authentication Error: Nonce retrieval blocked by authentication challenge NSURLAuthenticationMethodServerTrust`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="320" alt="image" src="https://github.com/user-attachments/assets/ff4f81f1-8e02-4c1a-a189-92ccf2938bb4" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.