### PR TITLE
[PushNotificaiton] Hide notification settings

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -78,8 +78,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .backgroundProductImageUpload:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .notificationSettings:
-            return true
         case .allowMerchantAIAPIKey:
             return false
         case .inventoryProductLabelsInPOS:

--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -107,7 +107,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .pointOfSaleRefundsi1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .selfDrivenPushToken:
-            return false
+            return true
         case .pointOfSaleOnlyProducts:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -107,7 +107,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .pointOfSaleRefundsi1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .selfDrivenPushToken:
-            return true
+            return false
         case .pointOfSaleOnlyProducts:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -163,10 +163,6 @@ public enum FeatureFlag: Int, CaseIterable {
     ///
     case backgroundProductImageUpload
 
-    /// Supports managing notification settings from the app settings
-    ///
-    case notificationSettings
-
     /// Allows merchants to use their own API keys for AI-powered features
     ///
     case allowMerchantAIAPIKey

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockFeatureFlagService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockFeatureFlagService.swift
@@ -20,7 +20,6 @@ final class MockFeatureFlagService: POSFeatureFlagProviding {
     var revampedShippingLabelCreation: Bool
     var hideSitesInStorePicker: Bool
     var backgroundProductImageUpload: Bool
-    var notificationSettings: Bool
     var allowMerchantAIAPIKey: Bool
     var isProductImageOptimizedHandlingEnabled: Bool
     var isFeatureFlagEnabledReturnValue: [FeatureFlag: Bool] = [:]
@@ -46,7 +45,6 @@ final class MockFeatureFlagService: POSFeatureFlagProviding {
          revampedShippingLabelCreation: Bool = false,
          hideSitesInStorePicker: Bool = false,
          backgroundProductImageUpload: Bool = false,
-         notificationSettings: Bool = false,
          allowMerchantAIAPIKey: Bool = false,
          isProductImageOptimizedHandlingEnabled: Bool = false,
          isCIABBookingsEnabled: Bool = false,
@@ -70,7 +68,6 @@ final class MockFeatureFlagService: POSFeatureFlagProviding {
         self.revampedShippingLabelCreation = revampedShippingLabelCreation
         self.hideSitesInStorePicker = hideSitesInStorePicker
         self.backgroundProductImageUpload = backgroundProductImageUpload
-        self.notificationSettings = notificationSettings
         self.allowMerchantAIAPIKey = allowMerchantAIAPIKey
         self.isProductImageOptimizedHandlingEnabled = isProductImageOptimizedHandlingEnabled
         self.isCIABBookingsEnabled = isCIABBookingsEnabled
@@ -122,8 +119,6 @@ final class MockFeatureFlagService: POSFeatureFlagProviding {
             return hideSitesInStorePicker
         case .backgroundProductImageUpload:
             return backgroundProductImageUpload
-        case .notificationSettings:
-            return notificationSettings
         case .allowMerchantAIAPIKey:
             return allowMerchantAIAPIKey
         case .productImageOptimizedHandling:

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -771,4 +771,8 @@ extension UserDefaults {
     @objc dynamic var wooPushnotificationToken: String? {
         string(forKey: Key.wooPushnotificationToken.rawValue)
     }
+
+    @objc dynamic var deviceToken: String? {
+        string(forKey: Key.deviceToken.rawValue)
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -106,10 +106,6 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     private let defaults: UserDefaults
     private let analytics: Analytics
 
-    /// Cached self-driven push token ID loaded from AppSettings (per site).
-    /// This keeps `configureSections()` synchronous while still reacting to persistence changes.
-    private var cachedSelfDrivenPushTokenID: Int64?
-
     /// Reference to the Zendesk shared instance
     ///
     private let zendeskShared: ZendeskManagerProtocol = ZendeskProvider.shared
@@ -194,22 +190,22 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
 private extension SettingsViewModel {
 
     func loadSelfDrivenPushTokenIDIfNeeded() {
-        guard let siteID = stores.sessionManager.defaultSite?.siteID else {
-            cachedSelfDrivenPushTokenID = nil
-            return
-        }
-
-        stores.dispatch(AppSettingsAction.loadSelfDrivenPushTokenID(siteID: siteID) { [weak self] tokenID in
-            guard let self else { return }
-
-            // Only refresh UI when the stored value actually changes.
-            guard self.cachedSelfDrivenPushTokenID != tokenID else {
-                return
-            }
-
-            self.cachedSelfDrivenPushTokenID = tokenID
-            self.reloadSettings()
-        })
+//        guard let siteID = stores.sessionManager.defaultSite?.siteID else {
+//            cachedSelfDrivenPushTokenID = nil
+//            return
+//        }
+//
+//        stores.dispatch(AppSettingsAction.loadSelfDrivenPushTokenID(siteID: siteID) { [weak self] tokenID in
+//            guard let self else { return }
+//
+//            // Only refresh UI when the stored value actually changes.
+//            guard self.cachedSelfDrivenPushTokenID != tokenID else {
+//                return
+//            }
+//
+//            self.cachedSelfDrivenPushTokenID = tokenID
+//            self.reloadSettings()
+//        })
     }
 
     func loadWhatsNewOnWooCommerce() {
@@ -314,7 +310,9 @@ private extension SettingsViewModel {
                 return site.isJetpackCPConnected == false
             }()
             let isSelfDrivenPushNotificationsRegistered: Bool = {
-                (cachedSelfDrivenPushTokenID != nil) && !stores.isAuthenticatedWithoutWPCom
+                let isWooTokenExists = defaults.wooPushnotificationToken != nil
+                let WPComTokenExists = defaults.deviceToken != nil
+                return (isWooTokenExists && ServiceLocator.featureFlagService.isFeatureFlagEnabled(.selfDrivenPushToken)) && !WPComTokenExists
             }()
             if (notificationAvailable && featureFlagService.isFeatureFlagEnabled(.notificationSettings)) && !isSelfDrivenPushNotificationsRegistered {
                 rows = [.notifications, .privacy]

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -106,6 +106,10 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     private let defaults: UserDefaults
     private let analytics: Analytics
 
+    /// Cached self-driven push token ID loaded from AppSettings (per site).
+    /// This keeps `configureSections()` synchronous while still reacting to persistence changes.
+    private var cachedSelfDrivenPushTokenID: Int64?
+
     /// Reference to the Zendesk shared instance
     ///
     private let zendeskShared: ZendeskManagerProtocol = ZendeskProvider.shared
@@ -157,6 +161,7 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
         loadPaymentGatewayAccounts()
         loadWhatsNewOnWooCommerce()
         loadSites()
+        loadSelfDrivenPushTokenIDIfNeeded()
         reloadSettings()
     }
 
@@ -165,6 +170,7 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     ///
     func onStorePickerDismiss() {
         loadSites()
+        loadSelfDrivenPushTokenIDIfNeeded()
         reloadSettings()
     }
 
@@ -186,6 +192,25 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
 }
 
 private extension SettingsViewModel {
+
+    func loadSelfDrivenPushTokenIDIfNeeded() {
+        guard let siteID = stores.sessionManager.defaultSite?.siteID else {
+            cachedSelfDrivenPushTokenID = nil
+            return
+        }
+
+        stores.dispatch(AppSettingsAction.loadSelfDrivenPushTokenID(siteID: siteID) { [weak self] tokenID in
+            guard let self else { return }
+
+            // Only refresh UI when the stored value actually changes.
+            guard self.cachedSelfDrivenPushTokenID != tokenID else {
+                return
+            }
+
+            self.cachedSelfDrivenPushTokenID = tokenID
+            self.reloadSettings()
+        })
+    }
 
     func loadWhatsNewOnWooCommerce() {
         stores.dispatch(AnnouncementsAction.loadSavedAnnouncement(onCompletion: { [weak self] result in
@@ -288,7 +313,10 @@ private extension SettingsViewModel {
                 }
                 return site.isJetpackCPConnected == false
             }()
-            if notificationAvailable, featureFlagService.isFeatureFlagEnabled(.notificationSettings) {
+            let isSelfDrivenPushNotificationsRegistered: Bool = {
+                (cachedSelfDrivenPushTokenID != nil) && !stores.isAuthenticatedWithoutWPCom
+            }()
+            if (notificationAvailable && featureFlagService.isFeatureFlagEnabled(.notificationSettings)) && !isSelfDrivenPushNotificationsRegistered {
                 rows = [.notifications, .privacy]
             } else {
                 rows = [.privacy]

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Combine
 import Yosemite
 import Storage
 import class Networking.UserAgent
@@ -106,6 +107,8 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     private let defaults: UserDefaults
     private let analytics: Analytics
 
+    private var subscriptions: Set<AnyCancellable> = []
+
     /// Reference to the Zendesk shared instance
     ///
     private let zendeskShared: ZendeskManagerProtocol = ZendeskProvider.shared
@@ -158,6 +161,7 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
         loadWhatsNewOnWooCommerce()
         loadSites()
         reloadSettings()
+        observeSelfDrivenPushTokenPersistence()
     }
 
     /// Reloads the sites when store picker gets dismissed.
@@ -180,6 +184,7 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     /// Reload the sections and refresh the view (presenter)
     ///
     func reloadSettings() {
+        print("self \(#function)")
         configureSections()
         presenter?.refreshViewContent()
     }
@@ -203,6 +208,25 @@ private extension SettingsViewModel {
     ///
     func loadSites() {
         sites = sitesResultsController.fetchedObjects
+    }
+
+    func observeSelfDrivenPushTokenPersistence() {
+        print("self \(#function)")
+
+        let wooTokenChanges = defaults
+            .publisher(for: \.wooPushnotificationToken)
+            .map { _ in () }
+
+        let wpComDeviceTokenChanges = defaults
+            .publisher(for: \.deviceToken)
+            .map { _ in () }
+
+        Publishers.Merge(wooTokenChanges, wpComDeviceTokenChanges)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.reloadSettings()
+            }
+            .store(in: &subscriptions)
     }
 
     func configureSections() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -184,7 +184,6 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     /// Reload the sections and refresh the view (presenter)
     ///
     func reloadSettings() {
-        print("self \(#function)")
         configureSections()
         presenter?.refreshViewContent()
     }
@@ -211,8 +210,6 @@ private extension SettingsViewModel {
     }
 
     func observeSelfDrivenPushTokenPersistence() {
-        print("self \(#function)")
-
         let wooTokenChanges = defaults
             .publisher(for: \.wooPushnotificationToken)
             .map { _ in () }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -157,7 +157,6 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
         loadPaymentGatewayAccounts()
         loadWhatsNewOnWooCommerce()
         loadSites()
-        loadSelfDrivenPushTokenIDIfNeeded()
         reloadSettings()
     }
 
@@ -166,7 +165,6 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     ///
     func onStorePickerDismiss() {
         loadSites()
-        loadSelfDrivenPushTokenIDIfNeeded()
         reloadSettings()
     }
 
@@ -188,26 +186,7 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
 }
 
 private extension SettingsViewModel {
-
-    func loadSelfDrivenPushTokenIDIfNeeded() {
-//        guard let siteID = stores.sessionManager.defaultSite?.siteID else {
-//            cachedSelfDrivenPushTokenID = nil
-//            return
-//        }
-//
-//        stores.dispatch(AppSettingsAction.loadSelfDrivenPushTokenID(siteID: siteID) { [weak self] tokenID in
-//            guard let self else { return }
-//
-//            // Only refresh UI when the stored value actually changes.
-//            guard self.cachedSelfDrivenPushTokenID != tokenID else {
-//                return
-//            }
-//
-//            self.cachedSelfDrivenPushTokenID = tokenID
-//            self.reloadSettings()
-//        })
-    }
-
+    
     func loadWhatsNewOnWooCommerce() {
         stores.dispatch(AnnouncementsAction.loadSavedAnnouncement(onCompletion: { [weak self] result in
             guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -293,7 +293,7 @@ private extension SettingsViewModel {
                 let WPComTokenExists = defaults.deviceToken != nil
                 return (isWooTokenExists && ServiceLocator.featureFlagService.isFeatureFlagEnabled(.selfDrivenPushToken)) && !WPComTokenExists
             }()
-            if (notificationAvailable && featureFlagService.isFeatureFlagEnabled(.notificationSettings)) && !isSelfDrivenPushNotificationsRegistered {
+            if notificationAvailable && !isSelfDrivenPushNotificationsRegistered {
                 rows = [.notifications, .privacy]
             } else {
                 rows = [.privacy]

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -186,7 +186,7 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
 }
 
 private extension SettingsViewModel {
-    
+
     func loadWhatsNewOnWooCommerce() {
         stores.dispatch(AnnouncementsAction.loadSavedAnnouncement(onCompletion: { [weak self] result in
             guard let self = self else { return }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -26,6 +26,7 @@ final class MockFeatureFlagService: FeatureFlagService, POSFeatureFlagProviding 
     var isProductImageOptimizedHandlingEnabled: Bool
     var isFeatureFlagEnabledReturnValue: [FeatureFlag: Bool] = [:]
     var isCIABBookingsEnabled: Bool
+    var selfDrivenPushToken: Bool
 
     init(isInboxOn: Bool = false,
          isShowInboxCTAEnabled: Bool = false,
@@ -48,7 +49,8 @@ final class MockFeatureFlagService: FeatureFlagService, POSFeatureFlagProviding 
          notificationSettings: Bool = false,
          allowMerchantAIAPIKey: Bool = false,
          isProductImageOptimizedHandlingEnabled: Bool = false,
-         isCIABBookingsEnabled: Bool = false) {
+         isCIABBookingsEnabled: Bool = false,
+         selfDrivenPushToken: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isShowInboxCTAEnabled = isShowInboxCTAEnabled
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -71,6 +73,7 @@ final class MockFeatureFlagService: FeatureFlagService, POSFeatureFlagProviding 
         self.allowMerchantAIAPIKey = allowMerchantAIAPIKey
         self.isProductImageOptimizedHandlingEnabled = isProductImageOptimizedHandlingEnabled
         self.isCIABBookingsEnabled = isCIABBookingsEnabled
+        self.selfDrivenPushToken = selfDrivenPushToken
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -125,6 +128,8 @@ final class MockFeatureFlagService: FeatureFlagService, POSFeatureFlagProviding 
             return isProductImageOptimizedHandlingEnabled
         case .ciabBookings:
             return isCIABBookingsEnabled
+        case .selfDrivenPushToken:
+            return selfDrivenPushToken
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -21,7 +21,6 @@ final class MockFeatureFlagService: FeatureFlagService, POSFeatureFlagProviding 
     var revampedShippingLabelCreation: Bool
     var hideSitesInStorePicker: Bool
     var backgroundProductImageUpload: Bool
-    var notificationSettings: Bool
     var allowMerchantAIAPIKey: Bool
     var isProductImageOptimizedHandlingEnabled: Bool
     var isFeatureFlagEnabledReturnValue: [FeatureFlag: Bool] = [:]
@@ -46,7 +45,6 @@ final class MockFeatureFlagService: FeatureFlagService, POSFeatureFlagProviding 
          revampedShippingLabelCreation: Bool = false,
          hideSitesInStorePicker: Bool = false,
          backgroundProductImageUpload: Bool = false,
-         notificationSettings: Bool = false,
          allowMerchantAIAPIKey: Bool = false,
          isProductImageOptimizedHandlingEnabled: Bool = false,
          isCIABBookingsEnabled: Bool = false,
@@ -69,7 +67,6 @@ final class MockFeatureFlagService: FeatureFlagService, POSFeatureFlagProviding 
         self.revampedShippingLabelCreation = revampedShippingLabelCreation
         self.hideSitesInStorePicker = hideSitesInStorePicker
         self.backgroundProductImageUpload = backgroundProductImageUpload
-        self.notificationSettings = notificationSettings
         self.allowMerchantAIAPIKey = allowMerchantAIAPIKey
         self.isProductImageOptimizedHandlingEnabled = isProductImageOptimizedHandlingEnabled
         self.isCIABBookingsEnabled = isCIABBookingsEnabled
@@ -120,8 +117,6 @@ final class MockFeatureFlagService: FeatureFlagService, POSFeatureFlagProviding 
             return hideSitesInStorePicker
         case .backgroundProductImageUpload:
             return backgroundProductImageUpload
-        case .notificationSettings:
-            return notificationSettings
         case .allowMerchantAIAPIKey:
             return allowMerchantAIAPIKey
         case .productImageOptimizedHandling:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -250,23 +250,9 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.whatsNew) })
     }
 
-    func test_sections_does_not_contain_notifications_row_when_feature_flag_is_disabled() {
-        // Given
-        let featureFlagService = MockFeatureFlagService(notificationSettings: false)
-        let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
-        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
-        let viewModel = SettingsViewModel(stores: stores, featureFlagService: featureFlagService)
-
-        // When
-        viewModel.onViewDidLoad()
-
-        // Then
-        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.notifications) })
-    }
-
     func test_sections_does_not_contain_notifications_row_when_user_is_authenticated_without_WPCom() {
         // Given
-        let featureFlagService = MockFeatureFlagService(notificationSettings: true)
+        let featureFlagService = MockFeatureFlagService()
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false, defaultSite: testSite))
         let viewModel = SettingsViewModel(stores: stores, featureFlagService: featureFlagService)
@@ -280,7 +266,7 @@ final class SettingsViewModelTests: XCTestCase {
 
     func test_sections_does_not_contain_notifications_row_when_site_is_JCP() {
         // Given
-        let featureFlagService = MockFeatureFlagService(notificationSettings: true)
+        let featureFlagService = MockFeatureFlagService()
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: false, isJetpackConnected: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
         let viewModel = SettingsViewModel(stores: stores, featureFlagService: featureFlagService)
@@ -294,7 +280,7 @@ final class SettingsViewModelTests: XCTestCase {
 
     func test_sections_contains_notifications_row_for_Jetpack_site_and_user_is_authenticated_with_WPCom() {
         // Given
-        let featureFlagService = MockFeatureFlagService(notificationSettings: true)
+        let featureFlagService = MockFeatureFlagService()
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
         let viewModel = SettingsViewModel(stores: stores, featureFlagService: featureFlagService)
@@ -308,7 +294,7 @@ final class SettingsViewModelTests: XCTestCase {
 
     func test_sections_contains_does_not_contain_notifications_row_for_selfregisteredtoken() {
         // Given
-        let featureFlagService = MockFeatureFlagService(notificationSettings: true, selfDrivenPushToken: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
         defaults.set("123", forKey: .wooPushnotificationToken)
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -306,6 +306,24 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.notifications) })
     }
 
+    func test_sections_contains_does_not_contain_notifications_row_for_selfregisteredtoken() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(notificationSettings: true, selfDrivenPushToken: true)
+        defaults.set("123", forKey: .wooPushnotificationToken)
+        let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
+        let viewModel = SettingsViewModel(stores: stores,
+                                          featureFlagService: featureFlagService,
+                                          defaults: defaults)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.notifications) })
+    }
+
+
     func test_sections_does_not_contain_connectivity_row_for_wpcom_site() {
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true, isWordPressComStore: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))


### PR DESCRIPTION
Closes [WOOMOB-1866](https://linear.app/a8c/issue/WOOMOB-1866/ios-hide-notification-settings-after-migration)

## Description
This PR hides the "Notification Settings" option from the app settings if self-driven PN registration was successful.

## Test Steps
You'll need to spin up a jurassic site, see the steps here p91TBi-dyW-p2#comment-14564 

1. Login to the new site with WPcom credentials.
2. Navigate to Menu/Settings
3. Note that under "APP SETTINGS" there is  "Notification settings" option.
4. Log out.
1. Edit the `selfDrivenPushToken` local FF to be `true`.
1. Login to the new site with WPcom credentials.
2. Navigate to Menu/Settings
3. Note that under "APP SETTINGS" there is **no** "Notification settings" option.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
