### PR TITLE
Adding debug view to override feature flags

### DIFF
--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -1,6 +1,6 @@
 /// FeatureFlag exposes a series of features to be conditionally enabled on different builds.
 ///
-public enum FeatureFlag: Int {
+public enum FeatureFlag: Int, CaseIterable {
 
     /// Throwaway case, to prevent a compiler error:
     /// `An enum with no cases cannot declare a raw type`

--- a/Modules/Sources/Experiments/FeatureFlagOverrideStore.swift
+++ b/Modules/Sources/Experiments/FeatureFlagOverrideStore.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+public protocol FeatureFlagOverrideStore {
+    /// `nil` means "no override", caller should fall back to defaults.
+    func overrideValue(for featureFlag: FeatureFlag) -> Bool?
+
+    /// Pass `nil` to clear the override for that flag.
+    func setOverrideValue(_ value: Bool?, for featureFlag: FeatureFlag)
+
+    func removeAllOverrides()
+}
+
+public final class UserDefaultsFeatureFlagOverrideStore: FeatureFlagOverrideStore {
+    private let userDefaults: UserDefaults
+    private let keyPrefix: String
+    private let lock = NSLock()
+
+    public init(
+        userDefaults: UserDefaults = .standard,
+        keyPrefix: String = "com.woocommerce.featureflag.override."
+    ) {
+        self.userDefaults = userDefaults
+        self.keyPrefix = keyPrefix
+    }
+
+    public func overrideValue(for featureFlag: FeatureFlag) -> Bool? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let key = storageKey(for: featureFlag)
+        guard userDefaults.object(forKey: key) != nil else {
+            return nil
+        }
+        return userDefaults.bool(forKey: key)
+    }
+
+    public func setOverrideValue(_ value: Bool?, for featureFlag: FeatureFlag) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let key = storageKey(for: featureFlag)
+        if let value {
+            userDefaults.set(value, forKey: key)
+        } else {
+            userDefaults.removeObject(forKey: key)
+        }
+    }
+
+    public func removeAllOverrides() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let keys = userDefaults.dictionaryRepresentation().keys
+        for key in keys where key.hasPrefix(keyPrefix) {
+            userDefaults.removeObject(forKey: key)
+        }
+    }
+
+    private func storageKey(for featureFlag: FeatureFlag) -> String {
+        // Use case name (stable even if rawValues shift when adding cases).
+        keyPrefix + String(describing: featureFlag)
+    }
+}

