### PR TITLE
Add deep link routing for POS promotion

### DIFF
--- a/WooCommerce/Classes/Destinations/POSPromotionDestination.swift
+++ b/WooCommerce/Classes/Destinations/POSPromotionDestination.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Deep link destinations for POS promotion flows.
+///
+enum POSPromotionDestination: DeepLinkDestinationProtocol {
+    /// Opens the POS promotion modal explaining POS benefits.
+    case learnMore
+}

--- a/WooCommerce/Classes/Universal Links/Routes/POSRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/POSRoute.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Links supported URLs with a /pos root path to POS-related destinations.
+///
+/// Example URL: `https://woocommerce.com/mobile/pos/learn-more`
+///
+struct POSRoute: Route {
+    private let deepLinkNavigator: DeepLinkNavigator
+
+    init(deepLinkNavigator: DeepLinkNavigator) {
+        self.deepLinkNavigator = deepLinkNavigator
+    }
+
+    func canHandle(subPath: String) -> Bool {
+        return deepLinkDestination(for: subPath) != nil
+    }
+
+    func perform(for subPath: String, with parameters: [String: String]) -> Bool {
+        guard let destination = deepLinkDestination(for: subPath) else {
+            return false
+        }
+
+        deepLinkNavigator.navigate(to: destination)
+
+        return true
+    }
+}
+
+private extension POSRoute {
+    func deepLinkDestination(for posDeepLinkSubPath: String) -> (any DeepLinkDestinationProtocol)? {
+        guard posDeepLinkSubPath.hasPrefix(Constants.posRoot) else {
+            return nil
+        }
+
+        let destinationSubPath = posDeepLinkSubPath
+            .removingPrefix(Constants.posRoot)
+            .removingPrefix("/")
+
+        switch destinationSubPath {
+        case "learn-more":
+            return POSPromotionDestination.learnMore
+        default:
+            return nil
+        }
+    }
+
+    enum Constants {
+        static let posRoot = "pos"
+    }
+}

--- a/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
+++ b/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
@@ -61,7 +61,8 @@ struct UniversalLinkRouter {
             return routes
         }
         return routes + [PaymentsRoute(deepLinkNavigator: navigator),
-                         OrdersRoute(deepLinkNavigator: navigator)]
+                         OrdersRoute(deepLinkNavigator: navigator),
+                         POSRoute(deepLinkNavigator: navigator)]
     }
 
     func handle(url: URL) {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -1,4 +1,5 @@
 import Combine
+import SwiftUI
 import UIKit
 import Yosemite
 import WordPressUI
@@ -715,9 +716,21 @@ extension MainTabBarController: DeepLinkNavigator {
             navigateTo(.orders) {
                 Self.ordersTabSplitViewWrapper()?.navigate(to: destination)
             }
+        case is POSPromotionDestination:
+            presentPOSPromotionModal()
         default:
             return
         }
+    }
+
+    private func presentPOSPromotionModal() {
+        let alertController = UIAlertController(
+            title: "POS Promotion",
+            message: "POS Promotion modal placeholder",
+            preferredStyle: .alert
+        )
+        alertController.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alertController, animated: true)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -734,6 +734,9 @@
 		20D3D4332C65E59B004CE6E3 /* OrdersRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D3D4322C65E59B004CE6E3 /* OrdersRoute.swift */; };
 		20D3D4352C65E640004CE6E3 /* OrdersDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D3D4342C65E640004CE6E3 /* OrdersDestination.swift */; };
 		20D3D4372C65EF72004CE6E3 /* OrdersRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D3D4362C65EF72004CE6E3 /* OrdersRouteTests.swift */; };
