### PR TITLE
[Woo POS][Products] `pos_products_only` handling for POS functions using products API

### DIFF
--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -93,7 +93,8 @@ public protocol ProductsRemoteProtocol {
     func loadPopularProductsForPointOfSale(for siteID: Int64,
                                            productTypes: [ProductType],
                                            pageNumber: Int,
-                                           perPage: Int) async throws -> PagedItems<POSProduct>
+                                           perPage: Int,
+                                           posProductsOnly: Bool?) async throws -> PagedItems<POSProduct>
 
     func loadPOSProductByGlobalUniqueIdentifier(for siteID: Int64,
                                                    globalUniqueID: String) async throws -> POSProduct
@@ -118,6 +119,19 @@ extension ProductsRemoteProtocol {
                                              productTypes: productTypes,
                                              pageNumber: pageNumber,
                                              posProductsOnly: nil)
+    }
+
+    // TODO:Remove when we remove the feature flag.
+    // This extension only exist to provide a default value to the protocols.
+    public func loadPopularProductsForPointOfSale(for siteID: Int64,
+                                                  productTypes: [ProductType],
+                                                  pageNumber: Int,
+                                                  perPage: Int) async throws -> PagedItems<POSProduct> {
+        try await loadPopularProductsForPointOfSale(for: siteID,
+                                                    productTypes: productTypes,
+                                                    pageNumber: pageNumber,
+                                                    perPage: perPage,
+                                                    posProductsOnly: false)
     }
 
 }
@@ -257,13 +271,15 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     public func loadPopularProductsForPointOfSale(for siteID: Int64,
                                                   productTypes: [ProductType] = [.simple],
                                                   pageNumber: Int = 1,
-                                                  perPage: Int = Default.pageSize) async throws -> PagedItems<POSProduct> {
+                                                  perPage: Int = Default.pageSize,
+                                                  posProductsOnly: Bool? = nil) async throws -> PagedItems<POSProduct> {
         let parameters = pointOfSaleProductFetchParameters(
             pageNumber: pageNumber,
             productsPerPage: String(perPage),
             productTypes: productTypes,
             orderBy: .popularity,
-            order: .descending
+            order: .descending,
+            posProductsOnly: posProductsOnly
         )
 
         return try await makePagedPointOfSaleProductsRequest(

--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -98,7 +98,8 @@ public protocol ProductsRemoteProtocol {
                                            posProductsOnly: Bool?) async throws -> PagedItems<POSProduct>
 
     func loadPOSProductByGlobalUniqueIdentifier(for siteID: Int64,
-                                                   globalUniqueID: String) async throws -> POSProduct
+                                                   globalUniqueID: String,
+                                                   posProductsOnly: Bool?) async throws -> POSProduct
 
     func loadPOSProduct(for siteID: Int64, productID: Int64) async throws -> POSProduct
 }
@@ -146,6 +147,15 @@ extension ProductsRemoteProtocol {
                                                productTypes: productTypes,
                                                pageNumber: pageNumber,
                                                posProductsOnly: false)
+    }
+
+    // TODO:Remove when we remove the feature flag.
+    // This extension only exist to provide a default value to the protocols.
+    public func loadPOSProductByGlobalUniqueIdentifier(for siteID: Int64,
+                                                       globalUniqueID: String) async throws -> POSProduct {
+        try await loadPOSProductByGlobalUniqueIdentifier(for: siteID,
+                                                         globalUniqueID: globalUniqueID,
+                                                         posProductsOnly: false)
     }
 
 }