--- a/Modules/Sources/Experiments/FeatureFlagOverrideStore.swift
+++ b/Modules/Sources/Experiments/FeatureFlagOverrideStore.swift
@@ -13,7 +13,7 @@ public protocol FeatureFlagOverrideStore {
 public final class UserDefaultsFeatureFlagOverrideStore: FeatureFlagOverrideStore {
     private let userDefaults: UserDefaults
     private let keyPrefix: String
-    private let lock = NSLock()
+    private let queue = DispatchQueue(label: "com.woocommerce.featureflag.override-store")
 
     public init(
         userDefaults: UserDefaults = .standard,
@@ -24,40 +24,36 @@ public final class UserDefaultsFeatureFlagOverrideStore: FeatureFlagOverrideStor
     }
 
     public func overrideValue(for featureFlag: FeatureFlag) -> Bool? {
-        lock.lock()
-        defer { lock.unlock() }
-
-        let key = storageKey(for: featureFlag)
-        guard userDefaults.object(forKey: key) != nil else {
-            return nil
+        queue.sync {
+            let key = storageKey(for: featureFlag)
+            guard userDefaults.object(forKey: key) != nil else {
+                return nil
+            }
+            return userDefaults.bool(forKey: key)
         }
-        return userDefaults.bool(forKey: key)
     }
 
     public func setOverrideValue(_ value: Bool?, for featureFlag: FeatureFlag) {
-        lock.lock()
-        defer { lock.unlock() }
-
-        let key = storageKey(for: featureFlag)
-        if let value {
-            userDefaults.set(value, forKey: key)
-        } else {
-            userDefaults.removeObject(forKey: key)
+        queue.sync {
+            let key = storageKey(for: featureFlag)
+            if let value {
+                userDefaults.set(value, forKey: key)
+            } else {
+                userDefaults.removeObject(forKey: key)
+            }
         }
     }
 
     public func removeAllOverrides() {
-        lock.lock()
-        defer { lock.unlock() }
-
-        let keys = userDefaults.dictionaryRepresentation().keys
-        for key in keys where key.hasPrefix(keyPrefix) {
-            userDefaults.removeObject(forKey: key)
+        queue.sync {
+            let keys = userDefaults.dictionaryRepresentation().keys
+            for key in keys where key.hasPrefix(keyPrefix) {
+                userDefaults.removeObject(forKey: key)
+            }
         }
     }
 
     private func storageKey(for featureFlag: FeatureFlag) -> String {
-        // Use case name (stable even if rawValues shift when adding cases).
         keyPrefix + String(describing: featureFlag)
     }
 }

--- a/Modules/Sources/Experiments/OverridableFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/OverridableFeatureFlagService.swift
@@ -1,0 +1,21 @@
+import WooFoundationCore
+
+public struct OverridableFeatureFlagService: FeatureFlagService {
+    private let base: FeatureFlagService
+    private let overrides: FeatureFlagOverrideStore
+
+    public init(base: FeatureFlagService, overrides: FeatureFlagOverrideStore) {
+        self.base = base
+        self.overrides = overrides
+    }
+
+    public func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
+        let buildConfig = BuildConfiguration.current
+        if buildConfig == .localDeveloper || buildConfig == .alpha,
+            let override = overrides.overrideValue(for: featureFlag) {
+            return override
+        }
+
+        return base.isFeatureFlagEnabled(featureFlag)
+    }
+}

--- a/Modules/Sources/Experiments/OverridableFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/OverridableFeatureFlagService.swift
@@ -10,6 +10,8 @@ public struct OverridableFeatureFlagService: FeatureFlagService {
     }
 
     public func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
+        // This is just double proofing ourself not to use the
+        // override values in prod.
         let buildConfig = BuildConfiguration.current
         if buildConfig == .localDeveloper || buildConfig == .alpha,
             let override = overrides.overrideValue(for: featureFlag) {

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -27,9 +27,15 @@ final class ServiceLocator {
 
     private static var _ciabEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker()
 
+    private static var _featureFlagOverrideStore: FeatureFlagOverrideStore = UserDefaultsFeatureFlagOverrideStore()
+
     /// FeatureFlagService
     ///
-    private static var _featureFlagService: FeatureFlagService = DefaultFeatureFlagService()
+    private static var _featureFlagService: FeatureFlagService =
+        OverridableFeatureFlagService(
+            base: DefaultFeatureFlagService(),
+            overrides: _featureFlagOverrideStore
+        )
 
     /// ImageService
     ///
@@ -125,6 +131,11 @@ final class ServiceLocator {
     static var analytics: Analytics {
         return _analytics
     }
+
+    static var featureFlagOverrideStore: FeatureFlagOverrideStore {
+        return _featureFlagOverrideStore
+    }
+
 
     /// Provides the access point to the feature flag service.
     /// - Returns: An implementation of the FeatureFlagService protocol. It defaults to DefaultFeatureFlagService

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -31,11 +31,16 @@ final class ServiceLocator {
 
     /// FeatureFlagService
     ///
-    private static var _featureFlagService: FeatureFlagService =
-        OverridableFeatureFlagService(
-            base: DefaultFeatureFlagService(),
-            overrides: _featureFlagOverrideStore
-        )
+    private static var _featureFlagService: FeatureFlagService = {
+        if BuildConfiguration.current == .appStore {
+            return DefaultFeatureFlagService()
+        } else {
+            return OverridableFeatureFlagService(
+                base: DefaultFeatureFlagService(),
+                overrides: _featureFlagOverrideStore
+            )
+        }
+    }()
 
     /// ImageService
     ///
@@ -132,13 +137,14 @@ final class ServiceLocator {
         return _analytics
     }
 
+    /// Provides the access point to the store for overriding FFs.
+    /// - Returns: An implementation of the FeatureFlagOverrideStore protocol. It defaults to UserDefaultsFeatureFlagOverrideStore
     static var featureFlagOverrideStore: FeatureFlagOverrideStore {
         return _featureFlagOverrideStore
     }
 
-
     /// Provides the access point to the feature flag service.
-    /// - Returns: An implementation of the FeatureFlagService protocol. It defaults to DefaultFeatureFlagService
+    /// - Returns: An implementation of the FeatureFlagService protocol. It defaults to OverridableFeatureFlagService
     static var featureFlagService: FeatureFlagService {
         return _featureFlagService
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/OverrideFeatureFlagsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/OverrideFeatureFlagsView.swift
@@ -4,6 +4,7 @@ import Experiments
 struct OverrideFeatureFlagsView: View {
     @State private var refreshID = UUID()
     @State private var searchText = ""
+    private let defaultFeatureFlagService = DefaultFeatureFlagService()
 
     private var filteredFeatureFlags: [FeatureFlag] {
         let allFlags = FeatureFlag.allCases
@@ -18,9 +19,13 @@ struct OverrideFeatureFlagsView: View {
     var body: some View {
         List {
             ForEach(filteredFeatureFlags, id: \.self) { flag in
-                FeatureFlagRow(featureFlag: flag)
+                FeatureFlagRow(
+                    featureFlag: flag,
+                    defaultFeatureFlagService: defaultFeatureFlagService
+                )
             }
         }
+        .contentMargins(20)
         .id(refreshID)
         .searchable(text: $searchText, prompt: "Search feature flags")
         .toolbar {
@@ -43,11 +48,19 @@ struct OverrideFeatureFlagsView: View {
 
 fileprivate struct FeatureFlagRow: View {
     let featureFlag: FeatureFlag
+    private let defaultFeatureFlagService: DefaultFeatureFlagService
+
+    init(featureFlag: FeatureFlag,
+         defaultFeatureFlagService: DefaultFeatureFlagService) {
+        self.featureFlag = featureFlag
+        self.defaultFeatureFlagService = defaultFeatureFlagService
+        _overrideValue = State(initialValue: ServiceLocator.featureFlagOverrideStore.overrideValue(for: featureFlag))
+    }
 
     @State private var overrideValue: Bool?
 
     private var defaultValue: Bool {
-        DefaultFeatureFlagService().isFeatureFlagEnabled(featureFlag)
+        defaultFeatureFlagService.isFeatureFlagEnabled(featureFlag)
     }
 
     private var effectiveValue: Bool {
@@ -56,11 +69,6 @@ fileprivate struct FeatureFlagRow: View {
 
     private var isOverridden: Bool {
         overrideValue != nil
-    }
-
-    init(featureFlag: FeatureFlag) {
-        self.featureFlag = featureFlag
-        _overrideValue = State(initialValue: ServiceLocator.featureFlagOverrideStore.overrideValue(for: featureFlag))
     }
 
     var body: some View {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/OverrideFeatureFlagsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/OverrideFeatureFlagsView.swift
@@ -44,7 +44,6 @@ struct OverrideFeatureFlagsView: View {
 fileprivate struct FeatureFlagRow: View {
     let featureFlag: FeatureFlag
 
-    // Keep local state so the row updates immediately when you toggle/reset.
     @State private var overrideValue: Bool?
 
     private var defaultValue: Bool {
@@ -61,112 +60,54 @@ fileprivate struct FeatureFlagRow: View {
 
     init(featureFlag: FeatureFlag) {
         self.featureFlag = featureFlag
-        // Load the persisted override once for initial rendering.
         _overrideValue = State(initialValue: ServiceLocator.featureFlagOverrideStore.overrideValue(for: featureFlag))
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text(featureFlag.title)
-                    .font(.body)
-
-                Spacer()
-
-                Toggle(isOn: Binding(
-                    get: { effectiveValue },
-                    set: { newValue in
-                        // If the user selects the default value, keep things clean and clear the override.
-                        if newValue == defaultValue {
-                            overrideValue = nil
-                            ServiceLocator.featureFlagOverrideStore.setOverrideValue(nil, for: featureFlag)
-                        } else {
-                            overrideValue = newValue
-                            ServiceLocator.featureFlagOverrideStore.setOverrideValue(newValue, for: featureFlag)
-                        }
-                    }
-                )) {
+        HStack {
+            VStack(alignment: .leading) {
+                HStack {
+                    Text(featureFlag.title)
+                        .font(.body)
                 }
-            }
 
-            HStack(spacing: 12) {
                 Text("Default: \(defaultValue ? "Enabled" : "Disabled")")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                Spacer()
-
                 if isOverridden {
                     Button("Reset") {
-                        overrideValue = nil
-                        ServiceLocator.featureFlagOverrideStore.setOverrideValue(nil, for: featureFlag)
+                        resetValue()
                     }
                     .disabled(!isOverridden)
                     .font(.caption)
                 }
             }
+
+            Spacer()
+
+            Toggle(isOn: Binding(
+                get: { effectiveValue },
+                set: { newValue in
+                    if newValue == defaultValue {
+                        resetValue()
+                    } else {
+                        overrideValue = newValue
+                        ServiceLocator.featureFlagOverrideStore.setOverrideValue(newValue, for: featureFlag)
+                    }
+                }
+            )) { EmptyView() }
         }
-        .padding(.vertical, 4)
+    }
+
+    private func resetValue() {
+            overrideValue = nil
+            ServiceLocator.featureFlagOverrideStore.setOverrideValue(nil, for: featureFlag)
     }
 }
 
-extension FeatureFlag {
-
+fileprivate extension FeatureFlag {
     var title: String {
-        switch self {
-        case .null: "null"
-        case .barcodeScanner: "barcodeScanner"
-        case .reviews: "reviews"
-        case .inbox: "inbox"
-        case .showInboxCTA: "showInboxCTA"
-        case .updateOrderOptimistically: "updateOrderOptimistically"
-        case .shippingLabelsOnboardingM1: "shippingLabelsOnboardingM1"
-        case .searchProductsBySKU: "searchProductsBySKU"
-        case .tapToPayOnIPhone: "tapToPayOnIPhone"
-        case .performanceMonitoring: "performanceMonitoring"
-        case .performanceMonitoringCoreData: "performanceMonitoringCoreData"
-        case .performanceMonitoringFileIO: "performanceMonitoringFileIO"
-        case .performanceMonitoringNetworking: "performanceMonitoringNetworking"
-        case .performanceMonitoringUserInteraction: "performanceMonitoringUserInteraction"
-        case .performanceMonitoringViewController: "performanceMonitoringViewController"
-        case .supportRequests: "supportRequests"
-        case .jetpackSetupWithApplicationPassword: "jetpackSetupWithApplicationPassword"
-        case .addProductToOrderViaSKUScanner: "addProductToOrderViaSKUScanner"
-        case .manualErrorHandlingForSiteCredentialLogin: "manualErrorHandlingForSiteCredentialLogin"
-        case .euShippingNotification: "euShippingNotification"
-        case .betterCustomerSelectionInOrder: "betterCustomerSelectionInOrder"
-        case .hazmatShipping: "hazmatShipping"
-        case .giftCardInOrderForm: "giftCardInOrderForm"
-        case .productBundlesInOrderForm: "productBundlesInOrderForm"
-        case .customLoginUIForAccountCreation: "customLoginUIForAccountCreation"
-        case .scanToUpdateInventory: "scanToUpdateInventory"
-        case .splitViewInProductsTab: "splitViewInProductsTab"
-        case .subscriptionsInOrderCreationUI: "subscriptionsInOrderCreationUI"
-        case .subscriptionsInOrderCreationCustomers: "subscriptionsInOrderCreationCustomers"
-        case .pointOfSale: "pointOfSale"
-        case .googleAdsCampaignCreationOnWebView: "googleAdsCampaignCreationOnWebView"
-        case .blazeEvergreenCampaigns: "blazeEvergreenCampaigns"
-        case .revampedShippingLabelCreation: "revampedShippingLabelCreation"
-        case .blazeCampaignObjective: "blazeCampaignObjective"
-        case .hideSitesInStorePicker: "hideSitesInStorePicker"
-        case .filterHistoryOnOrderAndProductLists: "filterHistoryOnOrderAndProductLists"
-        case .backgroundProductImageUpload: "backgroundProductImageUpload"
-        case .notificationSettings: "notificationSettings"
-        case .allowMerchantAIAPIKey: "allowMerchantAIAPIKey"
-        case .productImageOptimizedHandling: "productImageOptimizedHandling"
-        case .inventoryProductLabelsInPOS: "inventoryProductLabelsInPOS"
-        case .pointOfSaleOrdersi1: "pointOfSaleOrdersi1"
-        case .pointOfSaleOrdersi2: "pointOfSaleOrdersi2"
-        case .orderAddressMapSearch: "orderAddressMapSearch"
-        case .pointOfSaleHistoricalOrdersi1: "pointOfSaleHistoricalOrdersi1"
-        case .pointOfSaleLocalCatalogi1: "pointOfSaleLocalCatalogi1"
-        case .ciabBookings: "ciabBookings"
-        case .ciab: "ciab"
-        case .pointOfSaleSurveys: "pointOfSaleSurveys"
-        case .pointOfSaleCatalogAPI: "pointOfSaleCatalogAPI"
-        case .pointOfSaleRefundsi1: "pointOfSaleRefundsi1"
-        case .selfDrivenPushToken: "selfDrivenPushToken"
-        case .pointOfSaleOnlyProducts: "pointOfSaleOnlyProducts"
-        }
+        return String(describing: self)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/OverrideFeatureFlagsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/OverrideFeatureFlagsView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+import Experiments
+
+struct OverrideFeatureFlagsView: View {
+    @State private var refreshID = UUID()
+    @State private var searchText = ""
+
+    private var filteredFeatureFlags: [FeatureFlag] {
+        let allFlags = FeatureFlag.allCases
+        guard !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return allFlags
+        }
+
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return allFlags.filter { $0.title.lowercased().contains(query) }
+    }
+
+    var body: some View {
+        List {
+            ForEach(filteredFeatureFlags, id: \.self) { flag in
+                FeatureFlagRow(featureFlag: flag)
+            }
+        }
+        .id(refreshID)
+        .searchable(text: $searchText, prompt: "Search feature flags")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    ServiceLocator.featureFlagOverrideStore.removeAllOverrides()
+                    refreshID = UUID()
+                } label: {
+                    Text("Reset All")
+                }
+            }
+        }
+        .navigationTitle("Override Feature Flags")
+    }
+}
+
+#Preview {
+    OverrideFeatureFlagsView()
+}
+
+fileprivate struct FeatureFlagRow: View {
+    let featureFlag: FeatureFlag
+
+    // Keep local state so the row updates immediately when you toggle/reset.
+    @State private var overrideValue: Bool?
+
+    private var defaultValue: Bool {
+        DefaultFeatureFlagService().isFeatureFlagEnabled(featureFlag)
+    }
+
+    private var effectiveValue: Bool {
+        overrideValue ?? defaultValue
+    }
+
+    private var isOverridden: Bool {
+        overrideValue != nil
+    }
+
+    init(featureFlag: FeatureFlag) {
+        self.featureFlag = featureFlag
+        // Load the persisted override once for initial rendering.
+        _overrideValue = State(initialValue: ServiceLocator.featureFlagOverrideStore.overrideValue(for: featureFlag))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(featureFlag.title)
+                    .font(.body)
+
+                Spacer()
+
+                Toggle(isOn: Binding(
+                    get: { effectiveValue },
+                    set: { newValue in
+                        // If the user selects the default value, keep things clean and clear the override.
+                        if newValue == defaultValue {
+                            overrideValue = nil
+                            ServiceLocator.featureFlagOverrideStore.setOverrideValue(nil, for: featureFlag)
+                        } else {
+                            overrideValue = newValue
+                            ServiceLocator.featureFlagOverrideStore.setOverrideValue(newValue, for: featureFlag)
+                        }
+                    }
+                )) {
+                }
+            }
+
+            HStack(spacing: 12) {
+                Text("Default: \(defaultValue ? "Enabled" : "Disabled")")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                if isOverridden {
+                    Button("Reset") {
+                        overrideValue = nil
+                        ServiceLocator.featureFlagOverrideStore.setOverrideValue(nil, for: featureFlag)
+                    }
+                    .disabled(!isOverridden)
+                    .font(.caption)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+extension FeatureFlag {
+
+    var title: String {
+        switch self {
+        case .null: "null"
+        case .barcodeScanner: "barcodeScanner"
+        case .reviews: "reviews"
+        case .inbox: "inbox"
+        case .showInboxCTA: "showInboxCTA"
+        case .updateOrderOptimistically: "updateOrderOptimistically"
+        case .shippingLabelsOnboardingM1: "shippingLabelsOnboardingM1"
+        case .searchProductsBySKU: "searchProductsBySKU"
+        case .tapToPayOnIPhone: "tapToPayOnIPhone"
+        case .performanceMonitoring: "performanceMonitoring"
+        case .performanceMonitoringCoreData: "performanceMonitoringCoreData"
+        case .performanceMonitoringFileIO: "performanceMonitoringFileIO"
+        case .performanceMonitoringNetworking: "performanceMonitoringNetworking"
+        case .performanceMonitoringUserInteraction: "performanceMonitoringUserInteraction"
+        case .performanceMonitoringViewController: "performanceMonitoringViewController"
+        case .supportRequests: "supportRequests"
+        case .jetpackSetupWithApplicationPassword: "jetpackSetupWithApplicationPassword"
+        case .addProductToOrderViaSKUScanner: "addProductToOrderViaSKUScanner"
+        case .manualErrorHandlingForSiteCredentialLogin: "manualErrorHandlingForSiteCredentialLogin"
+        case .euShippingNotification: "euShippingNotification"
+        case .betterCustomerSelectionInOrder: "betterCustomerSelectionInOrder"
+        case .hazmatShipping: "hazmatShipping"
+        case .giftCardInOrderForm: "giftCardInOrderForm"
+        case .productBundlesInOrderForm: "productBundlesInOrderForm"
+        case .customLoginUIForAccountCreation: "customLoginUIForAccountCreation"
+        case .scanToUpdateInventory: "scanToUpdateInventory"
+        case .splitViewInProductsTab: "splitViewInProductsTab"
+        case .subscriptionsInOrderCreationUI: "subscriptionsInOrderCreationUI"
+        case .subscriptionsInOrderCreationCustomers: "subscriptionsInOrderCreationCustomers"
+        case .pointOfSale: "pointOfSale"
+        case .googleAdsCampaignCreationOnWebView: "googleAdsCampaignCreationOnWebView"
+        case .blazeEvergreenCampaigns: "blazeEvergreenCampaigns"
+        case .revampedShippingLabelCreation: "revampedShippingLabelCreation"
+        case .blazeCampaignObjective: "blazeCampaignObjective"
+        case .hideSitesInStorePicker: "hideSitesInStorePicker"
+        case .filterHistoryOnOrderAndProductLists: "filterHistoryOnOrderAndProductLists"
+        case .backgroundProductImageUpload: "backgroundProductImageUpload"
+        case .notificationSettings: "notificationSettings"
+        case .allowMerchantAIAPIKey: "allowMerchantAIAPIKey"
+        case .productImageOptimizedHandling: "productImageOptimizedHandling"
+        case .inventoryProductLabelsInPOS: "inventoryProductLabelsInPOS"
+        case .pointOfSaleOrdersi1: "pointOfSaleOrdersi1"
+        case .pointOfSaleOrdersi2: "pointOfSaleOrdersi2"
+        case .orderAddressMapSearch: "orderAddressMapSearch"
+        case .pointOfSaleHistoricalOrdersi1: "pointOfSaleHistoricalOrdersi1"
+        case .pointOfSaleLocalCatalogi1: "pointOfSaleLocalCatalogi1"
+        case .ciabBookings: "ciabBookings"
+        case .ciab: "ciab"
+        case .pointOfSaleSurveys: "pointOfSaleSurveys"
+        case .pointOfSaleCatalogAPI: "pointOfSaleCatalogAPI"
+        case .pointOfSaleRefundsi1: "pointOfSaleRefundsi1"
+        case .selfDrivenPushToken: "selfDrivenPushToken"
+        case .pointOfSaleOnlyProducts: "pointOfSaleOnlyProducts"
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -555,20 +555,16 @@ private extension SettingsViewController {
     }
 
     var featureOverrideAction: UIAlertAction {
-        return UIAlertAction(title: "Override Feature Flag", style: .default) { [weak self] _ in
+        return UIAlertAction(title: "Override Feature Flags", style: .default) { [weak self] _ in
             guard let self else { return }
 
             let hostingController = UIHostingController(rootView: OverrideFeatureFlagsView())
-            navigationController?.pushViewController(hostingController, animated: true)
+            self.navigationController?.pushViewController(hostingController, animated: true)
         }
     }
 
     var crashDebugMenuCancelAction: UIAlertAction {
         return UIAlertAction(title: Localization.HiddenSettingsMenu.cancel, style: .cancel, handler: nil)
-    }
-
-    @objc func dismissPresentedController() {
-        dismiss(animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -530,6 +530,7 @@ private extension SettingsViewController {
     @objc func didInvokeHiddenSettings(_ sender: UITapGestureRecognizer? = nil) {
         let hiddenSettingsMenu = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         hiddenSettingsMenu.addAction(resetPrivacyChoicesAction)
+        hiddenSettingsMenu.addAction(featureOverrideAction)
         hiddenSettingsMenu.addAction(crashDebugMenuCrashAction)
         hiddenSettingsMenu.addAction(crashDebugMenuCancelAction)
 
@@ -553,8 +554,21 @@ private extension SettingsViewController {
         }
     }
 
+    var featureOverrideAction: UIAlertAction {
+        return UIAlertAction(title: "Override Feature Flag", style: .default) { [weak self] _ in
+            guard let self else { return }
+
+            let hostingController = UIHostingController(rootView: OverrideFeatureFlagsView())
+            navigationController?.pushViewController(hostingController, animated: true)
+        }
+    }
+
     var crashDebugMenuCancelAction: UIAlertAction {
         return UIAlertAction(title: Localization.HiddenSettingsMenu.cancel, style: .cancel, handler: nil)
+    }
+
+    @objc func dismissPresentedController() {
+        dismiss(animated: true)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1341,6 +1341,7 @@
 		57F2C6CD246DECC10074063B /* SummaryTableViewCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F2C6CC246DECC10074063B /* SummaryTableViewCellViewModelTests.swift */; };
 		57F42E40253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F42E3F253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift */; };
 		640DA3482E97DE4F00317FB2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640DA3472E97DE4F00317FB2 /* SceneDelegate.swift */; };
+		643492C42F1A45B30080AEC1 /* OverrideFeatureFlagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 643492C32F1A45A80080AEC1 /* OverrideFeatureFlagsView.swift */; };
 		646FEDB82EE827DF00352BFF /* ApplicationLogProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 646FEDB72EE827DF00352BFF /* ApplicationLogProvider.swift */; };
 		647C05FB2ED5D9E800E5FF3F /* NotesContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647C05FA2ED5D9E200E5FF3F /* NotesContent.swift */; };
 		647C05FD2ED5E1C000E5FF3F /* BookingNotesRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647C05FC2ED5E1C000E5FF3F /* BookingNotesRowView.swift */; };
@@ -4244,6 +4245,7 @@
 		57F2C6CC246DECC10074063B /* SummaryTableViewCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryTableViewCellViewModelTests.swift; sourceTree = "<group>"; };
 		57F42E3F253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndEditableValueTableViewCellViewModelTests.swift; sourceTree = "<group>"; };
 		640DA3472E97DE4F00317FB2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		643492C32F1A45A80080AEC1 /* OverrideFeatureFlagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverrideFeatureFlagsView.swift; sourceTree = "<group>"; };
 		646FEDB72EE827DF00352BFF /* ApplicationLogProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogProvider.swift; sourceTree = "<group>"; };
 		647C05FA2ED5D9E200E5FF3F /* NotesContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesContent.swift; sourceTree = "<group>"; };
 		647C05FC2ED5E1C000E5FF3F /* BookingNotesRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingNotesRowView.swift; sourceTree = "<group>"; };
@@ -10468,6 +10470,7 @@
 		BAF1B3B32736595A00BA11DC /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				643492C32F1A45A80080AEC1 /* OverrideFeatureFlagsView.swift */,
 				027D4A8B2526FD1700108626 /* SettingsViewController.swift */,
 				BAE4F8422734325C00871344 /* SettingsViewModel.swift */,
 				027D4A8C2526FD1700108626 /* SettingsViewController.xib */,
@@ -14824,6 +14827,7 @@
 				DEB06E1F2E94A5D1007A2FB1 /* OfflineBannerViewRepresentable.swift in Sources */,
 				B9DC770329F18A8D0013B191 /* TopProductsFromCachedOrdersProvider.swift in Sources */,
 				86023FB12B199F6200A28F07 /* ThemesCarouselView.swift in Sources */,
+				643492C42F1A45B30080AEC1 /* OverrideFeatureFlagsView.swift in Sources */,
 				EE19058C2B5F744300617C53 /* BlazeAddPaymentMethodWebView.swift in Sources */,
 				68D23B5B2E14FD1C00316BA6 /* SummaryTableViewCellViewModel.swift in Sources */,
 				D83F5933225B2EB900626E75 /* ManualTrackingViewController.swift in Sources */,


### PR DESCRIPTION
## Description

Adds a new debug view that enables overriding feature flags for easier testing.

⚠️ The overriding mechanism is double-protected agains misusing in prod. Once in  [ServiceLocator](https://github.com/woocommerce/woocommerce-ios/pull/16521/changes#diff-becb50d9e9a7cd6db968589e1184e9928fcf43b15791003f233d0c0d0b6ab159R35) and also in [OverridableFeatureFlagService](https://github.com/woocommerce/woocommerce-ios/pull/16521/changes#diff-ea0d0493557794d59d445161790f093dffea3c359ca76b4aa6a2d8a286dff34dR15).

Changes:
- Added [‎Modules/Sources/Experiments/FeatureFlagOverrideStore.swift](https://github.com/woocommerce/woocommerce-ios/pull/16521/changes#diff-d5ea8ea5d97007eb3ace67ad7550a5a7b36fde5f49bdf21651fe1a156a18c224) to store overridden FF values in UserDefaults.
- Added [‎Modules/Sources/Experiments/OverridableFeatureFlagService.swift‎](https://github.com/woocommerce/woocommerce-ios/pull/16521/changes#diff-ea0d0493557794d59d445161790f093dffea3c359ca76b4aa6a2d8a286dff34d) to handle either reading from the override store of the default store.
- Extended [WooCommerce/Classes/ServiceLocator/ServiceLocator.swift‎](https://github.com/woocommerce/woocommerce-ios/pull/16521/changes#diff-becb50d9e9a7cd6db968589e1184e9928fcf43b15791003f233d0c0d0b6ab159)
- Added new [‎WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/OverrideFeatureFlagsView.swift‎](https://github.com/woocommerce/woocommerce-ios/pull/16521/changes#diff-e424fe506d712c7ac8c89b2b84b3cb8e1298682f02d921f5a5008b90a364ea94) as the view to set the FFs.

## Test Steps
1. Download the app
1. Login to any store
2. Navigate Menu/Settings
3. Scroll to the bottom
4. Tap ❤️ 4x times
5. Select "Override Feature Flags"
6. Fiddle with turning FFs on/off and reseting them
7. Test "Reset All" in the toolbar
8. Test searching
9. Override a FF and keep note of its name and state
10. Restart the app
11. Navigate to the view again
12. Note that the FF's state is the same as in step 9.

## Screenshots
![Simulator Screen Recording - iPhone 17 Pro - 2026-01-16 at 15 04 11](https://github.com/user-attachments/assets/f2e83024-b32f-4ed1-91da-500f1ab9fb03)


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
