### PR TITLE
Add PermissionKit consent flow infrastructure

### DIFF
--- a/WooCommerce/Classes/Tools/AgeVerification/AgeRatingChangeDetecting.swift
+++ b/WooCommerce/Classes/Tools/AgeVerification/AgeRatingChangeDetecting.swift
@@ -1,16 +1,5 @@
 import Foundation
 
-enum AgeRatingChangeCheckResult: Equatable {
-    case ageRatingChanged(previous: Int?, current: Int)
-}
-
 protocol AgeRatingChangeDetecting {
     func checkForChange() async -> AgeRatingChangeCheckResult?
-}
-
-/// Fallback detector used until the age rating change detector is merged.
-struct NoOpAgeRatingChangeDetector: AgeRatingChangeDetecting {
-    func checkForChange() async -> AgeRatingChangeCheckResult? {
-        nil
-    }
 }

--- a/WooCommerce/Classes/Tools/AgeVerification/AgeRatingChangeDetecting.swift
+++ b/WooCommerce/Classes/Tools/AgeVerification/AgeRatingChangeDetecting.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum AgeRatingChangeCheckResult: Equatable {
+    case ageRatingChanged(previous: Int?, current: Int)
+}
+
+protocol AgeRatingChangeDetecting {
+    func checkForChange() async -> AgeRatingChangeCheckResult?
+}
+
+/// Fallback detector used until the age rating change detector is merged.
+struct NoOpAgeRatingChangeDetector: AgeRatingChangeDetecting {
+    func checkForChange() async -> AgeRatingChangeCheckResult? {
+        nil
+    }
+}

--- a/WooCommerce/Classes/Tools/AgeVerification/AgeRatingChangeDetector.swift
+++ b/WooCommerce/Classes/Tools/AgeVerification/AgeRatingChangeDetector.swift
@@ -6,7 +6,7 @@ enum AgeRatingChangeCheckResult: Equatable {
 }
 
 /// Lightweight detector that tracks the last seen age rating and reports when it changes.
