### PR TITLE
Log webview errors when viewing receipts

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Receipts/ReceiptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Receipts/ReceiptViewController.swift
@@ -143,6 +143,16 @@ extension ReceiptViewController {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         activityIndicator.stopAnimating()
     }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        DDLogError("⛔️ Receipt WebView failed navigation for orderID \(viewModel.orderID): \(error.localizedDescription)")
+        activityIndicator.stopAnimating()
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        DDLogError("⛔️ Receipt WebView failed provisional navigation for orderID \(viewModel.orderID): \(error.localizedDescription)")
+        activityIndicator.stopAnimating()
+    }
 }
 extension ReceiptViewController {
     enum Constants {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds some error logging and display for errors retrieving a receipt in the webview.

This was prompted by a merchant issue where their site returned `"receipt_url": "http://$url"` from the `/wc/v3/orders/*/receipt` endpoint. When we tried to retrieve that using `http` rather than `https`, it failed because of the app transport security settings.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

I think that the site needs to actually serve it via `http` to reproduce the merchant's issue exactly, because even if you force this same situation, the app requests `https` when it loads the webview. Still, we can test other approaches using a proxy tool like Proxyman or Charles

1. Breakpoint `/wc/v3/orders/*/receipt`
2. Launch the app and open a paid order
3. Tap `See Receipt`
4. Edit the url in the response to have a nonsense scheme, like `fake://$host/$path`
5. Observe that the error is logged and shown in an alert

Repeat with a breakpoint on `wc/file/transient/*`, aborting the response. Observe that an error is logged and shown here too.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="1756" height="240" alt="CleanShot 2025-12-19 at 11 32 55@2x" src="https://github.com/user-attachments/assets/3b0262c7-7bc1-4455-8758-36f07cc8cff7" />

https://github.com/user-attachments/assets/ba1cd6c4-7380-4c6e-827a-75077d25c90f

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
