### PR TITLE
Add analytics and web view for POS promotion

### DIFF
--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -911,6 +911,12 @@ public enum WooAnalyticsStat: String {
     case firstCreatedProductShown = "first_created_product_shown"
     case firstCreatedProductShareTapped = "first_created_product_share_tapped"
 
+    // MARK: POS Promotion Modal
+    case posPromoModalViewed = "pos_promo_modal_viewed"
+    case posPromoModalSlideViewed = "pos_promo_modal_slide_viewed"
+    case posPromoModalDismissed = "pos_promo_modal_dismissed"
+    case posPromoModalExploreClicked = "pos_promo_modal_explore_clicked"
+
     // MARK: Product sharing AI
     //
     case productSharingAIDisplayed = "product_sharing_ai_displayed"

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,9 +5,7 @@
 -----
 - [*] Login: Show error alert when login with site credentials fails due to basic auth [https://github.com/woocommerce/woocommerce-ios/pull/16485]
 - [internal] Track WPCom connection type [https://github.com/woocommerce/woocommerce-ios/pull/16509]
-
-24.0
------
+- [*] Add POS learn more modal flow [https://github.com/woocommerce/woocommerce-ios/pull/16528]
 
 
 23.9

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -136,6 +136,10 @@ extension WooConstants {
         ///
         case helpCenter = "https://woocommerce.com/document/woocommerce-ios/"
 
+        /// POS Learn More URL
+        ///
+        case posLearnMore = "https://woocommerce.com/mobile/pos/learn-more"
+
         /// Help Center for "Enter your Store Address" screen
         ///
         case helpCenterForEnterStoreAddress = "https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-store-address"

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -724,15 +724,32 @@ extension MainTabBarController: DeepLinkNavigator {
     }
 
     private func presentPOSPromotionModal() {
+        var pendingWebViewModel: WebViewSheetViewModel?
+
         let modalView = POSPromotionModal_UIKit(
             onDismiss: { [weak self] in
-                self?.dismiss(animated: false)
+                self?.dismiss(animated: false) {
+                    if let webViewModel = pendingWebViewModel {
+                        self?.presentWebViewSheet(webViewModel)
+                    }
+                }
+            },
+            onShowWebView: { webViewModel in
+                pendingWebViewModel = webViewModel
             }
         )
         let hostingController = UIHostingController(rootView: modalView)
         hostingController.view.backgroundColor = .clear
         hostingController.modalPresentationStyle = .overFullScreen
         hostingController.modalTransitionStyle = .crossDissolve
+        present(hostingController, animated: true)
+    }
+
+    private func presentWebViewSheet(_ webViewModel: WebViewSheetViewModel) {
+        let webViewSheet = WebViewSheet(viewModel: webViewModel, done: { [weak self] in
+            self?.dismiss(animated: true)
+        })
+        let hostingController = UIHostingController(rootView: webViewSheet)
         present(hostingController, animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionView.swift
+++ b/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionView.swift
@@ -138,9 +138,10 @@ struct POSPromotionModal_UIKit: View {
     @State private var viewModel: POSPromotionViewModel
     let onDismiss: (() -> Void)?
 
-    init(onDismiss: (() -> Void)? = nil) {
+    init(onDismiss: (() -> Void)? = nil,
+         onShowWebView: @escaping (WebViewSheetViewModel) -> Void = { _ in }) {
         self.onDismiss = onDismiss
-        self._viewModel = State(wrappedValue: POSPromotionViewModel())
+        self._viewModel = State(wrappedValue: POSPromotionViewModel(onShowWebView: onShowWebView))
     }
 
     var body: some View {

--- a/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionViewModel.swift
@@ -1,5 +1,8 @@
 import Foundation
 import Observation
+import protocol WooFoundation.Analytics
+import struct WooFoundation.WooCommerceComUTMProvider
+import protocol Yosemite.StoresManager
 
 /// View model for the POS Promotion modal flow.
 ///
@@ -7,7 +10,12 @@ import Observation
 @Observable
 final class POSPromotionViewModel {
     /// The currently selected step index (0-indexed).
-    var selectedStep = 0
+    var selectedStep = 0 {
+        didSet {
+            guard selectedStep != oldValue else { return }
+            trackSlideViewed()
+        }
+    }
 
     /// The step descriptions to display in the modal.
     private(set) var stepDescriptions: [String]
@@ -34,16 +42,28 @@ final class POSPromotionViewModel {
         isOnFinalStep ? Localization.explorePOS : Localization.next
     }
 
+    private let analytics: Analytics
+    private let stores: StoresManager
     private let onDismiss: () -> Void
+    private let onShowWebView: (WebViewSheetViewModel) -> Void
+
+    /// Tracks whether the user tapped "Explore" to avoid double-tracking dismissal.
+    private var didTapExplore = false
 
     init(stepDescriptions: [String]? = nil,
          imageName: String = "pos-promotion-header",
          title: String = Localization.title,
-         onDismiss: @escaping () -> Void = {}) {
+         analytics: Analytics = ServiceLocator.analytics,
+         stores: StoresManager = ServiceLocator.stores,
+         onDismiss: @escaping () -> Void = {},
+         onShowWebView: @escaping (WebViewSheetViewModel) -> Void = { _ in }) {
         self.stepDescriptions = stepDescriptions ?? POSPromotionStepsFactory.stepDescriptions()
         self.imageName = imageName
         self.title = title
+        self.analytics = analytics
+        self.stores = stores
         self.onDismiss = onDismiss
+        self.onShowWebView = onShowWebView
     }
 
     // MARK: - Actions
@@ -51,10 +71,32 @@ final class POSPromotionViewModel {
     /// Called when the primary action button is tapped.
     func primaryActionTapped() {
         if isOnFinalStep {
+            didTapExplore = true
+            analytics.track(.posPromoModalExploreClicked)
+            showWebView()
             dismiss = true
         } else {
             selectedStep += 1
         }
+    }
+
+    private func showWebView() {
+        let siteID = stores.sessionManager.defaultStoreID
+        let utmProvider = WooCommerceComUTMProvider(
+            campaign: "pos_promotion_modal",
+            source: "my_store",
+            content: "pos_promotion_cta",
+            siteID: siteID
+        )
+        guard let url = utmProvider.urlWithUtmParams(string: WooConstants.URLs.posLearnMore.rawValue) else {
+            return
+        }
+        let webViewModel = WebViewSheetViewModel(
+            url: url,
+            navigationTitle: Localization.explorePOS,
+            authenticated: true
+        )
+        onShowWebView(webViewModel)
     }
 
     /// Called when the close button is tapped.
@@ -66,12 +108,22 @@ final class POSPromotionViewModel {
 
     /// Called when the view appears.
     func onAppear() {
-        // Analytics tracking will be added in the next PR
+        analytics.track(.posPromoModalViewed)
+        trackSlideViewed()
     }
 
     /// Called when the view disappears.
     func onDisappear() {
+        if !didTapExplore {
+            analytics.track(.posPromoModalDismissed)
+        }
         onDismiss()
+    }
+
+    // MARK: - Analytics
+
+    private func trackSlideViewed() {
+        analytics.track(.posPromoModalSlideViewed, withProperties: ["slide_index": selectedStep])
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/POS/Promotion/POSPromotionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/POS/Promotion/POSPromotionViewModelTests.swift
@@ -1,8 +1,31 @@
 import XCTest
 @testable import WooCommerce
+import Yosemite
 
 @MainActor
 final class POSPromotionViewModelTests: XCTestCase {
+
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
+    private var sessionManager: SessionManager!
+    private var stores: MockStoresManager!
+
+    override func setUp() {
+        super.setUp()
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        sessionManager = SessionManager.testingInstance
+        sessionManager.defaultStoreID = 123
+        stores = MockStoresManager(sessionManager: sessionManager)
+    }
+
+    override func tearDown() {
+        analytics = nil
+        analyticsProvider = nil
+        stores = nil
+        sessionManager = nil
+        super.tearDown()
+    }
 
     // MARK: - Initial State
 
@@ -52,20 +75,27 @@ final class POSPromotionViewModelTests: XCTestCase {
         XCTAssertEqual(sut.selectedStep, 1)
     }
 
-    func test_primaryActionTapped_dismisses_when_on_final_step() {
+    func test_primaryActionTapped_calls_onShowWebView_and_dismisses_when_on_final_step() {
         // Given
-        let sut = makeSUT()
+        var receivedWebViewModel: WebViewSheetViewModel?
+        let sut = makeSUT(onShowWebView: { webViewModel in
+            receivedWebViewModel = webViewModel
+        })
 
         // Navigate to final step
         for _ in 0..<4 {
             sut.primaryActionTapped()
         }
         XCTAssertTrue(sut.isOnFinalStep)
+        XCTAssertNil(receivedWebViewModel)
 
         // When
         sut.primaryActionTapped()
 
         // Then
+        XCTAssertNotNil(receivedWebViewModel)
+        XCTAssertTrue(receivedWebViewModel?.url.absoluteString.contains(WooConstants.URLs.posLearnMore.rawValue) == true)
+        XCTAssertTrue(receivedWebViewModel?.url.absoluteString.contains("utm_") == true)
         XCTAssertTrue(sut.dismiss)
     }
 
@@ -95,6 +125,105 @@ final class POSPromotionViewModelTests: XCTestCase {
         XCTAssertTrue(sut.dismiss)
     }
 
+    // MARK: - Analytics
+
+    func test_onAppear_tracks_modal_viewed_event() {
+        // Given
+        let sut = makeSUT()
+
+        // When
+        sut.onAppear()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("pos_promo_modal_viewed"))
+    }
+
+    func test_onAppear_tracks_initial_slide_viewed_event_with_index_zero() {
+        // Given
+        let sut = makeSUT()
+
+        // When
+        sut.onAppear()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("pos_promo_modal_slide_viewed"))
+        // The slide_viewed event is second (after modal_viewed), so its properties are at index 0
+        XCTAssertEqual(analyticsProvider.receivedProperties.first?["slide_index"] as? Int, 0)
+    }
+
+    func test_primaryActionTapped_tracks_slide_viewed_event_with_new_index() {
+        // Given
+        let sut = makeSUT()
+        sut.onAppear()
+        analyticsProvider.clearEvents()
+
+        // When
+        sut.primaryActionTapped()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("pos_promo_modal_slide_viewed"))
+        XCTAssertEqual(analyticsProvider.receivedProperties.first?["slide_index"] as? Int, 1)
+    }
+
+    func test_swiping_to_new_slide_tracks_slide_viewed_event() {
+        // Given
+        let sut = makeSUT()
+        sut.onAppear()
+        analyticsProvider.clearEvents()
+
+        // When - simulate swiping by directly changing selectedStep
+        sut.selectedStep = 3
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("pos_promo_modal_slide_viewed"))
+        XCTAssertEqual(analyticsProvider.receivedProperties.first?["slide_index"] as? Int, 3)
+    }
+
+    func test_onDisappear_tracks_dismissed_event() {
+        // Given
+        let sut = makeSUT()
+
+        // When
+        sut.onDisappear()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("pos_promo_modal_dismissed"))
+    }
+
+    func test_onDisappear_does_not_track_dismissed_event_after_explore_tapped() {
+        // Given
+        let sut = makeSUT()
+
+        // Navigate to final step and tap explore
+        for _ in 0..<4 {
+            sut.primaryActionTapped()
+        }
+        sut.primaryActionTapped()
+        analyticsProvider.clearEvents()
+
+        // When
+        sut.onDisappear()
+
+        // Then
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains("pos_promo_modal_dismissed"))
+    }
+
+    func test_primaryActionTapped_on_final_step_tracks_explore_clicked_event() {
+        // Given
+        let sut = makeSUT()
+
+        // Navigate to final step
+        for _ in 0..<4 {
+            sut.primaryActionTapped()
+        }
+
+        // When
+        sut.primaryActionTapped()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("pos_promo_modal_explore_clicked"))
+    }
+
     // MARK: - onDismiss callback
 
     func test_onDisappear_calls_onDismiss_callback() {
@@ -113,7 +242,13 @@ final class POSPromotionViewModelTests: XCTestCase {
 // MARK: - Helpers
 
 private extension POSPromotionViewModelTests {
-    func makeSUT(onDismiss: @escaping () -> Void = {}) -> POSPromotionViewModel {
-        POSPromotionViewModel(onDismiss: onDismiss)
+    func makeSUT(onDismiss: @escaping () -> Void = {},
+                 onShowWebView: @escaping (WebViewSheetViewModel) -> Void = { _ in }) -> POSPromotionViewModel {
+        POSPromotionViewModel(
+            analytics: analytics,
+            stores: stores,
+            onDismiss: onDismiss,
+            onShowWebView: onShowWebView
+        )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of: WOOMOB-1975
Merge after: #16527 

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the final CTA webview opening for the new POS learn more modal flow, and analytics for the flow.


## Summary
- Add analytics events for modal lifecycle:
  - `pos_promo_modal_viewed` - tracked on modal appear
  - `pos_promo_modal_slide_viewed` - tracked on slide change (swipe or Next button)
  - `pos_promo_modal_dismissed` - tracked when modal closes (except via Explore)
  - `pos_promo_modal_explore_clicked` - tracked when user taps Explore
- Open POS learn more URL in authenticated web view with UTM parameters
- Use callback pattern to present web view after modal dismisses to avoid presentation conflict

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Set up a network proxy tool using breakpoints or Map Local on /jetpack/v4/jitm. It's important to set this up for both WPcom tunneled requests and direct site requests. You can return a JITM using this payload:

```
{
  "data": [
    {
      "site_id": 216335538,
      "id": "test-message",
      "feature_class": "feature",
      "content": {
        "message": "Run WooCommerce POS on tablets",
        "description": "Take in‑person payments with Woo POS. Set up on a tablet and start selling today."
      },
      "CTA": {
        "message": "Learn more",
        "link": "https://woocommerce.com/mobile/pos/learn-more"
      },
      "assets": {
      "background_image_url": "https://sheer-trapdoor-clam.jurassic.ninja/wp-content/uploads/2026/01/pos-jitm-bg.png"
      },
      "template": "banner"
    }
  ]
}
```

Use your own site ID if you like but it doesn't actually matter in this payload...
Tap the link in the JITM

- Verify `pos_promo_modal_viewed` event is tracked
- Swipe to different pages and verify `pos_promo_modal_slide_viewed` is tracked with correct slide_index
- Tap Next and verify slide_viewed tracking
- Tap X to close modal and verify `pos_promo_modal_dismissed` is tracked
- Re-open modal, navigate to final step, tap "Explore WooCommerce POS"
- Verify `pos_promo_modal_explore_clicked` is tracked
- Verify web view opens with UTM parameters in URL
- Verify `pos_promo_modal_dismissed` is NOT tracked after Explore

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/1b9d589d-e92c-4f9f-94c4-84e2fc34d0e0



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.