### PR TITLE
[Woo POS][Products] Handle local catalog incremental sync when `pos_products_only` is used

### DIFF
--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
@@ -35,22 +35,20 @@ public struct POSCatalog {
     public let variations: [POSProductVariation]
     public let syncDate: Date
 
-    /// Product and variation IDs to remove from local catalog when these should be hidden when performing an incremental sync
-    /// This covers the case where these items are marked as not available for POS by the merchant in wp-admin, and the request passes `posProductsOnly=true`
-    /// In which case these would be simply ommited and not taken into account for the incremental sync.
+    /// Product IDs to remove from local catalog when these should be hidden when performing an incremental sync.
+    /// This covers the case where products are marked as not available for POS by the merchant in wp-admin,
+    /// and the request passes `posProductsOnly=true`. In which case these would be simply omitted.
+    /// Variations are not tracked separately, they cascade delete in GRDB when their parent product is removed.
     public let productsToRemove: [Int64]
-    public let variationsToRemove: [Int64]
 
     public init(products: [POSProduct],
                 variations: [POSProductVariation],
                 syncDate: Date,
-                productsToRemove: [Int64] = [],
-                variationsToRemove: [Int64] = []) {
+                productsToRemove: [Int64] = []) {
         self.products = products
         self.variations = variations
         self.syncDate = syncDate
         self.productsToRemove = productsToRemove
-        self.variationsToRemove = variationsToRemove
     }
 }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
@@ -34,6 +34,24 @@ public struct POSCatalog {
     public let products: [POSProduct]
     public let variations: [POSProductVariation]
     public let syncDate: Date
+
+    /// Product and variation IDs to remove from local catalog when these should be hidden when performing an incremental sync
+    /// This covers the case where these items are marked as not available for POS by the merchant in wp-admin, and the request passes `posProductsOnly=true`
+    /// In which case these would be simply ommited and not taken into account for the incremental sync.
+    public let productsToRemove: [Int64]
+    public let variationsToRemove: [Int64]
+
+    public init(products: [POSProduct],
+                variations: [POSProductVariation],
+                syncDate: Date,
+                productsToRemove: [Int64] = [],
+                variationsToRemove: [Int64] = []) {
+        self.products = products
+        self.variations = variations
+        self.syncDate = syncDate
+        self.productsToRemove = productsToRemove
+        self.variationsToRemove = variationsToRemove
+    }
 }
 
 // TODO - remove the periphery ignore comment when the service is integrated with POS.

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogIncrementalSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogIncrementalSyncService.swift
@@ -110,7 +110,7 @@ private extension POSCatalogIncrementalSyncService {
 
     /// Loads catalog with dual requests to detect products hidden from POS.
     /// Products hidden from POS don't appear in the `posProductsOnly=true` response, they're simply omitted.
-    /// To detect these, we compare against a second request without the flag: items present there but
+    /// To detect these, we compare against a second request without the flag: products present there but
     /// missing from the `posProductsOnly=true` response have been hidden and should be removed from the local DB.
     func loadCatalogWithHiddenDetection(for siteID: Int64,
                                         modifiedAfter: Date,
@@ -159,23 +159,12 @@ private extension POSCatalogIncrementalSyncService {
             }
         )
 
-        // Fetch ALL variations to compare and find hidden ones
-        async let allVariationsTask = batchedLoader.loadAll(
-            makeRequest: { pageNumber in
-                try await syncRemote.loadProductVariations(modifiedAfter: modifiedAfter,
-                                                           siteID: siteID,
-                                                           pageNumber: pageNumber,
-                                                           posProductsOnly: false)
-            }
-        )
-
-        let (posProducts, allProducts, trashedProducts, posVariations, allVariations) = try await (
-            posProductsTask, allProductsTask, trashedProductsTask, posVariationsTask, allVariationsTask
+        let (posProducts, allProducts, trashedProducts, posVariations) = try await (
+            posProductsTask, allProductsTask, trashedProductsTask, posVariationsTask
         )
 
         // Find products hidden from POS: present in "all" but missing from "POS"
         let hiddenProductIDs = findHiddenProductIDs(posProducts: posProducts, allProducts: allProducts)
-        let hiddenVariationIDs = findHiddenVariationIDs(posVariations: posVariations, allVariations: allVariations)
 
         // Aggregate regular and trashed products before persist them
         let productsToSync = posProducts + trashedProducts
@@ -183,8 +172,7 @@ private extension POSCatalogIncrementalSyncService {
         return POSCatalog(products: productsToSync,
                           variations: posVariations,
                           syncDate: syncStartDate,
-                          productsToRemove: hiddenProductIDs,
-                          variationsToRemove: hiddenVariationIDs)
+                          productsToRemove: hiddenProductIDs)
     }
 
     /// Loads catalog without hidden detection - single request mode.
@@ -241,15 +229,6 @@ private extension POSCatalogIncrementalSyncService {
         return allProducts
             .filter { !posProductIDs.contains($0.productID) }
             .map { $0.productID }
-    }
-
-    /// Finds variation IDs that are present in the unfiltered response but missing from the POS-filtered response.
-    /// These variations have been hidden from POS and should be removed from the local catalog.
-    func findHiddenVariationIDs(posVariations: [POSProductVariation], allVariations: [POSProductVariation]) -> [Int64] {
-        let posVariationIDs = Set(posVariations.map { $0.productVariationID })
-        return allVariations
-            .filter { !posVariationIDs.contains($0.productVariationID) }
-            .map { $0.productVariationID }
     }
 }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogIncrementalSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogIncrementalSyncService.swift
