### PR TITLE
POS Promotion: Web view sheet and analytics refinements

### DIFF
--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -374,9 +374,10 @@ public enum WooAnalyticsStat: String {
     case tapToPayEducationSkipped = "tap_to_pay_education_skipped"
 
     // MARK: POS Promotion Modal
-    case posPromotionModalShown = "pos_promotion_modal_shown"
-    case posPromotionModalDismissed = "pos_promotion_modal_dismissed"
-    case posPromotionModalCTATapped = "pos_promotion_modal_cta_tapped"
+    case posPromoModalViewed = "pos_promo_modal_viewed"
+    case posPromoModalSlideViewed = "pos_promo_modal_slide_viewed"
+    case posPromoModalDismissed = "pos_promo_modal_dismissed"
+    case posPromoModalExploreClicked = "pos_promo_modal_explore_clicked"
 
     // MARK: Cash on Delivery Enable events
     case enableCashOnDeliverySuccess = "enable_cash_on_delivery_success"

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -724,13 +724,32 @@ extension MainTabBarController: DeepLinkNavigator {
     }
 
     private func presentPOSPromotionModal() {
-        let modalView = POSPromotionModal_UIKit(onDismiss: { [weak self] in
-            self?.dismiss(animated: false)
-        })
+        var pendingWebViewModel: WebViewSheetViewModel?
+
+        let modalView = POSPromotionModal_UIKit(
+            onDismiss: { [weak self] in
+                self?.dismiss(animated: false) {
+                    if let webViewModel = pendingWebViewModel {
+                        self?.presentWebViewSheet(webViewModel)
+                    }
+                }
+            },
+            onShowWebView: { webViewModel in
+                pendingWebViewModel = webViewModel
+            }
+        )
         let hostingController = UIHostingController(rootView: modalView)
         hostingController.view.backgroundColor = .clear
         hostingController.modalPresentationStyle = .overFullScreen
         hostingController.modalTransitionStyle = .crossDissolve
+        present(hostingController, animated: true)
+    }
+
+    private func presentWebViewSheet(_ webViewModel: WebViewSheetViewModel) {
+        let webViewSheet = WebViewSheet(viewModel: webViewModel, done: { [weak self] in
+            self?.dismiss(animated: true)
+        })
+        let hostingController = UIHostingController(rootView: webViewSheet)
         present(hostingController, animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionView.swift
+++ b/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionView.swift
@@ -135,9 +135,10 @@ struct POSPromotionModal_UIKit: View {
     @StateObject private var viewModel: POSPromotionViewModel
     let onDismiss: (() -> Void)?
 
-    init(onDismiss: (() -> Void)? = nil) {
+    init(onDismiss: (() -> Void)? = nil,
+         onShowWebView: @escaping (WebViewSheetViewModel) -> Void = { _ in }) {
         self.onDismiss = onDismiss
-        self._viewModel = StateObject(wrappedValue: POSPromotionViewModel())
+        self._viewModel = StateObject(wrappedValue: POSPromotionViewModel(onShowWebView: onShowWebView))
     }
 
     var body: some View {

--- a/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionView.swift
+++ b/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionView.swift
@@ -58,6 +58,9 @@ struct POSPromotionView: View {
         .onAppear {
             viewModel.onAppear()
         }
+        .onDisappear {
+            viewModel.onDisappear()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionView.swift
+++ b/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// The content view for the POS Promotion modal, explaining POS benefits.
 ///
 struct POSPromotionView: View {
-    @ObservedObject var viewModel: POSPromotionViewModel
+    @Bindable var viewModel: POSPromotionViewModel
     @Binding var isPresented: Bool
     @Environment(\.verticalSizeClass) private var verticalSizeClass
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
@@ -132,13 +132,13 @@ private enum Layout {
 ///
 struct POSPromotionModal_UIKit: View {
     @State var isPresented: Bool = true
-    @StateObject private var viewModel: POSPromotionViewModel
+    @State private var viewModel: POSPromotionViewModel
     let onDismiss: (() -> Void)?
 
     init(onDismiss: (() -> Void)? = nil,
          onShowWebView: @escaping (WebViewSheetViewModel) -> Void = { _ in }) {
         self.onDismiss = onDismiss
-        self._viewModel = StateObject(wrappedValue: POSPromotionViewModel(onShowWebView: onShowWebView))
+        self._viewModel = State(wrappedValue: POSPromotionViewModel(onShowWebView: onShowWebView))
     }
 
     var body: some View {

--- a/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import protocol WooFoundation.Analytics
 import struct WooFoundation.WooCommerceComUTMProvider
@@ -39,6 +40,7 @@ final class POSPromotionViewModel: ObservableObject {
     private let stores: StoresManager
     private let onDismiss: () -> Void
     private let onShowWebView: (WebViewSheetViewModel) -> Void
+    private var cancellables: Set<AnyCancellable> = []
 
     init(stepDescriptions: [String]? = nil,
          imageName: String = "pos-promotion-header",
@@ -54,6 +56,18 @@ final class POSPromotionViewModel: ObservableObject {
         self.stores = stores
         self.onDismiss = onDismiss
         self.onShowWebView = onShowWebView
+
+        observeSelectedStep()
+    }
+
+    private func observeSelectedStep() {
+        $selectedStep
+            .dropFirst() // Skip initial value (handled in onAppear)
+            .removeDuplicates()
+            .sink { [weak self] step in
+                self?.trackSlideViewed(step: step)
+            }
+            .store(in: &cancellables)
     }
 
     // MARK: - Actions
@@ -61,7 +75,7 @@ final class POSPromotionViewModel: ObservableObject {
     /// Called when the primary action button is tapped.
     func primaryActionTapped() {
         if isOnFinalStep {
-            analytics.track(.posPromotionModalCTATapped)
+            analytics.track(.posPromoModalExploreClicked)
             showWebView()
             dismiss = true
         } else {
@@ -90,7 +104,7 @@ final class POSPromotionViewModel: ObservableObject {
 
     /// Called when the close button is tapped.
     func closeButtonTapped() {
-        analytics.track(.posPromotionModalDismissed)
+        analytics.track(.posPromoModalDismissed)
         dismiss = true
     }
 
@@ -98,12 +112,20 @@ final class POSPromotionViewModel: ObservableObject {
 
     /// Called when the view appears.
     func onAppear() {
-        analytics.track(.posPromotionModalShown)
+        analytics.track(.posPromoModalViewed)
+        trackSlideViewed()
     }
 
     /// Called when the view disappears.
     func onDisappear() {
         onDismiss()
+    }
+
+    // MARK: - Analytics
+
+    private func trackSlideViewed(step: Int? = nil) {
+        let stepToTrack = step ?? selectedStep
+        analytics.track(.posPromoModalSlideViewed, withProperties: ["slide_index": stepToTrack])
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionViewModel.swift
@@ -1,5 +1,7 @@
 import Foundation
 import protocol WooFoundation.Analytics
+import struct WooFoundation.WooCommerceComUTMProvider
+import protocol Yosemite.StoresManager
 
 /// View model for the POS Promotion modal flow.
 ///
@@ -34,21 +36,24 @@ final class POSPromotionViewModel: ObservableObject {
     }
 
     private let analytics: Analytics
-    private let urlOpener: URLOpener
+    private let stores: StoresManager
     private let onDismiss: () -> Void
+    private let onShowWebView: (WebViewSheetViewModel) -> Void
 
     init(stepDescriptions: [String]? = nil,
          imageName: String = "pos-promotion-header",
          title: String = Localization.title,
          analytics: Analytics = ServiceLocator.analytics,
-         urlOpener: URLOpener = ApplicationURLOpener(),
-         onDismiss: @escaping () -> Void = {}) {
+         stores: StoresManager = ServiceLocator.stores,
+         onDismiss: @escaping () -> Void = {},
+         onShowWebView: @escaping (WebViewSheetViewModel) -> Void = { _ in }) {
         self.stepDescriptions = stepDescriptions ?? POSPromotionStepsFactory.stepDescriptions()
         self.imageName = imageName
         self.title = title
         self.analytics = analytics
-        self.urlOpener = urlOpener
+        self.stores = stores
         self.onDismiss = onDismiss
+        self.onShowWebView = onShowWebView
     }
 
     // MARK: - Actions
@@ -57,11 +62,30 @@ final class POSPromotionViewModel: ObservableObject {
     func primaryActionTapped() {
         if isOnFinalStep {
             analytics.track(.posPromotionModalCTATapped)
-            urlOpener.open(WooConstants.URLs.posLearnMore.asURL())
+            showWebView()
             dismiss = true
         } else {
             selectedStep += 1
         }
+    }
+
+    private func showWebView() {
+        let siteID = stores.sessionManager.defaultStoreID
+        let utmProvider = WooCommerceComUTMProvider(
+            campaign: "pos_promotion_modal",
+            source: "my_store",
+            content: "pos_promotion_cta",
+            siteID: siteID
+        )
+        guard let url = utmProvider.urlWithUtmParams(string: WooConstants.URLs.posLearnMore.rawValue) else {
+            return
+        }
+        let webViewModel = WebViewSheetViewModel(
+            url: url,
+            navigationTitle: Localization.explorePOS,
+            authenticated: true
+        )
+        onShowWebView(webViewModel)
     }
 
     /// Called when the close button is tapped.

--- a/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionViewModel.swift
@@ -1,5 +1,5 @@
-import Combine
 import Foundation
+import Observation
 import protocol WooFoundation.Analytics
 import struct WooFoundation.WooCommerceComUTMProvider
 import protocol Yosemite.StoresManager
@@ -7,15 +7,21 @@ import protocol Yosemite.StoresManager
 /// View model for the POS Promotion modal flow.
 ///
 @MainActor
-final class POSPromotionViewModel: ObservableObject {
+@Observable
+final class POSPromotionViewModel {
     /// The currently selected step index (0-indexed).
-    @Published var selectedStep = 0
+    var selectedStep = 0 {
+        didSet {
+            guard selectedStep != oldValue else { return }
+            trackSlideViewed()
+        }
+    }
 
     /// The step descriptions to display in the modal.
-    @Published private(set) var stepDescriptions: [String]
+    private(set) var stepDescriptions: [String]
 
     /// When set to true, the modal should dismiss.
-    @Published var dismiss: Bool = false
+    var dismiss: Bool = false
 
     /// The total number of steps.
     var totalSteps: Int { stepDescriptions.count }
@@ -40,7 +46,6 @@ final class POSPromotionViewModel: ObservableObject {
     private let stores: StoresManager
     private let onDismiss: () -> Void
     private let onShowWebView: (WebViewSheetViewModel) -> Void
-    private var cancellables: Set<AnyCancellable> = []
 
     init(stepDescriptions: [String]? = nil,
          imageName: String = "pos-promotion-header",
@@ -56,18 +61,6 @@ final class POSPromotionViewModel: ObservableObject {
         self.stores = stores
         self.onDismiss = onDismiss
         self.onShowWebView = onShowWebView
-
-        observeSelectedStep()
-    }
-
-    private func observeSelectedStep() {
-        $selectedStep
-            .dropFirst() // Skip initial value (handled in onAppear)
-            .removeDuplicates()
-            .sink { [weak self] step in
-                self?.trackSlideViewed(step: step)
-            }
-            .store(in: &cancellables)
     }
 
     // MARK: - Actions
@@ -123,9 +116,8 @@ final class POSPromotionViewModel: ObservableObject {
 
     // MARK: - Analytics
 
-    private func trackSlideViewed(step: Int? = nil) {
-        let stepToTrack = step ?? selectedStep
-        analytics.track(.posPromoModalSlideViewed, withProperties: ["slide_index": stepToTrack])
+    private func trackSlideViewed() {
+        analytics.track(.posPromoModalSlideViewed, withProperties: ["slide_index": selectedStep])
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionViewModel.swift
@@ -47,6 +47,9 @@ final class POSPromotionViewModel {
     private let onDismiss: () -> Void
     private let onShowWebView: (WebViewSheetViewModel) -> Void
 
+    /// Tracks whether the user tapped "Explore" to avoid double-tracking dismissal.
+    private var didTapExplore = false
+
     init(stepDescriptions: [String]? = nil,
          imageName: String = "pos-promotion-header",
          title: String = Localization.title,
@@ -68,6 +71,7 @@ final class POSPromotionViewModel {
     /// Called when the primary action button is tapped.
     func primaryActionTapped() {
         if isOnFinalStep {
+            didTapExplore = true
             analytics.track(.posPromoModalExploreClicked)
             showWebView()
             dismiss = true
@@ -97,7 +101,6 @@ final class POSPromotionViewModel {
 
     /// Called when the close button is tapped.
     func closeButtonTapped() {
-        analytics.track(.posPromoModalDismissed)
         dismiss = true
     }
 
@@ -111,6 +114,9 @@ final class POSPromotionViewModel {
 
     /// Called when the view disappears.
     func onDisappear() {
+        if !didTapExplore {
+            analytics.track(.posPromoModalDismissed)
+        }
         onDismiss()
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/POS/Promotion/POSPromotionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/POS/Promotion/POSPromotionViewModelTests.swift
@@ -1,21 +1,29 @@
 import XCTest
 @testable import WooCommerce
+import Yosemite
 
 @MainActor
 final class POSPromotionViewModelTests: XCTestCase {
 
     private var analyticsProvider: MockAnalyticsProvider!
     private var analytics: WooAnalytics!
+    private var sessionManager: SessionManager!
+    private var stores: MockStoresManager!
 
     override func setUp() {
         super.setUp()
         analyticsProvider = MockAnalyticsProvider()
         analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        sessionManager = SessionManager.testingInstance
+        sessionManager.defaultStoreID = 123
+        stores = MockStoresManager(sessionManager: sessionManager)
     }
 
     override func tearDown() {
         analytics = nil
         analyticsProvider = nil
+        stores = nil
+        sessionManager = nil
         super.tearDown()
     }
 
@@ -67,25 +75,27 @@ final class POSPromotionViewModelTests: XCTestCase {
         XCTAssertEqual(sut.selectedStep, 1)
     }
 
-    func test_primaryActionTapped_opens_URL_and_dismisses_when_on_final_step() {
+    func test_primaryActionTapped_calls_onShowWebView_and_dismisses_when_on_final_step() {
         // Given
-        var openedURL: URL?
-        let urlOpener = MockURLOpener { url in
-            openedURL = url
-        }
-        let sut = makeSUT(urlOpener: urlOpener)
+        var receivedWebViewModel: WebViewSheetViewModel?
+        let sut = makeSUT(onShowWebView: { webViewModel in
+            receivedWebViewModel = webViewModel
+        })
 
         // Navigate to final step
         for _ in 0..<4 {
             sut.primaryActionTapped()
         }
         XCTAssertTrue(sut.isOnFinalStep)
+        XCTAssertNil(receivedWebViewModel)
 
         // When
         sut.primaryActionTapped()
 
         // Then
-        XCTAssertEqual(openedURL, WooConstants.URLs.posLearnMore.asURL())
+        XCTAssertNotNil(receivedWebViewModel)
+        XCTAssertTrue(receivedWebViewModel?.url.absoluteString.contains(WooConstants.URLs.posLearnMore.rawValue) == true)
+        XCTAssertTrue(receivedWebViewModel?.url.absoluteString.contains("utm_") == true)
         XCTAssertTrue(sut.dismiss)
     }
 
@@ -173,12 +183,13 @@ final class POSPromotionViewModelTests: XCTestCase {
 // MARK: - Helpers
 
 private extension POSPromotionViewModelTests {
-    func makeSUT(urlOpener: URLOpener = MockURLOpener(open: { _ in }),
-                 onDismiss: @escaping () -> Void = {}) -> POSPromotionViewModel {
+    func makeSUT(onDismiss: @escaping () -> Void = {},
+                 onShowWebView: @escaping (WebViewSheetViewModel) -> Void = { _ in }) -> POSPromotionViewModel {
         POSPromotionViewModel(
             analytics: analytics,
-            urlOpener: urlOpener,
-            onDismiss: onDismiss
+            stores: stores,
+            onDismiss: onDismiss,
+            onShowWebView: onShowWebView
         )
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/POS/Promotion/POSPromotionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/POS/Promotion/POSPromotionViewModelTests.swift
@@ -179,15 +179,33 @@ final class POSPromotionViewModelTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedProperties.first?["slide_index"] as? Int, 3)
     }
 
-    func test_closeButtonTapped_tracks_modal_dismissed_event() {
+    func test_onDisappear_tracks_dismissed_event() {
         // Given
         let sut = makeSUT()
 
         // When
-        sut.closeButtonTapped()
+        sut.onDisappear()
 
         // Then
         XCTAssertTrue(analyticsProvider.receivedEvents.contains("pos_promo_modal_dismissed"))
+    }
+
+    func test_onDisappear_does_not_track_dismissed_event_after_explore_tapped() {
+        // Given
+        let sut = makeSUT()
+
+        // Navigate to final step and tap explore
+        for _ in 0..<4 {
+            sut.primaryActionTapped()
+        }
+        sut.primaryActionTapped()
+        analyticsProvider.clearEvents()
+
+        // When
+        sut.onDisappear()
+
+        // Then
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains("pos_promo_modal_dismissed"))
     }
 
     func test_primaryActionTapped_on_final_step_tracks_explore_clicked_event() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/POS/Promotion/POSPromotionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/POS/Promotion/POSPromotionViewModelTests.swift
@@ -127,7 +127,7 @@ final class POSPromotionViewModelTests: XCTestCase {
 
     // MARK: - Analytics
 
-    func test_onAppear_tracks_modal_shown_event() {
+    func test_onAppear_tracks_modal_viewed_event() {
         // Given
         let sut = makeSUT()
 
@@ -135,7 +135,48 @@ final class POSPromotionViewModelTests: XCTestCase {
         sut.onAppear()
 
         // Then
-        XCTAssertTrue(analyticsProvider.receivedEvents.contains("pos_promotion_modal_shown"))
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("pos_promo_modal_viewed"))
+    }
+
+    func test_onAppear_tracks_initial_slide_viewed_event_with_index_zero() {
+        // Given
+        let sut = makeSUT()
+
+        // When
+        sut.onAppear()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("pos_promo_modal_slide_viewed"))
+        // The slide_viewed event is second (after modal_viewed), so its properties are at index 0
+        XCTAssertEqual(analyticsProvider.receivedProperties.first?["slide_index"] as? Int, 0)
+    }
+
+    func test_primaryActionTapped_tracks_slide_viewed_event_with_new_index() {
+        // Given
+        let sut = makeSUT()
+        sut.onAppear()
+        analyticsProvider.clearEvents()
+
+        // When
+        sut.primaryActionTapped()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("pos_promo_modal_slide_viewed"))
+        XCTAssertEqual(analyticsProvider.receivedProperties.first?["slide_index"] as? Int, 1)
+    }
+
+    func test_swiping_to_new_slide_tracks_slide_viewed_event() {
+        // Given
+        let sut = makeSUT()
+        sut.onAppear()
+        analyticsProvider.clearEvents()
+
+        // When - simulate swiping by directly changing selectedStep
+        sut.selectedStep = 3
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("pos_promo_modal_slide_viewed"))
+        XCTAssertEqual(analyticsProvider.receivedProperties.first?["slide_index"] as? Int, 3)
     }
 
     func test_closeButtonTapped_tracks_modal_dismissed_event() {
@@ -146,10 +187,10 @@ final class POSPromotionViewModelTests: XCTestCase {
         sut.closeButtonTapped()
 
         // Then
-        XCTAssertTrue(analyticsProvider.receivedEvents.contains("pos_promotion_modal_dismissed"))
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("pos_promo_modal_dismissed"))
     }
 
-    func test_primaryActionTapped_on_final_step_tracks_cta_tapped_event() {
+    func test_primaryActionTapped_on_final_step_tracks_explore_clicked_event() {
         // Given
         let sut = makeSUT()
 
@@ -162,7 +203,7 @@ final class POSPromotionViewModelTests: XCTestCase {
         sut.primaryActionTapped()
 
         // Then
-        XCTAssertTrue(analyticsProvider.receivedEvents.contains("pos_promotion_modal_cta_tapped"))
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("pos_promo_modal_explore_clicked"))
     }
 
     // MARK: - onDismiss callback


### PR DESCRIPTION
## Summary
- Opens POS learn more page in an in-app web view sheet instead of Safari
- Adds UTM parameters to the URL using `WooCommerceComUTMProvider`
- Updates analytics events to match tracking plan:
  - `pos_promo_modal_viewed`
  - `pos_promo_modal_slide_viewed` with `slide_index` property
  - `pos_promo_modal_dismissed`
  - `pos_promo_modal_explore_clicked`
- Tracks slide views on swipe (not just Next button)
- Tracks dismissal when tapping outside the modal
- Refactors view model to use `@Observable` instead of `ObservableObject`/Combine

## Test plan
- [ ] Tap "Explore WooCommerce POS" and verify web view sheet opens
- [ ] Verify URL contains UTM parameters
- [ ] Verify analytics events fire correctly:
  - [ ] `pos_promo_modal_viewed` on appear
  - [ ] `pos_promo_modal_slide_viewed` with correct index on swipe and Next
  - [ ] `pos_promo_modal_dismissed` on close button tap
  - [ ] `pos_promo_modal_dismissed` on tap outside modal
  - [ ] `pos_promo_modal_explore_clicked` on Explore tap (no dismissed event)

Part 3 of 3 for WOOMOB-1975

🤖 Generated with [Claude Code](https://claude.com/claude-code)