### PR TITLE
Update Sourcery for Xcode 26 compatibility

### DIFF
--- a/BuildTools/.sourcery.yml
+++ b/BuildTools/.sourcery.yml
@@ -1,4 +1,4 @@
-# At the time of writing and with Sourcery 2.2.6, running the tool via `swift
+# At the time of writing and with Sourcery 2.3.0, running the tool via `swift
 # package plugin` ignores the --config parameter, looking instead for the
 # .sourcery.yml configuration file.
 #

--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bb374fb1cfe6769494b51a8da522b904ded4d3987ad68cd369eadb59e59f5e74",
+  "originHash" : "4412d5fdffc8c6a0f1fee03cbe27277522313756b1e249a69170eff17e947872",
   "pins" : [
     {
       "identity" : "aexml",
@@ -33,8 +33,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzysztofzablocki/Sourcery.git",
       "state" : {
-        "revision" : "83205514943652219cb3b974fe0dc48db9ceddb1",
-        "version" : "2.2.6"
+        "revision" : "b703710aefe52f9e8303bc8afb1bec1f15b540af"
       }
     },
     {
@@ -69,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
-        "version" : "1.2.3"
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
       }
     },
     {
@@ -112,28 +111,28 @@
     {
       "identity" : "swift-driver",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/art-divin/swift-driver.git",
+      "location" : "https://github.com/swiftlang/swift-driver.git",
       "state" : {
-        "revision" : "1c07ced84c1dfc1f9c3253dcbaa216fc9c76ee25",
-        "version" : "1.0.1"
+        "branch" : "release/6.2",
+        "revision" : "aedacc6c1583db4f2989a367e3c41968558a5b8e"
       }
     },
     {
       "identity" : "swift-llbuild",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/art-divin/swift-llbuild.git",
+      "location" : "https://github.com/swiftlang/swift-llbuild.git",
       "state" : {
-        "revision" : "783aec21649a6c47d1a8314db4144bdceb11df30",
-        "version" : "1.0.0"
+        "branch" : "release/6.2",
+        "revision" : "073dff55529d7c4ecbd615ab5f5ac52ae5b380da"
       }
     },
     {
       "identity" : "swift-package-manager",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/art-divin/swift-package-manager.git",
+      "location" : "https://github.com/swiftlang/swift-package-manager.git",
       "state" : {
-        "revision" : "7df9321541e544d711dd93f5b97dd4e8bf7e100e",
-        "version" : "1.0.8"
+        "branch" : "swift-6.2-RELEASE",
+        "revision" : "3cf1cb66ebde00dab737dcebad96218e2017530d"
       }
     },
     {
@@ -141,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
-        "version" : "510.0.3"
+        "branch" : "release/6.2",
+        "revision" : "5a87516fc3dddbd23cb76358eb489915ee86b444"
       }
     },
     {
@@ -155,12 +154,21 @@
       }
     },
     {
+      "identity" : "swift-toolchain-sqlite",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-toolchain-sqlite",
+      "state" : {
+        "revision" : "b45b80b943e88db3cb8ddea798fa3fa9912375ff",
+        "version" : "1.0.7"
+      }
+    },
+    {
       "identity" : "swift-tools-support-core",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/art-divin/swift-tools-support-core.git",
+      "location" : "https://github.com/swiftlang/swift-tools-support-core.git",
       "state" : {
-        "revision" : "930e82e5ae2432c71fe05f440b5d778285270bdb",
-        "version" : "1.0.0"
+        "branch" : "release/6.2",
+        "revision" : "5a993c8848487c934d53ffceef8e1cad0a241dc1"
       }
     },
     {

--- a/BuildTools/Package.swift
+++ b/BuildTools/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 import Foundation
 import PackageDescription
 
@@ -7,7 +7,8 @@ let package = Package(
     platforms: [.macOS(.v10_13)],
     dependencies: [
         .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", exact: loadSwiftLintVersion()),
-        .package(url: "https://github.com/krzysztofzablocki/Sourcery.git", from: "2.2.6")
+        // version 2.3.0 for Xcode 26 compatibility
+        .package(url: "https://github.com/krzysztofzablocki/Sourcery.git", revision: "b703710aefe52f9e8303bc8afb1bec1f15b540af")
     ],
     targets: [.target(name: "BuildTools", path: "")]
 )

--- a/Modules/Sources/Codegen/Sourcery/Fakes/Fakes.swifttemplate
+++ b/Modules/Sources/Codegen/Sourcery/Fakes/Fakes.swifttemplate
@@ -51,7 +51,7 @@ let specsToGenerate: [FakeableSpec] = matchingTypes.map { type in
 
     let accessLevel = type.accessLevel == "internal" ? "" : "\(type.accessLevel) "
 
-    /// If we are generating for an `Enum`, return with `.value` for content 
+    /// If we are generating for an `Enum`, return with `.value` for content
     if let enumType = type as? Enum, let firstEnumCase = enumType.cases.first {
         var name = enumType.globalName
         // When passing an Xcode project with synchronized folders or a source from a Swift package, globalName will not include the module name.
@@ -59,7 +59,9 @@ let specsToGenerate: [FakeableSpec] = matchingTypes.map { type in
             name = "\(moduleName).\(name)"
         }
 
-        return FakeableSpec(name: name, accessLevelWithSpacePostfix: accessLevel, content: .value(firstEnumCase.name))
+        // If the enum case has associated values, add parentheses to call it as a function
+        let caseName = firstEnumCase.hasAssociatedValue ? "\(firstEnumCase.name)()" : firstEnumCase.name
+        return FakeableSpec(name: name, accessLevelWithSpacePostfix: accessLevel, content: .value(caseName))
     }
 
     /// Make sure we have at least one non throwable-initializer to work with.

--- a/Modules/Sources/Fakes/Hardware.generated.swift
+++ b/Modules/Sources/Fakes/Hardware.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Yosemite

--- a/Modules/Sources/Fakes/Networking.generated.swift
+++ b/Modules/Sources/Fakes/Networking.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Yosemite

--- a/Modules/Sources/Fakes/NetworkingCore.generated.swift
+++ b/Modules/Sources/Fakes/NetworkingCore.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Yosemite
@@ -44,7 +44,7 @@ extension NetworkingCore.DotcomError {
     /// Returns a "ready to use" type filled with fake values.
     ///
     public static func fake() -> NetworkingCore.DotcomError {
-        .empty()
+        .empty
     }
 }
 extension NetworkingCore.MetaContainer {

--- a/Modules/Sources/Fakes/NetworkingCore.generated.swift
+++ b/Modules/Sources/Fakes/NetworkingCore.generated.swift
@@ -44,7 +44,7 @@ extension NetworkingCore.DotcomError {
     /// Returns a "ready to use" type filled with fake values.
     ///
     public static func fake() -> NetworkingCore.DotcomError {
-        .empty
+        .empty()
     }
 }
 extension NetworkingCore.MetaContainer {

--- a/Modules/Sources/Fakes/WooFoundation.generated.swift
+++ b/Modules/Sources/Fakes/WooFoundation.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // Currently empty because none of the given sources conforms to GeneratedFakeable

--- a/Modules/Sources/Fakes/WooFoundationCore.generated.swift
+++ b/Modules/Sources/Fakes/WooFoundationCore.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Yosemite

--- a/Modules/Sources/Fakes/Yosemite.generated.swift
+++ b/Modules/Sources/Fakes/Yosemite.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Yosemite

--- a/Modules/Sources/Hardware/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Hardware/Model/Copiable/Models+Copiable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 import Codegen
 import Foundation

--- a/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 import CocoaLumberjackSwift
 import Codegen

--- a/Modules/Sources/NetworkingCore/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/NetworkingCore/Model/Copiable/Models+Copiable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 import Codegen
 import Foundation

--- a/Modules/Sources/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 import Codegen
 import Foundation

--- a/Modules/Sources/WooFoundation/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/WooFoundation/Model/Copiable/Models+Copiable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable line_length

--- a/Modules/Sources/WooFoundationCore/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/WooFoundationCore/Model/Copiable/Models+Copiable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable line_length

--- a/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 import Codegen
 import Foundation

--- a/WooCommerce/Classes/Copiable/Models+Copiable.generated.swift
+++ b/WooCommerce/Classes/Copiable/Models+Copiable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 import Codegen
 import Foundation

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
@@ -1,11 +1,11 @@
 import enum Networking.BookingAttendanceStatus
 
 extension WooAnalyticsEvent {
-    private enum Properties {
-        static let bookingStatus = "booking_status"
-    }
-
     enum BookingsDetail {
+        private enum Properties {
+            static let bookingStatus = "booking_status"
+        }
+
         static func bookingCancelled() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .bookingCancelled)
         }

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
@@ -1,6 +1,10 @@
 import enum Networking.BookingAttendanceStatus
 
 extension WooAnalyticsEvent {
+    private enum Properties {
+        static let bookingStatus = "booking_status"
+    }
+
     enum BookingsDetail {
         static func bookingCancelled() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .bookingCancelled)
@@ -24,11 +28,5 @@ extension WooAnalyticsEvent {
         static func bookingViewLinkedOrderTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .bookingViewLinkedOrderTapped)
         }
-    }
-}
-
-fileprivate extension WooAnalyticsEvent.BookingsDetail {
-    enum Properties {
-        static let bookingStatus = "booking_status"
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR:
- Updates Sourcery to `2.3.0` so that its dependencies will compile with Xcode 26
- Changes `Fakes.swifttemplate` to add parentheses to enum cases with an associated value, otherwise building for the test schema would fail
- Changes a `fileprivate extension` to instead be a private enum for the type, otherwise Sourcery's analysis would fail
- Applies the changes from running `rake generate`

This is required due to Xcode on CI [recently being upgraded](https://github.com/woocommerce/woocommerce-ios/pull/16459).

### More info

Running `swift package show-dependencies` shows that `swift-llbuild` is a sub-dependency of Sourcery and resolves to version `1.0.0`.

The root of this issue is due to a redeclaration of `posix_spawn_file_actions_addchdir`, one is `static` and the other is not:

```
woocommerce-ios/BuildTools/.build/checkouts/swift-llbuild/lib/Basic/Subprocess.cpp:89:12: error: static declaration of 'posix_spawn_file_actions_addchdir' follows non-static declaration
   89 | static int posix_spawn_file_actions_addchdir(posix_spawn_file_actions_t * __restrict file_actions,
      |            ^
/Applications/Xcode-26.2.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.2.sdk/usr/include/spawn.h:72:9: note: previous declaration is here
   72 | int     posix_spawn_file_actions_addchdir(posix_spawn_file_actions_t *,
      |         ^
1 error generated.
[15/489] Compiling llbuildBasic FileSystem.cpp
error: fatalError
```

Updating Sourcery appears to use a newer version of `swift-llbuild` where [this is resolved](https://github.com/swiftlang/swift-llbuild/issues/1002).

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Running `rake generate` locally on a system with Xcode 26 installed shouldn't fail nor produce any changes.
- CI should be all green.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
