### PR TITLE
[PushNotification] Use UserDefaults instead of GeneralStore to store token

### DIFF
--- a/Modules/Sources/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -131,8 +131,7 @@ extension Storage.GeneralStoreSettings {
         isPOSTabVisible: NullableCopiableProp<Bool> = .copy,
         lastPOSOpenedDate: NullableCopiableProp<Date> = .copy,
         firstPOSCatalogSyncDate: NullableCopiableProp<Date> = .copy,
-        syncPOSCatalogOverCellular: CopiableProp<Bool> = .copy,
-        selfDrivenPushTokenID: NullableCopiableProp<Int64> = .copy,
+        syncPOSCatalogOverCellular: CopiableProp<Bool> = .copy
     ) -> Storage.GeneralStoreSettings {
         let storeID = storeID ?? self.storeID
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable
@@ -157,7 +156,6 @@ extension Storage.GeneralStoreSettings {
         let lastPOSOpenedDate = lastPOSOpenedDate ?? self.lastPOSOpenedDate
         let firstPOSCatalogSyncDate = firstPOSCatalogSyncDate ?? self.firstPOSCatalogSyncDate
         let syncPOSCatalogOverCellular = syncPOSCatalogOverCellular ?? self.syncPOSCatalogOverCellular
-        let selfDrivenPushTokenID = selfDrivenPushTokenID ?? self.selfDrivenPushTokenID
 
         return Storage.GeneralStoreSettings(
             storeID: storeID,
@@ -182,8 +180,7 @@ extension Storage.GeneralStoreSettings {
             isPOSTabVisible: isPOSTabVisible,
             lastPOSOpenedDate: lastPOSOpenedDate,
             firstPOSCatalogSyncDate: firstPOSCatalogSyncDate,
-            syncPOSCatalogOverCellular: syncPOSCatalogOverCellular,
-            selfDrivenPushTokenID: selfDrivenPushTokenID
+            syncPOSCatalogOverCellular: syncPOSCatalogOverCellular
         )
     }
 }

--- a/Modules/Sources/Storage/Model/GeneralStoreSettings.swift
+++ b/Modules/Sources/Storage/Model/GeneralStoreSettings.swift
@@ -98,8 +98,6 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public var syncPOSCatalogOverCellular: Bool
 
-    public var selfDrivenPushTokenID: Int64?
-
     public init(storeID: String? = nil,
                 isTelemetryAvailable: Bool = false,
                 telemetryLastReportedTime: Date? = nil,
@@ -122,8 +120,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                 isPOSTabVisible: Bool? = nil,
                 lastPOSOpenedDate: Date? = nil,
                 firstPOSCatalogSyncDate: Date? = nil,
-                syncPOSCatalogOverCellular: Bool = true,
-                selfDrivenPushTokenID: Int64? = nil) {
+                syncPOSCatalogOverCellular: Bool = true) {
         self.storeID = storeID
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
@@ -147,7 +144,6 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
         self.lastPOSOpenedDate = lastPOSOpenedDate
         self.firstPOSCatalogSyncDate = firstPOSCatalogSyncDate
         self.syncPOSCatalogOverCellular = syncPOSCatalogOverCellular
-        self.selfDrivenPushTokenID = selfDrivenPushTokenID
     }
 
     public func erasingSelectedTaxRateID() -> GeneralStoreSettings {
@@ -209,7 +205,6 @@ extension GeneralStoreSettings {
         self.lastPOSOpenedDate = try container.decodeIfPresent(Date.self, forKey: .lastPOSOpenedDate)
         self.firstPOSCatalogSyncDate = try container.decodeIfPresent(Date.self, forKey: .firstPOSCatalogSyncDate)
         self.syncPOSCatalogOverCellular = try container.decodeIfPresent(Bool.self, forKey: .syncPOSCatalogOverCellular) ?? true
-        self.selfDrivenPushTokenID = try container.decodeIfPresent(Int64.self, forKey: .selfDrivenPushTokenID)
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/Modules/Sources/Yosemite/Actions/AppSettingsAction.swift
+++ b/Modules/Sources/Yosemite/Actions/AppSettingsAction.swift
@@ -437,10 +437,4 @@ public enum AppSettingsAction: Action {
 
     /// Gets whether we should allow cellular data use downloading POS catalogs for a specific site
     case getPOSLocalCatalogCellularDataAllowed(siteID: Int64, onCompletion: (Bool) -> Void)
-
-    /// Stores the self-driven push token ID (Woo Core push). Passing nil clears it.
-    case setSelfDrivenPushTokenID(siteID: Int64, tokenID: Int64?, onCompletion: ((Result<Void, Error>) -> Void)?)
-
-    /// Loads the stored self-driven push token ID (Woo Core push). Nil means “not registered”.
-    case loadSelfDrivenPushTokenID(siteID: Int64, onCompletion: (Int64?) -> Void)
 }

--- a/Modules/Sources/Yosemite/Stores/AppSettingsStore.swift
+++ b/Modules/Sources/Yosemite/Stores/AppSettingsStore.swift
@@ -332,11 +332,6 @@ public class AppSettingsStore: Store {
             setPOSLocalCatalogCellularDataAllowed(siteID: siteID, allowed: allowed, onCompletion: onCompletion)
         case .getPOSLocalCatalogCellularDataAllowed(let siteID, let onCompletion):
             getPOSLocalCatalogCellularDataAllowed(siteID: siteID, onCompletion: onCompletion)
-        case let .setSelfDrivenPushTokenID(siteID, tokenID, onCompletion):
-            setSelfDrivenPushTokenID(siteID: siteID, tokenID: tokenID, onCompletion: onCompletion)
-
-        case let .loadSelfDrivenPushTokenID(siteID, onCompletion):
-            loadSelfDrivenPushTokenID(siteID: siteID, onCompletion: onCompletion)
         }
     }
 }
@@ -1459,21 +1454,6 @@ private extension AppSettingsStore {
     func getPOSLocalCatalogCellularDataAllowed(siteID: Int64, onCompletion: (Bool) -> Void) {
         let allowed = siteSpecificAppSettingsStoreMethods.getPOSLocalCatalogCellularDataAllowed(siteID: siteID)
         onCompletion(allowed)
-    }
-}
-
-private extension AppSettingsStore {
-    func setSelfDrivenPushTokenID(siteID: Int64,
-                                  tokenID: Int64?,
-                                  onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
-        let storeSettings = getStoreSettings(for: siteID)
-        let updatedSettings = storeSettings.copy(selfDrivenPushTokenID: tokenID)
-        setStoreSettings(settings: updatedSettings, for: siteID, onCompletion: onCompletion)
-    }
-
-    func loadSelfDrivenPushTokenID(siteID: Int64,
-                                   onCompletion: (Int64?) -> Void) {
-        onCompletion(getStoreSettings(for: siteID).selfDrivenPushTokenID)
     }
 }
 

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -937,12 +937,6 @@ extension UserDefaults {
     @objc dynamic var wpcomSiteSuspended: Bool {
         bool(forKey: Key.wpcomSiteSuspended.rawValue)
     }
-
-    /// Only use this to get notified of the underlying value being changed and not to read the acutal value.
-    /// We need this as Int64? cannot be represented in objc.
-    @objc dynamic var wooPushnotificationTokenChangeNotifier: String? {
-        string(forKey: Key.wooPushnotificationToken.rawValue)
-    }
 }
 
 // MARK: - Help and support helpers

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -937,6 +937,10 @@ extension UserDefaults {
     @objc dynamic var wpcomSiteSuspended: Bool {
         bool(forKey: Key.wpcomSiteSuspended.rawValue)
     }
+
+    @objc dynamic var wooPushnotificationToken: String? {
+        string(forKey: Key.wooPushnotificationToken.rawValue)
+    }
 }
 
 // MARK: - Help and support helpers

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -938,7 +938,9 @@ extension UserDefaults {
         bool(forKey: Key.wpcomSiteSuspended.rawValue)
     }
 
-    @objc dynamic var wooPushnotificationToken: String? {
+    /// Only use this to get notified of the underlying value being changed and not to read the acutal value.
+    /// We need this as Int64? cannot be represented in objc.
+    @objc dynamic var wooPushnotificationTokenChangeNotifier: String? {
         string(forKey: Key.wooPushnotificationToken.rawValue)
     }
 }

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -18,6 +18,7 @@ extension UserDefaults {
         case defaultRoles
         case deviceID
         case deviceToken
+        case wooPushnotificationToken
         case errorLoginSiteAddress
         case hasFinishedOnboarding
         case installationDate

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -625,7 +625,6 @@ private extension PushNotificationsManager {
 
     func handleSelfDrivenRegistrationSuccess(tokenID: Int64, onCompletion: @escaping (Result<Int64, Error>) -> Void) {
         wooPushnotificationToken = "\(tokenID)"
-        NotificationCenter.default.post(name: .selfDrivenPushTokenPersisted, object: nil)
         unregisterDotcomDeviceIfNeededThenClearToken(onCompletion: {
             onCompletion(.success(tokenID))
         })
@@ -768,6 +767,8 @@ private extension PushNotificationsManager {
     }
 }
 
-extension Notification.Name {
-    static let selfDrivenPushTokenPersisted = Notification.Name("selfDrivenPushTokenPersisted")
+extension UserDefaults {
+    @objc dynamic var wooPushnotificationToken: String? {
+        string(forKey: Key.wooPushnotificationToken.rawValue)
+    }
 }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -106,6 +106,17 @@ final class PushNotificationsManager: PushNotesManager {
         }
     }
 
+    /// Self driven push notificaiton token
+    ///
+    private var wooPushnotificationToken: Int64? {
+        get {
+            return configuration.defaults.object(forKey: .wooPushnotificationToken)
+        }
+        set {
+            configuration.defaults.set(newValue, forKey: .wooPushnotificationToken)
+        }
+    }
+
     private var siteID: Int64? {
         stores.sessionManager.defaultStoreID
     }
@@ -617,24 +628,10 @@ private extension PushNotificationsManager {
     }
 
     func handleSelfDrivenRegistrationSuccess(tokenID: Int64, siteID: Int64, onCompletion: @escaping (Result<Int64, Error>) -> Void) {
-        persistSelfDrivenTokenID(tokenID, siteID: siteID)
+        wooPushnotificationToken = tokenID
         unregisterDotcomDeviceIfNeededThenClearToken(onCompletion: {
             onCompletion(.success(tokenID))
         })
-    }
-
-    func persistSelfDrivenTokenID(_ tokenID: Int64, siteID: Int64) {
-        let setTokenAction = AppSettingsAction.setSelfDrivenPushTokenID(siteID: siteID, tokenID: tokenID) { result in
-            switch result {
-            case .success:
-                NotificationCenter.default.post(
-                    name: .selfDrivenPushTokenIDDidPersist, object: nil
-                )
-            case .failure(let error):
-                DDLogError("⛔️ Unable to persist self-driven push token ID: \(error)")
-            }
-        }
-        stores.dispatch(setTokenAction)
     }
 
     func unregisterDotcomDeviceIfNeededThenClearToken(onCompletion: @escaping () -> Void) {

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -6,10 +6,6 @@ import AutomatticTracks
 import Yosemite
 import protocol WooFoundation.Analytics
 
-extension Notification.Name {
-    static let selfDrivenPushTokenIDDidPersist = Notification.Name("selfDrivenPushTokenIDDidPersist")
-}
-
 
 /// PushNotificationsManager: Encapsulates all the tasks related to Push Notifications Auth + Registration + Handling.
 ///
@@ -108,7 +104,7 @@ final class PushNotificationsManager: PushNotesManager {
 
     /// Self driven push notificaiton token
     ///
-    private var wooPushnotificationToken: Int64? {
+    private var wooPushnotificationToken: String? {
         get {
             return configuration.defaults.object(forKey: .wooPushnotificationToken)
         }
@@ -616,7 +612,7 @@ private extension PushNotificationsManager {
 
             switch result {
             case .success(let tokenID):
-                self.handleSelfDrivenRegistrationSuccess(tokenID: tokenID, siteID: siteID, onCompletion: onCompletion)
+                self.handleSelfDrivenRegistrationSuccess(tokenID: tokenID, onCompletion: onCompletion)
 
             case .failure(let error):
                 DDLogError("⛔️ Unable to register self-driven push token: \(error)")
@@ -627,8 +623,9 @@ private extension PushNotificationsManager {
         stores.dispatch(action)
     }
 
-    func handleSelfDrivenRegistrationSuccess(tokenID: Int64, siteID: Int64, onCompletion: @escaping (Result<Int64, Error>) -> Void) {
-        wooPushnotificationToken = tokenID
+    func handleSelfDrivenRegistrationSuccess(tokenID: Int64, onCompletion: @escaping (Result<Int64, Error>) -> Void) {
+        wooPushnotificationToken = "\(tokenID)"
+        NotificationCenter.default.post(name: .selfDrivenPushTokenPersisted, object: nil)
         unregisterDotcomDeviceIfNeededThenClearToken(onCompletion: {
             onCompletion(.success(tokenID))
         })
@@ -769,4 +766,8 @@ private extension PushNotificationsManager {
     enum Localization {
         static let viewInAppNotification = NSLocalizedString("View", comment: "Action title in an in-app notification to view more details.")
     }
+}
+
+extension Notification.Name {
+    static let selfDrivenPushTokenPersisted = Notification.Name("selfDrivenPushTokenPersisted")
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -541,12 +541,11 @@ private extension DashboardViewModel {
     }
 
     func observeSelfDrivenPushTokenPersistence() {
-        userDefaults.publisher(for: \.wooPushnotificationTokenChangeNotifier)
+        NotificationCenter.default.publisher(for: .selfDrivenPushTokenPersisted)
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
-                Task { @MainActor in
-                    await self.updateSelfDrivenPushRegistrationStatus()
-                }
+                self.updateSelfDrivenPushRegistrationStatus()
             }
             .store(in: &subscriptions)
     }
@@ -811,10 +810,8 @@ private extension DashboardViewModel {
         jetpackBannerVisibleFromAppSettings = await loadJetpackBannerVisibilityFromAppSettings()
     }
 
-    @MainActor
-    func updateSelfDrivenPushRegistrationStatus() async {
+    func updateSelfDrivenPushRegistrationStatus() {
         let tokenID: Int64? = userDefaults.value(forKey: UserDefaults.Key.wooPushnotificationToken.rawValue) as? Int64
-
         isSelfDrivenPushNotificationRegistered = (tokenID != nil) && stores.isAuthenticatedWithoutWPCom
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -541,7 +541,7 @@ private extension DashboardViewModel {
     }
 
     func observeSelfDrivenPushTokenPersistence() {
-        userDefaults.publisher(for: \.wooPushnotificationToken)
+        userDefaults.publisher(for: \.wooPushnotificationTokenChangeNotifier)
             .sink { [weak self] _ in
                 guard let self else { return }
                 Task { @MainActor in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -541,8 +541,7 @@ private extension DashboardViewModel {
     }
 
     func observeSelfDrivenPushTokenPersistence() {
-        NotificationCenter.default.publisher(for: .selfDrivenPushTokenIDDidPersist)
-            .receive(on: DispatchQueue.main)
+        userDefaults.publisher(for: \.wooPushnotificationToken)
             .sink { [weak self] _ in
                 guard let self else { return }
                 Task { @MainActor in
@@ -814,11 +813,7 @@ private extension DashboardViewModel {
 
     @MainActor
     func updateSelfDrivenPushRegistrationStatus() async {
-        let tokenID: Int64? = await withCheckedContinuation { continuation in
-            stores.dispatch(AppSettingsAction.loadSelfDrivenPushTokenID(siteID: siteID) { tokenID in
-                continuation.resume(returning: tokenID)
-            })
-        }
+        let tokenID: Int64? = userDefaults.value(forKey: UserDefaults.Key.wooPushnotificationToken.rawValue) as? Int64
 
         isSelfDrivenPushNotificationRegistered = (tokenID != nil) && stores.isAuthenticatedWithoutWPCom
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -541,11 +541,11 @@ private extension DashboardViewModel {
     }
 
     func observeSelfDrivenPushTokenPersistence() {
-        NotificationCenter.default.publisher(for: .selfDrivenPushTokenPersisted)
+        userDefaults.publisher(for: \.wooPushnotificationToken)
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
+            .sink { [weak self] token in
                 guard let self else { return }
-                self.updateSelfDrivenPushRegistrationStatus()
+                updateSelfDrivenPushRegistrationStatus()
             }
             .store(in: &subscriptions)
     }
@@ -811,7 +811,7 @@ private extension DashboardViewModel {
     }
 
     func updateSelfDrivenPushRegistrationStatus() {
-        let tokenID: Int64? = userDefaults.value(forKey: UserDefaults.Key.wooPushnotificationToken.rawValue) as? Int64
+        let tokenID = userDefaults.wooPushnotificationToken
         isSelfDrivenPushNotificationRegistered = (tokenID != nil) && stores.isAuthenticatedWithoutWPCom
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -543,7 +543,7 @@ private extension DashboardViewModel {
     func observeSelfDrivenPushTokenPersistence() {
         userDefaults.publisher(for: \.wooPushnotificationToken)
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] token in
+            .sink { [weak self] _ in
                 guard let self else { return }
                 updateSelfDrivenPushRegistrationStatus()
             }

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -643,7 +643,6 @@ final class PushNotificationsManagerTests: XCTestCase {
     func testRegisterDeviceToken_whenSelfDrivenGateEnabled_registersSelfDrivenToken_andPersistsDeviceID() {
         // Given
         mockSelfDrivenRegistrationActions(token: 123)
-        defaults.set("wpcom-device-id", forKey: .deviceID)
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(99)
 
@@ -677,15 +676,11 @@ final class PushNotificationsManagerTests: XCTestCase {
         // 2) It persists the resulting deviceID
         XCTAssertEqual(defaults.object(forKey: .deviceID), "123")
 
-        // 3) It persists the APNS device token
+        // 3) It clears WPcom token
         XCTAssertFalse(defaults.containsObject(forKey: .deviceToken))
 
-        // 4) It dispatches the app settings persistence action
-        let appSettingsActions = storesManager.receivedActions.compactMap { $0 as? AppSettingsAction }
-        XCTAssertTrue(appSettingsActions.contains(where: {
-            if case .setSelfDrivenPushTokenID = $0 { return true }
-            return false
-        }))
+        // 4) It dispatches the token persistence action
+        XCTAssertTrue(defaults.containsObject(forKey: .wooPushnotificationToken))
     }
 }
 
@@ -742,12 +737,6 @@ private extension PushNotificationsManagerTests {
 
             default:
                 break
-            }
-        }
-
-        storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            if case .setSelfDrivenPushTokenID(_, _, let completion) = action {
-                completion?(.success(()))
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -69,8 +69,6 @@ final class DashboardViewModelTests: XCTestCase {
                 onCompletion(false)
             case let .getPOSSurveyCurrentMerchantNotificationScheduled(onCompletion):
                 onCompletion(false)
-            case let .loadSelfDrivenPushTokenID(_, onCompletion):
-                onCompletion(nil)
             default:
                 break
             }
@@ -965,10 +963,12 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_updateSelfDrivenPushRegistrationStatus_sets_false_when_token_id_is_nil() async {
         // Given
-        mockReloadingData(selfDrivenTokenID: nil)
+        userDefaults.set(Int64?.none, forKey: .wooPushnotificationToken)
+        mockReloadingData()
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,
                                            storageManager: storageManager,
+                                           userDefaults: userDefaults,
                                            blazeEligibilityChecker: blazeEligibilityChecker,
                                            googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
@@ -982,11 +982,13 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_updateSelfDrivenPushRegistrationStatus_sets_true_when_token_id_exists_and_not_wpcom_login() async {
         // Given
-        mockReloadingData(selfDrivenTokenID: 123)
+        userDefaults.set(Int64(123), forKey: .wooPushnotificationToken)
+        mockReloadingData()
         stores.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,
                                            storageManager: storageManager,
+                                           userDefaults: userDefaults,
                                            blazeEligibilityChecker: blazeEligibilityChecker,
                                            googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
@@ -1000,12 +1002,14 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_updateSelfDrivenPushRegistrationStatus_sets_false_when_token_id_exists_and_wpcom_login() async {
         // Given
-        mockReloadingData(selfDrivenTokenID: 123)
+        userDefaults.set(Int64(123), forKey: .wooPushnotificationToken)
+        mockReloadingData()
         stores.authenticate(credentials: SessionSettings.wpcomCredentials)
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,
                                            storageManager: storageManager,
+                                           userDefaults: userDefaults,
                                            blazeEligibilityChecker: blazeEligibilityChecker,
                                            googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
@@ -1024,8 +1028,7 @@ private extension DashboardViewModelTests {
                            existingProducts: [Product] = [],
                            existingBlazeCampaigns: [BlazeCampaignListItem] = [],
                            storedDashboardCards: [DashboardCard] = [],
-                           shouldShowInAppFeedback: Bool = false,
-                           selfDrivenTokenID: Int64? = nil) {
+                           shouldShowInAppFeedback: Bool = false) {
         stores.whenReceivingAction(ofType: JustInTimeMessageAction.self) { action in
             switch action {
             case let .loadMessage(_, _, _, completion):
@@ -1057,8 +1060,6 @@ private extension DashboardViewModelTests {
                 onCompletion(false)
             case let .getPOSSurveyCurrentMerchantNotificationScheduled(onCompletion):
                 onCompletion(false)
-            case let .loadSelfDrivenPushTokenID(_, onCompletion):
-                onCompletion(selfDrivenTokenID)
             default:
                 break
             }


### PR DESCRIPTION
This is a follow-up on #16488 and especially on [this](https://github.com/woocommerce/woocommerce-ios/pull/16488#pullrequestreview-3660724782) comment.

## Description
This PR moves storing the new WooToken from the GeneralStore to UserDefaults. I've also planned to remove the use of the NotificationCenter but I could not get hiding the banner working via subscribing to the UserDefaults change.

## Test Steps

You'll need to spin up a jurassic site, see the steps here p91TBi-dyW-p2#comment-14564 

1. Edit the `selfDrivenPushToken` local FF to be `true`.
1. Login to the new site with the generated user/password
2. Navigate to Menu/Settings/Help & Support/View Application Log
3. Open the latest logs
4. Look for "Self Registering Push Notificaitons success: <ID>"
5. Also note that the jetpack benefits banner should not be presented.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
