### PR TITLE
[HACK Week] Attach connectivity test log to Zendesk issue

### DIFF
--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -23,7 +23,7 @@ struct ZendeskSupportRequest {
     let tags: [String]
     let subject: String
     let description: String
-    let attachment: ZendeskAttachment?
+    let attachments: [ZendeskAttachment]
 }
 
 /// Defines methods for showing Zendesk UI.
@@ -225,9 +225,9 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
     func createSupportRequest(_ request: ZendeskSupportRequest,
                               onCompletion: @escaping (Result<Void, Error>) -> Void) {
 
-        uploadAttachment(request.attachment) { uploadResponse  in
+        uploadAttachments(request.attachments) { uploadResponses  in
             let request = self.createAPIRequest(request: request,
-                                                attachment: uploadResponse)
+                                                attachments: uploadResponses)
             ZDKRequestProvider().createRequest(request) { _, error in
                 // `requestProvider.createRequest` invokes it's completion block on a background thread when the request creation fails.
                 // Lets make sure we always dispatch the completion block on the main queue.
@@ -242,7 +242,38 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
         }
     }
 
-    private func uploadAttachment(_ attachment: ZendeskAttachment?, _ completionHandler: @escaping (ZDKUploadResponse?) -> Void) {
+    private func uploadAttachments(
+        _ attachments: [ZendeskAttachment],
+        _ completionHandler: @escaping ([ZDKUploadResponse]) -> Void
+    ) {
+        guard !attachments.isEmpty else {
+            completionHandler([])
+            return
+        }
+
+        let dispatchGroup = DispatchGroup()
+        var responses: [ZDKUploadResponse] = []
+        let lock = NSLock()
+
+        attachments.forEach { attachment in
+            dispatchGroup.enter()
+
+            uploadSingleAttachment(attachment) { response in
+                if let response {
+                    lock.lock()
+                    responses.append(response)
+                    lock.unlock()
+                }
+                dispatchGroup.leave()
+            }
+        }
+
+        dispatchGroup.notify(queue: .main) {
+            completionHandler(responses)
+        }
+    }
+
+    private func uploadSingleAttachment(_ attachment: ZendeskAttachment?, _ completionHandler: @escaping (ZDKUploadResponse?) -> Void) {
         guard let attachment else {
             return completionHandler(nil)
         }
@@ -366,16 +397,14 @@ private extension ZendeskManager {
     /// Creates a Zendesk Request to be consumed by a Request Provider.
     ///
     func createAPIRequest(request: ZendeskSupportRequest,
-                          attachment: ZDKUploadResponse?) -> ZDKCreateRequest {
+                          attachments: [ZDKUploadResponse]) -> ZDKCreateRequest {
         let zdkRequest = ZDKCreateRequest()
         zdkRequest.ticketFormId = request.formID as NSNumber
         zdkRequest.customFields = request.customFields.map { CustomField(fieldId: $0, value: $1) }
         zdkRequest.tags = request.tags
         zdkRequest.subject = request.subject
         zdkRequest.requestDescription = request.description
-        if let attachment {
-            zdkRequest.attachments = [attachment]
-        }
+        zdkRequest.attachments = attachments
         return zdkRequest
     }
 

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -41,7 +41,11 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
     }
 
     private func showContactSupportForm() {
-        let supportController = SupportFormHostingController(viewModel: .init())
+        let attachments: [ZendeskAttachment] = {
+            guard let report = self.viewModel.zendeskAttachment() else { return [] }
+            return [report]
+        }()
+        let supportController = SupportFormHostingController(viewModel: SupportFormViewModel(attachments: attachments))
         supportController.show(from: self)
 
         ServiceLocator.analytics.track(event: .ConnectivityTool.contactSupportTapped())
@@ -176,6 +180,21 @@ struct ConnectivityToolCard: View {
                 return true
             default:
                 return false
+            }
+        }
+
+        var reportDescription: String {
+            switch self {
+            case .inProgress: return "In progress"
+            case .success: return "Success"
+            case .empty(let message): return message
+            case .error(_, let actions):
+                return actions.reduce("") { partialResult, action in
+                    if let technicalDetails = action.technicalDetails {
+                        return partialResult.appending("\(technicalDetails)\n")
+                    }
+                    return partialResult
+                }
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -42,8 +42,15 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
 
     private func showContactSupportForm() {
         let attachments: [ZendeskAttachment] = {
-            guard let report = self.viewModel.zendeskAttachment() else { return [] }
-            return [report]
+            guard let troubleshootingDescription = self.viewModel.troubleshootingDescription(),
+                  let data = troubleshootingDescription.data(using: .utf8) else { return [] }
+            return [
+                ZendeskAttachment(
+                    data: data,
+                    filename: "connectivitytest_log.txt",
+                    contentType: "text/plain"
+                )
+            ]
         }()
         let supportController = SupportFormHostingController(viewModel: SupportFormViewModel(attachments: attachments))
         supportController.show(from: self)
@@ -180,21 +187,6 @@ struct ConnectivityToolCard: View {
                 return true
             default:
                 return false
-            }
-        }
-
-        var reportDescription: String {
-            switch self {
-            case .inProgress: return "In progress"
-            case .success: return "Success"
-            case .empty(let message): return message
-            case .error(_, let actions):
-                return actions.reduce("") { partialResult, action in
-                    if let technicalDetails = action.technicalDetails {
-                        return partialResult.appending("\(technicalDetails)\n")
-                    }
-                    return partialResult
-                }
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -216,6 +216,7 @@ struct ConnectivityToolCard: View {
     /// Internal layout values
     ///
     private static let verticalSpacing = 16.0
+    private static let iconSize = 24.0
 
     @State private var selectedTechnicalDetails: TechnicalDetailsItem?
 
@@ -231,6 +232,7 @@ struct ConnectivityToolCard: View {
 
                 icon.buildAsset()
                     .foregroundColor(Color(uiColor: .text))
+                    .frame(width: Self.iconSize, height: Self.iconSize)
 
                 Text(title)
                     .bodyStyle()

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -36,6 +36,8 @@ final class ConnectivityToolViewModel {
     ///
     private let siteID: Int64
 
+    private var latestTestResult: [ConnectivityTestResult] = []
+
     init(session: SessionManagerProtocol = ServiceLocator.stores.sessionManager) {
 
         let network = AlamofireNetwork(credentials: session.defaultCredentials, selectedSite: nil, appPasswordSupportState: nil)
@@ -50,14 +52,10 @@ final class ConnectivityToolViewModel {
         }
     }
 
-    private var lastResults: [TestCaseResult] = []
-
     /// Sequentially runs all connectivity tests defined in `ConnectivityTest`.
     /// Provide a `sinceTest` parameter to omit test cases before it..
     ///
     private func startConnectivityTest(sinceTest: ConnectivityTest = .internetConnection) async {
-
-        lastResults = []
         let supportedTests: [ConnectivityTest] = {
             if ServiceLocator.stores.isAuthenticatedWithoutWPCom == false {
                 [.internetConnection, .wpComServers, .site, .siteOrders, .loadingProducts]
@@ -85,9 +83,9 @@ final class ConnectivityToolViewModel {
             // Track test result
             trackResponseEvent(for: testCase, success: testResult.isSuccess, timeTaken: timeTaken)
 
-            lastResults.append(TestCaseResult(test: testCase,
-                                              result: testResult,
-                                              timeTaken: timeTaken))
+            latestTestResult.append(ConnectivityTestResult(testCase: testCase,
+                                                           result: testResult,
+                                                           timeTaken: timeTaken))
 
             // Only continue with another test if the current test was successful.
             if !testResult.isSuccess {
@@ -101,11 +99,13 @@ final class ConnectivityToolViewModel {
 
     /// This is not a user facing text but will be part of the Zendesk submission for troubleshooting.
     func troubleshootingDescription() -> String? {
-        guard !lastResults.isEmpty else {
+        guard !latestTestResult.isEmpty else {
             return nil
         }
 
-        return lastResults.map { $0.description() }.joined()
+        return latestTestResult.enumerated().map { index, result in
+            "## \(index + 1). " + result.description()
+        }.joined()
     }
 
     /// Perform the test for a provided test case.
@@ -244,7 +244,9 @@ final class ConnectivityToolViewModel {
             UIApplication.shared.open(WooConstants.URLs.troubleshootErrorLoadingData.asURL())
             ServiceLocator.analytics.track(event: .ConnectivityTool.readMoreTapped())
         }
-        var readMoreAction = ConnectivityToolCard.ConnectivityState.Action(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction)
+        var readMoreAction = ConnectivityToolCard.ConnectivityState.Action(title: readMore,
+                                                                           systemImage: SystemImages.readMore.rawValue,
+                                                                           action: generalTroubleshootAction)
         let jetpackTroubleshootAction = {
             UIApplication.shared.open(WooConstants.URLs.troubleshootJetpackConnection.asURL())
             ServiceLocator.analytics.track(event: .ConnectivityTool.readMoreTapped())
@@ -379,15 +381,15 @@ final class ConnectivityToolViewModel {
     }
 }
 
-fileprivate struct TestCaseResult {
-    let test: ConnectivityToolViewModel.ConnectivityTest
+fileprivate struct ConnectivityTestResult {
+    let testCase: ConnectivityToolViewModel.ConnectivityTest
     let result: ConnectivityToolCard.ConnectivityState
     let timeTaken: TimeInterval
 
     /// This is not a user facing text, but will be part of the attachment sent to Zendesk
     func description() -> String {
         let lines: [String] = [
-            "## \(caseName)",
+            caseName,
             "Took: \(formattedTimeTaken)",
             "Result: \(resultDescription)",
             ""
@@ -402,7 +404,7 @@ fileprivate struct TestCaseResult {
 
     /// This is not a user facing text, but will be part of the attachment sent to Zendesk
     private var caseName: String {
-        switch test {
+        switch testCase {
         case .internetConnection: "Internet Connection"
         case .wpComServers: "Connecting to WordPress.com Servers"
         case .site: "Connecting to your site"

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -50,12 +50,6 @@ final class ConnectivityToolViewModel {
         }
     }
 
-    fileprivate struct TestCaseResult {
-        let test: ConnectivityToolViewModel.ConnectivityTest
-        let result: ConnectivityToolCard.ConnectivityState
-        let timeTaken: Double
-    }
-
     private var lastResults: [TestCaseResult] = []
 
     /// Sequentially runs all connectivity tests defined in `ConnectivityTest`.
@@ -91,7 +85,6 @@ final class ConnectivityToolViewModel {
             // Track test result
             trackResponseEvent(for: testCase, success: testResult.isSuccess, timeTaken: timeTaken)
 
-
             lastResults.append(TestCaseResult(test: testCase,
                                               result: testResult,
                                               timeTaken: timeTaken))
@@ -106,29 +99,13 @@ final class ConnectivityToolViewModel {
         cards.append(noConnectionsIssueState())
     }
 
-    func zendeskAttachment() -> ZendeskAttachment? {
+    /// This is not a user facing text but will be part of the Zendesk submission for troubleshooting.
+    func troubleshootingDescription() -> String? {
         guard !lastResults.isEmpty else {
             return nil
         }
 
-        var output = ""
-        lastResults.forEach { result in
-            output = output
-                .appending("## \(result.test.reportName) \n")
-                .appending("Took: \(result.timeTaken)ms \n")
-                .appending("Result: \n")
-                .appending(result.result.reportDescription)
-                .appending("\n")
-                .appending("\n")
-        }
-
-        guard let data = output.data(using: .utf8) else {
-            return nil
-        }
-
-        return ZendeskAttachment(data: data,
-                                 filename: "connectivitytest_log.txt",
-                                 contentType: "text/plain")
+        return lastResults.map { $0.description() }.joined()
     }
 
     /// Perform the test for a provided test case.
@@ -262,12 +239,12 @@ final class ConnectivityToolViewModel {
         }
 
         let message: String
-        let readMoreAction: ConnectivityToolCard.ConnectivityState.Action
         let readMore = Localization.Action.readMore
         let generalTroubleshootAction = {
             UIApplication.shared.open(WooConstants.URLs.troubleshootErrorLoadingData.asURL())
             ServiceLocator.analytics.track(event: .ConnectivityTool.readMoreTapped())
         }
+        var readMoreAction = ConnectivityToolCard.ConnectivityState.Action(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction)
         let jetpackTroubleshootAction = {
             UIApplication.shared.open(WooConstants.URLs.troubleshootJetpackConnection.asURL())
             ServiceLocator.analytics.track(event: .ConnectivityTool.readMoreTapped())
@@ -277,7 +254,8 @@ final class ConnectivityToolViewModel {
         switch (error, error.isTimeoutError) {
         case (_, true):
             message = Localization.ErrorMessage.timeout
-            readMoreAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction)
+            return .error(message, [readMoreAction, retryAction()])
+
         case (let decodingError as DecodingError, _):
             message = Localization.ErrorMessage.decodingError
             let technicalDetails = formatDecodingError(decodingError, operation: operation)
@@ -287,17 +265,25 @@ final class ConnectivityToolViewModel {
                 systemImage: SystemImages.viewDetails.rawValue,
                 technicalDetails: technicalDetails
             )
-            readMoreAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction)
             return .error(message, [viewDetailsAction, readMoreAction, retryAction()])
+
         case (DotcomError.jetpackNotConnected, _):
             message = Localization.ErrorMessage.noJetpackConnection
             readMoreAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: jetpackTroubleshootAction)
-        default:
-            message = Localization.ErrorMessage.generic
-            readMoreAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction)
-        }
+            return .error(message, [readMoreAction, retryAction()])
 
-        return .error(message, [readMoreAction, retryAction()])
+        case (let error, _):
+            message = Localization.ErrorMessage.generic
+            let technicalDetails = String(describing: error)
+            let viewDetailsTitle = Localization.Action.viewDetails
+            let viewDetailsAction = ConnectivityToolCard.ConnectivityState.Action(
+                title: viewDetailsTitle,
+                systemImage: SystemImages.viewDetails.rawValue,
+                technicalDetails: technicalDetails
+            )
+            readMoreAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction)
+            return .error(message, [viewDetailsAction, readMoreAction, retryAction()])
+        }
     }
 
     private func retryAction() -> ConnectivityToolCard.ConnectivityState.Action {
@@ -392,6 +378,52 @@ final class ConnectivityToolViewModel {
         return codingPath.map { $0.stringValue }.joined(separator: " → ")
     }
 }
+
+fileprivate struct TestCaseResult {
+    let test: ConnectivityToolViewModel.ConnectivityTest
+    let result: ConnectivityToolCard.ConnectivityState
+    let timeTaken: TimeInterval
+
+    /// This is not a user facing text, but will be part of the attachment sent to Zendesk
+    func description() -> String {
+        let lines: [String] = [
+            "## \(caseName)",
+            "Took: \(formattedTimeTaken)",
+            "Result: \(resultDescription)",
+            ""
+        ]
+        return lines.joined(separator: "\n")
+    }
+
+    private var formattedTimeTaken: String {
+        let milliseconds = timeTaken * 1000
+        return String(format: "%.0fms", milliseconds)
+    }
+
+    /// This is not a user facing text, but will be part of the attachment sent to Zendesk
+    private var caseName: String {
+        switch test {
+        case .internetConnection: "Internet Connection"
+        case .wpComServers: "Connecting to WordPress.com Servers"
+        case .site: "Connecting to your site"
+        case .siteOrders: "Fetching your site orders"
+        case .loadingProducts: "Fetching products in your store"
+        }
+    }
+
+    /// This is not a user facing text, but will be part of the attachment sent to Zendesk
+    private var resultDescription: String {
+        switch result {
+        case .inProgress: return "In progress"
+        case .success: return "Success"
+        case .empty(let message): return message
+        case .error(_, let actions):
+            let lines = actions.compactMap { $0.technicalDetails }
+            return lines.joined(separator: "\n")
+        }
+    }
+}
+
 
 private extension ConnectivityToolViewModel {
     enum Localization {
@@ -528,17 +560,6 @@ private extension ConnectivityToolViewModel {
 
         var inProgressCard: ConnectivityTool.Card {
             .init(title: title, icon: icon, state: .inProgress)
-        }
-
-        /// This is not a user facing text, but will be part of the attachment sent to Zendesk
-        var reportName: String {
-            switch self {
-            case .internetConnection: "Internet Connection"
-            case .wpComServers: "Connecting to WordPress.com Servers"
-            case .site: "Connecting to your site"
-            case .siteOrders: "Fetching your site orders"
-            case .loadingProducts: "Fetching products in your store"
-            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -50,11 +50,20 @@ final class ConnectivityToolViewModel {
         }
     }
 
+    fileprivate struct TestCaseResult {
+        let test: ConnectivityToolViewModel.ConnectivityTest
+        let result: ConnectivityToolCard.ConnectivityState
+        let timeTaken: Double
+    }
+
+    private var lastResults: [TestCaseResult] = []
+
     /// Sequentially runs all connectivity tests defined in `ConnectivityTest`.
     /// Provide a `sinceTest` parameter to omit test cases before it..
     ///
     private func startConnectivityTest(sinceTest: ConnectivityTest = .internetConnection) async {
 
+        lastResults = []
         let supportedTests: [ConnectivityTest] = {
             if ServiceLocator.stores.isAuthenticatedWithoutWPCom == false {
                 [.internetConnection, .wpComServers, .site, .siteOrders, .loadingProducts]
@@ -82,6 +91,11 @@ final class ConnectivityToolViewModel {
             // Track test result
             trackResponseEvent(for: testCase, success: testResult.isSuccess, timeTaken: timeTaken)
 
+
+            lastResults.append(TestCaseResult(test: testCase,
+                                              result: testResult,
+                                              timeTaken: timeTaken))
+
             // Only continue with another test if the current test was successful.
             if !testResult.isSuccess {
                 return // Exit connectivity test.
@@ -90,6 +104,31 @@ final class ConnectivityToolViewModel {
 
         // Add no connections issues card if all tests are successful.
         cards.append(noConnectionsIssueState())
+    }
+
+    func zendeskAttachment() -> ZendeskAttachment? {
+        guard !lastResults.isEmpty else {
+            return nil
+        }
+
+        var output = ""
+        lastResults.forEach { result in
+            output = output
+                .appending("## \(result.test.reportName) \n")
+                .appending("Took: \(result.timeTaken)ms \n")
+                .appending("Result: \n")
+                .appending(result.result.reportDescription)
+                .appending("\n")
+                .appending("\n")
+        }
+
+        guard let data = output.data(using: .utf8) else {
+            return nil
+        }
+
+        return ZendeskAttachment(data: data,
+                                 filename: "connectivitytest_log.txt",
+                                 contentType: "text/plain")
     }
 
     /// Perform the test for a provided test case.
@@ -489,6 +528,17 @@ private extension ConnectivityToolViewModel {
 
         var inProgressCard: ConnectivityTool.Card {
             .init(title: title, icon: icon, state: .inProgress)
+        }
+
+        /// This is not a user facing text, but will be part of the attachment sent to Zendesk
+        var reportName: String {
+            switch self {
+            case .internetConnection: "Internet Connection"
+            case .wpComServers: "Connecting to WordPress.com Servers"
+            case .site: "Connecting to your site"
+            case .siteOrders: "Fetching your site orders"
+            case .loadingProducts: "Fetching products in your store"
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -66,6 +66,8 @@ public final class SupportFormViewModel: ObservableObject {
     ///
     private let defaultSite: Site?
 
+    private let attachments: [ZendeskAttachment]
+
     /// Defines when the submit button should be enabled or not.
     ///
     var submitButtonDisabled: Bool {
@@ -98,13 +100,15 @@ public final class SupportFormViewModel: ObservableObject {
          zendeskProvider: ZendeskManagerProtocol = ZendeskProvider.shared,
          analyticsProvider: Analytics = ServiceLocator.analytics,
          applicationLogsProvider: ApplicationLogProvider = ServiceLocator.applicationLogProvider,
-         defaultSite: Site? = ServiceLocator.stores.sessionManager.defaultSite) {
+         defaultSite: Site? = ServiceLocator.stores.sessionManager.defaultSite,
+         attachments: [ZendeskAttachment] = []) {
         self.areas = areas
         self.sourceTag = sourceTag
         self.zendeskProvider = zendeskProvider
         self.analyticsProvider = analyticsProvider
         self.applicationLogsProvider = applicationLogsProvider
         self.defaultSite = defaultSite
+        self.attachments = attachments
     }
 
     /// Tracks when the support form is viewed.
@@ -141,7 +145,7 @@ public final class SupportFormViewModel: ObservableObject {
                                             tags: assembleTags(),
                                             subject: subject,
                                             description: description,
-                                            attachment: attachment())
+                                            attachments: wrapAttachments())
         zendeskProvider.createSupportRequest(request) { [weak self] result in
             guard let self else { return }
             self.showLoadingIndicator = false
@@ -221,13 +225,14 @@ private extension SupportFormViewModel {
         shouldShowIdentityInput = true
     }
 
-    func attachment() -> ZendeskAttachment? {
+    func wrapAttachments() -> [ZendeskAttachment] {
         guard let applicationLogs = applicationLogsProvider.applicationLogs()?.data(using: .utf8) else {
-            return nil
+            return []
         }
-        return ZendeskAttachment(data: applicationLogs,
-                                 filename: "application_log.txt",
-                                 contentType: "text/plain")
+
+        return attachments + [ZendeskAttachment(data: applicationLogs,
+                                                filename: "application_log.txt",
+                                                contentType: "text/plain")]
     }
 }
 


### PR DESCRIPTION
This is a follow-up on [HACK Week: Add details for decoding errors in troubleshooting tool](https://github.com/woocommerce/woocommerce-ios/pull/16444)

## Description
This PR attaches the troubleshooting tool's output as an attachment to the Zendesk issue if you navigate to the Contact Support page.

- I've updated ZendeskManager to support updating multiple attachments.
- Improved the sizing of the icon on the Troubleshooting Connection screen.
- Updated ConnectivityToolViewModel to include the technical details section for generic errors.

## Test Steps
⚠️ This is an E2E test. You'll need to resolve the opened issue in Zendesk.

1. Download the app from the build. You need the PR build as it contains the keys for creating the request.
2. Login with any store.
3. Navigate to Settings/Troubleshooting Connection/
4. [Optional] You can mock any of the network response to fail to see a more detailed report.
5. Wait for the report to finish.
6. Tap Contact Support
7 . Fill out required fields.
8. Tap "Submit Support Request"
9. Open Zendesk and locate the issue.
10.  Validate that logs are attached.
11. Download and the connectivitytest_log attachment and check it.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-10 at 14 35 45" src="https://github.com/user-attachments/assets/bf6f7f1e-a611-4566-8d4a-69ff5e3a05a0" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-10 at 14 37 01" src="https://github.com/user-attachments/assets/95fceb25-bf50-4a11-bdd0-b51eaac80f45" /> |

<img width="933" height="212" alt="Screenshot 2025-12-11 at 13 55 53" src="https://github.com/user-attachments/assets/83db06dd-e509-48c3-85bf-0d099e445f76" />


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
