### PR TITLE
[Woo POS][Products] Add `pos_products_only` to product/variations remotes 

### DIFF
--- a/Modules/Sources/Networking/Remote/ProductVariationsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductVariationsRemote.swift
@@ -14,7 +14,8 @@ public protocol ProductVariationsRemoteProtocol {
                                   completion: @escaping ([ProductVariation]?, Error?) -> Void)
     func loadVariationsForPointOfSale(for siteID: Int64,
                                       parentProductID: Int64,
-                                      pageNumber: Int) async throws -> PagedItems<POSProductVariation>
+                                      pageNumber: Int,
+                                      posProductsOnly: Bool?) async throws -> PagedItems<POSProductVariation>
     func loadProductVariation(for siteID: Int64, productID: Int64, variationID: Int64, completion: @escaping (Result<ProductVariation, Error>) -> Void)
     func createProductVariation(for siteID: Int64,
                                 productID: Int64,
@@ -35,6 +36,19 @@ public protocol ProductVariationsRemoteProtocol {
                                  productVariations: [ProductVariation],
                                  completion: @escaping (Result<[ProductVariation], Error>) -> Void)
     func deleteProductVariation(siteID: Int64, productID: Int64, variationID: Int64, completion: @escaping (Result<ProductVariation, Error>) -> Void)
+}
+
+extension ProductVariationsRemoteProtocol {
+    // TODO:Remove when we remove the feature flag.
+    // This extension only exist to provide a default value to the protocols.
+    public func loadVariationsForPointOfSale(for siteID: Int64,
+                                             parentProductID: Int64,
+                                             pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
+        try await loadVariationsForPointOfSale(for: siteID,
+                                               parentProductID: parentProductID,
+                                               pageNumber: pageNumber,
+                                               posProductsOnly: nil)
+    }
 }
 
 /// ProductVariation: Remote Endpoints
@@ -78,7 +92,8 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
     /// - Returns: Variations for the provided parent product.
     public func loadVariationsForPointOfSale(for siteID: Int64,
                                              parentProductID: Int64,
-                                             pageNumber: Int = Default.pageNumber) async throws -> PagedItems<POSProductVariation> {
+                                             pageNumber: Int = Default.pageNumber,
+                                             posProductsOnly: Bool? = nil) async throws -> PagedItems<POSProductVariation> {
         let request = productVariationsRequest(for: siteID,
                                                productID: parentProductID,
                                                variationIDs: [],
@@ -89,7 +104,8 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
                                                fields: POSProductVariation.requestFields,
                                                context: nil,
                                                pageNumber: pageNumber,
-                                               pageSize: POSConstants.variationsPerPage)
+                                               pageSize: POSConstants.variationsPerPage,
+                                               posProductsOnly: posProductsOnly)
         // N.B. POS is only available for WC 9.6 and later.
         // `parent_id` was added in WC 8.3, so we don't need to pass the parent product ID to the decoder.
         // https://github.com/woocommerce/woocommerce/pull/40606
@@ -110,11 +126,12 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
                                           fields: [String] = [],
                                           context: String?,
                                           pageNumber: Int,
-                                          pageSize: Int) -> JetpackRequest {
+                                          pageSize: Int,
+                                          posProductsOnly: Bool? = nil) -> JetpackRequest {
         let stringOfVariationIDs = variationIDs.map { String($0) }
             .joined(separator: ",")
         let stringOfRequiredFields = fields.joined(separator: ",")
-        let parameters = [
+        var parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),
             ParameterKey.downloadable: downloadable.map { String($0) },
@@ -126,6 +143,10 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
             ParameterKey.order: order?.rawValue
         ]
             .compactMapValues { $0 }
