### PR TITLE
[Woo POS] Remove local non-downloadable variation filtering, rely only in API

### DIFF
--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemService.swift
@@ -48,8 +48,7 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
             let pagedVariations = try await fetchStrategy.fetchVariations(parentProductID: parentProduct.productID,
                                                                           pageNumber: pageNumber)
             let variations = pagedVariations.items
-            // Remove this when WC version 9.7 has significant adoption in POS stores.
-                .filter { !$0.downloadable }
+
             return .init(
                 items: itemMapper.mapVariationsToPOSItems(variations: variations, parentProduct: parentProduct),
                 hasMorePages: pagedVariations.hasMorePages,


### PR DESCRIPTION
Closes WOOMOB-1706

## Description

This PR removes the local filtering for non-downloadable variations for POS, as [from Woo 9.7](https://github.com/woocommerce/woocommerce-ios/pull/14893) we filter these through the API by passing `downloadable: false` to remotes like `ProductVariationsRemote.loadVariationsForPointOfSale`

With this we avoid potential pagination issues.


## Test Steps
- On a site with Woo 9.7+, in any of your variable products, make a downloadable variation

<img width="1140" height="445" alt="Screenshot 2025-12-17 at 15 14 13" src="https://github.com/user-attachments/assets/44ac86c7-3387-4fa1-9e8c-f8696e2cd454" />

- Save changes, load POS, look for the variation and open them in POS
- Note only non-downloadable variations appear. Marking any variation as downloadable will make them disappear from the item list (you may need a pull to refresh and/or reload the local catalog here)

| Downloadable | Non-downloadable |
|--------|--------|
| <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-12-17 at 15 18 11" src="https://github.com/user-attachments/assets/899ecc3b-820a-49c4-bdfb-b5029b3917bb" /> | <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2025-12-17 at 15 17 00" src="https://github.com/user-attachments/assets/ca5926a8-3d75-4149-aa53-ba3d35cd6c5f" /> | 

