### PR TITLE
Fix UI test for test_create_new_order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -95,6 +95,7 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
 
     @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
     @State private var showingCustomerSearch: Bool = false
+    @State private var isShowingDifferentAddressForm: Bool = false
 
     var body: some View {
         Group {
@@ -120,7 +121,7 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                 }
 
                 if viewModel.showDifferentAddressToggle, let differentAddressToggleTitle = viewModel.differentAddressToggleTitle {
-                    TitleAndToggleRow(title: differentAddressToggleTitle, isOn: $viewModel.showDifferentAddressForm)
+                    TitleAndToggleRow(title: differentAddressToggleTitle, isOn: $isShowingDifferentAddressForm)
                         .padding(.horizontal, Constants.horizontalPadding)
                         .padding(.vertical, Constants.verticalPadding)
                         .padding(.horizontal, insets: safeAreaInsets)
@@ -129,7 +130,7 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                         .accessibilityIdentifier("order-creation-customer-details-shipping-address-toggle")
                 }
 
-                if viewModel.showDifferentAddressForm {
+                if isShowingDifferentAddressForm {
                     SingleAddressForm(fields: $viewModel.secondaryFields,
                                       countryViewModelClosure: viewModel.createSecondaryCountryViewModel,
                                       stateViewModelClosure: viewModel.createSecondaryStateViewModel,
@@ -176,7 +177,17 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
         .redacted(reason: viewModel.showPlaceholders ? .placeholder : [])
         .shimmering(active: viewModel.showPlaceholders)
         .onAppear {
+            isShowingDifferentAddressForm = viewModel.showDifferentAddressForm
             viewModel.onLoadTrigger.send()
+        }
+        .onChange(of: isShowingDifferentAddressForm) { _, newValue in
+            viewModel.showDifferentAddressForm = newValue
+        }
+        .onReceive(viewModel.objectWillChange) { _ in
+            let current = viewModel.showDifferentAddressForm
+            if current != isShowingDifferentAddressForm {
+                isShowingDifferentAddressForm = current
+            }
         }
         .notice($viewModel.notice)
         .sheet(isPresented: $showingCustomerSearch, content: {


### PR DESCRIPTION
Fixes [WOOMOB-1904](https://linear.app/a8c/issue/WOOMOB-1904)

## Description

After some back-and-forth, I've figured out that we might be hitting a bug in the iPad simulator that prevents the UI from being redrawn when the underlying toggle changes the binding value. I've opted to resolve the issue by using a `@State` property in the view and binding its value to the view model.

## Test Steps

1. Run rake mocks on local machine
2. Use Xcode 26.1.1
3. Use iPad Pro 13inc (M5) simulator
4. Make sure the simulator system language is EN
5. Make sure the simulator doesn't have other languages keyboards except English
6. Run `test_create_new_order`
7. Make sure test passes


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
