### PR TITLE
[Crash] Coupon view models sometimes have identical hashes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [*] Enabled site troubleshooting for users authenticated with site credentials [https://github.com/woocommerce/woocommerce-ios/pull/16441]
 - [*] Troubleshooting tool: Add step to load products and technical details for decoding errors [https://github.com/woocommerce/woocommerce-ios/pull/16444]
 - [*] Use authenticated web view for updating plugins [https://github.com/woocommerce/woocommerce-ios/pull/16448]
+- [*] Fix a rare crash when opening the Coupon list [https://github.com/woocommerce/woocommerce-ios/pull/16478]
 
 23.8
 -----

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponCellViewModel.swift
@@ -1,0 +1,14 @@
+import Yosemite
+
+typealias CouponCellViewModel = TitleAndSubtitleAndStatusTableViewCell.ViewModel
+
+extension CouponCellViewModel {
+    static func build(from coupon: Coupon) -> CouponCellViewModel {
+        CouponCellViewModel(id: "\(coupon.couponID)",
+                      title: coupon.code,
+                      subtitle: coupon.summary(),
+                      accessibilityLabel: coupon.description.isNotEmpty ? coupon.description : coupon.code,
+                      status: coupon.expiryStatus().localizedName,
+                      statusBackgroundColor: coupon.expiryStatus().statusBackgroundColor)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
@@ -76,8 +76,12 @@ final class CouponListViewModel {
     }
 
     func buildCouponViewModels() {
-        couponViewModels = resultsController.fetchedObjects.map { coupon in
-            CellViewModel(id: "\(coupon.couponID)",
+        var seenIdentifiers: Set<String> = Set<String>()
+
+        couponViewModels = resultsController.fetchedObjects.compactMap { coupon in
+            guard coupon.couponID > 0, coupon.code.isNotEmpty else { return nil }
+            guard seenIdentifiers.insert("\(coupon.couponID)").inserted else { return nil }
+            return CellViewModel(id: "\(coupon.couponID)",
                           title: coupon.code,
                           subtitle: coupon.summary(), // to be updated after UI is finalized
                           accessibilityLabel: coupon.description.isNotEmpty ? coupon.description : coupon.code,

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
@@ -80,7 +80,7 @@ final class CouponListViewModel {
             CellViewModel(id: "\(coupon.couponID)",
                           title: coupon.code,
                           subtitle: coupon.summary(), // to be updated after UI is finalized
-                          accessibilityLabel: coupon.description.isEmpty ? coupon.description : coupon.code,
+                          accessibilityLabel: coupon.description.isNotEmpty ? coupon.description : coupon.code,
                           status: coupon.expiryStatus().localizedName,
                           statusBackgroundColor: coupon.expiryStatus().statusBackgroundColor)
         }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
@@ -26,7 +26,7 @@ enum CouponListState {
 
 final class CouponListViewModel {
 
-    typealias CellViewModel = TitleAndSubtitleAndStatusTableViewCell.ViewModel
+    typealias CellViewModel = CouponCellViewModel
 
     /// Active state
     ///
@@ -81,12 +81,7 @@ final class CouponListViewModel {
         couponViewModels = resultsController.fetchedObjects.compactMap { coupon in
             guard coupon.couponID > 0, coupon.code.isNotEmpty else { return nil }
             guard seenIdentifiers.insert("\(coupon.couponID)").inserted else { return nil }
-            return CellViewModel(id: "\(coupon.couponID)",
-                          title: coupon.code,
-                          subtitle: coupon.summary(), // to be updated after UI is finalized
-                          accessibilityLabel: coupon.description.isNotEmpty ? coupon.description : coupon.code,
-                          status: coupon.expiryStatus().localizedName,
-                          statusBackgroundColor: coupon.expiryStatus().statusBackgroundColor)
+            return CouponCellViewModel.build(from: coupon)
         }
 
         if couponViewModels.isNotEmpty {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
@@ -7,7 +7,7 @@ import class SwiftUI.UIHostingController
 final class CouponSearchUICommand: SearchUICommand {
 
     typealias Model = Coupon
-    typealias CellViewModel = TitleAndSubtitleAndStatusTableViewCell.ViewModel
+    typealias CellViewModel = CouponCellViewModel
     typealias ResultsControllerModel = StorageCoupon
 
     let searchBarPlaceholder = Localization.searchBarPlaceholder
@@ -38,12 +38,7 @@ final class CouponSearchUICommand: SearchUICommand {
     }
 
     func createCellViewModel(model: Coupon) -> TitleAndSubtitleAndStatusTableViewCell.ViewModel {
-        CellViewModel(id: "\(model.couponID)",
-                      title: model.code,
-                      subtitle: model.discountType.localizedName, // to be updated after UI is finalized
-                      accessibilityLabel: model.description.isEmpty ? model.description : model.code,
-                      status: model.expiryStatus().localizedName,
-                      statusBackgroundColor: model.expiryStatus().statusBackgroundColor)
+        CouponCellViewModel.build(from: model)
     }
 
     func synchronizeModels(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)?) {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -735,6 +735,7 @@
 		20D3D4372C65EF72004CE6E3 /* OrdersRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D3D4362C65EF72004CE6E3 /* OrdersRouteTests.swift */; };
 		20D5CB512AFCF856009A39C3 /* PaymentsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D5CB502AFCF856009A39C3 /* PaymentsRow.swift */; };
 		20D5CB532AFCF8E7009A39C3 /* PaymentsToggleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D5CB522AFCF8E7009A39C3 /* PaymentsToggleRow.swift */; };
+		20DA45652EF975660007FD3B /* CouponCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20DA45642EF975660007FD3B /* CouponCellViewModel.swift */; };
 		20DA6DDB2B681175002AA0FB /* AdaptiveModalContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20DA6DDA2B681175002AA0FB /* AdaptiveModalContainer.swift */; };
 		20E188842AD059A50053E945 /* TapToPayEducationContactlessLimitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E188832AD059A50053E945 /* TapToPayEducationContactlessLimitView.swift */; };
 		20FA73882CDCC3A900554BE3 /* OrderDetailsSyncStateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20FA73872CDCC3A900554BE3 /* OrderDetailsSyncStateController.swift */; };
@@ -3658,6 +3659,7 @@
 		20D3D4362C65EF72004CE6E3 /* OrdersRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersRouteTests.swift; sourceTree = "<group>"; };
 		20D5CB502AFCF856009A39C3 /* PaymentsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsRow.swift; sourceTree = "<group>"; };
 		20D5CB522AFCF8E7009A39C3 /* PaymentsToggleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsToggleRow.swift; sourceTree = "<group>"; };
+		20DA45642EF975660007FD3B /* CouponCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponCellViewModel.swift; sourceTree = "<group>"; };
 		20DA6DDA2B681175002AA0FB /* AdaptiveModalContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveModalContainer.swift; sourceTree = "<group>"; };
 		20E188832AD059A50053E945 /* TapToPayEducationContactlessLimitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayEducationContactlessLimitView.swift; sourceTree = "<group>"; };
 		20FA73872CDCC3A900554BE3 /* OrderDetailsSyncStateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsSyncStateController.swift; sourceTree = "<group>"; };
@@ -7252,6 +7254,7 @@
 				03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */,
 				03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */,
 				DE7B478F27A153C20018742E /* CouponSearchUICommand.swift */,
+				20DA45642EF975660007FD3B /* CouponCellViewModel.swift */,
 				B95864072A657D2F002C4C6E /* EnhancedCouponListViewController.swift */,
 				B95864092A657F44002C4C6E /* EnhancedCouponListView.swift */,
 				B958640B2A66847B002C4C6E /* CouponListView.swift */,
@@ -15415,6 +15418,7 @@
 				4541D88A270718F6005A9E30 /* ShippingLabelCarriersSectionViewModel.swift in Sources */,
 				CE21FB262C2DB3A900303832 /* GoogleAdsCampaignReportCardViewModel.swift in Sources */,
 				77E53EBF2510C153003D385F /* ProductDownloadListViewModel.swift in Sources */,
+				20DA45652EF975660007FD3B /* CouponCellViewModel.swift in Sources */,
 				B910686027F1F28F00AD0575 /* GhostableViewController.swift in Sources */,
 				EE8B42122BF9A3340077C4E7 /* LastOrdersDashboardCardViewModel.swift in Sources */,
 				AE8AEA8628084EC90054BDA2 /* MaxWidthPreference.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponListViewModelTests.swift
@@ -30,7 +30,7 @@ final class CouponListViewModelTests: XCTestCase {
     }
 
     private func setUpWithCouponFetched(injectedStores: StoresManager? = nil) {
-        let coupon = Coupon.fake().copy(siteID: 123, code: "coupon")
+        let coupon = Coupon.fake().copy(siteID: 123, couponID: 1234, code: "coupon")
         mockStorageManager.insertSampleCoupon(readOnlyCoupon: coupon)
         if let stores = injectedStores {
             sut = CouponListViewModel(siteID: 123,
@@ -199,7 +199,7 @@ final class CouponListViewModelTests: XCTestCase {
     func test_state_is_coupons_if_enableCoupons_and_synchronizeFirstPage_succeed() {
         // Given
         let sampleSiteID: Int64 = 123
-        mockStorageManager.insertSampleCoupon(readOnlyCoupon: Coupon.fake().copy(siteID: sampleSiteID))
+        mockStorageManager.insertSampleCoupon(readOnlyCoupon: Coupon.fake().copy(siteID: sampleSiteID, couponID: 1, code: "senth"))
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: SettingAction.self) { action in
             switch action {
@@ -257,7 +257,7 @@ final class CouponListViewModelTests: XCTestCase {
 
     func test_state_is_empty_when_all_coupons_gets_deleted() {
         // Given
-        mockStorageManager.insertSampleCoupon(readOnlyCoupon: Coupon.fake().copy(siteID: 123))
+        mockStorageManager.insertSampleCoupon(readOnlyCoupon: Coupon.fake().copy(siteID: 123, couponID: 1, code: "riset"))
         sut = CouponListViewModel(siteID: 123, storageManager: mockStorageManager)
         assertEqual(.coupons, sut.state)
 
@@ -267,5 +267,60 @@ final class CouponListViewModelTests: XCTestCase {
 
         // Then
         assertEqual(.empty, sut.state)
+    }
+
+    func test_buildCouponViewModels_ignores_coupons_with_zero_id_or_empty_code() {
+        // Given
+        let validCoupon = Coupon.fake().copy(siteID: 123, couponID: 1, code: "VALID")
+        let zeroIdCoupon = Coupon.fake().copy(siteID: 123, couponID: 0, code: "ZERO_ID")
+        let emptyCodeCoupon = Coupon.fake().copy(siteID: 123, couponID: 2, code: "")
+
+        mockStorageManager.insertSampleCoupon(readOnlyCoupon: validCoupon)
+        mockStorageManager.insertSampleCoupon(readOnlyCoupon: zeroIdCoupon)
+        mockStorageManager.insertSampleCoupon(readOnlyCoupon: emptyCodeCoupon)
+
+        sut = CouponListViewModel(siteID: 123, storageManager: mockStorageManager)
+
+        // When
+        sut.buildCouponViewModels()
+
+        // Then
+        XCTAssertEqual(sut.couponViewModels.count, 1)
+        XCTAssertEqual(sut.couponViewModels.first?.id, "\(validCoupon.couponID)")
+        XCTAssertEqual(sut.state, .coupons)
+    }
+
+    func test_buildCouponViewModels_deduplicates_coupons_with_same_id() {
+        // Given
+        let firstCoupon = Coupon.fake().copy(siteID: 123, couponID: 10, code: "FIRST")
+        let duplicateIdCoupon = Coupon.fake().copy(siteID: 123, couponID: 10, code: "SECOND")
+
+        mockStorageManager.insertSampleCoupon(readOnlyCoupon: firstCoupon)
+        mockStorageManager.insertSampleCoupon(readOnlyCoupon: duplicateIdCoupon)
+
+        sut = CouponListViewModel(siteID: 123, storageManager: mockStorageManager)
+
+        // When
+        sut.buildCouponViewModels()
+
+        // Then
+        XCTAssertEqual(sut.couponViewModels.count, 1)
+        XCTAssertEqual(sut.couponViewModels.first?.id, "\(firstCoupon.couponID)")
+        XCTAssertEqual(sut.state, .coupons)
+    }
+
+    func test_buildCouponViewModels_sets_empty_state_when_all_coupons_filtered_out() {
+        // Given
+        let invalidCoupon = Coupon.fake().copy(siteID: 123, couponID: 0, code: "")
+        mockStorageManager.insertSampleCoupon(readOnlyCoupon: invalidCoupon)
+
+        sut = CouponListViewModel(siteID: 123, storageManager: mockStorageManager)
+
+        // When
+        sut.buildCouponViewModels()
+
+        // Then
+        XCTAssertTrue(sut.couponViewModels.isEmpty)
+        XCTAssertEqual(sut.state, .empty)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is a speculative fix for a crash

Using the same hash for multiple rows in a diffable datasource causes a crash. This is rare (affecting 15 users) but persistent (it’s happened 115 times over the last year.)

The crash logs show identical, empty CellViewModels, which would have the same hash (same ID, amount, title, subtitle, status etc). They use the default values in the Core Data model, so it’s likely that they were saved in error, e.g. inserted but never updated, then saved. Equally, they could have come from a corrupted API response. Once in the database though, the app would crash whenever coupons was opened.

It doesn’t make sense to show them anyway, so by filtering them out we restore the user’s ability to refresh the coupons, at least, and resolve the crash.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

I wasn't able to genuinely reproduce the hash, but I could by editing the API response. 

1. Set a network breakpoint on `/coupons`
2. Log out of the app, to clear the DB, then back in
3. Open Menu > Coupons
4. In your API tool, edit the response at the breakpoint adding two extra rows – these can be copied from the JSON you get back, then edit so that the ID is 0, the amount is an empty string, and the code is an empty string.
5. On trunk the app would crash here – observe that it doesn't with this fix.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
