### PR TITLE
[CIAB] Events: Extending events

### DIFF
--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -1059,6 +1059,7 @@ public enum WooAnalyticsStat: String {
 
     // MARK: - Bookings
     case bookingsSelected = "main_tab_bookings_selected"
+    case bookingsReselected = "main_tab_bookings_reselected"
 
     // MARK: Hub Menu
     //

--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -1057,6 +1057,9 @@ public enum WooAnalyticsStat: String {
     case jetpackInstallContactSupportButtonTapped = "jetpack_install_contact_support_button_tapped"
     case jetpackBenefitsModalWPAdminButtonTapped = "jetpack_benefits_modal_wpadmin_button_tapped"
 
+    // MARK: - Bookings
+    case bookingsSelected = "main_tab_bookings_selected"
+
     // MARK: Hub Menu
     //
     case hubMenuTabSelected = "main_tab_hub_menu_selected"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Products.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Products.swift
@@ -1,10 +1,13 @@
 import UIKit
+import Networking
 
 extension WooAnalyticsEvent {
     enum Products {
         /// Event property keys.
         private enum Key {
             static let horizontalSizeClass = "horizontal_size_class"
+            static let productType = "product_type"
+
         }
 
         static func productListSelected(horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
@@ -17,9 +20,13 @@ extension WooAnalyticsEvent {
                               properties: [Key.horizontalSizeClass: horizontalSizeClass.nameForAnalytics])
         }
 
-        static func productListProductTapped(horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
+        static func productListProductTapped(productType: ProductType,
+                                             horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productListProductTapped,
-                              properties: [Key.horizontalSizeClass: horizontalSizeClass.nameForAnalytics])
+                              properties: [
+                                Key.productType: productType.rawValue,
+                                Key.horizontalSizeClass: horizontalSizeClass.nameForAnalytics
+                              ])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Products.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Products.swift
@@ -7,7 +7,6 @@ extension WooAnalyticsEvent {
         private enum Key {
             static let horizontalSizeClass = "horizontal_size_class"
             static let productType = "product_type"
-
         }
 
         static func productListSelected(horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -418,13 +418,11 @@ private extension MainTabBarController {
             ServiceLocator.analytics.track(
                 event: .Products.productListSelected(horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
         case .bookings:
-            // TODO: Add bookings tab selected analytics
-            break
+            ServiceLocator.analytics.track(.bookingsSelected)
         case .hubMenu:
             ServiceLocator.analytics.track(.hubMenuTabSelected)
         case .pointOfSale:
             ServiceLocator.analytics.track(.pointOfSaleTabSelected)
-            break
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -439,8 +439,7 @@ private extension MainTabBarController {
             ServiceLocator.analytics.track(
                 event: .Products.productListReselected(horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
         case .bookings:
-            // TODO: Add bookings tab reselected analytics
-            break
+            ServiceLocator.analytics.track(.bookingsReselected)
         case .hubMenu:
             ServiceLocator.analytics.track(.hubMenuTabReselected)
             break

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -1140,7 +1140,9 @@ extension ProductsViewController: UITableViewDelegate {
             updatedSelectedItems()
         } else {
             ServiceLocator.analytics.track(event:
-                    .Products.productListProductTapped(horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
+                    .Products.productListProductTapped(
+                        productType: product.productType,
+                        horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
 
             didSelectProduct(product: product)
         }


### PR DESCRIPTION
Closes [WOOMOB-1883](https://linear.app/a8c/issue/WOOMOB-1883/extending-current-events)

## Description
This PR adds the first batch of the tracking events for CIAB bookings.

## Test Steps
1. Login to any store.
2. Make sure analytics is enabled.
3. Tap a product in the product list.
4. Tap on the main booking tab
5. Tap on the main booking tab again.
6. Navigate to Settings/Help & Support/View Application Logs
7. Validate you see `product_list_product_tapped` with a property for `product_type`.
8. Validate you see `main_tab_booking_selected`
9. Validate you see `main_tab_bookings_reselected`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
