### PR TITLE
[CIAB] Booking details events

### DIFF
--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -1063,6 +1063,7 @@ public enum WooAnalyticsStat: String {
     case bookingCancelled = "booking_detail_cancel_booking"
     case bookingAttenceStatusUpdated = "booking_detail_attendance_status_updated"
     case bookingAddNoteTapped = "booking_detail_add_note_tapped"
+    case bookingMarkAsPaidTapped = "booking_detail_mark_as_paid_tapped"
 
     // MARK: Hub Menu
     //

--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -1064,6 +1064,8 @@ public enum WooAnalyticsStat: String {
     case bookingAttenceStatusUpdated = "booking_detail_attendance_status_updated"
     case bookingAddNoteTapped = "booking_detail_add_note_tapped"
     case bookingMarkAsPaidTapped = "booking_detail_mark_as_paid_tapped"
+//    case bookingRefundTapped = "booking_detail_refund_tapped"
+    case bookingViewLinkedOrderTapped = "booking_detail_view_linked_order_tapped"
 
     // MARK: Hub Menu
     //

--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -1064,7 +1064,6 @@ public enum WooAnalyticsStat: String {
     case bookingAttenceStatusUpdated = "booking_detail_attendance_status_updated"
     case bookingAddNoteTapped = "booking_detail_add_note_tapped"
     case bookingMarkAsPaidTapped = "booking_detail_mark_as_paid_tapped"
-//    case bookingRefundTapped = "booking_detail_refund_tapped"
     case bookingViewLinkedOrderTapped = "booking_detail_view_linked_order_tapped"
 
     // MARK: Hub Menu

--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -1061,6 +1061,7 @@ public enum WooAnalyticsStat: String {
     case bookingsSelected = "main_tab_bookings_selected"
     case bookingsReselected = "main_tab_bookings_reselected"
     case bookingCancelled = "booking_detail_cancel_booking"
+    case bookingAttenceStatusUpdated = "booking_detail_attendance_status_updated"
 
     // MARK: Hub Menu
     //

--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -1060,6 +1060,7 @@ public enum WooAnalyticsStat: String {
     // MARK: - Bookings
     case bookingsSelected = "main_tab_bookings_selected"
     case bookingsReselected = "main_tab_bookings_reselected"
+    case bookingCancelled = "booking_detail_cancel_booking"
 
     // MARK: Hub Menu
     //

--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -1062,6 +1062,7 @@ public enum WooAnalyticsStat: String {
     case bookingsReselected = "main_tab_bookings_reselected"
     case bookingCancelled = "booking_detail_cancel_booking"
     case bookingAttenceStatusUpdated = "booking_detail_attendance_status_updated"
+    case bookingAddNoteTapped = "booking_detail_add_note_tapped"
 
     // MARK: Hub Menu
     //

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -198,6 +198,12 @@ private extension Analytics {
         updatedProperties[PropertyKeys.planKey] = site?.plan
         updatedProperties[PropertyKeys.siteURL] = site?.url
         updatedProperties[PropertyKeys.storeID] = ServiceLocator.stores.sessionManager.defaultStoreUUID
+        if let site {
+            updatedProperties[PropertyKeys.isCIAB] = ServiceLocator.ciabEligibilityChecker.isSiteCIAB(site)
+            if let gardenPartner = site.gardenPartner {
+                updatedProperties[PropertyKeys.gardenPartner] = gardenPartner
+            }
+        }
         return updatedProperties
     }
 
@@ -337,4 +343,6 @@ private enum PropertyKeys {
     static let planKey              = "plan"
     static let siteURL              = "site_url"
     static let storeID              = "store_id"
+    static let isCIAB               = "is_ciab"
+    static let gardenPartner        = "garden_partner"
 }

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -25,6 +25,8 @@ final class ServiceLocator {
     ///
     private static var _authenticationManager: Authentication = AuthenticationManager()
 
+    private static var _ciabEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker()
+
     /// FeatureFlagService
     ///
     private static var _featureFlagService: FeatureFlagService = DefaultFeatureFlagService()
@@ -164,6 +166,10 @@ final class ServiceLocator {
     /// - Returns: An implementation of the AuthenticationManager protocol. It defaults to DefaultAuthenticationManager
     static var authenticationManager: Authentication {
         return _authenticationManager
+    }
+
+    static var ciabEligibilityChecker: CIABEligibilityCheckerProtocol {
+        return _ciabEligibilityChecker
     }
 
     /// Shipping Settings

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
@@ -16,6 +16,10 @@ extension WooAnalyticsEvent {
         static func bookingAddNoteTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .bookingAddNoteTapped)
         }
+
+        static func bookingMarkAsPaidTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .bookingMarkAsPaidTapped)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
@@ -20,6 +20,14 @@ extension WooAnalyticsEvent {
         static func bookingMarkAsPaidTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .bookingMarkAsPaidTapped)
         }
+
+//        static func bookingRefundTapped() -> WooAnalyticsEvent {
+//            WooAnalyticsEvent(statName: .bookingRefundTapped)
+//        }
+
+        static func bookingViewLinkedOrderTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .bookingViewLinkedOrderTapped)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
@@ -21,10 +21,6 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .bookingMarkAsPaidTapped)
         }
 
-//        static func bookingRefundTapped() -> WooAnalyticsEvent {
-//            WooAnalyticsEvent(statName: .bookingRefundTapped)
-//        }
-
         static func bookingViewLinkedOrderTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .bookingViewLinkedOrderTapped)
         }

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
@@ -1,7 +1,22 @@
+import enum Networking.BookingAttendanceStatus
+
 extension WooAnalyticsEvent {
     enum BookingsDetail {
         static func bookingCancelled() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .bookingCancelled)
         }