+		20D3D4382F197A00004CE6E3 /* POSRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D3D4392F197A00004CE6E3 /* POSRoute.swift */; };
+		20D3D43A2F197A00004CE6E3 /* POSPromotionDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D3D43B2F197A00004CE6E3 /* POSPromotionDestination.swift */; };
+		20D3D43C2F197A00004CE6E3 /* POSRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D3D43D2F197A00004CE6E3 /* POSRouteTests.swift */; };
 		20D5CB512AFCF856009A39C3 /* PaymentsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D5CB502AFCF856009A39C3 /* PaymentsRow.swift */; };
 		20D5CB532AFCF8E7009A39C3 /* PaymentsToggleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D5CB522AFCF8E7009A39C3 /* PaymentsToggleRow.swift */; };
 		20DA45652EF975660007FD3B /* CouponCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20DA45642EF975660007FD3B /* CouponCellViewModel.swift */; };
@@ -3661,6 +3664,9 @@
 		20D3D4322C65E59B004CE6E3 /* OrdersRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersRoute.swift; sourceTree = "<group>"; };
 		20D3D4342C65E640004CE6E3 /* OrdersDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersDestination.swift; sourceTree = "<group>"; };
 		20D3D4362C65EF72004CE6E3 /* OrdersRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersRouteTests.swift; sourceTree = "<group>"; };
+		20D3D4392F197A00004CE6E3 /* POSRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSRoute.swift; sourceTree = "<group>"; };
+		20D3D43B2F197A00004CE6E3 /* POSPromotionDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSPromotionDestination.swift; sourceTree = "<group>"; };
+		20D3D43D2F197A00004CE6E3 /* POSRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSRouteTests.swift; sourceTree = "<group>"; };
 		20D5CB502AFCF856009A39C3 /* PaymentsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsRow.swift; sourceTree = "<group>"; };
 		20D5CB522AFCF8E7009A39C3 /* PaymentsToggleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsToggleRow.swift; sourceTree = "<group>"; };
 		20DA45642EF975660007FD3B /* CouponCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponCellViewModel.swift; sourceTree = "<group>"; };
@@ -7212,6 +7218,7 @@
 			children = (
 				0388E1A529E04433007DF84D /* PaymentsRouteTests.swift */,
 				20D3D4362C65EF72004CE6E3 /* OrdersRouteTests.swift */,
+				20D3D43D2F197A00004CE6E3 /* POSRouteTests.swift */,
 			);
 			path = Routes;
 			sourceTree = "<group>";
@@ -7354,6 +7361,7 @@
 				20AE33C42B0510BF00527B60 /* PaymentsMenuDestination.swift */,
 				20AE33C62B0510D200527B60 /* HubMenuDestination.swift */,
 				20D3D4342C65E640004CE6E3 /* OrdersDestination.swift */,
+				20D3D43B2F197A00004CE6E3 /* POSPromotionDestination.swift */,
 			);
 			path = Destinations;
 			sourceTree = "<group>";
@@ -10274,6 +10282,7 @@
 				B958A7C828B3D47B00823EEF /* Route.swift */,
 				B95112D928BF79CA00D9578D /* PaymentsRoute.swift */,
 				20D3D4322C65E59B004CE6E3 /* OrdersRoute.swift */,
+				20D3D4392F197A00004CE6E3 /* POSRoute.swift */,
 			);
 			path = Routes;
 			sourceTree = "<group>";
@@ -14974,6 +14983,8 @@
 				0294F8AB25E8A12C005B537A /* WooTabNavigationController.swift in Sources */,
 				029F29FA24D93E9E004751CA /* EditableProductModel.swift in Sources */,
 				20D3D4332C65E59B004CE6E3 /* OrdersRoute.swift in Sources */,
+				20D3D4382F197A00004CE6E3 /* POSRoute.swift in Sources */,
+				20D3D43A2F197A00004CE6E3 /* POSPromotionDestination.swift in Sources */,
 				2DCB54FA2E6AE8E100621F90 /* CIABEligibilityChecker.swift in Sources */,
 				31FC8CE927B476BA004B9456 /* CardReaderSettingsResultsControllers.swift in Sources */,
 				022266BC2AE7707000614F34 /* ConfigurableBundleItemViewModel.swift in Sources */,
