### PR TITLE
[Woo POS][App Listings] Add app name meta to `update_app_store_strings` lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1109,6 +1109,7 @@ platform :ios do
     files = {
 
       # Metadata fields
+      'app_store_name' => { desc: 'name.txt' },
       'app_store_desc' => { desc: 'description.txt' },
       'app_store_keywords' => { desc: 'keywords.txt' },
       'app_store_subtitle' => { desc: 'subtitle.txt' },

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -333,6 +333,7 @@ platform :ios do
 
     files = {
       whats_new: RELEASE_NOTES_PATH,
+      app_store_name: File.join(source_metadata_folder, 'name.txt'),
       app_store_subtitle: File.join(source_metadata_folder, 'subtitle.txt'),
       app_store_desc: File.join(source_metadata_folder, 'description.txt'),
       app_store_keywords: File.join(source_metadata_folder, 'keywords.txt'),

--- a/fastlane/appstoreres/metadata/source/name.txt
+++ b/fastlane/appstoreres/metadata/source/name.txt
@@ -1,0 +1,1 @@
+WooCommerce: Store & POS


### PR DESCRIPTION
Closes WOOMOB-1886

## Description
This PR addresses the app title not being localized in the app store, but using the default `en-US` language instead. This happens due the app name string not being uploaded to GlotPress during the code freeze and localization process, so it does not appear for translators on https://translate.wordpress.com/projects/woocommerce/woocommerce-ios/release-notes/

<img width="365" height="729" alt="Screenshot 2025-12-19 at 09 42 35" src="https://github.com/user-attachments/assets/e981d923-6915-4997-a1ee-a31ae4838066" />

## Test Steps
TBD

## Screenshots
N/A

