### PR TITLE
Force using Gregorian calendar when viewing application logs

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,8 +3,7 @@
 
 24.0
 -----
-- [*] Fixed an issue that could cause the keyboard to cover the product title when edited [https://github.com/woocommerce/woocommerce-ios/pull/16470]
-- [*] Fix application logs showing wrong year for some locales. (https://github.com/woocommerce/woocommerce-ios/pull/16471)
+
 
 23.9
 -----
@@ -17,6 +16,8 @@
 - [*] Troubleshooting tool: Add step to load products and technical details for decoding errors [https://github.com/woocommerce/woocommerce-ios/pull/16444]
 - [*] Use authenticated web view for updating plugins [https://github.com/woocommerce/woocommerce-ios/pull/16448]
 - [*] Fix a rare crash when opening the Coupon list [https://github.com/woocommerce/woocommerce-ios/pull/16478]
+- [*] Fixed an issue that could cause the keyboard to cover the product title when edited [https://github.com/woocommerce/woocommerce-ios/pull/16470]
+- [*] Fix application logs showing wrong year for some locales. (https://github.com/woocommerce/woocommerce-ios/pull/16471)
 - [internal] Update Stripe Terminal to 4.7.3 [https://github.com/woocommerce/woocommerce-ios/pull/16467]
 - [Internal] Fix display of Just in Time Message banners [https://github.com/woocommerce/woocommerce-ios/pull/16480]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 24.0
 -----
 - [*] Fixed an issue that could cause the keyboard to cover the product title when edited [https://github.com/woocommerce/woocommerce-ios/pull/16470]
+- [*] Fix application logs showing wrong year for some locales. (https://github.com/woocommerce/woocommerce-ios/pull/16471)
 
 23.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewModel.swift
@@ -10,6 +10,7 @@ struct ApplicationLogLine: Identifiable {
 
     private static let parsingFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()
+        dateFormatter.calendar = Calendar(identifier: .gregorian)
         dateFormatter.dateFormat = "YYYY-MM-dd HH:mm:ss:SSS"
         return dateFormatter
     }()


### PR DESCRIPTION
Fixes [WOOMOB-974](https://linear.app/a8c/issue/WOOMOB-974)

## Description
Fixes the linked issue by force using the Gregorian calendar when parsing the log entry date.

## Test Steps
1. Set your simulator/phone to use the Thai region
2. Open the app
3. Navigate to "Menu/Settings/Help & Support/View Application Log"
4. Tap on a log
5. Validate that the year is BE 2568

## Screenshots

| Before | After |
| --- | --- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-19 at 12 34 12" src="https://github.com/user-attachments/assets/6f3c4a7c-25dd-4284-80b6-d11d9d83c718" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-19 at 12 30 51" src="https://github.com/user-attachments/assets/a75b3ba7-c4ae-46b9-a1ae-5ceba2d0ef10" /> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
