### PR TITLE
Update POS promotional modal title and spacing

### DIFF
--- a/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionView.swift
+++ b/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionView.swift
@@ -68,13 +68,16 @@ private extension POSPromotionView {
     @ViewBuilder var descriptionPages: some View {
         TabView(selection: $viewModel.selectedStep) {
             ForEach(0..<viewModel.totalSteps, id: \.self) { index in
-                ScrollView {
-                    Text(viewModel.stepDescriptions[index])
-                        .font(.body)
-                        .foregroundStyle(Color(.label))
-                        .multilineTextAlignment(.center)
+                GeometryReader { geometry in
+                    ScrollView {
+                        Text(viewModel.stepDescriptions[index])
+                            .font(.body)
+                            .foregroundStyle(Color(.label))
+                            .multilineTextAlignment(.center)
+                            .frame(maxWidth: .infinity, minHeight: geometry.size.height)
+                    }
+                    .scrollBounceBehavior(.basedOnSize)
                 }
-                .scrollBounceBehavior(.basedOnSize)
                 .tag(index)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionViewModel.swift
@@ -132,7 +132,7 @@ final class POSPromotionViewModel {
 private enum Localization {
     static let title = NSLocalizedString(
         "posPromotion.title",
-        value: "Run POS with the WooCommerce mobile app",
+        value: "Point of Sale from WooCommerce",
         comment: "Title for the POS promotion modal (shown on all steps)"
     )
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR changes the title of the modal to `Point of Sale from WooCommerce` and vertically centres the description pages.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Set up a network proxy tool using breakpoints or Map Local on /jetpack/v4/jitm. It's important to set this up for both WPcom tunneled requests and direct site requests. You can return a JITM using this payload:

```
{
  "data": [
    {
      "site_id": 216335538,
      "id": "test-message",
      "feature_class": "feature",
      "content": {
        "message": "Run WooCommerce POS on tablets",
        "description": "Take in‑person payments with Woo POS. Set up on a tablet and start selling today."
      },
      "CTA": {
        "message": "Learn more",
        "link": "https://woocommerce.com/mobile/pos/learn-more"
      },
      "assets": {
      "background_image_url": "https://sheer-trapdoor-clam.jurassic.ninja/wp-content/uploads/2026/01/pos-jitm-bg.png"
      },
      "template": "banner"
    }
  ]
}
```

Use your own site ID if you like but it doesn't actually matter in this payload...

Open the app, and tap the link in the JITM.

- Verify modal appears with correct title
- Swipe through all 5 pages, verify that the text is vertically centred.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/219a215c-4d92-4c3e-8a0f-16a63f4a6c4f


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