@@ -92,6 +92,107 @@ private extension POSCatalogIncrementalSyncService {
                      posProductsOnly: Bool) async throws -> POSCatalog {
         let syncStartDate = Date.now
 
+        if posProductsOnly {
+            // Dual-request: Detect products/variations hidden from POS
+            return try await loadCatalogWithHiddenDetection(for: siteID,
+                                                            modifiedAfter: modifiedAfter,
+                                                            syncRemote: syncRemote,
+                                                            syncStartDate: syncStartDate)
+        } else {
+            // Single-request: No hidden detection needed
+            return try await loadCatalogWithoutFiltering(for: siteID,
+                                                         modifiedAfter: modifiedAfter,
+                                                         syncRemote: syncRemote,
+                                                         syncStartDate: syncStartDate,
+                                                         posProductsOnly: posProductsOnly)
+        }
+    }
+
+    /// Loads catalog with dual requests to detect products hidden from POS.
+    /// Products hidden from POS don't appear in the `posProductsOnly=true` response, they're simply omitted.
+    /// To detect these, we compare against a second request without the flag: items present there but
+    /// missing from the `posProductsOnly=true` response have been hidden and should be removed from the local DB.
+    func loadCatalogWithHiddenDetection(for siteID: Int64,
+                                        modifiedAfter: Date,
+                                        syncRemote: POSCatalogSyncRemoteProtocol,
+                                        syncStartDate: Date) async throws -> POSCatalog {
+        // Fetch POS-filtered products (excluding trash)
+        async let posProductsTask = batchedLoader.loadAll(
+            makeRequest: { pageNumber in
+                try await syncRemote.loadProducts(modifiedAfter: modifiedAfter,
+                                                  siteID: siteID,
+                                                  pageNumber: pageNumber,
+                                                  includeStatus: nil,
+                                                  posProductsOnly: true)
+            }
+        )
+
+        // Fetch ALL products (excluding trash) to compare and find hidden ones
+        async let allProductsTask = batchedLoader.loadAll(
+            makeRequest: { pageNumber in
+                try await syncRemote.loadProducts(modifiedAfter: modifiedAfter,
+                                                  siteID: siteID,
+                                                  pageNumber: pageNumber,
+                                                  includeStatus: nil,
+                                                  posProductsOnly: false)
+            }
+        )
+
+        // Fetch trashed products (POS-filtered) to detect products moved to trash
+        async let trashedProductsTask = batchedLoader.loadAll(
+            makeRequest: { pageNumber in
+                try await syncRemote.loadProducts(modifiedAfter: modifiedAfter,
+                                                  siteID: siteID,
+                                                  pageNumber: pageNumber,
+                                                  includeStatus: ProductStatus.trash.rawValue,
+                                                  posProductsOnly: true)
+            }
+        )
+
+        // Fetch POS-filtered variations
+        async let posVariationsTask = batchedLoader.loadAll(
+            makeRequest: { pageNumber in
+                try await syncRemote.loadProductVariations(modifiedAfter: modifiedAfter,
+                                                           siteID: siteID,
+                                                           pageNumber: pageNumber,
+                                                           posProductsOnly: true)
+            }
+        )
+
+        // Fetch ALL variations to compare and find hidden ones
+        async let allVariationsTask = batchedLoader.loadAll(
+            makeRequest: { pageNumber in
+                try await syncRemote.loadProductVariations(modifiedAfter: modifiedAfter,
+                                                           siteID: siteID,
+                                                           pageNumber: pageNumber,
+                                                           posProductsOnly: false)
+            }
+        )
+
+        let (posProducts, allProducts, trashedProducts, posVariations, allVariations) = try await (
+            posProductsTask, allProductsTask, trashedProductsTask, posVariationsTask, allVariationsTask
+        )
+
+        // Find products hidden from POS: present in "all" but missing from "POS"
+        let hiddenProductIDs = findHiddenProductIDs(posProducts: posProducts, allProducts: allProducts)
+        let hiddenVariationIDs = findHiddenVariationIDs(posVariations: posVariations, allVariations: allVariations)
+
+        // Aggregate regular and trashed products before persist them
+        let productsToSync = posProducts + trashedProducts
+
+        return POSCatalog(products: productsToSync,
+                          variations: posVariations,
+                          syncDate: syncStartDate,
+                          productsToRemove: hiddenProductIDs,
+                          variationsToRemove: hiddenVariationIDs)
+    }
+
+    /// Loads catalog without hidden detection - single request mode.
+    func loadCatalogWithoutFiltering(for siteID: Int64,
+                                     modifiedAfter: Date,
+                                     syncRemote: POSCatalogSyncRemoteProtocol,
+                                     syncStartDate: Date,
+                                     posProductsOnly: Bool) async throws -> POSCatalog {
         // Fetch regular products (excluding trash)
         async let regularProductsTask = batchedLoader.loadAll(
             makeRequest: { pageNumber in
@@ -129,6 +230,26 @@ private extension POSCatalogIncrementalSyncService {
         let allProducts = regularProducts + trashedProducts
 
         return POSCatalog(products: allProducts, variations: variations, syncDate: syncStartDate)
+    }
+}
+
+private extension POSCatalogIncrementalSyncService {
+    /// Finds product IDs that are present in the unfiltered response but missing from the POS-filtered response.
+    /// These products have been hidden from POS and should be removed from the local catalog.
+    func findHiddenProductIDs(posProducts: [POSProduct], allProducts: [POSProduct]) -> [Int64] {
+        let posProductIDs = Set(posProducts.map { $0.productID })
+        return allProducts
+            .filter { !posProductIDs.contains($0.productID) }
+            .map { $0.productID }
+    }
+
+    /// Finds variation IDs that are present in the unfiltered response but missing from the POS-filtered response.
+    /// These variations have been hidden from POS and should be removed from the local catalog.
+    func findHiddenVariationIDs(posVariations: [POSProductVariation], allVariations: [POSProductVariation]) -> [Int64] {
+        let posVariationIDs = Set(posVariations.map { $0.productVariationID })
+        return allVariations
+            .filter { !posVariationIDs.contains($0.productVariationID) }
+            .map { $0.productVariationID }
     }
 }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
@@ -150,6 +150,11 @@ final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
             try site?.updateChanges(db) { $0.lastCatalogIncrementalSyncDate = catalog.syncDate }
         }
 
+        // Delete products/variations hidden from POS when detected during incremental sync
+        if !catalog.productsToRemove.isEmpty || !catalog.variationsToRemove.isEmpty {
+            try await deleteProducts(catalog.productsToRemove, variationIDs: catalog.variationsToRemove, siteID: siteID)
+        }
+
         DDLogInfo("✅ Incremental catalog persistence complete")
 
         try await grdbManager.databaseConnection.read { db in

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
@@ -93,8 +93,7 @@ final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
     func persistIncrementalCatalogData(_ catalog: POSCatalog, siteID: Int64) async throws {
         DDLogInfo("💾 Persisting incremental catalog with \(catalog.products.count) updated products, " +
                   "\(catalog.variations.count) updated variations, " +
-                  "\(catalog.productsToRemove.count) products to remove, " +
-                  "\(catalog.variationsToRemove.count) variations to remove")
+                  "\(catalog.productsToRemove.count) products to remove")
 
         try await grdbManager.databaseConnection.write { db in
             for product in catalog.products {
@@ -153,9 +152,11 @@ final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
             try site?.updateChanges(db) { $0.lastCatalogIncrementalSyncDate = catalog.syncDate }
         }
 
-        // Delete products/variations hidden from POS when detected during incremental sync
-        if !catalog.productsToRemove.isEmpty || !catalog.variationsToRemove.isEmpty {
-            try await deleteProducts(catalog.productsToRemove, variationIDs: catalog.variationsToRemove, siteID: siteID)
+        // Delete products hidden from POS when detected during incremental sync
+        // Variations are not tracked separately, they cascade delete in GRDB when their parent product is removed,
+        // so there is no need to pass their IDs here.
+        if !catalog.productsToRemove.isEmpty {
+            try await deleteProducts(catalog.productsToRemove, variationIDs: [], siteID: siteID)
         }
 
         DDLogInfo("✅ Incremental catalog persistence complete")

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
@@ -91,7 +91,10 @@ final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
     }
 
     func persistIncrementalCatalogData(_ catalog: POSCatalog, siteID: Int64) async throws {
-        DDLogInfo("💾 Persisting incremental catalog with \(catalog.products.count) updated products and \(catalog.variations.count) updated variations")
+        DDLogInfo("💾 Persisting incremental catalog with \(catalog.products.count) updated products, " +
+                  "\(catalog.variations.count) updated variations, " +
+                  "\(catalog.productsToRemove.count) products to remove, " +
+                  "\(catalog.variationsToRemove.count) variations to remove")
 
         try await grdbManager.databaseConnection.write { db in
             for product in catalog.products {

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -377,8 +377,8 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
             let (totalProducts, totalVariations) = await getStorageCounts(for: siteID)
             trackAnalytics(WooAnalyticsEvent.LocalCatalog.syncCompleted(
                 syncType: POSCatalogSyncType.incremental.rawValue,
-                productsSynced: syncedCatalog.products.count,
-                variationsSynced: syncedCatalog.variations.count,
+                productsSynced: syncedCatalog.products.count + syncedCatalog.productsToRemove.count,
+                variationsSynced: syncedCatalog.variations.count + syncedCatalog.variationsToRemove.count,
                 totalProducts: totalProducts,
                 totalVariations: totalVariations,
                 syncDurationMs: syncDurationMs

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -378,7 +378,7 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
             trackAnalytics(WooAnalyticsEvent.LocalCatalog.syncCompleted(
                 syncType: POSCatalogSyncType.incremental.rawValue,
                 productsSynced: syncedCatalog.products.count + syncedCatalog.productsToRemove.count,
-                variationsSynced: syncedCatalog.variations.count + syncedCatalog.variationsToRemove.count,
+                variationsSynced: syncedCatalog.variations.count,
                 totalProducts: totalProducts,
                 totalVariations: totalVariations,
                 syncDurationMs: syncDurationMs

--- a/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogSyncRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogSyncRemote.swift
@@ -9,6 +9,10 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
     private(set) var incrementalVariationResults: [Int: Result<PagedItems<POSProductVariation>, Error>] = [:]
     private(set) var trashedProductResults: [Int: Result<PagedItems<POSProduct>, Error>] = [:]
 
+    // Results returned when posProductsOnly=false (used during dual-request hidden product detection)
+    private(set) var allProductResults: [Int: Result<PagedItems<POSProduct>, Error>] = [:]
+    private(set) var allVariationResults: [Int: Result<PagedItems<POSProductVariation>, Error>] = [:]
+
     var catalogRequestResult: Result<POSCatalogRequestResponse, Error> = .success(.init(status: .complete, downloadURL: "https://example.com/catalog.json"))
     var catalogDownloadResult: Result<POSCatalogResponse, Error> = .success(.init(products: [], variations: []))
 
@@ -83,6 +87,21 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
         }
     }
 
+    /* MARK: - Setup Methods for posProductsOnly=false requests
+     Dual-request mode is triggered when the feature flag posProductsOnly=true
+     Within that mode, we make requests with both values:
+        - posProductsOnly=true returns POS-eligible products (uses incrementalProductResults)
+        - posProductsOnly=false returns all products (uses allProductResults)
+     We compare the two to find hidden products (present in "all" but missing from "POS")
+     */
+    func setAllProductResult(pageNumber: Int, result: Result<PagedItems<POSProduct>, Error>) {
+        allProductResults[pageNumber] = result
+    }
+
+    func setAllVariationResult(pageNumber: Int, result: Result<PagedItems<POSProductVariation>, Error>) {
+        allVariationResults[pageNumber] = result
+    }
+
     // MARK: - Protocol Methods - Incremental Sync
 
     func loadProducts(modifiedAfter: Date,
@@ -92,7 +111,7 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
                       posProductsOnly: Bool) async throws -> PagedItems<POSProduct> {
         await includeStatusTracker.append(includeStatus)
 
-        // Route to appropriate results based on includeStatus
+        // Route to appropriate results based on includeStatus and posProductsOnly
         if includeStatus == "trash" {
             await loadTrashedProductsCallCount.increment()
             lastTrashedProductsModifiedAfter = modifiedAfter
@@ -104,6 +123,17 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
                 case .failure(let error):
                     throw error
                 }
+            }
+        } else if !posProductsOnly, let result = allProductResults[pageNumber] {
+            // Use all-products results when posProductsOnly=false and results are configured
+            await loadIncrementalProductsCallCount.increment()
+            lastIncrementalProductsModifiedAfter = modifiedAfter
+
+            switch result {
+            case .success(let pagedItems):
+                return pagedItems
+            case .failure(let error):
+                throw error
             }
         } else {
             await loadIncrementalProductsCallCount.increment()
@@ -127,6 +157,16 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
                                 posProductsOnly: Bool) async throws -> PagedItems<POSProductVariation> {
         await loadIncrementalProductVariationsCallCount.increment()
         lastIncrementalVariationsModifiedAfter = modifiedAfter
+
+        // Use all-variations results when posProductsOnly=false and results are configured
+        if !posProductsOnly, let result = allVariationResults[pageNumber] {
+            switch result {
+            case .success(let pagedItems):
+                return pagedItems
+            case .failure(let error):
+                throw error
+            }
+        }
 
         if let result = incrementalVariationResults[pageNumber] {
             switch result {

--- a/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogSyncRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogSyncRemote.swift
@@ -11,7 +11,6 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
 
     // Results returned when posProductsOnly=false (used during dual-request hidden product detection)
     private(set) var allProductResults: [Int: Result<PagedItems<POSProduct>, Error>] = [:]
-    private(set) var allVariationResults: [Int: Result<PagedItems<POSProductVariation>, Error>] = [:]
 
     var catalogRequestResult: Result<POSCatalogRequestResponse, Error> = .success(.init(status: .complete, downloadURL: "https://example.com/catalog.json"))
     var catalogDownloadResult: Result<POSCatalogResponse, Error> = .success(.init(products: [], variations: []))
@@ -98,10 +97,6 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
         allProductResults[pageNumber] = result
     }
 
-    func setAllVariationResult(pageNumber: Int, result: Result<PagedItems<POSProductVariation>, Error>) {
-        allVariationResults[pageNumber] = result
-    }
-
     // MARK: - Protocol Methods - Incremental Sync
 
     func loadProducts(modifiedAfter: Date,
@@ -157,16 +152,6 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
                                 posProductsOnly: Bool) async throws -> PagedItems<POSProductVariation> {
         await loadIncrementalProductVariationsCallCount.increment()
         lastIncrementalVariationsModifiedAfter = modifiedAfter
-
-        // Use all-variations results when posProductsOnly=false and results are configured
-        if !posProductsOnly, let result = allVariationResults[pageNumber] {
-            switch result {
-            case .success(let pagedItems):
-                return pagedItems
-            case .failure(let error):
-                throw error
-            }
-        }
 
         if let result = incrementalVariationResults[pageNumber] {
             switch result {

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogIncrementalSyncServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogIncrementalSyncServiceTests.swift
@@ -305,4 +305,157 @@ struct POSCatalogIncrementalSyncServiceTests {
         let persistedCatalog = try #require(mockPersistenceService.persistIncrementalCatalogDataLastPersistedCatalog)
         #expect(persistedCatalog.products.count == 1)
     }
+
+    // MARK: - Hidden Product Detection Tests (Dual-Request)
+
+    @Test func startIncrementalSync_detects_products_hidden_from_POS_when_posProductsOnly_is_true() async throws {
+        // Given
+        let lastFullSyncDate = Date(timeIntervalSince1970: 1000)
+
+        // Products visible in POS (posProductsOnly=true response)
+        let posProduct1 = POSProduct.fake().copy(productID: 1)
+        let posProduct2 = POSProduct.fake().copy(productID: 2)
+
+        // All products (posProductsOnly=false response) - includes a product hidden from POS
+        let allProduct1 = POSProduct.fake().copy(productID: 1)
+        let allProduct2 = POSProduct.fake().copy(productID: 2)
+        let hiddenProduct = POSProduct.fake().copy(productID: 3) // Hidden from POS
+
+        mockSyncRemote.setIncrementalProductResult(
+            pageNumber: 1,
+            result: .success(PagedItems(items: [posProduct1, posProduct2], hasMorePages: false, totalItems: 2))
+        )
+        mockSyncRemote.setAllProductResult(
+            pageNumber: 1,
+            result: .success(PagedItems(items: [allProduct1, allProduct2, hiddenProduct], hasMorePages: false, totalItems: 3))
+        )
+        mockSyncRemote.setTrashedProductResult(
+            pageNumber: 1,
+            result: .success(PagedItems(items: [], hasMorePages: false, totalItems: 0))
+        )
+        mockSyncRemote.setIncrementalVariationResult(
+            pageNumber: 1,
+            result: .success(PagedItems(items: [], hasMorePages: false, totalItems: 0))
+        )
+
+        // When - Sync with posProductsOnly=true (enables dual-request)
+        try await sut.startIncrementalSync(for: sampleSiteID,
+                                           lastFullSyncDate: lastFullSyncDate,
+                                           lastIncrementalSyncDate: nil,
+                                           posProductsOnly: true)
+
+        // Then - Hidden product ID should be in productsToRemove
+        let persistedCatalog = try #require(mockPersistenceService.persistIncrementalCatalogDataLastPersistedCatalog)
+        #expect(persistedCatalog.products.count == 2)
+        #expect(persistedCatalog.productsToRemove.contains(3))
+        #expect(persistedCatalog.productsToRemove.count == 1)
+    }
+
+    @Test func startIncrementalSync_detects_variations_hidden_from_POS_when_posProductsOnly_is_true() async throws {
+        // Given
+        let lastFullSyncDate = Date(timeIntervalSince1970: 1000)
+
+        // Variations visible in POS
+        let posVariation1 = POSProductVariation.fake().copy(productVariationID: 101)
+
+        // All variations - includes a variation hidden from POS
+        let allVariation1 = POSProductVariation.fake().copy(productVariationID: 101)
+        let hiddenVariation = POSProductVariation.fake().copy(productVariationID: 102) // Hidden from POS
+
+        mockSyncRemote.setIncrementalProductResult(
+            pageNumber: 1,
+            result: .success(PagedItems(items: [], hasMorePages: false, totalItems: 0))
+        )
+        mockSyncRemote.setTrashedProductResult(
+            pageNumber: 1,
+            result: .success(PagedItems(items: [], hasMorePages: false, totalItems: 0))
+        )
+        mockSyncRemote.setIncrementalVariationResult(
+            pageNumber: 1,
+            result: .success(PagedItems(items: [posVariation1], hasMorePages: false, totalItems: 1))
+        )
+        mockSyncRemote.setAllVariationResult(
+            pageNumber: 1,
+            result: .success(PagedItems(items: [allVariation1, hiddenVariation], hasMorePages: false, totalItems: 2))
+        )
+
+        // When
+        try await sut.startIncrementalSync(for: sampleSiteID,
+                                           lastFullSyncDate: lastFullSyncDate,
+                                           lastIncrementalSyncDate: nil,
+                                           posProductsOnly: true)
+
+        // Then - Hidden variation ID should be in variationsToRemove
+        let persistedCatalog = try #require(mockPersistenceService.persistIncrementalCatalogDataLastPersistedCatalog)
+        #expect(persistedCatalog.variations.count == 1)
+        #expect(persistedCatalog.variationsToRemove.contains(102))
+        #expect(persistedCatalog.variationsToRemove.count == 1)
+    }
+
+    @Test func startIncrementalSync_does_not_detect_hidden_products_when_posProductsOnly_is_false() async throws {
+        // Given
+        let lastFullSyncDate = Date(timeIntervalSince1970: 1000)
+        let products = [POSProduct.fake().copy(productID: 1)]
+
+        mockSyncRemote.setIncrementalProductResult(
+            pageNumber: 1,
+            result: .success(PagedItems(items: products, hasMorePages: false, totalItems: 1))
+        )
+        mockSyncRemote.setTrashedProductResult(
+            pageNumber: 1,
+            result: .success(PagedItems(items: [], hasMorePages: false, totalItems: 0))
+        )
+        mockSyncRemote.setIncrementalVariationResult(
+            pageNumber: 1,
+            result: .success(PagedItems(items: [], hasMorePages: false, totalItems: 0))
+        )
+
+        // When - Sync with posProductsOnly=false (single-request, no hidden product detection)
+        try await sut.startIncrementalSync(for: sampleSiteID,
+                                           lastFullSyncDate: lastFullSyncDate,
+                                           lastIncrementalSyncDate: nil,
+                                           posProductsOnly: false)
+
+        // Then - No products should be marked for removal
+        let persistedCatalog = try #require(mockPersistenceService.persistIncrementalCatalogDataLastPersistedCatalog)
+        #expect(persistedCatalog.productsToRemove.isEmpty)
+        #expect(persistedCatalog.variationsToRemove.isEmpty)
+    }
+
+    @Test func startIncrementalSync_handles_no_hidden_products_when_all_products_are_in_POS() async throws {
+        // Given
+        let lastFullSyncDate = Date(timeIntervalSince1970: 1000)
+
+        // Same products in both responses, nothing hidden
+        let product1 = POSProduct.fake().copy(productID: 1)
+        let product2 = POSProduct.fake().copy(productID: 2)
+
+        mockSyncRemote.setIncrementalProductResult(
+            pageNumber: 1,
+            result: .success(PagedItems(items: [product1, product2], hasMorePages: false, totalItems: 2))
+        )
+        mockSyncRemote.setAllProductResult(
+            pageNumber: 1,
+            result: .success(PagedItems(items: [product1, product2], hasMorePages: false, totalItems: 2))
+        )
+        mockSyncRemote.setTrashedProductResult(
+            pageNumber: 1,
+            result: .success(PagedItems(items: [], hasMorePages: false, totalItems: 0))
+        )
+        mockSyncRemote.setIncrementalVariationResult(
+            pageNumber: 1,
+            result: .success(PagedItems(items: [], hasMorePages: false, totalItems: 0))
+        )
+
+        // When
+        try await sut.startIncrementalSync(for: sampleSiteID,
+                                           lastFullSyncDate: lastFullSyncDate,
+                                           lastIncrementalSyncDate: nil,
+                                           posProductsOnly: true)
+
+        // Then, no products marked for removal
+        let persistedCatalog = try #require(mockPersistenceService.persistIncrementalCatalogDataLastPersistedCatalog)
+        #expect(persistedCatalog.products.count == 2)
+        #expect(persistedCatalog.productsToRemove.isEmpty)
+    }
 }

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogIncrementalSyncServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogIncrementalSyncServiceTests.swift
@@ -351,47 +351,6 @@ struct POSCatalogIncrementalSyncServiceTests {
         #expect(persistedCatalog.productsToRemove.count == 1)
     }
 
-    @Test func startIncrementalSync_detects_variations_hidden_from_POS_when_posProductsOnly_is_true() async throws {
-        // Given
-        let lastFullSyncDate = Date(timeIntervalSince1970: 1000)
-
-        // Variations visible in POS
-        let posVariation1 = POSProductVariation.fake().copy(productVariationID: 101)
-
-        // All variations - includes a variation hidden from POS
-        let allVariation1 = POSProductVariation.fake().copy(productVariationID: 101)
-        let hiddenVariation = POSProductVariation.fake().copy(productVariationID: 102) // Hidden from POS
-
-        mockSyncRemote.setIncrementalProductResult(
-            pageNumber: 1,
-            result: .success(PagedItems(items: [], hasMorePages: false, totalItems: 0))
-        )
-        mockSyncRemote.setTrashedProductResult(
-            pageNumber: 1,
-            result: .success(PagedItems(items: [], hasMorePages: false, totalItems: 0))
-        )
-        mockSyncRemote.setIncrementalVariationResult(
-            pageNumber: 1,
-            result: .success(PagedItems(items: [posVariation1], hasMorePages: false, totalItems: 1))
-        )
-        mockSyncRemote.setAllVariationResult(
-            pageNumber: 1,
-            result: .success(PagedItems(items: [allVariation1, hiddenVariation], hasMorePages: false, totalItems: 2))
-        )
-
-        // When
-        try await sut.startIncrementalSync(for: sampleSiteID,
-                                           lastFullSyncDate: lastFullSyncDate,
-                                           lastIncrementalSyncDate: nil,
-                                           posProductsOnly: true)
-
-        // Then - Hidden variation ID should be in variationsToRemove
-        let persistedCatalog = try #require(mockPersistenceService.persistIncrementalCatalogDataLastPersistedCatalog)
-        #expect(persistedCatalog.variations.count == 1)
-        #expect(persistedCatalog.variationsToRemove.contains(102))
-        #expect(persistedCatalog.variationsToRemove.count == 1)
-    }
-
     @Test func startIncrementalSync_does_not_detect_hidden_products_when_posProductsOnly_is_false() async throws {
         // Given
         let lastFullSyncDate = Date(timeIntervalSince1970: 1000)
@@ -419,7 +378,6 @@ struct POSCatalogIncrementalSyncServiceTests {
         // Then - No products should be marked for removal
         let persistedCatalog = try #require(mockPersistenceService.persistIncrementalCatalogDataLastPersistedCatalog)
         #expect(persistedCatalog.productsToRemove.isEmpty)
-        #expect(persistedCatalog.variationsToRemove.isEmpty)
     }
 
     @Test func startIncrementalSync_handles_no_hidden_products_when_all_products_are_in_POS() async throws {


### PR DESCRIPTION
Closes WOOMOB-1970

## Description
This PR handles presenting the correct products in POS when we perform a local catalog incremental sync. The problem when passing `pos_products_only=true` into the requests is that incremental sync wouldn't know about this change, products and variations are just removed from the response.

This is not an issue on full syncs, since the response is fresh.

In order to resolve this, we perform 2 requests when an incremental sync happens: One with `pos_products_only=true` and an additional one with `pos_products_only=false`, then we check the diff and remove discrepancies from the local database.

## Changes:
- Detect if we're calling `pos_products_only=false` (single request) or `pos_products_only=true` (double request)
- If double request, track a diff of the products and variations between the two requests
- Once we know the discrepancies, we remove them before persisting to local storage

## Test Steps

Setup: Your store needs https://github.com/woocommerce/woocommerce/pull/62534 to use the new filter. There are several options you can choose from:
- Create a new Jurassic ninja site with that branch
- Use my testing store https://indiemelon.mystagingwebsite.com/ , which currently has that version installed
- Install the plugin version that contains the changes [from this link](https://indiemelon.mystagingwebsite.com/wp-content/uploads/2026/01/woocommerce-20260109.zip) into your own store.

Testing: 
- Run the app and make a full POS sync if needed, just to have fresh data
- For one or more of your products, disable `available for POS` in wp-admin > products > edit > advanced.
- Re-run the app, and observe the product is deleted from the local catalog upon incremental sync
```
🗑️ Deleting 1 products and 0 variations from catalog
Deleted 1 products from catalog
✅ Catalog deletion complete
✅ Incremental catalog persistence complete
✅ POSCatalogSyncCoordinator completed incremental sync for site 215063064
```
- Search for it in the app, and confirm is not available

| Not available for POS | Not available after incremental sync |
|--------|--------|
| <img width="851" height="306" alt="Screenshot 2026-01-14 at 11 23 33" src="https://github.com/user-attachments/assets/5bb3475e-a9db-4e37-ad6d-8a2e9bf08437" /> | <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2026-01-14 at 11 40 18" src="https://github.com/user-attachments/assets/9b065f36-fa42-4bbf-bc1b-603e2c037f8b" /> | 

Analytics will also show the number of items updated, for example:
```
💾 Persisting incremental catalog with 1 updated products and 0 updated variations

🔵 Tracked pos_local_catalog_sync_completed, properties: [sync_duration_ms: 1183, total_products: 84, products_synced: 1, variations_synced: 0, sync_type: incremental, total_variations: 101]
```

I've updated the tracking to just add the number of products we've removed, as these have been effectively synced/modified, but let me know if that was not the intention of the event, or we may want to add some additional property here.

Toggling the product back to be available for POS and then pull to refresh should restore the item into POS as well as log the sync.