### PR TITLE
Fix keyboard scrolling product title

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,10 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 
+24.0
+-----
+- [*] Fixed an issue that could cause the keyboard to cover the product title when edited [https://github.com/woocommerce/woocommerce-ios/pull/16470]
+
 23.9
 -----
 - [*] Show specific error when a variation is missing at POS checkout via WPCom login [https://github.com/woocommerce/woocommerce-ios/pull/16430]

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -14,13 +14,6 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     @IBOutlet private weak var tableView: UITableView!
     @IBOutlet private weak var moreDetailsContainerView: UIView!
 
-    private lazy var keyboardFrameObserver: KeyboardFrameObserver = {
-        let keyboardFrameObserver = KeyboardFrameObserver { [weak self] keyboardFrame in
-            self?.handleKeyboardFrameUpdate(keyboardFrame: keyboardFrame)
-        }
-        return keyboardFrameObserver
-    }()
-
     private let viewModel: ViewModel
     private let eventLogger: ProductFormEventLoggerProtocol
 
@@ -159,8 +152,8 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         configureMainView()
         configureTableView()
         configureMoreDetailsContainerView()
+        configureKeyboardAvoidance()
 
-        startListeningToNotifications()
         handleSwipeBackGesture()
 
         observeProduct()
@@ -701,6 +694,23 @@ private extension ProductFormViewController {
         moreDetailsContainerView.setContentHuggingPriority(.required, for: .vertical)
 
         updateMoreDetailsButtonVisibility()
+    }
+
+    func configureKeyboardAvoidance() {
+        // This moves the bottom bar above the keyboard and naturally resizes the table view.
+        moreDetailsContainerView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+
+            moreDetailsContainerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            moreDetailsContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            moreDetailsContainerView.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor),
+            moreDetailsContainerView.topAnchor.constraint(equalTo: tableView.bottomAnchor)
+        ])
     }
 }
 
@@ -1373,22 +1383,6 @@ private extension ProductFormViewController {
         moreButton.accessibilityLabel = NSLocalizedString("More options", comment: "Accessibility label for the Edit Product More Options action sheet")
         moreButton.accessibilityIdentifier = "edit-product-more-options-button"
         return moreButton
-    }
-}
-
-// MARK: - Keyboard management
-//
-private extension ProductFormViewController {
-    /// Registers for all of the related Notifications
-    ///
-    func startListeningToNotifications() {
-        keyboardFrameObserver.startObservingKeyboardFrame()
-    }
-}
-
-extension ProductFormViewController: KeyboardScrollable {
-    var scrollable: UIScrollView {
-        return tableView
     }
 }
 


### PR DESCRIPTION
Fixes [WOOMOB-1864](https://linear.app/a8c/issue/WOOMOB-1864)

## Description
Fixes the linked issue by constraining the moreDetailsContainerView to the keyboardLayoutGuide.topAnchor instead of setting the contentInset via KeyboardFrameObserver.

## Test Steps
1. Log in to any store that has orders.
2. Tap a product in the "Top performers" card.
3. Tap in the title to edit.
4. Note that when the keyboard opens, the title is still visible.

## Screenshots
| Before | After |
| --- | --- |
| ![Simulator Screen Recording - iPhone 17 Pro - 2025-12-19 at 09 01 28](https://github.com/user-attachments/assets/40885613-4e3f-4388-a2f4-b66a8e2b4107) | ![Simulator Screen Recording - iPhone 17 Pro - 2025-12-19 at 10 02 43](https://github.com/user-attachments/assets/e3480e6d-983f-4a73-9840-781e2a746b17) |
| ![Simulator Screen Recording - iPad Pro 11-inch (M4) - 2025-12-19 at 09 59 52](https://github.com/user-attachments/assets/5f868fd8-e0ef-4133-aa5b-20e8d20e5bcf)  | ![Simulator Screen Recording - iPad Pro 11-inch (M4) - 2025-12-19 at 09 57 46](https://github.com/user-attachments/assets/6e301e37-1153-42aa-97ec-6339bed26d72) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
