### PR TITLE
Show JITMs even when onboarding is incomplete

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -18,15 +18,8 @@ final class DashboardViewModel: ObservableObject {
     @Published var modalJustInTimeMessageViewModel: JustInTimeMessageViewModel? = nil
 
     /// Whether the announcement banner should be shown.
-    /// Returns true if there's an announcement AND the onboarding card is not visible.
     var shouldShowAnnouncementBanner: Bool {
-        guard announcementViewModel != nil else {
-            return false
-        }
-        let onboardingCardIsVisible = dashboardCards.contains { card in
-            card.type == .onboarding && card.enabled && card.availability != .hide
-        }
-        return !onboardingCardIsVisible
+        return announcementViewModel != nil
     }
 
     let storeOnboardingViewModel: StoreOnboardingViewModel

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -891,10 +891,9 @@ final class DashboardViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_shouldShowAnnouncementBanner_returns_true_when_announcement_exists_and_onboarding_not_enabled() async throws {
+    func test_shouldShowAnnouncementBanner_returns_true_when_announcement_exists() async throws {
         // Given - announcement exists and onboarding card is not enabled (all tasks completed)
         let message = Yosemite.JustInTimeMessage.fake().copy(title: "JITM Message")
-        userDefaults[.completedAllStoreOnboardingTasks] = true
         mockReloadingData(jitmResult: .success([message]))
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
@@ -907,58 +906,8 @@ final class DashboardViewModelTests: XCTestCase {
         // When
         await viewModel.reloadAllData()
 
-        // Then - onboarding card should be disabled
-        let onboardingCard = try XCTUnwrap(viewModel.dashboardCards.first(where: { $0.type == .onboarding }))
-        XCTAssertFalse(onboardingCard.enabled)
-        // And banner should be visible
+        // Then - banner should be visible
         XCTAssertTrue(viewModel.shouldShowAnnouncementBanner)
-    }
-
-    @MainActor
-    func test_shouldShowAnnouncementBanner_returns_true_when_announcement_exists_and_onboarding_disabled() async throws {
-        // Given - announcement exists and onboarding card is disabled via stored dashboard cards
-        let message = Yosemite.JustInTimeMessage.fake().copy(title: "JITM Message")
-        let storedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: false)]
-        mockReloadingData(jitmResult: .success([message]), storedDashboardCards: storedCards)
-
-        let viewModel = DashboardViewModel(siteID: sampleSiteID,
-                                           stores: stores,
-                                           storageManager: storageManager,
-                                           blazeEligibilityChecker: blazeEligibilityChecker,
-                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
-
-        // When
-        await viewModel.reloadAllData()
-
-        // Then - onboarding card should be disabled
-        let onboardingCard = try XCTUnwrap(viewModel.dashboardCards.first(where: { $0.type == .onboarding }))
-        XCTAssertFalse(onboardingCard.enabled)
-        // And banner should be visible
-        XCTAssertTrue(viewModel.shouldShowAnnouncementBanner)
-    }
-
-    @MainActor
-    func test_shouldShowAnnouncementBanner_returns_false_when_onboarding_card_enabled_and_shown() async throws {
-        // Given - announcement exists but onboarding is enabled and visible
-        let message = Yosemite.JustInTimeMessage.fake().copy(title: "JITM Message")
-        let storedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: true)]
-        mockReloadingData(jitmResult: .success([message]), storedDashboardCards: storedCards)
-
-        let viewModel = DashboardViewModel(siteID: sampleSiteID,
-                                           stores: stores,
-                                           storageManager: storageManager,
-                                           blazeEligibilityChecker: blazeEligibilityChecker,
-                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
-
-        // When
-        await viewModel.reloadAllData()
-
-        // Then - onboarding card should be enabled and shown
-        let onboardingCard = try XCTUnwrap(viewModel.dashboardCards.first(where: { $0.type == .onboarding }))
-        XCTAssertTrue(onboardingCard.enabled)
-        XCTAssertEqual(onboardingCard.availability, .show)
-        // And banner should be hidden (onboarding takes priority)
-        XCTAssertFalse(viewModel.shouldShowAnnouncementBanner)
     }
 
     // MARK: Self-driven push registration


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR ensures that JITMs show even when there's onboarding steps still to complete.

Some stores may never complete their onboarding steps; we want to make sure they still see the messages we send. JITM is most useful if we can be sure that it'll go through to as many people as possible, in that way we can show information without doing an app release.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Make a new Jurassic Ninja site and connect to Jetpack
Set up a network proxy tool using breakpoints or Map Local on /jetpack/v4/jitm. It's important to set this up for both WPcom tunneled requests and direct site requests. You can return a JITM using this payload:

```
{
  "data": [
    {
      "site_id": 216335538,
      "id": "test-message",
      "feature_class": "feature",
      "content": {
        "message": "Run WooCommerce POS on tablets",
        "description": "Take in‑person payments with Woo POS. Set up on a tablet and start selling today."
      },
      "CTA": {
        "message": "Learn more",
        "link": "https://example.com"
      },
      "assets": {
      "background_image_url": "https://sheer-trapdoor-clam.jurassic.ninja/wp-content/uploads/2026/01/pos-jitm-bg.png"
      },
      "template": "banner"
    }
  ]
}
```

Use your own site ID if you like but it doesn't actually matter in this payload...

Open the app, and observe that the JITM is shown even when setup steps are shown.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="660" height="1434" alt="My Store 2" src="https://github.com/user-attachments/assets/82b1e2e6-23c0-4f6f-a9aa-754c51d25ca1" />

N.B. This was taken before #16513 was merged so still uses the old designs. When you test, it should show as a card
---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
