### PR TITLE
[Tooling] Add Claude Build Analysis

### DIFF
--- a/.buildkite/claude-analysis.yml
+++ b/.buildkite/claude-analysis.yml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+# This pipeline is dynamically uploaded at the end of the build after a wait step
+
+agents:
+  queue: default
+
+steps:
+  - label: ":claude: Claude Build Analysis"
+    key: claude-analysis
+    if: build.state == "failing"
+    soft_fail: true
+    command: "exit 1"
+    plugins:
+      - $CLAUDE_PLUGIN:
+          api_key: "$ANTHROPIC_API_KEY"
+          buildkite_api_token: "$BUILDKITE_TOKEN_FOR_CLAUDE"
+          analysis_level: "build"
+          trigger: "always"
+          custom_prompt: "Do not mention successful points, focus on failures and recovery to keep the analysis succint. Only add the `Best Practices` section if the changes in this PR are directly relevant to it. Only add a `Root Cause` section when you're sure about the issues' causes."
+          model: "claude-sonnet-4-5"
+
+  - label: ":claude: 💬 Comment Claude Analysis"
+    command: .buildkite/commands/comment-claude-analysis.sh
+    depends_on: claude-analysis
+    allow_dependency_failure: true
+    if: build.pull_request.id != null
+    plugins:
+      - $CI_TOOLKIT
+

--- a/.buildkite/commands/comment-claude-analysis.sh
+++ b/.buildkite/commands/comment-claude-analysis.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -eu
+
+# The claude-analysis step only runs when there are build failures,
+# so if it ran (and soft_failed), it means there were failures that Claude analyzed.
+CLAUDE_OUTCOME=$(buildkite-agent step get outcome --step claude-analysis 2>/dev/null || echo "not_run")
+
+if [[ "${CLAUDE_OUTCOME}" == "soft_failed" ]]; then
+  comment_on_pr --id claude-build-analysis "## 🤖 Build Failure Analysis
+
+This build has failures. Claude has analyzed them - <a href=\"${BUILDKITE_BUILD_URL}/annotations\" target=\"_blank\">check the build annotations</a> for details."
+else
+  # Remove the comment if the build is now passing (claude-analysis did not run)
+  comment_on_pr --id claude-build-analysis --if-exist delete
+fi
+

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -138,3 +138,16 @@ steps:
     notify:
       - github_commit_status:
           context: UI Tests (iPad)
+
+  #################
+  # Claude Build Analysis - dynamically uploaded so Build result conditions evaluate at runtime after the wait
+  #################
+  - wait: ~
+    continue_on_failure: true
+
+  - label: ":claude: 🕵️ Check for Build Failures and Run Claude Analysis"
+    command: |
+      source .buildkite/shared-pipeline-vars
+      buildkite-agent pipeline upload .buildkite/claude-analysis.yml
+    agents:
+      queue: upload

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -16,3 +16,4 @@ CI_TOOLKIT_PLUGIN_VERSION="6.0.0"
 
 export IMAGE_ID="xcode-$XCODE_VERSION"
 export CI_TOOLKIT="automattic/a8c-ci-toolkit#$CI_TOOLKIT_PLUGIN_VERSION"
+export CLAUDE_PLUGIN="claude-summarize#v1.1.0"

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -20,6 +20,8 @@ import class Yosemite.ScreenshotStoresManager
 
 import WormholySwift
 
+breaking compilation
+
 // MARK: - Woo's App Delegate!
 //
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -20,8 +20,6 @@ import class Yosemite.ScreenshotStoresManager
 
 import WormholySwift
 
-breaking compilation
-
 // MARK: - Woo's App Delegate!
 //
 class AppDelegate: UIResponder, UIApplicationDelegate {


### PR DESCRIPTION
Fixes AINFRA-1695

## Description
Adds to the project Claude Build Analysis, based on the recent work done on [WooCommerce Android](https://github.com/woocommerce/woocommerce-android/pull/15067).
Claude will then from now on run and analyze any build job that has failed, adding a report annotation about the build failure. We'll also add a PR comment mentioning the Claude build analysis.

## Test Steps
You can check the annotation by creating a Pull Request based on this branch and breaking any of the jobs in the build.

## Screenshots
Test failed [build](https://buildkite.com/automattic/woocommerce-ios/builds/33847) with annotation:
<img width="1470" height="596" alt="Screenshot 2026-01-05 at 20 22 54" src="https://github.com/user-attachments/assets/b3f4d118-ff14-4df7-9176-0c404ec132d9" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
