### PR TITLE
[Woo POS][Products] Hook POS products feature flag to fetch strategies, catalog, and network

### DIFF
--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -10,10 +10,11 @@ public protocol POSCatalogSyncRemoteProtocol {
     ///   - siteID: Site ID to load products from.
     ///   - pageNumber: Page number for pagination.
     ///   - includeStatus: Optional status to include (e.g., "trash" to fetch trashed products).
+    ///   - posProductsOnly: Whether to filter to POS-eligible products only.
     /// - Returns: Paginated list of POS products.
     // TODO - remove the periphery ignore comment when the incremental sync is integrated with POS.
     // periphery:ignore
-    func loadProducts(modifiedAfter: Date, siteID: Int64, pageNumber: Int, includeStatus: String?) async throws -> PagedItems<POSProduct>
+    func loadProducts(modifiedAfter: Date, siteID: Int64, pageNumber: Int, includeStatus: String?, posProductsOnly: Bool) async throws -> PagedItems<POSProduct>
 
     /// Loads POS product variations modified after the specified date for incremental sync.
     ///
@@ -21,10 +22,11 @@ public protocol POSCatalogSyncRemoteProtocol {
     ///   - modifiedAfter: Only variations modified after this date will be returned.
     ///   - siteID: Site ID to load variations from.
     ///   - pageNumber: Page number for pagination.
+    ///   - posProductsOnly: Whether to filter to POS-eligible variations only.
     /// - Returns: Paginated list of POS product variations.
     // TODO - remove the periphery ignore comment when the incremental sync is integrated with POS.
     // periphery:ignore
-    func loadProductVariations(modifiedAfter: Date, siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation>
+    func loadProductVariations(modifiedAfter: Date, siteID: Int64, pageNumber: Int, posProductsOnly: Bool) async throws -> PagedItems<POSProductVariation>
 
     /// Starts generation of a POS catalog.
     /// The catalog is generated asynchronously and a download URL may be returned when the file is ready.
@@ -62,8 +64,9 @@ public protocol POSCatalogSyncRemoteProtocol {
     ///   - siteID: Site ID to load products from.
     ///   - pageNumber: Page number for pagination.
     ///   - allowCellular: Should cellular data be used if required.
+    ///   - posProductsOnly: Whether to filter to POS-eligible products only.
     /// - Returns: Paginated list of POS products.
-    func loadProducts(siteID: Int64, pageNumber: Int, allowCellular: Bool) async throws -> PagedItems<POSProduct>
+    func loadProducts(siteID: Int64, pageNumber: Int, allowCellular: Bool, posProductsOnly: Bool) async throws -> PagedItems<POSProduct>
 
     /// Loads POS product variations for full sync.
     ///
@@ -71,20 +74,25 @@ public protocol POSCatalogSyncRemoteProtocol {
     ///   - siteID: Site ID to load variations from.
     ///   - pageNumber: Page number for pagination.
     ///   - allowCellular: Should cellular data be used if required.
+    ///   - posProductsOnly: Whether to filter to POS-eligible variations only.
     /// - Returns: Paginated list of POS product variations.
-    func loadProductVariations(siteID: Int64, pageNumber: Int, allowCellular: Bool) async throws -> PagedItems<POSProductVariation>
+    func loadProductVariations(siteID: Int64, pageNumber: Int, allowCellular: Bool, posProductsOnly: Bool) async throws -> PagedItems<POSProductVariation>
 
     /// Gets the total count of products for the specified site.
     ///
-    /// - Parameter siteID: Site ID to get product count for.
+    /// - Parameters:
+    ///   - siteID: Site ID to get product count for.
+    ///   - posProductsOnly: Whether to filter to POS-eligible products only.
     /// - Returns: Total number of products.
-    func getProductCount(siteID: Int64) async throws -> Int
+    func getProductCount(siteID: Int64, posProductsOnly: Bool) async throws -> Int
 
     /// Gets the total count of product variations for the specified site.
     ///
-    /// - Parameter siteID: Site ID to get variation count for.
+    /// - Parameters:
+    ///   - siteID: Site ID to get variation count for.
+    ///   - posProductsOnly: Whether to filter to POS-eligible variations only.
     /// - Returns: Total number of variations.
-    func getProductVariationCount(siteID: Int64) async throws -> Int
+    func getProductVariationCount(siteID: Int64, posProductsOnly: Bool) async throws -> Int
 }
 
 /// POS Catalog Sync: Remote Endpoints
@@ -111,16 +119,22 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     ///   - siteID: Site ID to load products from.
     ///   - pageNumber: Page number for pagination.
     ///   - includeStatus: Optional status to include (e.g., "trash" to fetch trashed products).
+    ///   - posProductsOnly: Whether to filter to POS-eligible products only.
     /// - Returns: Paginated list of POS products.
     ///
-    public func loadProducts(modifiedAfter: Date, siteID: Int64, pageNumber: Int, includeStatus: String? = nil)
+    public func loadProducts(modifiedAfter: Date,
+                             siteID: Int64,
+                             pageNumber: Int,
+                             includeStatus: String? = nil,
+                             posProductsOnly: Bool = true)
     async throws -> PagedItems<POSProduct> {
         let path = Path.products
         var parameters: [String: String] = [
             ParameterKey.modifiedAfter: dateFormatter.string(from: modifiedAfter),
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(Constants.defaultPageSize),
-            ParameterKey.fields: POSProduct.requestFields.joined(separator: ",")
+            ParameterKey.fields: POSProduct.requestFields.joined(separator: ","),
+            ParameterKey.posProductsOnly: String(posProductsOnly)
         ]
 
         if let includeStatus = includeStatus {
@@ -147,15 +161,20 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     ///   - modifiedAfter: Only variations modified after this date will be returned.
     ///   - siteID: Site ID to load variations from.
     ///   - pageNumber: Page number for pagination.
+    ///   - posProductsOnly: Whether to filter to POS-eligible variations only.
     /// - Returns: Paginated list of POS product variations.
     ///
-    public func loadProductVariations(modifiedAfter: Date, siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
+    public func loadProductVariations(modifiedAfter: Date,
+                                      siteID: Int64,
+                                      pageNumber: Int,
+                                      posProductsOnly: Bool = true) async throws -> PagedItems<POSProductVariation> {
         let path = Path.variations
         let parameters = [
             ParameterKey.modifiedAfter: dateFormatter.string(from: modifiedAfter),
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(Constants.defaultPageSize),
-            ParameterKey.fields: POSProductVariation.requestFields.joined(separator: ",")
+            ParameterKey.fields: POSProductVariation.requestFields.joined(separator: ","),
+            ParameterKey.posProductsOnly: String(posProductsOnly)
         ]
 
         let request = JetpackRequest(
@@ -292,14 +311,19 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     ///   - siteID: Site ID to load products from.
     ///   - pageNumber: Page number for pagination.
     ///   - allowCellular: Should cellular data be used if required.
+    ///   - posProductsOnly: Whether to filter to POS-eligible products only.
     /// - Returns: Paginated list of POS products.
     ///
-    public func loadProducts(siteID: Int64, pageNumber: Int, allowCellular: Bool) async throws -> PagedItems<POSProduct> {
+    public func loadProducts(siteID: Int64,
+                             pageNumber: Int,
+                             allowCellular: Bool,
+                             posProductsOnly: Bool = true) async throws -> PagedItems<POSProduct> {
         let path = Path.products
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(Constants.defaultPageSize),
-            ParameterKey.fields: POSProduct.requestFields.joined(separator: ",")
+            ParameterKey.fields: POSProduct.requestFields.joined(separator: ","),
+            ParameterKey.posProductsOnly: String(posProductsOnly)
         ]
 
         let request = JetpackRequest(
@@ -323,14 +347,19 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     ///   - siteID: Site ID to load variations from.
     ///   - pageNumber: Page number for pagination.
     ///   - allowCellular: Should cellular data be used if required.
+    ///   - posProductsOnly: Whether to filter to POS-eligible variations only.
     /// - Returns: Paginated list of POS product variations.
     ///
-    public func loadProductVariations(siteID: Int64, pageNumber: Int, allowCellular: Bool) async throws -> PagedItems<POSProductVariation> {
+    public func loadProductVariations(siteID: Int64,
+                                      pageNumber: Int,
+                                      allowCellular: Bool,
+                                      posProductsOnly: Bool = true) async throws -> PagedItems<POSProductVariation> {
         let path = Path.variations
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(Constants.defaultPageSize),
-            ParameterKey.fields: POSProductVariation.requestFields.joined(separator: ",")
+            ParameterKey.fields: POSProductVariation.requestFields.joined(separator: ","),
+            ParameterKey.posProductsOnly: String(posProductsOnly)
         ]
 
         let request = JetpackRequest(
@@ -352,14 +381,17 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
 
     /// Gets the total count of products for the specified site.
     ///
-    /// - Parameter siteID: Site ID to get product count for.
+    /// - Parameters:
+    ///   - siteID: Site ID to get product count for.
+    ///   - posProductsOnly: Whether to filter to POS-eligible products only.
     /// - Returns: Total number of products.
-    public func getProductCount(siteID: Int64) async throws -> Int {
+    public func getProductCount(siteID: Int64, posProductsOnly: Bool = true) async throws -> Int {
         let path = Path.products
         let parameters = [
             ParameterKey.page: String(1),
             ParameterKey.perPage: String(1),
-            ParameterKey.fields: POSProductVariation.requestFields.first ?? ""
+            ParameterKey.fields: POSProductVariation.requestFields.first ?? "",
+            ParameterKey.posProductsOnly: String(posProductsOnly)
         ]
 
         let request = JetpackRequest(
@@ -377,14 +409,17 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
 
     /// Gets the total count of product variations for the specified site.
     ///
-    /// - Parameter siteID: Site ID to get variation count for.
+    /// - Parameters:
+    ///   - siteID: Site ID to get variation count for.
+    ///   - posProductsOnly: Whether to filter to POS-eligible variations only.
     /// - Returns: Total number of variations.
-    public func getProductVariationCount(siteID: Int64) async throws -> Int {
+    public func getProductVariationCount(siteID: Int64, posProductsOnly: Bool = true) async throws -> Int {
         let path = Path.variations
         let parameters = [
             ParameterKey.page: String(1),
             ParameterKey.perPage: String(1),
-            ParameterKey.fields: POSProductVariation.requestFields.first ?? ""
+            ParameterKey.fields: POSProductVariation.requestFields.first ?? "",
+            ParameterKey.posProductsOnly: String(posProductsOnly)
         ]
 
         let request = JetpackRequest(
@@ -417,6 +452,7 @@ private extension POSCatalogSyncRemote {
         static let fullSyncVariationFields = "variation_fields"
         static let forceGenerate = "force_generate"
         static let includeStatus = "include_status"
+        static let posProductsOnly = "pos_products_only"
     }
 
     enum Path {

--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -126,7 +126,7 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
                              siteID: Int64,
                              pageNumber: Int,
                              includeStatus: String? = nil,
-                             posProductsOnly: Bool = true)
+                             posProductsOnly: Bool = false)
     async throws -> PagedItems<POSProduct> {
         let path = Path.products
         var parameters: [String: String] = [
@@ -167,7 +167,7 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     public func loadProductVariations(modifiedAfter: Date,
                                       siteID: Int64,
                                       pageNumber: Int,
-                                      posProductsOnly: Bool = true) async throws -> PagedItems<POSProductVariation> {
+                                      posProductsOnly: Bool = false) async throws -> PagedItems<POSProductVariation> {
         let path = Path.variations
         let parameters = [
             ParameterKey.modifiedAfter: dateFormatter.string(from: modifiedAfter),
@@ -317,7 +317,7 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     public func loadProducts(siteID: Int64,
                              pageNumber: Int,
                              allowCellular: Bool,
-                             posProductsOnly: Bool = true) async throws -> PagedItems<POSProduct> {
+                             posProductsOnly: Bool = false) async throws -> PagedItems<POSProduct> {
         let path = Path.products
         let parameters = [
             ParameterKey.page: String(pageNumber),
@@ -353,7 +353,7 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     public func loadProductVariations(siteID: Int64,
                                       pageNumber: Int,
                                       allowCellular: Bool,
-                                      posProductsOnly: Bool = true) async throws -> PagedItems<POSProductVariation> {
+                                      posProductsOnly: Bool = false) async throws -> PagedItems<POSProductVariation> {
         let path = Path.variations
         let parameters = [
             ParameterKey.page: String(pageNumber),
@@ -385,7 +385,7 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     ///   - siteID: Site ID to get product count for.
     ///   - posProductsOnly: Whether to filter to POS-eligible products only.
     /// - Returns: Total number of products.
-    public func getProductCount(siteID: Int64, posProductsOnly: Bool = true) async throws -> Int {
+    public func getProductCount(siteID: Int64, posProductsOnly: Bool = false) async throws -> Int {
         let path = Path.products
         let parameters = [
             ParameterKey.page: String(1),
@@ -413,7 +413,7 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     ///   - siteID: Site ID to get variation count for.
     ///   - posProductsOnly: Whether to filter to POS-eligible variations only.
     /// - Returns: Total number of variations.
-    public func getProductVariationCount(siteID: Int64, posProductsOnly: Bool = true) async throws -> Int {
+    public func getProductVariationCount(siteID: Int64, posProductsOnly: Bool = false) async throws -> Int {
         let path = Path.variations
         let parameters = [
             ParameterKey.page: String(1),

--- a/Modules/Sources/Networking/Remote/ProductVariationsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductVariationsRemote.swift
@@ -15,7 +15,7 @@ public protocol ProductVariationsRemoteProtocol {
     func loadVariationsForPointOfSale(for siteID: Int64,
                                       parentProductID: Int64,
                                       pageNumber: Int,
-                                      posProductsOnly: Bool?) async throws -> PagedItems<POSProductVariation>
+                                      posProductsOnly: Bool) async throws -> PagedItems<POSProductVariation>
     func loadProductVariation(for siteID: Int64, productID: Int64, variationID: Int64, completion: @escaping (Result<ProductVariation, Error>) -> Void)
     func createProductVariation(for siteID: Int64,
                                 productID: Int64,
@@ -38,18 +38,6 @@ public protocol ProductVariationsRemoteProtocol {
     func deleteProductVariation(siteID: Int64, productID: Int64, variationID: Int64, completion: @escaping (Result<ProductVariation, Error>) -> Void)
 }
 
-extension ProductVariationsRemoteProtocol {
-    // TODO:Remove when we remove the feature flag.
-    // This extension only exist to provide a default value to the protocols.
-    public func loadVariationsForPointOfSale(for siteID: Int64,
-                                             parentProductID: Int64,
-                                             pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
-        try await loadVariationsForPointOfSale(for: siteID,
-                                               parentProductID: parentProductID,
-                                               pageNumber: pageNumber,
-                                               posProductsOnly: nil)
-    }
-}
 
 /// ProductVariation: Remote Endpoints
 ///
@@ -93,7 +81,7 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
     public func loadVariationsForPointOfSale(for siteID: Int64,
                                              parentProductID: Int64,
                                              pageNumber: Int = Default.pageNumber,
-                                             posProductsOnly: Bool? = nil) async throws -> PagedItems<POSProductVariation> {
+                                             posProductsOnly: Bool = false) async throws -> PagedItems<POSProductVariation> {
         let request = productVariationsRequest(for: siteID,
                                                productID: parentProductID,
                                                variationIDs: [],
@@ -127,7 +115,7 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
                                           context: String?,
                                           pageNumber: Int,
                                           pageSize: Int,
-                                          posProductsOnly: Bool? = nil) -> JetpackRequest {
+                                          posProductsOnly: Bool = false) -> JetpackRequest {
         let stringOfVariationIDs = variationIDs.map { String($0) }
             .joined(separator: ",")
         let stringOfRequiredFields = fields.joined(separator: ",")
@@ -140,13 +128,10 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
             ParameterKey.include: variationIDs.isEmpty ? nil: stringOfVariationIDs,
             ParameterKey.status: status?.rawValue,
             ParameterKey.orderBy: orderBy?.rawValue,
-            ParameterKey.order: order?.rawValue
+            ParameterKey.order: order?.rawValue,
+            ParameterKey.posProductsOnly: String(posProductsOnly)
         ]
             .compactMapValues { $0 }
-
-        if let posProductsOnly {
-            parameters[ParameterKey.posProductsOnly] = String(posProductsOnly)
-        }
 
         let path = "\(Path.products)/\(productID)/variations"
         let request = JetpackRequest(wooApiVersion: .mark3,

--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -83,25 +83,25 @@ public protocol ProductsRemoteProtocol {
     func loadProductsForPointOfSale(for siteID: Int64,
                                     productTypes: [ProductType],
                                     pageNumber: Int,
-                                    posProductsOnly: Bool?) async throws -> PagedItems<POSProduct>
+                                    posProductsOnly: Bool) async throws -> PagedItems<POSProduct>
 
     func searchProductsForPointOfSale(for siteID: Int64,
                                       query: String,
                                       productTypes: [ProductType],
                                       pageNumber: Int,
-                                      posProductsOnly: Bool?) async throws -> PagedItems<POSProduct>
+                                      posProductsOnly: Bool) async throws -> PagedItems<POSProduct>
 
     func loadPopularProductsForPointOfSale(for siteID: Int64,
                                            productTypes: [ProductType],
                                            pageNumber: Int,
                                            perPage: Int,
-                                           posProductsOnly: Bool?) async throws -> PagedItems<POSProduct>
+                                           posProductsOnly: Bool) async throws -> PagedItems<POSProduct>
 
     func loadPOSProductByGlobalUniqueIdentifier(for siteID: Int64,
                                                    globalUniqueID: String,
-                                                   posProductsOnly: Bool?) async throws -> POSProduct
+                                                   posProductsOnly: Bool) async throws -> POSProduct
 
-    func loadPOSProduct(for siteID: Int64, productID: Int64, posProductsOnly: Bool?) async throws -> POSProduct
+    func loadPOSProduct(for siteID: Int64, productID: Int64, posProductsOnly: Bool) async throws -> POSProduct
 }
 
 extension ProductsRemoteProtocol {
@@ -110,60 +110,6 @@ extension ProductsRemoteProtocol {
                                by: productIDs,
                                pageNumber: ProductsRemote.Default.pageNumber,
                                pageSize: ProductsRemote.Default.pageSize)
-    }
-
-    // TODO:Remove when we remove the feature flag.
-    // This extension only exist to provide a default value to the protocols.
-    public func loadProductsForPointOfSale(for siteID: Int64,
-                                           productTypes: [ProductType],
-                                           pageNumber: Int) async throws -> PagedItems<POSProduct> {
-        try await loadProductsForPointOfSale(for: siteID,
-                                             productTypes: productTypes,
-                                             pageNumber: pageNumber,
-                                             posProductsOnly: nil)
-    }
-
-    // TODO:Remove when we remove the feature flag.
-    // This extension only exist to provide a default value to the protocols.
-    public func loadPopularProductsForPointOfSale(for siteID: Int64,
-                                                  productTypes: [ProductType],
-                                                  pageNumber: Int,
-                                                  perPage: Int) async throws -> PagedItems<POSProduct> {
-        try await loadPopularProductsForPointOfSale(for: siteID,
-                                                    productTypes: productTypes,
-                                                    pageNumber: pageNumber,
-                                                    perPage: perPage,
-                                                    posProductsOnly: false)
-    }
-
-    // TODO:Remove when we remove the feature flag.
-    // This extension only exist to provide a default value to the protocols.
-    public func searchProductsForPointOfSale(for siteID: Int64,
-                                             query: String,
-                                             productTypes: [ProductType],
-                                             pageNumber: Int) async throws -> PagedItems<POSProduct> {
-        try await searchProductsForPointOfSale(for: siteID,
-                                               query: query,
-                                               productTypes: productTypes,
-                                               pageNumber: pageNumber,
-                                               posProductsOnly: false)
-    }
-
-    // TODO:Remove when we remove the feature flag.
-    // This extension only exist to provide a default value to the protocols.
-    public func loadPOSProductByGlobalUniqueIdentifier(for siteID: Int64,
-                                                       globalUniqueID: String) async throws -> POSProduct {
-        try await loadPOSProductByGlobalUniqueIdentifier(for: siteID,
-                                                         globalUniqueID: globalUniqueID,
-                                                         posProductsOnly: false)
-    }
-
-    // TODO:Remove when we remove the feature flag.
-    // This extension only exist to provide a default value to the protocols.
-    public func loadPOSProduct(for siteID: Int64, productID: Int64) async throws -> POSProduct {
-        try await loadPOSProduct(for: siteID,
-                                 productID: productID,
-                                 posProductsOnly: false)
     }
 
 }
@@ -281,7 +227,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     public func loadProductsForPointOfSale(for siteID: Int64,
                                            productTypes: [ProductType] = [.simple],
                                            pageNumber: Int = 1,
-                                           posProductsOnly: Bool? = nil) async throws -> PagedItems<POSProduct> {
+                                           posProductsOnly: Bool = false) async throws -> PagedItems<POSProduct> {
         let parameters = pointOfSaleProductFetchParameters(
             pageNumber: pageNumber,
             productTypes: productTypes,
@@ -304,7 +250,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
                                                   productTypes: [ProductType] = [.simple],
                                                   pageNumber: Int = 1,
                                                   perPage: Int = Default.pageSize,
-                                                  posProductsOnly: Bool? = nil) async throws -> PagedItems<POSProduct> {
+                                                  posProductsOnly: Bool = false) async throws -> PagedItems<POSProduct> {
         let parameters = pointOfSaleProductFetchParameters(
             pageNumber: pageNumber,
             productsPerPage: String(perPage),
@@ -325,8 +271,8 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
                                                    productTypes: [ProductType],
                                                    orderBy: OrderKey = .name,
                                                    order: Order = .ascending,
-                                                   posProductsOnly: Bool? = nil) -> [String: any Hashable] {
-        var parameters: [String: any Hashable] = [
+                                                   posProductsOnly: Bool = false) -> [String: any Hashable] {
+        let parameters: [String: any Hashable] = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: productsPerPage,
             // When both productType and productTypes are provided, the productType is ignored in WC versions 9.6+.
@@ -336,12 +282,9 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.order: order.value,
             ParameterKey.productStatus: POSConstants.productStatus,
             ParameterKey.downloadable: String(false),
-            ParameterKey.fields: POSProduct.requestFields.joined(separator: ",")
+            ParameterKey.fields: POSProduct.requestFields.joined(separator: ","),
+            ParameterKey.posProductsOnly: String(posProductsOnly)
         ]
-
-        if let posProductsOnly {
-            parameters[ParameterKey.posProductsOnly] = String(posProductsOnly)
-        }
 
         return parameters
     }
@@ -374,7 +317,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
                                              query: String,
                                              productTypes: [ProductType] = [.simple],
                                              pageNumber: Int = 1,
-                                             posProductsOnly: Bool? = nil) async throws -> PagedItems<POSProduct> {
+                                             posProductsOnly: Bool = false) async throws -> PagedItems<POSProduct> {
         var parameters = pointOfSaleProductFetchParameters(
             pageNumber: pageNumber,
             productTypes: productTypes,
@@ -410,18 +353,16 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     ///
     public func loadPOSProductByGlobalUniqueIdentifier(for siteID: Int64,
                                                        globalUniqueID: String,
-                                                       posProductsOnly: Bool? = nil) async throws -> POSProduct {
-        var parameters: [String: Any] = [
+                                                       posProductsOnly: Bool = false) async throws -> POSProduct {
+        let parameters: [String: Any] = [
             ParameterKey.globalUniqueID: globalUniqueID,
             ParameterKey.page: "1",
             ParameterKey.perPage: "1",
             ParameterKey.contextKey: Default.context,
-            ParameterKey.fields: POSProduct.requestFields.joined(separator: ",")
+            ParameterKey.fields: POSProduct.requestFields.joined(separator: ","),
+            ParameterKey.posProductsOnly: String(posProductsOnly)
         ]
 
-        if let posProductsOnly {
-            parameters[ParameterKey.posProductsOnly] = String(posProductsOnly)
-        }
         let path = Path.products
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
         let mapper = ListMapper<POSProduct>(siteID: siteID)
@@ -440,14 +381,12 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     /// - Returns: A POSProduct if found
     /// - Throws: Error if the product is not found or if there's a network error
     ///
-    public func loadPOSProduct(for siteID: Int64, productID: Int64, posProductsOnly: Bool? = nil) async throws -> POSProduct {
-        var parameters: [String: Any] = [
-            ParameterKey.fields: POSProduct.requestFields.joined(separator: ",")
+    public func loadPOSProduct(for siteID: Int64, productID: Int64, posProductsOnly: Bool = false) async throws -> POSProduct {
+        let parameters: [String: Any] = [
+            ParameterKey.fields: POSProduct.requestFields.joined(separator: ","),
+            ParameterKey.posProductsOnly: String(posProductsOnly)
         ]
 
-        if let posProductsOnly {
-            parameters[ParameterKey.posProductsOnly] = String(posProductsOnly)
-        }
         let path = "\(Path.products)/\(productID)"
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
         let mapper = SingleItemMapper<POSProduct>(siteID: siteID)

--- a/Modules/Sources/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
@@ -5,12 +5,15 @@ import class WooFoundation.CurrencySettings
 struct POSProductOrVariationResolver {
     private let productsRemote: ProductsRemoteProtocol
     private let itemMapper: PointOfSaleItemMapperProtocol
+    private let posProductsOnly: Bool
 
     init (productsRemote: ProductsRemoteProtocol,
           currencySettings: CurrencySettings,
-          itemMapper: PointOfSaleItemMapperProtocol? = nil) {
+          itemMapper: PointOfSaleItemMapperProtocol? = nil,
+          posProductsOnly: Bool = false) {
         self.productsRemote = productsRemote
         self.itemMapper = itemMapper ?? PointOfSaleItemMapper(currencySettings: currencySettings)
+        self.posProductsOnly = posProductsOnly
     }
 
     func itemForProductOrVariation(_ productOrVariation: POSProduct,
@@ -62,7 +65,7 @@ struct POSProductOrVariationResolver {
         do {
             return try await productsRemote.loadPOSProduct(for: variation.siteID,
                                                            productID: variation.productID,
-                                                           posProductsOnly: false) //needs testing
+                                                           posProductsOnly: posProductsOnly)
         } catch {
             switch ProductLoadError(underlyingError: error) {
             case .notFound:

--- a/Modules/Sources/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
@@ -61,7 +61,8 @@ struct POSProductOrVariationResolver {
                                    scannedCode: String) async throws(PointOfSaleBarcodeScanError) -> POSProduct {
         do {
             return try await productsRemote.loadPOSProduct(for: variation.siteID,
-                                                           productID: variation.productID)
+                                                           productID: variation.productID,
+                                                           posProductsOnly: false) //needs testing
         } catch {
             switch ProductLoadError(underlyingError: error) {
             case .notFound:

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
@@ -31,27 +31,33 @@ public final class PointOfSaleBarcodeScanService: PointOfSaleBarcodeScanServiceP
     private let productsRemote: ProductsRemoteProtocol
     private let siteID: Int64
     private let itemResolver: POSProductOrVariationResolver
+    private let posProductsOnly: Bool
 
     init (siteID: Int64,
           productsRemote: ProductsRemoteProtocol,
-          currencySettings: CurrencySettings) {
+          currencySettings: CurrencySettings,
+          posProductsOnly: Bool = false) {
         self.siteID = siteID
         self.productsRemote = productsRemote
+        self.posProductsOnly = posProductsOnly
         self.itemResolver = POSProductOrVariationResolver(productsRemote: productsRemote,
-                                                          currencySettings: currencySettings)
+                                                          currencySettings: currencySettings,
+                                                          posProductsOnly: posProductsOnly)
     }
 
     public convenience init(siteID: Int64,
                             credentials: Credentials?,
                             selectedSite: AnyPublisher<JetpackSite?, Never>,
                             appPasswordSupportState: AnyPublisher<Bool, Never>,
-                            currencySettings: CurrencySettings) {
+                            currencySettings: CurrencySettings,
+                            posProductsOnly: Bool = false) {
         let network = AlamofireNetwork(credentials: credentials,
                                        selectedSite: selectedSite,
                                        appPasswordSupportState: appPasswordSupportState)
         self.init(siteID: siteID,
                   productsRemote: ProductsRemote(network: network),
-                  currencySettings: currencySettings)
+                  currencySettings: currencySettings,
+                  posProductsOnly: posProductsOnly)
     }
 
     /// Looks up a POSItem using a barcode scan string
@@ -70,7 +76,7 @@ public final class PointOfSaleBarcodeScanService: PointOfSaleBarcodeScanServiceP
         do {
             return try await productsRemote.loadPOSProductByGlobalUniqueIdentifier(for: siteID,
                                                                                    globalUniqueID: barcode,
-                                                                                   posProductsOnly: false)//needs testing
+                                                                                   posProductsOnly: posProductsOnly)
         } catch NetworkError.notFound {
             throw .notFound(scannedCode: barcode)
         } catch {

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
@@ -69,7 +69,8 @@ public final class PointOfSaleBarcodeScanService: PointOfSaleBarcodeScanServiceP
     private func loadPOSProduct(barcode: String) async throws(PointOfSaleBarcodeScanError) -> POSProduct {
         do {
             return try await productsRemote.loadPOSProductByGlobalUniqueIdentifier(for: siteID,
-                                                                                   globalUniqueID: barcode)
+                                                                                   globalUniqueID: barcode,
+                                                                                   posProductsOnly: false)//needs testing
         } catch NetworkError.notFound {
             throw .notFound(scannedCode: barcode)
         } catch {

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemFetchStrategyFactory.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemFetchStrategyFactory.swift
@@ -19,13 +19,15 @@ public final class PointOfSaleItemFetchStrategyFactory: PointOfSaleItemFetchStra
     private let variationsRemote: ProductVariationsRemote
     private let grdbManager: GRDBManagerProtocol?
     private let isLocalCatalogEnabled: Bool
+    private let posProductsOnlyEnabled: Bool
 
     public init(siteID: Int64,
                 credentials: Credentials?,
                 selectedSite: AnyPublisher<JetpackSite?, Never>? = nil,
                 appPasswordSupportState: AnyPublisher<Bool, Never>? = nil,
                 grdbManager: GRDBManagerProtocol? = nil,
-                isLocalCatalogEnabled: Bool = false) {
+                isLocalCatalogEnabled: Bool = false,
+                posProductsOnlyEnabled: Bool = false) {
         self.siteID = siteID
         let network = AlamofireNetwork(credentials: credentials,
                                        selectedSite: selectedSite,
@@ -34,13 +36,15 @@ public final class PointOfSaleItemFetchStrategyFactory: PointOfSaleItemFetchStra
         self.variationsRemote = ProductVariationsRemote(network: network)
         self.grdbManager = grdbManager
         self.isLocalCatalogEnabled = isLocalCatalogEnabled
+        self.posProductsOnlyEnabled = posProductsOnlyEnabled
     }
 
     public func defaultStrategy(analytics: POSItemFetchAnalyticsTracking) -> PointOfSalePurchasableItemFetchStrategy {
         PointOfSaleDefaultPurchasableItemFetchStrategy(siteID: siteID,
                                                        productsRemote: productsRemote,
                                                        variationsRemote: variationsRemote,
-                                                       analytics: analytics)
+                                                       analytics: analytics,
+                                                       posProductsOnly: posProductsOnlyEnabled)
     }
     public func searchStrategy(searchTerm: String,
                                analytics: POSItemFetchAnalyticsTracking) -> PointOfSalePurchasableItemFetchStrategy {
@@ -50,20 +54,23 @@ public final class PointOfSaleItemFetchStrategyFactory: PointOfSaleItemFetchStra
                                                                       searchTerm: searchTerm,
                                                                       grdbManager: grdbManager,
                                                                       variationsRemote: variationsRemote,
-                                                                      analytics: analytics)
+                                                                      analytics: analytics,
+                                                                      posProductsOnly: posProductsOnlyEnabled)
         }
         return PointOfSaleSearchPurchasableItemFetchStrategy(siteID: siteID,
                                                             searchTerm: searchTerm,
                                                             productsRemote: productsRemote,
                                                             variationsRemote: variationsRemote,
-                                                            analytics: analytics)
+                                                            analytics: analytics,
+                                                            posProductsOnly: posProductsOnlyEnabled)
     }
 
     public func popularStrategy(pageSize: Int = 10) -> PointOfSalePurchasableItemFetchStrategy {
         PointOfSalePopularPurchasableItemFetchStrategy(siteID: siteID,
                                                        pageSize: pageSize,
                                                        productsRemote: productsRemote,
-                                                       variationsRemote: variationsRemote)
+                                                       variationsRemote: variationsRemote,
+                                                       posProductsOnly: posProductsOnlyEnabled)
     }
 }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleLocalSearchPurchasableItemFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleLocalSearchPurchasableItemFetchStrategy.swift
@@ -11,19 +11,22 @@ struct PointOfSaleLocalSearchPurchasableItemFetchStrategy: PointOfSalePurchasabl
     private let variationsRemote: ProductVariationsRemoteProtocol
     private let analytics: POSItemFetchAnalyticsTracking
     private let pageSize: Int
+    private let posProductsOnly: Bool
 
     init(siteID: Int64,
          searchTerm: String,
          grdbManager: GRDBManagerProtocol,
          variationsRemote: ProductVariationsRemoteProtocol,
          analytics: POSItemFetchAnalyticsTracking,
-         pageSize: Int = 25) {
+         pageSize: Int = 25,
+         posProductsOnly: Bool = false) {
         self.siteID = siteID
         self.searchTerm = searchTerm
         self.grdbManager = grdbManager
         self.variationsRemote = variationsRemote
         self.analytics = analytics
         self.pageSize = pageSize
+        self.posProductsOnly = posProductsOnly
     }
 
     var debounceStrategy: SearchDebounceStrategy {

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
@@ -24,24 +24,28 @@ public struct PointOfSaleDefaultPurchasableItemFetchStrategy: PointOfSalePurchas
     private let productsRemote: ProductsRemoteProtocol
     private let variationsRemote: ProductVariationsRemoteProtocol
     private let analytics: POSItemFetchAnalyticsTracking
+    private let posProductsOnly: Bool
 
     static var defaultProductTypes: [ProductType] { [.simple, .variable] }
 
     init(siteID: Int64,
          productsRemote: ProductsRemoteProtocol,
          variationsRemote: ProductVariationsRemoteProtocol,
-         analytics: POSItemFetchAnalyticsTracking) {
+         analytics: POSItemFetchAnalyticsTracking,
+         posProductsOnly: Bool = false) {
         self.siteID = siteID
         self.productsRemote = productsRemote
         self.variationsRemote = variationsRemote
         self.analytics = analytics
+        self.posProductsOnly = posProductsOnly
     }
 
     public func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct> {
         let pagedProducts = try await productsRemote.loadProductsForPointOfSale(
             for: siteID,
             productTypes: PointOfSaleDefaultPurchasableItemFetchStrategy.defaultProductTypes,
-            pageNumber: pageNumber
+            pageNumber: pageNumber,
+            posProductsOnly: posProductsOnly
         )
 
         if pageNumber == 1 {
@@ -55,7 +59,8 @@ public struct PointOfSaleDefaultPurchasableItemFetchStrategy: PointOfSalePurchas
         try await variationsRemote
             .loadVariationsForPointOfSale(for: siteID,
                                           parentProductID: parentProductID,
-                                          pageNumber: pageNumber)
+                                          pageNumber: pageNumber,
+                                          posProductsOnly: posProductsOnly)
     }
 }
 
@@ -67,17 +72,20 @@ public struct PointOfSaleSearchPurchasableItemFetchStrategy: PointOfSalePurchasa
     private let productsRemote: ProductsRemoteProtocol
     private let variationsRemote: ProductVariationsRemoteProtocol
     private let analytics: POSItemFetchAnalyticsTracking
+    private let posProductsOnly: Bool
 
     init(siteID: Int64,
          searchTerm: String,
          productsRemote: ProductsRemoteProtocol,
          variationsRemote: ProductVariationsRemoteProtocol,
-         analytics: POSItemFetchAnalyticsTracking) {
+         analytics: POSItemFetchAnalyticsTracking,
+         posProductsOnly: Bool = false) {
         self.siteID = siteID
         self.searchTerm = searchTerm
         self.productsRemote = productsRemote
         self.variationsRemote = variationsRemote
         self.analytics = analytics
+        self.posProductsOnly = posProductsOnly
     }
 
     // periphery:ignore - Protocol requirement, used via protocol
@@ -94,7 +102,8 @@ public struct PointOfSaleSearchPurchasableItemFetchStrategy: PointOfSalePurchasa
             for: siteID,
             query: searchTerm,
             productTypes: PointOfSaleDefaultPurchasableItemFetchStrategy.defaultProductTypes,
-            pageNumber: pageNumber
+            pageNumber: pageNumber,
+            posProductsOnly: posProductsOnly
         )
         if pageNumber == 1 {
             let milliseconds = Int(Date().timeIntervalSince(startTime) * Double(MSEC_PER_SEC))
@@ -108,7 +117,8 @@ public struct PointOfSaleSearchPurchasableItemFetchStrategy: PointOfSalePurchasa
         try await variationsRemote
             .loadVariationsForPointOfSale(for: siteID,
                                           parentProductID: parentProductID,
-                                          pageNumber: pageNumber)
+                                          pageNumber: pageNumber,
+                                          posProductsOnly: posProductsOnly)
     }
 }
 
@@ -117,15 +127,18 @@ public struct PointOfSalePopularPurchasableItemFetchStrategy: PointOfSalePurchas
     private let productsRemote: ProductsRemoteProtocol
     private let variationsRemote: ProductVariationsRemoteProtocol
     private let pageSize: Int
+    private let posProductsOnly: Bool
 
     init(siteID: Int64,
          pageSize: Int,
          productsRemote: ProductsRemoteProtocol,
-         variationsRemote: ProductVariationsRemoteProtocol) {
+         variationsRemote: ProductVariationsRemoteProtocol,
+         posProductsOnly: Bool = false) {
         self.siteID = siteID
         self.productsRemote = productsRemote
         self.variationsRemote = variationsRemote
         self.pageSize = pageSize
+        self.posProductsOnly = posProductsOnly
     }
 
     public func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct> {
@@ -133,7 +146,8 @@ public struct PointOfSalePopularPurchasableItemFetchStrategy: PointOfSalePurchas
             for: siteID,
             productTypes: PointOfSaleDefaultPurchasableItemFetchStrategy.defaultProductTypes,
             pageNumber: pageNumber,
-            perPage: pageSize
+            perPage: pageSize,
+            posProductsOnly: posProductsOnly
         )
         let modifiedItems = PagedItems<POSProduct>(items: receivedItems.items,
                                                    hasMorePages: false,
@@ -145,6 +159,7 @@ public struct PointOfSalePopularPurchasableItemFetchStrategy: PointOfSalePurchas
         try await variationsRemote
             .loadVariationsForPointOfSale(for: siteID,
                                           parentProductID: parentProductID,
-                                          pageNumber: pageNumber)
+                                          pageNumber: pageNumber,
+                                          posProductsOnly: posProductsOnly)
     }
 }

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
@@ -80,7 +80,7 @@ public final class POSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol 
     public func startFullSync(for siteID: Int64,
                               regenerateCatalog: Bool = false,
                               allowCellular: Bool,
-                              posProductsOnly: Bool = true) async throws -> POSCatalog {
+                              posProductsOnly: Bool = false) async throws -> POSCatalog {
         DDLogInfo("🔄 Starting full catalog sync for site ID: \(siteID) with regenerateCatalog: \(regenerateCatalog), " +
                   "allowCellular: \(allowCellular), posProductsOnly: \(posProductsOnly)")
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
@@ -15,8 +15,9 @@ public protocol POSCatalogFullSyncServiceProtocol {
     ///   - siteID: The site ID to sync catalog for
     ///   - regenerateCatalog: Whether to force the catalog generation
     ///   - allowCellular: Should cellular data be used if required.
+    ///   - posProductsOnly: Whether to filter to POS-eligible products only.
     /// - Returns: The synced catalog containing products and variations
-    func startFullSync(for siteID: Int64, regenerateCatalog: Bool, allowCellular: Bool) async throws -> POSCatalog
+    func startFullSync(for siteID: Int64, regenerateCatalog: Bool, allowCellular: Bool, posProductsOnly: Bool) async throws -> POSCatalog
 
     /// Parses and persists a downloaded catalog file from a background download.
     /// - Parameters:
@@ -78,9 +79,10 @@ public final class POSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol 
 
     public func startFullSync(for siteID: Int64,
                               regenerateCatalog: Bool = false,
-                              allowCellular: Bool) async throws -> POSCatalog {
-        DDLogInfo("🔄 Starting full catalog sync for site ID: \(siteID) with regenerateCatalog: \(regenerateCatalog) " +
-                  "and allowCellular: \(allowCellular)")
+                              allowCellular: Bool,
+                              posProductsOnly: Bool = true) async throws -> POSCatalog {
+        DDLogInfo("🔄 Starting full catalog sync for site ID: \(siteID) with regenerateCatalog: \(regenerateCatalog), " +
+                  "allowCellular: \(allowCellular), posProductsOnly: \(posProductsOnly)")
 
         do {
             // Sync from network
@@ -91,7 +93,7 @@ public final class POSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol 
                                                               regenerateCatalog: regenerateCatalog,
                                                               allowCellular: allowCellular)
             } else {
-                catalog = try await loadCatalog(for: siteID, syncRemote: syncRemote, allowCellular: allowCellular)
+                catalog = try await loadCatalog(for: siteID, syncRemote: syncRemote, allowCellular: allowCellular, posProductsOnly: posProductsOnly)
             }
             DDLogInfo("✅ Loaded \(catalog.products.count) products and \(catalog.variations.count) variations for siteID \(siteID)")
 
@@ -131,17 +133,26 @@ public final class POSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol 
 // MARK: - Remote Loading
 
 private extension POSCatalogFullSyncService {
-    func loadCatalog(for siteID: Int64, syncRemote: POSCatalogSyncRemoteProtocol, allowCellular: Bool) async throws -> POSCatalog {
+    func loadCatalog(for siteID: Int64,
+                     syncRemote: POSCatalogSyncRemoteProtocol,
+                     allowCellular: Bool,
+                     posProductsOnly: Bool) async throws -> POSCatalog {
         let syncStartDate = Date.now
         // Loads products and variations in batches in parallel.
         async let productsTask = batchedLoader.loadAll(
             makeRequest: { pageNumber in
-                try await syncRemote.loadProducts(siteID: siteID, pageNumber: pageNumber, allowCellular: allowCellular)
+                try await syncRemote.loadProducts(siteID: siteID,
+                                                  pageNumber: pageNumber,
+                                                  allowCellular: allowCellular,
+                                                  posProductsOnly: posProductsOnly)
             }
         )
         async let variationsTask = batchedLoader.loadAll(
             makeRequest: { pageNumber in
-                try await syncRemote.loadProductVariations(siteID: siteID, pageNumber: pageNumber, allowCellular: allowCellular)
+                try await syncRemote.loadProductVariations(siteID: siteID,
+                                                           pageNumber: pageNumber,
+                                                           allowCellular: allowCellular,
+                                                           posProductsOnly: posProductsOnly)
             }
         )
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogIncrementalSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogIncrementalSyncService.swift
@@ -13,11 +13,14 @@ public protocol POSCatalogIncrementalSyncServiceProtocol {
     /// - Parameters:
     ///   - siteID: The site ID to sync catalog for.
     ///   - lastFullSyncDate: The date of the last full sync to use if no incremental sync date exists.
+    ///   - lastIncrementalSyncDate: The date of the last incremental sync.
+    ///   - posProductsOnly: Whether to filter to POS-eligible products only.
     /// - Returns: The synced catalog containing updated products and variations
     @discardableResult
     func startIncrementalSync(for siteID: Int64,
                               lastFullSyncDate: Date,
-                              lastIncrementalSyncDate: Date?) async throws -> POSCatalog
+                              lastIncrementalSyncDate: Date?,
+                              posProductsOnly: Bool) async throws -> POSCatalog
 }
 
 // TODO - remove the periphery ignore comment when the service is integrated with POS.
@@ -57,13 +60,16 @@ public final class POSCatalogIncrementalSyncService: POSCatalogIncrementalSyncSe
 
     // MARK: - Protocol Conformance
     @discardableResult
-    public func startIncrementalSync(for siteID: Int64, lastFullSyncDate: Date, lastIncrementalSyncDate: Date?) async throws -> POSCatalog {
+    public func startIncrementalSync(for siteID: Int64,
+                                     lastFullSyncDate: Date,
+                                     lastIncrementalSyncDate: Date?,
+                                     posProductsOnly: Bool = true) async throws -> POSCatalog {
         let modifiedAfter = latestSyncDate(fullSyncDate: lastFullSyncDate, incrementalSyncDate: lastIncrementalSyncDate)
 
-        DDLogInfo("🔄 Starting incremental catalog sync for site ID: \(siteID), modifiedAfter: \(modifiedAfter)")
+        DDLogInfo("🔄 Starting incremental catalog sync for site ID: \(siteID), modifiedAfter: \(modifiedAfter), posProductsOnly: \(posProductsOnly)")
 
         do {
-            let catalog = try await loadCatalog(for: siteID, modifiedAfter: modifiedAfter, syncRemote: syncRemote)
+            let catalog = try await loadCatalog(for: siteID, modifiedAfter: modifiedAfter, syncRemote: syncRemote, posProductsOnly: posProductsOnly)
             DDLogInfo("✅ Loaded \(catalog.products.count) updated products and \(catalog.variations.count) updated variations for siteID \(siteID)")
 
             try await persistenceService.persistIncrementalCatalogData(catalog, siteID: siteID)
@@ -80,13 +86,20 @@ public final class POSCatalogIncrementalSyncService: POSCatalogIncrementalSyncSe
 // MARK: - Remote Loading
 
 private extension POSCatalogIncrementalSyncService {
-    func loadCatalog(for siteID: Int64, modifiedAfter: Date, syncRemote: POSCatalogSyncRemoteProtocol) async throws -> POSCatalog {
+    func loadCatalog(for siteID: Int64,
+                     modifiedAfter: Date,
+                     syncRemote: POSCatalogSyncRemoteProtocol,
+                     posProductsOnly: Bool) async throws -> POSCatalog {
         let syncStartDate = Date.now
 
         // Fetch regular products (excluding trash)
         async let regularProductsTask = batchedLoader.loadAll(
             makeRequest: { pageNumber in
-                try await syncRemote.loadProducts(modifiedAfter: modifiedAfter, siteID: siteID, pageNumber: pageNumber, includeStatus: nil)
+                try await syncRemote.loadProducts(modifiedAfter: modifiedAfter,
+                                                  siteID: siteID,
+                                                  pageNumber: pageNumber,
+                                                  includeStatus: nil,
+                                                  posProductsOnly: posProductsOnly)
             }
         )
 
@@ -96,13 +109,17 @@ private extension POSCatalogIncrementalSyncService {
                 try await syncRemote.loadProducts(modifiedAfter: modifiedAfter,
                                                   siteID: siteID,
                                                   pageNumber: pageNumber,
-                                                  includeStatus: ProductStatus.trash.rawValue)
+                                                  includeStatus: ProductStatus.trash.rawValue,
+                                                  posProductsOnly: posProductsOnly)
             }
         )
 
         async let variationsTask = batchedLoader.loadAll(
             makeRequest: { pageNumber in
-                try await syncRemote.loadProductVariations(modifiedAfter: modifiedAfter, siteID: siteID, pageNumber: pageNumber)
+                try await syncRemote.loadProductVariations(modifiedAfter: modifiedAfter,
+                                                           siteID: siteID,
+                                                           pageNumber: pageNumber,
+                                                           posProductsOnly: posProductsOnly)
             }
         )
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogIncrementalSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogIncrementalSyncService.swift
@@ -63,7 +63,7 @@ public final class POSCatalogIncrementalSyncService: POSCatalogIncrementalSyncSe
     public func startIncrementalSync(for siteID: Int64,
                                      lastFullSyncDate: Date,
                                      lastIncrementalSyncDate: Date?,
-                                     posProductsOnly: Bool = true) async throws -> POSCatalog {
+                                     posProductsOnly: Bool = false) async throws -> POSCatalog {
         let modifiedAfter = latestSyncDate(fullSyncDate: lastFullSyncDate, incrementalSyncDate: lastIncrementalSyncDate)
 
         DDLogInfo("🔄 Starting incremental catalog sync for site ID: \(siteID), modifiedAfter: \(modifiedAfter), posProductsOnly: \(posProductsOnly)")

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSizeChecker.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSizeChecker.swift
@@ -30,8 +30,8 @@ public struct POSCatalogSizeChecker: POSCatalogSizeCheckerProtocol {
 
     public func checkCatalogSize(for siteID: Int64) async throws -> POSCatalogSize {
         // Make concurrent requests to get both counts
-        async let productCount = syncRemote.getProductCount(siteID: siteID)
-        async let variationCount = syncRemote.getProductVariationCount(siteID: siteID)
+        async let productCount = syncRemote.getProductCount(siteID: siteID, posProductsOnly: true)
+        async let variationCount = syncRemote.getProductVariationCount(siteID: siteID, posProductsOnly: true)
 
         do {
             return try await POSCatalogSize(

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSizeChecker.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSizeChecker.swift
@@ -17,7 +17,7 @@ public struct POSCatalogSizeChecker: POSCatalogSizeCheckerProtocol {
     private let posProductsOnlyEnabled: Bool
 
     public init(syncRemote: POSCatalogSyncRemoteProtocol,
-                posProductsOnlyEnabled: Bool = false) {
+                posProductsOnlyEnabled: Bool) {
         self.syncRemote = syncRemote
         self.posProductsOnlyEnabled = posProductsOnlyEnabled
     }
@@ -25,7 +25,7 @@ public struct POSCatalogSizeChecker: POSCatalogSizeCheckerProtocol {
     public init(credentials: Credentials?,
                 selectedSite: AnyPublisher<JetpackSite?, Never>,
                 appPasswordSupportState: AnyPublisher<Bool, Never>,
-                posProductsOnlyEnabled: Bool = false) {
+                posProductsOnlyEnabled: Bool) {
         let syncRemote = POSCatalogSyncRemote(network: AlamofireNetwork(credentials: credentials,
                                                                         selectedSite: selectedSite,
                                                                         appPasswordSupportState: appPasswordSupportState))

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSizeChecker.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSizeChecker.swift
@@ -14,24 +14,28 @@ public protocol POSCatalogSizeCheckerProtocol {
 /// Implementation of catalog size checker that uses the sync remote to get counts
 public struct POSCatalogSizeChecker: POSCatalogSizeCheckerProtocol {
     private let syncRemote: POSCatalogSyncRemoteProtocol
+    private let posProductsOnlyEnabled: Bool
 
-    public init(syncRemote: POSCatalogSyncRemoteProtocol) {
+    public init(syncRemote: POSCatalogSyncRemoteProtocol,
+                posProductsOnlyEnabled: Bool = false) {
         self.syncRemote = syncRemote
+        self.posProductsOnlyEnabled = posProductsOnlyEnabled
     }
 
     public init(credentials: Credentials?,
                 selectedSite: AnyPublisher<JetpackSite?, Never>,
-                appPasswordSupportState: AnyPublisher<Bool, Never>) {
+                appPasswordSupportState: AnyPublisher<Bool, Never>,
+                posProductsOnlyEnabled: Bool = false) {
         let syncRemote = POSCatalogSyncRemote(network: AlamofireNetwork(credentials: credentials,
                                                                         selectedSite: selectedSite,
                                                                         appPasswordSupportState: appPasswordSupportState))
-        self.init(syncRemote: syncRemote)
+        self.init(syncRemote: syncRemote, posProductsOnlyEnabled: posProductsOnlyEnabled)
     }
 
     public func checkCatalogSize(for siteID: Int64) async throws -> POSCatalogSize {
         // Make concurrent requests to get both counts
-        async let productCount = syncRemote.getProductCount(siteID: siteID, posProductsOnly: true)
-        async let variationCount = syncRemote.getProductVariationCount(siteID: siteID, posProductsOnly: true)
+        async let productCount = syncRemote.getProductCount(siteID: siteID, posProductsOnly: posProductsOnlyEnabled)
+        async let variationCount = syncRemote.getProductVariationCount(siteID: siteID, posProductsOnly: posProductsOnlyEnabled)
 
         do {
             return try await POSCatalogSize(

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -176,7 +176,8 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
         let syncTask = Task<POSCatalog, Error> {
             try await fullSyncService.startFullSync(for: siteID,
                                                     regenerateCatalog: regenerateCatalog,
-                                                    allowCellular: allowCellular)
+                                                    allowCellular: allowCellular,
+                                                    posProductsOnly: true)
         }
 
         // Store the task for potential cancellation
@@ -353,7 +354,8 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
         let syncTask = Task<POSCatalog, Error> {
             try await incrementalSyncService.startIncrementalSync(for: siteID,
                                                                   lastFullSyncDate: lastFullSyncDate,
-                                                                  lastIncrementalSyncDate: await lastIncrementalSyncDate(for: siteID))
+                                                                  lastIncrementalSyncDate: await lastIncrementalSyncDate(for: siteID),
+                                                                  posProductsOnly: true)
         }
 
         // Store the task for potential cancellation

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -113,6 +113,7 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
     private let siteSettings: SiteSpecificAppSettingsStoreMethodsProtocol
     private let analytics: Analytics?
     private let connectivityObserver: ConnectivityObserver?
+    private let posProductsOnlyEnabled: Bool
 
     /// Tracks ongoing incremental syncs by site ID to prevent duplicates
     private var ongoingIncrementalSyncs: Set<Int64> = []
@@ -132,7 +133,8 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
                 catalogEligibilityChecker: POSLocalCatalogEligibilityServiceProtocol,
                 siteSettings: SiteSpecificAppSettingsStoreMethodsProtocol? = nil,
                 analytics: Analytics? = nil,
-                connectivityObserver: ConnectivityObserver? = nil) {
+                connectivityObserver: ConnectivityObserver? = nil,
+                posProductsOnlyEnabled: Bool = false) {
         self.fullSyncService = fullSyncService
         self.incrementalSyncService = incrementalSyncService
         self.grdbManager = grdbManager
@@ -140,6 +142,7 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
         self.siteSettings = siteSettings ?? SiteSpecificAppSettingsStoreMethods(fileStorage: PListFileStorage())
         self.analytics = analytics
         self.connectivityObserver = connectivityObserver
+        self.posProductsOnlyEnabled = posProductsOnlyEnabled
     }
 
     public func performFullSyncIfApplicable(for siteID: Int64, maxAge: TimeInterval, regenerateCatalog: Bool) async throws {
@@ -177,7 +180,7 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
             try await fullSyncService.startFullSync(for: siteID,
                                                     regenerateCatalog: regenerateCatalog,
                                                     allowCellular: allowCellular,
-                                                    posProductsOnly: true)
+                                                    posProductsOnly: posProductsOnlyEnabled)
         }
 
         // Store the task for potential cancellation
@@ -355,7 +358,7 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
             try await incrementalSyncService.startIncrementalSync(for: siteID,
                                                                   lastFullSyncDate: lastFullSyncDate,
                                                                   lastIncrementalSyncDate: await lastIncrementalSyncDate(for: siteID),
-                                                                  posProductsOnly: true)
+                                                                  posProductsOnly: posProductsOnlyEnabled)
         }
 
         // Store the task for potential cancellation

--- a/Modules/Tests/NetworkingTests/Remote/POSProductsNetworkingTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSProductsNetworkingTests.swift
@@ -284,21 +284,21 @@ struct POSProductsNetworkingTests {
         #expect(request.parameters["_fields"] as? String == POSProduct.requestFields.joined(separator: ","))
     }
 
-    @Test func loadProductsForPointOfSale_excludes_posProductsOnly_when_not_specified() async throws {
+    @Test func loadProductsForPointOfSale_includes_posProductsOnly_false_when_default() async throws {
         // Given
         let remote = ProductsRemote(network: network)
 
-        // When - call without posProductsOnly parameter
         _ = try? await remote.loadProductsForPointOfSale(for: sampleSiteID,
                                                          productTypes: [.simple],
-                                                         pageNumber: 1)
+                                                         pageNumber: 1,
+                                                         posProductsOnly: false)
 
-        // Then - parameter should not be present
+        // Then
         let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
-        #expect(queryParametersDictionary["pos_products_only"] == nil)
+        #expect(queryParametersDictionary["pos_products_only"] as? String == "false")
     }
 
-    @Test func loadProductsForPointOfSale_includes_posProductsOnly_true_when_enabled() async throws {
+    @Test func loadProductsForPointOfSale_includes_posProductsOnly_when_true() async throws {
         // Given
         let remote = ProductsRemote(network: network)
 
@@ -313,54 +313,7 @@ struct POSProductsNetworkingTests {
         #expect(queryParametersDictionary["pos_products_only"] as? String == "true")
     }
 
-    @Test func loadProductsForPointOfSale_includes_posProductsOnly_false_when_disabled() async throws {
-        // Given
-        let remote = ProductsRemote(network: network)
-
-        // When
-        _ = try? await remote.loadProductsForPointOfSale(for: sampleSiteID,
-                                                         productTypes: [.simple],
-                                                         pageNumber: 1,
-                                                         posProductsOnly: false)
-
-        // Then
-        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
-        #expect(queryParametersDictionary["pos_products_only"] as? String == "false")
-    }
-
-    @Test func loadPopularProductsForPointOfSale_excludes_posProductsOnly_when_not_specified() async throws {
-        // Given
-        let remote = ProductsRemote(network: network)
-
-        // When - call without posProductsOnly parameter
-        _ = try? await remote.loadPopularProductsForPointOfSale(for: sampleSiteID,
-                                                                 productTypes: [.simple],
-                                                                 pageNumber: 1,
-                                                                 perPage: 25,
-                                                                 posProductsOnly: nil)
-
-        // Then - parameter should not be present
-        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
-        #expect(queryParametersDictionary["pos_products_only"] == nil)
-    }
-
-    @Test func loadPopularProductsForPointOfSale_includes_posProductsOnly_true_when_enabled() async throws {
-        // Given
-        let remote = ProductsRemote(network: network)
-
-        // When
-        _ = try? await remote.loadPopularProductsForPointOfSale(for: sampleSiteID,
-                                                                 productTypes: [.simple],
-                                                                 pageNumber: 1,
-                                                                 perPage: 25,
-                                                                 posProductsOnly: true)
-
-        // Then
-        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
-        #expect(queryParametersDictionary["pos_products_only"] as? String == "true")
-    }
-
-    @Test func loadPopularProductsForPointOfSale_includes_posProductsOnly_false_when_disabled() async throws {
+    @Test func loadPopularProductsForPointOfSale_includes_posProductsOnly_false_when_false() async throws {
         // Given
         let remote = ProductsRemote(network: network)
 
@@ -376,39 +329,23 @@ struct POSProductsNetworkingTests {
         #expect(queryParametersDictionary["pos_products_only"] as? String == "false")
     }
 
-    @Test func searchProductsForPointOfSale_excludes_posProductsOnly_when_not_specified() async throws {
-        // Given
-        let remote = ProductsRemote(network: network)
-
-        // When - call without posProductsOnly parameter
-        _ = try? await remote.searchProductsForPointOfSale(for: sampleSiteID,
-                                                            query: "test",
-                                                            productTypes: [.simple],
-                                                            pageNumber: 1,
-                                                            posProductsOnly: nil)
-
-        // Then - parameter should not be present
-        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
-        #expect(queryParametersDictionary["pos_products_only"] == nil)
-    }
-
-    @Test func searchProductsForPointOfSale_includes_posProductsOnly_true_when_enabled() async throws {
+    @Test func loadPopularProductsForPointOfSale_includes_posProductsOnly_when_true() async throws {
         // Given
         let remote = ProductsRemote(network: network)
 
         // When
-        _ = try? await remote.searchProductsForPointOfSale(for: sampleSiteID,
-                                                            query: "test",
-                                                            productTypes: [.simple],
-                                                            pageNumber: 1,
-                                                            posProductsOnly: true)
+        _ = try? await remote.loadPopularProductsForPointOfSale(for: sampleSiteID,
+                                                                 productTypes: [.simple],
+                                                                 pageNumber: 1,
+                                                                 perPage: 25,
+                                                                 posProductsOnly: true)
 
         // Then
         let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
         #expect(queryParametersDictionary["pos_products_only"] as? String == "true")
     }
 
-    @Test func searchProductsForPointOfSale_includes_posProductsOnly_false_when_disabled() async throws {
+    @Test func searchProductsForPointOfSale_includes_posProductsOnly_false_when_default() async throws {
         // Given
         let remote = ProductsRemote(network: network)
 
@@ -424,37 +361,23 @@ struct POSProductsNetworkingTests {
         #expect(queryParametersDictionary["pos_products_only"] as? String == "false")
     }
 
-    @Test func loadPOSProductByGlobalUniqueIdentifier_excludes_posProductsOnly_when_not_specified() async throws {
+    @Test func searchProductsForPointOfSale_includes_posProductsOnly_when_true() async throws {
         // Given
         let remote = ProductsRemote(network: network)
-        network.simulateResponse(requestUrlSuffix: "products", filename: "pos-products")
-
-        // When - call without posProductsOnly parameter
-        _ = try? await remote.loadPOSProductByGlobalUniqueIdentifier(for: sampleSiteID,
-                                                                      globalUniqueID: "123456789",
-                                                                      posProductsOnly: nil)
-
-        // Then - parameter should not be present
-        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
-        #expect(request.parameters["pos_products_only"] == nil)
-    }
-
-    @Test func loadPOSProductByGlobalUniqueIdentifier_includes_posProductsOnly_true_when_enabled() async throws {
-        // Given
-        let remote = ProductsRemote(network: network)
-        network.simulateResponse(requestUrlSuffix: "products", filename: "pos-products")
 
         // When
-        _ = try? await remote.loadPOSProductByGlobalUniqueIdentifier(for: sampleSiteID,
-                                                                      globalUniqueID: "123456789",
-                                                                      posProductsOnly: true)
+        _ = try? await remote.searchProductsForPointOfSale(for: sampleSiteID,
+                                                            query: "test",
+                                                            productTypes: [.simple],
+                                                            pageNumber: 1,
+                                                            posProductsOnly: true)
 
         // Then
-        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
-        #expect(request.parameters["pos_products_only"] as? String == "true")
+        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
+        #expect(queryParametersDictionary["pos_products_only"] as? String == "true")
     }
 
-    @Test func loadPOSProductByGlobalUniqueIdentifier_includes_posProductsOnly_false_when_disabled() async throws {
+    @Test func loadPOSProductByGlobalUniqueIdentifier_includes_posProductsOnly_false_when_default() async throws {
         // Given
         let remote = ProductsRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "products", filename: "pos-products")
@@ -469,35 +392,22 @@ struct POSProductsNetworkingTests {
         #expect(request.parameters["pos_products_only"] as? String == "false")
     }
 
-    @Test func loadPOSProduct_excludes_posProductsOnly_when_not_specified() async throws {
+    @Test func loadPOSProductByGlobalUniqueIdentifier_includes_posProductsOnly_when_true() async throws {
         // Given
         let remote = ProductsRemote(network: network)
-
-        // When - call without posProductsOnly parameter
-        _ = try? await remote.loadPOSProduct(for: sampleSiteID,
-                                              productID: 123,
-                                              posProductsOnly: nil)
-
-        // Then - parameter should not be present
-        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
-        #expect(request.parameters["pos_products_only"] == nil)
-    }
-
-    @Test func loadPOSProduct_includes_posProductsOnly_true_when_enabled() async throws {
-        // Given
-        let remote = ProductsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "pos-products")
 
         // When
-        _ = try? await remote.loadPOSProduct(for: sampleSiteID,
-                                              productID: 123,
-                                              posProductsOnly: true)
+        _ = try? await remote.loadPOSProductByGlobalUniqueIdentifier(for: sampleSiteID,
+                                                                      globalUniqueID: "123456789",
+                                                                      posProductsOnly: true)
 
         // Then
         let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
         #expect(request.parameters["pos_products_only"] as? String == "true")
     }
 
-    @Test func loadPOSProduct_includes_posProductsOnly_false_when_disabled() async throws {
+    @Test func loadPOSProduct_includes_posProductsOnly_false_when_default() async throws {
         // Given
         let remote = ProductsRemote(network: network)
 
@@ -509,5 +419,19 @@ struct POSProductsNetworkingTests {
         // Then
         let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
         #expect(request.parameters["pos_products_only"] as? String == "false")
+    }
+
+    @Test func loadPOSProduct_includes_posProductsOnly_when_true() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+
+        // When
+        _ = try? await remote.loadPOSProduct(for: sampleSiteID,
+                                              productID: 123,
+                                              posProductsOnly: true)
+
+        // Then
+        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
+        #expect(request.parameters["pos_products_only"] as? String == "true")
     }
 }

--- a/Modules/Tests/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -604,36 +604,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
         XCTAssertEqual(queryParametersDictionary["per_page"] as? String, "25")
     }
 
-    func test_loadVariationsForPointOfSale_excludes_posProductsOnly_when_not_specified() async throws {
-        // Given
-        let remote = ProductVariationsRemote(network: network)
-
-        // When - call without posProductsOnly parameter
-        _ = try? await remote.loadVariationsForPointOfSale(for: sampleSiteID,
-                                                           parentProductID: sampleProductID,
-                                                           pageNumber: 1)
-
-        // Then - parameter should not be present
-        let queryParametersDictionary = try XCTUnwrap(network.queryParametersDictionary)
-        XCTAssertNil(queryParametersDictionary["pos_products_only"])
-    }
-
-    func test_loadVariationsForPointOfSale_includes_posProductsOnly_true_when_enabled() async throws {
-        // Given
-        let remote = ProductVariationsRemote(network: network)
-
-        // When
-        _ = try? await remote.loadVariationsForPointOfSale(for: sampleSiteID,
-                                                           parentProductID: sampleProductID,
-                                                           pageNumber: 1,
-                                                           posProductsOnly: true)
-
-        // Then
-        let queryParametersDictionary = try XCTUnwrap(network.queryParametersDictionary)
-        XCTAssertEqual(queryParametersDictionary["pos_products_only"] as? String, "true")
-    }
-
-    func test_loadVariationsForPointOfSale_includes_posProductsOnly_false_when_disabled() async throws {
+    func test_loadVariationsForPointOfSale_includes_posProductsOnly_false_when_default() async throws {
         // Given
         let remote = ProductVariationsRemote(network: network)
 
@@ -646,6 +617,21 @@ final class ProductVariationsRemoteTests: XCTestCase {
         // Then
         let queryParametersDictionary = try XCTUnwrap(network.queryParametersDictionary)
         XCTAssertEqual(queryParametersDictionary["pos_products_only"] as? String, "false")
+    }
+
+    func test_loadVariationsForPointOfSale_includes_posProductsOnly_when_true() async throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+
+        // When
+        _ = try? await remote.loadVariationsForPointOfSale(for: sampleSiteID,
+                                                           parentProductID: sampleProductID,
+                                                           pageNumber: 1,
+                                                           posProductsOnly: true)
+
+        // Then
+        let queryParametersDictionary = try XCTUnwrap(network.queryParametersDictionary)
+        XCTAssertEqual(queryParametersDictionary["pos_products_only"] as? String, "true")
     }
 }
 

--- a/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogIncrementalSyncService.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogIncrementalSyncService.swift
@@ -14,7 +14,10 @@ final class MockPOSCatalogIncrementalSyncService: POSCatalogIncrementalSyncServi
     private var syncBlockedContinuations: [CheckedContinuation<Void, Never>] = []
 
     @discardableResult
-    func startIncrementalSync(for siteID: Int64, lastFullSyncDate: Date, lastIncrementalSyncDate: Date?) async throws -> POSCatalog {
+    func startIncrementalSync(for siteID: Int64,
+                              lastFullSyncDate: Date,
+                              lastIncrementalSyncDate: Date?,
+                              posProductsOnly: Bool) async throws -> POSCatalog {
         startIncrementalSyncCallCount += 1
         lastSyncSiteID = siteID
         self.lastFullSyncDate = lastFullSyncDate

--- a/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogSyncRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogSyncRemote.swift
@@ -88,7 +88,8 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
     func loadProducts(modifiedAfter: Date,
                       siteID: Int64,
                       pageNumber: Int,
-                      includeStatus: String?) async throws -> PagedItems<POSProduct> {
+                      includeStatus: String?,
+                      posProductsOnly: Bool) async throws -> PagedItems<POSProduct> {
         await includeStatusTracker.append(includeStatus)
 
         // Route to appropriate results based on includeStatus
@@ -120,7 +121,10 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
         return fallbackResult
     }
 
-    func loadProductVariations(modifiedAfter: Date, siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
+    func loadProductVariations(modifiedAfter: Date,
+                                siteID: Int64,
+                                pageNumber: Int,
+                                posProductsOnly: Bool) async throws -> PagedItems<POSProductVariation> {
         await loadIncrementalProductVariationsCallCount.increment()
         lastIncrementalVariationsModifiedAfter = modifiedAfter
 
@@ -137,7 +141,10 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
 
     // MARK: - Protocol Methods - Full Sync
 
-    func loadProducts(siteID: Int64, pageNumber: Int, allowCellular: Bool) async throws -> PagedItems<POSProduct> {
+    func loadProducts(siteID: Int64,
+                      pageNumber: Int,
+                      allowCellular: Bool,
+                      posProductsOnly: Bool) async throws -> PagedItems<POSProduct> {
         await loadProductsCallCount.increment()
 
         if let result = productResults[pageNumber] {
@@ -151,7 +158,10 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
         return fallbackResult
     }
 
-    func loadProductVariations(siteID: Int64, pageNumber: Int, allowCellular: Bool) async throws -> PagedItems<POSProductVariation> {
+    func loadProductVariations(siteID: Int64,
+                                pageNumber: Int,
+                                allowCellular: Bool,
+                                posProductsOnly: Bool) async throws -> PagedItems<POSProductVariation> {
         await loadProductVariationsCallCount.increment()
 
         if let result = variationResults[pageNumber] {
@@ -220,7 +230,7 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
     var getProductVariationCountResult: Result<Int, Error> = .success(0)
     var variationCountDelay: UInt64 = 0
 
-    func getProductCount(siteID: Int64) async throws -> Int {
+    func getProductCount(siteID: Int64, posProductsOnly: Bool) async throws -> Int {
         getProductCountCallCount += 1
         lastProductCountSiteID = siteID
 
@@ -236,7 +246,7 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
         }
     }
 
-    func getProductVariationCount(siteID: Int64) async throws -> Int {
+    func getProductVariationCount(siteID: Int64, posProductsOnly: Bool) async throws -> Int {
         getProductVariationCountCallCount += 1
         lastVariationCountSiteID = siteID
 

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
@@ -103,7 +103,7 @@ extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
     func loadVariationsForPointOfSale(for siteID: Int64,
                                       parentProductID: Int64,
                                       pageNumber: Int,
-                                      posProductsOnly: Bool?) async throws -> PagedItems<POSProductVariation> {
+                                      posProductsOnly: Bool) async throws -> PagedItems<POSProductVariation> {
         let key = ResultKey(siteID: siteID, productID: parentProductID, productVariationIDs: [])
         guard let result = variationsForPointOfSaleResults[key] else {
             throw NetworkError.notFound()

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -448,7 +448,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
     func loadProductsForPointOfSale(for siteID: Int64,
                                     productTypes: [ProductType],
                                     pageNumber: Int,
-                                    posProductsOnly: Bool?) async throws -> PagedItems<POSProduct> {
+                                    posProductsOnly: Bool) async throws -> PagedItems<POSProduct> {
         guard let result = posProductsResultsBySiteID[siteID] else {
             throw NetworkError.notFound()
         }
@@ -464,7 +464,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
                                       query: String,
                                       productTypes: [ProductType],
                                       pageNumber: Int,
-                                      posProductsOnly: Bool?) async throws -> PagedItems<POSProduct> {
+                                      posProductsOnly: Bool) async throws -> PagedItems<POSProduct> {
         guard let result = posSearchResultsByQuery[query] else {
             throw NetworkError.notFound()
         }
@@ -476,7 +476,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         }
     }
 
-    func loadPOSProductByGlobalUniqueIdentifier(for siteID: Int64, globalUniqueID: String, posProductsOnly: Bool?) async throws -> POSProduct {
+    func loadPOSProductByGlobalUniqueIdentifier(for siteID: Int64, globalUniqueID: String, posProductsOnly: Bool) async throws -> POSProduct {
             return POSProduct.fake().copy(siteID: siteID,
                                           globalUniqueID: globalUniqueID)
     }
@@ -485,7 +485,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
                                            productTypes: [ProductType],
                                            pageNumber: Int,
                                            perPage: Int,
-                                           posProductsOnly: Bool?) async throws -> PagedItems<POSProduct> {
+                                           posProductsOnly: Bool) async throws -> PagedItems<POSProduct> {
         lastRequestedPageSize = perPage
         guard let result = posPopularProductsResultsBySiteID[siteID] else {
             throw NetworkError.notFound()
@@ -498,7 +498,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         }
     }
 
-    func loadPOSProduct(for siteID: Int64, productID: Int64, posProductsOnly: Bool?) async throws -> POSProduct {
+    func loadPOSProduct(for siteID: Int64, productID: Int64, posProductsOnly: Bool) async throws -> POSProduct {
         invocationCountOfLoadPOSProduct += 1
         requestedProductIDsForFetchingPOSProduct.append(productID)
 

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSizeCheckerTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSizeCheckerTests.swift
@@ -9,7 +9,7 @@ struct POSCatalogSizeCheckerTests {
 
     init() throws {
         self.mockSyncRemote = MockPOSCatalogSyncRemote()
-        self.sut = POSCatalogSizeChecker(syncRemote: mockSyncRemote)
+        self.sut = POSCatalogSizeChecker(syncRemote: mockSyncRemote, posProductsOnlyEnabled: false)
     }
 
     @Test func checkCatalogSize_returns_combined_count_from_remote() async throws {

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
@@ -589,7 +589,10 @@ final class MockPOSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol {
     private(set) var lastSyncSiteID: Int64?
     private(set) var lastAllowCellular: Bool?
 
-    func startFullSync(for siteID: Int64, regenerateCatalog: Bool, allowCellular: Bool) async throws -> POSCatalog {
+    func startFullSync(for siteID: Int64,
+                        regenerateCatalog: Bool,
+                        allowCellular: Bool,
+                        posProductsOnly: Bool) async throws -> POSCatalog {
         startFullSyncCallCount += 1
         lastSyncSiteID = siteID
         lastAllowCellular = allowCellular

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -94,11 +94,13 @@ final class POSTabCoordinator {
                                                      currencySettings: currencySettings)
         } else {
             // Fall back to remote barcode scanning
+            let posProductsOnlyEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleOnlyProducts)
             return PointOfSaleBarcodeScanService(siteID: siteID,
                                                 credentials: credentials,
                                                 selectedSite: defaultSitePublisher,
                                                 appPasswordSupportState: isAppPasswordSupported,
-                                                currencySettings: currencySettings)
+                                                currencySettings: currencySettings,
+                                                posProductsOnly: posProductsOnlyEnabled)
         }
     }
 

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -50,12 +50,14 @@ final class POSTabCoordinator {
 
     /// Creates item fetch strategy factory with current local catalog eligibility
     private func createItemFetchStrategyFactory(isLocalCatalogEnabled: Bool) -> PointOfSaleItemFetchStrategyFactory {
-        PointOfSaleItemFetchStrategyFactory(siteID: siteID,
-                                            credentials: credentials,
-                                            selectedSite: defaultSitePublisher,
-                                            appPasswordSupportState: isAppPasswordSupported,
-                                            grdbManager: isLocalCatalogEnabled ? ServiceLocator.grdbManager : nil,
-                                            isLocalCatalogEnabled: isLocalCatalogEnabled)
+        let posProductsOnlyEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleOnlyProducts)
+        return PointOfSaleItemFetchStrategyFactory(siteID: siteID,
+                                                   credentials: credentials,
+                                                   selectedSite: defaultSitePublisher,
+                                                   appPasswordSupportState: isAppPasswordSupported,
+                                                   grdbManager: isLocalCatalogEnabled ? ServiceLocator.grdbManager : nil,
+                                                   isLocalCatalogEnabled: isLocalCatalogEnabled,
+                                                   posProductsOnlyEnabled: posProductsOnlyEnabled)
     }
 
     /// Creates popular item fetch strategy factory with current local catalog eligibility

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -185,13 +185,15 @@ class AuthenticatedState: StoresManagerState {
             appPasswordSupportState: appPasswordSupportState.eraseToAnyPublisher(),
             grdbManager: ServiceLocator.grdbManager
            ) {
+            let posProductsOnlyEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleOnlyProducts)
 
             // Create eligibility service
             let eligibilityService = POSLocalCatalogEligibilityService(
                 catalogSizeChecker: POSCatalogSizeChecker(
                     credentials: credentials,
                     selectedSite: site,
-                    appPasswordSupportState: appPasswordSupportState.eraseToAnyPublisher()
+                    appPasswordSupportState: appPasswordSupportState.eraseToAnyPublisher(),
+                    posProductsOnlyEnabled: posProductsOnlyEnabled
                 ),
                 systemStatusService: POSSystemStatusService(
                     credentials: credentials,
@@ -216,7 +218,8 @@ class AuthenticatedState: StoresManagerState {
                 grdbManager: ServiceLocator.grdbManager,
                 catalogEligibilityChecker: eligibilityService,
                 analytics: ServiceLocator.analytics,
-                connectivityObserver: ServiceLocator.connectivityObserver
+                connectivityObserver: ServiceLocator.connectivityObserver,
+                posProductsOnlyEnabled: posProductsOnlyEnabled
             )
 
             // Note: POS eligibility will be set later by POSTabCoordinator.updatePOSEligibility


### PR DESCRIPTION
Closes WOOMOB-1981

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
This PR hooks the feature flag for using "pos_products_only" filter parameter into the different remote and local catalog product/variation fetch strategies. 
- When the flag is disabled, we pass"pos_products_only=false", which applies no filter or is ignored
- When the flag is enabled, we pass"pos_products_only=true", which applies the filtering and returns products/variations marked as POS.

Regarding local catalog, right now only handles full sync. When performing incremental syncs, it the merchant hides products from POS, these won't be filtered out as they are not in the response. This will be handled on the next PR (ref: p1768227906827499-slack-C070SJRA8DP)

## Changes
- Inject feature flag through `POSTabCoordinator`
- We update the parameter to be non optional in order to make some code simplification, it's either false (will be ignore if not present) or true.
- Updates the different fetch strategies to use the parameter
- Updates the different product/variations endpoints to use the parameter
- Updates the different catalog endpoints remotes to use the parameter

## Test Steps

Setup: Your store needs [this PR](https://github.com/woocommerce/woocommerce/pull/62534) to use the new filter. There are several options you can choose from:
  - Create a new Jurassic ninja site with that branch
  - Use my testing store https://indiemelon.mystagingwebsite.com/ , which currently has that version installed
  - Install the plugin version that contains the changes [from this link](https://indiemelon.mystagingwebsite.com/wp-content/uploads/2026/01/woocommerce-20260109.zip) into your own store.

Once this is done, observe that if you enable/disable `available for POS` in to wp-admin > Products > edit > advance, the product won't be included in the response. 

<img width="851" height="306" alt="Screenshot 2026-01-14 at 11 23 33" src="https://github.com/user-attachments/assets/87a24ad0-dd10-41ff-b398-d00d048be9c2" />

Adding the parameter to the different endpoints should return the correct number of items. ie:
```
// Should return the same number of products with and without parameter
GET https://yoursite.com/wp-json/wc/v3/products?pos_products_only=false 

// Should return only POS products, that is all eligible products 
GET https://yoursite.com/wp-json/wc/v3/products?pos_products_only=true
```

1. In the app, for testing the remotes you can add some debugging code to the `ProductsRemote` line 304 and `ProductVariationsRemote` line 104. 
```
let totalItems = responseHeaders?[PaginationHeaderKey.totalCount] ?? "nil"
debugPrint("Headers: X-WP-Total=\(totalItems)")
```

2. Local catalog should behave the same as long as you're performing full syncs, in order to test this faster I added some "clear catalog" code as a helper so I could delete it on demand:

```swift
// POSSettingsLocalCatalogDetailView.swift, in line 26
Button("DEBUG: Clear Catalog") {
   Task {
      await viewModel.clearCatalog()
   }
}
.foregroundColor(.white)
.background(Color.red)

// POSSettingsLocalCatalogViewModel.swift, in line 97
@MainActor
       func clearCatalog() async {
           do {
               try await catalogSyncCoordinator.clearAllCatalogData(for: siteID)
               await loadCatalogData()
           } catch {
               DDLogError("⛔️ POSSettingsLocalCatalog: Failed to clear catalog: \(error)")
           }
       }

// POSCatalogPersistenceService.swift in line 195
    func clearAllCatalogData(siteID: Int64) async throws {
        DDLogInfo("🍍 DEBUG: Clearing all POS catalog data for site \(siteID)")

        try await grdbManager.databaseConnection.write { db in
            try PersistedSite.deleteOne(db, key: siteID)

            let deletedProducts = try PersistedProduct
                .filter(PersistedProduct.Columns.siteID == siteID)
                .deleteAll(db)

            let deletedVariations = try PersistedProductVariation
                .filter(PersistedProductVariation.Columns.siteID == siteID)
                .deleteAll(db)

            DDLogInfo("🍍 DEBUG: Cleared \(deletedProducts) products and \(deletedVariations) variations for site \(siteID)")
        }

        DDLogInfo("🍍 DEBUG: All POS catalog data cleared for site \(siteID)")
    }

// no-op to PreviewHelpers.swift, POSCatalogSyncCoordinator.swift, MockPOSCatalogSyncCoordinator.swift
func clearAllCatalogData(for siteID: Int64) async throws { }
```

| pos_products_only=false | pos_products_only=true |
|--------|--------|
| <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2026-01-14 at 11 43 01" src="https://github.com/user-attachments/assets/caf3af32-cc26-4004-a356-da37cd4cdd63" /> | <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2026-01-14 at 11 40 18" src="https://github.com/user-attachments/assets/0b131d3d-13e5-4be8-ac9b-67f86909014d" /> | 
