### PR TITLE
Stripe SDK update to 5.0 (3) - Payment intents

### DIFF
--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -349,9 +349,7 @@ extension StripeCardReaderService: CardReaderService {
             .flatMap {
                 self.createPaymentIntent(parameters)
             }.flatMap { intent in
-                self.collectPaymentMethod(intent: intent)
-            }.flatMap { intent in
-                self.processPayment(intent: intent)
+                self.processPaymentIntent(intent: intent)
             }
             .map(PaymentIntent.init(intent:))
             .eraseToAnyPublisher()
@@ -363,11 +361,8 @@ extension StripeCardReaderService: CardReaderService {
                 .eraseToAnyPublisher()
         }
         switch activePaymentIntent.status {
-        case .requiresPaymentMethod:
-            return collectPaymentMethod(intent: activePaymentIntent)
-                .flatMap { intent in
-                    self.processPayment(intent: intent)
-                }
+        case .requiresPaymentMethod, .requiresConfirmation:
+            return processPaymentIntent(intent: activePaymentIntent)
                 .map(PaymentIntent.init(intent:))
                 .mapError { [weak self] error in
                     if case CardReaderServiceError.paymentMethodCollection = error {
@@ -380,10 +375,6 @@ extension StripeCardReaderService: CardReaderService {
                     }
                     return error
                 }
-                .eraseToAnyPublisher()
-        case .requiresConfirmation:
-            return processPayment(intent: activePaymentIntent)
-                .map(PaymentIntent.init(intent:))
                 .eraseToAnyPublisher()
         case .requiresCapture:
             return Just(PaymentIntent(intent: activePaymentIntent))
@@ -680,66 +671,38 @@ private extension StripeCardReaderService {
         }
     }
 
-    func collectPaymentMethod(intent: StripeTerminal.PaymentIntent) -> AnyPublisher<StripeTerminal.PaymentIntent, Error> {
-        let collectPaymentMethodFuture = Future<StripeTerminal.PaymentIntent, Error>() { [weak self] promise in
-            /// Collect Payment method returns a cancellable
-            /// Because we are chaining promises, we need to retain a reference
-            /// to this cancellable if we want to cancel
-            self?.paymentCancellable = Terminal.shared.collectPaymentMethod(intent) { (intent, error) in
+    func processPaymentIntent(intent: StripeTerminal.PaymentIntent) -> AnyPublisher<StripeTerminal.PaymentIntent, Error> {
+        let processPaymentIntentFuture = Future<StripeTerminal.PaymentIntent, Error>() { [weak self] promise in
+            // Send event immediately to preserve "Processing..." UI behavior, since the new Stripe API (5.0) does not have an intermediate callback between
+            // "card read" and "confimation complete"
+            self?.sendReaderEvent(.cardDetailsCollected)
+
+            self?.paymentCancellable = Terminal.shared.processPaymentIntent(
+                intent,
+                collectConfig: nil,
+                confirmConfig: nil
+            ) { (intent, error) in
+                guard let self = self else { return }
+                self.paymentCancellable = nil
+
                 if let error = error {
                     var underlyingError = Self.logAndDecodeError(error)
-                    /// the completion block for collectPaymentMethod will be called
-                    /// with error Canceled when collectPaymentMethod is canceled
-                    /// https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)collectPaymentMethod:delegate:completion:
+
                     if case .commandCancelled(let cancellationSource) = underlyingError {
-                        DDLogWarn("💳 Warning: collect payment cancelled \(error)")
+                        DDLogWarn("💳 Warning: process payment intent cancelled \(error)")
                         if case .unknown = cancellationSource {
-                            if self?.cancellationStartedInApp != nil {
+                            if self.cancellationStartedInApp != nil {
                                 underlyingError = .commandCancelled(from: .app)
                             } else {
                                 underlyingError = .commandCancelled(from: .reader)
                             }
                         }
                     } else {
-                        DDLogError("💳 Error: collect payment method \(underlyingError)")
+                        DDLogError("💳 Error: process payment intent \(underlyingError)")
                     }
-                    self?.paymentCancellable = nil
-                    promise(.failure(CardReaderServiceError.paymentMethodCollection(underlyingError: underlyingError)))
-                }
 
-                if let intent = intent {
-                    self?.paymentCancellable = nil
-                    self?.sendReaderEvent(.cardDetailsCollected)
-                    promise(.success(intent))
-                }
-            }
-        }
-
-        switch connectedReadersSubject.value.first?.readerType {
-        case .tapToPay:
-            // Don't add a timeout to Tap to Pay, because Apple handle it in their UI.
-            return collectPaymentMethodFuture
-                .eraseToAnyPublisher()
-        case .chipper, .stripeM2, .wisepad3, .other, .none:
-            return collectPaymentMethodFuture
-                .timeout(120, scheduler: DispatchQueue.main, customError: { [weak self] in
-                    // Cancel the payment if a card isn't provided to an external reader within two minutes
-                    _ = self?.cancelPaymentIntent()
-                    return CardReaderServiceError.paymentMethodCollection(
-                        underlyingError: .paymentMethodCollectionTimedOut)
-                })
-                .eraseToAnyPublisher()
-        }
-    }
-
-    func processPayment(intent: StripeTerminal.PaymentIntent) -> Future<StripeTerminal.PaymentIntent, Error> {
-        return Future() { [weak self] promise in
-            Terminal.shared.confirmPaymentIntent(intent) { (intent, error) in
-                guard let self = self else { return }
-                if let error = error {
-                    let underlyingError = Self.logAndDecodeError(error)
-
-                    guard let paymentIntent = error.paymentIntent else {
+                    // TODO: Switch between error cases and handle separately to make more explicit?
+                    guard let confirmError = error as? ConfirmPaymentIntentError, let paymentIntent = confirmError.paymentIntent else {
                         return promise(.failure(CardReaderServiceError.paymentCapture(underlyingError: underlyingError)))
                     }
 
@@ -762,6 +725,22 @@ private extension StripeCardReaderService {
                     return promise(.success(intent))
                 }
             }
+        }
+
+        switch connectedReadersSubject.value.first?.readerType {
+        case .tapToPay:
+            // Don't add a timeout to Tap to Pay, because Apple handles it in their UI.
+            return processPaymentIntentFuture
+                .eraseToAnyPublisher()
+        case .chipper, .stripeM2, .wisepad3, .other, .none:
+            return processPaymentIntentFuture
+                .timeout(120, scheduler: DispatchQueue.main, customError: { [weak self] in
+                    // Cancel the payment if a card isn't provided to an external reader within two minutes
+                    _ = self?.cancelPaymentIntent()
+                    return CardReaderServiceError.paymentMethodCollection(
+                        underlyingError: .paymentMethodCollectionTimedOut)
+                })
+                .eraseToAnyPublisher()
         }
     }
 }


### PR DESCRIPTION
Continuation from https://github.com/woocommerce/woocommerce-ios/pull/16493 , which needs to be merged first. I'll merge the SDK updates into the main PR, and we can test the full payments/refunds flow fully before actually merging to trunk.

## Description
This is part 3 from the SDK migration. The Stripe SDK API for payment collection and payment intents has changed in 5.0+ from having 2 different APIs (collect the payment method + process the payment) to a single `processPaymentIntent` which handles both internally.

## Changes
- Remove `collectPaymentMethod` and `processPayment` in favor of `processPaymentIntent`
- Call `sendReaderEvent(.cardDetailsCollected)` at the start of the flow. Previously, we would fire an event after the card was successfully read but before confirmation, however in the new API there is no intermediate callback between "card read" and "confirmation complete", it just fires at the end. By sending the event at the beginning of the flow, we keep the "Processing..." state in the UI, so nothing changes, just a slight different timing from before. 

## Test Steps
Process one/several orders using WooCommerce Payments, Stripe, and Tap to Pay (app and POS). You should see no hiccups, and should work normally.

Tested using iPhone 14 on iOS 18.7.2, and iPad Pro on iOS 26.0, using Stripe M2 reader

## Screenshots
N/A
