### PR TITLE
Revert #16446 Error when site credential login blocked by basic auth

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,7 +8,6 @@
 - [Internal] Cleaned up logic for push notification token registration [https://github.com/woocommerce/woocommerce-ios/pull/16434]
 - [*] Fixed possible sync issue in POS (https://github.com/woocommerce/woocommerce-ios/pull/16423)
 - [*] Prevent POS cash payment button showing during a card payment (https://github.com/woocommerce/woocommerce-ios/pull/16440)
-- [*] Login: Show error alert when login with site credentials fails due to basic auth [https://github.com/woocommerce/woocommerce-ios/pull/16446]
 - [*] Enabled site troubleshooting for users authenticated with site credentials [https://github.com/woocommerce/woocommerce-ios/pull/16441]
 - [*] Troubleshooting tool: Add step to load products and technical details for decoding errors [https://github.com/woocommerce/woocommerce-ios/pull/16444]
 - [*] Use authenticated web view for updating plugins [https://github.com/woocommerce/woocommerce-ios/pull/16448]

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordTutorialViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordTutorialViewModel.swift
@@ -23,8 +23,6 @@ struct ApplicationPasswordTutorialViewModel {
                                      comment: "Reason for why the user could not login tin the application password tutorial screen")
         case .invalidCredentials:
             return error.localizedDescription
-        case .failedAuthenticationChallenge:
-            fatalError("Failure to handle authentication challenge is not eligible for application password flow.")
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -363,9 +363,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
 
         let isAppPasswordAuthError = {
             switch error {
-            case SiteCredentialLoginError.genericFailure,
-                SiteCredentialLoginError.invalidCredentials,
-                SiteCredentialLoginError.failedAuthenticationChallenge:
+            case SiteCredentialLoginError.genericFailure, SiteCredentialLoginError.invalidCredentials:
                 return false
             case is SiteCredentialLoginError:
                 return true

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -15,7 +15,6 @@ enum SiteCredentialLoginError: LocalizedError {
     case inaccessibleLoginPage
     case inaccessibleAdminPage
     case unacceptableStatusCode(code: Int)
-    case failedAuthenticationChallenge
     case genericFailure(underlyingError: Error)
 
     /// Used for tracking error code
@@ -27,8 +26,7 @@ enum SiteCredentialLoginError: LocalizedError {
              .invalidLoginResponse,
              .invalidCredentials,
              .loginFailed,
-             .unacceptableStatusCode,
-             .failedAuthenticationChallenge:
+             .unacceptableStatusCode:
             return NSError(domain: Self.errorDomain, code: errorCode, userInfo: [NSLocalizedDescriptionKey: errorMessage])
         case .genericFailure(let underlyingError):
             return underlyingError as NSError
@@ -47,8 +45,6 @@ enum SiteCredentialLoginError: LocalizedError {
             return 401
         case .unacceptableStatusCode(let code):
             return code
-        case .failedAuthenticationChallenge:
-            return -2
         case .genericFailure(let underlyingError):
             return (underlyingError as NSError).code
         }
@@ -68,8 +64,6 @@ enum SiteCredentialLoginError: LocalizedError {
             return message
         case .unacceptableStatusCode(let code):
             return String(format: Localization.unacceptableStatusCode, code)
-        case .failedAuthenticationChallenge:
-            return Localization.failedAuthenticationChallenge
         case .genericFailure:
             return ""
         }
@@ -89,8 +83,7 @@ enum SiteCredentialLoginError: LocalizedError {
             comment: "Error message explaining login failure due to blocked WP Admin page"
         )
         static let invalidLoginResponse = NSLocalizedString(
-            "siteCredentialLoginError.invalidLoginResponse.message",
-            value: "Unable to login due to an unexpected response from your site.",
+            "Unable to login due to an unexpected response from your site. We are working on fixing this issue.",
             comment: "Error message explaining login failure due to unexpected response."
         )
         static let unacceptableStatusCode = NSLocalizedString(
@@ -100,11 +93,6 @@ enum SiteCredentialLoginError: LocalizedError {
         static let invalidCredentials = NSLocalizedString(
             "It seems the username or password you entered doesn't quite match. Double-check your credentials and try again.",
             comment: "Error message explaining login failure due to invalid credentials."
-        )
-        static let failedAuthenticationChallenge = NSLocalizedString(
-            "siteCredentialLoginError.failedAuthenticationChallenge.message",
-            value: "Unable to log in due to an unexpected security measure on your store. Please contact support for troubleshooting.",
-            comment: "Error message explaining login failure due to an unexpected authentication challenge."
         )
     }
 }
@@ -116,19 +104,12 @@ enum SiteCredentialLoginError: LocalizedError {
 /// - If the request does not redirect or the redirect fails, login fails.
 /// Ref: pe5sF9-1iQ-p2
 ///
-final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol, URLSessionTaskDelegate {
+final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
     private let siteURL: String
     private let cookieJar: HTTPCookieStorage
     private var successHandler: (() -> Void)?
     private var errorHandler: ((SiteCredentialLoginError) -> Void)?
-
-    private var receivedAuthChallengeMethod: String?
-
-    private lazy var session = {
-        var configuration = URLSessionConfiguration.default
-        configuration.timeoutIntervalForResource = 60
-        return URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
-    }()
+    private lazy var session = URLSession(configuration: .default)
 
     init(siteURL: String,
          cookieJar: HTTPCookieStorage = HTTPCookieStorage.shared) {
@@ -147,14 +128,10 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol, U
         // Old cookies can make the login succeeds even with incorrect credentials
         // So we need to clear all cookies before login.
         clearAllCookies()
-
-        receivedAuthChallengeMethod = nil
-
         guard let loginRequest = buildLoginRequest(username: username, password: password) else {
             DDLogError("⛔️ Error constructing login requests")
             return
         }
-
         Task { @MainActor in
             do {
                 try await startLogin(with: loginRequest)
@@ -162,12 +139,7 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol, U
             } catch let error as SiteCredentialLoginError {
                 errorHandler?(error)
             } catch {
-                if let receivedAuthChallengeMethod {
-                    errorHandler?(.failedAuthenticationChallenge)
-                    DDLogError("⛔️ Authentication Error: Nonce retrieval blocked by authentication challenge \(receivedAuthChallengeMethod)")
-                } else {
-                    errorHandler?(.genericFailure(underlyingError: error as NSError))
-                }
+                errorHandler?(.genericFailure(underlyingError: error as NSError))
             }
         }
     }
@@ -323,16 +295,5 @@ private extension String {
             return false
         }
         return wholeMatch(of: regex) != nil
-    }
-}
-
-// MARK: - URLSessionTaskDelegate
-extension SiteCredentialLoginUseCase {
-    func urlSession(_ session: URLSession,
-                    didReceive challenge: URLAuthenticationChallenge,
-                    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        let authMethod = challenge.protectionSpace.authenticationMethod
-        receivedAuthChallengeMethod = authMethod
-        completionHandler(.cancelAuthenticationChallenge, nil)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

#16446 broke site credential login in some cases, as the `SiteCredentialLoginUseCase.urlSession(_:didReceive:completionHandler:)` delegate function it introduced would cancel any request with an auth challenge. In my case, the auth challenge was `NSURLAuthenticationMethodServerTrust`, caused by additional certificates (for Proxyman) on my device. These were fully valid and trusted, but iOS calls the function to give us a chance to reject them, e.g. for certificate pinning reasons.

This reverts commit c85ab3b0ba9af1abc902a67da6006d93fc481280, reversing changes made to 811329934d5356729bbb6d0befdcca58d6748b9f.

We can consider reintroducing these changes with more careful handling of auth challenges.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Log in to a Jurassic Ninja, Pressable, or any other test site using site credentials.
Check that you don't recieve an error like the one below:

![IMG_DB9F13836444-1](https://github.com/user-attachments/assets/5da37d4d-db8b-476c-a508-dbf7c78f2c62)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
