### PR TITLE
[Push notifications] Call new endpoint from UI

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -106,6 +106,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return false
         case .pointOfSaleRefundsi1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .selfDrivenPushToken:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -220,4 +220,8 @@ public enum FeatureFlag: Int {
     /// Enables the refunds functionality within POS
     ///
     case pointOfSaleRefundsi1
+
+    /// Enabels self driven push token registration
+    ///
+    case selfDrivenPushToken
 }

--- a/Modules/Sources/Networking/Remote/DevicesRemote.swift
+++ b/Modules/Sources/Networking/Remote/DevicesRemote.swift
@@ -86,6 +86,7 @@ public class DevicesRemote: Remote {
                                      method: .post,
                                      siteID: siteID,
                                      path: Paths.selfDrivenPN,
+                                     parameters: parameters,
                                      availableAsRESTRequest: true)
         let mapper = TokenIDMapper()
         return try await enqueue(request, mapper: mapper)

--- a/Modules/Sources/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -131,7 +131,8 @@ extension Storage.GeneralStoreSettings {
         isPOSTabVisible: NullableCopiableProp<Bool> = .copy,
         lastPOSOpenedDate: NullableCopiableProp<Date> = .copy,
         firstPOSCatalogSyncDate: NullableCopiableProp<Date> = .copy,
-        syncPOSCatalogOverCellular: CopiableProp<Bool> = .copy
+        syncPOSCatalogOverCellular: CopiableProp<Bool> = .copy,
+        selfDrivenPushTokenID: NullableCopiableProp<Int64> = .copy,
     ) -> Storage.GeneralStoreSettings {
         let storeID = storeID ?? self.storeID
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable
@@ -156,6 +157,7 @@ extension Storage.GeneralStoreSettings {
         let lastPOSOpenedDate = lastPOSOpenedDate ?? self.lastPOSOpenedDate
         let firstPOSCatalogSyncDate = firstPOSCatalogSyncDate ?? self.firstPOSCatalogSyncDate
         let syncPOSCatalogOverCellular = syncPOSCatalogOverCellular ?? self.syncPOSCatalogOverCellular
+        let selfDrivenPushTokenID = selfDrivenPushTokenID ?? self.selfDrivenPushTokenID
 
         return Storage.GeneralStoreSettings(
             storeID: storeID,
@@ -180,7 +182,8 @@ extension Storage.GeneralStoreSettings {
             isPOSTabVisible: isPOSTabVisible,
             lastPOSOpenedDate: lastPOSOpenedDate,
             firstPOSCatalogSyncDate: firstPOSCatalogSyncDate,
-            syncPOSCatalogOverCellular: syncPOSCatalogOverCellular
+            syncPOSCatalogOverCellular: syncPOSCatalogOverCellular,
+            selfDrivenPushTokenID: selfDrivenPushTokenID
         )
     }
 }

--- a/Modules/Sources/Storage/Model/GeneralStoreSettings.swift
+++ b/Modules/Sources/Storage/Model/GeneralStoreSettings.swift
@@ -98,6 +98,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public var syncPOSCatalogOverCellular: Bool
 
+    public var selfDrivenPushTokenID: Int64?
+
     public init(storeID: String? = nil,
                 isTelemetryAvailable: Bool = false,
                 telemetryLastReportedTime: Date? = nil,
@@ -120,7 +122,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                 isPOSTabVisible: Bool? = nil,
                 lastPOSOpenedDate: Date? = nil,
                 firstPOSCatalogSyncDate: Date? = nil,
-                syncPOSCatalogOverCellular: Bool = true) {
+                syncPOSCatalogOverCellular: Bool = true,
+                selfDrivenPushTokenID: Int64? = nil) {
         self.storeID = storeID
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
@@ -144,6 +147,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
         self.lastPOSOpenedDate = lastPOSOpenedDate
         self.firstPOSCatalogSyncDate = firstPOSCatalogSyncDate
         self.syncPOSCatalogOverCellular = syncPOSCatalogOverCellular
+        self.selfDrivenPushTokenID = selfDrivenPushTokenID
     }
 
     public func erasingSelectedTaxRateID() -> GeneralStoreSettings {
@@ -205,6 +209,7 @@ extension GeneralStoreSettings {
         self.lastPOSOpenedDate = try container.decodeIfPresent(Date.self, forKey: .lastPOSOpenedDate)
         self.firstPOSCatalogSyncDate = try container.decodeIfPresent(Date.self, forKey: .firstPOSCatalogSyncDate)
         self.syncPOSCatalogOverCellular = try container.decodeIfPresent(Bool.self, forKey: .syncPOSCatalogOverCellular) ?? true
+        self.selfDrivenPushTokenID = try container.decodeIfPresent(Int64.self, forKey: .selfDrivenPushTokenID)
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/Modules/Sources/Yosemite/Actions/AppSettingsAction.swift
+++ b/Modules/Sources/Yosemite/Actions/AppSettingsAction.swift
@@ -437,4 +437,10 @@ public enum AppSettingsAction: Action {
 
     /// Gets whether we should allow cellular data use downloading POS catalogs for a specific site
     case getPOSLocalCatalogCellularDataAllowed(siteID: Int64, onCompletion: (Bool) -> Void)
+
+    /// Stores the self-driven push token ID (Woo Core push). Passing nil clears it.
+    case setSelfDrivenPushTokenID(siteID: Int64, tokenID: Int64?, onCompletion: ((Result<Void, Error>) -> Void)?)
+
+    /// Loads the stored self-driven push token ID (Woo Core push). Nil means “not registered”.
+    case loadSelfDrivenPushTokenID(siteID: Int64, onCompletion: (Int64?) -> Void)
 }

--- a/Modules/Sources/Yosemite/Stores/AppSettingsStore.swift
+++ b/Modules/Sources/Yosemite/Stores/AppSettingsStore.swift
@@ -332,6 +332,11 @@ public class AppSettingsStore: Store {
             setPOSLocalCatalogCellularDataAllowed(siteID: siteID, allowed: allowed, onCompletion: onCompletion)
         case .getPOSLocalCatalogCellularDataAllowed(let siteID, let onCompletion):
             getPOSLocalCatalogCellularDataAllowed(siteID: siteID, onCompletion: onCompletion)
+        case let .setSelfDrivenPushTokenID(siteID, tokenID, onCompletion):
+            setSelfDrivenPushTokenID(siteID: siteID, tokenID: tokenID, onCompletion: onCompletion)
+
+        case let .loadSelfDrivenPushTokenID(siteID, onCompletion):
+            loadSelfDrivenPushTokenID(siteID: siteID, onCompletion: onCompletion)
         }
     }
 }
@@ -1454,6 +1459,21 @@ private extension AppSettingsStore {
     func getPOSLocalCatalogCellularDataAllowed(siteID: Int64, onCompletion: (Bool) -> Void) {
         let allowed = siteSpecificAppSettingsStoreMethods.getPOSLocalCatalogCellularDataAllowed(siteID: siteID)
         onCompletion(allowed)
+    }
+}
+
+private extension AppSettingsStore {
+    func setSelfDrivenPushTokenID(siteID: Int64,
+                                  tokenID: Int64?,
+                                  onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let updatedSettings = storeSettings.copy(selfDrivenPushTokenID: tokenID)
+        setStoreSettings(settings: updatedSettings, for: siteID, onCompletion: onCompletion)
+    }
+
+    func loadSelfDrivenPushTokenID(siteID: Int64,
+                                   onCompletion: (Int64?) -> Void) {
+        onCompletion(getStoreSettings(for: siteID).selfDrivenPushTokenID)
     }
 }
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -230,16 +230,45 @@ extension PushNotificationsManager {
 
         deviceToken = newToken
 
-        // Register in the Dotcom's Infrastructure
-        registerDotcomDevice(with: newToken) { (device, error) in
-            guard let deviceID = device?.deviceID else {
-                DDLogError("⛔️ Dotcom Push Notifications Registration Failure: \(error.debugDescription)")
-                return
+        if shouldRegisterSelfDrivenPushNotificaiton {
+            // We will need to remove the old registartion, this is just for the newly registered stores
+            registerSelfDrivenPushNotification(with: newToken) { result in
+                switch result {
+                case .failure(let error):
+                    DDLogError("⛔️ Self Registering Push Notifications Registration Failure: \(error)")
+                case .success(let token):
+                    self.deviceID = "\(token)"
+                }
             }
-
-            DDLogVerbose("📱 Successfully registered Device ID \(deviceID) for Push Notifications")
-            self.deviceID = deviceID
         }
+        else {
+            // Register in the Dotcom's Infrastructure
+            registerDotcomDevice(with: newToken) { (device, error) in
+                guard let deviceID = device?.deviceID else {
+                    DDLogError("⛔️ Dotcom Push Notifications Registration Failure: \(error.debugDescription)")
+                    return
+                }
+
+                DDLogVerbose("📱 Successfully registered Device ID \(deviceID) for Push Notifications")
+                self.deviceID = deviceID
+            }
+        }
+    }
+
+    private var shouldRegisterSelfDrivenPushNotificaiton: Bool {
+        return ServiceLocator.featureFlagService.isFeatureFlagEnabled(.selfDrivenPushToken)
+    }
+
+    private var isWPAdminLogin: Bool {
+        guard let credentials = stores.sessionManager.defaultCredentials else {
+            return false
+        }
+
+        if case .wpcom = credentials {
+            return true
+        }
+
+        return false
     }
 
 
@@ -562,6 +591,45 @@ private extension PushNotificationsManager {
                                                        applicationId: WooConstants.pushApplicationID,
                                                        applicationVersion: Bundle.main.version,
                                                        onCompletion: onCompletion)
+        stores.dispatch(action)
+    }
+
+    func registerSelfDrivenPushNotification(with deviceToken: String, onCompletion: @escaping (Result<Int64, Error>) -> Void) {
+        guard let siteID else { return }
+
+        // Register Woo token
+        let device = APNSDevice(deviceToken: deviceToken)
+        let action = NotificationAction.registerDeviceForSelfDrivenPushNotifications(siteID: siteID,
+                                                                                     device: device,
+                                                                                     applicationID: WooConstants.pushApplicationID) { result in
+            switch result {
+            case .success(let token):
+                // Persist token locally
+                let setTokenAction = AppSettingsAction.setSelfDrivenPushTokenID(siteID: siteID, tokenID: Int64(token)) { result in
+                    switch result {
+                    case .success:
+                        break
+                    case .failure(let error):
+                        DDLogError("⛔️ Unable to set self-driven push token ID: \(error)")
+                    }
+                }
+                self.stores.dispatch(setTokenAction)
+
+                // Unregister WP token if exists if auth with WP com
+                if self.isWPAdminLogin {
+                    self.unregisterDotcomDeviceIfPossible { error in
+                        if let error {
+                            DDLogError("⛔️ Unable to unregister WP token: \(error)")
+                        }
+                        // Remove WP token locally
+
+                    }
+                }
+            case .failure(let error):
+                DDLogError("⛔️ Unable register self-driven push token: \(error)")
+                // Do nothing
+            }
+        }
         stores.dispatch(action)
     }
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -231,8 +231,9 @@ extension PushNotificationsManager {
         deviceToken = newToken
 
         if shouldRegisterSelfDrivenPushNotificaiton {
+            DDLogInfo("📱 Self Registering Push Notifications")
             // We will need to remove the old registartion, this is just for the newly registered stores
-            registerSelfDrivenPushNotification(with: newToken) { result in
+            registerSelfDrivenPushNotificationFlow(with: newToken) { result in
                 switch result {
                 case .failure(let error):
                     DDLogError("⛔️ Self Registering Push Notifications Registration Failure: \(error)")
@@ -594,10 +595,11 @@ private extension PushNotificationsManager {
         stores.dispatch(action)
     }
 
-    func registerSelfDrivenPushNotification(with deviceToken: String, onCompletion: @escaping (Result<Int64, Error>) -> Void) {
+    func registerSelfDrivenPushNotificationFlow(with deviceToken: String, onCompletion: @escaping (Result<Int64, Error>) -> Void) {
         guard let siteID else { return }
 
         // Register Woo token
+        DDLogInfo("📱 Registering self driven push notification token")
         let device = APNSDevice(deviceToken: deviceToken)
         let action = NotificationAction.registerDeviceForSelfDrivenPushNotifications(siteID: siteID,
                                                                                      device: device,
@@ -605,6 +607,7 @@ private extension PushNotificationsManager {
             switch result {
             case .success(let token):
                 // Persist token locally
+                DDLogInfo("📱 Registering self driven push notification successful token: \(token)")
                 let setTokenAction = AppSettingsAction.setSelfDrivenPushTokenID(siteID: siteID, tokenID: Int64(token)) { result in
                     switch result {
                     case .success:

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -6,6 +6,10 @@ import AutomatticTracks
 import Yosemite
 import protocol WooFoundation.Analytics
 
+extension Notification.Name {
+    static let selfDrivenPushTokenIDDidPersist = Notification.Name("selfDrivenPushTokenIDDidPersist")
+}
+
 
 /// PushNotificationsManager: Encapsulates all the tasks related to Push Notifications Auth + Registration + Handling.
 ///
@@ -113,7 +117,7 @@ final class PushNotificationsManager: PushNotesManager {
     private let analytics: Analytics
 
     private let backgroundSynchronizerFactory: PushNotificationBackgroundSynchronizerFactoryProtocol
-    private let shouldRegisterSelfDrivenPushNotification: () -> Bool
+    private let shouldRegisterSelfDrivenPushNotification: Bool
 
     /// Initializes the PushNotificationsManager.
     ///
@@ -122,7 +126,7 @@ final class PushNotificationsManager: PushNotesManager {
     init(configuration: PushNotificationsConfiguration = .default,
          backgroundSynchronizerFactory: PushNotificationBackgroundSynchronizerFactoryProtocol = PushNotificationBackgroundSynchronizerFactory(),
          analytics: Analytics = ServiceLocator.analytics,
-         shouldRegisterSelfDrivenPushNotification: @escaping () -> Bool = { ServiceLocator.featureFlagService.isFeatureFlagEnabled(.selfDrivenPushToken) }) {
+         shouldRegisterSelfDrivenPushNotification: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.selfDrivenPushToken)) {
         self.configuration = configuration
         self.backgroundSynchronizerFactory = backgroundSynchronizerFactory
         self.analytics = analytics
@@ -233,7 +237,7 @@ extension PushNotificationsManager {
 
         deviceToken = newToken
 
-        if shouldRegisterSelfDrivenPushNotification() {
+        if shouldRegisterSelfDrivenPushNotification {
             DDLogInfo("📱 Self Registering Push Notifications")
             // We will need to remove the old registartion, this is just for the newly registered stores
             registerSelfDrivenPushNotificationFlow(with: newToken) { result in
@@ -258,18 +262,6 @@ extension PushNotificationsManager {
                 self.deviceID = deviceID
             }
         }
-    }
-
-    private var isWPAdminLogin: Bool {
-        guard let credentials = stores.sessionManager.defaultCredentials else {
-            return false
-        }
-
-        if case .wpcom = credentials {
-            return true
-        }
-
-        return false
     }
 
 
@@ -633,7 +625,12 @@ private extension PushNotificationsManager {
 
     func persistSelfDrivenTokenID(_ tokenID: Int64, siteID: Int64) {
         let setTokenAction = AppSettingsAction.setSelfDrivenPushTokenID(siteID: siteID, tokenID: tokenID) { result in
-            if case let .failure(error) = result {
+            switch result {
+            case .success:
+                NotificationCenter.default.post(
+                    name: .selfDrivenPushTokenIDDidPersist, object: nil
+                )
+            case .failure(let error):
                 DDLogError("⛔️ Unable to persist self-driven push token ID: \(error)")
             }
         }
@@ -641,7 +638,7 @@ private extension PushNotificationsManager {
     }
 
     func unregisterDotcomDeviceIfNeededThenClearToken(onCompletion: @escaping () -> Void) {
-        guard isWPAdminLogin else {
+        guard !stores.isAuthenticatedWithoutWPCom else {
             onCompletion()
             return
         }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -625,12 +625,8 @@ private extension PushNotificationsManager {
     }
 
     func handleSelfDrivenRegistrationSuccess(tokenID: Int64, siteID: Int64, onCompletion: @escaping (Result<Int64, Error>) -> Void) {
-        DDLogInfo("📱 Self-driven push token registration succeeded: \(tokenID)")
-
         persistSelfDrivenTokenID(tokenID, siteID: siteID)
-        unregisterDotcomDeviceIfNeededThenClearToken(onCompletion: { [weak self] in
-            guard let self = self else { return }
-            // If we successfully unregistered the WP.com token (or no cleanup was needed), we are done.
+        unregisterDotcomDeviceIfNeededThenClearToken(onCompletion: {
             onCompletion(.success(tokenID))
         })
     }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -596,45 +596,69 @@ private extension PushNotificationsManager {
     }
 
     func registerSelfDrivenPushNotificationFlow(with deviceToken: String, onCompletion: @escaping (Result<Int64, Error>) -> Void) {
-        guard let siteID else { return }
+        guard let siteID else {
+            DDLogError("⛔️ Unable to register self-driven push token: missing siteID")
+            return
+        }
 
-        // Register Woo token
-        DDLogInfo("📱 Registering self driven push notification token")
+        DDLogInfo("📱 Registering self-driven push notification token")
+
         let device = APNSDevice(deviceToken: deviceToken)
-        let action = NotificationAction.registerDeviceForSelfDrivenPushNotifications(siteID: siteID,
-                                                                                     device: device,
-                                                                                     applicationID: WooConstants.pushApplicationID) { result in
-            switch result {
-            case .success(let token):
-                // Persist token locally
-                DDLogInfo("📱 Registering self driven push notification successful token: \(token)")
-                let setTokenAction = AppSettingsAction.setSelfDrivenPushTokenID(siteID: siteID, tokenID: Int64(token)) { result in
-                    switch result {
-                    case .success:
-                        break
-                    case .failure(let error):
-                        DDLogError("⛔️ Unable to set self-driven push token ID: \(error)")
-                    }
-                }
-                self.stores.dispatch(setTokenAction)
+        let action = NotificationAction.registerDeviceForSelfDrivenPushNotifications(
+            siteID: siteID,
+            device: device,
+            applicationID: WooConstants.pushApplicationID
+        ) { [weak self] result in
+            guard let self = self else { return }
 
-                // Unregister WP token if exists if auth with WP com
-                if self.isWPAdminLogin {
-                    self.unregisterDotcomDeviceIfPossible { error in
-                        if let error {
-                            DDLogError("⛔️ Unable to unregister WP token: \(error)")
-                        }
-                        // Remove WP token locally
-                        self.deviceToken = nil
-                    }
-                }
-                onCompletion(.success(token))
+            switch result {
+            case .success(let tokenID):
+                self.handleSelfDrivenRegistrationSuccess(tokenID: tokenID, siteID: siteID, onCompletion: onCompletion)
+
             case .failure(let error):
-                DDLogError("⛔️ Unable register self-driven push token: \(error)")
+                DDLogError("⛔️ Unable to register self-driven push token: \(error)")
                 onCompletion(.failure(error))
             }
         }
+
         stores.dispatch(action)
+    }
+
+    func handleSelfDrivenRegistrationSuccess(tokenID: Int64, siteID: Int64, onCompletion: @escaping (Result<Int64, Error>) -> Void) {
+        DDLogInfo("📱 Self-driven push token registration succeeded: \(tokenID)")
+
+        persistSelfDrivenTokenID(tokenID, siteID: siteID)
+        unregisterDotcomDeviceIfNeededThenClearToken(onCompletion: { [weak self] in
+            guard let self = self else { return }
+            // If we successfully unregistered the WP.com token (or no cleanup was needed), we are done.
+            onCompletion(.success(tokenID))
+        })
+    }
+
+    func persistSelfDrivenTokenID(_ tokenID: Int64, siteID: Int64) {
+        let setTokenAction = AppSettingsAction.setSelfDrivenPushTokenID(siteID: siteID, tokenID: tokenID) { result in
+            if case let .failure(error) = result {
+                DDLogError("⛔️ Unable to persist self-driven push token ID: \(error)")
+            }
+        }
+        stores.dispatch(setTokenAction)
+    }
+
+    func unregisterDotcomDeviceIfNeededThenClearToken(onCompletion: @escaping () -> Void) {
+        guard isWPAdminLogin else {
+            onCompletion()
+            return
+        }
+
+        unregisterDotcomDeviceIfPossible { [weak self] error in
+            if let error {
+                DDLogError("⛔️ Unable to unregister WP.com push token: \(error)")
+            }
+
+            // Remove the WP.com token locally regardless of unregister success.
+            self?.deviceToken = nil
+            onCompletion()
+        }
     }
 
     /// Unregisters the known DeviceID (if any) from the Push Notifications Backend.

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -113,6 +113,7 @@ final class PushNotificationsManager: PushNotesManager {
     private let analytics: Analytics
 
     private let backgroundSynchronizerFactory: PushNotificationBackgroundSynchronizerFactoryProtocol
+    private let shouldRegisterSelfDrivenPushNotification: () -> Bool
 
     /// Initializes the PushNotificationsManager.
     ///
@@ -120,10 +121,12 @@ final class PushNotificationsManager: PushNotesManager {
     ///
     init(configuration: PushNotificationsConfiguration = .default,
          backgroundSynchronizerFactory: PushNotificationBackgroundSynchronizerFactoryProtocol = PushNotificationBackgroundSynchronizerFactory(),
-         analytics: Analytics = ServiceLocator.analytics) {
+         analytics: Analytics = ServiceLocator.analytics,
+         shouldRegisterSelfDrivenPushNotification: @escaping () -> Bool = { ServiceLocator.featureFlagService.isFeatureFlagEnabled(.selfDrivenPushToken) }) {
         self.configuration = configuration
         self.backgroundSynchronizerFactory = backgroundSynchronizerFactory
         self.analytics = analytics
+        self.shouldRegisterSelfDrivenPushNotification = shouldRegisterSelfDrivenPushNotification
     }
 }
 
@@ -230,7 +233,7 @@ extension PushNotificationsManager {
 
         deviceToken = newToken
 
-        if shouldRegisterSelfDrivenPushNotificaiton {
+        if shouldRegisterSelfDrivenPushNotification() {
             DDLogInfo("📱 Self Registering Push Notifications")
             // We will need to remove the old registartion, this is just for the newly registered stores
             registerSelfDrivenPushNotificationFlow(with: newToken) { result in
@@ -255,10 +258,6 @@ extension PushNotificationsManager {
                 self.deviceID = deviceID
             }
         }
-    }
-
-    private var shouldRegisterSelfDrivenPushNotificaiton: Bool {
-        return ServiceLocator.featureFlagService.isFeatureFlagEnabled(.selfDrivenPushToken)
     }
 
     private var isWPAdminLogin: Bool {

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -238,6 +238,7 @@ extension PushNotificationsManager {
                 case .failure(let error):
                     DDLogError("⛔️ Self Registering Push Notifications Registration Failure: \(error)")
                 case .success(let token):
+                    DDLogInfo("📱 Self Registering Push Notifications success: \(token)")
                     self.deviceID = "\(token)"
                 }
             }
@@ -625,12 +626,13 @@ private extension PushNotificationsManager {
                             DDLogError("⛔️ Unable to unregister WP token: \(error)")
                         }
                         // Remove WP token locally
-
+                        self.deviceToken = nil
                     }
                 }
+                onCompletion(.success(token))
             case .failure(let error):
                 DDLogError("⛔️ Unable register self-driven push token: \(error)")
-                // Do nothing
+                onCompletion(.failure(error))
             }
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -76,7 +76,7 @@ struct DashboardView: View {
         return (isJetpackCPSite || isNonJetpackSite) &&
             viewModel.isSiteEligibleToInstallJetpack &&
             viewModel.jetpackBannerVisibleFromAppSettings &&
-            !viewModel.isSelfDrivenPushNotificationRegisteredIfExpected &&
+            !viewModel.isSelfDrivenPushNotificationRegistered &&
             dismissedJetpackBenefitBanner == false
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -76,6 +76,7 @@ struct DashboardView: View {
         return (isJetpackCPSite || isNonJetpackSite) &&
             viewModel.isSiteEligibleToInstallJetpack &&
             viewModel.jetpackBannerVisibleFromAppSettings &&
+            !viewModel.isSelfDrivenPushNotificationRegistered &&
             dismissedJetpackBenefitBanner == false
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -76,7 +76,7 @@ struct DashboardView: View {
         return (isJetpackCPSite || isNonJetpackSite) &&
             viewModel.isSiteEligibleToInstallJetpack &&
             viewModel.jetpackBannerVisibleFromAppSettings &&
-            !viewModel.isSelfDrivenPushNotificationRegistered &&
+            !viewModel.isSelfDrivenPushNotificationRegisteredIfExpected &&
             dismissedJetpackBenefitBanner == false
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -77,7 +77,7 @@ final class DashboardViewModel: ObservableObject {
 
     @Published private(set) var isSiteEligibleToInstallJetpack = true
 
-    @Published private(set) var isSelfDrivenPushNotificationRegisteredIfExpected = false
+    @Published private(set) var isSelfDrivenPushNotificationRegistered = false
 
     @Published private var hasOrders = false
 
@@ -190,6 +190,7 @@ final class DashboardViewModel: ObservableObject {
         configureOrdersResultController()
         setupDashboardCards()
         observeWPCOMSiteSuspendedState()
+        observeSelfDrivenPushTokenPersistence()
     }
 
     /// Must be called by the `View` during the `onAppear()` event. This will
@@ -539,6 +540,18 @@ private extension DashboardViewModel {
             .assign(to: &$isSiteEligibleToInstallJetpack)
     }
 
+    func observeSelfDrivenPushTokenPersistence() {
+        NotificationCenter.default.publisher(for: .selfDrivenPushTokenIDDidPersist)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                Task { @MainActor in
+                    await self.updateSelfDrivenPushRegistrationStatus()
+                }
+            }
+            .store(in: &subscriptions)
+    }
+
     /// Checks for Just In Time Messages and prepares the announcement if needed.
     ///
     @MainActor
@@ -807,20 +820,7 @@ private extension DashboardViewModel {
             })
         }
 
-        isSelfDrivenPushNotificationRegisteredIfExpected = (tokenID != nil) && !isWPAdminLogin
-    }
-
-
-    private var isWPAdminLogin: Bool {
-        guard let credentials = stores.sessionManager.defaultCredentials else {
-            return false
-        }
-
-        if case .wpcom = credentials {
-            return true
-        }
-
-        return false
+        isSelfDrivenPushNotificationRegistered = (tokenID != nil) && stores.isAuthenticatedWithoutWPCom
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -77,6 +77,8 @@ final class DashboardViewModel: ObservableObject {
 
     @Published private(set) var isSiteEligibleToInstallJetpack = true
 
+    @Published private(set) var isSelfDrivenPushNotificationRegistered = true
+
     @Published private var hasOrders = false
 
     @Published private(set) var isEligibleForInbox = false
@@ -344,6 +346,9 @@ private extension DashboardViewModel {
             }
             group.addTask { [weak self] in
                 await self?.googleAdsDashboardCardViewModel.checkAvailability()
+            }
+            group.addTask { [weak self] in
+                await self?.updateSelfDrivenPushRegistrationStatus()
             }
         }
     }
@@ -792,6 +797,17 @@ private extension DashboardViewModel {
     @MainActor
     func updateJetpackBannerVisibilityFromAppSettings() async {
         jetpackBannerVisibleFromAppSettings = await loadJetpackBannerVisibilityFromAppSettings()
+    }
+
+    @MainActor
+    func updateSelfDrivenPushRegistrationStatus() async {
+        let tokenID: Int64? = await withCheckedContinuation { continuation in
+            stores.dispatch(AppSettingsAction.loadSelfDrivenPushTokenID(siteID: siteID) { tokenID in
+                continuation.resume(returning: tokenID)
+            })
+        }
+
+        isSelfDrivenPushNotificationRegistered = (tokenID != nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -77,7 +77,7 @@ final class DashboardViewModel: ObservableObject {
 
     @Published private(set) var isSiteEligibleToInstallJetpack = true
 
-    @Published private(set) var isSelfDrivenPushNotificationRegistered = true
+    @Published private(set) var isSelfDrivenPushNotificationRegisteredIfExpected = false
 
     @Published private var hasOrders = false
 
@@ -807,7 +807,20 @@ private extension DashboardViewModel {
             })
         }
 
-        isSelfDrivenPushNotificationRegistered = (tokenID != nil)
+        isSelfDrivenPushNotificationRegisteredIfExpected = (tokenID != nil) && !isWPAdminLogin
+    }
+
+
+    private var isWPAdminLogin: Bool {
+        guard let credentials = stores.sessionManager.defaultCredentials else {
+            return false
+        }
+
+        if case .wpcom = credentials {
+            return true
+        }
+
+        return false
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -65,7 +65,7 @@ final class PushNotificationsManagerTests: XCTestCase {
 
             return PushNotificationsManager(configuration: configuration,
                                             backgroundSynchronizerFactory: backgroundSynchronizerFactory,
-                                            shouldRegisterSelfDrivenPushNotification: { false })
+                                            shouldRegisterSelfDrivenPushNotification: false)
         }()
     }
 
@@ -655,7 +655,7 @@ final class PushNotificationsManagerTests: XCTestCase {
 
             return PushNotificationsManager(configuration: configuration,
                                            backgroundSynchronizerFactory: backgroundSynchronizerFactory,
-                                           shouldRegisterSelfDrivenPushNotification: { true })
+                                           shouldRegisterSelfDrivenPushNotification: true)
         }()
 
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -63,7 +63,9 @@ final class PushNotificationsManagerTests: XCTestCase {
                                                                storesManager: self.storesManager,
                                                                userNotificationsCenter: self.userNotificationCenter)
 
-            return PushNotificationsManager(configuration: configuration, backgroundSynchronizerFactory: backgroundSynchronizerFactory)
+            return PushNotificationsManager(configuration: configuration,
+                                            backgroundSynchronizerFactory: backgroundSynchronizerFactory,
+                                            shouldRegisterSelfDrivenPushNotification: { false })
         }()
     }
 
@@ -637,6 +639,54 @@ final class PushNotificationsManagerTests: XCTestCase {
         // Then
         XCTAssertTrue(application.presentInAppMessages.isEmpty)
     }
+
+    func testRegisterDeviceToken_whenSelfDrivenGateEnabled_registersSelfDrivenToken_andPersistsDeviceID() {
+        // Given
+        mockSelfDrivenRegistrationActions(token: 123)
+        defaults.set("wpcom-device-id", forKey: .deviceID)
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(99)
+
+        manager = {
+            let configuration = PushNotificationsConfiguration(application: self.application,
+                                                               defaults: self.defaults,
+                                                               storesManager: self.storesManager,
+                                                               userNotificationsCenter: self.userNotificationCenter)
+
+            return PushNotificationsManager(configuration: configuration,
+                                           backgroundSynchronizerFactory: backgroundSynchronizerFactory,
+                                           shouldRegisterSelfDrivenPushNotification: { true })
+        }()
+
+        guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
+            XCTFail("Invalid sample token")
+            return
+        }
+
+        // When
+        manager.registerDeviceToken(with: tokenAsData)
+
+        // Then
+        // 1) It dispatches the self-driven registration action
+        let notificationActions = storesManager.receivedActions.compactMap { $0 as? NotificationAction }
+        XCTAssertTrue(notificationActions.contains(where: {
+            if case .registerDeviceForSelfDrivenPushNotifications = $0 { return true }
+            return false
+        }))
+
+        // 2) It persists the resulting deviceID
+        XCTAssertEqual(defaults.object(forKey: .deviceID), "123")
+
+        // 3) It persists the APNS device token
+        XCTAssertFalse(defaults.containsObject(forKey: .deviceToken))
+
+        // 4) It dispatches the app settings persistence action
+        let appSettingsActions = storesManager.receivedActions.compactMap { $0 as? AppSettingsAction }
+        XCTAssertTrue(appSettingsActions.contains(where: {
+            if case .setSelfDrivenPushTokenID = $0 { return true }
+            return false
+        }))
+    }
 }
 
 
@@ -672,6 +722,32 @@ private extension PushNotificationsManagerTests {
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
             if case .synchronizeNotifications(let completion) = action {
                 completion(error)
+            }
+        }
+    }
+
+    func mockSelfDrivenRegistrationActions(token: Int64 = 42, error: Error? = nil) {
+        storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case .registerDeviceForSelfDrivenPushNotifications(_, _, _, let completion):
+                if let error {
+                    completion(.failure(error))
+                } else {
+                    completion(.success(token))
+                }
+
+            case .unregisterDevice(let deviceID, let onCompletion):
+                XCTAssertEqual(deviceID, "wpcom-device-id")
+                onCompletion(nil)
+
+            default:
+                break
+            }
+        }
+
+        storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            if case .setSelfDrivenPushTokenID(_, _, let completion) = action {
+                completion?(.success(()))
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -960,6 +960,61 @@ final class DashboardViewModelTests: XCTestCase {
         // And banner should be hidden (onboarding takes priority)
         XCTAssertFalse(viewModel.shouldShowAnnouncementBanner)
     }
+
+    // MARK: Self-driven push registration
+    @MainActor
+    func test_updateSelfDrivenPushRegistrationStatus_sets_false_when_token_id_is_nil() async {
+        // Given
+        mockReloadingData(selfDrivenTokenID: nil)
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
+
+        // When
+        await viewModel.reloadAllData()
+
+        // Then
+        XCTAssertFalse(viewModel.isSelfDrivenPushNotificationRegisteredIfExpected)
+    }
+
+    @MainActor
+    func test_updateSelfDrivenPushRegistrationStatus_sets_true_when_token_id_exists_and_not_wpcom_login() async {
+        // Given
+        mockReloadingData(selfDrivenTokenID: 123)
+        stores.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
+
+        // When
+        await viewModel.reloadAllData()
+
+        // Then
+        XCTAssertTrue(viewModel.isSelfDrivenPushNotificationRegisteredIfExpected)
+    }
+
+    @MainActor
+    func test_updateSelfDrivenPushRegistrationStatus_sets_false_when_token_id_exists_and_wpcom_login() async {
+        // Given
+        mockReloadingData(selfDrivenTokenID: 123)
+        stores.authenticate(credentials: SessionSettings.wpcomCredentials)
+
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
+
+        // When
+        await viewModel.reloadAllData()
+
+        // Then
+        XCTAssertFalse(viewModel.isSelfDrivenPushNotificationRegisteredIfExpected)
+    }
 }
 
 private extension DashboardViewModelTests {
@@ -969,7 +1024,8 @@ private extension DashboardViewModelTests {
                            existingProducts: [Product] = [],
                            existingBlazeCampaigns: [BlazeCampaignListItem] = [],
                            storedDashboardCards: [DashboardCard] = [],
-                           shouldShowInAppFeedback: Bool = false) {
+                           shouldShowInAppFeedback: Bool = false,
+                           selfDrivenTokenID: Int64? = nil) {
         stores.whenReceivingAction(ofType: JustInTimeMessageAction.self) { action in
             switch action {
             case let .loadMessage(_, _, _, completion):
@@ -1002,7 +1058,7 @@ private extension DashboardViewModelTests {
             case let .getPOSSurveyCurrentMerchantNotificationScheduled(onCompletion):
                 onCompletion(false)
             case let .loadSelfDrivenPushTokenID(_, onCompletion):
-                onCompletion(nil)
+                onCompletion(selfDrivenTokenID)
             default:
                 break
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -976,7 +976,7 @@ final class DashboardViewModelTests: XCTestCase {
         await viewModel.reloadAllData()
 
         // Then
-        XCTAssertFalse(viewModel.isSelfDrivenPushNotificationRegisteredIfExpected)
+        XCTAssertFalse(viewModel.isSelfDrivenPushNotificationRegistered)
     }
 
     @MainActor
@@ -994,7 +994,7 @@ final class DashboardViewModelTests: XCTestCase {
         await viewModel.reloadAllData()
 
         // Then
-        XCTAssertTrue(viewModel.isSelfDrivenPushNotificationRegisteredIfExpected)
+        XCTAssertTrue(viewModel.isSelfDrivenPushNotificationRegistered)
     }
 
     @MainActor
@@ -1013,7 +1013,7 @@ final class DashboardViewModelTests: XCTestCase {
         await viewModel.reloadAllData()
 
         // Then
-        XCTAssertFalse(viewModel.isSelfDrivenPushNotificationRegisteredIfExpected)
+        XCTAssertFalse(viewModel.isSelfDrivenPushNotificationRegistered)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -69,6 +69,8 @@ final class DashboardViewModelTests: XCTestCase {
                 onCompletion(false)
             case let .getPOSSurveyCurrentMerchantNotificationScheduled(onCompletion):
                 onCompletion(false)
+            case let .loadSelfDrivenPushTokenID(_, onCompletion):
+                onCompletion(nil)
             default:
                 break
             }
@@ -999,6 +1001,8 @@ private extension DashboardViewModelTests {
                 onCompletion(false)
             case let .getPOSSurveyCurrentMerchantNotificationScheduled(onCompletion):
                 onCompletion(false)
+            case let .loadSelfDrivenPushTokenID(_, onCompletion):
+                onCompletion(nil)
             default:
                 break
             }


### PR DESCRIPTION
Closes [WOOMOB-1597](https://linear.app/a8c/issue/WOOMOB-1597) and [WOOMOB-1857](https://linear.app/a8c/issue/WOOMOB-1857)

## Description

This PR intergrates the new token endpoint to the UI.

- [Added](https://github.com/woocommerce/woocommerce-ios/pull/16488/changes#diff-043cf9f12996f8517cd9a5f4608e12b0ce1f23b66955223d1650c886558b146f) a selfDrivenPushToken  local FF to hide the changes from prod and only enabling it for local and alpha builds.
- [Added](https://github.com/woocommerce/woocommerce-ios/pull/16488/changes#diff-13bb5736a5bd176d964fd25cd40589c285db217004f65b0525ba5c0cf6b5c78c) selfDrivenPushTokenID to GeneraStoreSettings as a flag to check whether registering the token was successful. Which we need to decide if jetpack banner is needed.
- Most of the changes are to [PushNotificationsManager](https://github.com/woocommerce/woocommerce-ios/pull/16488/changes#diff-9e8b41ce9b767f7a2ef32434891f864524459ee3434d14b1573b3f4858f15d61)
I've extended the registerDeviceToken function to check wether we should use the new registration flow.
Encapsulated the new [flow](https://github.com/woocommerce/woocommerce-ios/pull/16488/changes#diff-9e8b41ce9b767f7a2ef32434891f864524459ee3434d14b1573b3f4858f15d61R599) in registerSelfDrivenPushNotificationFlow.
- Added tests

## Screenshots

<img width="585" height="133" alt="My Store" src="https://github.com/user-attachments/assets/07ecaf58-681c-4e68-b98a-79ff65285861" />

## Testing steps

You'll need to spin up a jurassic site, see the steps here p91TBi-dyW-p2#comment-14564 

1. Login to the new site with the generated user/password
2. Navigate to Menu/Settings/Help & Support/View Application Log
3. Open the latest logs
4. Look for "Self Registering Push Notificaitons success: <ID>"

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.