### PR TITLE
Stripe SDK update to 5.0 (2) - Refunds

### DIFF
--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -800,50 +800,38 @@ extension StripeCardReaderService {
         }
     }
 
-    /// Calling any other SDK methods between collectRefundPaymentMethod and processRefund will result in undefined behavior.
-    /// We have a spinlock to prevent other SDK methods being used until processRefund is done. It will need a timeout.
+    /// Processes a refund using the unified processRefund API (SDK 5.0+).
     ///
     func refund(_ parameters: StripeTerminal.RefundParameters) -> Future<StripeTerminal.Refund, Error> {
         return Future() { [weak self] promise in
-            self?.refundCancellable = Terminal.shared.collectRefundPaymentMethod(parameters) { [weak self] collectError in
-                if let error = collectError {
-                    self?.refundCancellable = nil
-                    let underlyingError = Self.logAndDecodeError(error)
+            self?.refundCancellable = Terminal.shared.processRefund(parameters, collectConfig: nil) { [weak self] processedRefund, processError in
+                guard let self = self else { return }
+                self.refundCancellable = nil
+
+                if let error = processError {
                     promise(.failure(CardReaderServiceError.refundPayment(
-                        underlyingError: underlyingError,
-                        shouldRetry: true
+                        underlyingError: Self.logAndDecodeError(error),
+                        shouldRetry: self.shouldRetryRefund(after: error)
                     )))
-                } else {
-                    // Process refund
-                    Terminal.shared.confirmRefund { [weak self] processedRefund, processError in
-                        guard let self = self else { return }
-                        self.refundCancellable = nil
-                        if let error = processError {
-                            promise(.failure(CardReaderServiceError.refundPayment(
-                                underlyingError: Self.logAndDecodeError(error),
-                                shouldRetry: self.shouldRetryRefund(after: error)
-                            )))
-                        } else if let refund = processedRefund {
-                            switch refund.status {
-                                //TODO: Find out how best to handle pending and unknown. Succeed for now based on Stripe's sample code
-                            case .succeeded, .pending, .unknown:
-                                promise(.success(refund))
-                            case .failed:
-                                promise(.failure(CardReaderServiceError.refundPayment(
-                                    underlyingError: .internalServiceError,
-                                    shouldRetry: self.shouldRetryRefundAfterFailureDeterminer.shouldRetryRefund(after: refund.failureReason)
-                                )))
-                            @unknown default:
-                                break
-                            }
-                        } else {
-                            promise(.failure(CardReaderServiceError.refundPayment(
-                                underlyingError: .internalServiceError,
-                                shouldRetry: false
-                            )))
-                            //TODO: check why we might have no refund and no error
-                        }
+                } else if let refund = processedRefund {
+                    switch refund.status {
+                        //TODO: Find out how best to handle pending and unknown. Succeed for now based on Stripe's sample code
+                    case .succeeded, .pending, .unknown:
+                        promise(.success(refund))
+                    case .failed:
+                        promise(.failure(CardReaderServiceError.refundPayment(
+                            underlyingError: .internalServiceError,
+                            shouldRetry: self.shouldRetryRefundAfterFailureDeterminer.shouldRetryRefund(after: refund.failureReason)
+                        )))
+                    @unknown default:
+                        break
                     }
+                } else {
+                    promise(.failure(CardReaderServiceError.refundPayment(
+                        underlyingError: .internalServiceError,
+                        shouldRetry: false
+                    )))
+                    //TODO: check why we might have no refund and no error
                 }
             }
         }
@@ -851,7 +839,7 @@ extension StripeCardReaderService {
 
     /// Implements refund retry logic as recommended by Stripe
     /// https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)processRefund
-    /// > When `confirmRefund` fails, the SDK returns an error that either includes the failed `SCPRefund` or the `SCPRefundParameters` that led to a failure.
+    /// > When `processRefund` fails, the SDK returns an error that either includes the failed `SCPRefund` or the `SCPRefundParameters` that led to a failure.
     /// > Your app should inspect the `SCPConfirmRefundError` to decide how to proceed.
     /// >
     /// > If the `refund` property is nil, the request to Stripe's servers timed out and the refund's status is unknown.


### PR DESCRIPTION
Continuation from https://github.com/woocommerce/woocommerce-ios/pull/16493 , which needs to be merged first. I'll merge the SDK updates into the main PR, and we can test the full payments/refunds flow fully before actually merging to trunk.

## Description
This is part 2 from the SDK migration. The Stripe SDK API for refunds has changed in 5.0+ from having 2 nested calls ( collect refund + confirm refund ) in the refund flow, to 1 single call ( process refund ), with only 1 nested level for the callback and single error handler. 


## Changes
- Removes usage of `Terminal.shared.collectRefundPaymentMethod` and `Terminal.shared.confirmRefund` in favor of `Terminal.shared.processRefund( ... )` to process refunds

There is a new optional property `CollectRefundConfiguration` that we can use if needed, this allows us to enable/disable the ability for customers to cancel refunds mid-flow if we wanted. I've left it as `nil` as that's the current behavior for 4.0 ( defaults to "allow if it's available") and does not need additional specific handling.

```
enum SCPCustomerCancellation {
      case enableIfAvailable   // (default) Allow cancel button on reader
      case disableIfAvailable  // Hide cancel button on reader
  }
```

## Test Steps
Process several orders and refund them. Using WooCommerce Payments, Stripe, and Tap to Pay. Test both partial refunds (only some items) and fully (all items of an order). You should see no hiccups, and should work normally.

Tested using iPhone 14 on iOS 18.7.2, using Stripe M2 reader

## Screenshots
N/A
