### PR TITLE
[POS Refunds] Reason Screen

### DIFF
--- a/Modules/Sources/PointOfSale/Models/POSRefundReviewData.swift
+++ b/Modules/Sources/PointOfSale/Models/POSRefundReviewData.swift
@@ -8,5 +8,5 @@ struct POSRefundReviewData: Equatable {
     let formattedTax: String
     let formattedRefundTotal: String
     let paymentMethodDescription: String
-    let refundReason: String?
+    var refundReason: String?
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -501,11 +501,13 @@ private extension POSOrderDetailsView {
 enum RefundModalState: Identifiable, Equatable {
     case itemSelection
     case review(POSRefundReviewData)
+    case reasonInput(POSRefundReviewData)
 
     var id: String {
         switch self {
         case .itemSelection: return "itemSelection"
         case .review: return "review"
+        case .reasonInput: return "reasonInput"
         }
     }
 }
@@ -539,7 +541,7 @@ private extension POSOrderDetailsView {
                 paymentMethodDescription: reviewData.paymentMethodDescription,
                 refundReason: reviewData.refundReason,
                 onAddReason: {
-                    // TODO: Show reason input modal
+                    refundModalState = .reasonInput(reviewData)
                 },
                 onContinue: {
                     // TODO: Process refund
@@ -547,6 +549,18 @@ private extension POSOrderDetailsView {
                 },
                 onEditRefund: {
                     refundModalState = .itemSelection
+                }
+            )
+        case .reasonInput(let reviewData):
+            POSRefundReasonView(
+                initialReason: reviewData.refundReason,
+                onSave: { reason in
+                    var updatedReviewData = reviewData
+                    updatedReviewData.refundReason = reason
+                    refundModalState = .review(updatedReviewData)
+                },
+                onCancel: {
+                    refundModalState = .review(reviewData)
                 }
             )
         }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -559,8 +559,11 @@ private extension POSOrderDetailsView {
                     updatedReviewData.refundReason = reason
                     refundModalState = .review(updatedReviewData)
                 },
-                onCancel: {
+                onBack: {
                     refundModalState = .review(reviewData)
+                },
+                onClose: {
+                    refundModalState = nil
                 }
             )
         }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReasonView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReasonView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct POSRefundReasonView: View {
-    @Environment(\.posModalParentSize) private var parentSize
     @State private var reasonText: String
     @FocusState private var isTextFieldFocused: Bool
 
@@ -34,11 +33,15 @@ struct POSRefundReasonView: View {
             textFieldView
 
             Spacer()
-
-            buttonSection
         }
-        .frame(width: parentSize.width, height: parentSize.height)
+        .safeAreaInset(edge: .bottom) {
+            buttonSection
+                .padding(.bottom, POSPadding.xLarge)
+                .background(Color.posSurfaceBright)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.posSurfaceBright)
+        .posModalFullScreen()
         .onAppear {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 isTextFieldFocused = true
@@ -102,7 +105,7 @@ private extension POSRefundReasonView {
         })
         .buttonStyle(POSFilledButtonStyle(size: .normal))
         .disabled(!isAddButtonEnabled)
-        .padding(POSPadding.xLarge)
+        .padding(.horizontal, POSPadding.xLarge)
     }
 }
 
@@ -160,7 +163,7 @@ private extension POSRefundReasonView {
         onBack: {},
         onClose: {}
     )
-    .environment(\.posModalParentSize, CGSize(width: 1192, height: 822))
+    .environmentObject(POSModalManager())
 }
 
 #Preview("POSRefundReasonView - With Existing Reason") {
@@ -170,6 +173,6 @@ private extension POSRefundReasonView {
         onBack: {},
         onClose: {}
     )
