### PR TITLE
Fix App Store strings

### DIFF
--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -120,6 +120,7 @@ msgstr ""
 #. No specified characters limit here, but try to keep as short as the source one.
 msgctxt "app_store_screenshot-8"
 msgid ""
-"\n"
-"\n"
+"Get notified of\n"
+"every sale\n"
 msgstr ""
+

--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -76,14 +76,6 @@ msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
 #. No specified characters limit here, but try to keep as short as the source one.
-msgctxt "app_store_screenshot-1_b"
-msgid ""
-"Made with 💜\n"
-"at Automattic\n"
-msgstr ""
-
-#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
-#. No specified characters limit here, but try to keep as short as the source one.
 msgctxt "app_store_screenshot-2"
 msgid ""
 "Create orders\n"
@@ -124,3 +116,10 @@ msgid ""
 "with a touch\n"
 msgstr ""
 
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one.
+msgctxt "app_store_screenshot-8"
+msgid ""
+"\n"
+"\n"
+msgstr ""


### PR DESCRIPTION
Fixes AINFRA-1722

## Description
I've manually added an empty `app_store_screenshot-8` and removed the unused `1_b` (82e00c27f924855a0bbba41bd644557729a2cb21) and then ran `update_app_store_strings` (e5b34a575ca2412c86bc5d709be760a6b98e7250).

**Note**: this change needs to be back merged to `trunk` so that this is sent to GlotPress.