### PR TITLE
Update POS barcode scanner documentation URL

### DIFF
--- a/Modules/Sources/PointOfSale/Utils/POSConstants.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSConstants.swift
@@ -14,7 +14,7 @@ enum POSConstants {
 
         /// URL for Point of Sale's barcode scanner documentation
         ///
-        case pointOfSaleBarcodeScannerDocumentation = "https://woocommerce.com/document/barcode-and-qr-code-scanner/"
+        case pointOfSaleBarcodeScannerDocumentation = "https://woocommerce.com/document/point-of-sale-mode-barcode-scanning/"
 
         /// URL for Point of Sale's IPP Woo Payments documentation
         ///

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -18,6 +18,7 @@
 - [*] Fix a rare crash when opening the Coupon list [https://github.com/woocommerce/woocommerce-ios/pull/16478]
 - [*] Fixed an issue that could cause the keyboard to cover the product title when edited [https://github.com/woocommerce/woocommerce-ios/pull/16470]
 - [*] Fix application logs showing wrong year for some locales. (https://github.com/woocommerce/woocommerce-ios/pull/16471)
+- [*] Updated barcode scanner documentation URL in POS [https://github.com/woocommerce/woocommerce-ios/pull/16490]
 - [internal] Update Stripe Terminal to 4.7.3 [https://github.com/woocommerce/woocommerce-ios/pull/16467]
 - [Internal] Fix display of Just in Time Message banners [https://github.com/woocommerce/woocommerce-ios/pull/16480]
 


### PR DESCRIPTION
Closes WOOMOB-1947

## Description
Updates the URL for barcode scanner documentation URL to be `https://woocommerce.com/document/point-of-sale-mode-barcode-scanning/`, rather than the more general camera scanning functionality from the app.

## Test Steps
- Open POS
- Navigate to Settings > Hardware > Barcode scanners > Documentation
- Tap and observe the new URL is loaded:

![simulator_screenshot_578DBBC4-88F5-4247-BFC8-89420F06A2C5](https://github.com/user-attachments/assets/ac739361-1af5-49fb-b613-189e0641b661)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
