### PR TITLE
[HACK week] DO NOT MERGE: Use Store Api for POS checkout

### DIFF
--- a/Modules/Sources/Fakes/Networking.generated.swift
+++ b/Modules/Sources/Fakes/Networking.generated.swift
@@ -815,7 +815,8 @@ extension Networking.POSProduct {
             stockQuantity: .fake(),
             stockStatusKey: .fake(),
             statusKey: .fake(),
-            variationIDs: .fake()
+            variationIDs: .fake(),
+            metaData: .fake()
         )
     }
 }

--- a/Modules/Sources/Fakes/NetworkingCore.generated.swift
+++ b/Modules/Sources/Fakes/NetworkingCore.generated.swift
@@ -44,7 +44,7 @@ extension NetworkingCore.DotcomError {
     /// Returns a "ready to use" type filled with fake values.
     ///
     public static func fake() -> NetworkingCore.DotcomError {
-        .empty()
+        .empty
     }
 }
 extension NetworkingCore.MetaContainer {

--- a/Modules/Sources/Fakes/Yosemite.generated.swift
+++ b/Modules/Sources/Fakes/Yosemite.generated.swift
@@ -67,7 +67,9 @@ extension Yosemite.POSSimpleProduct {
             bundledItems: .fake(),
             manageStock: .fake(),
             stockQuantity: .fake(),
-            stockStatusKey: .fake()
+            stockStatusKey: .fake(),
+            downloadable: .fake(),
+            isGiftCard: .fake()
         )
     }
 }

--- a/Modules/Sources/Networking/Mapper/StoreAPICartMapper.swift
+++ b/Modules/Sources/Networking/Mapper/StoreAPICartMapper.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Mapper: Store API Cart
+///
+struct StoreAPICartMapper: Mapper {
+    /// (Attempts) to convert response data into a StoreAPICart.
+    ///
+    func map(response: Data) throws -> StoreAPICart {
+        let decoder = JSONDecoder()
+        return try decoder.decode(StoreAPICart.self, from: response)
+    }
+}

--- a/Modules/Sources/Networking/Mapper/StoreAPICheckoutResponseMapper.swift
+++ b/Modules/Sources/Networking/Mapper/StoreAPICheckoutResponseMapper.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Mapper: Store API Checkout Response
+///
+struct StoreAPICheckoutResponseMapper: Mapper {
+    /// (Attempts) to convert response data into a StoreAPICheckoutResponse.
+    ///
+    func map(response: Data) throws -> StoreAPICheckoutResponse {
+        let decoder = JSONDecoder()
+        return try decoder.decode(StoreAPICheckoutResponse.self, from: response)
+    }
+}

--- a/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -3,6 +3,7 @@
 import CocoaLumberjackSwift
 import Codegen
 import Foundation
+import NetworkingCore
 import WooFoundation
 import struct Alamofire.JSONEncoding
 import struct NetworkingCore.JetpackSite
@@ -1372,7 +1373,8 @@ extension Networking.POSProduct {
         stockQuantity: NullableCopiableProp<Decimal> = .copy,
         stockStatusKey: CopiableProp<String> = .copy,
         statusKey: CopiableProp<String> = .copy,
-        variationIDs: CopiableProp<[Int64]> = .copy
+        variationIDs: CopiableProp<[Int64]> = .copy,
+        metaData: CopiableProp<[MetaData]> = .copy
     ) -> Networking.POSProduct {
         let siteID = siteID ?? self.siteID
         let productID = productID ?? self.productID
@@ -1392,6 +1394,7 @@ extension Networking.POSProduct {
         let stockStatusKey = stockStatusKey ?? self.stockStatusKey
         let statusKey = statusKey ?? self.statusKey
         let variationIDs = variationIDs ?? self.variationIDs
+        let metaData = metaData ?? self.metaData
 
         return Networking.POSProduct(
             siteID: siteID,
@@ -1411,7 +1414,8 @@ extension Networking.POSProduct {
             stockQuantity: stockQuantity,
             stockStatusKey: stockStatusKey,
             statusKey: statusKey,
-            variationIDs: variationIDs
+            variationIDs: variationIDs,
+            metaData: metaData
         )
     }
 }

--- a/Modules/Sources/Networking/Model/POSProduct.swift
+++ b/Modules/Sources/Networking/Model/POSProduct.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Codegen
+import NetworkingCore
 
 /// Represents a Product Entity, for use in Point of Sale.
 /// This deliberately only includes a subset of the fields available for Product.
@@ -51,6 +52,8 @@ public struct POSProduct: Codable, Equatable, GeneratedCopiable, GeneratedFakeab
 
     public let variationIDs: [Int64]
 
+    public let metaData: [MetaData]
+
     public init(siteID: Int64,
                 productID: Int64,
                 name: String,
@@ -68,7 +71,8 @@ public struct POSProduct: Codable, Equatable, GeneratedCopiable, GeneratedFakeab
                 stockQuantity: Decimal?,
                 stockStatusKey: String,
                 statusKey: String,
-                variationIDs: [Int64]) {
+                variationIDs: [Int64],
+                metaData: [MetaData]) {
         self.siteID = siteID
         self.productID = productID
         self.name = name
@@ -95,6 +99,8 @@ public struct POSProduct: Codable, Equatable, GeneratedCopiable, GeneratedFakeab
         self.statusKey = statusKey
 
         self.variationIDs = variationIDs
+
+        self.metaData = metaData
     }
 
     public init(from decoder: any Decoder) throws {
@@ -142,6 +148,8 @@ public struct POSProduct: Codable, Equatable, GeneratedCopiable, GeneratedFakeab
 
         let variationIDs = try container.decodeIfPresent([Int64].self, forKey: .variationIDs) ?? []
 
+        let metaData = try container.decodeIfPresent([MetaData].self, forKey: .metaData) ?? []
+
         self.init(siteID: siteID,
                   productID: productID,
                   name: name,
@@ -159,7 +167,8 @@ public struct POSProduct: Codable, Equatable, GeneratedCopiable, GeneratedFakeab
                   stockQuantity: stockQuantity,
                   stockStatusKey: stockStatusKey,
                   statusKey: statusKey,
-                  variationIDs: variationIDs)
+                  variationIDs: variationIDs,
+                  metaData: metaData)
     }
 
     static let requestFields: [String] = {
@@ -194,5 +203,6 @@ private extension POSProduct {
         case stockStatusKey = "stock_status"
         case statusKey = "status"
         case variationIDs = "variations"
+        case metaData = "meta_data"
     }
 }

--- a/Modules/Sources/Networking/Model/StoreAPI/StoreAPICart.swift
+++ b/Modules/Sources/Networking/Model/StoreAPI/StoreAPICart.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Represents a WooCommerce Store API Cart response.
+///
+public struct StoreAPICart: Decodable, Equatable {
+    /// List of items in the cart.
+    public let items: [StoreAPICartItem]
+
+    /// Total number of items in the cart.
+    public let itemsCount: Int
+
+    /// Total number of items (including quantities) in the cart.
+    public let itemsWeight: Double
+
+    /// List of applied coupons.
+    public let coupons: [StoreAPICartCoupon]
+
+    /// Whether the cart needs payment (total > 0).
+    public let needsPayment: Bool
+
+    /// Whether the cart needs shipping.
+    public let needsShipping: Bool
+
+    /// Cart totals.
+    public let totals: StoreAPICartTotals
+
+    public init(
+        items: [StoreAPICartItem],
+        itemsCount: Int,
+        itemsWeight: Double,
+        coupons: [StoreAPICartCoupon],
+        needsPayment: Bool,
+        needsShipping: Bool,
+        totals: StoreAPICartTotals
+    ) {
+        self.items = items
+        self.itemsCount = itemsCount
+        self.itemsWeight = itemsWeight
+        self.coupons = coupons
+        self.needsPayment = needsPayment
+        self.needsShipping = needsShipping
+        self.totals = totals
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        items = try container.decode([StoreAPICartItem].self, forKey: .items)
+        itemsCount = try container.decode(Int.self, forKey: .itemsCount)
+        itemsWeight = try container.decodeIfPresent(Double.self, forKey: .itemsWeight) ?? 0
+        coupons = try container.decode([StoreAPICartCoupon].self, forKey: .coupons)
+        needsPayment = try container.decode(Bool.self, forKey: .needsPayment)
+        needsShipping = try container.decode(Bool.self, forKey: .needsShipping)
+        totals = try container.decode(StoreAPICartTotals.self, forKey: .totals)
+    }
+}
+
+private extension StoreAPICart {
+    enum CodingKeys: String, CodingKey {
+        case items
+        case itemsCount = "items_count"
+        case itemsWeight = "items_weight"
+        case coupons
+        case needsPayment = "needs_payment"
+        case needsShipping = "needs_shipping"
+        case totals
+    }
+}

--- a/Modules/Sources/Networking/Model/StoreAPI/StoreAPICartCoupon.swift
+++ b/Modules/Sources/Networking/Model/StoreAPI/StoreAPICartCoupon.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Represents a coupon applied to the WooCommerce Store API Cart.
+///
+public struct StoreAPICartCoupon: Decodable, Equatable {
+    /// Coupon code.
+    public let code: String
+
+    /// Discount type (e.g., "percent", "fixed_cart", "fixed_product").
+    public let discountType: String
+
+    /// Totals for this coupon.
+    public let totals: StoreAPICartCouponTotals
+
+    public init(
+        code: String,
+        discountType: String,
+        totals: StoreAPICartCouponTotals
+    ) {
+        self.code = code
+        self.discountType = discountType
+        self.totals = totals
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        code = try container.decode(String.self, forKey: .code)
+        discountType = try container.decodeIfPresent(String.self, forKey: .discountType) ?? ""
+        totals = try container.decode(StoreAPICartCouponTotals.self, forKey: .totals)
+    }
+}
+
+private extension StoreAPICartCoupon {
+    enum CodingKeys: String, CodingKey {
+        case code
+        case discountType = "discount_type"
+        case totals
+    }
+}
+
+// MARK: - Coupon Totals
+
+/// Totals for a coupon in the cart.
+///
+public struct StoreAPICartCouponTotals: Decodable, Equatable {
+    /// Total discount from this coupon in minor units.
+    public let totalDiscount: String
+
+    /// Total discount tax in minor units.
+    public let totalDiscountTax: String
+
+    /// Currency code.
+    public let currencyCode: String
+
+    /// Number of decimals.
+    public let currencyMinorUnit: Int
+
+    public init(
+        totalDiscount: String,
+        totalDiscountTax: String,
+        currencyCode: String,
+        currencyMinorUnit: Int
+    ) {
+        self.totalDiscount = totalDiscount
+        self.totalDiscountTax = totalDiscountTax
+        self.currencyCode = currencyCode
+        self.currencyMinorUnit = currencyMinorUnit
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        totalDiscount = try container.decode(String.self, forKey: .totalDiscount)
+        totalDiscountTax = try container.decodeIfPresent(String.self, forKey: .totalDiscountTax) ?? "0"
+        currencyCode = try container.decode(String.self, forKey: .currencyCode)
+        currencyMinorUnit = try container.decodeIfPresent(Int.self, forKey: .currencyMinorUnit) ?? 2
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case totalDiscount = "total_discount"
+        case totalDiscountTax = "total_discount_tax"
+        case currencyCode = "currency_code"
+        case currencyMinorUnit = "currency_minor_unit"
+    }
+}

--- a/Modules/Sources/Networking/Model/StoreAPI/StoreAPICartItem.swift
+++ b/Modules/Sources/Networking/Model/StoreAPI/StoreAPICartItem.swift
@@ -1,0 +1,223 @@
+import Foundation
+
+/// Represents an item in the WooCommerce Store API Cart.
+///
+public struct StoreAPICartItem: Decodable, Equatable {
+    /// Unique identifier for the item within the cart (used for update/remove operations).
+    public let key: String
+
+    /// Product ID.
+    public let id: Int64
+
+    /// Variation ID (0 if not a variation).
+    public let variationID: Int64
+
+    /// Quantity of this item in the cart.
+    public let quantity: Int
+
+    /// Product name.
+    public let name: String
+
+    /// Short description of the product.
+    public let shortDescription: String
+
+    /// Product SKU.
+    public let sku: String
+
+    /// Product prices information.
+    public let prices: StoreAPICartItemPrices
+
+    /// Item totals.
+    public let totals: StoreAPICartItemTotals
+
+    public init(
+        key: String,
+        id: Int64,
+        variationID: Int64,
+        quantity: Int,
+        name: String,
+        shortDescription: String,
+        sku: String,
+        prices: StoreAPICartItemPrices,
+        totals: StoreAPICartItemTotals
+    ) {
+        self.key = key
+        self.id = id
+        self.variationID = variationID
+        self.quantity = quantity
+        self.name = name
+        self.shortDescription = shortDescription
+        self.sku = sku
+        self.prices = prices
+        self.totals = totals
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        key = try container.decode(String.self, forKey: .key)
+        id = try container.decode(Int64.self, forKey: .id)
+        variationID = try container.decodeIfPresent(Int64.self, forKey: .variationID) ?? 0
+        quantity = try container.decode(Int.self, forKey: .quantity)
+        name = try container.decode(String.self, forKey: .name)
+        shortDescription = try container.decodeIfPresent(String.self, forKey: .shortDescription) ?? ""
+        sku = try container.decodeIfPresent(String.self, forKey: .sku) ?? ""
+        prices = try container.decode(StoreAPICartItemPrices.self, forKey: .prices)
+        totals = try container.decode(StoreAPICartItemTotals.self, forKey: .totals)
+    }
+}
+
+private extension StoreAPICartItem {
+    enum CodingKeys: String, CodingKey {
+        case key
+        case id
+        case variationID = "variation_id"
+        case quantity
+        case name
+        case shortDescription = "short_description"
+        case sku
+        case prices
+        case totals
+    }
+}
+
+// MARK: - Item Prices
+
+/// Prices information for a cart item.
+///
+public struct StoreAPICartItemPrices: Decodable, Equatable {
+    /// Currency code (e.g., "USD").
+    public let currencyCode: String
+
+    /// Number of decimal places for the currency.
+    public let currencyDecimalSeparator: String
+
+    /// Thousand separator for the currency.
+    public let currencyThousandSeparator: String
+
+    /// Number of decimals.
+    public let currencyMinorUnit: Int
+
+    /// Currency prefix.
+    public let currencyPrefix: String
+
+    /// Currency suffix.
+    public let currencySuffix: String
+
+    /// Price of a single item (in minor units).
+    public let price: String
+
+    /// Regular price of a single item (in minor units).
+    public let regularPrice: String
+
+    /// Sale price of a single item (in minor units), empty if not on sale.
+    public let salePrice: String
+
+    public init(
+        currencyCode: String,
+        currencyDecimalSeparator: String,
+        currencyThousandSeparator: String,
+        currencyMinorUnit: Int,
+        currencyPrefix: String,
+        currencySuffix: String,
+        price: String,
+        regularPrice: String,
+        salePrice: String
+    ) {
+        self.currencyCode = currencyCode
+        self.currencyDecimalSeparator = currencyDecimalSeparator
+        self.currencyThousandSeparator = currencyThousandSeparator
+        self.currencyMinorUnit = currencyMinorUnit
+        self.currencyPrefix = currencyPrefix
+        self.currencySuffix = currencySuffix
+        self.price = price
+        self.regularPrice = regularPrice
+        self.salePrice = salePrice
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        currencyCode = try container.decode(String.self, forKey: .currencyCode)
+        currencyDecimalSeparator = try container.decodeIfPresent(String.self, forKey: .currencyDecimalSeparator) ?? "."
+        currencyThousandSeparator = try container.decodeIfPresent(String.self, forKey: .currencyThousandSeparator) ?? ","
+        currencyMinorUnit = try container.decodeIfPresent(Int.self, forKey: .currencyMinorUnit) ?? 2
+        currencyPrefix = try container.decodeIfPresent(String.self, forKey: .currencyPrefix) ?? ""
+        currencySuffix = try container.decodeIfPresent(String.self, forKey: .currencySuffix) ?? ""
+        price = try container.decode(String.self, forKey: .price)
+        regularPrice = try container.decode(String.self, forKey: .regularPrice)
+        salePrice = try container.decodeIfPresent(String.self, forKey: .salePrice) ?? ""
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case currencyCode = "currency_code"
+        case currencyDecimalSeparator = "currency_decimal_separator"
+        case currencyThousandSeparator = "currency_thousand_separator"
+        case currencyMinorUnit = "currency_minor_unit"
+        case currencyPrefix = "currency_prefix"
+        case currencySuffix = "currency_suffix"
+        case price
+        case regularPrice = "regular_price"
+        case salePrice = "sale_price"
+    }
+}
+
+// MARK: - Item Totals
+
+/// Totals for a cart item.
+///
+public struct StoreAPICartItemTotals: Decodable, Equatable {
+    /// Line subtotal (before discounts) in minor units.
+    public let lineSubtotal: String
+
+    /// Line subtotal tax in minor units.
+    public let lineSubtotalTax: String
+
+    /// Line total (after discounts) in minor units.
+    public let lineTotal: String
+
+    /// Line total tax in minor units.
+    public let lineTotalTax: String
+
+    /// Currency code.
+    public let currencyCode: String
+
+    /// Number of decimals.
+    public let currencyMinorUnit: Int
+
+    public init(
+        lineSubtotal: String,
+        lineSubtotalTax: String,
+        lineTotal: String,
+        lineTotalTax: String,
+        currencyCode: String,
+        currencyMinorUnit: Int
+    ) {
+        self.lineSubtotal = lineSubtotal
+        self.lineSubtotalTax = lineSubtotalTax
+        self.lineTotal = lineTotal
+        self.lineTotalTax = lineTotalTax
+        self.currencyCode = currencyCode
+        self.currencyMinorUnit = currencyMinorUnit
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        lineSubtotal = try container.decode(String.self, forKey: .lineSubtotal)
+        lineSubtotalTax = try container.decodeIfPresent(String.self, forKey: .lineSubtotalTax) ?? "0"
+        lineTotal = try container.decode(String.self, forKey: .lineTotal)
+        lineTotalTax = try container.decodeIfPresent(String.self, forKey: .lineTotalTax) ?? "0"
+        currencyCode = try container.decode(String.self, forKey: .currencyCode)
+        currencyMinorUnit = try container.decodeIfPresent(Int.self, forKey: .currencyMinorUnit) ?? 2
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case lineSubtotal = "line_subtotal"
+        case lineSubtotalTax = "line_subtotal_tax"
+        case lineTotal = "line_total"
+        case lineTotalTax = "line_total_tax"
+        case currencyCode = "currency_code"
+        case currencyMinorUnit = "currency_minor_unit"
+    }
+}

--- a/Modules/Sources/Networking/Model/StoreAPI/StoreAPICartTotals.swift
+++ b/Modules/Sources/Networking/Model/StoreAPI/StoreAPICartTotals.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Represents the totals for a WooCommerce Store API Cart.
+///
+public struct StoreAPICartTotals: Decodable, Equatable {
+    /// Currency code (e.g., "USD").
+    public let currencyCode: String
+
+    /// Currency symbol (e.g., "$").
+    public let currencySymbol: String
+
+    /// Number of decimals.
+    public let currencyMinorUnit: Int
+
+    /// Decimal separator.
+    public let currencyDecimalSeparator: String
+
+    /// Thousand separator.
+    public let currencyThousandSeparator: String
+
+    /// Currency prefix.
+    public let currencyPrefix: String
+
+    /// Currency suffix.
+    public let currencySuffix: String
+
+    /// Total price of items in the cart (in minor units).
+    public let totalItems: String
+
+    /// Total tax on items in the cart (in minor units).
+    public let totalItemsTax: String
+
+    /// Total fees in the cart (in minor units).
+    public let totalFees: String
+
+    /// Total fees tax (in minor units).
+    public let totalFeesTax: String
+
+    /// Total discount from coupons (in minor units).
+    public let totalDiscount: String
+
+    /// Total discount tax (in minor units).
+    public let totalDiscountTax: String
+
+    /// Total shipping cost (in minor units).
+    public let totalShipping: String
+
+    /// Total shipping tax (in minor units).
+    public let totalShippingTax: String
+
+    /// Total tax (in minor units).
+    public let totalTax: String
+
+    /// Total price of the cart (in minor units).
+    public let totalPrice: String
+
+    public init(
+        currencyCode: String,
+        currencySymbol: String,
+        currencyMinorUnit: Int,
+        currencyDecimalSeparator: String,
+        currencyThousandSeparator: String,
+        currencyPrefix: String,
+        currencySuffix: String,
+        totalItems: String,
+        totalItemsTax: String,
+        totalFees: String,
+        totalFeesTax: String,
+        totalDiscount: String,
+        totalDiscountTax: String,
+        totalShipping: String,
+        totalShippingTax: String,
+        totalTax: String,
+        totalPrice: String
+    ) {
+        self.currencyCode = currencyCode
+        self.currencySymbol = currencySymbol
+        self.currencyMinorUnit = currencyMinorUnit
+        self.currencyDecimalSeparator = currencyDecimalSeparator
+        self.currencyThousandSeparator = currencyThousandSeparator
+        self.currencyPrefix = currencyPrefix
+        self.currencySuffix = currencySuffix
+        self.totalItems = totalItems
+        self.totalItemsTax = totalItemsTax
+        self.totalFees = totalFees
+        self.totalFeesTax = totalFeesTax
+        self.totalDiscount = totalDiscount
+        self.totalDiscountTax = totalDiscountTax
+        self.totalShipping = totalShipping
+        self.totalShippingTax = totalShippingTax
+        self.totalTax = totalTax
+        self.totalPrice = totalPrice
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        currencyCode = try container.decode(String.self, forKey: .currencyCode)
+        currencySymbol = try container.decodeIfPresent(String.self, forKey: .currencySymbol) ?? ""
+        currencyMinorUnit = try container.decodeIfPresent(Int.self, forKey: .currencyMinorUnit) ?? 2
+        currencyDecimalSeparator = try container.decodeIfPresent(String.self, forKey: .currencyDecimalSeparator) ?? "."
+        currencyThousandSeparator = try container.decodeIfPresent(String.self, forKey: .currencyThousandSeparator) ?? ","
+        currencyPrefix = try container.decodeIfPresent(String.self, forKey: .currencyPrefix) ?? ""
+        currencySuffix = try container.decodeIfPresent(String.self, forKey: .currencySuffix) ?? ""
+        totalItems = try container.decode(String.self, forKey: .totalItems)
+        totalItemsTax = try container.decodeIfPresent(String.self, forKey: .totalItemsTax) ?? "0"
+        totalFees = try container.decodeIfPresent(String.self, forKey: .totalFees) ?? "0"
+        totalFeesTax = try container.decodeIfPresent(String.self, forKey: .totalFeesTax) ?? "0"
+        totalDiscount = try container.decodeIfPresent(String.self, forKey: .totalDiscount) ?? "0"
+        totalDiscountTax = try container.decodeIfPresent(String.self, forKey: .totalDiscountTax) ?? "0"
+        totalShipping = try container.decodeIfPresent(String.self, forKey: .totalShipping) ?? "0"
+        totalShippingTax = try container.decodeIfPresent(String.self, forKey: .totalShippingTax) ?? "0"
+        totalTax = try container.decodeIfPresent(String.self, forKey: .totalTax) ?? "0"
+        totalPrice = try container.decode(String.self, forKey: .totalPrice)
+    }
+}
+
+private extension StoreAPICartTotals {
+    enum CodingKeys: String, CodingKey {
+        case currencyCode = "currency_code"
+        case currencySymbol = "currency_symbol"
+        case currencyMinorUnit = "currency_minor_unit"
+        case currencyDecimalSeparator = "currency_decimal_separator"
+        case currencyThousandSeparator = "currency_thousand_separator"
+        case currencyPrefix = "currency_prefix"
+        case currencySuffix = "currency_suffix"
+        case totalItems = "total_items"
+        case totalItemsTax = "total_items_tax"
+        case totalFees = "total_fees"
+        case totalFeesTax = "total_fees_tax"
+        case totalDiscount = "total_discount"
+        case totalDiscountTax = "total_discount_tax"
+        case totalShipping = "total_shipping"
+        case totalShippingTax = "total_shipping_tax"
+        case totalTax = "total_tax"
+        case totalPrice = "total_price"
+    }
+}