+
+        static func bookingAttenceStatusUpdated(status: BookingAttendanceStatus) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(
+                statName: .bookingAttenceStatusUpdated,
+                properties: [Properties.bookingStatus: status.rawValue]
+            )
+        }
+    }
+}
+
+fileprivate extension WooAnalyticsEvent.BookingsDetail {
+    enum Properties {
+        static let bookingStatus = "booking_status"
     }
 }

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
@@ -1,0 +1,7 @@
+extension WooAnalyticsEvent {
+    enum BookingsDetail {
+        static func bookingCancelled() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .bookingCancelled)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
@@ -12,6 +12,10 @@ extension WooAnalyticsEvent {
                 properties: [Properties.bookingStatus: status.rawValue]
             )
         }
+
+        static func bookingAddNoteTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .bookingAddNoteTapped)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -256,6 +256,7 @@ extension BookingDetailsViewModel {
             }
         }
         stores.dispatch(action)
+        analytics.track(event: .BookingsDetail.bookingAttenceStatusUpdated(status: newStatus))
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -439,6 +439,7 @@ extension BookingDetailsViewModel {
 
 extension BookingDetailsViewModel {
     func navigateToOrderDetails() {
+        analytics.track(event: .BookingsDetail.bookingViewLinkedOrderTapped())
         MainTabBarController.navigateToOrderDetails(with: booking.orderID, siteID: booking.siteID)
     }
 }

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -350,6 +350,7 @@ extension BookingDetailsViewModel {
 
     @MainActor
     func markBookingAsPaid() async throws {
+        analytics.track(event: .BookingsDetail.bookingMarkAsPaidTapped())
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             stores.dispatch(BookingAction.markBookingAsPaid(siteID: booking.siteID, bookingID: booking.bookingID) { error in
                 if let error {

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Yosemite
 import protocol Storage.StorageManagerType
+import protocol WooFoundation.Analytics
 import SwiftUI
 
 final class BookingDetailsViewModel: ObservableObject {
@@ -19,6 +20,7 @@ final class BookingDetailsViewModel: ObservableObject {
     private let attendanceContent = AttendanceContent()
     private let paymentContent = PaymentContent()
     private let notesContent = NotesContent()
+    private let analytics: Analytics
 
     // EntityListener: Update / Deletion Notifications.
     ///
@@ -37,9 +39,11 @@ final class BookingDetailsViewModel: ObservableObject {
 
     init(booking: Booking,
          stores: StoresManager = ServiceLocator.stores,
-         storage: StorageManagerType = ServiceLocator.storageManager) {
+         storage: StorageManagerType = ServiceLocator.storageManager,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.booking = booking
         self.stores = stores
+        self.analytics = analytics
         self.bookingResource = storage.viewStorage.loadBookingResource(
             siteID: booking.siteID,
             resourceID: booking.resourceID
@@ -309,11 +313,12 @@ extension BookingDetailsViewModel {
     @MainActor
     func cancelBooking() async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            stores.dispatch(BookingAction.cancelBooking(siteID: booking.siteID, bookingID: booking.bookingID) { error in
+            stores.dispatch(BookingAction.cancelBooking(siteID: booking.siteID, bookingID: booking.bookingID) { [analytics] error in
                 if let error {
                     continuation.resume(throwing: error)
                 } else {
                     continuation.resume(returning: ())
+                    analytics.track(event: .BookingsDetail.bookingCancelled())
                 }
             })
         }

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -259,6 +259,10 @@ extension BookingDetailsViewModel {
         analytics.track(event: .BookingsDetail.bookingAttenceStatusUpdated(status: newStatus))
     }
 
+    func notesTapped() {
+        analytics.track(event: .BookingsDetail.bookingAddNoteTapped())
+    }
+
     @MainActor
     func updateNote(to newNote: String) async -> MultilineCommitResult {
         await withCheckedContinuation { continuation in

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -160,9 +160,12 @@ private extension BookingDetailsView {
         case .payment(let content):
             paymentDetailsView(with: content)
         case .bookingNotes(let content):
-            BookingNotesRowView(content: content) { newNote in
+            BookingNotesRowView(content: content) {
+                viewModel.notesTapped()
+            } onCommit: { newNote in
                 await viewModel.updateNote(to: newNote)
             }
+
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingNotesRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingNotesRowView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct BookingNotesRowView: View {
     @ObservedObject var content: BookingDetailsViewModel.NotesContent
+    let onTap: (() -> Void)?
     let onCommit: (String) async -> MultilineCommitResult
 
     var body: some View {
@@ -9,6 +10,7 @@ struct BookingNotesRowView: View {
             value: $content.value,
             placeholder: BookingDetailsView.Localization.bookingNotesRowText,
             detailTitle: BookingDetailsView.Localization.bookingNoteNavbarText,
+            onTap: onTap,
             onCommit: onCommit
         )
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultilineEditableTextRow/MultilineEditableTextRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultilineEditableTextRow/MultilineEditableTextRow.swift
@@ -4,16 +4,19 @@ struct MultilineEditableTextRow: View {
     @Binding var value: String
     let placeholder: String
     let detailTitle: String?
+    let onTap: (() -> Void)?
     let onCommit: (String) async -> MultilineCommitResult
 
     init(value: Binding<String>,
          placeholder: String,
          detailTitle: String? = nil,
+         onTap: (() -> Void)? = nil,
          onCommit: @escaping (String) async -> MultilineCommitResult
     ) {
         self._value = value
         self.placeholder = placeholder
         self.detailTitle = detailTitle
+        self.onTap = onTap
         self.onCommit = onCommit
     }
 
@@ -23,6 +26,9 @@ struct MultilineEditableTextRow: View {
         } label: {
             content
         }
+        .simultaneousGesture(TapGesture().onEnded {
+            onTap?()
+        })
     }
 
     @ViewBuilder
@@ -35,6 +41,7 @@ struct MultilineEditableTextRow: View {
             DisclosureIndicator()
         }
         .padding(.vertical, Layout.padding)
+        .contentShape(Rectangle())
     }
 
     @ViewBuilder

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1344,6 +1344,7 @@
 		647C05FD2ED5E1C000E5FF3F /* BookingNotesRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647C05FC2ED5E1C000E5FF3F /* BookingNotesRowView.swift */; };
 		6489DFFF2EA78E0D00D96802 /* MockProductDetailCoordinatorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6489DFFE2EA78E0D00D96802 /* MockProductDetailCoordinatorFactory.swift */; };
 		6489E0012EA78E2D00D96802 /* MockProductDetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6489E0002EA78E2D00D96802 /* MockProductDetailCoordinator.swift */; };
+		6497C0D42EF14F1F00DA63F1 /* BookingDetailsViewModel+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6497C0D32EF14F1300DA63F1 /* BookingDetailsViewModel+Analytics.swift */; };
 		64D355A52E99048E005F53F7 /* TestingSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D355A42E99048E005F53F7 /* TestingSceneDelegate.swift */; };
 		68051E1E2E9DFE5500228196 /* POSNotificationSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68051E1D2E9DFE5100228196 /* POSNotificationSchedulerTests.swift */; };
 		680E36B52BD8B9B900E8BCEA /* OrderSubscriptionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 680E36B42BD8B9B900E8BCEA /* OrderSubscriptionTableViewCell.xib */; };
@@ -4242,6 +4243,7 @@
 		647C05FC2ED5E1C000E5FF3F /* BookingNotesRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingNotesRowView.swift; sourceTree = "<group>"; };
 		6489DFFE2EA78E0D00D96802 /* MockProductDetailCoordinatorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductDetailCoordinatorFactory.swift; sourceTree = "<group>"; };
 		6489E0002EA78E2D00D96802 /* MockProductDetailCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductDetailCoordinator.swift; sourceTree = "<group>"; };
+		6497C0D32EF14F1300DA63F1 /* BookingDetailsViewModel+Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BookingDetailsViewModel+Analytics.swift"; sourceTree = "<group>"; };
 		64D355A42E99048E005F53F7 /* TestingSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingSceneDelegate.swift; sourceTree = "<group>"; };
 		68051E1D2E9DFE5100228196 /* POSNotificationSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSNotificationSchedulerTests.swift; sourceTree = "<group>"; };
 		680BA5992A4C377900F5559D /* UpgradeViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradeViewState.swift; sourceTree = "<group>"; };
@@ -7924,6 +7926,7 @@
 		2DAC251E2E829FF9008521AF /* Booking Details */ = {
 			isa = PBXGroup;
 			children = (
+				6497C0D32EF14F1300DA63F1 /* BookingDetailsViewModel+Analytics.swift */,
 				647C05FA2ED5D9E200E5FF3F /* NotesContent.swift */,
 				2D05E8122E8AADB2004111FD /* PaymentContent.swift */,
 				2D05E8102E8A98FE004111FD /* CustomerContent.swift */,
@@ -15257,6 +15260,7 @@
 				DEA90D352C8EE55D0021ABC3 /* UserDefaults+BlazeCampaignObjective.swift in Sources */,
 				DE279BA626E9C582002BA963 /* ShippingLabelPackagesFormViewModel.swift in Sources */,
 				02038C582AF0D0F400CD36D9 /* ConfigurableVariableBundleAttributePicker.swift in Sources */,
+				6497C0D42EF14F1F00DA63F1 /* BookingDetailsViewModel+Analytics.swift in Sources */,
 				02B1AA6729A4709400D54FCB /* FilterTabBar.swift in Sources */,
 				CECC758C23D2227000486676 /* ProductDetailsCellViewModel.swift in Sources */,
 				DE58D0062D8A9F45005914DF /* SiteNotificationSettingsView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
@@ -2,6 +2,7 @@ import Foundation
 import protocol WooFoundation.AnalyticsProvider
 @testable import WooCommerce
 @testable import WordPressShared
+import XCTest
 
 public class MockAnalyticsProvider: NSObject, AnalyticsProvider, WPAnalyticsTracker {
     var receivedEvents = [String]()
@@ -76,5 +77,33 @@ extension MockAnalyticsProvider {
         static let propertyKeyTimeInApp = "time_in_app"
         static let blogIDKey = "blog_id"
         static let wpcomStoreKey = "is_wpcom_store"
+    }
+}
+
+// MARK: - Helper
+extension MockAnalyticsProvider {
+    func assertReceived(
+        event: String,
+        with expectedProperties: [String: Any],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let index = receivedEvents.firstIndex(of: event) else {
+            XCTFail("Expected analytics event not received: \(event)", file: file, line: line)
+            return
+        }
+
+        let properties = receivedProperties[index]
+
+        for (key, expectedValue) in expectedProperties {
+            let actualValue = properties[key] as Any?
+            XCTAssertEqual(
+                actualValue as? NSObject,
+                expectedValue as? NSObject,
+                "Mismatch for analytics property '\(key)'",
+                file: file,
+                line: line
+            )
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
@@ -84,7 +84,7 @@ extension MockAnalyticsProvider {
 extension MockAnalyticsProvider {
     func assertReceived(
         event: String,
-        with expectedProperties: [String: Any],
+        with expectedProperties: [String: Any] = [:],
         file: StaticString = #filePath,
         line: UInt = #line
     ) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
@@ -9,17 +9,23 @@ import Fakes
 final class BookingDetailsViewModelTests: XCTestCase {
     private var storesManager: MockStoresManager!
     private var storageManager: MockStorageManager!
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
 
     override func setUp() {
         super.setUp()
         storesManager = MockStoresManager(sessionManager: .makeForTesting())
         storageManager = MockStorageManager()
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
     }
 
     override func tearDown() {
         super.tearDown()
         storesManager = nil
         storageManager = nil
+        analytics = nil
+        analyticsProvider = nil
     }
 
     func test_setupSections_populates_all_sections_with_complete_booking() {
@@ -57,7 +63,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
         let booking = Booking.fake().copy(orderInfo: orderInfo)
 
         // When
-        let viewModel = BookingDetailsViewModel(booking: booking, stores: storesManager)
+        let viewModel = givenViewModel(booking: booking)
 
         // Then
         XCTAssertEqual(viewModel.sections.count, 6)
@@ -111,7 +117,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
         let booking = Booking.fake().copy(orderInfo: orderInfo)
 
         // When
-        let viewModel = BookingDetailsViewModel(booking: booking, stores: storesManager)
+        let viewModel = givenViewModel(booking: booking)
 
         // Then
         XCTAssertEqual(viewModel.sections.count, 5)
@@ -143,7 +149,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
         let booking = Booking.fake().copy(orderInfo: orderInfo)
 
         // When
-        let viewModel = BookingDetailsViewModel(booking: booking, stores: storesManager)
+        let viewModel = givenViewModel(booking: booking)
 
         // Then
         let headerSection = viewModel.sections.first { section in
@@ -187,7 +193,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
         let booking = Booking.fake().copy(orderInfo: orderInfo)
 
         // When
-        let viewModel = BookingDetailsViewModel(booking: booking, stores: storesManager)
+        let viewModel = givenViewModel(booking: booking)
 
         // Then
         let customerSection = viewModel.sections.first { section in
@@ -233,7 +239,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
         let booking = Booking.fake().copy(orderInfo: orderInfo)
 
         // When
-        let viewModel = BookingDetailsViewModel(booking: booking, stores: storesManager)
+        let viewModel = givenViewModel(booking: booking)
 
         // Then
         let customerSection = viewModel.sections.first { section in
@@ -257,16 +263,16 @@ final class BookingDetailsViewModelTests: XCTestCase {
         let booking = Booking.fake().copy(bookingID: 12345)
 
         // When
-        let viewModel = BookingDetailsViewModel(booking: booking, stores: storesManager)
+        let viewModel = givenViewModel(booking: booking)
 
         // Then
         XCTAssertTrue(viewModel.navigationTitle.contains("12345"))
     }
 
-    func test_updateAttendanceStatus_whenNewStatusIsProvided_dispatchesUpdateBookingAttendanceStatusAction() {
+    func test_updateAttendanceStatus_whenNewStatusIsProvided_dispatchesUpdateBookingAttendanceStatusAction() throws {
         // Given
         let booking = Booking.fake()
-        let viewModel = BookingDetailsViewModel(booking: booking, stores: storesManager)
+        let viewModel = givenViewModel(booking: booking)
         let newStatus = BookingAttendanceStatus.checkedIn
 
         // When
@@ -287,12 +293,15 @@ final class BookingDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(siteID, booking.siteID)
         XCTAssertEqual(bookingID, booking.bookingID)
         XCTAssertEqual(status, newStatus)
+
+        analyticsProvider.assertReceived(event: "booking_detail_attendance_status_updated",
+                                         with: ["booking_status": "checked-in"])
     }
 
     func test_error_notice_displayed_when_attendance_staus_update_fails() {
         // Given
         let booking = Booking.fake()
-        let viewModel = BookingDetailsViewModel(booking: booking, stores: storesManager)
+        let viewModel = givenViewModel(booking: booking)
         let newStatus = BookingAttendanceStatus.checkedIn
         enum TestError: Error { case generic }
 
@@ -333,7 +342,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
         )
 
         // When
-        let viewModel = BookingDetailsViewModel(booking: booking, stores: storesManager)
+        let viewModel = givenViewModel(booking: booking)
 
         // Then
         let headerSection = viewModel.sections.first { section in
@@ -358,7 +367,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
         )
 
         // When
-        let viewModel = BookingDetailsViewModel(booking: booking, stores: storesManager)
+        let viewModel = givenViewModel(booking: booking)
 
         // Then
         let attendanceSection = viewModel.sections.first { section in
@@ -385,7 +394,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
         )
 
         // When
-        let viewModel = BookingDetailsViewModel(booking: booking, stores: storesManager)
+        let viewModel = givenViewModel(booking: booking)
 
         // Then
         let containsAttendanceSection = viewModel.sections.contains { section in
@@ -405,7 +414,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
         )
 
         // When
-        let viewModel = BookingDetailsViewModel(booking: booking, stores: storesManager)
+        let viewModel = givenViewModel(booking: booking)
 
         // Then
         let paymentSection = viewModel.sections.first { section in
@@ -423,5 +432,11 @@ final class BookingDetailsViewModelTests: XCTestCase {
 
         XCTAssertFalse(viewModel.isViewOrderAvailable)
         XCTAssertFalse(paymentContent.actions.contains(.viewOrder))
+    }
+}
+
+private extension BookingDetailsViewModelTests {
+    func givenViewModel(booking: Booking) -> BookingDetailsViewModel {
+        return BookingDetailsViewModel(booking: booking, stores: storesManager, analytics: analytics)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
@@ -433,10 +433,75 @@ final class BookingDetailsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isViewOrderAvailable)
         XCTAssertFalse(paymentContent.actions.contains(.viewOrder))
     }
+
+    func test_event_fired_when_booking_marked_as_paid() async throws {
+        // Given
+        let viewModel = givenViewModel()
+
+        // When
+        let task = Task { try await viewModel.markBookingAsPaid() }
+        let action = try await waitForFirstBookingAction()
+        guard case let .markBookingAsPaid(_, _, onCompletion) = action else {
+            return XCTFail("Expected markBookingAsPaid action")
+        }
+        onCompletion(nil)
+        try await task.value
+
+        // Then
+        analyticsProvider.assertReceived(event: "booking_detail_mark_as_paid_tapped")
+    }
+
+    func test_event_fired_when_booking_cancelled() async throws {
+        // Given
+        let viewModel = givenViewModel()
+
+        // When
+        let task = Task { try await viewModel.cancelBooking() }
+        let action = try await waitForFirstBookingAction()
+        guard case let .cancelBooking(_, _, onCompletion) = action else {
+            return XCTFail("Expected cancelBooking action")
+        }
+        onCompletion(nil)
+        try await task.value
+
+        // Then
+        analyticsProvider.assertReceived(event: "booking_detail_cancel_booking")
+    }
+
+    func test_event_fired_when_notes_tapped() {
+        // Given
+        let viewModel = givenViewModel()
+
+        // When
+        viewModel.notesTapped()
+
+        // Then
+        analyticsProvider.assertReceived(event: "booking_detail_add_note_tapped")
+    }
+
+
 }
 
 private extension BookingDetailsViewModelTests {
-    func givenViewModel(booking: Booking) -> BookingDetailsViewModel {
+    func givenViewModel(booking: Booking = Booking.fake()) -> BookingDetailsViewModel {
         return BookingDetailsViewModel(booking: booking, stores: storesManager, analytics: analytics)
+    }
+
+    func waitForFirstBookingAction(
+        timeout: TimeInterval = 1,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws -> BookingAction {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            if let action = storesManager.receivedActions.first as? BookingAction {
+                return action
+            }
+            await Task.yield()
+        }
+
+        XCTFail("Timed out waiting for BookingAction to be dispatched", file: file, line: line)
+        throw XCTSkip("No BookingAction dispatched")
     }
 }


### PR DESCRIPTION
Closes: [WOOMOB-1884](https://linear.app/a8c/issue/WOOMOB-1884), [WOOMOB-1882](https://linear.app/a8c/issue/WOOMOB-1882)

## Description
The PR adds the `is_ciab` and `garden_partner` general properties to every analytics events.

It also adds the following tracking events:

Event | Trigger | Properties
-- | -- | --
woocommerceios_booking_detail_cancel_booking | Booking details: booking is cancelled |  
woocommerceios_booking_detail_attendance_status_updated | Booking details: booking status is updated | booking_status : booked \| checked-in \| no-show
woocommerceios_booking_detail_add_note_tapped | Booking details, taps on add now |  
woocommerceios_booking_detail_mark_as_paid_tapped | Booking detail, taps on marks as paid button |  
woocommerceios_booking_detail_view_linked_order_tapped | Booking details: action to view order |  

The ticket also specifies adding `woocommerceios_booking_detail_refund_tapped` but there is no decision yet if that is actually needed.

## Test Steps
The most straightforward approach is to check out the branch locally and validate that events are firing by monitoring the debug console in Xcode while the app is running.

Validate that trackgs events now contains the `is_ciab` and `garden_partner` properties.

Fired | When
-- | --
woocommerceios_booking_detail_cancel_booking | Accepting the alert to cancel a booking
woocommerceios_booking_detail_attendance_status_updated | Changing the status of a booking <br> Also validate the status property
woocommerceios_booking_detail_add_note_tapped | Tapping add note regardless if the note is empty or not
woocommerceios_booking_detail_mark_as_paid_tapped | Marking a booking as paid
woocommerceios_booking_detail_view_linked_order_tapped | Tapping "View order" on the booking details

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
