### PR TITLE
Add analytics event to track WPCom connection type

### DIFF
--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -121,6 +121,7 @@ public enum WooAnalyticsStat: String {
     // MARK: Dashboard View Events
     //
     case dashboardLoaded = "dashboard_loaded"
+    case siteConnectionTypeIdentified = "site_connection_type_identified"
     case dashboardSelected = "main_tab_dashboard_selected"
     case dashboardReselected = "main_tab_dashboard_reselected"
     case dashboardPulledToRefresh = "dashboard_pulled_to_refresh"

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 24.0
 -----
 - [*] Login: Show error alert when login with site credentials fails due to basic auth [https://github.com/woocommerce/woocommerce-ios/pull/16485]
+- [internal] Track WPCom connection type [https://github.com/woocommerce/woocommerce-ios/pull/16509]
 
 24.0
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
@@ -1,5 +1,6 @@
 import Foundation
 import enum Yosemite.StatsTimeRangeV4
+import struct Yosemite.Site
 
 extension WooAnalyticsEvent {
     enum Dashboard {
@@ -8,6 +9,15 @@ extension WooAnalyticsEvent {
             static let range = "range"
             static let localTimezone = "local_timezone"
             static let storeTimezone = "store_timezone"
+            static let siteConnectionType = "site_connection_type"
+        }
+
+        /// Tracked once per session when the site connection type is identified on the dashboard.
+        /// - Parameter siteConnectionType: the type of connection for the site.
+        static func siteConnectionTypeIdentified(siteConnectionType: SiteConnectionType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .siteConnectionTypeIdentified, properties: [
+                Keys.siteConnectionType: siteConnectionType.analyticsValue
+            ])
         }
 
         /// Tracked when the store stats are loaded with fresh data either via first load, event driven refresh, or manual refresh.
@@ -60,6 +70,49 @@ private extension StatsTimeRangeV4 {
             return "years"
         case .custom:
             return "custom"
+        }
+    }
+}
+
+/// The type of connection for a site, for analytics purposes.
+enum SiteConnectionType {
+    /// Site is not connected to Jetpack
+    case nonJetpack
+    /// Site is connected via Jetpack Connection Package (not the full plugin)
+    case jetpackConnectionPackage
+    /// Site has the full Jetpack plugin installed and connected
+    case fullJetpack
+    /// Unknown connection type
+    case unknown
+
+    /// Creates a `SiteConnectionType` from a `Site`.
+    init(site: Site?) {
+        guard let site else {
+            self = .unknown
+            return
+        }
+
+        if !site.isJetpackConnected {
+            self = .nonJetpack
+        } else if site.isJetpackCPConnected {
+            self = .jetpackConnectionPackage
+        } else if site.isJetpackThePluginInstalled {
+            self = .fullJetpack
+        } else {
+            self = .unknown
+        }
+    }
+
+    var analyticsValue: String {
+        switch self {
+        case .nonJetpack:
+            return "non_jetpack"
+        case .jetpackConnectionPackage:
+            return "jetpack_connection_package"
+        case .fullJetpack:
+            return "full_jetpack"
+        case .unknown:
+            return "unknown"
         }
     }
 }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -508,6 +508,12 @@ private extension DefaultStoresManager {
         dispatch(action)
     }
 
+    /// Tracks the site connection type for the default site.
+    private func trackSiteConnectionType() {
+        let siteConnectionType = SiteConnectionType(site: sessionManager.defaultSite)
+        ServiceLocator.analytics.track(event: .Dashboard.siteConnectionTypeIdentified(siteConnectionType: siteConnectionType))
+    }
+
     /// Synchronizes the settings for the specified site, if possible.
     ///
     func synchronizeSettings(with siteID: Int64, onCompletion: @escaping () -> Void) {
@@ -800,6 +806,7 @@ private extension DefaultStoresManager {
                                                     isJetpackConnected: info.isJetpackConnected,
                                                     isWordPressComStore: info.isWPCom)
                         self.sessionManager.defaultSite = updatedSite
+                        trackSiteConnectionType()
                         self.updateAndReloadWidgetInformation(with: site.siteID)
                     case .failure(let error):
                         DDLogError("⛔️ Cannot fetch generic site info: \(error)")
@@ -832,6 +839,7 @@ private extension DefaultStoresManager {
                 case .success(let siteAPI):
                     let updatedSite = site.copy(applicationPasswordAvailable: siteAPI.applicationPasswordAvailable)
                     sessionManager.defaultSite = updatedSite
+                    trackSiteConnectionType()
                     updateAndReloadWidgetInformation(with: siteID)
                 case .failure(let error):
                     DDLogError("⛔️ Cannot trigger root endpoint: \(error)")

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -722,6 +722,7 @@
 		20AE33C52B0510BF00527B60 /* PaymentsMenuDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20AE33C42B0510BF00527B60 /* PaymentsMenuDestination.swift */; };
 		20AE33C72B0510D200527B60 /* HubMenuDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20AE33C62B0510D200527B60 /* HubMenuDestination.swift */; };
 		20B0D65E2AD45BDE0059735A /* TapToPayEducationContactlessLimitViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B0D65D2AD45BDE0059735A /* TapToPayEducationContactlessLimitViewModelTests.swift */; };
+		20B259352F18DB7A006DF96E /* SiteConnectionTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B259332F18DB7A006DF96E /* SiteConnectionTypeTests.swift */; };
 		20BBD62C2B3060A300A903F6 /* AddOrderComponentsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BBD62B2B3060A300A903F6 /* AddOrderComponentsSection.swift */; };
 		20BCF6EE2B0E478B00954840 /* WooPaymentsPayoutsOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6ED2B0E478B00954840 /* WooPaymentsPayoutsOverviewViewModel.swift */; };
 		20BCF6F02B0E48CC00954840 /* WooPaymentsPayoutsOverviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BCF6EF2B0E48CC00954840 /* WooPaymentsPayoutsOverviewViewModelTests.swift */; };