@@ -355,10 +365,12 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     public func searchProductsForPointOfSale(for siteID: Int64,
                                              query: String,
                                              productTypes: [ProductType] = [.simple],
-                                             pageNumber: Int = 1) async throws -> PagedItems<POSProduct> {
+                                             pageNumber: Int = 1,
+                                             posProductsOnly: Bool? = nil) async throws -> PagedItems<POSProduct> {
         var parameters = pointOfSaleProductFetchParameters(
             pageNumber: pageNumber,
-            productTypes: productTypes
+            productTypes: productTypes,
+            posProductsOnly: posProductsOnly
         )
 
         parameters.updateValue(query, forKey: ParameterKey.search)
@@ -389,14 +401,19 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     /// - Throws: Error if the product is not found or if there's a network error
     ///
     public func loadPOSProductByGlobalUniqueIdentifier(for siteID: Int64,
-                                                       globalUniqueID: String) async throws -> POSProduct {
-        let parameters = [
+                                                       globalUniqueID: String,
+                                                       posProductsOnly: Bool? = nil) async throws -> POSProduct {
+        var parameters: [String: Any] = [
             ParameterKey.globalUniqueID: globalUniqueID,
             ParameterKey.page: "1",
             ParameterKey.perPage: "1",
             ParameterKey.contextKey: Default.context,
             ParameterKey.fields: POSProduct.requestFields.joined(separator: ",")
         ]
+
+        if let posProductsOnly {
+            parameters[ParameterKey.posProductsOnly] = String(posProductsOnly)
+        }
         let path = Path.products
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
         let mapper = ListMapper<POSProduct>(siteID: siteID)

--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -101,7 +101,7 @@ public protocol ProductsRemoteProtocol {
                                                    globalUniqueID: String,
                                                    posProductsOnly: Bool?) async throws -> POSProduct
 
-    func loadPOSProduct(for siteID: Int64, productID: Int64) async throws -> POSProduct
+    func loadPOSProduct(for siteID: Int64, productID: Int64, posProductsOnly: Bool?) async throws -> POSProduct
 }
 
 extension ProductsRemoteProtocol {
@@ -156,6 +156,14 @@ extension ProductsRemoteProtocol {
         try await loadPOSProductByGlobalUniqueIdentifier(for: siteID,
                                                          globalUniqueID: globalUniqueID,
                                                          posProductsOnly: false)
+    }
+
+    // TODO:Remove when we remove the feature flag.
+    // This extension only exist to provide a default value to the protocols.
+    public func loadPOSProduct(for siteID: Int64, productID: Int64) async throws -> POSProduct {
+        try await loadPOSProduct(for: siteID,
+                                 productID: productID,
+                                 posProductsOnly: false)
     }
 
 }
@@ -432,10 +440,14 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     /// - Returns: A POSProduct if found
     /// - Throws: Error if the product is not found or if there's a network error
     ///
-    public func loadPOSProduct(for siteID: Int64, productID: Int64) async throws -> POSProduct {
-        let parameters = [
+    public func loadPOSProduct(for siteID: Int64, productID: Int64, posProductsOnly: Bool? = nil) async throws -> POSProduct {
+        var parameters: [String: Any] = [
             ParameterKey.fields: POSProduct.requestFields.joined(separator: ",")
         ]
+
+        if let posProductsOnly {
+            parameters[ParameterKey.posProductsOnly] = String(posProductsOnly)
+        }
         let path = "\(Path.products)/\(productID)"
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
         let mapper = SingleItemMapper<POSProduct>(siteID: siteID)

--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -88,7 +88,8 @@ public protocol ProductsRemoteProtocol {
     func searchProductsForPointOfSale(for siteID: Int64,
                                       query: String,
                                       productTypes: [ProductType],
-                                      pageNumber: Int) async throws -> PagedItems<POSProduct>
+                                      pageNumber: Int,
+                                      posProductsOnly: Bool?) async throws -> PagedItems<POSProduct>
 
     func loadPopularProductsForPointOfSale(for siteID: Int64,
                                            productTypes: [ProductType],
@@ -132,6 +133,19 @@ extension ProductsRemoteProtocol {
                                                     pageNumber: pageNumber,
                                                     perPage: perPage,
                                                     posProductsOnly: false)
+    }
+
+    // TODO:Remove when we remove the feature flag.
+    // This extension only exist to provide a default value to the protocols.
+    public func searchProductsForPointOfSale(for siteID: Int64,
+                                             query: String,
+                                             productTypes: [ProductType],
+                                             pageNumber: Int) async throws -> PagedItems<POSProduct> {
+        try await searchProductsForPointOfSale(for: siteID,
+                                               query: query,
+                                               productTypes: productTypes,
+                                               pageNumber: pageNumber,
+                                               posProductsOnly: false)
     }
 
 }

--- a/Modules/Tests/NetworkingTests/Remote/POSProductsNetworkingTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSProductsNetworkingTests.swift
@@ -327,4 +327,187 @@ struct POSProductsNetworkingTests {
         let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
         #expect(queryParametersDictionary["pos_products_only"] as? String == "false")
     }
+
+    @Test func loadPopularProductsForPointOfSale_excludes_posProductsOnly_when_not_specified() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+
+        // When - call without posProductsOnly parameter
+        _ = try? await remote.loadPopularProductsForPointOfSale(for: sampleSiteID,
+                                                                 productTypes: [.simple],
+                                                                 pageNumber: 1,
+                                                                 perPage: 25,
+                                                                 posProductsOnly: nil)
+
+        // Then - parameter should not be present
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        #expect(queryParametersDictionary["pos_products_only"] == nil)
+    }
+
+    @Test func loadPopularProductsForPointOfSale_includes_posProductsOnly_true_when_enabled() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+
+        // When
+        _ = try? await remote.loadPopularProductsForPointOfSale(for: sampleSiteID,
+                                                                 productTypes: [.simple],
+                                                                 pageNumber: 1,
+                                                                 perPage: 25,
+                                                                 posProductsOnly: true)
+
+        // Then
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        #expect(queryParametersDictionary["pos_products_only"] as? String == "true")
+    }
+
+    @Test func loadPopularProductsForPointOfSale_includes_posProductsOnly_false_when_disabled() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+
+        // When
+        _ = try? await remote.loadPopularProductsForPointOfSale(for: sampleSiteID,
+                                                                 productTypes: [.simple],
+                                                                 pageNumber: 1,
+                                                                 perPage: 25,
+                                                                 posProductsOnly: false)
+
+        // Then
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        #expect(queryParametersDictionary["pos_products_only"] as? String == "false")
+    }
+
+    @Test func searchProductsForPointOfSale_excludes_posProductsOnly_when_not_specified() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+
+        // When - call without posProductsOnly parameter
+        _ = try? await remote.searchProductsForPointOfSale(for: sampleSiteID,
+                                                            query: "test",
+                                                            productTypes: [.simple],
+                                                            pageNumber: 1,
+                                                            posProductsOnly: nil)
+
+        // Then - parameter should not be present
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        #expect(queryParametersDictionary["pos_products_only"] == nil)
+    }
+
+    @Test func searchProductsForPointOfSale_includes_posProductsOnly_true_when_enabled() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+
+        // When
+        _ = try? await remote.searchProductsForPointOfSale(for: sampleSiteID,
+                                                            query: "test",
+                                                            productTypes: [.simple],
+                                                            pageNumber: 1,
+                                                            posProductsOnly: true)
+
+        // Then
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        #expect(queryParametersDictionary["pos_products_only"] as? String == "true")
+    }
+
+    @Test func searchProductsForPointOfSale_includes_posProductsOnly_false_when_disabled() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+
+        // When
+        _ = try? await remote.searchProductsForPointOfSale(for: sampleSiteID,
+                                                            query: "test",
+                                                            productTypes: [.simple],
+                                                            pageNumber: 1,
+                                                            posProductsOnly: false)
+
+        // Then
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        #expect(queryParametersDictionary["pos_products_only"] as? String == "false")
+    }
+
+    @Test func loadPOSProductByGlobalUniqueIdentifier_excludes_posProductsOnly_when_not_specified() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "pos-products")
+
+        // When - call without posProductsOnly parameter
+        _ = try? await remote.loadPOSProductByGlobalUniqueIdentifier(for: sampleSiteID,
+                                                                      globalUniqueID: "123456789",
+                                                                      posProductsOnly: nil)
+
+        // Then - parameter should not be present
+        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
+        #expect(request.parameters["pos_products_only"] == nil)
+    }
+
+    @Test func loadPOSProductByGlobalUniqueIdentifier_includes_posProductsOnly_true_when_enabled() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "pos-products")
+
+        // When
+        _ = try? await remote.loadPOSProductByGlobalUniqueIdentifier(for: sampleSiteID,
+                                                                      globalUniqueID: "123456789",
+                                                                      posProductsOnly: true)
+
+        // Then
+        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
+        #expect(request.parameters["pos_products_only"] as? String == "true")
+    }
+
+    @Test func loadPOSProductByGlobalUniqueIdentifier_includes_posProductsOnly_false_when_disabled() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "pos-products")
+
+        // When
+        _ = try? await remote.loadPOSProductByGlobalUniqueIdentifier(for: sampleSiteID,
+                                                                      globalUniqueID: "123456789",
+                                                                      posProductsOnly: false)
+
+        // Then
+        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
+        #expect(request.parameters["pos_products_only"] as? String == "false")
+    }
+
+    @Test func loadPOSProduct_excludes_posProductsOnly_when_not_specified() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+
+        // When - call without posProductsOnly parameter
+        _ = try? await remote.loadPOSProduct(for: sampleSiteID,
+                                              productID: 123,
+                                              posProductsOnly: nil)
+
+        // Then - parameter should not be present
+        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
+        #expect(request.parameters["pos_products_only"] == nil)
+    }
+
+    @Test func loadPOSProduct_includes_posProductsOnly_true_when_enabled() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+
+        // When
+        _ = try? await remote.loadPOSProduct(for: sampleSiteID,
+                                              productID: 123,
+                                              posProductsOnly: true)
+
+        // Then
+        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
+        #expect(request.parameters["pos_products_only"] as? String == "true")
+    }
+
+    @Test func loadPOSProduct_includes_posProductsOnly_false_when_disabled() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+
+        // When
+        _ = try? await remote.loadPOSProduct(for: sampleSiteID,
+                                              productID: 123,
+                                              posProductsOnly: false)
+
+        // Then
+        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
+        #expect(request.parameters["pos_products_only"] as? String == "false")
+    }
 }

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -498,7 +498,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         }
     }
 