+
+        if let posProductsOnly {
+            parameters[ParameterKey.posProductsOnly] = String(posProductsOnly)
+        }
 
         let path = "\(Path.products)/\(productID)/variations"
         let request = JetpackRequest(wooApiVersion: .mark3,
@@ -350,6 +371,7 @@ public extension ProductVariationsRemote {
         static let status: String = "status"
         static let orderBy: String    = "orderby"
         static let order: String      = "order"
+        static let posProductsOnly: String = "pos_products_only"
     }
 
     enum OrderByField: String {

--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -82,7 +82,8 @@ public protocol ProductsRemoteProtocol {
 
     func loadProductsForPointOfSale(for siteID: Int64,
                                     productTypes: [ProductType],
-                                    pageNumber: Int) async throws -> PagedItems<POSProduct>
+                                    pageNumber: Int,
+                                    posProductsOnly: Bool?) async throws -> PagedItems<POSProduct>
 
     func searchProductsForPointOfSale(for siteID: Int64,
                                       query: String,
@@ -107,6 +108,18 @@ extension ProductsRemoteProtocol {
                                pageNumber: ProductsRemote.Default.pageNumber,
                                pageSize: ProductsRemote.Default.pageSize)
     }
+
+    // TODO:Remove when we remove the feature flag.
+    // This extension only exist to provide a default value to the protocols.
+    public func loadProductsForPointOfSale(for siteID: Int64,
+                                           productTypes: [ProductType],
+                                           pageNumber: Int) async throws -> PagedItems<POSProduct> {
+        try await loadProductsForPointOfSale(for: siteID,
+                                             productTypes: productTypes,
+                                             pageNumber: pageNumber,
+                                             posProductsOnly: nil)
+    }
+
 }
 
 /// Product: Remote Endpoints
@@ -221,10 +234,12 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     ///
     public func loadProductsForPointOfSale(for siteID: Int64,
                                            productTypes: [ProductType] = [.simple],
-                                           pageNumber: Int = 1) async throws -> PagedItems<POSProduct> {
+                                           pageNumber: Int = 1,
+                                           posProductsOnly: Bool? = nil) async throws -> PagedItems<POSProduct> {
         let parameters = pointOfSaleProductFetchParameters(
             pageNumber: pageNumber,
-            productTypes: productTypes)
+            productTypes: productTypes,
+            posProductsOnly: posProductsOnly)
 
         return try await makePagedPointOfSaleProductsRequest(
             for: siteID,
@@ -261,8 +276,9 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
                                                    productsPerPage: String = POSConstants.productsPerPage,
                                                    productTypes: [ProductType],
                                                    orderBy: OrderKey = .name,
-                                                   order: Order = .ascending) -> [String: any Hashable] {
-        [
+                                                   order: Order = .ascending,
+                                                   posProductsOnly: Bool? = nil) -> [String: any Hashable] {
+        var parameters: [String: any Hashable] = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: productsPerPage,
             // When both productType and productTypes are provided, the productType is ignored in WC versions 9.6+.
@@ -274,6 +290,12 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.downloadable: String(false),
             ParameterKey.fields: POSProduct.requestFields.joined(separator: ",")
         ]
+
+        if let posProductsOnly {
+            parameters[ParameterKey.posProductsOnly] = String(posProductsOnly)
+        }
+
+        return parameters
     }
 
     private func makePagedPointOfSaleProductsRequest(for siteID: Int64,
@@ -306,7 +328,8 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
                                              pageNumber: Int = 1) async throws -> PagedItems<POSProduct> {
         var parameters = pointOfSaleProductFetchParameters(
             pageNumber: pageNumber,
-            productTypes: productTypes)
+            productTypes: productTypes
+        )
 
         parameters.updateValue(query, forKey: ParameterKey.search)
 
@@ -774,6 +797,7 @@ public extension ProductsRemote {
         static let after = "after"
         static let extendedInfo = "extended_info"
         static let downloadable = "downloadable"
+        static let posProductsOnly = "pos_products_only"
     }
 
     private enum ParameterValues {

--- a/Modules/Tests/NetworkingTests/Remote/POSProductsNetworkingTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSProductsNetworkingTests.swift
@@ -283,4 +283,48 @@ struct POSProductsNetworkingTests {
         #expect(request.parameters["context"] as? String == "edit")
         #expect(request.parameters["_fields"] as? String == POSProduct.requestFields.joined(separator: ","))
     }
+
+    @Test func loadProductsForPointOfSale_excludes_posProductsOnly_when_not_specified() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+
+        // When - call without posProductsOnly parameter
+        _ = try? await remote.loadProductsForPointOfSale(for: sampleSiteID,
+                                                         productTypes: [.simple],
+                                                         pageNumber: 1)
+
+        // Then - parameter should not be present
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        #expect(queryParametersDictionary["pos_products_only"] == nil)
+    }
+
+    @Test func loadProductsForPointOfSale_includes_posProductsOnly_true_when_enabled() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+
+        // When
+        _ = try? await remote.loadProductsForPointOfSale(for: sampleSiteID,
+                                                         productTypes: [.simple],
+                                                         pageNumber: 1,
+                                                         posProductsOnly: true)
+
+        // Then
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        #expect(queryParametersDictionary["pos_products_only"] as? String == "true")
+    }
+
+    @Test func loadProductsForPointOfSale_includes_posProductsOnly_false_when_disabled() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+
+        // When
+        _ = try? await remote.loadProductsForPointOfSale(for: sampleSiteID,
+                                                         productTypes: [.simple],
+                                                         pageNumber: 1,
+                                                         posProductsOnly: false)
+
+        // Then
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        #expect(queryParametersDictionary["pos_products_only"] as? String == "false")
+    }
 }

