### PR TITLE
Wrap age verification triggering behind a local FF

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -106,6 +106,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return false
         case .pointOfSaleRefundsi1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .ageRangeRequirementsCompliance:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -220,4 +220,9 @@ public enum FeatureFlag: Int {
     /// Enables the refunds functionality within POS
     ///
     case pointOfSaleRefundsi1
+
+    /// Enables age range verification features
+    /// https://developer.apple.com/news/?id=2ezb6jhj
+    ///
+    case ageRangeRequirementsCompliance
 }

--- a/WooCommerce/Classes/ViewRelated/AgeGate/AgeRangeVerificationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AgeGate/AgeRangeVerificationCoordinator.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Experiments
 
 protocol AgeRangeVerificationCoordinatorProtocol {
     func triggerAgeVerificationIfNeeded(
@@ -14,6 +15,12 @@ extension AgeRangeVerificationCoordinator {
 }
 
 final class AgeRangeVerificationCoordinator: AgeRangeVerificationCoordinatorProtocol {
+    private let featureFlagService: FeatureFlagService
+
+    init(featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+        self.featureFlagService = featureFlagService
+    }
+
     /// Triggers the age range verification flow.
     /// Handles "blocking UI" presenting in case of ineligible age and performs a logout.
     /// - Parameters:
@@ -23,6 +30,11 @@ final class AgeRangeVerificationCoordinator: AgeRangeVerificationCoordinatorProt
         hostingWindow: UIWindow,
         onResult: @escaping (Bool, AgeRangeVerificationResult) -> Void
     ) {
+        guard featureFlagService.isFeatureFlagEnabled(.ageRangeRequirementsCompliance) else {
+            onResult(true, .featureUnavailable)
+            return
+        }
+
         guard let anchor = hostingWindow.topmostPresentedViewController else {
             DDLogWarn("Failed to obtain view controller to present `Declared Age Range` SDK dialogue.")
             // Allow flow to continue if we can't present the dialogue.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1987

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
- Adds the `ageRangeRequirementsCompliance` local FF to gate the age rating checks until the feature is released. This will allow to merge the base feature [PR](https://github.com/woocommerce/woocommerce-ios/pull/16452).
- The FF is defined as `buildConfig == .localDeveloper || buildConfig == .alpha`. The feature will be available in debug and alpha builds.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
- No manual testing needed. CI should be green.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