--- a/Modules/Sources/Networking/Model/StoreAPI/StoreAPICartTotals.swift
+++ b/Modules/Sources/Networking/Model/StoreAPI/StoreAPICartTotals.swift
@@ -115,6 +115,68 @@ public struct StoreAPICartTotals: Decodable, Equatable {
     }
 }
 
+// MARK: - Formatting Helpers
+//
+public extension StoreAPICartTotals {
+    /// Converts a value from minor units (cents) to a decimal string.
+    ///
+    /// Store API returns values in minor units (e.g., "1000" for $10.00).
+    /// This converts them to decimal format (e.g., "10.00") for compatibility
+    /// with REST API models like `Order` which expect decimal strings.
+    ///
+    /// - Parameter minorUnitsValue: The value in minor units as a string.
+    /// - Returns: The value as a decimal string.
+    ///
+    func formatAsDecimalString(_ minorUnitsValue: String) -> String {
+        guard let intValue = Int(minorUnitsValue) else {
+            return minorUnitsValue
+        }
+
+        let divisor = pow(10.0, Double(currencyMinorUnit))
+        let decimalValue = Double(intValue) / divisor
+
+        return String(format: "%.\(currencyMinorUnit)f", decimalValue)
+    }
+
+    /// Converts a value from minor units to a formatted currency string for display.
+    ///
+    /// Store API returns values in minor units (e.g., "1000" for $10.00).
+    /// This formats them with the currency symbol and separators (e.g., "$10.00").
+    ///
+    /// - Parameter minorUnitsValue: The value in minor units as a string.
+    /// - Returns: The formatted currency string for display.
+    ///
+    func formatAsCurrencyString(_ minorUnitsValue: String) -> String {
+        guard let intValue = Int(minorUnitsValue) else {
+            return minorUnitsValue
+        }
+
+        let divisor = pow(10.0, Double(currencyMinorUnit))
+        let decimalValue = Double(intValue) / divisor
+
+        // Format the number with proper decimal places
+        let formatter = NumberFormatter()
+        formatter.minimumFractionDigits = currencyMinorUnit
+        formatter.maximumFractionDigits = currencyMinorUnit
+        formatter.decimalSeparator = currencyDecimalSeparator
+        formatter.groupingSeparator = currencyThousandSeparator
+        formatter.usesGroupingSeparator = true
+
+        let formattedNumber = formatter.string(from: NSNumber(value: decimalValue)) ?? String(format: "%.\(currencyMinorUnit)f", decimalValue)
+
+        return "\(currencyPrefix)\(formattedNumber)\(currencySuffix)"
+    }
+
+    /// Returns the total price as a Decimal value.
+    ///
+    var totalPriceDecimal: Decimal {
+        guard let intValue = Int(totalPrice) else {
+            return 0
+        }
+        return Decimal(intValue) / pow(10, currencyMinorUnit)
+    }
+}
+
 private extension StoreAPICartTotals {
     enum CodingKeys: String, CodingKey {
         case currencyCode = "currency_code"

--- a/Modules/Sources/Networking/Model/StoreAPI/StoreAPICheckoutResponse.swift
+++ b/Modules/Sources/Networking/Model/StoreAPI/StoreAPICheckoutResponse.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// Represents the response from a WooCommerce Store API checkout request.
+///
+public struct StoreAPICheckoutResponse: Decodable, Equatable {
+    /// The created order ID.
+    public let orderID: Int64
+
+    /// Order status (e.g., "pending", "completed").
+    public let status: String
+
+    /// Unique key for the order.
+    public let orderKey: String
+
+    /// Customer ID (0 for guest).
+    public let customerID: Int64
+
+    /// Payment result information.
+    public let paymentResult: StoreAPIPaymentResult
+
+    public init(
+        orderID: Int64,
+        status: String,
+        orderKey: String,
+        customerID: Int64,
+        paymentResult: StoreAPIPaymentResult
+    ) {
+        self.orderID = orderID
+        self.status = status
+        self.orderKey = orderKey
+        self.customerID = customerID
+        self.paymentResult = paymentResult
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        orderID = try container.decode(Int64.self, forKey: .orderID)
+        status = try container.decode(String.self, forKey: .status)
+        orderKey = try container.decodeIfPresent(String.self, forKey: .orderKey) ?? ""
+        customerID = try container.decodeIfPresent(Int64.self, forKey: .customerID) ?? 0
+        paymentResult = try container.decode(StoreAPIPaymentResult.self, forKey: .paymentResult)
+    }
+}
+
+private extension StoreAPICheckoutResponse {
+    enum CodingKeys: String, CodingKey {
+        case orderID = "order_id"
+        case status
+        case orderKey = "order_key"
+        case customerID = "customer_id"
+        case paymentResult = "payment_result"
+    }
+}
+
+// MARK: - Payment Result
+
+/// Payment result from a Store API checkout.
+///
+public struct StoreAPIPaymentResult: Decodable, Equatable {
+    /// Payment status (e.g., "success", "pending", "failure").
+    public let paymentStatus: String
+
+    /// Details about the payment result.
+    public let paymentDetails: [StoreAPIPaymentDetail]
+
+    /// URL to redirect the customer to (if applicable).
+    public let redirectURL: String
+
+    public init(
+        paymentStatus: String,
+        paymentDetails: [StoreAPIPaymentDetail],
+        redirectURL: String
+    ) {
+        self.paymentStatus = paymentStatus
+        self.paymentDetails = paymentDetails
+        self.redirectURL = redirectURL
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        paymentStatus = try container.decode(String.self, forKey: .paymentStatus)
+        paymentDetails = try container.decodeIfPresent([StoreAPIPaymentDetail].self, forKey: .paymentDetails) ?? []
+        redirectURL = try container.decodeIfPresent(String.self, forKey: .redirectURL) ?? ""
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case paymentStatus = "payment_status"
+        case paymentDetails = "payment_details"
+        case redirectURL = "redirect_url"
+    }
+}
+
+// MARK: - Payment Detail
+
+/// A key-value detail from the payment result.
+///
+public struct StoreAPIPaymentDetail: Decodable, Equatable {
+    /// Detail key.
+    public let key: String
+
+    /// Detail value.
+    public let value: String
+
+    public init(key: String, value: String) {
+        self.key = key
+        self.value = value
+    }
+}

--- a/Modules/Sources/Networking/Remote/POSStoreAPIRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSStoreAPIRemote.swift
@@ -54,9 +54,17 @@ public final class POSStoreAPIRemote: Remote {
     ///   - productID: The product ID to add.
     ///   - quantity: The quantity to add.
     ///   - variationID: Optional variation ID (for variable products).
+    ///   - giftCardRecipientEmail: Optional recipient email for gift card products.
+    ///   - giftCardSenderName: Optional sender name for gift card products.
     /// - Returns: The updated cart.
     ///
-    public func addItem(productID: Int64, quantity: Int, variationID: Int64? = nil) async throws -> StoreAPICart {
+    public func addItem(
+        productID: Int64,
+        quantity: Int,
+        variationID: Int64? = nil,
+        giftCardRecipientEmail: String? = nil,
+        giftCardSenderName: String? = nil
+    ) async throws -> StoreAPICart {
         var parameters: [String: Any] = [
             ParameterKey.id: productID,
             ParameterKey.quantity: quantity
@@ -64,6 +72,14 @@ public final class POSStoreAPIRemote: Remote {
 
         if let variationID, variationID > 0 {
             parameters[ParameterKey.variation] = variationID
+        }
+
+        if let email = giftCardRecipientEmail {
+            parameters[ParameterKey.giftCardTo] = email
+        }
+
+        if let senderName = giftCardSenderName {
+            parameters[ParameterKey.giftCardFrom] = senderName
         }
 
         let request = POSStoreAPIRequest(
@@ -171,5 +187,7 @@ private extension POSStoreAPIRemote {
         static let paymentMethod = "payment_method"
         static let billingAddress = "billing_address"
         static let paymentData = "payment_data"
+        static let giftCardTo = "wc_gc_giftcard_to"
+        static let giftCardFrom = "wc_gc_giftcard_from"
     }
 }

--- a/Modules/Sources/Networking/Remote/POSStoreAPIRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSStoreAPIRemote.swift
@@ -51,28 +51,23 @@ public final class POSStoreAPIRemote: Remote {
     /// Adds an item to the cart.
     ///
     /// - Parameters:
-    ///   - productID: The product ID to add.
+    ///   - id: The product or variation ID to add. For simple products, use the product ID.
+    ///         For variations, use the variation ID directly.
     ///   - quantity: The quantity to add.
-    ///   - variationID: Optional variation ID (for variable products).
     ///   - giftCardRecipientEmail: Optional recipient email for gift card products.
     ///   - giftCardSenderName: Optional sender name for gift card products.
     /// - Returns: The updated cart.
     ///
     public func addItem(
-        productID: Int64,
+        id: Int64,
         quantity: Int,
-        variationID: Int64? = nil,
         giftCardRecipientEmail: String? = nil,
         giftCardSenderName: String? = nil
     ) async throws -> StoreAPICart {
         var parameters: [String: Any] = [
-            ParameterKey.id: productID,
+            ParameterKey.id: id,
             ParameterKey.quantity: quantity
         ]
-
-        if let variationID, variationID > 0 {
-            parameters[ParameterKey.variation] = variationID
-        }
 
         if let email = giftCardRecipientEmail {
             parameters[ParameterKey.giftCardTo] = email
@@ -182,7 +177,6 @@ private extension POSStoreAPIRemote {
     enum ParameterKey {
         static let id = "id"
         static let quantity = "quantity"
-        static let variation = "variation"
         static let code = "code"
         static let paymentMethod = "payment_method"
         static let billingAddress = "billing_address"

--- a/Modules/Sources/Networking/Remote/POSStoreAPIRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSStoreAPIRemote.swift
@@ -1,0 +1,175 @@
+import Foundation
+import NetworkingCore
+
+/// Remote for WooCommerce Store API operations used in Point of Sale.
+///
+/// This remote uses the Store API (`/wc/store/v1/`) with the `X-WC-POS: 1` header
+/// for cart and checkout operations.
+///
+public final class POSStoreAPIRemote: Remote {
+    /// Site URL for making requests.
+    private let siteURL: String
+
+    /// Initializer.
+    ///
+    /// - Parameters:
+    ///   - network: Network layer for making requests.
+    ///   - siteURL: URL of the site to make requests to.
+    ///
+    public init(network: Network, siteURL: String) {
+        self.siteURL = siteURL
+        super.init(network: network)
+    }
+
+    // MARK: - Cart Operations
+
+    /// Retrieves the current cart.
+    ///
+    /// - Returns: The current cart state.
+    ///
+    public func getCart() async throws -> StoreAPICart {
+        let request = POSStoreAPIRequest(
+            siteURL: siteURL,
+            method: .get,
+            path: Path.cart
+        )
+        let mapper = StoreAPICartMapper()
+        return try await enqueue(request, mapper: mapper)
+    }
+
+    /// Clears all items from the cart.
+    ///
+    public func clearCart() async throws {
+        let request = POSStoreAPIRequest(
+            siteURL: siteURL,
+            method: .delete,
+            path: Path.cartItems
+        )
+        try await enqueue(request)
+    }
+
+    /// Adds an item to the cart.
+    ///
+    /// - Parameters:
+    ///   - productID: The product ID to add.
+    ///   - quantity: The quantity to add.
+    ///   - variationID: Optional variation ID (for variable products).
+    /// - Returns: The updated cart.
+    ///
+    public func addItem(productID: Int64, quantity: Int, variationID: Int64? = nil) async throws -> StoreAPICart {
+        var parameters: [String: Any] = [
+            ParameterKey.id: productID,
+            ParameterKey.quantity: quantity
+        ]
+
+        if let variationID, variationID > 0 {
+            parameters[ParameterKey.variation] = variationID
+        }
+
+        let request = POSStoreAPIRequest(
+            siteURL: siteURL,
+            method: .post,
+            path: Path.cartAddItem,
+            parameters: parameters
+        )
+        let mapper = StoreAPICartMapper()
+        return try await enqueue(request, mapper: mapper)
+    }
+
+    /// Applies a coupon to the cart.
+    ///
+    /// - Parameter code: The coupon code to apply.
+    /// - Returns: The updated cart.
+    ///
+    public func applyCoupon(code: String) async throws -> StoreAPICart {
+        let parameters: [String: Any] = [
+            ParameterKey.code: code
+        ]
+
+        let request = POSStoreAPIRequest(
+            siteURL: siteURL,
+            method: .post,
+            path: Path.cartApplyCoupon,
+            parameters: parameters
+        )
+        let mapper = StoreAPICartMapper()
+        return try await enqueue(request, mapper: mapper)
+    }
+
+    /// Removes a coupon from the cart.
+    ///
+    /// - Parameter code: The coupon code to remove.
+    /// - Returns: The updated cart.
+    ///
+    public func removeCoupon(code: String) async throws -> StoreAPICart {
+        let parameters: [String: Any] = [
+            ParameterKey.code: code
+        ]
+
+        let request = POSStoreAPIRequest(
+            siteURL: siteURL,
+            method: .post,
+            path: Path.cartRemoveCoupon,
+            parameters: parameters
+        )
+        let mapper = StoreAPICartMapper()
+        return try await enqueue(request, mapper: mapper)
+    }
+
+    // MARK: - Checkout Operations
+
+    /// Performs checkout to create or complete an order.
+    ///
+    /// - Parameters:
+    ///   - paymentMethod: Payment method ID (e.g., "pos_cash", "pos_card").
+    ///   - billingAddress: Billing address fields (can be empty for POS).
+    ///   - paymentData: Payment data array (e.g., containing payment_intent_id for card capture).
+    /// - Returns: The checkout response with order details.
+    ///
+    public func checkout(
+        paymentMethod: String,
+        billingAddress: [String: Any] = [:],
+        paymentData: [[String: String]] = []
+    ) async throws -> StoreAPICheckoutResponse {
+        var parameters: [String: Any] = [
+            ParameterKey.paymentMethod: paymentMethod,
+            ParameterKey.billingAddress: billingAddress
+        ]
+
+        if !paymentData.isEmpty {
+            parameters[ParameterKey.paymentData] = paymentData
+        }
+
+        let request = POSStoreAPIRequest(
+            siteURL: siteURL,
+            method: .post,
+            path: Path.checkout,
+            parameters: parameters
+        )
+        let mapper = StoreAPICheckoutResponseMapper()
+        return try await enqueue(request, mapper: mapper)
+    }
+}
+
+// MARK: - Constants
+
+private extension POSStoreAPIRemote {
+    enum Path {
+        static let cart = "cart"
+        static let cartItems = "cart/items"
+        static let cartAddItem = "cart/add-item"
+        static let cartApplyCoupon = "cart/apply-coupon"
+        static let cartRemoveCoupon = "cart/remove-coupon"
+        static let checkout = "checkout"
+    }
+
+    enum ParameterKey {
+        static let id = "id"
+        static let quantity = "quantity"
+        static let variation = "variation"
+        static let code = "code"
+        static let paymentMethod = "payment_method"
+        static let billingAddress = "billing_address"
+        static let paymentData = "payment_data"
+    }
+}

--- a/Modules/Sources/Networking/Remote/ProductVariationsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductVariationsRemote.swift
@@ -82,7 +82,7 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
         let request = productVariationsRequest(for: siteID,
                                                productID: parentProductID,
                                                variationIDs: [],
-                                               downloadable: false,
+                                               downloadable: nil,
                                                status: .published,
                                                orderBy: .menuOrder,
                                                order: .ascending,

--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -271,7 +271,6 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.orderBy: orderBy.value,
             ParameterKey.order: order.value,
             ParameterKey.productStatus: POSConstants.productStatus,
-            ParameterKey.downloadable: String(false),
             ParameterKey.fields: POSProduct.requestFields.joined(separator: ",")
         ]
     }

--- a/Modules/Sources/NetworkingCore/Requests/POSStoreAPIRequest.swift
+++ b/Modules/Sources/NetworkingCore/Requests/POSStoreAPIRequest.swift
@@ -3,25 +3,16 @@ import Alamofire
 
 /// Represents a WooCommerce Store API request for Point of Sale operations.
 ///
-/// This request type wraps a standard REST request and adds the `X-WC-POS: 1` header
+/// This request type wraps a `RESTRequest` and adds the `X-WC-POS: 1` header
 /// required for POS Store API operations.
 ///
+/// By wrapping `RESTRequest`, this request type is properly authenticated using
+/// application passwords (Basic auth) instead of WPCOM token auth.
+///
 public struct POSStoreAPIRequest: Request {
-    /// URL of the site to make the request with
+    /// The underlying REST request
     ///
-    private let siteURL: String
-
-    /// HTTP Request Method
-    ///
-    private let method: HTTPMethod
-
-    /// Path to the target endpoint (relative to Store API version path)
-    ///
-    private let path: String
-
-    /// Parameters
-    ///
-    private let parameters: [String: Any]?
+    private let restRequest: RESTRequest
 
     /// Designated Initializer.
     ///
@@ -35,36 +26,26 @@ public struct POSStoreAPIRequest: Request {
                 method: HTTPMethod,
                 path: String,
                 parameters: [String: Any]? = nil) {
-        self.siteURL = siteURL
-        self.method = method
-        self.path = path
-        self.parameters = parameters
+        // Build the full path with Store API version
+        let fullPath = [WooAPIVersion.storeV1.path, path]
+            .map { $0.trimSlashes() }
+            .filter { $0.isEmpty == false }
+            .joined(separator: "/")
+
+        self.restRequest = RESTRequest(
+            siteURL: siteURL,
+            method: method,
+            path: fullPath,
+            parameters: parameters,
+            additionalHeaders: [Settings.posHeaderKey: Settings.posHeaderValue]
+        )
     }
 
     /// Returns a URLRequest instance representing the current POS Store API Request.
     ///
     public func asURLRequest() throws -> URLRequest {
-        let components = [siteURL, Settings.basePath, WooAPIVersion.storeV1.path, path]
-            .compactMap { $0 }
-            .map { $0.trimSlashes() }
-            .filter { $0.isEmpty == false }
-        let url = try components.joined(separator: "/").asURL()
-
-        var request = try URLRequest(url: url, method: method)
-
-        // Add the POS header
-        request.setValue(Settings.posHeaderValue, forHTTPHeaderField: Settings.posHeaderKey)
-
-        // Encode parameters
-        switch method {
-        case .post, .put:
-            return try JSONEncoding.default.encode(request, with: parameters)
-        case .delete:
-            // DELETE requests may have parameters in the URL
-            return try URLEncoding.default.encode(request, with: parameters)
-        default:
-            return try URLEncoding.default.encode(request, with: parameters)
-        }
+        // The POS header is included in the underlying REST request via additionalHeaders
+        try restRequest.asURLRequest()
     }
 
     public func responseDataValidator() -> ResponseDataValidator {
@@ -72,11 +53,19 @@ public struct POSStoreAPIRequest: Request {
     }
 }
 
+// MARK: - RESTRequestConvertible conformance for authentication
+//
+extension POSStoreAPIRequest: RESTRequestConvertible {
+    func asRESTRequest(with siteAddress: String) -> RESTRequest? {
+        // Return the underlying REST request for proper authentication handling
+        restRequest
+    }
+}
+
 // MARK: - Constants
 //
 private extension POSStoreAPIRequest {
     enum Settings {
-        static let basePath = "?rest_route="
         static let posHeaderKey = "X-WC-POS"
         static let posHeaderValue = "1"
     }

--- a/Modules/Sources/NetworkingCore/Requests/POSStoreAPIRequest.swift
+++ b/Modules/Sources/NetworkingCore/Requests/POSStoreAPIRequest.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Alamofire
+
+/// Represents a WooCommerce Store API request for Point of Sale operations.
+///
+/// This request type wraps a standard REST request and adds the `X-WC-POS: 1` header
+/// required for POS Store API operations.
+///
+public struct POSStoreAPIRequest: Request {
+    /// URL of the site to make the request with
+    ///
+    private let siteURL: String
+
+    /// HTTP Request Method
+    ///
+    private let method: HTTPMethod
+
+    /// Path to the target endpoint (relative to Store API version path)
+    ///
+    private let path: String
+
+    /// Parameters
+    ///
+    private let parameters: [String: Any]?
+
+    /// Designated Initializer.
+    ///
+    /// - Parameters:
+    ///     - siteURL: URL of the site to send the request to.
+    ///     - method: HTTP Method to use.
+    ///     - path: Path to the target endpoint (e.g., "cart", "checkout").
+    ///     - parameters: Collection of parameters to be passed to the endpoint.
+    ///
+    public init(siteURL: String,
+                method: HTTPMethod,
+                path: String,
+                parameters: [String: Any]? = nil) {
+        self.siteURL = siteURL
+        self.method = method
+        self.path = path
+        self.parameters = parameters
+    }
+
+    /// Returns a URLRequest instance representing the current POS Store API Request.
+    ///
+    public func asURLRequest() throws -> URLRequest {
+        let components = [siteURL, Settings.basePath, WooAPIVersion.storeV1.path, path]
+            .compactMap { $0 }
+            .map { $0.trimSlashes() }
+            .filter { $0.isEmpty == false }
+        let url = try components.joined(separator: "/").asURL()
+
+        var request = try URLRequest(url: url, method: method)
+
+        // Add the POS header
+        request.setValue(Settings.posHeaderValue, forHTTPHeaderField: Settings.posHeaderKey)
+
+        // Encode parameters
+        switch method {
+        case .post, .put:
+            return try JSONEncoding.default.encode(request, with: parameters)
+        case .delete:
+            // DELETE requests may have parameters in the URL
+            return try URLEncoding.default.encode(request, with: parameters)
+        default:
+            return try URLEncoding.default.encode(request, with: parameters)
+        }
+    }
+
+    public func responseDataValidator() -> ResponseDataValidator {
+        PlaceholderDataValidator()
+    }
+}
+
+// MARK: - Constants
+//
+private extension POSStoreAPIRequest {
+    enum Settings {
+        static let basePath = "?rest_route="
+        static let posHeaderKey = "X-WC-POS"
+        static let posHeaderValue = "1"
+    }
+}

--- a/Modules/Sources/NetworkingCore/Requests/RESTRequest.swift
+++ b/Modules/Sources/NetworkingCore/Requests/RESTRequest.swift
@@ -28,18 +28,24 @@ public struct RESTRequest: Request {
     ///
     let allowsCellularAccess: Bool
 
+    /// Additional headers to include in the request
+    ///
+    let additionalHeaders: [String: String]
+
     private init(siteURL: String,
                  apiVersionPath: String?,
                  method: HTTPMethod,
                  path: String,
                  parameters: [String: Any]? = nil,
-                 allowsCellularAccess: Bool = true) {
+                 allowsCellularAccess: Bool = true,
+                 additionalHeaders: [String: String] = [:]) {
         self.siteURL = siteURL
         self.apiVersionPath = apiVersionPath
         self.method = method
         self.path = path
         self.parameters = parameters
         self.allowsCellularAccess = allowsCellularAccess
+        self.additionalHeaders = additionalHeaders
     }
 
     /// - Parameters:
@@ -48,13 +54,15 @@ public struct RESTRequest: Request {
     ///     - path: path to the target endpoint.
     ///     - parameters: Collection of String parameters to be passed over to our target endpoint.
     ///     - allowsCellularAccess: Whether the request should allow cellular data access.
+    ///     - additionalHeaders: Additional HTTP headers to include in the request.
     ///
     public init(siteURL: String,
          method: HTTPMethod,
          path: String,
          parameters: [String: Any]? = nil,
-         allowsCellularAccess: Bool = true) {
-        self.init(siteURL: siteURL, apiVersionPath: nil, method: method, path: path, parameters: parameters, allowsCellularAccess: allowsCellularAccess)
+         allowsCellularAccess: Bool = true,
+         additionalHeaders: [String: String] = [:]) {
+        self.init(siteURL: siteURL, apiVersionPath: nil, method: method, path: path, parameters: parameters, allowsCellularAccess: allowsCellularAccess, additionalHeaders: additionalHeaders)
     }
 
     /// - Parameters:
@@ -64,19 +72,22 @@ public struct RESTRequest: Request {
     ///     - path: path to the target endpoint.
     ///     - parameters: Collection of String parameters to be passed over to our target endpoint.
     ///     - allowsCellularAccess: Whether the request should allow cellular data access.
+    ///     - additionalHeaders: Additional HTTP headers to include in the request.
     ///
     init(siteURL: String,
          wooApiVersion: WooAPIVersion,
          method: HTTPMethod,
          path: String,
          parameters: [String: Any]? = nil,
-         allowsCellularAccess: Bool = true) {
+         allowsCellularAccess: Bool = true,
+         additionalHeaders: [String: String] = [:]) {
         self.init(siteURL: siteURL,
                   apiVersionPath: wooApiVersion.path,
                   method: method,
                   path: path,
                   parameters: parameters,
-                  allowsCellularAccess: allowsCellularAccess)
+                  allowsCellularAccess: allowsCellularAccess,
+                  additionalHeaders: additionalHeaders)
     }
 
     /// - Parameters:
@@ -86,6 +97,7 @@ public struct RESTRequest: Request {
     ///     - path: path to the target endpoint.
     ///     - parameters: Collection of String parameters to be passed over to our target endpoint.
     ///     - allowsCellularAccess: Whether the request should allow cellular data access.
+    ///     - additionalHeaders: Additional HTTP headers to include in the request.
     ///
     // periphery:ignore - we include the cellular parameter for all inits
     init(siteURL: String,
@@ -93,13 +105,15 @@ public struct RESTRequest: Request {
          method: HTTPMethod,
          path: String,
          parameters: [String: Any]? = nil,
-         allowsCellularAccess: Bool = true) {
+         allowsCellularAccess: Bool = true,
+         additionalHeaders: [String: String] = [:]) {
         self.init(siteURL: siteURL,
                   apiVersionPath: wordpressApiVersion.path,
                   method: method,
                   path: path,
                   parameters: parameters,
-                  allowsCellularAccess: allowsCellularAccess)
+                  allowsCellularAccess: allowsCellularAccess,
+                  additionalHeaders: additionalHeaders)
     }
 
     /// Returns a URLRequest instance representing the current REST API Request.
@@ -112,6 +126,12 @@ public struct RESTRequest: Request {
         let url = try components.joined(separator: "/").asURL()
         var request = try URLRequest(url: url, method: method)
         request.allowsCellularAccess = allowsCellularAccess
+
+        // Add any additional headers
+        for (key, value) in additionalHeaders {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+
         switch method {
         case .post, .put:
             return try JSONEncoding.default.encode(request, with: parameters)

--- a/Modules/Sources/NetworkingCore/Settings/WooAPIVersion.swift
+++ b/Modules/Sources/NetworkingCore/Settings/WooAPIVersion.swift
@@ -54,6 +54,11 @@ public enum WooAPIVersion: String {
     ///
     case wcBookings = "wc-bookings/v2"
 
+    /// WooCommerce Store API v1.
+    /// Used for cart and checkout operations, particularly in Point of Sale.
+    ///
+    case storeV1 = "wc/store/v1"
+
     /// Returns the path for the current API Version
     ///
     var path: String {

--- a/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentFacade.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentFacade.swift
@@ -50,6 +50,18 @@ public protocol CardPresentPaymentFacade {
                         using connectionMethod: CardReaderConnectionMethod,
                         channel: PaymentChannel) async throws -> CardPresentPaymentResult
 
+    /// Collects a card present payment for a POS order using Store API for capture.
+    /// - Parameters:
+    ///   - order: The order to collect payment for.
+    ///   - connectionMethod: Allows specifying Tap to Pay or bluetooth reader.
+    ///   - captureHandler: Async closure called with payment intent ID to capture via Store API.
+    /// - Returns: `CardPresentPaymentResult` for a success, or cancellation.
+    /// - Throws: `CardPresentPaymentError` for any failures.
+    /// - Output: publishes intermediate events on the `paymentEventPublisher` as required.
+    func collectPOSPayment(for order: Order,
+                           using connectionMethod: CardReaderConnectionMethod,
+                           captureHandler: @escaping (String) async throws -> Void) async throws -> CardPresentPaymentResult
+
     /// Cancels any in-progress payment.
     func cancelPayment()
 

--- a/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentPreviewService.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/CardPresentPaymentPreviewService.swift
@@ -31,6 +31,12 @@ final class CardPresentPaymentPreviewService: CardPresentPaymentFacade {
         // no-op
     }
 
+    func collectPOSPayment(for order: Yosemite.Order,
+                           using connectionMethod: CardReaderConnectionMethod,
+                           captureHandler: @escaping (String) async throws -> Void) async throws -> CardPresentPaymentResult {
+        .success(CardPresentPaymentTransaction())
+    }
+
     func collectPayment(for order: Yosemite.Order,
                         using connectionMethod: CardReaderConnectionMethod,
                         channel: PaymentChannel) async throws -> CardPresentPaymentResult {

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
@@ -285,7 +285,7 @@ private extension PointOfSaleOrderController {
 
 // MARK: - Mapping
 
-private extension POSCart {
+extension POSCart {
     init(cart: Cart) {
         let items = cart.purchasableItems.compactMap { (purchasableItem: Cart.PurchasableItem) -> POSCartItem? in
             guard case let .loaded(item) = purchasableItem.state else { return nil }

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
@@ -298,7 +298,7 @@ extension POSCart {
     init(cart: Cart) {
         let items = cart.purchasableItems.compactMap { (purchasableItem: Cart.PurchasableItem) -> POSCartItem? in
             guard case let .loaded(item) = purchasableItem.state else { return nil }
-            return POSCartItem(item: item, quantity: Decimal(purchasableItem.quantity))
+            return POSCartItem(id: purchasableItem.id, item: item, quantity: Decimal(purchasableItem.quantity))
         }
         let coupons = cart.coupons.map { POSCoupon(id: $0.posItemIdentifier, code: $0.code, summary: $0.summary) }
         self.init(items: items, coupons: coupons)

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
@@ -43,6 +43,10 @@ protocol PointOfSaleOrderControllerProtocol {
     func sendReceipt(recipientEmail: String) async throws
     func clearOrder()
     func collectCashPayment(changeDueAmount: String?) async throws
+
+    /// Sets the order state for Store API checkout.
+    /// This is used when bypassing the REST API order sync in favor of Store API checkout.
+    func setOrderState(totals: PointOfSaleOrderTotals, order: Order)
 }
 
 @Observable final class PointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
@@ -122,6 +126,11 @@ protocol PointOfSaleOrderControllerProtocol {
     func clearOrder() {
         order = nil
         orderState = .idle
+    }
+
+    func setOrderState(totals: PointOfSaleOrderTotals, order: Order) {
+        self.order = order
+        self.orderState = .loaded(totals, order)
     }
 
     private func celebrate() {

--- a/Modules/Sources/PointOfSale/Models/Cart.swift
+++ b/Modules/Sources/PointOfSale/Models/Cart.swift
@@ -3,6 +3,8 @@ import protocol Yosemite.POSOrderableItem
 import enum Yosemite.POSItem
 import enum Yosemite.PointOfSaleBarcodeScanError
 import struct Yosemite.POSItemIdentifier
+import struct Yosemite.POSSimpleProduct
+import struct Yosemite.POSVariation
 
 struct Cart {
     var purchasableItems: [Cart.PurchasableItem] = []
@@ -149,5 +151,18 @@ extension Cart {
 
     var isNotEmpty: Bool {
         return !isEmpty
+    }
+
+    /// Returns true if any purchasable item in the cart is a downloadable product
+    var containsDownloadableItems: Bool {
+        purchasableItems.contains { item in
+            guard case .loaded(let orderableItem) = item.state else { return false }
+            if let simpleProduct = orderableItem as? POSSimpleProduct {
+                return simpleProduct.downloadable
+            } else if let variation = orderableItem as? POSVariation {
+                return variation.downloadable
+            }
+            return false
+        }
     }
 }

--- a/Modules/Sources/PointOfSale/Models/Cart.swift
+++ b/Modules/Sources/PointOfSale/Models/Cart.swift
@@ -165,4 +165,30 @@ extension Cart {
             return false
         }
     }
+
+    /// Returns true if any purchasable item in the cart is a gift card product
+    var containsGiftCards: Bool {
+        purchasableItems.contains { item in
+            guard case .loaded(let orderableItem) = item.state else { return false }
+            if let simpleProduct = orderableItem as? POSSimpleProduct {
+                return simpleProduct.isGiftCard
+            } else if let variation = orderableItem as? POSVariation {
+                return variation.isGiftCard
+            }
+            return false
+        }
+    }
+
+    /// Returns all gift card items in the cart
+    var giftCardItems: [Cart.PurchasableItem] {
+        purchasableItems.filter { item in
+            guard case .loaded(let orderableItem) = item.state else { return false }
+            if let simpleProduct = orderableItem as? POSSimpleProduct {
+                return simpleProduct.isGiftCard
+            } else if let variation = orderableItem as? POSVariation {
+                return variation.isGiftCard
+            }
+            return false
+        }
+    }
 }

--- a/Modules/Sources/PointOfSale/Models/GiftCardInfo.swift
+++ b/Modules/Sources/PointOfSale/Models/GiftCardInfo.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Information required for a gift card item during checkout.
+/// This data is sent with the `add-item` API call using:
+/// - `wc_gc_giftcard_to`: recipientEmail
+/// - `wc_gc_giftcard_from`: senderName
+struct GiftCardInfo: Equatable {
+    let recipientEmail: String
+    let senderName: String
+}

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -459,49 +459,8 @@ extension PointOfSaleAggregateModel {
         checkoutResult: POSStoreAPICheckoutResult,
         checkoutService: POSStoreAPICheckoutServiceProtocol
     ) async throws {
-        // Create a minimal Order object with the data we need for payment collection
-        let order = Order(
-            siteID: siteID,
-            orderID: checkoutResult.checkoutResponse.orderID,
-            parentID: 0,
-            customerID: 0,
-            orderKey: checkoutResult.checkoutResponse.orderKey,
-            isEditable: false,
-            needsPayment: true,
-            needsProcessing: false,
-            number: String(checkoutResult.checkoutResponse.orderID),
-            status: .pending,
-            currency: checkoutResult.cartTotals.currencyCode,
-            currencySymbol: "",
-            customerNote: nil,
-            dateCreated: Date(),
-            dateModified: Date(),
-            datePaid: nil,
-            discountTotal: "0",
-            discountTax: "0",
-            shippingTotal: "0",
-            shippingTax: "0",
-            total: checkoutResult.cartTotals.totalPrice,
-            totalTax: checkoutResult.cartTotals.totalTax,
-            paymentMethodID: "pos_card",
-            paymentMethodTitle: "POS Card",
-            paymentURL: nil,
-            chargeID: nil,
-            items: [],
-            billingAddress: nil,
-            shippingAddress: nil,
-            shippingLines: [],
-            coupons: [],
-            refunds: [],
-            fees: [],
-            taxes: [],
-            customFields: [],
-            renewalSubscriptionID: nil,
-            appliedGiftCards: [],
-            attributionInfo: nil,
-            shippingLabels: [],
-            createdVia: "store-api"
-        )
+        // Get the order from createOrderAndTotals (reusing the same order we set on orderController)
+        let (order, _) = createOrderAndTotals(from: checkoutResult)
 
         // Create capture handler that uses Store API checkout
         let captureHandler: (String) async throws -> Void = { [checkoutService] paymentIntentID in
@@ -788,6 +747,13 @@ extension PointOfSaleAggregateModel {
             // Store the checkout result for use in card payment capture
             storeAPICheckoutResult = checkoutResult
 
+            // Create the order and totals for the UI
+            let (order, totals) = createOrderAndTotals(from: checkoutResult)
+            orderController.setOrderState(totals: totals, order: order)
+
+            // Track analytics for order sync success
+            collectOrderPaymentAnalyticsTracker.trackOrderSyncSuccess()
+
             // Start payment collection when card reader is connected
             await startPaymentWhenCardReaderConnected()
         } catch {
@@ -800,6 +766,67 @@ extension PointOfSaleAggregateModel {
             await removeMissingProductsFromCatalogAfterSync()
             await startPaymentWhenCardReaderConnected()
         }
+    }
+
+    /// Creates an Order and PointOfSaleOrderTotals from Store API checkout result.
+    ///
+    private func createOrderAndTotals(from checkoutResult: POSStoreAPICheckoutResult) -> (Order, PointOfSaleOrderTotals) {
+        let cartTotals = checkoutResult.cartTotals
+
+        // Create Order object with properly formatted totals
+        let order = Order(
+            siteID: siteID,
+            orderID: checkoutResult.checkoutResponse.orderID,
+            parentID: 0,
+            customerID: 0,
+            orderKey: checkoutResult.checkoutResponse.orderKey,
+            isEditable: false,
+            needsPayment: true,
+            needsProcessing: false,
+            number: String(checkoutResult.checkoutResponse.orderID),
+            status: .pending,
+            currency: cartTotals.currencyCode,
+            currencySymbol: cartTotals.currencySymbol,
+            customerNote: nil,
+            dateCreated: Date(),
+            dateModified: Date(),
+            datePaid: nil,
+            discountTotal: cartTotals.formatAsDecimalString(cartTotals.totalDiscount),
+            discountTax: cartTotals.formatAsDecimalString(cartTotals.totalDiscountTax),
+            shippingTotal: cartTotals.formatAsDecimalString(cartTotals.totalShipping),
+            shippingTax: cartTotals.formatAsDecimalString(cartTotals.totalShippingTax),
+            total: cartTotals.formatAsDecimalString(cartTotals.totalPrice),
+            totalTax: cartTotals.formatAsDecimalString(cartTotals.totalTax),
+            paymentMethodID: "pos_card",
+            paymentMethodTitle: "POS Card",
+            paymentURL: nil,
+            chargeID: nil,
+            items: [],
+            billingAddress: nil,
+            shippingAddress: nil,
+            shippingLines: [],
+            coupons: [],
+            refunds: [],
+            fees: [],
+            taxes: [],
+            customFields: [],
+            renewalSubscriptionID: nil,
+            appliedGiftCards: [],
+            attributionInfo: nil,
+            shippingLabels: [],
+            createdVia: "store-api"
+        )
+
+        // Create formatted totals for display
+        let totals = PointOfSaleOrderTotals(
+            cartTotal: cartTotals.formatAsCurrencyString(cartTotals.totalItems),
+            orderTotal: cartTotals.formatAsCurrencyString(cartTotals.totalPrice),
+            taxTotal: cartTotals.formatAsCurrencyString(cartTotals.totalTax),
+            orderTotalDecimal: cartTotals.totalPriceDecimal,
+            discountTotal: Int(cartTotals.totalDiscount) ?? 0 > 0 ? cartTotals.formatAsCurrencyString(cartTotals.totalDiscount) : nil
+        )
+
+        return (order, totals)
     }
 
     /// Removes unavailable products from the local catalog after detecting them during order sync

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -5,7 +5,7 @@ import Observation
 
 import protocol Yosemite.POSOrderableItem
 import protocol WooFoundation.Analytics
-import struct Yosemite.Order
+import struct Networking.Order
 import struct Yosemite.OrderItem
 import struct Yosemite.POSCoupon
 import enum Yosemite.POSItem
@@ -19,6 +19,9 @@ import class Yosemite.POSCatalogSyncCoordinator
 import enum Yosemite.CardReaderSoftwareUpdateState
 import struct Yosemite.POSSimpleProduct
 import struct Yosemite.POSVariation
+import protocol Yosemite.POSStoreAPICheckoutServiceProtocol
+import struct Yosemite.POSCart
+import struct Yosemite.POSStoreAPICheckoutResult
 
 protocol PointOfSaleAggregateModelProtocol {
     var cart: Cart { get }
@@ -66,6 +69,10 @@ protocol PointOfSaleAggregateModelProtocol {
     private let barcodeScanService: PointOfSaleBarcodeScanServiceProtocol
     private let siteID: Int64
     private let catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol?
+    private let storeAPICheckoutService: POSStoreAPICheckoutServiceProtocol?
+
+    /// Result from Store API checkout, used for card payment capture.
+    private var storeAPICheckoutResult: POSStoreAPICheckoutResult?
 
     private var startPaymentOnCardReaderConnection: AnyCancellable?
     private var cardReaderDisconnection: AnyCancellable?
@@ -119,7 +126,8 @@ protocol PointOfSaleAggregateModelProtocol {
          paymentState: PointOfSalePaymentState = .idle,
          siteID: Int64,
          catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol? = nil,
-         isLocalCatalogEligible: Bool = false) {
+         isLocalCatalogEligible: Bool = false,
+         storeAPICheckoutService: POSStoreAPICheckoutServiceProtocol? = nil) {
         self.entryPointController = entryPointController
         self.purchasableItemsController = itemsController
         self.purchasableItemsSearchController = purchasableItemsSearchController
@@ -138,6 +146,7 @@ protocol PointOfSaleAggregateModelProtocol {
         self.siteID = siteID
         self.catalogSyncCoordinator = catalogSyncCoordinator
         self.isLocalCatalogEligible = isLocalCatalogEligible
+        self.storeAPICheckoutService = storeAPICheckoutService
 
         publishCardReaderConnectionStatus()
         publishCardReaderUpdateState()
@@ -415,6 +424,21 @@ extension PointOfSaleAggregateModel {
 
     @MainActor
     private func collectCardPayment() async {
+        // If we have a Store API checkout result, use that for payment
+        if let checkoutResult = storeAPICheckoutResult,
+           let checkoutService = storeAPICheckoutService {
+            do {
+                try await collectPOSPaymentViaStoreAPI(
+                    checkoutResult: checkoutResult,
+                    checkoutService: checkoutService
+                )
+            } catch {
+                DDLogError("Error taking POS Store API payment: \(error)")
+            }
+            return
+        }
+
+        // Fall back to REST API order-based payment
         guard case let .loaded(totals, order) = internalOrderState,
               totals.orderTotalDecimal > 0.0
         else {
@@ -426,6 +450,74 @@ extension PointOfSaleAggregateModel {
         } catch {
             DDLogError("Error taking payment: \(error)")
         }
+    }
+
+    /// Collects card payment using Store API for capture.
+    ///
+    @MainActor
+    private func collectPOSPaymentViaStoreAPI(
+        checkoutResult: POSStoreAPICheckoutResult,
+        checkoutService: POSStoreAPICheckoutServiceProtocol
+    ) async throws {
+        // Create a minimal Order object with the data we need for payment collection
+        let order = Order(
+            siteID: siteID,
+            orderID: checkoutResult.checkoutResponse.orderID,
+            parentID: 0,
+            customerID: 0,
+            orderKey: checkoutResult.checkoutResponse.orderKey,
+            isEditable: false,
+            needsPayment: true,
+            needsProcessing: false,
+            number: String(checkoutResult.checkoutResponse.orderID),
+            status: .pending,
+            currency: checkoutResult.cartTotals.currencyCode,
+            currencySymbol: "",
+            customerNote: nil,
+            dateCreated: Date(),
+            dateModified: Date(),
+            datePaid: nil,
+            discountTotal: "0",
+            discountTax: "0",
+            shippingTotal: "0",
+            shippingTax: "0",
+            total: checkoutResult.cartTotals.totalPrice,
+            totalTax: checkoutResult.cartTotals.totalTax,
+            paymentMethodID: "pos_card",
+            paymentMethodTitle: "POS Card",
+            paymentURL: nil,
+            chargeID: nil,
+            items: [],
+            billingAddress: nil,
+            shippingAddress: nil,
+            shippingLines: [],
+            coupons: [],
+            refunds: [],
+            fees: [],
+            taxes: [],
+            customFields: [],
+            renewalSubscriptionID: nil,
+            appliedGiftCards: [],
+            attributionInfo: nil,
+            shippingLabels: [],
+            createdVia: "store-api"
+        )
+
+        // Create capture handler that uses Store API checkout
+        let captureHandler: (String) async throws -> Void = { [checkoutService] paymentIntentID in
+            DDLogInfo("🔄 Capturing POS payment via Store API with payment intent: \(paymentIntentID)")
+            _ = try await checkoutService.captureCardPayment(paymentIntentID: paymentIntentID)
+            DDLogInfo("✅ POS payment captured successfully")
+        }
+
+        _ = try await cardPresentPaymentService.collectPOSPayment(
+            for: order,
+            using: .bluetooth,
+            captureHandler: captureHandler
+        )
+
+        // Clear the checkout result after successful payment
+        storeAPICheckoutResult = nil
     }
 
     // Prevents card payments from the moment the merchant decides we start collecting cash
@@ -659,12 +751,55 @@ extension PointOfSaleAggregateModel {
     func checkOut() async {
         collectOrderPaymentAnalyticsTracker.trackCheckoutTapped()
         orderStage = .finalizing
-        let syncOrderResult = await orderController.syncOrder(for: cart, retryHandler: { [weak self] in
-            await self?.checkOut()
-        })
-        trackOrderSyncState(syncOrderResult)
-        await removeMissingProductsFromCatalogAfterSync()
-        await startPaymentWhenCardReaderConnected()
+
+        // Use Store API checkout if service is available
+        if let storeAPICheckoutService {
+            await checkOutViaStoreAPI(checkoutService: storeAPICheckoutService)
+        } else {
+            // Fall back to REST API order sync
+            let syncOrderResult = await orderController.syncOrder(for: cart, retryHandler: { [weak self] in
+                await self?.checkOut()
+            })
+            trackOrderSyncState(syncOrderResult)
+            await removeMissingProductsFromCatalogAfterSync()
+            await startPaymentWhenCardReaderConnected()
+        }
+    }
+
+    /// Performs checkout via Store API for card payments.
+    ///
+    /// This creates a pending order using Store API checkout with `pos_card` payment method.
+    /// The order is completed when the card payment is captured.
+    ///
+    @MainActor
+    private func checkOutViaStoreAPI(checkoutService: POSStoreAPICheckoutServiceProtocol) async {
+        do {
+            let posCart = POSCart(cart: cart)
+
+            // Call Store API checkout with pos_card to create pending order
+            let checkoutResult = try await checkoutService.checkout(
+                cart: posCart,
+                paymentMethod: .card,
+                billingEmail: nil
+            )
+
+            DDLogInfo("✅ Store API checkout created order \(checkoutResult.checkoutResponse.orderID)")
+
+            // Store the checkout result for use in card payment capture
+            storeAPICheckoutResult = checkoutResult
+
+            // Start payment collection when card reader is connected
+            await startPaymentWhenCardReaderConnected()
+        } catch {
+            DDLogError("⛔️ Store API checkout failed: \(error)")
+            // TODO: Handle error state - for now, fall back to REST API
+            let syncOrderResult = await orderController.syncOrder(for: cart, retryHandler: { [weak self] in
+                await self?.checkOut()
+            })
+            trackOrderSyncState(syncOrderResult)
+            await removeMissingProductsFromCatalogAfterSync()
+            await startPaymentWhenCardReaderConnected()
+        }
     }
 
     /// Removes unavailable products from the local catalog after detecting them during order sync

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -109,6 +109,16 @@ protocol PointOfSaleAggregateModelProtocol {
         cart.containsDownloadableItems
     }
 
+    /// Whether the email is valid (basic validation)
+    private var isValidEmail: Bool {
+        billingEmail.contains("@") && billingEmail.contains(".")
+    }
+
+    /// Whether checkout can proceed (email valid or not required)
+    var canProceedWithCheckout: Bool {
+        !requiresEmailForCheckout || isValidEmail
+    }
+
     var showStaleSyncWarning: Bool {
         // Only show warning if using local catalog
         guard isLocalCatalogEligible else {
@@ -724,6 +734,26 @@ extension PointOfSaleAggregateModel {
         collectOrderPaymentAnalyticsTracker.trackCheckoutTapped()
         orderStage = .finalizing
 
+        // For downloadable products, wait for email before proceeding
+        // User enters email in TotalsView, then calls proceedWithCheckout()
+        guard canProceedWithCheckout else {
+            return
+        }
+
+        await performCheckout()
+    }
+
+    /// Proceeds with checkout after email validation (for downloadable products)
+    @MainActor
+    func proceedWithCheckout() async {
+        guard canProceedWithCheckout else {
+            return
+        }
+        await performCheckout()
+    }
+
+    @MainActor
+    private func performCheckout() async {
         // Use Store API checkout if service is available
         if let storeAPICheckoutService {
             await checkOutViaStoreAPI(checkoutService: storeAPICheckoutService)
@@ -749,10 +779,11 @@ extension PointOfSaleAggregateModel {
             let posCart = POSCart(cart: cart)
 
             // Call Store API checkout with pos_card to create pending order
+            // Pass billing email for downloadable product fulfillment
             let checkoutResult = try await checkoutService.checkout(
                 cart: posCart,
                 paymentMethod: .card,
-                billingEmail: nil
+                billingEmail: billingEmail.isEmpty ? nil : billingEmail
             )
 
             DDLogInfo("✅ Store API checkout created order \(checkoutResult.checkoutResponse.orderID)")

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -101,6 +101,14 @@ protocol PointOfSaleAggregateModelProtocol {
     var isSyncStale: Bool = false
     var isStaleSyncWarningDismissed: Bool = false
 
+    // Billing email for downloadable products checkout
+    private(set) var billingEmail: String = ""
+
+    /// Whether checkout requires an email (cart contains downloadable items)
+    var requiresEmailForCheckout: Bool {
+        cart.containsDownloadableItems
+    }
+
     var showStaleSyncWarning: Bool {
         // Only show warning if using local catalog
         guard isLocalCatalogEligible else {
@@ -197,6 +205,11 @@ extension PointOfSaleAggregateModel {
         orderController.clearOrder()
         setStateForEditing()
         viewStateCoordinator.reset()
+        billingEmail = ""
+    }
+
+    func setBillingEmail(_ email: String) {
+        billingEmail = email
     }
 
     private func setStateForEditing() {

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -22,6 +22,7 @@ import struct Yosemite.POSVariation
 import protocol Yosemite.POSStoreAPICheckoutServiceProtocol
 import struct Yosemite.POSCart
 import struct Yosemite.POSStoreAPICheckoutResult
+import struct Yosemite.POSGiftCardItemInfo
 
 protocol PointOfSaleAggregateModelProtocol {
     var cart: Cart { get }
@@ -114,9 +115,26 @@ protocol PointOfSaleAggregateModelProtocol {
         billingEmail.contains("@") && billingEmail.contains(".")
     }
 
-    /// Whether checkout can proceed (email valid or not required)
+    // Gift card info per cart item (keyed by Cart.PurchasableItem UUID)
+    private(set) var giftCardInfo: [UUID: GiftCardInfo] = [:]
+
+    /// Whether checkout requires gift card info (cart contains gift cards)
+    var requiresGiftCardInfoForCheckout: Bool {
+        cart.containsGiftCards
+    }
+
+    /// Whether all gift cards in the cart have their required info
+    var allGiftCardsHaveInfo: Bool {
+        cart.giftCardItems.allSatisfy { item in
+            giftCardInfo[item.id] != nil
+        }
+    }
+
+    /// Whether checkout can proceed (all required data is present)
     var canProceedWithCheckout: Bool {
-        !requiresEmailForCheckout || isValidEmail
+        let emailOK = !requiresEmailForCheckout || isValidEmail
+        let giftCardOK = !requiresGiftCardInfoForCheckout || allGiftCardsHaveInfo
+        return emailOK && giftCardOK
     }
 
     var showStaleSyncWarning: Bool {
@@ -216,10 +234,19 @@ extension PointOfSaleAggregateModel {
         setStateForEditing()
         viewStateCoordinator.reset()
         billingEmail = ""
+        giftCardInfo = [:]
     }
 
     func setBillingEmail(_ email: String) {
         billingEmail = email
+    }
+
+    func setGiftCardInfo(_ info: GiftCardInfo, for itemID: UUID) {
+        giftCardInfo[itemID] = info
+    }
+
+    func removeGiftCardInfo(for itemID: UUID) {
+        giftCardInfo[itemID] = nil
     }
 
     private func setStateForEditing() {
@@ -769,12 +796,19 @@ extension PointOfSaleAggregateModel {
         do {
             let posCart = POSCart(cart: cart)
 
+            // Convert local GiftCardInfo to POSGiftCardItemInfo for the API
+            let posGiftCardInfo = giftCardInfo.mapValues { info in
+                POSGiftCardItemInfo(recipientEmail: info.recipientEmail, senderName: info.senderName)
+            }
+
             // Call Store API checkout with pos_card to create pending order
             // Pass billing email for downloadable product fulfillment
+            // Pass gift card info for gift card products
             let checkoutResult = try await checkoutService.checkout(
                 cart: posCart,
                 paymentMethod: .card,
-                billingEmail: billingEmail.isEmpty ? nil : billingEmail
+                billingEmail: billingEmail.isEmpty ? nil : billingEmail,
+                giftCardInfo: posGiftCardInfo
             )
 
             DDLogInfo("✅ Store API checkout created order \(checkoutResult.checkoutResponse.orderID)")

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -734,21 +734,12 @@ extension PointOfSaleAggregateModel {
         collectOrderPaymentAnalyticsTracker.trackCheckoutTapped()
         orderStage = .finalizing
 
-        // For downloadable products, wait for email before proceeding
-        // User enters email in TotalsView, then calls proceedWithCheckout()
+        // Guard for downloadable products - checkout button should be disabled
+        // when email is required but not provided, but this is a safety check
         guard canProceedWithCheckout else {
             return
         }
 
-        await performCheckout()
-    }
-
-    /// Proceeds with checkout after email validation (for downloadable products)
-    @MainActor
-    func proceedWithCheckout() async {
-        guard canProceedWithCheckout else {
-            return
-        }
         await performCheckout()
     }
 

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
@@ -46,6 +46,15 @@ enum PointOfSaleOrderState: Equatable {
         }
     }
 
+    var isIdle: Bool {
+        switch self {
+        case .idle:
+            return true
+        default:
+            return false
+        }
+    }
+
     var isSyncing: Bool {
         switch self {
         case .syncing:

--- a/Modules/Sources/PointOfSale/Presentation/CartView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CartView.swift
@@ -24,6 +24,7 @@ struct CartView: View {
 
     @State private var showBarcodeScanningModal: Bool = false
     @State private var showEmailSheet: Bool = false
+    @State private var giftCardSheetItem: GiftCardSheetItem?
 
     var body: some View {
         ZStack {
@@ -55,7 +56,8 @@ struct CartView: View {
                         offSetPosition: $offSetPosition,
                         cartContentHeight: $cartContentHeight,
                         scrollViewHeight: $scrollViewHeight,
-                        showEmailSheet: $showEmailSheet
+                        showEmailSheet: $showEmailSheet,
+                        giftCardSheetItem: $giftCardSheetItem
                     )
                 } else {
                     Spacer()
@@ -85,6 +87,21 @@ struct CartView: View {
                     }
                 )
             }
+            .sheet(item: $giftCardSheetItem) { sheetItem in
+                if let cartItem = posModel.cart.purchasableItems.first(where: { $0.id == sheetItem.id }) {
+                    POSGiftCardEntrySheet(
+                        productName: cartItem.title,
+                        existingInfo: posModel.giftCardInfo[sheetItem.id],
+                        onSave: { info in
+                            posModel.setGiftCardInfo(info, for: sheetItem.id)
+                            giftCardSheetItem = nil
+                        },
+                        onCancel: {
+                            giftCardSheetItem = nil
+                        }
+                    )
+                }
+            }
             .animation(Constants.cartAnimation, value: posModel.cart.isEmpty)
             .frame(maxWidth: .infinity)
             .background(content: {
@@ -97,6 +114,11 @@ struct CartView: View {
             .accessibilityIdentifier("pos-cart-view")
         }
     }
+}
+
+/// Wrapper struct to make cart item ID identifiable for sheet presentation
+private struct GiftCardSheetItem: Identifiable {
+    let id: UUID
 }
 
 private struct ScrollOffSetPreferenceKey: PreferenceKey {
@@ -282,6 +304,7 @@ private struct CartScrollViewContent: View {
     @Binding var cartContentHeight: CGFloat
     @Binding var scrollViewHeight: CGFloat
     @Binding var showEmailSheet: Bool
+    @Binding var giftCardSheetItem: GiftCardSheetItem?
 
     @State private var shouldShowItemImages: Bool = false
 
@@ -296,7 +319,8 @@ private struct CartScrollViewContent: View {
                     CouponsCartSection(shouldShowItemImages: $shouldShowItemImages)
 
                     PurchasableItemsCartSection(shouldShowItemImages: $shouldShowItemImages,
-                                                showEmailSheet: $showEmailSheet)
+                                                showEmailSheet: $showEmailSheet,
+                                                giftCardSheetItem: $giftCardSheetItem)
                 }
                 .padding(.bottom, Constants.cartLastItemBottomPadding)
                 .background(GeometryReader { geometry in
@@ -422,6 +446,7 @@ private struct PurchasableItemsCartSection: View {
     @Environment(\.posAnalytics) private var analytics
     @Binding var shouldShowItemImages: Bool
     @Binding var showEmailSheet: Bool
+    @Binding var giftCardSheetItem: GiftCardSheetItem?
     @AccessibilityFocusState private var accessibilityFocusedItem: UUID?
 
     var body: some View {
@@ -435,6 +460,10 @@ private struct PurchasableItemsCartSection: View {
                     billingEmail: posModel.billingEmail,
                     onSetEmailTapped: posModel.orderStage == .building ? {
                         showEmailSheet = true
+                    } : nil,
+                    giftCardInfo: posModel.giftCardInfo[cartItem.id],
+                    onSetGiftCardInfoTapped: posModel.orderStage == .building ? {
+                        giftCardSheetItem = GiftCardSheetItem(id: cartItem.id)
                     } : nil
                 )
                 .id(cartItem.id)

--- a/Modules/Sources/PointOfSale/Presentation/CartView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CartView.swift
@@ -23,6 +23,7 @@ struct CartView: View {
     }
 
     @State private var showBarcodeScanningModal: Bool = false
+    @State private var showEmailSheet: Bool = false
 
     var body: some View {
         ZStack {
@@ -53,7 +54,8 @@ struct CartView: View {
                     CartScrollViewContent(
                         offSetPosition: $offSetPosition,
                         cartContentHeight: $cartContentHeight,
-                        scrollViewHeight: $scrollViewHeight
+                        scrollViewHeight: $scrollViewHeight,
+                        showEmailSheet: $showEmailSheet
                     )
                 } else {
                     Spacer()
@@ -70,6 +72,18 @@ struct CartView: View {
             }
             .posModal(isPresented: $showBarcodeScanningModal) {
                 POSBarcodeScannerSetup(isPresented: $showBarcodeScanningModal, analytics: analytics)
+            }
+            .sheet(isPresented: $showEmailSheet) {
+                POSEmailEntrySheet(
+                    email: posModel.billingEmail,
+                    onSave: { email in
+                        posModel.setBillingEmail(email)
+                        showEmailSheet = false
+                    },
+                    onCancel: {
+                        showEmailSheet = false
+                    }
+                )
             }
             .animation(Constants.cartAnimation, value: posModel.cart.isEmpty)
             .frame(maxWidth: .infinity)
@@ -175,7 +189,7 @@ private extension CartView {
             Text(Localization.checkoutButtonTitle)
         }
         .buttonStyle(POSFilledButtonStyle(size: .normal))
-        .disabled(CartViewHelper().hasUnresolvedItems(cart: posModel.cart))
+        .disabled(CartViewHelper().hasUnresolvedItems(cart: posModel.cart) || !posModel.canProceedWithCheckout)
         .accessibilityIdentifier("pos-checkout-button")
     }
 
@@ -267,6 +281,7 @@ private struct CartScrollViewContent: View {
     @Binding var offSetPosition: CGFloat
     @Binding var cartContentHeight: CGFloat
     @Binding var scrollViewHeight: CGFloat
+    @Binding var showEmailSheet: Bool
 
     @State private var shouldShowItemImages: Bool = false
 
@@ -280,7 +295,8 @@ private struct CartScrollViewContent: View {
                 VStack(spacing: Constants.cartItemSpacing) {
                     CouponsCartSection(shouldShowItemImages: $shouldShowItemImages)
 
-                    PurchasableItemsCartSection(shouldShowItemImages: $shouldShowItemImages)
+                    PurchasableItemsCartSection(shouldShowItemImages: $shouldShowItemImages,
+                                                showEmailSheet: $showEmailSheet)
                 }
                 .padding(.bottom, Constants.cartLastItemBottomPadding)
                 .background(GeometryReader { geometry in
@@ -405,6 +421,7 @@ private struct PurchasableItemsCartSection: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.posAnalytics) private var analytics
     @Binding var shouldShowItemImages: Bool
+    @Binding var showEmailSheet: Bool
     @AccessibilityFocusState private var accessibilityFocusedItem: UUID?
 
     var body: some View {
@@ -414,7 +431,11 @@ private struct PurchasableItemsCartSection: View {
                     cartItem: cartItem,
                     showImage: $shouldShowItemImages,
                     onItemRemoveTapped: itemRemoveCallback(for: cartItem),
-                    onCancelLoading: cancelLoadingCallback(for: cartItem)
+                    onCancelLoading: cancelLoadingCallback(for: cartItem),
+                    billingEmail: posModel.billingEmail,
+                    onSetEmailTapped: posModel.orderStage == .building ? {
+                        showEmailSheet = true
+                    } : nil
                 )
                 .id(cartItem.id)
                 .transition(.opacity)

--- a/Modules/Sources/PointOfSale/Presentation/ItemRowView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemRowView.swift
@@ -1,9 +1,13 @@
 import SwiftUI
+import struct Yosemite.POSSimpleProduct
+import struct Yosemite.POSVariation
 
 struct ItemRowView: View {
     private let cartItem: Cart.PurchasableItem
     private let onItemRemoveTapped: (() -> Void)?
     private let onCancelLoading: (() -> Void)?
+    private let billingEmail: String?
+    private let onSetEmailTapped: (() -> Void)?
 
     @ScaledMetric private var scale: CGFloat = 1.0
     @Binding private var showProductImage: Bool
@@ -12,14 +16,29 @@ struct ItemRowView: View {
         min(Constants.productCardSize * scale, Constants.maximumProductCardSize)
     }
 
+    /// Whether this cart item is a downloadable product
+    private var isDownloadable: Bool {
+        guard case .loaded(let orderableItem) = cartItem.state else { return false }
+        if let simpleProduct = orderableItem as? POSSimpleProduct {
+            return simpleProduct.downloadable
+        } else if let variation = orderableItem as? POSVariation {
+            return variation.downloadable
+        }
+        return false
+    }
+
     init(cartItem: Cart.PurchasableItem,
          showImage: Binding<Bool> = .constant(true),
          onItemRemoveTapped: (() -> Void)? = nil,
-         onCancelLoading: (() -> Void)? = nil) {
+         onCancelLoading: (() -> Void)? = nil,
+         billingEmail: String? = nil,
+         onSetEmailTapped: (() -> Void)? = nil) {
         self.cartItem = cartItem
         self._showProductImage = showImage
         self.onItemRemoveTapped = onItemRemoveTapped
         self.onCancelLoading = onCancelLoading
+        self.billingEmail = billingEmail
+        self.onSetEmailTapped = onSetEmailTapped
     }
 
     var body: some View {
@@ -67,6 +86,11 @@ struct ItemRowView: View {
                     Text(item.formattedPrice)
                         .foregroundColor(PointOfSaleItemListCardConstants.detailColor)
                         .font(Constants.itemPriceFont)
+                }
+
+                // Show email recipient info for downloadable items
+                if isDownloadable {
+                    downloadableEmailRow
                 }
             }
             .multilineTextAlignment(.leading)
@@ -119,6 +143,48 @@ struct ItemRowView: View {
                 .compactMap { $0 }
                 .joined(separator: ",")
         }
+    }
+
+    /// Shows the email recipient for downloadable products, or a button to set it
+    @ViewBuilder
+    private var downloadableEmailRow: some View {
+        HStack(spacing: POSSpacing.xSmall) {
+            Image(systemName: "envelope")
+                .font(.posBodySmallRegular())
+                .foregroundColor(.posOnSurfaceVariantLowest)
+
+            if let email = billingEmail, !email.isEmpty {
+                Text(email)
+                    .font(.posBodySmallRegular())
+                    .foregroundColor(.posOnSurfaceVariantLowest)
+                    .lineLimit(1)
+            }
+
+            if let onSetEmailTapped {
+                Button {
+                    onSetEmailTapped()
+                } label: {
+                    Text(billingEmail?.isEmpty ?? true ? Localization.setEmail : Localization.changeEmail)
+                        .font(.posBodySmallRegular())
+                        .foregroundColor(.posPrimary)
+                }
+            }
+        }
+    }
+}
+
+private extension ItemRowView {
+    enum Localization {
+        static let setEmail = NSLocalizedString(
+            "pos.itemRow.downloadable.setEmail",
+            value: "Set recipient",
+            comment: "Button to set the email recipient for a downloadable product in POS cart"
+        )
+        static let changeEmail = NSLocalizedString(
+            "pos.itemRow.downloadable.changeEmail",
+            value: "Change",
+            comment: "Button to change the email recipient for a downloadable product in POS cart"
+        )
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/ItemRowView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemRowView.swift
@@ -8,6 +8,8 @@ struct ItemRowView: View {
     private let onCancelLoading: (() -> Void)?
     private let billingEmail: String?
     private let onSetEmailTapped: (() -> Void)?
+    private let giftCardInfo: GiftCardInfo?
+    private let onSetGiftCardInfoTapped: (() -> Void)?
 
     @ScaledMetric private var scale: CGFloat = 1.0
     @Binding private var showProductImage: Bool
@@ -27,18 +29,33 @@ struct ItemRowView: View {
         return false
     }
 
+    /// Whether this cart item is a gift card product
+    private var isGiftCard: Bool {
+        guard case .loaded(let orderableItem) = cartItem.state else { return false }
+        if let simpleProduct = orderableItem as? POSSimpleProduct {
+            return simpleProduct.isGiftCard
+        } else if let variation = orderableItem as? POSVariation {
+            return variation.isGiftCard
+        }
+        return false
+    }
+
     init(cartItem: Cart.PurchasableItem,
          showImage: Binding<Bool> = .constant(true),
          onItemRemoveTapped: (() -> Void)? = nil,
          onCancelLoading: (() -> Void)? = nil,
          billingEmail: String? = nil,
-         onSetEmailTapped: (() -> Void)? = nil) {
+         onSetEmailTapped: (() -> Void)? = nil,
+         giftCardInfo: GiftCardInfo? = nil,
+         onSetGiftCardInfoTapped: (() -> Void)? = nil) {
         self.cartItem = cartItem
         self._showProductImage = showImage
         self.onItemRemoveTapped = onItemRemoveTapped
         self.onCancelLoading = onCancelLoading
         self.billingEmail = billingEmail
         self.onSetEmailTapped = onSetEmailTapped
+        self.giftCardInfo = giftCardInfo
+        self.onSetGiftCardInfoTapped = onSetGiftCardInfoTapped
     }
 
     var body: some View {
@@ -91,6 +108,11 @@ struct ItemRowView: View {
                 // Show email recipient info for downloadable items
                 if isDownloadable {
                     downloadableEmailRow
+                }
+
+                // Show gift card info for gift card items
+                if isGiftCard {
+                    giftCardInfoRow
                 }
             }
             .multilineTextAlignment(.leading)
@@ -171,6 +193,33 @@ struct ItemRowView: View {
             }
         }
     }
+
+    /// Shows the gift card recipient/sender info, or a button to set it
+    @ViewBuilder
+    private var giftCardInfoRow: some View {
+        HStack(spacing: POSSpacing.xSmall) {
+            Image(systemName: "gift")
+                .font(.posBodySmallRegular())
+                .foregroundColor(.posOnSurfaceVariantLowest)
+
+            if let info = giftCardInfo {
+                Text(Localization.giftCardInfoSummary(recipient: info.recipientEmail, sender: info.senderName))
+                    .font(.posBodySmallRegular())
+                    .foregroundColor(.posOnSurfaceVariantLowest)
+                    .lineLimit(1)
+            }
+
+            if let onSetGiftCardInfoTapped {
+                Button {
+                    onSetGiftCardInfoTapped()
+                } label: {
+                    Text(giftCardInfo == nil ? Localization.setGiftCardDetails : Localization.changeGiftCardDetails)
+                        .font(.posBodySmallRegular())
+                        .foregroundColor(.posPrimary)
+                }
+            }
+        }
+    }
 }
 
 private extension ItemRowView {
@@ -185,6 +234,24 @@ private extension ItemRowView {
             value: "Change",
             comment: "Button to change the email recipient for a downloadable product in POS cart"
         )
+        static let setGiftCardDetails = NSLocalizedString(
+            "pos.itemRow.giftCard.setDetails",
+            value: "Set details",
+            comment: "Button to set the recipient and sender details for a gift card in POS cart"
+        )
+        static let changeGiftCardDetails = NSLocalizedString(
+            "pos.itemRow.giftCard.changeDetails",
+            value: "Change",
+            comment: "Button to change the recipient and sender details for a gift card in POS cart"
+        )
+
+        static func giftCardInfoSummary(recipient: String, sender: String) -> String {
+            String(format: NSLocalizedString(
+                "pos.itemRow.giftCard.summary",
+                value: "To: %@ from %@",
+                comment: "Summary of gift card recipient and sender. %1$@ is the recipient email, %2$@ is the sender name"
+            ), recipient, sender)
+        }
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/POSEmailInputView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSEmailInputView.swift
@@ -13,7 +13,7 @@ struct POSEmailInputView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
             Text(Localization.title)
-                .font(.posBodyRegular())
+                .font(.posBodyMediumRegular())
                 .foregroundColor(.posOnSurface)
 
             TextField(Localization.placeholder, text: $email)
@@ -47,7 +47,7 @@ private struct POSEmailTextFieldStyle: TextFieldStyle {
                 RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value)
                     .stroke(Color.posOutline, lineWidth: 1)
             )
-            .font(.posBodyRegular())
+            .font(.posBodyMediumRegular())
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/POSEmailInputView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSEmailInputView.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+/// A view for collecting the customer's email address during POS checkout.
+/// Required when the cart contains downloadable products.
+struct POSEmailInputView: View {
+    @Binding var email: String
+    @FocusState private var isTextFieldFocused: Bool
+
+    private var isValidEmail: Bool {
+        email.contains("@") && email.contains(".")
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
+            Text(Localization.title)
+                .font(.posBodyRegular())
+                .foregroundColor(.posOnSurface)
+
+            TextField(Localization.placeholder, text: $email)
+                .textFieldStyle(POSEmailTextFieldStyle())
+                .keyboardType(.emailAddress)
+                .textContentType(.emailAddress)
+                .autocapitalization(.none)
+                .autocorrectionDisabled()
+                .focused($isTextFieldFocused)
+                .accessibilityIdentifier("pos-email-input-field")
+
+            if !email.isEmpty && !isValidEmail {
+                Text(Localization.invalidEmailHint)
+                    .font(.posBodySmallRegular())
+                    .foregroundColor(.posError)
+            }
+        }
+        .padding(.horizontal, POSPadding.medium)
+        .padding(.vertical, POSPadding.small)
+    }
+}
+
+/// Custom text field style for email input in POS
+private struct POSEmailTextFieldStyle: TextFieldStyle {
+    func _body(configuration: TextField<Self._Label>) -> some View {
+        configuration
+            .padding(POSPadding.small)
+            .background(Color.posSurfaceBright)
+            .cornerRadius(POSCornerRadiusStyle.small.value)
+            .overlay(
+                RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value)
+                    .stroke(Color.posOutline, lineWidth: 1)
+            )
+            .font(.posBodyRegular())
+    }
+}
+
+private extension POSEmailInputView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pos.emailInput.title",
+            value: "Customer email",
+            comment: "Title for the email input field in POS checkout for downloadable products"
+        )
+        static let placeholder = NSLocalizedString(
+            "pos.emailInput.placeholder",
+            value: "Enter email for digital delivery",
+            comment: "Placeholder text for the email input field in POS checkout"
+        )
+        static let invalidEmailHint = NSLocalizedString(
+            "pos.emailInput.invalidEmail",
+            value: "Please enter a valid email address",
+            comment: "Error message shown when the email format is invalid"
+        )
+    }
+}
+
+#if DEBUG
+#Preview("Empty") {
+    POSEmailInputView(email: .constant(""))
+}
+
+#Preview("With Email") {
+    POSEmailInputView(email: .constant("customer@example.com"))
+}
+
+#Preview("Invalid Email") {
+    POSEmailInputView(email: .constant("invalid-email"))
+}
+#endif

--- a/Modules/Sources/PointOfSale/Presentation/POSEmailInputView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSEmailInputView.swift
@@ -71,6 +71,109 @@ private extension POSEmailInputView {
     }
 }
 
+// MARK: - Email Entry Sheet
+
+/// A sheet for entering/editing the customer email for downloadable products
+struct POSEmailEntrySheet: View {
+    let email: String
+    let onSave: (String) -> Void
+    let onCancel: () -> Void
+
+    @State private var emailInput: String = ""
+    @FocusState private var isTextFieldFocused: Bool
+
+    private var isValidEmail: Bool {
+        emailInput.contains("@") && emailInput.contains(".")
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: POSSpacing.large) {
+                VStack(alignment: .leading, spacing: POSSpacing.small) {
+                    Text(Localization.sheetDescription)
+                        .font(.posBodyMediumRegular())
+                        .foregroundColor(.posOnSurfaceVariantLowest)
+
+                    TextField(Localization.placeholder, text: $emailInput)
+                        .textFieldStyle(POSEmailTextFieldStyle())
+                        .keyboardType(.emailAddress)
+                        .textContentType(.emailAddress)
+                        .autocapitalization(.none)
+                        .autocorrectionDisabled()
+                        .focused($isTextFieldFocused)
+                        .accessibilityIdentifier("pos-email-sheet-input-field")
+
+                    if !emailInput.isEmpty && !isValidEmail {
+                        Text(Localization.invalidEmailHint)
+                            .font(.posBodySmallRegular())
+                            .foregroundColor(.posError)
+                    }
+                }
+                .padding(.horizontal, POSPadding.medium)
+
+                Spacer()
+
+                Button {
+                    onSave(emailInput)
+                } label: {
+                    Text(Localization.saveButton)
+                }
+                .buttonStyle(POSFilledButtonStyle(size: .normal))
+                .disabled(!isValidEmail)
+                .padding(.horizontal, POSPadding.medium)
+                .padding(.bottom, POSPadding.medium)
+            }
+            .navigationTitle(Localization.sheetTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.cancelButton) {
+                        onCancel()
+                    }
+                }
+            }
+        }
+        .onAppear {
+            emailInput = email
+            isTextFieldFocused = true
+        }
+        .presentationDetents([.medium])
+    }
+
+    private enum Localization {
+        static let sheetTitle = NSLocalizedString(
+            "pos.emailSheet.title",
+            value: "Digital delivery",
+            comment: "Title for the email entry sheet in POS for downloadable products"
+        )
+        static let sheetDescription = NSLocalizedString(
+            "pos.emailSheet.description",
+            value: "Enter the customer's email address to deliver digital products after checkout.",
+            comment: "Description in the email entry sheet for downloadable products"
+        )
+        static let placeholder = NSLocalizedString(
+            "pos.emailSheet.placeholder",
+            value: "customer@example.com",
+            comment: "Placeholder for the email field in the email entry sheet"
+        )
+        static let invalidEmailHint = NSLocalizedString(
+            "pos.emailSheet.invalidEmail",
+            value: "Please enter a valid email address",
+            comment: "Error shown when email is invalid in the email entry sheet"
+        )
+        static let saveButton = NSLocalizedString(
+            "pos.emailSheet.save",
+            value: "Save",
+            comment: "Save button in the email entry sheet"
+        )
+        static let cancelButton = NSLocalizedString(
+            "pos.emailSheet.cancel",
+            value: "Cancel",
+            comment: "Cancel button in the email entry sheet"
+        )
+    }
+}
+
 #if DEBUG
 #Preview("Empty") {
     POSEmailInputView(email: .constant(""))
@@ -82,5 +185,13 @@ private extension POSEmailInputView {
 
 #Preview("Invalid Email") {
     POSEmailInputView(email: .constant("invalid-email"))
+}
+
+#Preview("Email Sheet") {
+    POSEmailEntrySheet(
+        email: "",
+        onSave: { _ in },
+        onCancel: { }
+    )
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/POSGiftCardEntrySheet.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSGiftCardEntrySheet.swift
@@ -1,0 +1,196 @@
+import SwiftUI
+
+/// A sheet for entering gift card recipient and sender details.
+/// This information is required for each gift card item in the cart.
+struct POSGiftCardEntrySheet: View {
+    let productName: String
+    let existingInfo: GiftCardInfo?
+    let onSave: (GiftCardInfo) -> Void
+    let onCancel: () -> Void
+
+    @State private var recipientEmail: String = ""
+    @State private var senderName: String = ""
+    @FocusState private var focusedField: Field?
+
+    private enum Field {
+        case recipientEmail
+        case senderName
+    }
+
+    private var isValidEmail: Bool {
+        recipientEmail.contains("@") && recipientEmail.contains(".")
+    }
+
+    private var isValid: Bool {
+        isValidEmail && !senderName.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: POSSpacing.large) {
+                VStack(alignment: .leading, spacing: POSSpacing.medium) {
+                    Text(Localization.sheetDescription)
+                        .font(.posBodyMediumRegular())
+                        .foregroundColor(.posOnSurfaceVariantLowest)
+
+                    // Recipient email field
+                    VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
+                        Text(Localization.recipientEmailLabel)
+                            .font(.posBodySmallRegular())
+                            .foregroundColor(.posOnSurfaceVariantLowest)
+
+                        TextField(Localization.recipientEmailPlaceholder, text: $recipientEmail)
+                            .textFieldStyle(POSGiftCardTextFieldStyle())
+                            .keyboardType(.emailAddress)
+                            .textContentType(.emailAddress)
+                            .autocapitalization(.none)
+                            .autocorrectionDisabled()
+                            .focused($focusedField, equals: .recipientEmail)
+                            .accessibilityIdentifier("pos-gift-card-recipient-email-field")
+
+                        if !recipientEmail.isEmpty && !isValidEmail {
+                            Text(Localization.invalidEmailHint)
+                                .font(.posBodySmallRegular())
+                                .foregroundColor(.posError)
+                        }
+                    }
+
+                    // Sender name field
+                    VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
+                        Text(Localization.senderNameLabel)
+                            .font(.posBodySmallRegular())
+                            .foregroundColor(.posOnSurfaceVariantLowest)
+
+                        TextField(Localization.senderNamePlaceholder, text: $senderName)
+                            .textFieldStyle(POSGiftCardTextFieldStyle())
+                            .textContentType(.name)
+                            .autocorrectionDisabled()
+                            .focused($focusedField, equals: .senderName)
+                            .accessibilityIdentifier("pos-gift-card-sender-name-field")
+
+                        if !senderName.trimmingCharacters(in: .whitespaces).isEmpty == false && focusedField != .senderName {
+                            // Only show error after user has interacted
+                        }
+                    }
+                }
+                .padding(.horizontal, POSPadding.medium)
+
+                Spacer()
+
+                Button {
+                    let info = GiftCardInfo(
+                        recipientEmail: recipientEmail.trimmingCharacters(in: .whitespaces),
+                        senderName: senderName.trimmingCharacters(in: .whitespaces)
+                    )
+                    onSave(info)
+                } label: {
+                    Text(Localization.saveButton)
+                }
+                .buttonStyle(POSFilledButtonStyle(size: .normal))
+                .disabled(!isValid)
+                .padding(.horizontal, POSPadding.medium)
+                .padding(.bottom, POSPadding.medium)
+            }
+            .navigationTitle(Localization.sheetTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.cancelButton) {
+                        onCancel()
+                    }
+                }
+            }
+        }
+        .onAppear {
+            if let existingInfo {
+                recipientEmail = existingInfo.recipientEmail
+                senderName = existingInfo.senderName
+            }
+            focusedField = .recipientEmail
+        }
+        .presentationDetents([.medium])
+    }
+
+    private enum Localization {
+        static let sheetTitle = NSLocalizedString(
+            "pos.giftCardSheet.title",
+            value: "Gift card details",
+            comment: "Title for the gift card entry sheet in POS"
+        )
+        static let sheetDescription = NSLocalizedString(
+            "pos.giftCardSheet.description",
+            value: "Enter the gift card recipient and sender details.",
+            comment: "Description in the gift card entry sheet"
+        )
+        static let recipientEmailLabel = NSLocalizedString(
+            "pos.giftCardSheet.recipientEmail.label",
+            value: "Recipient email",
+            comment: "Label for the recipient email field in gift card entry sheet"
+        )
+        static let recipientEmailPlaceholder = NSLocalizedString(
+            "pos.giftCardSheet.recipientEmail.placeholder",
+            value: "recipient@example.com",
+            comment: "Placeholder for the recipient email field in gift card entry sheet"
+        )
+        static let senderNameLabel = NSLocalizedString(
+            "pos.giftCardSheet.senderName.label",
+            value: "Sender name",
+            comment: "Label for the sender name field in gift card entry sheet"
+        )
+        static let senderNamePlaceholder = NSLocalizedString(
+            "pos.giftCardSheet.senderName.placeholder",
+            value: "From...",
+            comment: "Placeholder for the sender name field in gift card entry sheet"
+        )
+        static let invalidEmailHint = NSLocalizedString(
+            "pos.giftCardSheet.invalidEmail",
+            value: "Please enter a valid email address",
+            comment: "Error shown when email is invalid in the gift card entry sheet"
+        )
+        static let saveButton = NSLocalizedString(
+            "pos.giftCardSheet.save",
+            value: "Save",
+            comment: "Save button in the gift card entry sheet"
+        )
+        static let cancelButton = NSLocalizedString(
+            "pos.giftCardSheet.cancel",
+            value: "Cancel",
+            comment: "Cancel button in the gift card entry sheet"
+        )
+    }
+}
+
+/// Custom text field style for gift card input in POS
+private struct POSGiftCardTextFieldStyle: TextFieldStyle {
+    func _body(configuration: TextField<Self._Label>) -> some View {
+        configuration
+            .padding(POSPadding.small)
+            .background(Color.posSurfaceBright)
+            .cornerRadius(POSCornerRadiusStyle.small.value)
+            .overlay(
+                RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value)
+                    .stroke(Color.posOutline, lineWidth: 1)
+            )
+            .font(.posBodyMediumRegular())
+    }
+}
+
+#if DEBUG
+#Preview("Empty") {
+    POSGiftCardEntrySheet(
+        productName: "Gift Card",
+        existingInfo: nil,
+        onSave: { _ in },
+        onCancel: { }
+    )
+}
+
+#Preview("With Existing Info") {
+    POSGiftCardEntrySheet(
+        productName: "Gift Card",
+        existingInfo: GiftCardInfo(recipientEmail: "recipient@example.com", senderName: "John"),
+        onSave: { _ in },
+        onCancel: { }
+    )
+}
+#endif

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -16,6 +16,7 @@ import protocol Yosemite.PointOfSaleSettingsServiceProtocol
 import struct Yosemite.SiteSetting
 import protocol Yosemite.PointOfSaleCouponFetchStrategyFactoryProtocol
 import protocol Yosemite.PointOfSaleItemServiceProtocol
+import protocol Yosemite.POSStoreAPICheckoutServiceProtocol
 
 /// periphery: ignore - public in preparation of move to POS module
 public struct PointOfSaleEntryPointView: View {
@@ -44,6 +45,7 @@ public struct PointOfSaleEntryPointView: View {
     private let siteID: Int64
     private let catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol?
     private let isLocalCatalogEligible: Bool
+    private let storeAPICheckoutService: POSStoreAPICheckoutServiceProtocol?
 
     /// periphery: ignore - public in preparation of move to POS module
     public init(siteID: Int64,
@@ -69,7 +71,8 @@ public struct PointOfSaleEntryPointView: View {
          catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol?,
          isLocalCatalogEligible: Bool,
          services: POSDependencyProviding,
-         itemProvider: PointOfSaleItemServiceProtocol? = nil) {
+         itemProvider: PointOfSaleItemServiceProtocol? = nil,
+         storeAPICheckoutService: POSStoreAPICheckoutServiceProtocol? = nil) {
         self.onPointOfSaleModeActiveStateChange = onPointOfSaleModeActiveStateChange
 
         let selectedItemProvider = itemProvider ?? PointOfSaleItemService(currencySettings: services.currency.currencySettings)
@@ -138,6 +141,7 @@ public struct PointOfSaleEntryPointView: View {
         self.siteID = siteID
         self.catalogSyncCoordinator = catalogSyncCoordinator
         self.isLocalCatalogEligible = isLocalCatalogEligible
+        self.storeAPICheckoutService = storeAPICheckoutService
     }
 
     public var body: some View {
@@ -169,7 +173,8 @@ public struct PointOfSaleEntryPointView: View {
                 barcodeScanService: barcodeScanService,
                 siteID: siteID,
                 catalogSyncCoordinator: catalogSyncCoordinator,
-                isLocalCatalogEligible: isLocalCatalogEligible)
+                isLocalCatalogEligible: isLocalCatalogEligible,
+                storeAPICheckoutService: storeAPICheckoutService)
         }
         .environment(\.posAnalytics, services.analytics)
         .environment(\.posCurrencyProvider, services.currency)

--- a/Modules/Sources/PointOfSale/Presentation/SimpleProductsOnlyInformation.swift
+++ b/Modules/Sources/PointOfSale/Presentation/SimpleProductsOnlyInformation.swift
@@ -55,7 +55,7 @@ private extension SimpleProductsOnlyInformation {
 
         static let variableAndSimpleProductsOnlyIssueMessage = NSLocalizedString(
             "pos.simpleProductsModal.message.issue.variableAndSimple",
-            value: "Only simple and variable non-downloadable products can be used with POS right now.",
+            value: "Only simple and variable products can be used with POS right now.",
             comment: "Message in the simple products information modal in POS when variable products are supported"
         )
         static let variableAndSimpleProductsOnlyFutureMessage = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -49,7 +49,8 @@ struct TotalsView: View {
                                 totalsFieldAnimation: totalsFieldAnimation,
                                 requiresEmail: posModel.requiresEmailForCheckout,
                                 billingEmail: posModel.billingEmail,
-                                onEmailChange: { posModel.setBillingEmail($0) }
+                                onEmailChange: { posModel.setBillingEmail($0) },
+                                onProceedWithCheckout: { await posModel.proceedWithCheckout() }
                             )
                             .opacity(shouldShowTotalsFields ? 1 : 0)
                         }
@@ -294,9 +295,19 @@ private struct TotalsFieldsContent: View {
     let requiresEmail: Bool
     let billingEmail: String
     let onEmailChange: (String) -> Void
+    let onProceedWithCheckout: () async -> Void
     private let viewHelper = TotalsViewHelper()
 
     @State private var emailInput: String = ""
+
+    private var isValidEmail: Bool {
+        emailInput.contains("@") && emailInput.contains(".")
+    }
+
+    /// Whether to show a continue button (waiting for email before proceeding)
+    private var shouldShowContinueButton: Bool {
+        requiresEmail && orderState.isIdle
+    }
 
     /// Used for synchronizing animations of shimmeringLine and textField
     static let matchedGeometryId: String = "pos_totals_view_matched_geometry_id"
@@ -311,6 +322,20 @@ private struct TotalsFieldsContent: View {
                     .onAppear {
                         emailInput = billingEmail
                     }
+            }
+
+            if shouldShowContinueButton {
+                Button {
+                    Task { @MainActor in
+                        await onProceedWithCheckout()
+                    }
+                } label: {
+                    Text(Localization.continueButtonTitle)
+                }
+                .buttonStyle(POSFilledButtonStyle(size: .normal))
+                .disabled(!isValidEmail)
+                .padding(.horizontal, POSPadding.medium)
+                .accessibilityIdentifier("pos-continue-checkout-button")
             }
 
             HStack(alignment: .center) {
@@ -329,6 +354,14 @@ private struct TotalsFieldsContent: View {
         .opacity(viewHelper.shouldShowTotalsFields(for: paymentState) ? 1 : 0)
         .layoutPriority(1)
         .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+    }
+
+    private enum Localization {
+        static let continueButtonTitle = NSLocalizedString(
+            "pos.totalsView.continue.button.title",
+            value: "Continue",
+            comment: "Title for the continue button when email is required for downloadable products"
+        )
     }
 
     @ViewBuilder func totalsFields(orderTotals: PointOfSaleOrderTotals?) -> some View {

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -46,7 +46,10 @@ struct TotalsView: View {
                                 orderState: posModel.orderState,
                                 paymentState: posModel.paymentState,
                                 cart: posModel.cart,
-                                totalsFieldAnimation: totalsFieldAnimation
+                                totalsFieldAnimation: totalsFieldAnimation,
+                                requiresEmail: posModel.requiresEmailForCheckout,
+                                billingEmail: posModel.billingEmail,
+                                onEmailChange: { posModel.setBillingEmail($0) }
                             )
                             .opacity(shouldShowTotalsFields ? 1 : 0)
                         }
@@ -288,21 +291,38 @@ private struct TotalsFieldsContent: View {
     let paymentState: PointOfSalePaymentState
     let cart: Cart
     let totalsFieldAnimation: Namespace.ID
+    let requiresEmail: Bool
+    let billingEmail: String
+    let onEmailChange: (String) -> Void
     private let viewHelper = TotalsViewHelper()
+
+    @State private var emailInput: String = ""
 
     /// Used for synchronizing animations of shimmeringLine and textField
     static let matchedGeometryId: String = "pos_totals_view_matched_geometry_id"
 
     var body: some View {
-        HStack(alignment: .center) {
-            Spacer()
-            switch orderState {
-            case .idle, .syncing, .error:
-                totalsFields(orderTotals: nil)
-            case .loaded(let orderTotals):
-                totalsFields(orderTotals: orderTotals)
+        VStack(spacing: POSSpacing.medium) {
+            if requiresEmail {
+                POSEmailInputView(email: $emailInput)
+                    .onChange(of: emailInput) { _, newValue in
+                        onEmailChange(newValue)
+                    }
+                    .onAppear {
+                        emailInput = billingEmail
+                    }
             }
-            Spacer()
+
+            HStack(alignment: .center) {
+                Spacer()
+                switch orderState {
+                case .idle, .syncing, .error:
+                    totalsFields(orderTotals: nil)
+                case .loaded(let orderTotals):
+                    totalsFields(orderTotals: orderTotals)
+                }
+                Spacer()
+            }
         }
         .transition(.opacity)
         .animation(.default, value: orderState.isSyncing)

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -46,11 +46,7 @@ struct TotalsView: View {
                                 orderState: posModel.orderState,
                                 paymentState: posModel.paymentState,
                                 cart: posModel.cart,
-                                totalsFieldAnimation: totalsFieldAnimation,
-                                requiresEmail: posModel.requiresEmailForCheckout,
-                                billingEmail: posModel.billingEmail,
-                                onEmailChange: { posModel.setBillingEmail($0) },
-                                onProceedWithCheckout: { await posModel.proceedWithCheckout() }
+                                totalsFieldAnimation: totalsFieldAnimation
                             )
                             .opacity(shouldShowTotalsFields ? 1 : 0)
                         }
@@ -292,52 +288,13 @@ private struct TotalsFieldsContent: View {
     let paymentState: PointOfSalePaymentState
     let cart: Cart
     let totalsFieldAnimation: Namespace.ID
-    let requiresEmail: Bool
-    let billingEmail: String
-    let onEmailChange: (String) -> Void
-    let onProceedWithCheckout: () async -> Void
     private let viewHelper = TotalsViewHelper()
-
-    @State private var emailInput: String = ""
-
-    private var isValidEmail: Bool {
-        emailInput.contains("@") && emailInput.contains(".")
-    }
-
-    /// Whether to show a continue button (waiting for email before proceeding)
-    private var shouldShowContinueButton: Bool {
-        requiresEmail && orderState.isIdle
-    }
 
     /// Used for synchronizing animations of shimmeringLine and textField
     static let matchedGeometryId: String = "pos_totals_view_matched_geometry_id"
 
     var body: some View {
         VStack(spacing: POSSpacing.medium) {
-            if requiresEmail {
-                POSEmailInputView(email: $emailInput)
-                    .onChange(of: emailInput) { _, newValue in
-                        onEmailChange(newValue)
-                    }
-                    .onAppear {
-                        emailInput = billingEmail
-                    }
-            }
-
-            if shouldShowContinueButton {
-                Button {
-                    Task { @MainActor in
-                        await onProceedWithCheckout()
-                    }
-                } label: {
-                    Text(Localization.continueButtonTitle)
-                }
-                .buttonStyle(POSFilledButtonStyle(size: .normal))
-                .disabled(!isValidEmail)
-                .padding(.horizontal, POSPadding.medium)
-                .accessibilityIdentifier("pos-continue-checkout-button")
-            }
-
             HStack(alignment: .center) {
                 Spacer()
                 switch orderState {
@@ -354,14 +311,6 @@ private struct TotalsFieldsContent: View {
         .opacity(viewHelper.shouldShowTotalsFields(for: paymentState) ? 1 : 0)
         .layoutPriority(1)
         .dynamicTypeSize(...DynamicTypeSize.accessibility1)
-    }
-
-    private enum Localization {
-        static let continueButtonTitle = NSLocalizedString(
-            "pos.totalsView.continue.button.title",
-            value: "Continue",
-            comment: "Title for the continue button when email is required for downloadable products"
-        )
     }
 
     @ViewBuilder func totalsFields(orderTotals: PointOfSaleOrderTotals?) -> some View {

--- a/Modules/Sources/PointOfSale/Utils/PointOfSalePreviewOrderController.swift
+++ b/Modules/Sources/PointOfSale/Utils/PointOfSalePreviewOrderController.swift
@@ -25,5 +25,7 @@ class PointOfSalePreviewOrderController: PointOfSaleOrderControllerProtocol {
     func clearOrder() { }
 
     func collectCashPayment(changeDueAmount: String?) async throws {}
+
+    func setOrderState(totals: PointOfSaleOrderTotals, order: Yosemite.Order) { }
 }
 #endif

--- a/Modules/Sources/Storage/GRDB/Model/PersistedProduct.swift
+++ b/Modules/Sources/Storage/GRDB/Model/PersistedProduct.swift
@@ -161,7 +161,6 @@ public extension PersistedProduct {
         return PersistedProduct
             .filter(Columns.siteID == siteID)
             .filter([ProductType.simple.rawValue, ProductType.variable.rawValue].contains(Columns.productTypeKey))
-            .filter(Columns.downloadable == false)
             .filter(!excludedStatuses.contains(Columns.statusKey))
     }
 }

--- a/Modules/Sources/Storage/GRDB/Model/PersistedProductVariation.swift
+++ b/Modules/Sources/Storage/GRDB/Model/PersistedProductVariation.swift
@@ -87,12 +87,11 @@ extension PersistedProductVariation: FetchableRecord, PersistableRecord {
 
 // MARK: - Point of Sale Requests
 public extension PersistedProductVariation {
-    /// Returns a request for non-downloadable variations of a parent product, ordered by ID
+    /// Returns a request for variations of a parent product, ordered by ID
     static func posVariationsRequest(siteID: Int64, parentProductID: Int64) -> QueryInterfaceRequest<PersistedProductVariation> {
         return PersistedProductVariation
             .filter(Columns.siteID == siteID)
             .filter(Columns.productID == parentProductID)
-            .filter(Columns.downloadable == false)
             .order(Columns.id)
     }
 

--- a/Modules/Sources/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Modules/Sources/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -102,4 +102,26 @@ public enum CardPresentPaymentAction: Action {
     /// Fetches Charge details by charge ID
     ///
     case fetchWCPayCharge(siteID: Int64, chargeID: String, onCompletion: (Result<WCPayCharge, Error>) -> Void)
+
+    /// Collects payment for a POS order using Store API for capture.
+    ///
+    /// This is similar to `collectPayment` but uses the Store API checkout endpoint
+    /// with the payment_intent_id to capture the payment, instead of `capture_terminal_payment`.
+    ///
+    /// - Parameters:
+    ///   - siteID: The site ID.
+    ///   - orderID: The order ID (from Store API checkout).
+    ///   - parameters: Payment parameters for the card reader.
+    ///   - captureHandler: Closure called with payment intent ID to capture via Store API.
+    ///   - onCardReaderMessage: Callback for card reader events.
+    ///   - onProcessingCompletion: Callback when payment is processed (before capture).
+    ///   - onCompletion: Final completion with success or failure.
+    ///
+    case collectPOSPayment(siteID: Int64,
+                           orderID: Int64,
+                           parameters: PaymentParameters,
+                           captureHandler: (String) async throws -> Void,
+                           onCardReaderMessage: (CardReaderEvent) -> Void,
+                           onProcessingCompletion: (PaymentIntent) -> Void,
+                           onCompletion: (Result<PaymentIntent, Error>) -> Void)
 }

--- a/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -136,7 +136,9 @@ extension Yosemite.POSSimpleProduct {
         bundledItems: CopiableProp<[Networking.ProductBundleItem]> = .copy,
         manageStock: CopiableProp<Bool> = .copy,
         stockQuantity: NullableCopiableProp<Decimal> = .copy,
-        stockStatusKey: CopiableProp<String> = .copy
+        stockStatusKey: CopiableProp<String> = .copy,
+        downloadable: CopiableProp<Bool> = .copy,
+        isGiftCard: CopiableProp<Bool> = .copy
     ) -> Yosemite.POSSimpleProduct {
         let id = id ?? self.id
         let name = name ?? self.name
@@ -149,6 +151,8 @@ extension Yosemite.POSSimpleProduct {
         let manageStock = manageStock ?? self.manageStock
         let stockQuantity = stockQuantity ?? self.stockQuantity
         let stockStatusKey = stockStatusKey ?? self.stockStatusKey
+        let downloadable = downloadable ?? self.downloadable
+        let isGiftCard = isGiftCard ?? self.isGiftCard
 
         return Yosemite.POSSimpleProduct(
             id: id,
@@ -161,7 +165,9 @@ extension Yosemite.POSSimpleProduct {
             bundledItems: bundledItems,
             manageStock: manageStock,
             stockQuantity: stockQuantity,
-            stockStatusKey: stockStatusKey
+            stockStatusKey: stockStatusKey,
+            downloadable: downloadable,
+            isGiftCard: isGiftCard
         )
     }
 }

--- a/Modules/Sources/Yosemite/Model/Payments/OrderPaymentMethod.swift
+++ b/Modules/Sources/Yosemite/Model/Payments/OrderPaymentMethod.swift
@@ -18,6 +18,8 @@ public enum OrderPaymentMethod: RawRepresentable {
     /// Other
     case unknown
 
+    case posCard
+
     /// Designated Initializer.
     ///
     public init(rawValue: String) {
@@ -32,6 +34,8 @@ public enum OrderPaymentMethod: RawRepresentable {
             self = .stripe
         case Keys.none:
             self = .none
+        case Keys.posCard:
+            self = .posCard
         default:
             self = .unknown
         }
@@ -49,6 +53,8 @@ public enum OrderPaymentMethod: RawRepresentable {
             return Keys.stripe
         case .none:
             return Keys.none
+        case .posCard:
+            return Keys.posCard
         default:
             return Keys.unknown
         }
@@ -63,4 +69,5 @@ private enum Keys {
     static let stripe = "stripe"
     static let none = ""
     static let unknown = "unknown"
+    static let posCard = "pos_card"
 }

--- a/Modules/Sources/Yosemite/Model/Storage/PersistedProduct+Conversions.swift
+++ b/Modules/Sources/Yosemite/Model/Storage/PersistedProduct+Conversions.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NetworkingCore
 import Storage
 
 // MARK: - PersistedProduct Conversions
@@ -24,7 +25,7 @@ extension PersistedProduct {
         )
     }
 
-    func toPOSProduct(images: [ProductImage] = [], attributes: [ProductAttribute] = [], variationIDs: [Int64] = []) -> POSProduct {
+    func toPOSProduct(images: [ProductImage] = [], attributes: [ProductAttribute] = [], variationIDs: [Int64] = [], metaData: [MetaData] = []) -> POSProduct {
         return POSProduct(
             siteID: siteID,
             productID: id,
@@ -43,7 +44,8 @@ extension PersistedProduct {
             stockQuantity: stockQuantity,
             stockStatusKey: stockStatusKey,
             statusKey: statusKey,
-            variationIDs: variationIDs
+            variationIDs: variationIDs,
+            metaData: metaData
         )
     }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
@@ -17,10 +17,6 @@ struct POSProductOrVariationResolver {
                                    scannedCode: String) async throws(PointOfSaleBarcodeScanError) -> POSItem {
         let items: [POSItem]
 
-        guard productOrVariation.downloadable == false else {
-            throw .downloadableProduct(scannedCode: scannedCode, productName: productOrVariation.name)
-        }
-
         switch productOrVariation.productType {
         case .simple:
             let product = productOrVariation

--- a/Modules/Sources/Yosemite/PointOfSale/Items/POSSimpleProduct.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/POSSimpleProduct.swift
@@ -24,6 +24,9 @@ public struct POSSimpleProduct: POSOrderableItem, OrderSyncProductTypeProtocol {
         return ProductStockStatus(rawValue: stockStatusKey)
     }
 
+    // Digital product
+    public let downloadable: Bool
+
     public init(id: POSItemIdentifier,
                 name: String,
                 formattedPrice: String,
@@ -34,7 +37,8 @@ public struct POSSimpleProduct: POSOrderableItem, OrderSyncProductTypeProtocol {
                 bundledItems: [ProductBundleItem] = [],
                 manageStock: Bool,
                 stockQuantity: Decimal?,
-                stockStatusKey: String) {
+                stockStatusKey: String,
+                downloadable: Bool = false) {
         self.id = id
         self.name = name
         self.formattedPrice = formattedPrice
@@ -44,6 +48,7 @@ public struct POSSimpleProduct: POSOrderableItem, OrderSyncProductTypeProtocol {
         self.manageStock = manageStock
         self.stockQuantity = stockQuantity
         self.stockStatusKey = stockStatusKey
+        self.downloadable = downloadable
     }
 }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Items/POSSimpleProduct.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/POSSimpleProduct.swift
@@ -26,6 +26,7 @@ public struct POSSimpleProduct: POSOrderableItem, OrderSyncProductTypeProtocol {
 
     // Digital product
     public let downloadable: Bool
+    public let isGiftCard: Bool
 
     public init(id: POSItemIdentifier,
                 name: String,
@@ -38,7 +39,8 @@ public struct POSSimpleProduct: POSOrderableItem, OrderSyncProductTypeProtocol {
                 manageStock: Bool,
                 stockQuantity: Decimal?,
                 stockStatusKey: String,
-                downloadable: Bool = false) {
+                downloadable: Bool = false,
+                isGiftCard: Bool = false) {
         self.id = id
         self.name = name
         self.formattedPrice = formattedPrice
@@ -49,6 +51,7 @@ public struct POSSimpleProduct: POSOrderableItem, OrderSyncProductTypeProtocol {
         self.stockQuantity = stockQuantity
         self.stockStatusKey = stockStatusKey
         self.downloadable = downloadable
+        self.isGiftCard = isGiftCard
     }
 }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Items/POSVariation.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/POSVariation.swift
@@ -19,6 +19,7 @@ public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Ha
 
     // Digital product
     public let downloadable: Bool
+    public let isGiftCard: Bool
 
     public init(id: POSItemIdentifier,
                 name: String,
@@ -28,7 +29,8 @@ public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Ha
                 productID: Int64,
                 variationID: Int64,
                 parentProductName: String,
-                downloadable: Bool = false) {
+                downloadable: Bool = false,
+                isGiftCard: Bool = false) {
         self.id = id
         self.name = name
         self.formattedPrice = formattedPrice
@@ -38,6 +40,7 @@ public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Ha
         self.productVariationID = variationID
         self.parentProductName = parentProductName
         self.downloadable = downloadable
+        self.isGiftCard = isGiftCard
     }
 }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Items/POSVariation.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/POSVariation.swift
@@ -17,6 +17,9 @@ public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Ha
     // Variation specific
     public let parentProductName: String
 
+    // Digital product
+    public let downloadable: Bool
+
     public init(id: POSItemIdentifier,
                 name: String,
                 formattedPrice: String,
@@ -24,7 +27,8 @@ public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Ha
                 productImageSource: String? = nil,
                 productID: Int64,
                 variationID: Int64,
-                parentProductName: String) {
+                parentProductName: String,
+                downloadable: Bool = false) {
         self.id = id
         self.name = name
         self.formattedPrice = formattedPrice
@@ -33,6 +37,7 @@ public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Ha
         self.productID = productID
         self.productVariationID = variationID
         self.parentProductName = parentProductName
+        self.downloadable = downloadable
     }
 }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemMapper.swift
@@ -32,7 +32,8 @@ final class PointOfSaleItemMapper: PointOfSaleItemMapperProtocol {
                                                            price: product.price,
                                                            manageStock: product.manageStock,
                                                            stockQuantity: product.stockQuantity,
-                                                           stockStatusKey: product.stockStatusKey))
+                                                           stockStatusKey: product.stockStatusKey,
+                                                           downloadable: product.downloadable))
                 case .variable:
                     return .variableParentProduct(POSVariableParentProduct(
                         id: id,
@@ -63,7 +64,8 @@ final class PointOfSaleItemMapper: PointOfSaleItemMapperProtocol {
                                  productImageSource: variation.image?.src,
                                  productID: variation.productID,
                                  variationID: variation.productVariationID,
-                                 parentProductName: parentProduct.name))
+                                 parentProductName: parentProduct.name,
+                                 downloadable: variation.downloadable))
         }
     }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemMapper.swift
@@ -1,6 +1,7 @@
 import Foundation
 import class WooFoundation.CurrencySettings
 import class WooFoundation.CurrencyFormatter
+import NetworkingCore
 
 public protocol PointOfSaleItemMapperProtocol {
     func mapProductsToPOSItems(products: [POSProduct]) -> [POSItem]
@@ -21,6 +22,7 @@ final class PointOfSaleItemMapper: PointOfSaleItemMapperProtocol {
         return products.compactMap { product in
             let thumbnailSource = product.images.first?.src
             let id = POSItemIdentifier(underlyingType: .product, itemID: product.productID)
+            let isGiftCard = isGiftCardProduct(product.metaData)
 
             switch product.productType {
                 case .simple:
@@ -33,7 +35,8 @@ final class PointOfSaleItemMapper: PointOfSaleItemMapperProtocol {
                                                            manageStock: product.manageStock,
                                                            stockQuantity: product.stockQuantity,
                                                            stockStatusKey: product.stockStatusKey,
-                                                           downloadable: product.downloadable))
+                                                           downloadable: product.downloadable,
+                                                           isGiftCard: isGiftCard))
                 case .variable:
                     return .variableParentProduct(POSVariableParentProduct(
                         id: id,
@@ -72,5 +75,11 @@ final class PointOfSaleItemMapper: PointOfSaleItemMapperProtocol {
     private func formatPrice(_ price: String) -> String {
         let zeroOrPlaceholder = currencyFormatter.formatAmount("0") ?? "-"
         return currencyFormatter.formatAmount(price) ?? zeroOrPlaceholder
+    }
+
+    /// Checks if a product is a gift card based on its meta_data.
+    /// Gift cards have `_gift_card: "yes"` in their meta_data.
+    private func isGiftCardProduct(_ metaData: [MetaData]) -> Bool {
+        metaData.contains { $0.key == "_gift_card" && $0.value.stringValue == "yes" }
     }
 }

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemService.swift
@@ -48,8 +48,6 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
             let pagedVariations = try await fetchStrategy.fetchVariations(parentProductID: parentProduct.productID,
                                                                           pageNumber: pageNumber)
             let variations = pagedVariations.items
-            // Remove this when WC version 9.7 has significant adoption in POS stores.
-                .filter { !$0.downloadable }
             return .init(
                 items: itemMapper.mapVariationsToPOSItems(variations: variations, parentProduct: parentProduct),
                 hasMorePages: pagedVariations.hasMorePages,

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleLocalBarcodeScanService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleLocalBarcodeScanService.swift
@@ -71,10 +71,6 @@ public final class PointOfSaleLocalBarcodeScanService: PointOfSaleBarcodeScanSer
             // Validate that the product status is allowed for POS
             try validateProductStatus(posProduct, scannedCode: scannedCode)
 
-            guard !posProduct.downloadable else {
-                throw PointOfSaleBarcodeScanError.downloadableProduct(scannedCode: scannedCode, productName: posProduct.name)
-            }
-
             // Validate product type - only simple products can be scanned directly
             // Variable parent products cannot be added to cart (only their variations can)
             guard posProduct.productType == .simple else {
@@ -115,11 +111,6 @@ public final class PointOfSaleLocalBarcodeScanService: PointOfSaleBarcodeScanSer
                   case .variableParentProduct(let variableParentProduct) = mappedParent,
                   let item = itemMapper.mapVariationsToPOSItems(variations: [posVariation], parentProduct: variableParentProduct).first else {
                 throw PointOfSaleBarcodeScanError.variationCouldNotBeConverted(scannedCode: scannedCode)
-            }
-
-            guard !persistedVariation.downloadable else {
-                throw PointOfSaleBarcodeScanError.downloadableProduct(scannedCode: scannedCode,
-                                                                      productName: variationName(for: item))
             }
 
             return item

--- a/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -362,7 +362,7 @@ private extension CardPresentPaymentStore {
     private func capturePOSPayment(paymentIntentID: String,
                                    captureHandler: @escaping (String) async throws -> Void) -> AnyPublisher<Result<Void, Error>, Never> {
         Future<Result<Void, Error>, Never> { promise in
-            Task {
+            Task { @MainActor in
                 do {
                     try await captureHandler(paymentIntentID)
                     promise(.success(.success(())))

--- a/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -138,6 +138,20 @@ public final class CardPresentPaymentStore: Store {
             publishCardReaderConnections(onCompletion: completion)
         case .fetchWCPayCharge(let siteID, let chargeID, let completion):
             fetchCharge(siteID: siteID, chargeID: chargeID, completion: completion)
+        case .collectPOSPayment(let siteID,
+                                let orderID,
+                                let parameters,
+                                let captureHandler,
+                                let onCardReaderMessage,
+                                let onProcessingCompletion,
+                                let onCompletion):
+            collectPOSPayment(siteID: siteID,
+                              orderID: orderID,
+                              parameters: parameters,
+                              captureHandler: captureHandler,
+                              onCardReaderMessage: onCardReaderMessage,
+                              onProcessingCompletion: onProcessingCompletion,
+                              onCompletion: onCompletion)
         }
     }
 }
@@ -280,6 +294,85 @@ private extension CardPresentPaymentStore {
                                                  onCardReaderMessage: onCardReaderMessage,
                                                  onProcessingCompletion: onProcessingCompletion,
                                                  onCompletion: onCompletion)
+    }
+
+    /// Collects payment for POS using a custom capture handler (Store API).
+    ///
+    func collectPOSPayment(siteID: Int64,
+                           orderID: Int64,
+                           parameters: PaymentParameters,
+                           captureHandler: @escaping (String) async throws -> Void,
+                           onCardReaderMessage: @escaping (CardReaderEvent) -> Void,
+                           onProcessingCompletion: @escaping (PaymentIntent) -> Void,
+                           onCompletion: @escaping (Result<PaymentIntent, Error>) -> Void) {
+        // Observe status events fired by the card reader
+        let readerEventsSubscription = cardReaderService.readerEvents.sink { event in
+            onCardReaderMessage(event)
+        }
+
+        paymentCancellable = handlePOSPaymentEvents(from: cardReaderService.capturePayment(parameters),
+                                                    readerEventsSubscription: readerEventsSubscription,
+                                                    captureHandler: captureHandler,
+                                                    onCardReaderMessage: onCardReaderMessage,
+                                                    onProcessingCompletion: onProcessingCompletion,
+                                                    onCompletion: onCompletion)
+    }
+
+    /// Handles payment events for POS, using a custom capture handler instead of WCPay/Stripe capture.
+    ///
+    private func handlePOSPaymentEvents(from paymentEventPublisher: AnyPublisher<PaymentIntent, Error>,
+                                        readerEventsSubscription: AnyCancellable,
+                                        captureHandler: @escaping (String) async throws -> Void,
+                                        onCardReaderMessage: @escaping (CardReaderEvent) -> Void,
+                                        onProcessingCompletion: @escaping (PaymentIntent) -> Void,
+                                        onCompletion: @escaping (Result<PaymentIntent, Error>) -> Void) -> AnyCancellable? {
+        return paymentEventPublisher.handleEvents(receiveOutput: { intent in
+            onProcessingCompletion(intent)
+        })
+        .flatMap { intent in
+            Publishers.CombineLatest(
+                self.cardReaderService.waitForInsertedCardToBeRemoved()
+                    .handleEvents(receiveOutput: {
+                        onCardReaderMessage(.cardRemovedAfterClientSidePaymentCapture)
+                    })
+                    .map { intent },
+                self.capturePOSPayment(paymentIntentID: intent.id, captureHandler: captureHandler)
+            )
+        }
+        .sink { completion in
+            readerEventsSubscription.cancel()
+            switch completion {
+            case .failure(let error):
+                onCompletion(.failure(error))
+            default:
+                break
+            }
+        } receiveValue: { intent, captureResult in
+            switch captureResult {
+            case .success:
+                onCompletion(.success(intent))
+            case .failure(let error):
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    /// Captures a POS payment using the provided capture handler.
+    ///
+    private func capturePOSPayment(paymentIntentID: String,
+                                   captureHandler: @escaping (String) async throws -> Void) -> AnyPublisher<Result<Void, Error>, Never> {
+        Future<Result<Void, Error>, Never> { promise in
+            Task {
+                do {
+                    try await captureHandler(paymentIntentID)
+                    promise(.success(.success(())))
+                } catch {
+                    DDLogError("⛔️ POS payment capture failed: \(error)")
+                    promise(.success(.failure(error)))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
     }
 
     private func handlePaymentEvents(from paymentEventPublisher: AnyPublisher<PaymentIntent, Error>,

--- a/Modules/Sources/Yosemite/Stores/Order/Order+CardPresentPayment.swift
+++ b/Modules/Sources/Yosemite/Stores/Order/Order+CardPresentPayment.swift
@@ -51,7 +51,7 @@ import protocol Storage.StorageManagerType
     private var isPaymentMethodEligibleForCardPayment: Bool {
         let paymentMethod = OrderPaymentMethod(rawValue: paymentMethodID)
         switch paymentMethod {
-        case .booking, .cod, .woocommercePayments, .stripe, .none:
+        case .booking, .cod, .woocommercePayments, .stripe, .none, .posCard:
             return true
         case .unknown:
             return false

--- a/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
@@ -14,10 +14,12 @@ public struct POSCart {
 }
 
 public struct POSCartItem {
+    public let id: UUID
     public let item: POSOrderableItem
     public let quantity: Decimal
 
-    public init(item: POSOrderableItem, quantity: Decimal) {
+    public init(id: UUID = UUID(), item: POSOrderableItem, quantity: Decimal) {
+        self.id = id
         self.item = item
         self.quantity = quantity
     }
@@ -87,7 +89,7 @@ extension [POSCartItem] {
         let consolidatedCartItems = self.reduce(into: [POSCartItem]()) { partialResult, nextItem in
             if let matchingIndex = partialResult.firstIndex(where: { $0.item.isEqual(to: nextItem.item) }) {
                 let itemToUpdate = partialResult[matchingIndex]
-                partialResult[matchingIndex] = POSCartItem(item: itemToUpdate.item, quantity: itemToUpdate.quantity + nextItem.quantity)
+                partialResult[matchingIndex] = POSCartItem(id: itemToUpdate.id, item: itemToUpdate.item, quantity: itemToUpdate.quantity + nextItem.quantity)
             } else {
                 partialResult.append(nextItem)
             }

--- a/Modules/Sources/Yosemite/Tools/POS/POSStoreAPICheckoutService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSStoreAPICheckoutService.swift
@@ -147,16 +147,15 @@ public final class POSStoreAPICheckoutService: POSStoreAPICheckoutServiceProtoco
 
         // Step 2: Add all cart items
         for cartItem in cart.items {
-            let (productID, variationID) = extractProductIDs(from: cartItem.item)
+            let itemID = extractItemID(from: cartItem.item)
             let quantity = Int(truncating: cartItem.quantity as NSDecimalNumber)
 
             // Get gift card info for this cart item if available
             let gcInfo = giftCardInfo[cartItem.id]
 
             _ = try await remote.addItem(
-                productID: productID,
+                id: itemID,
                 quantity: quantity,
-                variationID: variationID > 0 ? variationID : nil,
                 giftCardRecipientEmail: gcInfo?.recipientEmail,
                 giftCardSenderName: gcInfo?.senderName
             )
@@ -210,17 +209,20 @@ public final class POSStoreAPICheckoutService: POSStoreAPICheckoutServiceProtoco
 // MARK: - Private Helpers
 
 private extension POSStoreAPICheckoutService {
-    /// Extracts product and variation IDs from a POS orderable item.
+    /// Extracts the item ID to use for the Store API add-item request.
     ///
-    func extractProductIDs(from item: POSOrderableItem) -> (productID: Int64, variationID: Int64) {
+    /// For simple products, returns the product ID.
+    /// For variations, returns the variation ID (not the parent product ID).
+    ///
+    func extractItemID(from item: POSOrderableItem) -> Int64 {
         if let simpleProduct = item as? POSSimpleProduct {
-            return (simpleProduct.productID, 0)
+            return simpleProduct.productID
         } else if let variation = item as? POSVariation {
-            return (variation.productID, variation.productVariationID)
+            return variation.productVariationID
         }
         // Fallback - shouldn't happen for valid cart items
         DDLogWarn("⚠️ Unknown POSOrderableItem type: \(type(of: item))")
-        return (0, 0)
+        return 0
     }
 }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSStoreAPICheckoutService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSStoreAPICheckoutService.swift
@@ -1,0 +1,224 @@
+import Foundation
+import Networking
+import struct Combine.AnyPublisher
+import struct NetworkingCore.JetpackSite
+
+/// Payment methods supported by POS Store API checkout.
+///
+public enum POSStoreAPIPaymentMethod: String {
+    case cash = "pos_cash"
+    case card = "pos_card"
+}
+
+/// Result of a Store API checkout operation.
+///
+public struct POSStoreAPICheckoutResult {
+    /// The checkout response from the Store API.
+    public let checkoutResponse: StoreAPICheckoutResponse
+
+    /// The cart totals at the time of checkout.
+    public let cartTotals: StoreAPICartTotals
+
+    public init(checkoutResponse: StoreAPICheckoutResponse, cartTotals: StoreAPICartTotals) {
+        self.checkoutResponse = checkoutResponse
+        self.cartTotals = cartTotals
+    }
+}
+
+/// Protocol for POS Store API checkout operations.
+///
+public protocol POSStoreAPICheckoutServiceProtocol {
+    /// Syncs local cart to Store API and initiates checkout.
+    ///
+    /// This method:
+    /// 1. Clears any existing Store API cart
+    /// 2. Adds all local cart items to the Store API cart
+    /// 3. Applies all coupons
+    /// 4. Gets cart totals
+    /// 5. Calls checkout with the specified payment method
+    ///
+    /// - Parameters:
+    ///   - cart: The local POS cart to sync and checkout.
+    ///   - paymentMethod: Payment method to use (cash or card).
+    ///   - billingEmail: Optional billing email for the order.
+    /// - Returns: Checkout result with order details and cart totals.
+    ///
+    func checkout(
+        cart: POSCart,
+        paymentMethod: POSStoreAPIPaymentMethod,
+        billingEmail: String?
+    ) async throws -> POSStoreAPICheckoutResult
+
+    /// Captures a card payment by calling checkout with the payment intent ID.
+    ///
+    /// This is the second step of the two-step card payment flow:
+    /// 1. Initial checkout creates a pending order
+    /// 2. Terminal SDK collects payment and returns payment_intent_id
+    /// 3. This method calls checkout again with the payment_intent_id to complete
+    ///
+    /// - Parameter paymentIntentID: The Stripe payment intent ID from the Terminal SDK.
+    /// - Returns: The checkout response (order should now be completed).
+    ///
+    func captureCardPayment(paymentIntentID: String) async throws -> StoreAPICheckoutResponse
+
+    /// Clears the Store API cart.
+    ///
+    func clearCart() async throws
+}
+
+/// Service for POS Store API checkout operations.
+///
+public final class POSStoreAPICheckoutService: POSStoreAPICheckoutServiceProtocol {
+    private let remote: POSStoreAPIRemote
+
+    /// Creates a checkout service with the provided credentials.
+    ///
+    /// - Parameters:
+    ///   - siteURL: URL of the WooCommerce site.
+    ///   - credentials: Authentication credentials.
+    ///   - selectedSite: Publisher for the selected site.
+    ///   - appPasswordSupportState: Publisher for app password support state.
+    ///
+    public convenience init?(
+        siteURL: String,
+        credentials: Credentials?,
+        selectedSite: AnyPublisher<JetpackSite?, Never>,
+        appPasswordSupportState: AnyPublisher<Bool, Never>
+    ) {
+        guard let credentials else {
+            DDLogError("⛔️ Could not create POSStoreAPICheckoutService due to missing credentials")
+            return nil
+        }
+        let network = AlamofireNetwork(
+            credentials: credentials,
+            selectedSite: selectedSite,
+            appPasswordSupportState: appPasswordSupportState
+        )
+        let remote = POSStoreAPIRemote(network: network, siteURL: siteURL)
+        self.init(remote: remote)
+    }
+
+    /// Creates a checkout service with a pre-configured remote.
+    ///
+    /// - Parameter remote: The Store API remote to use for requests.
+    ///
+    public init(remote: POSStoreAPIRemote) {
+        self.remote = remote
+    }
+
+    // MARK: - POSStoreAPICheckoutServiceProtocol
+
+    public func checkout(
+        cart: POSCart,
+        paymentMethod: POSStoreAPIPaymentMethod,
+        billingEmail: String?
+    ) async throws -> POSStoreAPICheckoutResult {
+        // Step 1: Clear any existing cart
+        try await clearCart()
+
+        // Step 2: Add all cart items
+        for cartItem in cart.items {
+            let (productID, variationID) = extractProductIDs(from: cartItem.item)
+            let quantity = Int(truncating: cartItem.quantity as NSDecimalNumber)
+
+            _ = try await remote.addItem(
+                productID: productID,
+                quantity: quantity,
+                variationID: variationID > 0 ? variationID : nil
+            )
+        }
+
+        // Step 3: Apply all coupons
+        for coupon in cart.coupons {
+            _ = try await remote.applyCoupon(code: coupon.code)
+        }
+
+        // Step 4: Get cart to retrieve totals
+        let cartWithTotals = try await remote.getCart()
+
+        // Step 5: Build billing address (only include email if provided)
+        var billingAddress: [String: Any] = [:]
+        if let email = billingEmail, !email.isEmpty {
+            billingAddress["email"] = email
+        }
+
+        // Step 6: Call checkout
+        let checkoutResponse = try await remote.checkout(
+            paymentMethod: paymentMethod.rawValue,
+            billingAddress: billingAddress
+        )
+
+        return POSStoreAPICheckoutResult(
+            checkoutResponse: checkoutResponse,
+            cartTotals: cartWithTotals.totals
+        )
+    }
+
+    public func captureCardPayment(paymentIntentID: String) async throws -> StoreAPICheckoutResponse {
+        // Call checkout with the payment_intent_id to capture the payment
+        // The cart can be empty for this call - it just needs the payment data
+        let paymentData: [[String: String]] = [
+            ["key": "payment_intent_id", "value": paymentIntentID]
+        ]
+
+        return try await remote.checkout(
+            paymentMethod: POSStoreAPIPaymentMethod.card.rawValue,
+            billingAddress: [:],
+            paymentData: paymentData
+        )
+    }
+
+    public func clearCart() async throws {
+        try await remote.clearCart()
+    }
+}
+
+// MARK: - Private Helpers
+
+private extension POSStoreAPICheckoutService {
+    /// Extracts product and variation IDs from a POS orderable item.
+    ///
+    func extractProductIDs(from item: POSOrderableItem) -> (productID: Int64, variationID: Int64) {
+        if let simpleProduct = item as? POSSimpleProduct {
+            return (simpleProduct.productID, 0)
+        } else if let variation = item as? POSVariation {
+            return (variation.productID, variation.productVariationID)
+        }
+        // Fallback - shouldn't happen for valid cart items
+        DDLogWarn("⚠️ Unknown POSOrderableItem type: \(type(of: item))")
+        return (0, 0)
+    }
+}
+
+// MARK: - Errors
+
+public extension POSStoreAPICheckoutService {
+    enum CheckoutError: Error, LocalizedError {
+        case failedToSyncCart
+        case failedToCheckout
+        case failedToCapturePayment
+
+        public var errorDescription: String? {
+            switch self {
+            case .failedToSyncCart:
+                return NSLocalizedString(
+                    "posStoreAPICheckoutService.error.failedToSyncCart",
+                    value: "Failed to sync cart to server",
+                    comment: "Error message when Store API cart sync fails"
+                )
+            case .failedToCheckout:
+                return NSLocalizedString(
+                    "posStoreAPICheckoutService.error.failedToCheckout",
+                    value: "Failed to complete checkout",
+                    comment: "Error message when Store API checkout fails"
+                )
+            case .failedToCapturePayment:
+                return NSLocalizedString(
+                    "posStoreAPICheckoutService.error.failedToCapturePayment",
+                    value: "Failed to capture payment",
+                    comment: "Error message when Store API payment capture fails"
+                )
+            }
+        }
+    }
+}

--- a/Modules/Sources/Yosemite/Tools/POS/POSStoreAPICheckoutService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSStoreAPICheckoutService.swift
@@ -71,6 +71,20 @@ public protocol POSStoreAPICheckoutServiceProtocol {
 public final class POSStoreAPICheckoutService: POSStoreAPICheckoutServiceProtocol {
     private let remote: POSStoreAPIRemote
 
+    /// Creates a checkout service with a pre-configured network.
+    ///
+    /// Use this initializer when you have an existing network that's already
+    /// configured for application password authentication.
+    ///
+    /// - Parameters:
+    ///   - siteURL: URL of the WooCommerce site.
+    ///   - network: Pre-configured network for making requests.
+    ///
+    public convenience init(siteURL: String, network: Network) {
+        let remote = POSStoreAPIRemote(network: network, siteURL: siteURL)
+        self.init(remote: remote)
+    }
+
     /// Creates a checkout service with the provided credentials.
     ///
     /// - Parameters:

--- a/Modules/Sources/Yosemite/Tools/POS/POSStoreAPICheckoutService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSStoreAPICheckoutService.swift
@@ -10,6 +10,18 @@ public enum POSStoreAPIPaymentMethod: String {
     case card = "pos_card"
 }
 
+/// Gift card information for a cart item during checkout.
+///
+public struct POSGiftCardItemInfo {
+    public let recipientEmail: String
+    public let senderName: String
+
+    public init(recipientEmail: String, senderName: String) {
+        self.recipientEmail = recipientEmail
+        self.senderName = senderName
+    }
+}
+
 /// Result of a Store API checkout operation.
 ///
 public struct POSStoreAPICheckoutResult {
@@ -41,12 +53,14 @@ public protocol POSStoreAPICheckoutServiceProtocol {
     ///   - cart: The local POS cart to sync and checkout.
     ///   - paymentMethod: Payment method to use (cash or card).
     ///   - billingEmail: Optional billing email for the order.
+    ///   - giftCardInfo: Gift card info per cart item, keyed by cart item UUID.
     /// - Returns: Checkout result with order details and cart totals.
     ///
     func checkout(
         cart: POSCart,
         paymentMethod: POSStoreAPIPaymentMethod,
-        billingEmail: String?
+        billingEmail: String?,
+        giftCardInfo: [UUID: POSGiftCardItemInfo]
     ) async throws -> POSStoreAPICheckoutResult
 
     /// Captures a card payment by calling checkout with the payment intent ID.
@@ -125,7 +139,8 @@ public final class POSStoreAPICheckoutService: POSStoreAPICheckoutServiceProtoco
     public func checkout(
         cart: POSCart,
         paymentMethod: POSStoreAPIPaymentMethod,
-        billingEmail: String?
+        billingEmail: String?,
+        giftCardInfo: [UUID: POSGiftCardItemInfo] = [:]
     ) async throws -> POSStoreAPICheckoutResult {
         // Step 1: Clear any existing cart
         try await clearCart()
@@ -135,10 +150,15 @@ public final class POSStoreAPICheckoutService: POSStoreAPICheckoutServiceProtoco
             let (productID, variationID) = extractProductIDs(from: cartItem.item)
             let quantity = Int(truncating: cartItem.quantity as NSDecimalNumber)
 
+            // Get gift card info for this cart item if available
+            let gcInfo = giftCardInfo[cartItem.id]
+
             _ = try await remote.addItem(
                 productID: productID,
                 quantity: quantity,
-                variationID: variationID > 0 ? variationID : nil
+                variationID: variationID > 0 ? variationID : nil,
+                giftCardRecipientEmail: gcInfo?.recipientEmail,
+                giftCardSenderName: gcInfo?.senderName
             )
         }
 

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift
@@ -108,6 +108,87 @@ final class CardPresentPaymentCollectOrderPaymentUseCaseAdaptor {
             }
         }
     }
+
+    /// Creates a task for collecting POS payment with Store API capture.
+    ///
+    func collectPOSPaymentTask(for order: Order,
+                               using connectionMethod: CardReaderConnectionMethod,
+                               siteID: Int64,
+                               preflightController: CardPresentPaymentPreflightController<
+                               CardPresentPaymentTapToPayReaderConnectionAlertsProvider,
+                               CardPresentPaymentBluetoothReaderConnectionAlertsProvider,
+                               CardPresentPaymentsAlertPresenterAdaptor>,
+                               configuration: CardPresentPaymentsConfiguration,
+                               alertsPresenter: CardPresentPaymentsAlertPresenterAdaptor,
+                               paymentEventSubject: any Subject<CardPresentPaymentEvent, Never>,
+                               captureHandler: @escaping (String) async throws -> Void) -> Task<CardPresentPaymentAdaptedCollectOrderPaymentResult, Error> {
+        return Task {
+            guard let formattedAmount = currencyFormatter.formatAmount(order.total, with: order.currency) else {
+                throw CardPresentPaymentServiceError.invalidAmount
+            }
+
+            let invalidatablePaymentOrchestrator = CardPresentPaymentInvalidatablePaymentOrchestrator()
+
+            let orderPaymentUseCase = CollectOrderPaymentUseCase<CardPresentPaymentsTransactionAlertsProvider,
+                                                                 CardPresentPaymentsTransactionAlertsProvider,
+                                                                    CardPresentPaymentsAlertPresenterAdaptor>(
+                siteID: siteID,
+                order: order,
+                formattedAmount: formattedAmount,
+                rootViewController: NullViewControllerPresenting(),
+                configuration: configuration,
+                paymentOrchestrator: invalidatablePaymentOrchestrator,
+                alertsPresenter: alertsPresenter,
+                tapToPayAlertsProvider: CardPresentPaymentsTransactionAlertsProvider(),
+                bluetoothAlertsProvider: CardPresentPaymentsTransactionAlertsProvider(),
+                preflightController: preflightController,
+                analyticsTracker: collectOrderPaymentAnalyticsTracker,
+                posCaptureHandler: captureHandler)
+
+            return try await withTaskCancellationHandler {
+                return try await withCheckedThrowingContinuation { continuation in
+                    var nillableContinuation: CheckedContinuation<CardPresentPaymentAdaptedCollectOrderPaymentResult, Error>? = continuation
+
+                    orderPaymentUseCase.collectPayment(
+                        using: connectionMethod.discoveryMethod,
+                        channel: .pos,
+                        onFailure: { error in
+                            guard let continuation = nillableContinuation else { return }
+                            nillableContinuation = nil
+
+                            if let error = error as? CardPaymentErrorProtocol {
+                                continuation.resume(throwing: error)
+                            } else {
+                                continuation.resume(throwing: CardPresentPaymentServiceError.unknownPaymentError(underlyingError: error))
+                            }
+                        },
+                        onCancel: {
+                            guard let continuation = nillableContinuation else { return }
+                            nillableContinuation = nil
+                            paymentEventSubject.send(.idle)
+                            continuation.resume(returning: CardPresentPaymentAdaptedCollectOrderPaymentResult.cancellation)
+                        },
+                        onPaymentCompletion: {
+                            guard let continuation = nillableContinuation else { return }
+                            nillableContinuation = nil
+                            continuation.resume(returning: CardPresentPaymentAdaptedCollectOrderPaymentResult.success)
+                        },
+                        onCompleted: {
+                            // Not required for this use case
+                        }
+                    )
+                }
+            } onCancel: {
+                invalidatablePaymentOrchestrator.invalidatePayment()
+                switch latestPaymentEvent {
+                    case .show(let eventDetails):
+                        onCancel(paymentEventDetails: eventDetails, paymentOrchestrator: invalidatablePaymentOrchestrator)
+                    case .idle, .showOnboarding:
+                        return
+                }
+            }
+        }
+    }
 }
 
 enum CardPresentPaymentAdaptedCollectOrderPaymentResult {

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentInvalidatablePaymentOrchestrator.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentInvalidatablePaymentOrchestrator.swift
@@ -40,6 +40,37 @@ final class CardPresentPaymentInvalidatablePaymentOrchestrator: PaymentCaptureOr
                                            onCompletion: onCompletion)
     }
 
+    func collectPOSPayment(for order: Order,
+                           orderTotal: NSDecimalNumber,
+                           paymentGatewayAccount: PaymentGatewayAccount,
+                           paymentMethodTypes: [PaymentMethodType],
+                           stripeSmallestCurrencyUnitMultiplier: Decimal,
+                           captureHandler: @escaping (String) async throws -> Void,
+                           onPreparingReader: @escaping () -> Void,
+                           onWaitingForInput: @escaping (CardReaderInput) -> Void,
+                           onCardInserted: @escaping () -> Void,
+                           onProcessingMessage: @escaping () -> Void,
+                           onDisplayMessage: @escaping (String) -> Void,
+                           onProcessingCompletion: @escaping (PaymentIntent) -> Void,
+                           onCompletion: @escaping (Result<CardPresentCapturedPaymentData, any Error>) -> Void) {
+        guard invalidated == false else {
+            return onCompletion(.failure(CardPresentPaymentInvalidatablePaymentOrchestratorError.paymentInvalidated))
+        }
+        paymentOrchestrator.collectPOSPayment(for: order,
+                                              orderTotal: orderTotal,
+                                              paymentGatewayAccount: paymentGatewayAccount,
+                                              paymentMethodTypes: paymentMethodTypes,
+                                              stripeSmallestCurrencyUnitMultiplier: stripeSmallestCurrencyUnitMultiplier,
+                                              captureHandler: captureHandler,
+                                              onPreparingReader: onPreparingReader,
+                                              onWaitingForInput: onWaitingForInput,
+                                              onCardInserted: onCardInserted,
+                                              onProcessingMessage: onProcessingMessage,
+                                              onDisplayMessage: onDisplayMessage,
+                                              onProcessingCompletion: onProcessingCompletion,
+                                              onCompletion: onCompletion)
+    }
+
     func retryPayment(for order: Order,
                       onCompletion: @escaping (Result<CardPresentCapturedPaymentData, any Error>) -> Void) {
         guard invalidated == false else {

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentService.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentService.swift
@@ -179,6 +179,37 @@ final class CardPresentPaymentService: CardPresentPaymentFacade {
         }
     }
 
+    @MainActor
+    func collectPOSPayment(for order: Order,
+                           using connectionMethod: CardReaderConnectionMethod,
+                           captureHandler: @escaping (String) async throws -> Void) async throws -> CardPresentPaymentResult {
+        paymentTask?.cancel()
+
+        let preflightController = createPreflightController()
+
+        let paymentTask = CardPresentPaymentCollectOrderPaymentUseCaseAdaptor(paymentEventPublisher: paymentEventPublisher,
+                                                                              collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker
+        ).collectPOSPaymentTask(
+            for: order,
+            using: connectionMethod,
+            siteID: siteID,
+            preflightController: preflightController,
+            configuration: cardPresentPaymentsConfiguration,
+            alertsPresenter: paymentAlertsPresenterAdaptor,
+            paymentEventSubject: paymentEventSubject,
+            captureHandler: captureHandler)
+
+        self.paymentTask = paymentTask
+
+        switch try await paymentTask.value {
+        case .success:
+            let transaction = CardPresentPaymentTransaction()
+            return .success(transaction)
+        case .cancellation:
+            return .cancellation
+        }
+    }
+
     func cancelPayment() {
         cancelPaymentTask()
     }

--- a/WooCommerce/Classes/POS/Mocks/CardPresentPaymentServiceScreenshotMock.swift
+++ b/WooCommerce/Classes/POS/Mocks/CardPresentPaymentServiceScreenshotMock.swift
@@ -68,6 +68,24 @@ final class CardPresentPaymentServiceScreenshotMock: CardPresentPaymentFacade {
         return .success(CardPresentPaymentTransaction())
     }
 
+    func collectPOSPayment(for order: Yosemite.Order, using connectionMethod: PointOfSale.CardReaderConnectionMethod, captureHandler: @escaping (String) async throws -> Void) async throws -> PointOfSale.CardPresentPaymentResult {
+        // 1. Validating order
+        paymentEventSubject.send(.show(eventDetails: .validatingOrder(cancelPayment: {})))
+        try await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+
+        // 2. Preparing reader
+        paymentEventSubject.send(.show(eventDetails: .preparingForPayment(cancelPayment: {})))
+        try await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+
+        // 3. Ready to accept card
+        let inputMethods: Yosemite.CardReaderInput = [.tap, .swipe, .insert]
+        paymentEventSubject.send(.show(eventDetails: .tapSwipeOrInsertCard(inputMethods: inputMethods, cancelPayment: {})))
+
+        try await Task.sleep(nanoseconds: 3_000_000_000) // 3 seconds, give it some time for the screenshot
+
+        return .success(CardPresentPaymentTransaction())
+    }
+
     func cancelPayment() {
         // No-op for screenshots
     }

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -254,6 +254,20 @@ private extension POSTabCoordinator {
                     itemProvider = PointOfSaleItemServiceScreenshotMock()
                 }
 
+                // Create Store API checkout service for POS
+                let storeAPICheckoutService: POSStoreAPICheckoutService?
+                if let siteURL = storesManager.sessionManager.defaultSite?.url {
+                    storeAPICheckoutService = POSStoreAPICheckoutService(
+                        siteURL: siteURL,
+                        credentials: credentials,
+                        selectedSite: defaultSitePublisher,
+                        appPasswordSupportState: isAppPasswordSupported
+                    )
+                } else {
+                    storeAPICheckoutService = nil
+                    DDLogWarn("⚠️ Could not create POSStoreAPICheckoutService - no site URL available")
+                }
+
                 let posView = PointOfSaleEntryPointView(
                     siteID: siteID,
                     itemFetchStrategyFactory: createItemFetchStrategyFactory(isLocalCatalogEnabled: isLocalCatalogEligible),
@@ -287,7 +301,8 @@ private extension POSTabCoordinator {
                     catalogSyncCoordinator: catalogSyncCoordinator,
                     isLocalCatalogEligible: isLocalCatalogEligible,
                     services: serviceAdaptor,
-                    itemProvider: itemProvider
+                    itemProvider: itemProvider,
+                    storeAPICheckoutService: storeAPICheckoutService
                 )
 
                 let hostingController = UIHostingController(rootView: posView)

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -9,6 +9,8 @@ import protocol Storage.GRDBManagerProtocol
 import protocol Storage.StorageManagerType
 import struct NetworkingCore.JetpackSite
 import struct NetworkingCore.OrderItem
+import class NetworkingCore.AlamofireNetwork
+import enum NetworkingCore.RequestAuthenticationMode
 import PointOfSale
 
 protocol POSTabVisibilityCheckerProtocol {
@@ -257,11 +259,28 @@ private extension POSTabCoordinator {
                 // Create Store API checkout service for POS
                 let storeAPICheckoutService: POSStoreAPICheckoutService?
                 if let siteURL = storesManager.sessionManager.defaultSite?.url {
-                    storeAPICheckoutService = POSStoreAPICheckoutService(
-                        siteURL: siteURL,
+                    let storeAPINetwork = AlamofireNetwork(
                         credentials: credentials,
                         selectedSite: defaultSitePublisher,
                         appPasswordSupportState: isAppPasswordSupported
+                    )
+
+                    // Wait for the network to switch to app password authentication mode.
+                    // For WPCOM-authenticated Jetpack sites, this happens asynchronously when
+                    // the site publisher emits. We poll briefly to ensure the network is ready.
+                    var attempts = 0
+                    while storeAPINetwork.authenticationMode != .appPasswordsWithJetpack && attempts < 10 {
+                        try? await Task.sleep(nanoseconds: 10_000_000) // 10ms
+                        attempts += 1
+                    }
+
+                    if storeAPINetwork.authenticationMode != .appPasswordsWithJetpack {
+                        DDLogWarn("⚠️ Store API network did not switch to app password mode, auth mode: \(String(describing: storeAPINetwork.authenticationMode))")
+                    }
+
+                    storeAPICheckoutService = POSStoreAPICheckoutService(
+                        siteURL: siteURL,
+                        network: storeAPINetwork
                     )
                 } else {
                     storeAPICheckoutService = nil

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -26,6 +26,37 @@ protocol PaymentCaptureOrchestrating {
                         onProcessingCompletion: @escaping (PaymentIntent) -> Void,
                         onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> Void)
 
+    /// Collects payment for POS using Store API for capture.
+    ///
+    /// - Parameters:
+    ///   - order: The order to collect payment for.
+    ///   - orderTotal: The order total as decimal.
+    ///   - paymentGatewayAccount: Payment gateway configuration.
+    ///   - paymentMethodTypes: Allowed payment methods.
+    ///   - stripeSmallestCurrencyUnitMultiplier: Currency multiplier for Stripe.
+    ///   - captureHandler: Async closure called with payment intent ID to capture via Store API.
+    ///   - onPreparingReader: Called when preparing the reader.
+    ///   - onWaitingForInput: Called when waiting for card input.
+    ///   - onCardInserted: Called when card is inserted.
+    ///   - onProcessingMessage: Called during processing.
+    ///   - onDisplayMessage: Called to display reader messages.
+    ///   - onProcessingCompletion: Called when payment is processed (before capture).
+    ///   - onCompletion: Final completion handler.
+    ///
+    func collectPOSPayment(for order: Order,
+                           orderTotal: NSDecimalNumber,
+                           paymentGatewayAccount: PaymentGatewayAccount,
+                           paymentMethodTypes: [PaymentMethodType],
+                           stripeSmallestCurrencyUnitMultiplier: Decimal,
+                           captureHandler: @escaping (String) async throws -> Void,
+                           onPreparingReader: @escaping () -> Void,
+                           onWaitingForInput: @escaping (CardReaderInput) -> Void,
+                           onCardInserted: @escaping () -> Void,
+                           onProcessingMessage: @escaping () -> Void,
+                           onDisplayMessage: @escaping (String) -> Void,
+                           onProcessingCompletion: @escaping (PaymentIntent) -> Void,
+                           onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> Void)
+
     func retryPayment(for order: Order,
                       onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> Void)
 
@@ -105,6 +136,72 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
             siteID: order.siteID,
             orderID: order.orderID,
             parameters: parameters,
+            onCardReaderMessage: { event in
+                switch event {
+                case .waitingForInput(let inputMethods):
+                    onWaitingForInput(inputMethods)
+                case .displayMessage(let message):
+                    onDisplayMessage(message)
+                case .cardDetailsCollected, .cardRemovedAfterClientSidePaymentCapture:
+                    onProcessingMessage()
+                case .cardInserted:
+                    onCardInserted()
+                case .cardRemoved, .lowBattery, .lowBatteryResolved, .disconnected:
+                    DDLogInfo("💳 Unhandled card reader event received: \(event)")
+                }
+            },
+            onProcessingCompletion: { intent in
+                onProcessingCompletion(intent)
+            },
+            onCompletion: { [weak self] result in
+                self?.allowPassPresentation()
+                self?.completePaymentIntentCapture(
+                    order: order,
+                    captureResult: result,
+                    onCompletion: onCompletion
+                )
+            }
+        )
+
+        stores.dispatch(paymentAction)
+    }
+
+    func collectPOSPayment(for order: Order,
+                           orderTotal: NSDecimalNumber,
+                           paymentGatewayAccount: PaymentGatewayAccount,
+                           paymentMethodTypes: [PaymentMethodType],
+                           stripeSmallestCurrencyUnitMultiplier: Decimal,
+                           captureHandler: @escaping (String) async throws -> Void,
+                           onPreparingReader: @escaping () -> Void,
+                           onWaitingForInput: @escaping (CardReaderInput) -> Void,
+                           onCardInserted: @escaping () -> Void,
+                           onProcessingMessage: @escaping () -> Void,
+                           onDisplayMessage: @escaping (String) -> Void,
+                           onProcessingCompletion: @escaping (PaymentIntent) -> Void,
+                           onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> Void) {
+        handlersForActivePayment = PaymentHandlers(onPreparingReader: onPreparingReader,
+                                                   onWaitingForInput: onWaitingForInput,
+                                                   onCardInserted: onCardInserted,
+                                                   onProcessingMessage: onProcessingMessage,
+                                                   onDisplayMessage: onDisplayMessage,
+                                                   onProcessingCompletion: onProcessingCompletion)
+        onPreparingReader()
+
+        let parameters = paymentParameters(order: order,
+                                           orderTotal: orderTotal,
+                                           country: paymentGatewayAccount.country,
+                                           statementDescriptor: paymentGatewayAccount.statementDescriptor,
+                                           paymentMethodTypes: paymentMethodTypes,
+                                           stripeSmallestCurrencyUnitMultiplier: stripeSmallestCurrencyUnitMultiplier,
+                                           channel: .pos)
+
+        suppressPassPresentation()
+
+        let paymentAction = CardPresentPaymentAction.collectPOSPayment(
+            siteID: order.siteID,
+            orderID: order.orderID,
+            parameters: parameters,
+            captureHandler: captureHandler,
             onCardReaderMessage: { event in
                 switch event {
                 case .waitingForInput(let inputMethods):

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -92,6 +92,10 @@ where TapToPayAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
 
     private let receiptEligibilityUseCase: ReceiptEligibilityUseCaseProtocol
 
+    /// Optional capture handler for POS Store API payments.
+    /// When set, uses `collectPOSPayment` instead of `collectPayment`.
+    private let posCaptureHandler: ((String) async throws -> Void)?
+
     private var cancellables: Set<AnyCancellable> = []
 
     init(siteID: Int64,
@@ -107,7 +111,8 @@ where TapToPayAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
          bluetoothAlertsProvider: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
          preflightController: CardPresentPaymentPreflightControllerProtocol,
          analyticsTracker: CollectOrderPaymentAnalyticsTracking? = nil,
-         receiptEligibilityUseCase: ReceiptEligibilityUseCaseProtocol = ReceiptEligibilityUseCase()) {
+         receiptEligibilityUseCase: ReceiptEligibilityUseCaseProtocol = ReceiptEligibilityUseCase(),
+         posCaptureHandler: ((String) async throws -> Void)? = nil) {
         self.siteID = siteID
         self.order = order
         self.formattedAmount = formattedAmount
@@ -124,6 +129,7 @@ where TapToPayAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
                                                                                  configuration: configuration,
                                                                                  orderDurationRecorder: orderDurationRecorder)
         self.receiptEligibilityUseCase = receiptEligibilityUseCase
+        self.posCaptureHandler = posCaptureHandler
     }
 
     /// Starts the collect payment flow.
@@ -309,81 +315,116 @@ private extension CollectOrderPaymentUseCase {
                     return
                 }
 
-                // Start collect payment process
-                self.paymentOrchestrator.collectPayment(
-                    for: self.order,
-                    orderTotal: orderTotal,
-                    paymentGatewayAccount: paymentGatewayAccount,
-                    paymentMethodTypes: self.configuration.paymentMethods,
-                    stripeSmallestCurrencyUnitMultiplier: self.configuration.stripeSmallestCurrencyUnitMultiplier,
-                    channel: channel,
-                    onPreparingReader: { [weak self] in
-                        self?.alertsPresenter.present(viewModel: paymentAlerts.preparingReader(onCancel: {
-                            self?.cancelPayment(from: .paymentPreparingReader) {
-                                onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
-                            }
-                        }))
-                    },
-                    onWaitingForInput: { [weak self] inputMethods in
-                        guard let self = self else { return }
-                        self.alertsPresenter.present(
-                            viewModel: paymentAlerts.tapOrInsertCard(
-                                title: CollectOrderPaymentUseCaseDefinitions.Localization.collectPaymentTitle(
-                                    username: self.order.billingAddress?.firstName),
-                                amount: self.formattedAmount,
-                                inputMethods: inputMethods,
-                                onCancel: { [weak self] in
-                                    self?.cancelPayment(from: .paymentWaitingForInput) {
-                                        onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
-                                    }
-                                })
-                        )
-                    }, onCardInserted: { [weak self] in
-                        guard let self = self else { return }
-                        self.alertsPresenter.present(viewModel: paymentAlerts.cardInserted(
+                // Define common handlers
+                let onPreparingReader: () -> Void = { [weak self] in
+                    self?.alertsPresenter.present(viewModel: paymentAlerts.preparingReader(onCancel: {
+                        self?.cancelPayment(from: .paymentPreparingReader) {
+                            onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
+                        }
+                    }))
+                }
+
+                let onWaitingForInput: (CardReaderInput) -> Void = { [weak self] inputMethods in
+                    guard let self = self else { return }
+                    self.alertsPresenter.present(
+                        viewModel: paymentAlerts.tapOrInsertCard(
                             title: CollectOrderPaymentUseCaseDefinitions.Localization.collectPaymentTitle(
                                 username: self.order.billingAddress?.firstName),
                             amount: self.formattedAmount,
+                            inputMethods: inputMethods,
                             onCancel: { [weak self] in
                                 self?.cancelPayment(from: .paymentWaitingForInput) {
                                     onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
                                 }
                             })
-                        )
-                    }, onProcessingMessage: { [weak self] in
-                        guard let self = self else { return }
-                        // Waiting message
-                        self.alertsPresenter.present(
-                            viewModel: paymentAlerts.processingTransaction(
-                                title: CollectOrderPaymentUseCaseDefinitions.Localization.processingPaymentTitle(
-                                    username: self.order.billingAddress?.firstName)))
-                    }, onDisplayMessage: { [weak self] message in
-                        guard let self = self else { return }
-                        // Reader messages. EG: Remove Card
-                        self.alertsPresenter.present(viewModel: paymentAlerts.displayReaderMessage(message: message))
-                    }, onProcessingCompletion: { [weak self] intent in
-                        self?.analyticsTracker.trackProcessingCompletion(intent: intent)
-                        self?.markOrderAsPaidIfNeeded(intent: intent)
-                    }, onCompletion: { [weak self] result in
-                        switch result {
-                        case .success(let capturedPaymentData):
-                            self?.handleSuccessfulPayment(capturedPaymentData: capturedPaymentData)
-                            onCompletion(.success(capturedPaymentData))
-                        case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelled(let cancellationSource))):
-                            switch cancellationSource {
-                            case .reader:
-                                self?.handlePaymentCancellationFromReader(alertProvider: paymentAlerts)
-                            default:
-                                self?.handlePaymentCancellation(from: .other)
+                    )
+                }
+
+                let onCardInserted: () -> Void = { [weak self] in
+                    guard let self = self else { return }
+                    self.alertsPresenter.present(viewModel: paymentAlerts.cardInserted(
+                        title: CollectOrderPaymentUseCaseDefinitions.Localization.collectPaymentTitle(
+                            username: self.order.billingAddress?.firstName),
+                        amount: self.formattedAmount,
+                        onCancel: { [weak self] in
+                            self?.cancelPayment(from: .paymentWaitingForInput) {
+                                onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
                             }
-                        case .failure(let error):
-                            self?.checkThenHandlePaymentFailureAndRetryPayment(error,
-                                                                               alertProvider: paymentAlerts,
-                                                                               paymentGatewayAccount: paymentGatewayAccount,
-                                                                               channel: channel,
-                                                                               onCompletion: onCompletion)
+                        })
+                    )
+                }
+
+                let onProcessingMessage: () -> Void = { [weak self] in
+                    guard let self = self else { return }
+                    self.alertsPresenter.present(
+                        viewModel: paymentAlerts.processingTransaction(
+                            title: CollectOrderPaymentUseCaseDefinitions.Localization.processingPaymentTitle(
+                                username: self.order.billingAddress?.firstName)))
+                }
+
+                let onDisplayMessage: (String) -> Void = { [weak self] message in
+                    guard let self = self else { return }
+                    self.alertsPresenter.present(viewModel: paymentAlerts.displayReaderMessage(message: message))
+                }
+
+                let onProcessingCompletion: (PaymentIntent) -> Void = { [weak self] intent in
+                    self?.analyticsTracker.trackProcessingCompletion(intent: intent)
+                    self?.markOrderAsPaidIfNeeded(intent: intent)
+                }
+
+                let onPaymentCompletion: (Result<CardPresentCapturedPaymentData, Error>) -> Void = { [weak self] result in
+                    switch result {
+                    case .success(let capturedPaymentData):
+                        self?.handleSuccessfulPayment(capturedPaymentData: capturedPaymentData)
+                        onCompletion(.success(capturedPaymentData))
+                    case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelled(let cancellationSource))):
+                        switch cancellationSource {
+                        case .reader:
+                            self?.handlePaymentCancellationFromReader(alertProvider: paymentAlerts)
+                        default:
+                            self?.handlePaymentCancellation(from: .other)
                         }
-                    })
+                    case .failure(let error):
+                        self?.checkThenHandlePaymentFailureAndRetryPayment(error,
+                                                                           alertProvider: paymentAlerts,
+                                                                           paymentGatewayAccount: paymentGatewayAccount,
+                                                                           channel: channel,
+                                                                           onCompletion: onCompletion)
+                    }
+                }
+
+                // Start collect payment process - use POS capture if handler is provided
+                if let captureHandler = self.posCaptureHandler {
+                    self.paymentOrchestrator.collectPOSPayment(
+                        for: self.order,
+                        orderTotal: orderTotal,
+                        paymentGatewayAccount: paymentGatewayAccount,
+                        paymentMethodTypes: self.configuration.paymentMethods,
+                        stripeSmallestCurrencyUnitMultiplier: self.configuration.stripeSmallestCurrencyUnitMultiplier,
+                        captureHandler: captureHandler,
+                        onPreparingReader: onPreparingReader,
+                        onWaitingForInput: onWaitingForInput,
+                        onCardInserted: onCardInserted,
+                        onProcessingMessage: onProcessingMessage,
+                        onDisplayMessage: onDisplayMessage,
+                        onProcessingCompletion: onProcessingCompletion,
+                        onCompletion: onPaymentCompletion)
+                } else {
+                    self.paymentOrchestrator.collectPayment(
+                        for: self.order,
+                        orderTotal: orderTotal,
+                        paymentGatewayAccount: paymentGatewayAccount,
+                        paymentMethodTypes: self.configuration.paymentMethods,
+                        stripeSmallestCurrencyUnitMultiplier: self.configuration.stripeSmallestCurrencyUnitMultiplier,
+                        channel: channel,
+                        onPreparingReader: onPreparingReader,
+                        onWaitingForInput: onWaitingForInput,
+                        onCardInserted: onCardInserted,
+                        onProcessingMessage: onProcessingMessage,
+                        onDisplayMessage: onDisplayMessage,
+                        onProcessingCompletion: onProcessingCompletion,
+                        onCompletion: onPaymentCompletion)
+                }
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/Mocks/MockPaymentCaptureOrchestrator.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPaymentCaptureOrchestrator.swift
@@ -46,6 +46,23 @@ final class MockPaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
                                    onCompletion)
     }
 
+    var spyDidCallCollectPOSPayment = false
+    func collectPOSPayment(for order: Order,
+                           orderTotal: NSDecimalNumber,
+                           paymentGatewayAccount: PaymentGatewayAccount,
+                           paymentMethodTypes: [PaymentMethodType],
+                           stripeSmallestCurrencyUnitMultiplier: Decimal,
+                           captureHandler: @escaping (String) async throws -> Void,
+                           onPreparingReader: @escaping () -> Void,
+                           onWaitingForInput: @escaping (CardReaderInput) -> Void,
+                           onCardInserted: @escaping () -> Void,
+                           onProcessingMessage: @escaping () -> Void,
+                           onDisplayMessage: @escaping (String) -> Void,
+                           onProcessingCompletion: @escaping (PaymentIntent) -> Void,
+                           onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> Void) {
+        spyDidCallCollectPOSPayment = true
+    }
+
     var spyDidCallRetryPayment = false
     func retryPayment(for order: Yosemite.Order,
                       onCompletion: @escaping (Result<WooCommerce.CardPresentCapturedPaymentData, Error>) -> Void) {


### PR DESCRIPTION
This is a HACK week project and should not be merged.

It updates POS to use the Store API for order creation and payment. This provides fulfillment of downloadable products and gift cards (from the WooCommerce [first party plugin](https://woocommerce.com/products/gift-cards/).)

This only works with site credentials login, and with Local Catalog switched off.

To test, set up a site with WooCommerce at this PR: https://github.com/woocommerce/woocommerce/pull/62455 and WooPayments testing configured.