@@ -16399,6 +16410,7 @@
 				6856D2A5C2076F5BF14F2C11 /* KeyboardStateProviderTests.swift in Sources */,
 				B9DA153E28101BE100FC67DD /* MockOrderRefundsOptionsDeterminer.swift in Sources */,
 				20D3D4372C65EF72004CE6E3 /* OrdersRouteTests.swift in Sources */,
+				20D3D43C2F197A00004CE6E3 /* POSRouteTests.swift in Sources */,
 				09C6A26227C01166001FAD73 /* BulkUpdateViewModelTests.swift in Sources */,
 				6856D806DE7DB61522D54044 /* NSMutableAttributedStringHelperTests.swift in Sources */,
 				023D69442588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Universal Links/Routes/POSRouteTests.swift
+++ b/WooCommerce/WooCommerceTests/Universal Links/Routes/POSRouteTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+@testable import WooCommerce
+
+final class POSRouteTests: XCTestCase {
+
+    private var deepLinkNavigator: MockDeepLinkNavigator!
+    private var sut: POSRoute!
+
+    override func setUp() {
+        deepLinkNavigator = MockDeepLinkNavigator()
+        sut = POSRoute(deepLinkNavigator: deepLinkNavigator)
+    }
+
+    func test_canHandle_returns_true_for_pos_learn_more_deep_link_path() {
+        XCTAssertTrue(sut.canHandle(subPath: "pos/learn-more"))
+    }
+
+    func test_canHandle_returns_false_for_pos_root_without_subpath() {
+        XCTAssertFalse(sut.canHandle(subPath: "pos"))
+    }
+
+    func test_canHandle_returns_false_for_unrelated_path() {
+        XCTAssertFalse(sut.canHandle(subPath: "orders"))
+    }
+
+    func test_performAction_forwards_pos_learn_more_deep_link() throws {
+        // Given
+        let path = "pos/learn-more"
+
+        // When
+        let reportedHandled = sut.perform(for: path, with: [:])
+
+        // Then
+        XCTAssertTrue(reportedHandled)
+        let navigatedDestination = try XCTUnwrap(deepLinkNavigator.spyNavigatedDestination as? POSPromotionDestination)
+        assertEqual(POSPromotionDestination.learnMore, navigatedDestination)
+    }
+
+    func test_performAction_does_not_forward_unrecognised_deep_link() {
+        // Given
+        let path = "pos/some-future-feature"
+
+        // When
+        let reportedHandled = sut.perform(for: path, with: [:])
+
+        // Then
+        XCTAssertFalse(reportedHandled)
+        XCTAssertFalse(deepLinkNavigator.spyDidNavigate)
+    }
+}

--- a/WooCommerce/WooCommerceTests/Universal Links/UniversalLinkRouterTests.swift
+++ b/WooCommerce/WooCommerceTests/Universal Links/UniversalLinkRouterTests.swift
@@ -169,12 +169,13 @@ final class UniversalLinkRouterTests: XCTestCase {
         let routes = UniversalLinkRouter.defaultRoutes(navigator: mockNavigator)
 
         // Then
-        assertEqual(4, routes.count)
+        assertEqual(5, routes.count)
 
         XCTAssert(routes.contains { $0 is OrderDetailsRoute })
         XCTAssert(routes.contains { $0 is MyStoreRoute })
         XCTAssert(routes.contains { $0 is PaymentsRoute })
         XCTAssert(routes.contains { $0 is OrdersRoute })
+        XCTAssert(routes.contains { $0 is POSRoute })
     }
 
     func test_canHandle_returns_false_for_magic_link_url() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of: WOOMOB-1975

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds deeplink handling for a route which will in future, open a POS info modal flow. This will be used from a JITM to show more details of POS without having to actually go to the web.

For now, it only shows a placeholder alert.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Build and run the app
- Add "https://woocommerce.com/mobile/pos/learn-more" as a link in Notes/Reminders, and tap it
- Verify placeholder alert appears


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/309f2c1f-a748-428d-b186-65fb1519135d


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
