### PR TITLE
[Woo POS][POS Products] Enable `pointOfSaleOnlyProducts` in release builds

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -109,7 +109,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .selfDrivenPushToken:
             return false
         case .pointOfSaleOnlyProducts:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         default:
             return true
         }


### PR DESCRIPTION
## Description
This PR switches the `pointOfSaleOnlyProducts` to true, releasing the only POS products project.

## Test Steps

1. Setup: Your store needs to run these changes: [woocommerce/pull/62824](https://href.li/?https://github.com/woocommerce/woocommerce/pull/62824) to use the new filter, which will come out with WooCommerce 10.5. There are several options you can choose from:

- Create a new Jurassic ninja site with this branch (wooplug-6145-addingremoving-pos-hidden-taxonomy-on-variations-doesnt).
- Use my testing store [https://indiemelon.mystagingwebsite.com/](https://href.li/?https://indiemelon.mystagingwebsite.com/), which currently has that version installed (let me know if you need access)
- Install the plugin version that contains the changes [from this link](https://href.li/?https://indiemelon.mystagingwebsite.com/wp-content/uploads/2026/01/woocommerce-20260116.zip) into your own store.
- Install [Jetpack Beta Tester](https://href.li/?https://jetpack.com/download-jetpack-beta/) plugin on your own store and select the branch mentioned above.

2. Test

- Update the app's build configuration to `release`
- In wp-admin, go to WooCommerce > Products. Select one or several POS-eligible products, and under the advanced tab, unselect the available for POS checkbox and save the changes
- Load POS. The unchecked products shouldn't appear in the item list.
