### PR TITLE
Show JITM banners when onboarding card hidden

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [*] Enabled site troubleshooting for users authenticated with site credentials [https://github.com/woocommerce/woocommerce-ios/pull/16441]
 - [*] Troubleshooting tool: Add step to load products and technical details for decoding errors [https://github.com/woocommerce/woocommerce-ios/pull/16444]
 - [*] Use authenticated web view for updating plugins [https://github.com/woocommerce/woocommerce-ios/pull/16448]
+- [Internal] Fix display of Just in Time Message banners [https://github.com/woocommerce/woocommerce-ios/pull/16480]
 
 23.8
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -383,8 +383,8 @@ private extension DashboardView {
 
     @ViewBuilder
     var featureAnnouncementCard: some View {
-        if let announcementViewModel = viewModel.announcementViewModel,
-           viewModel.dashboardCards.contains(where: { $0.type == .onboarding && $0.enabled && $0.availability != .hide }) == false {
+        if viewModel.shouldShowAnnouncementBanner,
+           let announcementViewModel = viewModel.announcementViewModel {
             FeatureAnnouncementCardView(viewModel: announcementViewModel, dismiss: {
                 viewModel.announcementViewModel = nil
             })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -384,7 +384,7 @@ private extension DashboardView {
     @ViewBuilder
     var featureAnnouncementCard: some View {
         if let announcementViewModel = viewModel.announcementViewModel,
-           viewModel.dashboardCards.contains(where: { $0.type == .onboarding }) == false {
+           viewModel.dashboardCards.contains(where: { $0.type == .onboarding && $0.enabled && $0.availability != .hide }) == false {
             FeatureAnnouncementCardView(viewModel: announcementViewModel, dismiss: {
                 viewModel.announcementViewModel = nil
             })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -149,17 +149,20 @@ final class DashboardViewModel: ObservableObject {
                                                      storageManager: storageManager,
                                                      blazeEligibilityChecker: blazeEligibilityChecker)
         self.storePerformanceViewModel = .init(siteID: siteID,
+                                               stores: stores,
                                                usageTracksEventEmitter: usageTracksEventEmitter)
         self.topPerformersViewModel = .init(siteID: siteID,
+                                            stores: stores,
                                             usageTracksEventEmitter: usageTracksEventEmitter)
-        self.inboxViewModel = InboxDashboardCardViewModel(siteID: siteID)
-        self.reviewsViewModel = ReviewsDashboardCardViewModel(siteID: siteID)
-        self.mostActiveCouponsViewModel = MostActiveCouponsCardViewModel(siteID: siteID)
-        self.productStockCardViewModel = ProductStockDashboardCardViewModel(siteID: siteID)
-        self.lastOrdersCardViewModel = LastOrdersDashboardCardViewModel(siteID: siteID)
+        self.inboxViewModel = InboxDashboardCardViewModel(siteID: siteID, stores: stores)
+        self.reviewsViewModel = ReviewsDashboardCardViewModel(siteID: siteID, stores: stores)
+        self.mostActiveCouponsViewModel = MostActiveCouponsCardViewModel(siteID: siteID, stores: stores)
+        self.productStockCardViewModel = ProductStockDashboardCardViewModel(siteID: siteID, stores: stores)
+        self.lastOrdersCardViewModel = LastOrdersDashboardCardViewModel(siteID: siteID, stores: stores)
         self.googleAdsDashboardCardViewModel = GoogleAdsDashboardCardViewModel(
             siteID: siteID,
-            eligibilityChecker: googleAdsEligibilityChecker
+            eligibilityChecker: googleAdsEligibilityChecker,
+            stores: stores
         )
 
         self.inboxEligibilityChecker = inboxEligibilityChecker

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -17,6 +17,18 @@ final class DashboardViewModel: ObservableObject {
 
     @Published var modalJustInTimeMessageViewModel: JustInTimeMessageViewModel? = nil
 
+    /// Whether the announcement banner should be shown.
+    /// Returns true if there's an announcement AND the onboarding card is not visible.
+    var shouldShowAnnouncementBanner: Bool {
+        guard announcementViewModel != nil else {
+            return false
+        }
+        let onboardingCardIsVisible = dashboardCards.contains { card in
+            card.type == .onboarding && card.enabled && card.availability != .hide
+        }
+        return !onboardingCardIsVisible
+    }
+
     let storeOnboardingViewModel: StoreOnboardingViewModel
     let blazeCampaignDashboardViewModel: BlazeCampaignDashboardViewModel
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -40,6 +40,87 @@ final class DashboardViewModelTests: XCTestCase {
 
         stores.updateDefaultStore(storeID: sampleSiteID)
         stores.updateDefaultStore(site)
+
+        // Set up basic mocks for actions dispatched during DashboardViewModel initialization.
+        // Child view models dispatch actions in Task blocks during init, so these mocks
+        // must be in place before any DashboardViewModel is created.
+        setUpBasicMocks()
+    }
+
+    /// Sets up mock handlers for actions that are dispatched during DashboardViewModel initialization.
+    /// This prevents Swift continuation leaks from unhandled async actions in child view models.
+    private func setUpBasicMocks(for targetStores: MockStoresManager? = nil) {
+        let storesManager = targetStores ?? stores!
+
+        // AppSettingsAction - dispatched by child view models during init and data loading
+        storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .loadLastSelectedPerformanceTimeRange(_, onCompletion):
+                onCompletion(nil)
+            case let .loadLastSelectedTopPerformersTimeRange(_, onCompletion):
+                onCompletion(nil)
+            case let .loadLastSelectedMostActiveCouponsTimeRange(_, onCompletion):
+                onCompletion(nil)
+            case let .loadLastSelectedStockType(_, onCompletion):
+                onCompletion(nil)
+            case let .loadLastSelectedOrderStatus(_, onCompletion):
+                onCompletion(nil)
+            case let .getPOSSurveyPotentialMerchantNotificationScheduled(onCompletion):
+                onCompletion(false)
+            case let .getPOSSurveyCurrentMerchantNotificationScheduled(onCompletion):
+                onCompletion(false)
+            default:
+                break
+            }
+        }
+
+        // OrderAction - dispatched by configureOrdersResultController during init
+        storesManager.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .checkIfStoreHasOrders(_, onCompletion):
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
+
+        // FeatureFlagAction - dispatched by child view models checking feature availability
+        storesManager.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            switch action {
+            case let .isRemoteFeatureFlagEnabled(_, _, onCompletion):
+                onCompletion(false)
+            default:
+                break
+            }
+        }
+
+        // StatsActionV4 - dispatched by stats view models during data sync
+        storesManager.whenReceivingAction(ofType: StatsActionV4.self) { action in
+            switch action {
+            case let .retrieveStats(_, _, _, _, _, _, _, onCompletion):
+                onCompletion(.success(()))
+            case let .retrieveSiteVisitStats(_, _, _, _, onCompletion):
+                onCompletion(.success(()))
+            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, onCompletion):
+                onCompletion(.success(.fake()))
+            case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, _, onCompletion):
+                onCompletion(.success(.fake()))
+            default:
+                break
+            }
+        }
+
+        // GoogleAdsAction - dispatched by Google Ads view models
+        storesManager.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
+            switch action {
+            case let .checkConnection(_, onCompletion):
+                onCompletion(.success(.fake()))
+            case let .fetchAdsCampaigns(_, onCompletion):
+                onCompletion(.success([]))
+            default:
+                break
+            }
+        }
     }
 
     @MainActor
@@ -187,8 +268,9 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         let sessionManager = SessionManager.makeForTesting()
         sessionManager.defaultSite = Site.fake().copy(visibility: .privateSite)
-        let stores = MockStoresManager(sessionManager: sessionManager)
-        let viewModel = DashboardViewModel(siteID: 123, stores: stores)
+        let localStores = MockStoresManager(sessionManager: sessionManager)
+        setUpBasicMocks(for: localStores)
+        let viewModel = DashboardViewModel(siteID: 123, stores: localStores)
 
         // When
         let siteURLToShare = viewModel.siteURLToShare
@@ -203,8 +285,9 @@ final class DashboardViewModelTests: XCTestCase {
         let sessionManager = SessionManager.makeForTesting()
         let expectedURL = "https://example.com"
         sessionManager.defaultSite = Site.fake().copy(url: expectedURL, visibility: .publicSite)
-        let stores = MockStoresManager(sessionManager: sessionManager)
-        let viewModel = DashboardViewModel(siteID: 123, stores: stores)
+        let localStores = MockStoresManager(sessionManager: sessionManager)
+        setUpBasicMocks(for: localStores)
+        let viewModel = DashboardViewModel(siteID: 123, stores: localStores)
 
         // When
         let siteURLToShare = viewModel.siteURLToShare
@@ -764,7 +847,8 @@ final class DashboardViewModelTests: XCTestCase {
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,
                                            storageManager: storageManager,
-                                           blazeEligibilityChecker: blazeEligibilityChecker)
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         // When
         await viewModel.reloadAllData()
@@ -779,13 +863,14 @@ final class DashboardViewModelTests: XCTestCase {
         // Given - announcement exists and onboarding card is not enabled (all tasks completed)
         let message = Yosemite.JustInTimeMessage.fake().copy(title: "JITM Message")
         userDefaults[.completedAllStoreOnboardingTasks] = true
+        mockReloadingData(jitmResult: .success([message]))
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,
                                            storageManager: storageManager,
                                            userDefaults: userDefaults,
-                                           blazeEligibilityChecker: blazeEligibilityChecker)
-        mockReloadingData(jitmResult: .success([message]))
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         // When
         await viewModel.reloadAllData()
@@ -802,12 +887,13 @@ final class DashboardViewModelTests: XCTestCase {
         // Given - announcement exists and onboarding card is hidden via stored dashboard cards
         let message = Yosemite.JustInTimeMessage.fake().copy(title: "JITM Message")
         let storedCards = [DashboardCard(type: .onboarding, availability: .hide, enabled: true)]
+        mockReloadingData(jitmResult: .success([message]), storedDashboardCards: storedCards)
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,
                                            storageManager: storageManager,
-                                           blazeEligibilityChecker: blazeEligibilityChecker)
-        mockReloadingData(jitmResult: .success([message]), storedDashboardCards: storedCards)
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         // When
         await viewModel.reloadAllData()
@@ -824,12 +910,13 @@ final class DashboardViewModelTests: XCTestCase {
         // Given - announcement exists but onboarding is enabled and visible
         let message = Yosemite.JustInTimeMessage.fake().copy(title: "JITM Message")
         let storedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: true)]
+        mockReloadingData(jitmResult: .success([message]), storedDashboardCards: storedCards)
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,
                                            storageManager: storageManager,
-                                           blazeEligibilityChecker: blazeEligibilityChecker)
-        mockReloadingData(jitmResult: .success([message]), storedDashboardCards: storedCards)
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         // When
         await viewModel.reloadAllData()
@@ -868,6 +955,29 @@ private extension DashboardViewModelTests {
                 onCompletion(storedDashboardCards)
             case let .loadFeedbackVisibility(_, onCompletion):
                 onCompletion(.success(shouldShowInAppFeedback))
+            case let .loadLastSelectedPerformanceTimeRange(_, onCompletion):
+                onCompletion(nil)
+            case let .loadLastSelectedTopPerformersTimeRange(_, onCompletion):
+                onCompletion(nil)
+            case let .loadLastSelectedMostActiveCouponsTimeRange(_, onCompletion):
+                onCompletion(nil)
+            case let .loadLastSelectedStockType(_, onCompletion):
+                onCompletion(nil)
+            case let .loadLastSelectedOrderStatus(_, onCompletion):
+                onCompletion(nil)
+            case let .getPOSSurveyPotentialMerchantNotificationScheduled(onCompletion):
+                onCompletion(false)
+            case let .getPOSSurveyCurrentMerchantNotificationScheduled(onCompletion):
+                onCompletion(false)
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            switch action {
+            case let .isRemoteFeatureFlagEnabled(_, _, onCompletion):
+                onCompletion(false)
             default:
                 break
             }
@@ -899,6 +1009,32 @@ private extension DashboardViewModelTests {
             case .synchronizeCampaignsList(_, _, _, let onCompletion):
                 self?.insertCampaigns(existingBlazeCampaigns)
                 onCompletion(.success(false))
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
+            switch action {
+            case let .retrieveStats(_, _, _, _, _, _, _, onCompletion):
+                onCompletion(.success(()))
+            case let .retrieveSiteVisitStats(_, _, _, _, onCompletion):
+                onCompletion(.success(()))
+            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, onCompletion):
+                onCompletion(.success(.fake()))
+            case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, _, onCompletion):
+                onCompletion(.success(.fake()))
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
+            switch action {
+            case let .checkConnection(_, onCompletion):
+                onCompletion(.success(.fake()))
+            case let .fetchAdsCampaigns(_, onCompletion):
+                onCompletion(.success([]))
             default:
                 break
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -89,8 +89,6 @@ final class DashboardViewModelTests: XCTestCase {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, onCompletion):
                 onCompletion(false)
-            default:
-                break
             }
         }
 
@@ -126,7 +124,9 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_default_statsVersion_is_v4() {
         // Given
-        let viewModel = DashboardViewModel(siteID: 0)
+        let viewModel = DashboardViewModel(siteID: 0,
+                                           stores: stores,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         // Then
         XCTAssertEqual(viewModel.statsVersion, .v4)
@@ -140,7 +140,8 @@ final class DashboardViewModelTests: XCTestCase {
         let viewModel = DashboardViewModel(siteID: 0,
                                            stores: stores,
                                            storageManager: storageManager,
-                                           blazeEligibilityChecker: blazeEligibilityChecker)
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         // When
         await viewModel.reloadAllData()
@@ -156,7 +157,8 @@ final class DashboardViewModelTests: XCTestCase {
         let viewModel = DashboardViewModel(siteID: 0,
                                            stores: stores,
                                            storageManager: storageManager,
-                                           blazeEligibilityChecker: blazeEligibilityChecker)
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         // When
         await viewModel.reloadAllData()
@@ -178,7 +180,8 @@ final class DashboardViewModelTests: XCTestCase {
                                            stores: stores,
                                            storageManager: storageManager,
                                            analytics: analytics,
-                                           blazeEligibilityChecker: blazeEligibilityChecker)
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         // When
         await viewModel.reloadAllData()
@@ -206,7 +209,8 @@ final class DashboardViewModelTests: XCTestCase {
                                            stores: stores,
                                            storageManager: storageManager,
                                            analytics: analytics,
-                                           blazeEligibilityChecker: blazeEligibilityChecker)
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         // When
         await viewModel.reloadAllData()
@@ -224,7 +228,8 @@ final class DashboardViewModelTests: XCTestCase {
                                            stores: stores,
                                            storageManager: storageManager,
                                            analytics: analytics,
-                                           blazeEligibilityChecker: blazeEligibilityChecker)
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         // When
         await viewModel.reloadAllData()
@@ -250,7 +255,8 @@ final class DashboardViewModelTests: XCTestCase {
                                            stores: stores,
                                            storageManager: storageManager,
                                            analytics: analytics,
-                                           blazeEligibilityChecker: blazeEligibilityChecker)
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
         viewModel.announcementViewModel = JustInTimeMessageViewModel(
             justInTimeMessage: .fake(),
             screenName: "my_store",
@@ -270,7 +276,9 @@ final class DashboardViewModelTests: XCTestCase {
         sessionManager.defaultSite = Site.fake().copy(visibility: .privateSite)
         let localStores = MockStoresManager(sessionManager: sessionManager)
         setUpBasicMocks(for: localStores)
-        let viewModel = DashboardViewModel(siteID: 123, stores: localStores)
+        let viewModel = DashboardViewModel(siteID: 123,
+                                           stores: localStores,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         // When
         let siteURLToShare = viewModel.siteURLToShare
@@ -287,7 +295,9 @@ final class DashboardViewModelTests: XCTestCase {
         sessionManager.defaultSite = Site.fake().copy(url: expectedURL, visibility: .publicSite)
         let localStores = MockStoresManager(sessionManager: sessionManager)
         setUpBasicMocks(for: localStores)
-        let viewModel = DashboardViewModel(siteID: 123, stores: localStores)
+        let viewModel = DashboardViewModel(siteID: 123,
+                                           stores: localStores,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         // When
         let siteURLToShare = viewModel.siteURLToShare
@@ -301,7 +311,10 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         let localTimezone = TimeZone(secondsFromGMT: -3600)
         let siteGMTOffset = 0.0
-        let viewModel = DashboardViewModel(siteID: 0, stores: stores, analytics: analytics)
+        let viewModel = DashboardViewModel(siteID: 0,
+                                           stores: stores,
+                                           analytics: analytics,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         // When
         viewModel.trackStatsTimezone(localTimezone: localTimezone!, siteGMTOffset: siteGMTOffset)
@@ -322,7 +335,10 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         let localTimezone = TimeZone(secondsFromGMT: -5400)
         let siteGMTOffset = 2.50000
-        let viewModel = DashboardViewModel(siteID: 0, stores: stores, analytics: analytics)
+        let viewModel = DashboardViewModel(siteID: 0,
+                                           stores: stores,
+                                           analytics: analytics,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         // When
         viewModel.trackStatsTimezone(localTimezone: localTimezone!, siteGMTOffset: siteGMTOffset)
@@ -343,7 +359,10 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         let localTimezone = TimeZone(secondsFromGMT: -7200)
         let siteGMTOffset = -2.0
-        let viewModel = DashboardViewModel(siteID: 0, stores: stores, analytics: analytics)
+        let viewModel = DashboardViewModel(siteID: 0,
+                                           stores: stores,
+                                           analytics: analytics,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         // When
         viewModel.trackStatsTimezone(localTimezone: localTimezone!, siteGMTOffset: siteGMTOffset)
@@ -361,7 +380,8 @@ final class DashboardViewModelTests: XCTestCase {
         defaults[.completedAllStoreOnboardingTasks] = true
         let viewModel = DashboardViewModel(siteID: 0,
                                            stores: stores,
-                                           userDefaults: defaults)
+                                           userDefaults: defaults,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
         var setDashboardCardsActionCalled = false
 
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
@@ -380,7 +400,10 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_editorSaveTapped_is_tracked_when_customizing_onboarding_card() throws {
         // Given
-        let viewModel = DashboardViewModel(siteID: sampleSiteID, analytics: analytics)
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           analytics: analytics,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
         let cards: [DashboardCard] = [DashboardCard(type: .onboarding, availability: .show, enabled: false),
                                       DashboardCard(type: .performance, availability: .show, enabled: true),
                                       DashboardCard(type: .blaze, availability: .show, enabled: true),
@@ -638,6 +661,7 @@ final class DashboardViewModelTests: XCTestCase {
                                            stores: stores,
                                            storageManager: storageManager,
                                            userDefaults: userDefaults,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker,
                                            siteIsCIABEligibilityChecker: siteCIABChecker)
 
         mockReloadingData()
@@ -665,6 +689,7 @@ final class DashboardViewModelTests: XCTestCase {
                                            stores: stores,
                                            storageManager: storageManager,
                                            userDefaults: userDefaults,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker,
                                            siteIsCIABEligibilityChecker: siteCIABChecker)
 
         mockReloadingData()
@@ -688,7 +713,8 @@ final class DashboardViewModelTests: XCTestCase {
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,
-                                           inboxEligibilityChecker: inboxEligibilityChecker)
+                                           inboxEligibilityChecker: inboxEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
         let completeCardsSet: [DashboardCard] = [
             .init(type: .inbox, availability: .show, enabled: true),
             .init(type: .reviews, availability: .show, enabled: true),
@@ -713,7 +739,8 @@ final class DashboardViewModelTests: XCTestCase {
                                            stores: stores,
                                            storageManager: storageManager,
                                            blazeEligibilityChecker: blazeEligibilityChecker,
-                                           inboxEligibilityChecker: inboxEligibilityChecker)
+                                           inboxEligibilityChecker: inboxEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
         let incompleteNewCardsSet: [DashboardCard] = []
         mockReloadingData(storedDashboardCards: incompleteNewCardsSet)
 
@@ -736,7 +763,8 @@ final class DashboardViewModelTests: XCTestCase {
                                            stores: stores,
                                            storageManager: storageManager,
                                            blazeEligibilityChecker: blazeEligibilityChecker,
-                                           inboxEligibilityChecker: inboxEligibilityChecker)
+                                           inboxEligibilityChecker: inboxEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
         mockReloadingData(storedDashboardCards: incompleteNewCardsSet)
 
         // When
@@ -811,6 +839,7 @@ final class DashboardViewModelTests: XCTestCase {
                                storageManager: storageManager,
                                blazeEligibilityChecker: blazeEligibilityChecker,
                                inboxEligibilityChecker: inboxEligibilityChecker,
+                               googleAdsEligibilityChecker: googleAdsEligibilityChecker,
                                localNotificationScheduler: scheduler)
 
         // Then
@@ -826,6 +855,7 @@ final class DashboardViewModelTests: XCTestCase {
                                            storageManager: storageManager,
                                            blazeEligibilityChecker: blazeEligibilityChecker,
                                            inboxEligibilityChecker: inboxEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker,
                                            localNotificationScheduler: scheduler)
         mockReloadingData()
 
@@ -978,8 +1008,6 @@ private extension DashboardViewModelTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, onCompletion):
                 onCompletion(false)
-            default:
-                break
             }
         }
 
@@ -1042,22 +1070,25 @@ private extension DashboardViewModelTests {
     }
 
     func insertProduct(_ readOnlyProduct: Product) {
-        let newProduct = storage.insertNewObject(ofType: StorageProduct.self)
-        newProduct.update(with: readOnlyProduct)
-        storage.saveIfNeeded()
+        storageManager.performAndSave({ storage in
+            let newProduct = storage.insertNewObject(ofType: StorageProduct.self)
+            newProduct.update(with: readOnlyProduct)
+        }, completion: nil, on: .main)
     }
 
     func insertCampaigns(_ readOnlyCampaigns: [BlazeCampaignListItem]) {
-        readOnlyCampaigns.forEach { campaign in
-            let newCampaign = storage.insertNewObject(ofType: StorageBlazeCampaignListItem.self)
-            newCampaign.update(with: campaign)
-        }
-        storage.saveIfNeeded()
+        storageManager.performAndSave({ storage in
+            readOnlyCampaigns.forEach { campaign in
+                let newCampaign = storage.insertNewObject(ofType: StorageBlazeCampaignListItem.self)
+                newCampaign.update(with: campaign)
+            }
+        }, completion: nil, on: .main)
     }
 
     func insertSampleOrder(readOnlyOrder: Order) {
-        let newOrder = storage.insertNewObject(ofType: StorageOrder.self)
-        newOrder.update(with: readOnlyOrder)
-        storage.saveIfNeeded()
+        storageManager.performAndSave({ storage in
+            let newOrder = storage.insertNewObject(ofType: StorageOrder.self)
+            newOrder.update(with: readOnlyOrder)
+        }, completion: nil, on: .main)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -913,10 +913,10 @@ final class DashboardViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_shouldShowAnnouncementBanner_returns_true_when_announcement_exists_and_onboarding_hidden() async throws {
-        // Given - announcement exists and onboarding card is hidden via stored dashboard cards
+    func test_shouldShowAnnouncementBanner_returns_true_when_announcement_exists_and_onboarding_disabled() async throws {
+        // Given - announcement exists and onboarding card is disabled via stored dashboard cards
         let message = Yosemite.JustInTimeMessage.fake().copy(title: "JITM Message")
-        let storedCards = [DashboardCard(type: .onboarding, availability: .hide, enabled: true)]
+        let storedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: false)]
         mockReloadingData(jitmResult: .success([message]), storedDashboardCards: storedCards)
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
@@ -928,9 +928,9 @@ final class DashboardViewModelTests: XCTestCase {
         // When
         await viewModel.reloadAllData()
 
-        // Then - onboarding card should be hidden
+        // Then - onboarding card should be disabled
         let onboardingCard = try XCTUnwrap(viewModel.dashboardCards.first(where: { $0.type == .onboarding }))
-        XCTAssertEqual(onboardingCard.availability, .hide)
+        XCTAssertFalse(onboardingCard.enabled)
         // And banner should be visible
         XCTAssertTrue(viewModel.shouldShowAnnouncementBanner)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -754,6 +754,93 @@ final class DashboardViewModelTests: XCTestCase {
             scheduler.scheduleNoCampaignReminderCalled == true
         }
     }
+
+    // MARK: - Announcement Banner Visibility Tests
+
+    @MainActor
+    func test_shouldShowAnnouncementBanner_returns_false_when_no_announcement() async {
+        // Given
+        mockReloadingData(jitmResult: .success([]))
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           blazeEligibilityChecker: blazeEligibilityChecker)
+
+        // When
+        await viewModel.reloadAllData()
+
+        // Then
+        XCTAssertNil(viewModel.announcementViewModel)
+        XCTAssertFalse(viewModel.shouldShowAnnouncementBanner)
+    }
+
+    @MainActor
+    func test_shouldShowAnnouncementBanner_returns_true_when_announcement_exists_and_onboarding_not_enabled() async throws {
+        // Given - announcement exists and onboarding card is not enabled (all tasks completed)
+        let message = Yosemite.JustInTimeMessage.fake().copy(title: "JITM Message")
+        userDefaults[.completedAllStoreOnboardingTasks] = true
+
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           userDefaults: userDefaults,
+                                           blazeEligibilityChecker: blazeEligibilityChecker)
+        mockReloadingData(jitmResult: .success([message]))
+
+        // When
+        await viewModel.reloadAllData()
+
+        // Then - onboarding card should be disabled
+        let onboardingCard = try XCTUnwrap(viewModel.dashboardCards.first(where: { $0.type == .onboarding }))
+        XCTAssertFalse(onboardingCard.enabled)
+        // And banner should be visible
+        XCTAssertTrue(viewModel.shouldShowAnnouncementBanner)
+    }
+
+    @MainActor
+    func test_shouldShowAnnouncementBanner_returns_true_when_announcement_exists_and_onboarding_hidden() async throws {
+        // Given - announcement exists and onboarding card is hidden via stored dashboard cards
+        let message = Yosemite.JustInTimeMessage.fake().copy(title: "JITM Message")
+        let storedCards = [DashboardCard(type: .onboarding, availability: .hide, enabled: true)]
+
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           blazeEligibilityChecker: blazeEligibilityChecker)
+        mockReloadingData(jitmResult: .success([message]), storedDashboardCards: storedCards)
+
+        // When
+        await viewModel.reloadAllData()
+
+        // Then - onboarding card should be hidden
+        let onboardingCard = try XCTUnwrap(viewModel.dashboardCards.first(where: { $0.type == .onboarding }))
+        XCTAssertEqual(onboardingCard.availability, .hide)
+        // And banner should be visible
+        XCTAssertTrue(viewModel.shouldShowAnnouncementBanner)
+    }
+
+    @MainActor
+    func test_shouldShowAnnouncementBanner_returns_false_when_onboarding_card_enabled_and_shown() async throws {
+        // Given - announcement exists but onboarding is enabled and visible
+        let message = Yosemite.JustInTimeMessage.fake().copy(title: "JITM Message")
+        let storedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: true)]
+
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           blazeEligibilityChecker: blazeEligibilityChecker)
+        mockReloadingData(jitmResult: .success([message]), storedDashboardCards: storedCards)
+
+        // When
+        await viewModel.reloadAllData()
+
+        // Then - onboarding card should be enabled and shown
+        let onboardingCard = try XCTUnwrap(viewModel.dashboardCards.first(where: { $0.type == .onboarding }))
+        XCTAssertTrue(onboardingCard.enabled)
+        XCTAssertEqual(onboardingCard.availability, .show)
+        // And banner should be hidden (onboarding takes priority)
+        XCTAssertFalse(viewModel.shouldShowAnnouncementBanner)
+    }
 }
 
 private extension DashboardViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes the display of JITM banners.

Originally, a check was added to prevent JITM banners showing while the dashboard onboarding flow was on screen, to keep the home screen focused on the task at hand.

When that check was added, `dashboardCards` was an array of enum cases, including `.onboarding`, so the check was simply for whether that array contained `.onboarding`.

Over time, that changed to an array of structs, each with an `enabled: Bool` property, and an `availability` setting. Simply being present in the array no longer meant that the onboarding view was shown. In fact, it's always present in the array. [This was incorrectly refactored when the move to structs was made.](https://github.com/woocommerce/woocommerce-ios/commit/e5b64717d10884f971b9a34e9be7d2a03420f615#diff-9b48c8193ddc5598342e536bc43291d4e4885152fbf46aac277d4c6de29b27b1L212-L214)

By checking for the enabled and availability values, we can keep the intent but restore JITM functionality.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Set up a network proxy tool using breakpoints or Map Local on /jetpack/v4/jitm. It's important to set this up for both WPcom tunneled requests and direct site requests. You can return a JITM using this payload:

```
[
  {
    "site_id": 216335538,
    "id": "test-message",
    "feature_class": "feature",
    "content": {
      "message": "Hello, world!",
      "description": "This is a test message"
    },
    "CTA": {
      "message": "Click this",
      "link": "https://example.com"
    },
    "assets": {},
    "template": "banner"
  }
]
```

Use your own site ID if you like but it doesn't actually matter in this payload...

Open the app using a Jetpack connected store and account – you should see the banner show on the dashboard.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/200f4647-3773-40c3-af0a-8b1c51fbb096


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