-    .environment(\.posModalParentSize, CGSize(width: 1192, height: 822))
+    .environmentObject(POSModalManager())
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReasonView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReasonView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct POSRefundReasonView: View {
+    @Environment(\.posModalParentSize) private var parentSize
     @State private var reasonText: String
     @FocusState private var isTextFieldFocused: Bool
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReasonView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReasonView.swift
@@ -7,15 +7,18 @@ struct POSRefundReasonView: View {
 
     private let initialReason: String?
     private let onSave: (String) -> Void
-    private let onCancel: () -> Void
+    private let onBack: () -> Void
+    private let onClose: () -> Void
 
     init(initialReason: String?,
          onSave: @escaping (String) -> Void,
-         onCancel: @escaping () -> Void) {
+         onBack: @escaping () -> Void,
+         onClose: @escaping () -> Void) {
         self._reasonText = State(initialValue: initialReason ?? "")
         self.initialReason = initialReason
         self.onSave = onSave
-        self.onCancel = onCancel
+        self.onBack = onBack
+        self.onClose = onClose
     }
 
     private var isAddButtonEnabled: Bool {
@@ -34,7 +37,8 @@ struct POSRefundReasonView: View {
 
             buttonSection
         }
-        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding * 2))
+        .frame(width: parentSize.width, height: parentSize.height)
+        .background(Color.posSurfaceBright)
         .onAppear {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 isTextFieldFocused = true
@@ -49,7 +53,7 @@ private extension POSRefundReasonView {
     var headerView: some View {
         HStack(spacing: POSSpacing.medium) {
             Button {
-                onCancel()
+                onBack()
             } label: {
                 Text(Image(systemName: "chevron.backward"))
                     .font(.posButtonSymbolLarge)
@@ -64,7 +68,7 @@ private extension POSRefundReasonView {
             Spacer()
 
             Button {
-                onCancel()
+                onClose()
             } label: {
                 Text(Image(systemName: "xmark"))
                     .font(.posButtonSymbolLarge)
@@ -153,7 +157,8 @@ private extension POSRefundReasonView {
     POSRefundReasonView(
         initialReason: nil,
         onSave: { _ in },
-        onCancel: {}
+        onBack: {},
+        onClose: {}
     )
     .environment(\.posModalParentSize, CGSize(width: 1192, height: 822))
 }
@@ -162,7 +167,8 @@ private extension POSRefundReasonView {
     POSRefundReasonView(
         initialReason: "Customer not happy with the order.",
         onSave: { _ in },
-        onCancel: {}
+        onBack: {},
+        onClose: {}
     )
     .environment(\.posModalParentSize, CGSize(width: 1192, height: 822))
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReasonView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReasonView.swift
@@ -44,9 +44,7 @@ struct POSRefundReasonView: View {
         .background(Color.posSurfaceBright)
         .posModalFullScreen()
         .onAppear {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                isTextFieldFocused = true
-            }
+            isTextFieldFocused = true
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReasonView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReasonView.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+
+struct POSRefundReasonView: View {
+    @Environment(\.posModalParentSize) private var parentSize
+    @State private var reasonText: String
+    @FocusState private var isTextFieldFocused: Bool
+
+    private let initialReason: String?
+    private let onSave: (String) -> Void
+    private let onCancel: () -> Void
+
+    init(initialReason: String?,
+         onSave: @escaping (String) -> Void,
+         onCancel: @escaping () -> Void) {
+        self._reasonText = State(initialValue: initialReason ?? "")
+        self.initialReason = initialReason
+        self.onSave = onSave
+        self.onCancel = onCancel
+    }
+
+    private var isAddButtonEnabled: Bool {
+        !reasonText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        VStack(spacing: POSSpacing.none) {
+            headerView
+
+            Spacer()
+
+            textFieldView
+
+            Spacer()
+
+            buttonSection
+        }
+        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding * 2))
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                isTextFieldFocused = true
+            }
+        }
+    }
+}
+
+// MARK: - Subviews
+
+private extension POSRefundReasonView {
+    var headerView: some View {
+        HStack(spacing: POSSpacing.medium) {
+            Button {
+                onCancel()
+            } label: {
+                Text(Image(systemName: "chevron.backward"))
+                    .font(.posButtonSymbolLarge)
+            }
+            .accessibilityLabel(Localization.backButtonAccessibilityLabel)
+
+            Text(Localization.title)
+                .font(.posHeadingBold)
+                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                .lineLimit(1)
+
+            Spacer()
+
+            Button {
+                onCancel()
+            } label: {
+                Text(Image(systemName: "xmark"))
+                    .font(.posButtonSymbolLarge)
+            }
+            .accessibilityLabel(Localization.closeButtonAccessibilityLabel)
+        }
+        .foregroundColor(Color.posOnSurface)
+        .padding(POSPadding.xLarge)
+    }
+
+    var textFieldView: some View {
+        TextField("",
+                  text: $reasonText,
+                  prompt: Text(Localization.placeholder).foregroundColor(.posOnSurfaceVariantLowest))
+            .foregroundStyle(Color.posOnSurface)
+            .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+            .multilineTextAlignment(.center)
+            .font(POSFontStyle.posHeadingRegular)
+            .focused($isTextFieldFocused)
+            .onSubmit {
+                saveReasonIfValid()
+            }
+            .padding(.horizontal, POSPadding.xLarge)
+    }
+
+    var buttonSection: some View {
+        Button(action: {
+            saveReasonIfValid()
+        }, label: {
+            Text(Localization.addButton)
+        })
+        .buttonStyle(POSFilledButtonStyle(size: .normal))
+        .disabled(!isAddButtonEnabled)
+        .padding(POSPadding.xLarge)
+    }
+}
+
+// MARK: - Private Methods
+
+private extension POSRefundReasonView {
+    func saveReasonIfValid() {
+        let trimmedReason = reasonText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedReason.isEmpty else { return }
+        onSave(trimmedReason)
+    }
+}
+
+// MARK: - Localization
+
+private extension POSRefundReasonView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pos.refundReasonView.title",
+            value: "Refund reason",
+            comment: "Title for the refund reason input screen"
+        )
+
+        static let backButtonAccessibilityLabel = NSLocalizedString(
+            "pos.refundReasonView.backButton.accessibilityLabel",
+            value: "Back",
+            comment: "Accessibility label for back button on refund reason screen"
+        )
+
+        static let closeButtonAccessibilityLabel = NSLocalizedString(
+            "pos.refundReasonView.closeButton.accessibilityLabel",
+            value: "Close",
+            comment: "Accessibility label for close button on refund reason screen"
+        )
+
+        static let placeholder = NSLocalizedString(
+            "pos.refundReasonView.placeholder",
+            value: "Reason for refunding order",
+            comment: "Placeholder text for the refund reason text field"
+        )
+
+        static let addButton = NSLocalizedString(
+            "pos.refundReasonView.addButton",
+            value: "Add",
+            comment: "Button to add the refund reason"
+        )
+    }
+}
+
+#if DEBUG
+#Preview("POSRefundReasonView - Empty") {
+    POSRefundReasonView(
+        initialReason: nil,
+        onSave: { _ in },
+        onCancel: {}
+    )
+    .environment(\.posModalParentSize, CGSize(width: 1192, height: 822))
+}
+
+#Preview("POSRefundReasonView - With Existing Reason") {
+    POSRefundReasonView(
+        initialReason: "Customer not happy with the order.",
+        onSave: { _ in },
+        onCancel: {}
+    )
+    .environment(\.posModalParentSize, CGSize(width: 1192, height: 822))
+}
+#endif

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
@@ -103,11 +103,11 @@ private extension POSRefundReviewView {
                     .foregroundColor(.posOnSurface)
                 Spacer()
                 Button(action: onAddReason) {
-                    Text(Localization.addReasonButton)
+                    Text(refundReason != nil ? Localization.editReasonButton : Localization.addReasonButton)
                         .font(.posBodyMediumRegular(underline: true))
                         .foregroundColor(.posPrimary)
                 }
-                .accessibilityLabel(Localization.addReasonAccessibilityLabel)
+                .accessibilityLabel(refundReason != nil ? Localization.editReasonAccessibilityLabel : Localization.addReasonAccessibilityLabel)
             }
             Text(refundReason ?? Localization.reasonPlaceholder)
                 .font(.posBodyMediumRegular())
@@ -185,10 +185,22 @@ private extension POSRefundReviewView {
             comment: "Button to add a reason for the refund"
         )
 
+        static let editReasonButton = NSLocalizedString(
+            "pos.refundReviewView.editReasonButton",
+            value: "Edit reason",
+            comment: "Button to edit an existing refund reason"
+        )
+
         static let addReasonAccessibilityLabel = NSLocalizedString(
             "pos.refundReviewView.addReason.accessibilityLabel",
             value: "Add refund reason",
             comment: "Accessibility label for add reason button in refund review"
+        )
+
+        static let editReasonAccessibilityLabel = NSLocalizedString(
+            "pos.refundReviewView.editReason.accessibilityLabel",
+            value: "Edit refund reason",
+            comment: "Accessibility label for edit reason button in refund review"
         )
 
         static let reasonPlaceholder = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalManager.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalManager.swift
@@ -3,6 +3,7 @@ import SwiftUI
 class POSModalManager: ObservableObject {
     @Published private(set) var isPresented: Bool = false
     @Published private(set) var allowsInteractiveDismissal: Bool = true
+    @Published private(set) var isFullScreen: Bool = false
     private var contentBuilder: (() -> AnyView)?
     private var onDismiss: (() -> Void)?
 
@@ -26,6 +27,10 @@ class POSModalManager: ObservableObject {
         allowsInteractiveDismissal = allowed
     }
 
+    func setFullScreen(_ fullScreen: Bool) {
+        isFullScreen = fullScreen
+    }
+
     func onDisappear() {
         reset()
     }
@@ -33,6 +38,7 @@ class POSModalManager: ObservableObject {
     private func reset() {
         onDismiss = nil
         allowsInteractiveDismissal = true
+        isFullScreen = false
         contentBuilder = nil
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -33,7 +33,7 @@ struct POSRootModalViewModifier: ViewModifier {
                             .cornerRadius(modalManager.isFullScreen ? 0 : POSCornerRadiusStyle.extraLarge.value)
                             .posShadow(modalManager.isFullScreen ? .none : .large,
                                        cornerRadius: modalManager.isFullScreen ? 0 : POSCornerRadiusStyle.extraLarge.value)
-                            .padding(modalManager.isFullScreen ? 0 : 16)
+                            .padding(modalManager.isFullScreen ? POSPadding.none : POSPadding.medium)
                             .ignoresSafeArea(.container, edges: modalManager.isFullScreen ? .all : [])
                     }
                     .zIndex(1)

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -30,9 +30,11 @@ struct POSRootModalViewModifier: ViewModifier {
                         modalManager.getContent()
                             .environment(\.posModalParentSize, modalParentSize)
                             .background(Color.posSurfaceBright)
-                            .cornerRadius(POSCornerRadiusStyle.extraLarge.value)
-                            .posShadow(.large, cornerRadius: POSCornerRadiusStyle.extraLarge.value)
-                            .padding()
+                            .cornerRadius(modalManager.isFullScreen ? 0 : POSCornerRadiusStyle.extraLarge.value)
+                            .posShadow(modalManager.isFullScreen ? .none : .large,
+                                       cornerRadius: modalManager.isFullScreen ? 0 : POSCornerRadiusStyle.extraLarge.value)
+                            .padding(modalManager.isFullScreen ? 0 : 16)
+                            .ignoresSafeArea(.container, edges: modalManager.isFullScreen ? .all : [])
                     }
                     .zIndex(1)
                     // Scale the modal container in and out, fading appropriately.
@@ -194,6 +196,32 @@ extension View {
     /// Prevents a POS Modal from being dismissed by tapping on the background.
     func posInteractiveDismissDisabled(_ disabled: Bool = true) -> some View {
         self.modifier(POSInteractiveDismissModifier(disabled: disabled))
+    }
+}
+
+struct POSModalFullScreenModifier: ViewModifier {
+    @EnvironmentObject var modalManager: POSModalManager
+
+    let enabled: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: enabled) { _, newValue in
+                modalManager.setFullScreen(newValue)
+            }
+            .onAppear {
+                modalManager.setFullScreen(enabled)
+            }
+            .onDisappear {
+                modalManager.setFullScreen(false)
+            }
+    }
+}
+
+extension View {
+    /// Presents the POS Modal in full-screen mode, covering the entire screen including the status bar.
+    func posModalFullScreen(_ enabled: Bool = true) -> some View {
+        self.modifier(POSModalFullScreenModifier(enabled: enabled))
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -219,7 +219,6 @@ struct POSModalFullScreenModifier: ViewModifier {
 }
 
 extension View {
-    /// Presents the POS Modal in full-screen mode, covering the entire screen including the status bar.
     func posModalFullScreen(_ enabled: Bool = true) -> some View {
         self.modifier(POSModalFullScreenModifier(enabled: enabled))
     }

--- a/Modules/Sources/PointOfSale/Utils/POSShadowStyle.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSShadowStyle.swift
@@ -5,6 +5,7 @@ import UIKit
 /// Defines shadow styles used across POS UI components.
 /// Design ref: 1qcjzXitBHU7xPnpCOWnNM-fi-22_7198
 enum POSShadowStyle {
+    case none
     case medium
     case large
 }
@@ -40,6 +41,8 @@ struct POSShadowStyleModifier: ViewModifier {
 
     private func shadowLayers(for style: POSShadowStyle) -> [POSShadowLayer] {
         switch style {
+        case .none:
+            return []
         case .medium:
             return [
                 POSShadowLayer(color: UIColor(Color.posShadow), opacity: 0.02, radius: 16, offset: CGSize(width: 0, height: 16)),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
Part of WOOMOB-1786

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement the reason screen to the refunds flow. User can add the reason, edit, go back, or close all the flow.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Go to POS
2. Go to Orders
3. Tap on Issue Refund
4. Select items to refund
5. On the review screen, tap on Add Reason
6. Add a reason and tap add. See that the reason is shown in the Review Screen. 
7. Tap Edit
8. Edit the reason and tap Add. 
9. See that the reason is edited in the Review Screen
10. Verify also that the back and X button do what's expected

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/02ff6af9-9d1b-40d7-bb88-bbe0b7c36e6e




---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