@@ -3646,6 +3647,7 @@
 		20AE33C42B0510BF00527B60 /* PaymentsMenuDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsMenuDestination.swift; sourceTree = "<group>"; };
 		20AE33C62B0510D200527B60 /* HubMenuDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubMenuDestination.swift; sourceTree = "<group>"; };
 		20B0D65D2AD45BDE0059735A /* TapToPayEducationContactlessLimitViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayEducationContactlessLimitViewModelTests.swift; sourceTree = "<group>"; };
+		20B259332F18DB7A006DF96E /* SiteConnectionTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteConnectionTypeTests.swift; sourceTree = "<group>"; };
 		20BBD62B2B3060A300A903F6 /* AddOrderComponentsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOrderComponentsSection.swift; sourceTree = "<group>"; };
 		20BCF6ED2B0E478B00954840 /* WooPaymentsPayoutsOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsOverviewViewModel.swift; sourceTree = "<group>"; };
 		20BCF6EF2B0E48CC00954840 /* WooPaymentsPayoutsOverviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsOverviewViewModelTests.swift; sourceTree = "<group>"; };
@@ -7352,6 +7354,14 @@
 			path = Destinations;
 			sourceTree = "<group>";
 		};
+		20B259342F18DB7A006DF96E /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				20B259332F18DB7A006DF96E /* SiteConnectionTypeTests.swift */,
+			);
+			path = Analytics;
+			sourceTree = "<group>";
+		};
 		20BBD62A2B30608200A903F6 /* AddOrderComponentsSection */ = {
 			isa = PBXGroup;
 			children = (
@@ -9681,6 +9691,7 @@
 		B56DB3E02049BFAA00D4AA8E /* WooCommerceTests */ = {
 			isa = PBXGroup;
 			children = (
+				20B259342F18DB7A006DF96E /* Analytics */,
 				6489D8522EA667AC00D96802 /* Routing */,
 				DEB387962C2E80060025256E /* GoogleAds */,
 				DABF35242C11B40C006AF826 /* POS */,
@@ -16088,6 +16099,7 @@
 				03CF78D127C3DBC000523706 /* WCPayCardBrand+IconsTests.swift in Sources */,
 				CEEF742C2B9A052300B03948 /* OrdersReportCardViewModelTests.swift in Sources */,
 				DEA64C552E41A2D000791018 /* Product+Helpers.swift in Sources */,
+				20B259352F18DB7A006DF96E /* SiteConnectionTypeTests.swift in Sources */,
 				DEFE1B242DF2C6C8005B3D39 /* UPSTermsViewModelTests.swift in Sources */,
 				AEFF77AA29786DAA00667F7A /* PriceInputViewModelTests.swift in Sources */,
 				EEC2D27F292CF60E0072132E /* JetpackSetupHostingControllerTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Analytics/SiteConnectionTypeTests.swift
+++ b/WooCommerce/WooCommerceTests/Analytics/SiteConnectionTypeTests.swift
@@ -19,7 +19,7 @@ final class SiteConnectionTypeTests: XCTestCase {
 
     func test_init_with_non_jetpack_connected_site_returns_nonJetpack() {
         // Given
-        let site = Site.fake().copy(isJetpackConnected: false, isJetpackThePluginInstalled: false)
+        let site = Site.fake().copy(isJetpackThePluginInstalled: false, isJetpackConnected: false)
 
         // When
         let siteConnectionType = SiteConnectionType(site: site)
@@ -31,7 +31,7 @@ final class SiteConnectionTypeTests: XCTestCase {
     func test_init_with_jetpack_connected_but_plugin_not_installed_returns_jetpackConnectionPackage() {
         // Given
         // isJetpackCPConnected is computed as: isJetpackConnected && !isJetpackThePluginInstalled
-        let site = Site.fake().copy(isJetpackConnected: true, isJetpackThePluginInstalled: false)
+        let site = Site.fake().copy(isJetpackThePluginInstalled: false, isJetpackConnected: true)
 
         // When
         let siteConnectionType = SiteConnectionType(site: site)
@@ -42,7 +42,7 @@ final class SiteConnectionTypeTests: XCTestCase {
 
     func test_init_with_jetpack_connected_and_plugin_installed_returns_fullJetpack() {
         // Given
-        let site = Site.fake().copy(isJetpackConnected: true, isJetpackThePluginInstalled: true)
+        let site = Site.fake().copy(isJetpackThePluginInstalled: true, isJetpackConnected: true)
 
         // When
         let siteConnectionType = SiteConnectionType(site: site)

--- a/WooCommerce/WooCommerceTests/Analytics/SiteConnectionTypeTests.swift
+++ b/WooCommerce/WooCommerceTests/Analytics/SiteConnectionTypeTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class SiteConnectionTypeTests: XCTestCase {
+
+    // MARK: - init(site:) tests
+
+    func test_init_with_nil_site_returns_unknown() {
+        // Given
+        let site: Site? = nil
+
+        // When
+        let siteConnectionType = SiteConnectionType(site: site)
+
+        // Then
+        XCTAssertEqual(siteConnectionType, .unknown)
+    }
+
+    func test_init_with_non_jetpack_connected_site_returns_nonJetpack() {
+        // Given
+        let site = Site.fake().copy(isJetpackConnected: false, isJetpackThePluginInstalled: false)
+
+        // When
+        let siteConnectionType = SiteConnectionType(site: site)
+
+        // Then
+        XCTAssertEqual(siteConnectionType, .nonJetpack)
+    }
+
+    func test_init_with_jetpack_connected_but_plugin_not_installed_returns_jetpackConnectionPackage() {
+        // Given
+        // isJetpackCPConnected is computed as: isJetpackConnected && !isJetpackThePluginInstalled
+        let site = Site.fake().copy(isJetpackConnected: true, isJetpackThePluginInstalled: false)
+
+        // When
+        let siteConnectionType = SiteConnectionType(site: site)
+
+        // Then
+        XCTAssertEqual(siteConnectionType, .jetpackConnectionPackage)
+    }
+
+    func test_init_with_jetpack_connected_and_plugin_installed_returns_fullJetpack() {
+        // Given
+        let site = Site.fake().copy(isJetpackConnected: true, isJetpackThePluginInstalled: true)
+
+        // When
+        let siteConnectionType = SiteConnectionType(site: site)
+
+        // Then
+        XCTAssertEqual(siteConnectionType, .fullJetpack)
+    }
+
+    // MARK: - analyticsValue tests
+
+    func test_analyticsValue_for_nonJetpack_returns_correct_string() {
+        XCTAssertEqual(SiteConnectionType.nonJetpack.analyticsValue, "non_jetpack")
+    }
+
+    func test_analyticsValue_for_jetpackConnectionPackage_returns_correct_string() {
+        XCTAssertEqual(SiteConnectionType.jetpackConnectionPackage.analyticsValue, "jetpack_connection_package")
+    }
+
+    func test_analyticsValue_for_fullJetpack_returns_correct_string() {
+        XCTAssertEqual(SiteConnectionType.fullJetpack.analyticsValue, "full_jetpack")
+    }
+
+    func test_analyticsValue_for_unknown_returns_correct_string() {
+        XCTAssertEqual(SiteConnectionType.unknown.analyticsValue, "unknown")
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds an event to track a site's connection status with WPCom – Full Jetpack, Jetpack Connection Package, or non-Jetpack. We'll use this, initially, to check whether we can rely on JITMs for testing messages to merchants.

### Known issue
It's not perfect – if you have Jetpack installed, connected, and then deactivate it, we'll still track that as `full_jetpack`, when really it should probably be JCP. I don't want to add to the pile of hacks that is Site determination for this, so I'll note it in the registration.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Launch the app and observe `🔵 Tracked site_connection_type_identified` is tracked in the console.
Switch stores, and log in using site credentials, to sites with different connections.

1. Full Jetpack – install the plugin and connect it
2. JCP – install WooPayments and start the set up process – you only need to go as far as completing the WPCom connection
3. Make a new site without the Jetpack plugin (you can deselect it in JN, or delete it)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="1276" height="838" alt="CleanShot 2026-01-13 at 17 34 54@2x" src="https://github.com/user-attachments/assets/7b17a797-267a-474a-86fe-d9679d7e030f" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
