### PR TITLE
Use authenticated web view for updating plugins if possible

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [*] Fixed possible sync issue in POS (https://github.com/woocommerce/woocommerce-ios/pull/16423)
 - [*] Enabled site troubleshooting for users authenticated with site credentials [https://github.com/woocommerce/woocommerce-ios/pull/16441]
 - [*] Troubleshooting tool: Add step to load products and technical details for decoding errors [https://github.com/woocommerce/woocommerce-ios/pull/16444]
+- [*] Use authenticated web view for updating plugins [https://github.com/woocommerce/woocommerce-ios/pull/16448]
 
 23.8
 -----

--- a/WooCommerce/Classes/Extensions/Site+URL.swift
+++ b/WooCommerce/Classes/Extensions/Site+URL.swift
@@ -26,6 +26,14 @@ extension Site {
         adminURL + "admin.php?page=wc-settings&tab=checkout&section=" + plugin.setupURLSectionPath
     }
 
+    /// URL to update a plugin
+    func pluginUpdateURL(for plugin: SystemPlugin) -> String? {
+        if let directoryName = plugin.plugin.components(separatedBy: "/").first {
+            return adminURL + "plugin-install.php?tab=plugin-information&plugin=" + directoryName
+        }
+        return nil
+    }
+
     /// Returns the plugin URL from wp-admin that handles pending tasks or requirements during onboarding.
     ///
     func cardPresentPluginHasPendingTasksURL(plugin: CardPresentPaymentsPlugin) -> String {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/PluginDetailsRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/PluginDetailsRowView.swift
@@ -59,7 +59,7 @@ struct PluginDetailsRowView: View {
                     viewModel.refreshPlugin()
                 }) {
                     if let updateURL = viewModel.updateURL {
-                        SafariView(url: updateURL)
+                        AuthenticatableWebView(url: updateURL, title: viewModel.updatePluginTitle)
                     }
                 }
         },

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginDetailsViewModel.swift
@@ -43,6 +43,8 @@ final class PluginDetailsViewModel: ObservableObject {
     ///
     let title: String
 
+    let updatePluginTitle: String
+
     var updateAvailable: Bool {
         guard let plugin = plugin else {
             return false
@@ -79,6 +81,7 @@ final class PluginDetailsViewModel: ObservableObject {
         self.storesManager = storesManager
         self.storageManager = storageManager
         self.title = String(format: Localization.pluginDetailTitle, pluginName)
+        self.updatePluginTitle = String.localizedStringWithFormat(Localization.updatePluginTitle, pluginName)
         self.plugin = nil
         self.updateURL = nil
         self.version = ""
@@ -124,6 +127,12 @@ private enum Localization {
         "%1$@",
         comment: "Title for the plugin detail row in settings. %1$@ is a placeholder for the plugin name. " +
         "This is displayed with the current version number, and whether an update is available.")
+
+    static let updatePluginTitle = NSLocalizedString(
+        "pluginDetailsViewModel.updatePluginTitle",
+        value: "Update %1$@",
+        comment: "Title of the web view to update an outdated plugin. %1$@ is a placeholder for the plugin name."
+    )
 
     static let unknownVersionValue = NSLocalizedString(
         "unknown",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginDetailsViewModel.swift
@@ -105,13 +105,16 @@ final class PluginDetailsViewModel: ObservableObject {
 
 private extension PluginDetailsViewModel {
     private func updateURL(for plugin: SystemPlugin?) -> URL? {
-        guard let url = storesManager.sessionManager.defaultSite?.pluginsURL,
-              updateAvailable(for: plugin)
-        else {
+        guard let plugin, updateAvailable(for: plugin) else {
             return nil
         }
 
-        return URL(string: url)
+        if let pluginInfoURL = storesManager.sessionManager.defaultSite?.pluginUpdateURL(for: plugin) {
+            return URL(string: pluginInfoURL)
+        } else if let url = storesManager.sessionManager.defaultSite?.pluginsURL {
+            return URL(string: url)
+        }
+        return nil
     }
 
     private func updateAvailable(for plugin: SystemPlugin?) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -433,7 +433,8 @@ private extension SettingsViewController {
         guard let url = woocommercePluginViewModel.updateURL else {
             return
         }
-        let vc = SFSafariViewController(url: url)
+        let webView = AuthenticatableWebView(url: url, title: Localization.updateWooCommerce)
+        let vc = UIHostingController(rootView: webView)
         vc.modalPresentationStyle = .formSheet
 
         present(vc, animated: true)
@@ -885,6 +886,12 @@ private extension SettingsViewController {
         static let wooCommerce = NSLocalizedString(
             "WooCommerce",
             comment: "Navigates to about WooCommerce app screen"
+        )
+
+        static let updateWooCommerce = NSLocalizedString(
+            "settingsViewController.title.updateWooCommerce",
+            value: "Update WooCommerce",
+            comment: "Title of the web view to update WooCommerce plugin"
         )
 
         static let openDeviceSettings = NSLocalizedString(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-549

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the code points that open the wp-admin page for updating plugin to use the authenticated web view if possible. This helps avoid authenticating again.

Additionally, I improved the logic to show the plugin info screen for updating rather than showing the plugin list. cc @iamgabrielma as you expressed concerns in the past about this, but it seems to work fine from my testing. Let me know what you think.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Pre-requisites: Set up a Jurassic Ninja site with an outdated version of WooCommerce by uploading the zip of an older version [here](https://github.com/woocommerce/woocommerce/releases).
- If you want to test the site with WPCom authenticated, ensure that SSO is enabled in Jetpack > My Jetpack > Products > Secure Sign On. Otherwise, you'll have to log in to wp-admin with site credentials.
- Navigate to Menu tab > Settings.
- Confirm that in the Plugins section, WooCommerce is displayed as outdated. Tap on that row and confirm that a web view is displayed and you're authenticated right away.
- Dismiss the web view and select Plugins. Tap the WooCommerce row again and confirm that you see an authenticated web view here too.
- Try updating the plugin from the web view if needed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->



https://github.com/user-attachments/assets/9968bd59-4749-4e2f-a760-5127abe77317



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
