### PR TITLE
[Basic Auth] Identify basic auth challenge

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -18,6 +18,7 @@
 - [*] Fix a rare crash when opening the Coupon list [https://github.com/woocommerce/woocommerce-ios/pull/16478]
 - [*] Fixed an issue that could cause the keyboard to cover the product title when edited [https://github.com/woocommerce/woocommerce-ios/pull/16470]
 - [*] Fix application logs showing wrong year for some locales. (https://github.com/woocommerce/woocommerce-ios/pull/16471)
+- [*] Login: Show error alert when login with site credentials fails due to basic auth [https://github.com/woocommerce/woocommerce-ios/pull/16485]
 - [internal] Update Stripe Terminal to 4.7.3 [https://github.com/woocommerce/woocommerce-ios/pull/16467]
 - [Internal] Fix display of Just in Time Message banners [https://github.com/woocommerce/woocommerce-ios/pull/16480]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 24.0
 -----
-
+- [*] Login: Show error alert when login with site credentials fails due to basic auth [https://github.com/woocommerce/woocommerce-ios/pull/16485]
 
 23.9
 -----
@@ -18,7 +18,6 @@
 - [*] Fix a rare crash when opening the Coupon list [https://github.com/woocommerce/woocommerce-ios/pull/16478]
 - [*] Fixed an issue that could cause the keyboard to cover the product title when edited [https://github.com/woocommerce/woocommerce-ios/pull/16470]
 - [*] Fix application logs showing wrong year for some locales. (https://github.com/woocommerce/woocommerce-ios/pull/16471)
-- [*] Login: Show error alert when login with site credentials fails due to basic auth [https://github.com/woocommerce/woocommerce-ios/pull/16485]
 - [internal] Update Stripe Terminal to 4.7.3 [https://github.com/woocommerce/woocommerce-ios/pull/16467]
 - [Internal] Fix display of Just in Time Message banners [https://github.com/woocommerce/woocommerce-ios/pull/16480]
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooApp.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooApp.swift
@@ -2867,6 +2867,7 @@ extension WooAnalyticsEvent {
             case isJetpackActive = "is_jetpack_active"
             case isJetpackConnected = "is_jetpack_connected"
             case urlAfterRedirects = "url_after_redirects"
+            case requiredAuthChallenge = "required_auth_challenge"
         }
 
         enum LoginSiteCredentialStep: String {
@@ -2886,10 +2887,16 @@ extension WooAnalyticsEvent {
 
         /// Tracks when the login with site credentials failed.
         ///
-        static func siteCredentialFailed(step: LoginSiteCredentialStep, error: Error?) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .loginSiteCredentialsFailed,
-                              properties: [Key.step.rawValue: step.rawValue],
-                              error: error)
+        static func siteCredentialFailed(step: LoginSiteCredentialStep,
+                                         error: Error?,
+                                         challengeType: String? = nil) -> WooAnalyticsEvent {
+            var properties: [String: String] = [Key.step.rawValue: step.rawValue]
+            if let challengeType {
+                properties[Key.requiredAuthChallenge.rawValue] = challengeType
+            }
+            return WooAnalyticsEvent(statName: .loginSiteCredentialsFailed,
+                                     properties: properties,
+                                     error: error)
         }
 
         /// Tracks when site info is fetched during site address login.

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordTutorialViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordTutorialViewModel.swift
@@ -21,7 +21,7 @@ struct ApplicationPasswordTutorialViewModel {
         case .inaccessibleLoginPage, .inaccessibleAdminPage, .unacceptableStatusCode:
             return NSLocalizedString("This could be because your store has some extra security steps in place.",
                                      comment: "Reason for why the user could not login tin the application password tutorial screen")
-        case .invalidCredentials:
+        case .invalidCredentials, .basicAuthenticationRequired:
             return error.localizedDescription
         }
     }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -363,7 +363,9 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
 
         let isAppPasswordAuthError = {
             switch error {
-            case SiteCredentialLoginError.genericFailure, SiteCredentialLoginError.invalidCredentials:
+            case SiteCredentialLoginError.genericFailure,
+                 SiteCredentialLoginError.invalidCredentials,
+                 SiteCredentialLoginError.basicAuthenticationRequired:
                 return false
             case is SiteCredentialLoginError:
                 return true

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -346,7 +346,15 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             guard let self else { return }
             onLoading(false)
             onFailure(error, false)
-            self.analytics.track(event: .Login.siteCredentialFailed(step: .authentication, error: error.underlyingError))
+            let challengeType: String? = {
+                if case .basicAuthenticationRequired = error {
+                    return "basic_auth"
+                }
+                return nil
+            }()
+            self.analytics.track(event: .Login.siteCredentialFailed(step: .authentication,
+                                                                    error: error.underlyingError,
+                                                                    challengeType: challengeType))
         })
         self.siteCredentialLoginUseCase = useCase
 

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -10,6 +10,7 @@ protocol SiteCredentialLoginProtocol {
 enum SiteCredentialLoginError: LocalizedError {
     static let errorDomain = "SiteCredentialLogin"
     case invalidCredentials
+    case basicAuthenticationRequired
     case loginFailed(message: String)
     case invalidLoginResponse
     case inaccessibleLoginPage
@@ -24,6 +25,7 @@ enum SiteCredentialLoginError: LocalizedError {
         case .inaccessibleLoginPage,
              .inaccessibleAdminPage,
              .invalidLoginResponse,
+             .basicAuthenticationRequired,
              .invalidCredentials,
              .loginFailed,
              .unacceptableStatusCode:
@@ -43,6 +45,8 @@ enum SiteCredentialLoginError: LocalizedError {
             return 403
         case .invalidCredentials:
             return 401
+        case .basicAuthenticationRequired:
+            return -2
         case .unacceptableStatusCode(let code):
             return code
         case .genericFailure(let underlyingError):
@@ -56,6 +60,8 @@ enum SiteCredentialLoginError: LocalizedError {
             return Localization.inaccessibleLoginPage
         case .inaccessibleAdminPage:
             return Localization.inaccessibleAdminPage
+        case .basicAuthenticationRequired:
+            return Localization.basicAuthenticationRequired
         case .invalidLoginResponse:
             return Localization.invalidLoginResponse
         case .invalidCredentials:
@@ -93,6 +99,10 @@ enum SiteCredentialLoginError: LocalizedError {
         static let invalidCredentials = NSLocalizedString(
             "It seems the username or password you entered doesn't quite match. Double-check your credentials and try again.",
             comment: "Error message explaining login failure due to invalid credentials."
+        )
+        static let basicAuthenticationRequired = NSLocalizedString(
+            "This site is protected by basic authentication. To log in with the WooCommerce app, turn off basic authentication or allow the app through.",
+            comment: "Error message explaining login failure because the site is protected by HTTP basic authentication."
         )
     }
 }
@@ -155,9 +165,22 @@ private extension SiteCredentialLoginUseCase {
     }
 
     func startLogin(with loginRequest: URLRequest) async throws {
-        let (data, response) = try await session.data(for: loginRequest)
+        try await detectBasicAuthProbe()
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: loginRequest)
+        } catch {
+            try throwIfBasicAuth(error)
+            throw error
+        }
+
         guard let response = response as? HTTPURLResponse else {
             throw SiteCredentialLoginError.invalidLoginResponse
+        }
+
+        if response.containsHTTPBasicAuthenticationChallenge {
+            throw SiteCredentialLoginError.basicAuthenticationRequired
         }
 
         /// The login request comes with a redirect header to nonce retrieval URL.
@@ -223,6 +246,51 @@ private extension SiteCredentialLoginUseCase {
         request.httpBody = components.percentEncodedQuery?.addingPercentEncoding(withAllowedCharacters: characterSet)?.data(using: .utf8)
         return request
     }
+
+    /// Issues a lightweight GET to detect Basic Auth without engaging URLSession auth challenge flow.
+    /// Sends a dummy Authorization header so the server immediately responds with 401 + WWW-Authenticate.
+    func detectBasicAuthProbe() async throws {
+        guard let loginURL = URL(string: siteURL + Constants.loginPath) else {
+            return
+        }
+        var request = URLRequest(
+            url: loginURL,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 8
+        )
+        request.httpMethod = "GET"
+        request.setValue(
+            preflightAuthorizationHeader,
+            forHTTPHeaderField: "Authorization"
+        )
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else { return }
+            if http.containsHTTPBasicAuthenticationChallenge {
+                throw SiteCredentialLoginError.basicAuthenticationRequired
+            }
+        } catch {
+            try throwIfBasicAuth(error)
+            // Propagate other errors so the caller can decide how to handle them.
+            throw error
+        }
+    }
+}
+
+private extension SiteCredentialLoginUseCase {
+    var preflightAuthorizationHeader: String {
+        // Use dummy credentials so the server responds with 401 immediately.
+        let token = "wcapp-probe:probe".data(using: .utf8)?.base64EncodedString() ?? ""
+        return "Basic \(token)"
+    }
+
+    func throwIfBasicAuth(_ error: Error) throws {
+        let nsError = error as NSError
+        if nsError.isHTTPBasicAuthRequired {
+            throw SiteCredentialLoginError.basicAuthenticationRequired
+        }
+    }
 }
 
 extension SiteCredentialLoginUseCase {
@@ -231,6 +299,32 @@ extension SiteCredentialLoginUseCase {
         static let adminPath = "/wp-admin"
         static let wporgNoncePath = "/admin-ajax.php?action=rest-nonce"
         static let captchaText = "captcha"
+    }
+}
+
+extension HTTPURLResponse {
+    /// Detects whether the server requires HTTP Basic authentication.
+    ///
+    /// When a site is behind basic auth it responds with a 401 and a `WWW-Authenticate` header containing `Basic`.
+    /// That reliably distinguishes it from a normal WordPress login failure, which returns 200.
+    var containsHTTPBasicAuthenticationChallenge: Bool {
+        guard statusCode == 401 else {
+            return false
+        }
+        return value(forHTTPHeaderField: "WWW-Authenticate")?
+            .localizedCaseInsensitiveContains("basic") == true
+    }
+}
+
+private extension NSError {
+    /// Maps URLSession auth errors to a Basic Auth requirement.
+    var isHTTPBasicAuthRequired: Bool {
+        domain == NSURLErrorDomain &&
+        (
+            code == NSURLErrorUserAuthenticationRequired ||
+            code == NSURLErrorUserCancelledAuthentication ||
+            code == NSURLErrorCancelled    // occurs if we cancel the auth challenge
+        )
     }
 }
 

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -61,7 +61,7 @@ enum SiteCredentialLoginError: LocalizedError {
         case .inaccessibleAdminPage:
             return Localization.inaccessibleAdminPage
         case .basicAuthenticationRequired:
-            return Localization.basicAuthenticationRequired
+            return Localization.failedAuthenticationChallenge
         case .invalidLoginResponse:
             return Localization.invalidLoginResponse
         case .invalidCredentials:
@@ -89,7 +89,8 @@ enum SiteCredentialLoginError: LocalizedError {
             comment: "Error message explaining login failure due to blocked WP Admin page"
         )
         static let invalidLoginResponse = NSLocalizedString(
-            "Unable to login due to an unexpected response from your site. We are working on fixing this issue.",
+            "siteCredentialLoginError.invalidLoginResponse.message",
+            value: "Unable to login due to an unexpected response from your site.",
             comment: "Error message explaining login failure due to unexpected response."
         )
         static let unacceptableStatusCode = NSLocalizedString(
@@ -100,9 +101,10 @@ enum SiteCredentialLoginError: LocalizedError {
             "It seems the username or password you entered doesn't quite match. Double-check your credentials and try again.",
             comment: "Error message explaining login failure due to invalid credentials."
         )
-        static let basicAuthenticationRequired = NSLocalizedString(
-            "This site is protected by basic authentication. To log in with the WooCommerce app, turn off basic authentication or allow the app through.",
-            comment: "Error message explaining login failure because the site is protected by HTTP basic authentication."
+        static let failedAuthenticationChallenge = NSLocalizedString(
+            "siteCredentialLoginError.failedAuthenticationChallenge.message",
+            value: "Unable to log in due to an unexpected security measure on your store. Please contact support for troubleshooting.",
+            comment: "Error message explaining login failure due to an unexpected authentication challenge."
         )
     }
 }

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -169,13 +169,7 @@ private extension SiteCredentialLoginUseCase {
     func startLogin(with loginRequest: URLRequest) async throws {
         try await detectBasicAuthProbe()
 
-        let (data, response): (Data, URLResponse)
-        do {
-            (data, response) = try await session.data(for: loginRequest)
-        } catch {
-            try throwIfBasicAuth(error)
-            throw error
-        }
+        let (data, response): (Data, URLResponse) = try await session.data(for: loginRequest)
 
         guard let response = response as? HTTPURLResponse else {
             throw SiteCredentialLoginError.invalidLoginResponse
@@ -250,7 +244,6 @@ private extension SiteCredentialLoginUseCase {
     }
 
     /// Issues a lightweight GET to detect Basic Auth without engaging URLSession auth challenge flow.
-    /// Sends a dummy Authorization header so the server immediately responds with 401 + WWW-Authenticate.
     func detectBasicAuthProbe() async throws {
         guard let loginURL = URL(string: siteURL + Constants.loginPath) else {
             return
@@ -262,24 +255,9 @@ private extension SiteCredentialLoginUseCase {
         )
         request.httpMethod = "GET"
 
-        do {
-            let (_, response) = try await session.data(for: request)
-            guard let http = response as? HTTPURLResponse else { return }
-            if http.containsHTTPBasicAuthenticationChallenge {
-                throw SiteCredentialLoginError.basicAuthenticationRequired
-            }
-        } catch {
-            try throwIfBasicAuth(error)
-            // Propagate other errors so the caller can decide how to handle them.
-            throw error
-        }
-    }
-}
-
-private extension SiteCredentialLoginUseCase {
-    func throwIfBasicAuth(_ error: Error) throws {
-        let nsError = error as NSError
-        if nsError.isHTTPBasicAuthRequired {
+        let (_, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else { return }
+        if http.containsHTTPBasicAuthenticationChallenge {
             throw SiteCredentialLoginError.basicAuthenticationRequired
         }
     }
@@ -305,18 +283,6 @@ extension HTTPURLResponse {
         }
         return value(forHTTPHeaderField: "WWW-Authenticate")?
             .localizedCaseInsensitiveContains("basic") == true
-    }
-}
-
-private extension NSError {
-    /// Maps URLSession auth errors to a Basic Auth requirement.
-    var isHTTPBasicAuthRequired: Bool {
-        domain == NSURLErrorDomain &&
-        (
-            code == NSURLErrorUserAuthenticationRequired ||
-            code == NSURLErrorUserCancelledAuthentication ||
-            code == NSURLErrorCancelled    // occurs if we cancel the auth challenge
-        )
     }
 }
 

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -261,13 +261,9 @@ private extension SiteCredentialLoginUseCase {
             timeoutInterval: 8
         )
         request.httpMethod = "GET"
-        request.setValue(
-            preflightAuthorizationHeader,
-            forHTTPHeaderField: "Authorization"
-        )
 
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await session.data(for: request)
             guard let http = response as? HTTPURLResponse else { return }
             if http.containsHTTPBasicAuthenticationChallenge {
                 throw SiteCredentialLoginError.basicAuthenticationRequired
@@ -281,12 +277,6 @@ private extension SiteCredentialLoginUseCase {
 }
 
 private extension SiteCredentialLoginUseCase {
-    var preflightAuthorizationHeader: String {
-        // Use dummy credentials so the server responds with 401 immediately.
-        let token = "wcapp-probe:probe".data(using: .utf8)?.base64EncodedString() ?? ""
-        return "Basic \(token)"
-    }
-
     func throwIfBasicAuth(_ error: Error) throws {
         let nsError = error as NSError
         if nsError.isHTTPBasicAuthRequired {

--- a/WooCommerce/WooCommerceTests/Authentication/SiteCredentialLoginUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/SiteCredentialLoginUseCaseTests.swift
@@ -18,4 +18,38 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
         // Then
         XCTAssertEqual(cookieJar.cookies?.isEmpty, true)
     }
+
+    func test_basicAuthenticationChallenge_is_detected_from_response_headers() throws {
+        // Given
+        let response = try XCTUnwrap(makeHTTPURLResponse(
+            statusCode: 401,
+            headers: ["WWW-Authenticate": "Basic realm=\"Restricted Area\""]
+        ))
+
+        // Then
+        XCTAssertTrue(response.containsHTTPBasicAuthenticationChallenge)
+    }
+
+    func test_basicAuthenticationChallenge_returns_false_when_header_is_missing() throws {
+        // Given
+        let response = try XCTUnwrap(makeHTTPURLResponse(
+            statusCode: 401,
+            headers: ["Content-Type": "text/html"]
+        ))
+
+        // Then
+        XCTAssertFalse(response.containsHTTPBasicAuthenticationChallenge)
+    }
+}
+
+// MARK: - Helpers
+private extension SiteCredentialLoginUseCaseTests {
+    func makeHTTPURLResponse(statusCode: Int, headers: [String: String]) -> HTTPURLResponse? {
+        HTTPURLResponse(
+            url: URL(string: "https://example.com")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: headers
+        )
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1703

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Detect Basic Auth with a lightweight probe: perform a GET to wp-login.php (no Authorization header) before login. If the initial response is 401 with WWW-Authenticate: Basic or an auth error, we immediately surface basicAuthenticationRequired (code -2) and stop the flow. No URLSession auth delegates are used; this avoids hangs and timeouts.
- Simplified probe: removed redirect-blocking and dummy credentials; rely on the server’s direct 401 challenge to wp-login.php.
- Analytics: when basicAuthenticationRequired occurs, we tag the existing login_site_credentials_login_failed event with required_auth_challenge: "basic_auth" for tracking.

Note - no delegates: URLSession’s auth challenge handling can suppress/delay Basic challenges (especially over HTTP/2), causing the UI to spin. The explicit probe avoids that and gives deterministic detection.

## Tracked Event Example

```
🔵 Tracked login_site_credentials_login_failed, properties: [error_code: -2, required_auth_challenge: basic_auth, error_description: Error Domain=SiteCredentialLogin Code=-2 "Unable to log in due to an unexpected security measure on your store. Please contact support for troubleshooting." UserInfo={NSLocalizedDescription=Unable to log in due to an unexpected security measure on your store. Please contact support for troubleshooting.}, error_domain: SiteCredentialLogin, step: authentication]
```

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Steps stolen from https://github.com/woocommerce/woocommerce-ios/pull/16446

- Ensure that you have a Pressable site. Check for "Live & Test Environments: Pressable" in the field guide if you don't have one yet.
- Enable basic auth on your site by logging in to Pressable > select the site > Settings > Advanced > Basic auth.
- Build the app and log in to your site with site credentials.
- Confirm that login fails with an alert mentioning security measure. There should be no entry point to application password login.
- Check Xcode console and confirm that the failure is tracked: login_site_credentials_login_failed with error_code: -2 and error_domain: SiteCredentialLogin.
- Smoke the non-basic-auth with store credentials.
- Smoke regular wp.com auth.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/459647cf-3807-43fd-aac9-cae40260acf7

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
