### PR TITLE
[POS Refunds] Confirmation Screen

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -502,12 +502,14 @@ enum RefundModalState: Identifiable, Equatable {
     case itemSelection
     case review(POSRefundReviewData)
     case reasonInput(POSRefundReviewData)
+    case confirmation(POSRefundReviewData)
 
     var id: String {
         switch self {
         case .itemSelection: return "itemSelection"
         case .review: return "review"
         case .reasonInput: return "reasonInput"
+        case .confirmation: return "confirmation"
         }
     }
 }
@@ -536,8 +538,7 @@ private extension POSOrderDetailsView {
                     refundModalState = .reasonInput(reviewData)
                 },
                 onContinue: {
-                    // TODO: Process refund
-                    refundModalState = nil
+                    refundModalState = .confirmation(reviewData)
                 },
                 onEditRefund: {
                     refundModalState = .itemSelection
@@ -556,6 +557,21 @@ private extension POSOrderDetailsView {
                 },
                 onClose: {
                     refundModalState = nil
+                }
+            )
+        case .confirmation(let reviewData):
+            POSRefundConfirmationView(
+                formattedRefundTotal: reviewData.formattedRefundTotal,
+                paymentMethodDescription: reviewData.paymentMethodDescription,
+                onClose: {
+                    refundModalState = nil
+                },
+                onConfirm: {
+                    // TODO: Process refund
+                    refundModalState = nil
+                },
+                onBack: {
+                    refundModalState = .review(reviewData)
                 }
             )
         }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+struct POSRefundConfirmationView: View {
+    let formattedRefundTotal: String
+    let paymentMethodDescription: String
+    let onClose: () -> Void
+    let onConfirm: () -> Void
+    let onBack: () -> Void
+
+    @Environment(\.posModalParentSize) private var parentSize
+
+    var body: some View {
+        VStack(spacing: POSSpacing.none) {
+            headerView
+            messageView
+            buttonsSection
+        }
+        .background(Color.posSurfaceBright)
+        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
+        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding * 2))
+    }
+}
+
+// MARK: - Subviews
+
+private extension POSRefundConfirmationView {
+    var headerView: some View {
+        HStack {
+            Text(String(format: Localization.titleFormat, formattedRefundTotal))
+                .font(.posHeadingBold)
+                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                .lineLimit(1)
+            Spacer()
+            Button {
+                onClose()
+            } label: {
+                Text(Image(systemName: "xmark"))
+                    .font(.posButtonSymbolLarge)
+            }
+            .accessibilityLabel(Localization.closeButtonAccessibilityLabel)
+        }
+        .foregroundColor(Color.posOnSurface)
+        .padding(POSPadding.xLarge)
+    }
+
+    var messageView: some View {
+        Text(String(format: Localization.confirmationMessageFormat,
+                    formattedRefundTotal,
+                    paymentMethodDescription))
+            .font(.posBodyLargeRegular())
+            .foregroundColor(Color.posOnSurface)
+            .multilineTextAlignment(.leading)
+            .padding(.horizontal, POSPadding.xLarge)
+    }
+
+    var buttonsSection: some View {
+        VStack(spacing: POSSpacing.medium) {
+            Button(Localization.confirmButton, action: onConfirm)
+                .buttonStyle(POSFilledButtonStyle(size: .normal))
+
+            Button(Localization.backButton, action: onBack)
+                .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+        }
+        .padding(POSPadding.xLarge)
+    }
+}
+
+// MARK: - Localization
+
+private extension POSRefundConfirmationView {
+    enum Localization {
+        static let titleFormat = NSLocalizedString(
+            "pos.refundConfirmationView.titleFormat",
+            value: "Refund %@",
+            comment: "Title for the refund confirmation modal. %@ is the formatted refund amount."
+        )
+
+        static let closeButtonAccessibilityLabel = NSLocalizedString(
+            "pos.refundConfirmationView.closeButton.accessibilityLabel",
+            value: "Close",
+            comment: "Accessibility label for close button on refund confirmation modal"
+        )
+
+        static let confirmationMessageFormat = NSLocalizedString(
+            "pos.refundConfirmationView.confirmationMessageFormat",
+            value: "Are you sure you wish to process to refund %1$@ %2$@? This action cannot be undone.",
+            comment: "Confirmation message for the refund. %1$@ is the formatted amount, %2$@ is the payment method description."
+        )
+
+        static let confirmButton = NSLocalizedString(
+            "pos.refundConfirmationView.confirmButton",
+            value: "Yes, proceed",
+            comment: "Button to confirm and process the refund"
+        )
+
+        static let backButton = NSLocalizedString(
+            "pos.refundConfirmationView.backButton",
+            value: "Back",
+            comment: "Button to go back to the previous screen"
+        )
+    }
+}
+
+#if DEBUG
+#Preview("POSRefundConfirmationView") {
+    POSRefundConfirmationView(
+        formattedRefundTotal: "$132.60",
+        paymentMethodDescription: "via payment card ••••1456",
+        onClose: {},
+        onConfirm: {},
+        onBack: {}
+    )
+    .environment(\.posModalParentSize, CGSize(width: 1192, height: 822))
+}
+#endif


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
Part of WOOMOB-1786

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement the confirmation screen of the refunds flow. The user can close the flow, proceed with the refund, or go back.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Go to POS
2. Go to Orders
3. Tap on Issue Refund for any order
4. Follow the flow until the confirmation screen (see video below)
5. Try closing the flow, proceeding, and going back

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/8ec75989-10c1-4ce2-8cda-78f1047c0ca4



---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