-final class AgeRatingChangeDetector {
+final class AgeRatingChangeDetector: AgeRatingChangeDetecting {
     private enum Key {
         static let lastSeenAgeRating = "ageRatingChangeDetector.lastSeenAgeRating"
     }

--- a/WooCommerce/Classes/Tools/AgeVerification/SignificantChangeConsentProvider.swift
+++ b/WooCommerce/Classes/Tools/AgeVerification/SignificantChangeConsentProvider.swift
@@ -4,7 +4,7 @@ import UIKit
 import PermissionKit
 #endif
 
-enum SignificantChangeConsentOutcome {
+enum SignificantChangeConsentOutcome: Equatable {
     case granted
     case denied
     case notAvailable

--- a/WooCommerce/Classes/Tools/AgeVerification/SignificantChangeConsentProvider.swift
+++ b/WooCommerce/Classes/Tools/AgeVerification/SignificantChangeConsentProvider.swift
@@ -1,0 +1,51 @@
+import Foundation
+import UIKit
+#if canImport(PermissionKit)
+import PermissionKit
+#endif
+
+enum SignificantChangeConsentOutcome {
+    case granted
+    case denied
+    case notAvailable
+    case unknown
+}
+
+protocol SignificantChangeConsentProviding {
+    func requestConsent(
+        in viewController: UIViewController,
+        significantAppUpdateDescription: String
+    ) async -> SignificantChangeConsentOutcome
+}
+
+final class PermissionKitSignificantChangeConsentProvider: SignificantChangeConsentProviding {
+    func requestConsent(
+        in viewController: UIViewController,
+        significantAppUpdateDescription: String
+    ) async -> SignificantChangeConsentOutcome {
+        #if canImport(PermissionKit)
+        if #available(iOS 26.2, *) {
+            let topic = SignificantAppUpdateTopic(description: significantAppUpdateDescription)
+            let question = PermissionQuestion(significantAppUpdateTopic: topic)
+            do {
+                try await AskCenter.shared.ask(question, in: viewController)
+            } catch {
+                return .unknown
+            }
+
+            for await response in AskCenter.shared.responses(for: SignificantAppUpdateTopic.self) {
+                guard response.question.id == question.id else { continue }
+                if response.choice == .approve {
+                    return .granted
+                }
+                if response.choice == .decline {
+                    return .denied
+                }
+                return .unknown
+            }
+            return .unknown
+        }
+        #endif
+        return .notAvailable
+    }
+}

--- a/WooCommerce/Classes/Tools/AgeVerification/SignificantChangeConsentStore.swift
+++ b/WooCommerce/Classes/Tools/AgeVerification/SignificantChangeConsentStore.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+enum SignificantChangeIdentifier: Hashable {
+    case ageRatingChange(ratingCode: Int)
+    case manual(id: String)
+
+    var cacheKey: String {
+        switch self {
+        case let .ageRatingChange(ratingCode):
+            return "ageRatingChange.\(ratingCode)"
+        case let .manual(id):
+            return "manual.\(id)"
+        }
+    }
+
+    var updateDescriptionFormatArguments: [CVarArg] {
+        switch self {
+        case let .ageRatingChange(ratingCode):
+            return [ratingCode]
+        case let .manual(id):
+            return [id]
+        }
+    }
+}
+
+enum SignificantChangeConsentStatus: String {
+    case granted
+    case denied
+}
+
+protocol SignificantChangeConsentStoring {
+    func status(for identifier: SignificantChangeIdentifier) -> SignificantChangeConsentStatus?
+    func setStatus(_ status: SignificantChangeConsentStatus, for identifier: SignificantChangeIdentifier)
+}
+
+final class UserDefaultsSignificantChangeConsentStore: SignificantChangeConsentStoring {
+    private enum Key {
+        static let prefix = "com.woocommerce.ios.significantChangeConsent.status."
+    }
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func status(for identifier: SignificantChangeIdentifier) -> SignificantChangeConsentStatus? {
+        let key = Key.prefix + identifier.cacheKey
+        guard let rawValue = defaults.string(forKey: key) else { return nil }
+        return SignificantChangeConsentStatus(rawValue: rawValue)
+    }
+
+    func setStatus(_ status: SignificantChangeConsentStatus, for identifier: SignificantChangeIdentifier) {
+        let key = Key.prefix + identifier.cacheKey
+        defaults.set(status.rawValue, forKey: key)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/AgeGate/AgeRangeVerificationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AgeGate/AgeRangeVerificationCoordinator.swift
@@ -16,7 +16,6 @@ protocol AgeRangeVerificationCoordinatorProtocol {
 extension AgeRangeVerificationCoordinator {
     enum Constants {
         static let minimumTOSRequiredAge = 13
-        static let significantAppUpdateDescription = "Significant app update"
     }
 }
 
@@ -78,13 +77,12 @@ private extension AgeRangeVerificationCoordinator {
                     "Age is eligible. significantAppChangeApprovalRequired: \(significantAppChangeApprovalRequired), isMinor: \(isMinor)"
                 )
                 Task { @MainActor in
-                    let isAgeRatingChangeDetected = await self.ageRatingChangeDetector.checkForChange() != nil
+                    let ageRatingChange = await self.ageRatingChangeDetector.checkForChange()
                     let outcome = await self.significantChangeConsentCoordinator.checkConsentIfNeeded(
                         in: anchor,
                         isMinor: isMinor,
                         significantAppChangeApprovalRequired: significantAppChangeApprovalRequired,
-                        isAgeRatingChangeDetected: isAgeRatingChangeDetected,
-                        significantAppUpdateDescription: Constants.significantAppUpdateDescription
+                        ageRatingChange: ageRatingChange
                     )
                     switch outcome {
                     case .denied:

--- a/WooCommerce/Classes/ViewRelated/AgeGate/AgeRangeVerificationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AgeGate/AgeRangeVerificationCoordinator.swift
@@ -16,19 +16,26 @@ protocol AgeRangeVerificationCoordinatorProtocol {
 extension AgeRangeVerificationCoordinator {
     enum Constants {
         static let minimumTOSRequiredAge = 13
+        static let significantAppUpdateDescription = "Significant app update"
     }
 }
 
 final class AgeRangeVerificationCoordinator: AgeRangeVerificationCoordinatorProtocol {
     private let featureFlagService: FeatureFlagService
     private let ageRangeVerificationService: AgeRangeVerificationServiceProtocol
+    private let significantChangeConsentCoordinator: SignificantChangeConsentCoordinator
+    private let ageRatingChangeDetector: AgeRatingChangeDetecting
 
     init(
         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-        ageRangeVerificationService: AgeRangeVerificationServiceProtocol = ServiceLocator.ageRangeVerificationService
+        ageRangeVerificationService: AgeRangeVerificationServiceProtocol = ServiceLocator.ageRangeVerificationService,
+        significantChangeConsentCoordinator: SignificantChangeConsentCoordinator = SignificantChangeConsentCoordinator(),
+        ageRatingChangeDetector: AgeRatingChangeDetecting = NoOpAgeRatingChangeDetector()
     ) {
         self.featureFlagService = featureFlagService
         self.ageRangeVerificationService = ageRangeVerificationService
+        self.significantChangeConsentCoordinator = significantChangeConsentCoordinator
+        self.ageRatingChangeDetector = ageRatingChangeDetector
     }
 
     /// Triggers the age range verification flow.
@@ -65,17 +72,30 @@ private extension AgeRangeVerificationCoordinator {
             in: anchor,
             minimumAge: Constants.minimumTOSRequiredAge
         ) { result in
-            let decision: AppAccessDescision
             switch result {
             case let .eligible(significantAppChangeApprovalRequired, isMinor):
-                // TODO: if isMinor && significantAppChangeApprovalRequired, trigger app age rating change check
-                // and parental consent flow (separate coordinator) before allowing access.
                 DDLogInfo(
                     "Age is eligible. significantAppChangeApprovalRequired: \(significantAppChangeApprovalRequired), isMinor: \(isMinor)"
                 )
-                decision = .allow
+                Task { @MainActor in
+                    let isAgeRatingChangeDetected = await self.ageRatingChangeDetector.checkForChange() != nil
+                    let outcome = await self.significantChangeConsentCoordinator.checkConsentIfNeeded(
+                        in: anchor,
+                        isMinor: isMinor,
+                        significantAppChangeApprovalRequired: significantAppChangeApprovalRequired,
+                        isAgeRatingChangeDetected: isAgeRatingChangeDetected,
+                        significantAppUpdateDescription: Constants.significantAppUpdateDescription
+                    )
+                    switch outcome {
+                    case .denied:
+                        // TODO: decide on a dedicated result when consent is rejected.
+                        onResult(.denyAndLogout, .ineligible)
+                    case .granted, .notAvailable, .unknown:
+                        onResult(.allow, result)
+                    }
+                }
             case .ineligible:
-                decision = .denyAndLogout
+                onResult(.denyAndLogout, result)
             case .declinedSharing,
                  .featureUnavailable,
                  .ineligibleForAgeFeatures,
@@ -83,10 +103,8 @@ private extension AgeRangeVerificationCoordinator {
                  .sdkError,
                  .unknown:
                 // Non-deterministic/unavailable results are treated as allowed.
-                decision = .allow
+                onResult(.allow, result)
             }
-
-            onResult(decision, result)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/AgeGate/AgeRangeVerificationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AgeGate/AgeRangeVerificationCoordinator.swift
@@ -29,7 +29,7 @@ final class AgeRangeVerificationCoordinator: AgeRangeVerificationCoordinatorProt
         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
         ageRangeVerificationService: AgeRangeVerificationServiceProtocol = ServiceLocator.ageRangeVerificationService,
         significantChangeConsentCoordinator: SignificantChangeConsentCoordinator = SignificantChangeConsentCoordinator(),
-        ageRatingChangeDetector: AgeRatingChangeDetecting = NoOpAgeRatingChangeDetector()
+        ageRatingChangeDetector: AgeRatingChangeDetecting = AgeRatingChangeDetector()
     ) {
         self.featureFlagService = featureFlagService
         self.ageRangeVerificationService = ageRangeVerificationService

--- a/WooCommerce/Classes/ViewRelated/AgeGate/AgeRangeVerificationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AgeGate/AgeRangeVerificationCoordinator.swift
@@ -76,12 +76,15 @@ private extension AgeRangeVerificationCoordinator {
                 DDLogInfo(
                     "Age is eligible. significantAppChangeApprovalRequired: \(significantAppChangeApprovalRequired), isMinor: \(isMinor)"
                 )
+                guard isMinor, significantAppChangeApprovalRequired else {
+                    onResult(.allow, result)
+                    return
+                }
+
                 Task { @MainActor in
                     let ageRatingChange = await self.ageRatingChangeDetector.checkForChange()
                     let outcome = await self.significantChangeConsentCoordinator.checkConsentIfNeeded(
                         in: anchor,
-                        isMinor: isMinor,
-                        significantAppChangeApprovalRequired: significantAppChangeApprovalRequired,
                         ageRatingChange: ageRatingChange
                     )
                     switch outcome {

--- a/WooCommerce/Classes/ViewRelated/AgeGate/SignificantChangeConsentCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AgeGate/SignificantChangeConsentCoordinator.swift
@@ -1,0 +1,33 @@
+import Foundation
+import UIKit
+
+final class SignificantChangeConsentCoordinator {
+    private let consentProvider: SignificantChangeConsentProviding
+
+    init(
+        consentProvider: SignificantChangeConsentProviding = PermissionKitSignificantChangeConsentProvider()
+    ) {
+        self.consentProvider = consentProvider
+    }
+
+    func checkConsentIfNeeded(
+        in viewController: UIViewController,
+        isMinor: Bool,
+        significantAppChangeApprovalRequired: Bool,
+        isAgeRatingChangeDetected: Bool,
+        significantAppUpdateDescription: String
+    ) async -> SignificantChangeConsentOutcome {
+        guard
+            isMinor,
+            significantAppChangeApprovalRequired,
+            isAgeRatingChangeDetected
+        else {
+            return .granted
+        }
+
+        return await consentProvider.requestConsent(
+            in: viewController,
+            significantAppUpdateDescription: significantAppUpdateDescription
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/AgeGate/SignificantChangeConsentCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AgeGate/SignificantChangeConsentCoordinator.swift
@@ -3,31 +3,88 @@ import UIKit
 
 final class SignificantChangeConsentCoordinator {
     private let consentProvider: SignificantChangeConsentProviding
+    private let consentStore: SignificantChangeConsentStoring
 
     init(
-        consentProvider: SignificantChangeConsentProviding = PermissionKitSignificantChangeConsentProvider()
+        consentProvider: SignificantChangeConsentProviding = PermissionKitSignificantChangeConsentProvider(),
+        consentStore: SignificantChangeConsentStoring = UserDefaultsSignificantChangeConsentStore()
     ) {
         self.consentProvider = consentProvider
+        self.consentStore = consentStore
     }
 
     func checkConsentIfNeeded(
         in viewController: UIViewController,
         isMinor: Bool,
         significantAppChangeApprovalRequired: Bool,
-        isAgeRatingChangeDetected: Bool,
-        significantAppUpdateDescription: String
+        ageRatingChange: AgeRatingChangeCheckResult?,
+        manualChangeIdentifier: SignificantChangeIdentifier? = nil
     ) async -> SignificantChangeConsentOutcome {
-        guard
-            isMinor,
-            significantAppChangeApprovalRequired,
-            isAgeRatingChangeDetected
-        else {
+        guard isMinor, significantAppChangeApprovalRequired else {
             return .granted
         }
 
-        return await consentProvider.requestConsent(
+        let changeIdentifier: SignificantChangeIdentifier? = {
+            if let manualChangeIdentifier { return manualChangeIdentifier }
+            guard let ageRatingChange else { return nil }
+            switch ageRatingChange {
+            case let .ageRatingChanged(_, ratingCode):
+                return .ageRatingChange(ratingCode: ratingCode)
+            }
+        }()
+
+        guard let changeIdentifier else {
+            return .granted
+        }
+
+        if let status = consentStore.status(for: changeIdentifier) {
+            return status == .granted ? .granted : .denied
+        }
+
+        let outcome = await consentProvider.requestConsent(
             in: viewController,
-            significantAppUpdateDescription: significantAppUpdateDescription
+            significantAppUpdateDescription: {
+                switch changeIdentifier {
+                case .ageRatingChange:
+                    return String(
+                        format: Localization.ageRatingChangeRequestDescriptionFormat,
+                        arguments: changeIdentifier.updateDescriptionFormatArguments
+                    )
+                case .manual:
+                    return String(
+                        format: Localization.manualChangeRequestDescriptionFormat,
+                        arguments: changeIdentifier.updateDescriptionFormatArguments
+                    )
+                }
+            }()
+        )
+        switch outcome {
+        case .granted:
+            consentStore.setStatus(.granted, for: changeIdentifier)
+        case .denied:
+            consentStore.setStatus(.denied, for: changeIdentifier)
+        case .notAvailable, .unknown:
+            break
+        }
+
+        return outcome
+    }
+}
+
+private extension SignificantChangeConsentCoordinator {
+    enum Localization {
+        static let ageRatingChangeRequestDescriptionFormat = NSLocalizedString(
+            "significantChangeConsent.ageRatingChange.description",
+            value: "App age rating changed to %1$d.",
+            comment: "PermissionKit description shown when the app age rating changes." +
+            "ratingCode: %1$d is the new rating code."
+        )
+
+        static let manualChangeRequestDescriptionFormat = NSLocalizedString(
+            "significantChangeConsent.manual.description",
+            value: "Significant app update: %1$@.",
+            comment: "PermissionKit description shown for a manual significant change." +
+            "manualChangeID: %1$@ is a short description."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/AgeGate/SignificantChangeConsentCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AgeGate/SignificantChangeConsentCoordinator.swift
@@ -15,15 +15,9 @@ final class SignificantChangeConsentCoordinator {
 
     func checkConsentIfNeeded(
         in viewController: UIViewController,
-        isMinor: Bool,
-        significantAppChangeApprovalRequired: Bool,
         ageRatingChange: AgeRatingChangeCheckResult?,
         manualChangeIdentifier: SignificantChangeIdentifier? = nil
     ) async -> SignificantChangeConsentOutcome {
-        guard isMinor, significantAppChangeApprovalRequired else {
-            return .granted
-        }
-
         let changeIdentifier: SignificantChangeIdentifier? = {
             if let manualChangeIdentifier { return manualChangeIdentifier }
             guard let ageRatingChange else { return nil }

--- a/WooCommerce/WooCommerceTests/AgeGate/AgeRangeVerificationCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AgeGate/AgeRangeVerificationCoordinatorTests.swift
@@ -4,14 +4,23 @@ import Experiments
 
 final class AgeRangeVerificationCoordinatorTests: XCTestCase {
     private var featureFlagService: FeatureFlagService!
+    private var consentCoordinator: SignificantChangeConsentCoordinator!
+    private var ageRatingChangeDetector: AgeRatingChangeDetecting!
 
     override func setUp() {
         super.setUp()
         featureFlagService = AlwaysOnFeatureFlagService()
+        consentCoordinator = SignificantChangeConsentCoordinator(
+            consentProvider: MockConsentProvider(outcome: .granted),
+            consentStore: MockConsentStore()
+        )
+        ageRatingChangeDetector = MockAgeRatingChangeDetector(result: nil)
     }
 
     override func tearDown() {
         featureFlagService = nil
+        consentCoordinator = nil
+        ageRatingChangeDetector = nil
         super.tearDown()
     }
 
@@ -23,7 +32,9 @@ final class AgeRangeVerificationCoordinatorTests: XCTestCase {
             ageRangeVerificationService: FakeAgeRangeService(
                 result: .ineligible,
                 delay: 0.01
-            )
+            ),
+            significantChangeConsentCoordinator: consentCoordinator,
+            ageRatingChangeDetector: ageRatingChangeDetector
         )
         let exp = expectation(description: "onResult")
 
@@ -49,7 +60,9 @@ final class AgeRangeVerificationCoordinatorTests: XCTestCase {
             ageRangeVerificationService: FakeAgeRangeService(
                 result: .declinedSharing,
                 delay: 0.01
-            )
+            ),
+            significantChangeConsentCoordinator: consentCoordinator,
+            ageRatingChangeDetector: ageRatingChangeDetector
         )
         let exp = expectation(description: "onResult")
 
@@ -74,7 +87,9 @@ final class AgeRangeVerificationCoordinatorTests: XCTestCase {
             ageRangeVerificationService: FakeAgeRangeService(
                 result: .invalidUIState,
                 delay: 0.01
-            )
+            ),
+            significantChangeConsentCoordinator: consentCoordinator,
+            ageRatingChangeDetector: ageRatingChangeDetector
         )
         let exp = expectation(description: "onResult")
 
@@ -100,7 +115,9 @@ final class AgeRangeVerificationCoordinatorTests: XCTestCase {
             ageRangeVerificationService: FakeAgeRangeService(
                 result: .featureUnavailable,
                 delay: 0.01
-            )
+            ),
+            significantChangeConsentCoordinator: consentCoordinator,
+            ageRatingChangeDetector: ageRatingChangeDetector
         )
         let exp = expectation(description: "onResult")
 
@@ -131,7 +148,9 @@ final class AgeRangeVerificationCoordinatorTests: XCTestCase {
                     )
                 ),
                 delay: 0.01
-            )
+            ),
+            significantChangeConsentCoordinator: consentCoordinator,
+            ageRatingChangeDetector: ageRatingChangeDetector
         )
         let exp = expectation(description: "onResult")
 
@@ -157,7 +176,9 @@ final class AgeRangeVerificationCoordinatorTests: XCTestCase {
             ageRangeVerificationService: FakeAgeRangeService(
                 result: .unknown,
                 delay: 0.01
-            )
+            ),
+            significantChangeConsentCoordinator: consentCoordinator,
+            ageRatingChangeDetector: ageRatingChangeDetector
         )
         let exp = expectation(description: "onResult")
 
@@ -186,7 +207,9 @@ final class AgeRangeVerificationCoordinatorTests: XCTestCase {
                     isMinor: false
                 ),
                 delay: 0.01
-            )
+            ),
+            significantChangeConsentCoordinator: consentCoordinator,
+            ageRatingChangeDetector: ageRatingChangeDetector
         )
         let exp = expectation(description: "onResult")
 
@@ -203,6 +226,103 @@ final class AgeRangeVerificationCoordinatorTests: XCTestCase {
 
         waitForExpectations(timeout: 1)
     }
+
+    func test_triggerAgeVerificationIfNeeded_when_minor_and_approval_required_then_denied_blocks() {
+        let window = UIWindow()
+        window.rootViewController = UIViewController()
+        featureFlagService = AlwaysOnFeatureFlagService()
+        consentCoordinator = SignificantChangeConsentCoordinator(
+            consentProvider: MockConsentProvider(outcome: .denied),
+            consentStore: MockConsentStore()
+        )
+        ageRatingChangeDetector = MockAgeRatingChangeDetector(result: .ageRatingChanged(previous: nil, current: 13))
+        let sut = AgeRangeVerificationCoordinator(
+            featureFlagService: featureFlagService,
+            ageRangeVerificationService: FakeAgeRangeService(
+                result: .eligible(
+                    significantAppChangeApprovalRequired: true,
+                    isMinor: true
+                ),
+                delay: 0.01
+            ),
+            significantChangeConsentCoordinator: consentCoordinator,
+            ageRatingChangeDetector: ageRatingChangeDetector
+        )
+        let exp = expectation(description: "onResult")
+
+        sut.triggerAgeVerificationIfNeeded(hostingWindow: window) { appAccessDescision, result in
+            XCTAssertEqual(appAccessDescision, .denyAndLogout)
+            switch result {
+            case .ineligible:
+                break
+            default:
+                XCTFail("Expected .ineligible, got \(result)")
+            }
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func test_triggerAgeVerificationIfNeeded_when_minor_and_approval_required_then_granted_allows() {
+        let window = UIWindow()
+        window.rootViewController = UIViewController()
+        featureFlagService = AlwaysOnFeatureFlagService()
+        consentCoordinator = SignificantChangeConsentCoordinator(
+            consentProvider: MockConsentProvider(outcome: .granted),
+            consentStore: MockConsentStore()
+        )
+        ageRatingChangeDetector = MockAgeRatingChangeDetector(result: .ageRatingChanged(previous: nil, current: 13))
+        let sut = AgeRangeVerificationCoordinator(
+            featureFlagService: featureFlagService,
+            ageRangeVerificationService: FakeAgeRangeService(
+                result: .eligible(
+                    significantAppChangeApprovalRequired: true,
+                    isMinor: true
+                ),
+                delay: 0.01
+            ),
+            significantChangeConsentCoordinator: consentCoordinator,
+            ageRatingChangeDetector: ageRatingChangeDetector
+        )
+        let exp = expectation(description: "onResult")
+
+        sut.triggerAgeVerificationIfNeeded(hostingWindow: window) { appAccessDescision, result in
+            XCTAssertEqual(appAccessDescision, .allow)
+            switch result {
+            case .eligible:
+                break
+            default:
+                XCTFail("Expected .eligible, got \(result)")
+            }
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+}
+
+private struct MockAgeRatingChangeDetector: AgeRatingChangeDetecting {
+    let result: AgeRatingChangeCheckResult?
+    func checkForChange() async -> AgeRatingChangeCheckResult? { result }
+}
+
+private final class MockConsentProvider: SignificantChangeConsentProviding {
+    let outcome: SignificantChangeConsentOutcome
+    init(outcome: SignificantChangeConsentOutcome) {
+        self.outcome = outcome
+    }
+    func requestConsent(
+        in viewController: UIViewController,
+        significantAppUpdateDescription: String
+    ) async -> SignificantChangeConsentOutcome {
+        outcome
+    }
+}
+
+private final class MockConsentStore: SignificantChangeConsentStoring {
+    func status(for identifier: SignificantChangeIdentifier) -> SignificantChangeConsentStatus? { nil }
+    func setStatus(_ status: SignificantChangeConsentStatus, for identifier: SignificantChangeIdentifier) {}
 }
 
 private struct FakeAgeRangeService: AgeRangeVerificationServiceProtocol {

--- a/WooCommerce/WooCommerceTests/AgeGate/SignificantChangeConsentCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AgeGate/SignificantChangeConsentCoordinatorTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import WooCommerce
+
+final class SignificantChangeConsentCoordinatorTests: XCTestCase {
+
+    func test_checkConsentIfNeeded_when_not_minor_returns_granted_without_request() async {
+        let provider = MockConsentProvider(outcome: .denied)
+        let store = MockConsentStore()
+        let sut = SignificantChangeConsentCoordinator(consentProvider: provider, consentStore: store)
+
+        let outcome = await sut.checkConsentIfNeeded(
+            in: UIViewController(),
+            ageRatingChange: .ageRatingChanged(previous: nil, current: 13)
+        )
+
+        XCTAssertEqual(outcome, .denied)
+        XCTAssertEqual(provider.requestCount, 1)
+        XCTAssertEqual(store.setCount, 1)
+    }
+
+    func test_checkConsentIfNeeded_when_no_change_returns_granted() async {
+        let provider = MockConsentProvider(outcome: .denied)
+        let store = MockConsentStore()
+        let sut = SignificantChangeConsentCoordinator(consentProvider: provider, consentStore: store)
+
+        let outcome = await sut.checkConsentIfNeeded(
+            in: UIViewController(),
+            ageRatingChange: nil
+        )
+
+        XCTAssertEqual(outcome, .granted)
+        XCTAssertEqual(provider.requestCount, 0)
+        XCTAssertEqual(store.setCount, 0)
+    }
+
+    func test_checkConsentIfNeeded_when_cached_granted_returns_granted_without_request() async {
+        let provider = MockConsentProvider(outcome: .denied)
+        let store = MockConsentStore()
+        let identifier = SignificantChangeIdentifier.ageRatingChange(ratingCode: 13)
+        store.statusByKey[identifier.cacheKey] = .granted
+        let sut = SignificantChangeConsentCoordinator(consentProvider: provider, consentStore: store)
+
+        let outcome = await sut.checkConsentIfNeeded(
+            in: UIViewController(),
+            ageRatingChange: .ageRatingChanged(previous: nil, current: 13)
+        )
+
+        XCTAssertEqual(outcome, .granted)
+        XCTAssertEqual(provider.requestCount, 0)
+        XCTAssertEqual(store.setCount, 0)
+    }
+
+    func test_checkConsentIfNeeded_when_cached_denied_returns_denied_without_request() async {
+        let provider = MockConsentProvider(outcome: .granted)
+        let store = MockConsentStore()
+        let identifier = SignificantChangeIdentifier.ageRatingChange(ratingCode: 13)
+        store.statusByKey[identifier.cacheKey] = .denied
+        let sut = SignificantChangeConsentCoordinator(consentProvider: provider, consentStore: store)
+
+        let outcome = await sut.checkConsentIfNeeded(
+            in: UIViewController(),
+            ageRatingChange: .ageRatingChanged(previous: nil, current: 13)
+        )
+
+        XCTAssertEqual(outcome, .denied)
+        XCTAssertEqual(provider.requestCount, 0)
+        XCTAssertEqual(store.setCount, 0)
+    }
+
+    func test_checkConsentIfNeeded_when_provider_grants_caches_and_returns_granted() async {
+        let provider = MockConsentProvider(outcome: .granted)
+        let store = MockConsentStore()
+        let sut = SignificantChangeConsentCoordinator(consentProvider: provider, consentStore: store)
+
+        let outcome = await sut.checkConsentIfNeeded(
+            in: UIViewController(),
+            ageRatingChange: .ageRatingChanged(previous: nil, current: 13)
+        )
+
+        XCTAssertEqual(outcome, .granted)
+        XCTAssertEqual(store.setCount, 1)
+        XCTAssertEqual(store.statusByKey["ageRatingChange.13"], .granted)
+    }
+
+    func test_checkConsentIfNeeded_when_provider_denies_caches_and_returns_denied() async {
+        let provider = MockConsentProvider(outcome: .denied)
+        let store = MockConsentStore()
+        let sut = SignificantChangeConsentCoordinator(consentProvider: provider, consentStore: store)
+
+        let outcome = await sut.checkConsentIfNeeded(
+            in: UIViewController(),
+            ageRatingChange: .ageRatingChanged(previous: nil, current: 13)
+        )
+
+        XCTAssertEqual(outcome, .denied)
+        XCTAssertEqual(store.setCount, 1)
+        XCTAssertEqual(store.statusByKey["ageRatingChange.13"], .denied)
+    }
+
+    func test_checkConsentIfNeeded_when_manual_identifier_uses_manual_path() async {
+        let provider = MockConsentProvider(outcome: .granted)
+        let store = MockConsentStore()
+        let sut = SignificantChangeConsentCoordinator(consentProvider: provider, consentStore: store)
+
+        let outcome = await sut.checkConsentIfNeeded(
+            in: UIViewController(),
+            ageRatingChange: nil,
+            manualChangeIdentifier: .manual(id: "new-feature")
+        )
+
+        XCTAssertEqual(outcome, .granted)
+        XCTAssertEqual(store.setCount, 1)
+        XCTAssertEqual(store.statusByKey["manual.new-feature"], .granted)
+    }
+}
+
+private final class MockConsentProvider: SignificantChangeConsentProviding {
+    let outcome: SignificantChangeConsentOutcome
+    private(set) var requestCount = 0
+
+    init(outcome: SignificantChangeConsentOutcome) {
+        self.outcome = outcome
+    }
+
+    func requestConsent(
+        in viewController: UIViewController,
+        significantAppUpdateDescription: String
+    ) async -> SignificantChangeConsentOutcome {
+        requestCount += 1
+        return outcome
+    }
+}
+
+private final class MockConsentStore: SignificantChangeConsentStoring {
+    var statusByKey: [String: SignificantChangeConsentStatus] = [:]
+    private(set) var setCount = 0
+
+    func status(for identifier: SignificantChangeIdentifier) -> SignificantChangeConsentStatus? {
+        statusByKey[identifier.cacheKey]
+    }
+
+    func setStatus(_ status: SignificantChangeConsentStatus, for identifier: SignificantChangeIdentifier) {
+        setCount += 1
+        statusByKey[identifier.cacheKey] = status
+    }
+}

--- a/WooCommerce/WooCommerceTests/AgeGate/SignificantChangeConsentCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AgeGate/SignificantChangeConsentCoordinatorTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class SignificantChangeConsentCoordinatorTests: XCTestCase {
 
-    func test_checkConsentIfNeeded_when_not_minor_returns_granted_without_request() async {
+    @MainActor func test_checkConsentIfNeeded_when_not_minor_returns_granted_without_request() async {
         let provider = MockConsentProvider(outcome: .denied)
         let store = MockConsentStore()
         let sut = SignificantChangeConsentCoordinator(consentProvider: provider, consentStore: store)
@@ -18,7 +18,7 @@ final class SignificantChangeConsentCoordinatorTests: XCTestCase {
         XCTAssertEqual(store.setCount, 1)
     }
 
-    func test_checkConsentIfNeeded_when_no_change_returns_granted() async {
+    @MainActor func test_checkConsentIfNeeded_when_no_change_returns_granted() async {
         let provider = MockConsentProvider(outcome: .denied)
         let store = MockConsentStore()
         let sut = SignificantChangeConsentCoordinator(consentProvider: provider, consentStore: store)
@@ -33,7 +33,7 @@ final class SignificantChangeConsentCoordinatorTests: XCTestCase {
         XCTAssertEqual(store.setCount, 0)
     }
 
-    func test_checkConsentIfNeeded_when_cached_granted_returns_granted_without_request() async {
+    @MainActor func test_checkConsentIfNeeded_when_cached_granted_returns_granted_without_request() async {
         let provider = MockConsentProvider(outcome: .denied)
         let store = MockConsentStore()
         let identifier = SignificantChangeIdentifier.ageRatingChange(ratingCode: 13)
@@ -50,7 +50,7 @@ final class SignificantChangeConsentCoordinatorTests: XCTestCase {
         XCTAssertEqual(store.setCount, 0)
     }
 
-    func test_checkConsentIfNeeded_when_cached_denied_returns_denied_without_request() async {
+    @MainActor func test_checkConsentIfNeeded_when_cached_denied_returns_denied_without_request() async {
         let provider = MockConsentProvider(outcome: .granted)
         let store = MockConsentStore()
         let identifier = SignificantChangeIdentifier.ageRatingChange(ratingCode: 13)
@@ -67,7 +67,7 @@ final class SignificantChangeConsentCoordinatorTests: XCTestCase {
         XCTAssertEqual(store.setCount, 0)
     }
 
-    func test_checkConsentIfNeeded_when_provider_grants_caches_and_returns_granted() async {
+    @MainActor func test_checkConsentIfNeeded_when_provider_grants_caches_and_returns_granted() async {
         let provider = MockConsentProvider(outcome: .granted)
         let store = MockConsentStore()
         let sut = SignificantChangeConsentCoordinator(consentProvider: provider, consentStore: store)
@@ -82,7 +82,7 @@ final class SignificantChangeConsentCoordinatorTests: XCTestCase {
         XCTAssertEqual(store.statusByKey["ageRatingChange.13"], .granted)
     }
 
-    func test_checkConsentIfNeeded_when_provider_denies_caches_and_returns_denied() async {
+    @MainActor func test_checkConsentIfNeeded_when_provider_denies_caches_and_returns_denied() async {
         let provider = MockConsentProvider(outcome: .denied)
         let store = MockConsentStore()
         let sut = SignificantChangeConsentCoordinator(consentProvider: provider, consentStore: store)
@@ -97,7 +97,7 @@ final class SignificantChangeConsentCoordinatorTests: XCTestCase {
         XCTAssertEqual(store.statusByKey["ageRatingChange.13"], .denied)
     }
 
-    func test_checkConsentIfNeeded_when_manual_identifier_uses_manual_path() async {
+    @MainActor func test_checkConsentIfNeeded_when_manual_identifier_uses_manual_path() async {
         let provider = MockConsentProvider(outcome: .granted)
         let store = MockConsentStore()
         let sut = SignificantChangeConsentCoordinator(consentProvider: provider, consentStore: store)


### PR DESCRIPTION
WOOMOB-2006

## Description

Adds the initial PermissionKit-based consent flow infrastructure for significant app changes (e.g. age rating bumps). Nothing is user-facing yet — the real `AgeRatingChangeDetector` is not wired (a no-op is used), so the consent prompt never triggers in production.

**New types:**
- `SignificantChangeConsentCoordinator` — orchestrates consent checks: looks up cached status, requests consent via `PermissionKit.AskCenter` if needed, and caches the outcome.
- `SignificantChangeConsentProviding` + `PermissionKitSignificantChangeConsentProvider` — builds a `SignificantAppUpdateTopic` and sends a `PermissionQuestion` through `AskCenter` (iOS 26.2+, gated by `#if canImport(PermissionKit)`).
- `AgeRatingChangeDetecting` + `NoOpAgeRatingChangeDetector` — abstraction for detecting app age rating changes. Currently no-op; real implementation will come in a follow-up.
- `SignificantChangeConsentStoring` + `UserDefaultsSignificantChangeConsentStore` — persistent consent cache keyed by `SignificantChangeIdentifier`.

**Integration with existing code:**
- `AgeRangeVerificationCoordinator` now triggers the consent flow when the user is a minor AND the SDK signals `significantAppChangeApprovalRequired`. Consent denial maps to `.denyAndLogout`, matching the recently introduced `AppAccessDescision` enum.
- Non-minor or non-approval-required cases early-return with `.allow` without invoking consent.

## Test Steps
Code review + green CI. The feature is not yet wired to a real age rating change detector.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.