--- a/Modules/Tests/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -603,6 +603,50 @@ final class ProductVariationsRemoteTests: XCTestCase {
         XCTAssertEqual(queryParametersDictionary["page"] as? String, "1")
         XCTAssertEqual(queryParametersDictionary["per_page"] as? String, "25")
     }
+
+    func test_loadVariationsForPointOfSale_excludes_posProductsOnly_when_not_specified() async throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+
+        // When - call without posProductsOnly parameter
+        _ = try? await remote.loadVariationsForPointOfSale(for: sampleSiteID,
+                                                           parentProductID: sampleProductID,
+                                                           pageNumber: 1)
+
+        // Then - parameter should not be present
+        let queryParametersDictionary = try XCTUnwrap(network.queryParametersDictionary)
+        XCTAssertNil(queryParametersDictionary["pos_products_only"])
+    }
+
+    func test_loadVariationsForPointOfSale_includes_posProductsOnly_true_when_enabled() async throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+
+        // When
+        _ = try? await remote.loadVariationsForPointOfSale(for: sampleSiteID,
+                                                           parentProductID: sampleProductID,
+                                                           pageNumber: 1,
+                                                           posProductsOnly: true)
+
+        // Then
+        let queryParametersDictionary = try XCTUnwrap(network.queryParametersDictionary)
+        XCTAssertEqual(queryParametersDictionary["pos_products_only"] as? String, "true")
+    }
+
+    func test_loadVariationsForPointOfSale_includes_posProductsOnly_false_when_disabled() async throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+
+        // When
+        _ = try? await remote.loadVariationsForPointOfSale(for: sampleSiteID,
+                                                           parentProductID: sampleProductID,
+                                                           pageNumber: 1,
+                                                           posProductsOnly: false)
+
+        // Then
+        let queryParametersDictionary = try XCTUnwrap(network.queryParametersDictionary)
+        XCTAssertEqual(queryParametersDictionary["pos_products_only"] as? String, "false")
+    }
 }
 
 private extension ProductVariationsRemoteTests {

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
@@ -100,7 +100,10 @@ extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
         // no-op
     }
 
-    func loadVariationsForPointOfSale(for siteID: Int64, parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
+    func loadVariationsForPointOfSale(for siteID: Int64,
+                                      parentProductID: Int64,
+                                      pageNumber: Int,
+                                      posProductsOnly: Bool?) async throws -> PagedItems<POSProductVariation> {
         let key = ResultKey(siteID: siteID, productID: parentProductID, productVariationIDs: [])
         guard let result = variationsForPointOfSaleResults[key] else {
             throw NetworkError.notFound()

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -447,7 +447,8 @@ extension MockProductsRemote: ProductsRemoteProtocol {
 
     func loadProductsForPointOfSale(for siteID: Int64,
                                     productTypes: [ProductType],
-                                    pageNumber: Int) async throws -> PagedItems<POSProduct> {
+                                    pageNumber: Int,
+                                    posProductsOnly: Bool?) async throws -> PagedItems<POSProduct> {
         guard let result = posProductsResultsBySiteID[siteID] else {
             throw NetworkError.notFound()
         }


### PR DESCRIPTION
Closes WOOMOB-1939

## Description
This PR updates the remotes for POS products and variations to include the `pos_products_only` filter parameter [added to core](https://github.com/woocommerce/woocommerce/pull/62534), and available from 10.5. 

This new parameter does the following:
- If not present in the request, it does nothing.
- If present in the request, but the store does not use it (ie: not on WooCommerce 10.5+, pos disabled, etc, ...) does nothing.
- When `pos_products_only=false` we apply no filtering, so it will return all eligible products as we've always done. 
- When `pos_products_only=true`, will return only POS products marked as such from the site. This means all eligible products by default, unless POS eligibility has been unchecked  from the product details under Advanced > Available for POS.

<img width="823" height="271" alt="Screenshot 2026-01-13 at 14 32 37" src="https://github.com/user-attachments/assets/acd8b885-3b1d-4b8c-900b-6fd24ba60d51" />

## Changes
- Updates the remotes to add `pos_products_only` to the requests when retrieving products/variations
- Adds a `posProductsOnly: Bool?` param to the remote signatures. I opted for making this optional just because might not exist, but since is a filter param does not really matter if we send it over. I'm ok with changing the signature to make it non-optional if that makes things simpler 🤔 

## Test Steps
- Remotes are not being used yet, is enough for CI to pass. 

## Screenshots
N/A