-    func loadPOSProduct(for siteID: Int64, productID: Int64) async throws -> POSProduct {
+    func loadPOSProduct(for siteID: Int64, productID: Int64, posProductsOnly: Bool?) async throws -> POSProduct {
         invocationCountOfLoadPOSProduct += 1
         requestedProductIDsForFetchingPOSProduct.append(productID)
 

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -483,7 +483,8 @@ extension MockProductsRemote: ProductsRemoteProtocol {
     func loadPopularProductsForPointOfSale(for siteID: Int64,
                                            productTypes: [ProductType],
                                            pageNumber: Int,
-                                           perPage: Int) async throws -> PagedItems<POSProduct> {
+                                           perPage: Int,
+                                           posProductsOnly: Bool?) async throws -> PagedItems<POSProduct> {
         lastRequestedPageSize = perPage
         guard let result = posPopularProductsResultsBySiteID[siteID] else {
             throw NetworkError.notFound()

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -463,7 +463,8 @@ extension MockProductsRemote: ProductsRemoteProtocol {
     func searchProductsForPointOfSale(for siteID: Int64,
                                       query: String,
                                       productTypes: [ProductType],
-                                      pageNumber: Int) async throws -> PagedItems<POSProduct> {
+                                      pageNumber: Int,
+                                      posProductsOnly: Bool?) async throws -> PagedItems<POSProduct> {
         guard let result = posSearchResultsByQuery[query] else {
             throw NetworkError.notFound()
         }

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -476,7 +476,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         }
     }
 
-    func loadPOSProductByGlobalUniqueIdentifier(for siteID: Int64, globalUniqueID: String) async throws -> POSProduct {
+    func loadPOSProductByGlobalUniqueIdentifier(for siteID: Int64, globalUniqueID: String, posProductsOnly: Bool?) async throws -> POSProduct {
             return POSProduct.fake().copy(siteID: siteID,
                                           globalUniqueID: globalUniqueID)
     }


### PR DESCRIPTION
## Description
Continuation of https://github.com/woocommerce/woocommerce-ios/pull/16505

This PR updates other functions that use the POS products or variations endpoint to reach the network, so we're sure to also pass the `pos_products_only` parameter to perform any server-side filtering as needed. This includes:

- loadPopularProductsForPointOfSale (used for fetching products ordered via `.popularity`)
- searchProductsForPointOfSale (used for search)
- loadPOSProductByGlobalUniqueIdentifier (used for barcode scanner)
- loadPOSProduct (used for barcode scanner)

## Test Steps
- Remotes are not being used yet, is enough for CI to pass.

## Screenshots
N/A
