### PR TITLE
Push Notifications: Avoid duplicated PNs from Woo and WPCom

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -105,7 +105,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .pointOfSaleRefundsi1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .selfDrivenPushToken:
-            return true
+            return false
         case .pointOfSaleOnlyProducts:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -105,7 +105,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .pointOfSaleRefundsi1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .selfDrivenPushToken:
-            return false
+            return true
         case .pointOfSaleOnlyProducts:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -18,7 +18,7 @@ extension UserDefaults {
         case defaultRoles
         case deviceID
         case deviceToken
-        case wooPushnotificationToken
+        case wooPushNotificationToken
         case errorLoginSiteAddress
         case hasFinishedOnboarding
         case installationDate

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -77,6 +77,9 @@ extension UserDefaults {
 
         // CIAB Bookings tab availability
         case ciabBookingsTabAvailable
+
+        /// Registered site IDs separated by commas
+        case siteIDsRegisteredForWooPushNotifications
     }
 }
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -102,9 +102,12 @@ final class PushNotificationsManager: PushNotesManager {
             if let newValue,
                let deviceID = Int64(newValue),
                siteIDsRegisteredForWooPNs.isNotEmpty {
-                disableWPComPushNotificationsForRelevantSites(
+                disableWPComPushNotifications(
                     siteIDs: siteIDsRegisteredForWooPNs,
-                    deviceID: deviceID
+                    deviceID: deviceID,
+                    onCompletion: { result in
+                        // TODO: add tracking for failure
+                    }
                 )
             }
         }
@@ -702,7 +705,7 @@ private extension PushNotificationsManager {
               !configuration.storesManager.isAuthenticatedWithoutWPCom else {
             return onCompletion(.success(tokenID))
         }
-        disableWPComPushNotifications(siteID: siteID, deviceID: deviceIDInt) { result in
+        disableWPComPushNotifications(siteIDs: [siteID], deviceID: deviceIDInt) { result in
             if let error = result.failure {
                 // TODO: add tracking for failure
             }
@@ -728,26 +731,16 @@ private extension PushNotificationsManager {
         configuration.storesManager.dispatch(action)
     }
 
-    /// Disables mobile push notifications for a site ID.
+    /// Disables mobile push notifications for given site IDs.
     ///
-    func disableWPComPushNotifications(siteID: Int64, deviceID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        let updatedBlog = NotificationSettings.Blog(blogID: siteID, devices: [
-            .init(deviceID: deviceID, newComment: false, storeOrder: false)
-        ])
-        let siteSettings = NotificationSettings(blogs: [updatedBlog])
-        stores.dispatch(AccountAction.updateNotificationSettings(notificationSettings: siteSettings, onCompletion: onCompletion))
-    }
-
-    func disableWPComPushNotificationsForRelevantSites(siteIDs: [Int64], deviceID: Int64) {
+    func disableWPComPushNotifications(siteIDs: [Int64], deviceID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
         let updatedBlogs = siteIDs.map {
             NotificationSettings.Blog(blogID: $0, devices: [
                 .init(deviceID: deviceID, newComment: false, storeOrder: false)
             ])
         }
         let siteSettings = NotificationSettings(blogs: updatedBlogs)
-        stores.dispatch(AccountAction.updateNotificationSettings(notificationSettings: siteSettings) { result in
-            // TODO: add tracking for failure
-        })
+        stores.dispatch(AccountAction.updateNotificationSettings(notificationSettings: siteSettings, onCompletion: onCompletion))
     }
 
     func unregisterFromWooPushNotificationsIfPossible(completion: @escaping (Result<Void, Error>) -> Void) {

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -281,19 +281,7 @@ extension PushNotificationsManager {
 
         deviceToken = newToken
 
-        if selfDrivenPushNotificationEnabled {
-            DDLogInfo("📱 Self Registering Push Notifications")
-            // We will need to remove the old registartion, this is just for the newly registered stores
-            registerSelfDrivenPushNotificationFlow(with: newToken) { result in
-                switch result {
-                case .failure(let error):
-                    DDLogError("⛔️ Self Registering Push Notifications Registration Failure: \(error)")
-                case .success(let token):
-                    DDLogInfo("📱 Self Registering Push Notifications success: \(token)")
-                }
-            }
-        }
-        else {
+        func registerForWPComPushNotifications() {
             // Register in the Dotcom's Infrastructure
             registerDotcomDevice(with: newToken) { (device, error) in
                 guard let deviceID = device?.deviceID else {
@@ -304,6 +292,26 @@ extension PushNotificationsManager {
                 DDLogVerbose("📱 Successfully registered Device ID \(deviceID) for Push Notifications")
                 self.deviceID = deviceID
             }
+        }
+
+        if selfDrivenPushNotificationEnabled {
+            DDLogInfo("📱 Self Registering Push Notifications")
+            // We will need to remove the old registartion, this is just for the newly registered stores
+            registerSelfDrivenPushNotificationFlow(with: newToken) { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case .failure(let error):
+                    DDLogError("⛔️ Self Registering Push Notifications Registration Failure: \(error)")
+                    // Fall back to dotcom PNs if authenticated with WPCom
+                    if !stores.isAuthenticatedWithoutWPCom {
+                        registerForWPComPushNotifications()
+                    }
+                case .success(let token):
+                    DDLogInfo("📱 Self Registering Push Notifications success: \(token)")
+                }
+            }
+        } else {
+            registerForWPComPushNotifications()
         }
     }
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -140,7 +140,7 @@ final class PushNotificationsManager: PushNotesManager {
     private let analytics: Analytics
 
     private let backgroundSynchronizerFactory: PushNotificationBackgroundSynchronizerFactoryProtocol
-    private let shouldRegisterSelfDrivenPushNotification: Bool
+    private let selfDrivenPushNotificationEnabled: Bool
 
     /// Initializes the PushNotificationsManager.
     ///
@@ -153,7 +153,7 @@ final class PushNotificationsManager: PushNotesManager {
         self.configuration = configuration
         self.backgroundSynchronizerFactory = backgroundSynchronizerFactory
         self.analytics = analytics
-        self.shouldRegisterSelfDrivenPushNotification = shouldRegisterSelfDrivenPushNotification
+        self.selfDrivenPushNotificationEnabled = shouldRegisterSelfDrivenPushNotification
     }
 }
 
@@ -201,17 +201,20 @@ extension PushNotificationsManager {
         DDLogInfo("📱 Unregistering For Remote Notifications...")
 
         let group = DispatchGroup()
-        group.enter()
-        unregisterFromWooPushNotificationsIfPossible { result in
-            switch result {
-            case .success:
-                DDLogInfo("📱 Successfully unregistered from Woo Push Notifications!")
-            case .failure(let error):
-                DDLogError("⛔️ Unable to unregister from Woo Push Notifications: \(error)")
+
+        if selfDrivenPushNotificationEnabled {
+            group.enter()
+            unregisterFromWooPushNotificationsIfPossible { result in
+                switch result {
+                case .success:
+                    DDLogInfo("📱 Successfully unregistered from Woo Push Notifications!")
+                case .failure(let error):
+                    DDLogError("⛔️ Unable to unregister from Woo Push Notifications: \(error)")
+                }
+                self.wooPushNotificationToken = nil
+                self.siteIDsRegisteredForWooPNs = []
+                group.leave()
             }
-            self.wooPushNotificationToken = nil
-            self.siteIDsRegisteredForWooPNs = []
-            group.leave()
         }
 
         group.enter()
@@ -278,7 +281,7 @@ extension PushNotificationsManager {
 
         deviceToken = newToken
 
-        if shouldRegisterSelfDrivenPushNotification {
+        if selfDrivenPushNotificationEnabled {
             DDLogInfo("📱 Self Registering Push Notifications")
             // We will need to remove the old registartion, this is just for the newly registered stores
             registerSelfDrivenPushNotificationFlow(with: newToken) { result in

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -345,6 +345,11 @@ extension PushNotificationsManager {
         handleRemoteNotificationInAllAppStates(content.userInfo)
 
         if let foregroundNotification = PushNotification.from(userInfo: content.userInfo) {
+            if siteIDsRegisteredForWooPNs.contains(foregroundNotification.siteID),
+               foregroundNotification.noteID == nil {
+                // Ignore WPCom PNs if site is registered for Woo PNs
+                return UNNotificationPresentationOptions(rawValue: 0)
+            }
             configuration.application
                 .presentInAppNotification(title: foregroundNotification.title,
                                           subtitle: foregroundNotification.subtitle,

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -310,7 +310,12 @@ extension PushNotificationsManager {
                 switch result {
                 case .failure(let error):
                     DDLogError("⛔️ Self Registering Push Notifications Registration Failure: \(error)")
-                    // Fall back to dotcom PNs if authenticated with WPCom
+                    // Removes site from registered list if exists.
+                    if let siteID, siteIDsRegisteredForWooPNs.contains(siteID) {
+                        let updatedList = siteIDsRegisteredForWooPNs.filter { $0 != siteID }
+                        siteIDsRegisteredForWooPNs = updatedList
+                    }
+                    // Falls back to dotcom PNs if authenticated with WPCom
                     if !stores.isAuthenticatedWithoutWPCom {
                         registerForWPComPushNotifications()
                     }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -104,12 +104,12 @@ final class PushNotificationsManager: PushNotesManager {
 
     /// Self driven push notificaiton token
     ///
-    private var wooPushnotificationToken: String? {
+    private var wooPushNotificationToken: String? {
         get {
-            return configuration.defaults.object(forKey: .wooPushnotificationToken)
+            return configuration.defaults.object(forKey: .wooPushNotificationToken)
         }
         set {
-            configuration.defaults.set(newValue, forKey: .wooPushnotificationToken)
+            configuration.defaults.set(newValue, forKey: .wooPushNotificationToken)
         }
     }
 
@@ -200,15 +200,33 @@ extension PushNotificationsManager {
     func unregisterForRemoteNotifications(onCompletion: @escaping () -> Void) {
         DDLogInfo("📱 Unregistering For Remote Notifications...")
 
+        let group = DispatchGroup()
+        group.enter()
+        unregisterFromWooPushNotificationsIfPossible { result in
+            switch result {
+            case .success:
+                DDLogInfo("📱 Successfully unregistered from Woo Push Notifications!")
+            case .failure(let error):
+                DDLogError("⛔️ Unable to unregister from Woo Push Notifications: \(error)")
+            }
+            self.wooPushNotificationToken = nil
+            self.siteIDsRegisteredForWooPNs = []
+            group.leave()
+        }
+
+        group.enter()
         unregisterDotcomDeviceIfPossible() { error in
             if let error = error {
                 DDLogError("⛔️ Unable to unregister from WordPress.com Push Notifications: \(error)")
             } else {
                 DDLogInfo("📱 Successfully unregistered from WordPress.com Push Notifications!")
-                self.deviceID = nil
-                self.deviceToken = nil
             }
-            // Always call completion, even on error
+            self.deviceID = nil
+            self.deviceToken = nil
+            group.leave()
+        }
+
+        group.notify(queue: .main) {
             onCompletion()
         }
     }
@@ -640,7 +658,7 @@ private extension PushNotificationsManager {
     }
 
     func handleSelfDrivenRegistrationSuccess(tokenID: Int64, onCompletion: @escaping (Result<Int64, Error>) -> Void) {
-        wooPushnotificationToken = "\(tokenID)"
+        wooPushNotificationToken = "\(tokenID)"
 
         guard let siteID,
               let deviceID,
@@ -689,6 +707,19 @@ private extension PushNotificationsManager {
         ])
         let siteSettings = NotificationSettings(blogs: [updatedBlog])
         stores.dispatch(AccountAction.updateNotificationSettings(notificationSettings: siteSettings, onCompletion: onCompletion))
+    }
+
+    func unregisterFromWooPushNotificationsIfPossible(completion: @escaping (Result<Void, Error>) -> Void) {
+        guard let siteID,
+              let tokenID = wooPushNotificationToken,
+              let tokenIDInt = Int64(tokenID) else {
+            return completion(.success(()))
+        }
+        stores.dispatch(NotificationAction.unregisterFromSelfDrivenPushNotifications(
+            siteID: siteID,
+            tokenID: tokenIDInt,
+            onCompletion: completion
+        ))
     }
 }
 
@@ -794,8 +825,8 @@ private extension PushNotificationsManager {
 }
 
 extension UserDefaults {
-    @objc dynamic var wooPushnotificationToken: String? {
-        string(forKey: Key.wooPushnotificationToken.rawValue)
+    @objc dynamic var wooPushNotificationToken: String? {
+        string(forKey: Key.wooPushNotificationToken.rawValue)
     }
 
     @objc dynamic var deviceToken: String? {

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -99,16 +99,8 @@ final class PushNotificationsManager: PushNotesManager {
         }
         set {
             configuration.defaults.set(newValue, forKey: .deviceID)
-            if let newValue,
-               let deviceID = Int64(newValue),
-               siteIDsRegisteredForWooPNs.isNotEmpty {
-                disableWPComPushNotifications(
-                    siteIDs: siteIDsRegisteredForWooPNs,
-                    deviceID: deviceID,
-                    onCompletion: { result in
-                        // TODO: add tracking for failure
-                    }
-                )
+            disableWPComPushNotificationsIfNeeded(siteIDs: siteIDsRegisteredForWooPNs, deviceID: newValue) { result in
+                // TODO: track error
             }
         }
     }
@@ -700,12 +692,7 @@ private extension PushNotificationsManager {
             siteIDsRegisteredForWooPNs = registeredIDs
         }
 
-        guard let deviceID,
-              let deviceIDInt = Int64(deviceID),
-              !configuration.storesManager.isAuthenticatedWithoutWPCom else {
-            return onCompletion(.success(tokenID))
-        }
-        disableWPComPushNotifications(siteIDs: [siteID], deviceID: deviceIDInt) { result in
+        disableWPComPushNotificationsIfNeeded(siteIDs: [siteID], deviceID: deviceID) { result in
             if let error = result.failure {
                 // TODO: add tracking for failure
             }
@@ -733,10 +720,15 @@ private extension PushNotificationsManager {
 
     /// Disables mobile push notifications for given site IDs.
     ///
-    func disableWPComPushNotifications(siteIDs: [Int64], deviceID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+    func disableWPComPushNotificationsIfNeeded(siteIDs: [Int64], deviceID: String?, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        guard let deviceID, let deviceIDInt = Int64(deviceID),
+              siteIDs.isNotEmpty,
+              !configuration.storesManager.isAuthenticatedWithoutWPCom else {
+            return onCompletion(.success(()))
+        }
         let updatedBlogs = siteIDs.map {
             NotificationSettings.Blog(blogID: $0, devices: [
-                .init(deviceID: deviceID, newComment: false, storeOrder: false)
+                .init(deviceID: deviceIDInt, newComment: false, storeOrder: false)
             ])
         }
         let siteSettings = NotificationSettings(blogs: updatedBlogs)

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -364,7 +364,7 @@ extension PushNotificationsManager {
             if siteIDsRegisteredForWooPNs.contains(foregroundNotification.siteID),
                foregroundNotification.noteID != nil {
                 // Ignore WPCom PNs if site is registered for Woo PNs
-                return UNNotificationPresentationOptions(rawValue: 0)
+                return []
             }
             configuration.application
                 .presentInAppNotification(title: foregroundNotification.title,
@@ -813,7 +813,7 @@ private extension PushNotificationsManager {
 
 private extension UNNotificationContent {
     var isRemoteNotification: Bool {
-        userInfo[APNSKey.identifier] != nil
+        userInfo[APNSKey.type] != nil
     }
 }
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -367,7 +367,7 @@ extension PushNotificationsManager {
 
         if let foregroundNotification = PushNotification.from(userInfo: content.userInfo) {
             if siteIDsRegisteredForWooPNs.contains(foregroundNotification.siteID),
-               foregroundNotification.noteID == nil {
+               foregroundNotification.noteID != nil {
                 // Ignore WPCom PNs if site is registered for Woo PNs
                 return UNNotificationPresentationOptions(rawValue: 0)
             }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -113,6 +113,22 @@ final class PushNotificationsManager: PushNotesManager {
         }
     }
 
+    /// Site IDs registered to Woo PN system, separated by commas
+    ///
+    private var siteIDsRegisteredForWooPNs: [Int64] {
+        get {
+            let ids: String? = configuration.defaults.object(forKey: .siteIDsRegisteredForWooPushNotifications)
+            return ids?.components(separatedBy: ",")
+                .compactMap { Int64($0) } ?? []
+        }
+        set {
+            configuration.defaults.set(
+                newValue.map { "\($0)" }.joined(separator: ","),
+                forKey: .siteIDsRegisteredForWooPushNotifications
+            )
+        }
+    }
+
     private var siteID: Int64? {
         stores.sessionManager.defaultStoreID
     }
@@ -625,25 +641,25 @@ private extension PushNotificationsManager {
 
     func handleSelfDrivenRegistrationSuccess(tokenID: Int64, onCompletion: @escaping (Result<Int64, Error>) -> Void) {
         wooPushnotificationToken = "\(tokenID)"
-        unregisterDotcomDeviceIfNeededThenClearToken(onCompletion: {
-            onCompletion(.success(tokenID))
-        })
-    }
 
-    func unregisterDotcomDeviceIfNeededThenClearToken(onCompletion: @escaping () -> Void) {
-        guard !stores.isAuthenticatedWithoutWPCom else {
-            onCompletion()
-            return
+        guard let siteID,
+              let deviceID,
+              let deviceIDInt = Int64(deviceID),
+              !configuration.storesManager.isAuthenticatedWithoutWPCom else {
+            return onCompletion(.success(tokenID))
         }
 
-        unregisterDotcomDeviceIfPossible { [weak self] error in
-            if let error {
-                DDLogError("⛔️ Unable to unregister WP.com push token: \(error)")
-            }
+        var registeredIDs = siteIDsRegisteredForWooPNs
+        if registeredIDs.contains(siteID) == false {
+            registeredIDs.append(siteID)
+            siteIDsRegisteredForWooPNs = registeredIDs
+        }
 
-            // Remove the WP.com token locally regardless of unregister success.
-            self?.deviceToken = nil
-            onCompletion()
+        disableWPComPushNotifications(siteID: siteID, deviceID: deviceIDInt) { result in
+            if let error = result.failure {
+                // TODO: add tracking, save site ID and device ID
+            }
+            onCompletion(.success(tokenID))
         }
     }
 
@@ -663,6 +679,16 @@ private extension PushNotificationsManager {
     func unregisterDotcomDevice(with deviceID: String, onCompletion: @escaping (Error?) -> Void) {
         let action = NotificationAction.unregisterDevice(deviceId: deviceID, onCompletion: onCompletion)
         configuration.storesManager.dispatch(action)
+    }
+
+    /// Disables mobile push notifications for a site ID.
+    ///
+    func disableWPComPushNotifications(siteID: Int64, deviceID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        let updatedBlog = NotificationSettings.Blog(blogID: siteID, devices: [
+            .init(deviceID: deviceID, newComment: false, storeOrder: false)
+        ])
+        let siteSettings = NotificationSettings(blogs: [updatedBlog])
+        stores.dispatch(AccountAction.updateNotificationSettings(notificationSettings: siteSettings, onCompletion: onCompletion))
     }
 }
 
@@ -774,5 +800,11 @@ extension UserDefaults {
 
     @objc dynamic var deviceToken: String? {
         string(forKey: Key.deviceToken.rawValue)
+    }
+
+    @objc dynamic var siteIDsRegisteredForWooPushNotifications: [Int64] {
+        string(forKey: Key.siteIDsRegisteredForWooPushNotifications.rawValue)?
+            .components(separatedBy: ",")
+            .compactMap { Int64($0) } ?? []
     }
 }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -678,7 +678,7 @@ private extension PushNotificationsManager {
 
         disableWPComPushNotificationsIfPossible(siteID: siteID) { result in
             if let error = result.failure {
-                // TODO: add tracking, save site ID and device ID
+                // TODO: add tracking, save site ID and device ID to retry later
             }
             onCompletion(.success(tokenID))
         }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -195,7 +195,7 @@ extension PushNotificationsManager {
     }
 
 
-    /// Unregisters the Application from WordPress.com Push Notifications Service.
+    /// Unregisters the Application from both Woo and WordPress.com Push Notifications Services.
     ///
     func unregisterForRemoteNotifications(onCompletion: @escaping () -> Void) {
         DDLogInfo("📱 Unregistering For Remote Notifications...")
@@ -290,7 +290,6 @@ extension PushNotificationsManager {
                     DDLogError("⛔️ Self Registering Push Notifications Registration Failure: \(error)")
                 case .success(let token):
                     DDLogInfo("📱 Self Registering Push Notifications success: \(token)")
-                    self.deviceID = "\(token)"
                 }
             }
         }
@@ -663,20 +662,16 @@ private extension PushNotificationsManager {
     func handleSelfDrivenRegistrationSuccess(tokenID: Int64, onCompletion: @escaping (Result<Int64, Error>) -> Void) {
         wooPushNotificationToken = "\(tokenID)"
 
-        guard let siteID,
-              let deviceID,
-              let deviceIDInt = Int64(deviceID),
-              !configuration.storesManager.isAuthenticatedWithoutWPCom else {
+        guard let siteID else {
             return onCompletion(.success(tokenID))
         }
-
         var registeredIDs = siteIDsRegisteredForWooPNs
         if registeredIDs.contains(siteID) == false {
             registeredIDs.append(siteID)
             siteIDsRegisteredForWooPNs = registeredIDs
         }
 
-        disableWPComPushNotifications(siteID: siteID, deviceID: deviceIDInt) { result in
+        disableWPComPushNotificationsIfPossible(siteID: siteID) { result in
             if let error = result.failure {
                 // TODO: add tracking, save site ID and device ID
             }
@@ -704,9 +699,14 @@ private extension PushNotificationsManager {
 
     /// Disables mobile push notifications for a site ID.
     ///
-    func disableWPComPushNotifications(siteID: Int64, deviceID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+    func disableWPComPushNotificationsIfPossible(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        guard let deviceID,
+              let deviceIDInt = Int64(deviceID),
+              !configuration.storesManager.isAuthenticatedWithoutWPCom else {
+            return onCompletion(.success(()))
+        }
         let updatedBlog = NotificationSettings.Blog(blogID: siteID, devices: [
-            .init(deviceID: deviceID, newComment: false, storeOrder: false)
+            .init(deviceID: deviceIDInt, newComment: false, storeOrder: false)
         ])
         let siteSettings = NotificationSettings(blogs: [updatedBlog])
         stores.dispatch(AccountAction.updateNotificationSettings(notificationSettings: siteSettings, onCompletion: onCompletion))

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -99,6 +99,14 @@ final class PushNotificationsManager: PushNotesManager {
         }
         set {
             configuration.defaults.set(newValue, forKey: .deviceID)
+            if let newValue,
+               let deviceID = Int64(newValue),
+               siteIDsRegisteredForWooPNs.isNotEmpty {
+                disableWPComPushNotificationsForRelevantSites(
+                    siteIDs: siteIDsRegisteredForWooPNs,
+                    deviceID: deviceID
+                )
+            }
         }
     }
 
@@ -684,9 +692,14 @@ private extension PushNotificationsManager {
             siteIDsRegisteredForWooPNs = registeredIDs
         }
 
-        disableWPComPushNotificationsIfPossible(siteID: siteID) { result in
+        guard let deviceID,
+              let deviceIDInt = Int64(deviceID),
+              !configuration.storesManager.isAuthenticatedWithoutWPCom else {
+            return onCompletion(.success(tokenID))
+        }
+        disableWPComPushNotifications(siteID: siteID, deviceID: deviceIDInt) { result in
             if let error = result.failure {
-                // TODO: add tracking, save site ID and device ID to retry later
+                // TODO: add tracking for failure
             }
             onCompletion(.success(tokenID))
         }
@@ -712,17 +725,24 @@ private extension PushNotificationsManager {
 
     /// Disables mobile push notifications for a site ID.
     ///
-    func disableWPComPushNotificationsIfPossible(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        guard let deviceID,
-              let deviceIDInt = Int64(deviceID),
-              !configuration.storesManager.isAuthenticatedWithoutWPCom else {
-            return onCompletion(.success(()))
-        }
+    func disableWPComPushNotifications(siteID: Int64, deviceID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
         let updatedBlog = NotificationSettings.Blog(blogID: siteID, devices: [
-            .init(deviceID: deviceIDInt, newComment: false, storeOrder: false)
+            .init(deviceID: deviceID, newComment: false, storeOrder: false)
         ])
         let siteSettings = NotificationSettings(blogs: [updatedBlog])
         stores.dispatch(AccountAction.updateNotificationSettings(notificationSettings: siteSettings, onCompletion: onCompletion))
+    }
+
+    func disableWPComPushNotificationsForRelevantSites(siteIDs: [Int64], deviceID: Int64) {
+        let updatedBlogs = siteIDs.map {
+            NotificationSettings.Blog(blogID: $0, devices: [
+                .init(deviceID: deviceID, newComment: false, storeOrder: false)
+            ])
+        }
+        let siteSettings = NotificationSettings(blogs: updatedBlogs)
+        stores.dispatch(AccountAction.updateNotificationSettings(notificationSettings: siteSettings) { result in
+            // TODO: add tracking for failure
+        })
     }
 
     func unregisterFromWooPushNotificationsIfPossible(completion: @escaping (Result<Void, Error>) -> Void) {

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -248,6 +248,7 @@ final class SessionManager: SessionManagerProtocol {
         defaults[.applicationPasswordUnsupportedList] = nil
         defaults[.applicationPasswordsExperimentRemoteFFValue] = nil
         defaults[.ciabBookingsTabAvailable] = nil
+        defaults[.siteIDsRegisteredForWooPushNotifications] = nil
         resetTimestampsValues()
         imageCache.clearCache()
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -534,7 +534,7 @@ private extension DashboardViewModel {
     }
 
     func observeSelfDrivenPushTokenPersistence() {
-        userDefaults.publisher(for: \.wooPushnotificationToken)
+        userDefaults.publisher(for: \.siteIDsRegisteredForWooPushNotifications)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
@@ -804,8 +804,8 @@ private extension DashboardViewModel {
     }
 
     func updateSelfDrivenPushRegistrationStatus() {
-        let tokenID = userDefaults.wooPushnotificationToken
-        isSelfDrivenPushNotificationRegistered = (tokenID != nil) && stores.isAuthenticatedWithoutWPCom
+        let registeredSiteIDs = userDefaults.siteIDsRegisteredForWooPushNotifications
+        isSelfDrivenPushNotificationRegistered = registeredSiteIDs.contains(siteID) && stores.isAuthenticatedWithoutWPCom
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -210,15 +210,7 @@ private extension SettingsViewModel {
     }
 
     func observeSelfDrivenPushTokenPersistence() {
-        let wooTokenChanges = defaults
-            .publisher(for: \.wooPushnotificationToken)
-            .map { _ in () }
-
-        let wpComDeviceTokenChanges = defaults
-            .publisher(for: \.deviceToken)
-            .map { _ in () }
-
-        Publishers.Merge(wooTokenChanges, wpComDeviceTokenChanges)
+        defaults.publisher(for: \.siteIDsRegisteredForWooPushNotifications)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.reloadSettings()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -310,9 +310,11 @@ private extension SettingsViewModel {
                 return site.isJetpackCPConnected == false
             }()
             let isSelfDrivenPushNotificationsRegistered: Bool = {
-                let isWooTokenExists = defaults.wooPushnotificationToken != nil
-                let WPComTokenExists = defaults.deviceToken != nil
-                return (isWooTokenExists && ServiceLocator.featureFlagService.isFeatureFlagEnabled(.selfDrivenPushToken)) && !WPComTokenExists
+                guard let siteID = stores.sessionManager.defaultSite?.siteID else {
+                    return false
+                }
+                return featureFlagService.isFeatureFlagEnabled(.selfDrivenPushToken) &&
+                defaults.siteIDsRegisteredForWooPushNotifications.contains(siteID)
             }()
             if notificationAvailable && !isSelfDrivenPushNotificationsRegistered {
                 rows = [.notifications, .privacy]

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -663,7 +663,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         XCTAssertTrue(application.presentInAppMessages.isEmpty)
     }
 
-    func testRegisterDeviceToken_whenSelfDrivenGateEnabled_registersSelfDrivenToken_andPersistsDeviceID() {
+    func test_registerDeviceToken_when_self_driven_gate_enabled_registers_self_driven_token_and_disables_WPCom_notifications() {
         // Given
         defaults.set("456", forKey: .deviceID)
         mockSelfDrivenRegistrationActions(token: 123)
@@ -714,6 +714,49 @@ final class PushNotificationsManagerTests: XCTestCase {
                device.storeOrder == false {
                 return true
             }
+            return false
+        }))
+    }
+
+    func test_registerDeviceToken_when_self_driven_gate_enabled_and_self_driven_token_registration_fails_falls_back_to_wpcom() {
+        // Given
+        mockSelfDrivenRegistrationActions(token: 123)
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(99)
+
+        manager = {
+            let configuration = PushNotificationsConfiguration(application: self.application,
+                                                               defaults: self.defaults,
+                                                               storesManager: self.storesManager,
+                                                               userNotificationsCenter: self.userNotificationCenter)
+
+            return PushNotificationsManager(configuration: configuration,
+                                           backgroundSynchronizerFactory: backgroundSynchronizerFactory,
+                                           shouldRegisterSelfDrivenPushNotification: true)
+        }()
+
+        guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
+            XCTFail("Invalid sample token")
+            return
+        }
+
+        storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, onCompletion):
+                onCompletion(.failure(NSError(domain: "Failure", code: 404)))
+            default:
+                break
+            }
+        }
+
+        // When
+        manager.registerDeviceToken(with: tokenAsData)
+
+        // Then
+        // It dispatches the WPCom device registration request
+        let notificationActions = storesManager.receivedActions.compactMap { $0 as? NotificationAction }
+        XCTAssertTrue(notificationActions.contains(where: {
+            if case .registerDevice = $0 { return true }
             return false
         }))
     }

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -338,6 +338,29 @@ final class PushNotificationsManagerTests: XCTestCase {
         XCTAssertNil(application.presentInAppMessages.first?.message)
     }
 
+    func test_handleNotification_does_not_display_inApp_notice_if_no_noteID_in_payload_and_site_registered_with_Woo() async throws {
+        // Given
+        let siteID: Int64 = 132
+        let payload = notificationPayload(noteID: nil, siteID: siteID, title: Sample.defaultTitle, message: nil)
+        defaults.set("\(siteID)", forKey: .siteIDsRegisteredForWooPushNotifications)
+        manager = {
+            let configuration = PushNotificationsConfiguration(application: self.application,
+                                                               defaults: self.defaults,
+                                                               storesManager: self.storesManager,
+                                                               userNotificationsCenter: self.userNotificationCenter)
+
+            return PushNotificationsManager(configuration: configuration, backgroundSynchronizerFactory: backgroundSynchronizerFactory)
+        }()
+
+        // When
+        application.applicationState = .active
+        let notification = try XCTUnwrap(MockNotification(userInfo: payload))
+        _ = await manager.handleNotificationInTheForeground(notification)
+
+        // Then
+        XCTAssertNil(application.presentInAppMessages.first)
+    }
+
     // MARK: - Foreground Notification Observable
 
     func test_it_emits_foreground_notifications_when_it_receives_a_notification_while_app_is_active() async throws {
@@ -680,6 +703,19 @@ final class PushNotificationsManagerTests: XCTestCase {
         // It persists Woo token and registered site ID
         XCTAssertTrue(defaults.containsObject(forKey: .wooPushNotificationToken))
         XCTAssertTrue(defaults.containsObject(forKey: .siteIDsRegisteredForWooPushNotifications))
+
+        // It dispatches the WPCom PN setting update to disable mobile PNs from WPCom for the current siteID and deviceID
+        let accountActions = storesManager.receivedActions.compactMap { $0 as? AccountAction }
+        XCTAssertTrue(accountActions.contains(where: {
+            if case let .updateNotificationSettings(settings, _) = $0,
+               let blog = settings.blogs.first(where: { $0.blogID == 99 }),
+               let device = blog.devices.first(where: { $0.deviceID == 456 }),
+               device.newComment == false,
+               device.storeOrder == false {
+                return true
+            }
+            return false
+        }))
     }
 }
 
@@ -691,13 +727,13 @@ private extension PushNotificationsManagerTests {
     /// Returns a Sample Notification Payload
     ///
     func notificationPayload(badgeCount: Int = 0,
-                             noteID: Int64 = 1234,
+                             noteID: Int64? = 1234,
                              type: Note.Kind = .comment,
                              siteID: Int64 = 134,
                              title: String = Sample.defaultTitle,
                              subtitle: String? = nil,
                              message: String? = nil) -> [String: Any] {
-        [
+        var payload: [String: Any] = [
             "aps": [
                 "badge": badgeCount,
                 "alert": [
@@ -706,10 +742,13 @@ private extension PushNotificationsManagerTests {
                     "body": message
                 ]
             ] as [String: Any],
-            "note_id": noteID,
             "type": type.rawValue,
             "blog": siteID
         ]
+        if let noteID {
+            payload["note_id"] = noteID
+        }
+        return payload
     }
 
     func mockSynchronizeNotificationsAction(error: Error? = nil) {

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -341,7 +341,7 @@ final class PushNotificationsManagerTests: XCTestCase {
     func test_handleNotification_does_not_display_inApp_notice_if_no_noteID_in_payload_and_site_registered_with_Woo() async throws {
         // Given
         let siteID: Int64 = 132
-        let payload = notificationPayload(noteID: nil, siteID: siteID, title: Sample.defaultTitle, message: nil)
+        let payload = notificationPayload(siteID: siteID, title: Sample.defaultTitle, message: nil)
         defaults.set("\(siteID)", forKey: .siteIDsRegisteredForWooPushNotifications)
         manager = {
             let configuration = PushNotificationsConfiguration(application: self.application,

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -642,6 +642,7 @@ final class PushNotificationsManagerTests: XCTestCase {
 
     func testRegisterDeviceToken_whenSelfDrivenGateEnabled_registersSelfDrivenToken_andPersistsDeviceID() {
         // Given
+        defaults.set("456", forKey: .deviceID)
         mockSelfDrivenRegistrationActions(token: 123)
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(99)
@@ -666,21 +667,19 @@ final class PushNotificationsManagerTests: XCTestCase {
         manager.registerDeviceToken(with: tokenAsData)
 
         // Then
-        // 1) It dispatches the self-driven registration action
+        // It dispatches the self-driven registration action
         let notificationActions = storesManager.receivedActions.compactMap { $0 as? NotificationAction }
         XCTAssertTrue(notificationActions.contains(where: {
             if case .registerDeviceForSelfDrivenPushNotifications = $0 { return true }
             return false
         }))
 
-        // 2) It persists the resulting deviceID
-        XCTAssertEqual(defaults.object(forKey: .deviceID), "123")
+        // It does not clear WPcom token
+        XCTAssertTrue(defaults.containsObject(forKey: .deviceToken))
 
-        // 3) It clears WPcom token
-        XCTAssertFalse(defaults.containsObject(forKey: .deviceToken))
-
-        // 4) It dispatches the token persistence action
-        XCTAssertTrue(defaults.containsObject(forKey: .wooPushnotificationToken))
+        // It persists Woo token and registered site ID
+        XCTAssertTrue(defaults.containsObject(forKey: .wooPushNotificationToken))
+        XCTAssertTrue(defaults.containsObject(forKey: .siteIDsRegisteredForWooPushNotifications))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -422,6 +422,28 @@ final class SessionManagerTests: XCTestCase {
         XCTAssertNil(defaults[.ciabBookingsTabAvailable])
     }
 
+    /// Verifies that image cache is cleared upon reset
+    ///
+    func test_siteIDsRegisteredForWooPushNotifications_is_cleared_upon_reset() throws {
+        // Given
+        let siteID: Int64 = 13
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let sut = SessionManager(defaults: defaults, keychainServiceName: Settings.keychainServiceName)
+
+        // When
+        defaults[.siteIDsRegisteredForWooPushNotifications] = siteID.description
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(defaults[.siteIDsRegisteredForWooPushNotifications] as? String), siteID.description)
+
+        // When
+        sut.reset()
+
+        // Then
+        XCTAssertNil(defaults[.siteIDsRegisteredForWooPushNotifications])
+    }
+
     /// Verifies that `removeDefaultCredentials` effectively nukes everything from the keychain
     ///
     func testDefaultCredentialsAreEffectivelyNuked() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -912,7 +912,7 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_updateSelfDrivenPushRegistrationStatus_sets_false_when_token_id_is_nil() async {
         // Given
-        userDefaults.set(Int64?.none, forKey: .wooPushnotificationToken)
+        userDefaults.set([], forKey: .siteIDsRegisteredForWooPushNotifications)
         mockReloadingData()
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,
@@ -931,7 +931,7 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_updateSelfDrivenPushRegistrationStatus_sets_true_when_token_id_exists_and_not_wpcom_login() async {
         // Given
-        userDefaults.set(Int64(123), forKey: .wooPushnotificationToken)
+        userDefaults.set([Int64(123)], forKey: .siteIDsRegisteredForWooPushNotifications)
         mockReloadingData()
         stores.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
@@ -951,7 +951,7 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_updateSelfDrivenPushRegistrationStatus_sets_false_when_token_id_exists_and_wpcom_login() async {
         // Given
-        userDefaults.set(Int64(123), forKey: .wooPushnotificationToken)
+        userDefaults.set([Int64(123)], forKey: .siteIDsRegisteredForWooPushNotifications)
         mockReloadingData()
         stores.authenticate(credentials: SessionSettings.wpcomCredentials)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -912,7 +912,7 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_updateSelfDrivenPushRegistrationStatus_sets_false_when_token_id_is_nil() async {
         // Given
-        userDefaults.set([], forKey: .siteIDsRegisteredForWooPushNotifications)
+        userDefaults.set("", forKey: .siteIDsRegisteredForWooPushNotifications)
         mockReloadingData()
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,
@@ -931,7 +931,7 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_updateSelfDrivenPushRegistrationStatus_sets_true_when_token_id_exists_and_not_wpcom_login() async {
         // Given
-        userDefaults.set([Int64(123)], forKey: .siteIDsRegisteredForWooPushNotifications)
+        userDefaults.set("\(sampleSiteID)", forKey: .siteIDsRegisteredForWooPushNotifications)
         mockReloadingData()
         stores.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
@@ -951,7 +951,7 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_updateSelfDrivenPushRegistrationStatus_sets_false_when_token_id_exists_and_wpcom_login() async {
         // Given
-        userDefaults.set([Int64(123)], forKey: .siteIDsRegisteredForWooPushNotifications)
+        userDefaults.set("123", forKey: .siteIDsRegisteredForWooPushNotifications)
         mockReloadingData()
         stores.authenticate(credentials: SessionSettings.wpcomCredentials)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -306,7 +306,7 @@ final class SettingsViewModelTests: XCTestCase {
         viewModel.onViewDidLoad()
 
         // Then
-        XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.notifications) })
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.notifications) })
     }
 
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -295,7 +295,7 @@ final class SettingsViewModelTests: XCTestCase {
     func test_sections_contains_does_not_contain_notifications_row_for_selfregisteredtoken() {
         // Given
         let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
-        defaults.set("123", forKey: .wooPushnotificationToken)
+        defaults.set("123", forKey: .siteIDsRegisteredForWooPushNotifications)
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
         let viewModel = SettingsViewModel(stores: stores,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of WOOMOB-2030

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds changes to `PushNotificationManager` to avoid duplicated PNs when a user authenticated with WPCom has some site registered with Woo PN system. Specifically:
- Adds a new user default key to store all site IDs registered with Woo PN system. The value is the string values of all IDs, separated by commas.
- Updates `registerDeviceToken` logic for when user is authenticated with WPCom: if registration with Woo PN system fails, fall back to register with WPCom system.
- Disables WPCom PN for sites registered with Woo in two cases:
  - after registering with Woo succeeds
  - when WPCom device ID is updated
- Ignore WPCom PNs in the foreground if site already registered for Woo PNs. 
- Unregisters from Woo PN system when logging out if feature flag is enabled
- Updates logic in My Store screen to use the registered site ID list instead of PN tokens.
- Updates logic in Settings screen to hide Notification settings to use the registered site ID list instead of tokens.

The handling for edge case when disabling WPCom PNs fails will be handled in a separate PR.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

### TC1: Smoke testing My Store screen
1. Enable `selfDrivenPushToken` feature flag and build the app to a physical device.
2. Log in to a store supporting new Woo PN system with site credentials.
3. After login succeeds, confirm that Jetpack benefit banner is not displayed.

### TC2: Smoke testing Settings screen
1. Enable `selfDrivenPushToken` feature flag and build the app to a physical device.
2. Log in to a store supporting new Woo PN system with WPCom credentials.
3. After login succeeds, navigate to Menu > Settings.
4. Confirm that Notification Settings item is not available.
5. Switch to a store that doesn't support new Woo PN system.
6. Confirm that Notification Settings item is available in Menu > Settings.

### TC3: Disabling WPCom PN after registering with Woo
1. Enable `selfDrivenPushToken` feature flag and build the app to a physical device.
2. Log in to a store supporting new Woo PN system (store A) with WPCom credentials.
3. Put the app to background then place an order on store A.
4. Confirm that you don't receive push notification for this store (since Woo PN is not ready yet - you should confirm in Xcode console that registration succeeds tho).
5. Switch to a store that doesn't support Woo PN system (store B).
6. Place an order on store B and confirm that you receive PN for that order.
7. Place an order on store A and confirm that you don't receive PN for that order.
8. While still selecting store B, go to Menu > Settings > Notification Settings.
9. Confirm that PNs for store A is off in the list.

### TC4: Unregistering from Woo upon logout
1. Continue from TC3 - log out of the app.
2. Check the app log or Xcode console and confirm that you see `📱 Successfully unregistered from Woo Push Notifications!` if you're selecting store A, or `⛔️ Unable to unregister from Woo Push Notifications` if you're selecting store B.

### TC5: Falling back to WPCom when registering with Woo fails
1. Enable `selfDrivenPushToken` feature flag and build the app to a physical device.
3. Log in to a store that doesn't support new Woo PN system with WPCom credentials.
4. Put the app in background then place an order for the store.
5. Confirm that you receive PN for the store.

### TC6: Ignoring WPCom PNs when site already registered for Woo PNs.
1. Comment out the simulator check on line 271 of `AppDelegate` and build the app to a simulator.
2. Use the following format to create a `.apns` file on your computer:

<details>
<summary>Tap here to see content</summary>

```json
{
  "Simulator Target Bundle": "com.automattic.woocommerce",
  "aps": {
    "category": "store_order",
    "badge": 1,
    "sound": "o.caf",
    "content-available": 1,
    "mutable-content": 1,
    "thread-id": "211011480 - store_order",
    "alert": {
      "body": "New order for $2.00 on the store",
      "title": "You have a new order! 🎉"
    }
  },
  "note_id": 123,
  "blog": "{replace_this}",
  "type": "store_order",
  "blog_id": "{replace_this}",
  "user": "212589093",
  "title": "You have a new order! 🎉",
  "content-available": 1,
  "mutable-content": 1
}
```

</details>


Ensure to replace the content in `blog`, `blog_id` to match your test store ID.

3. Put a breakpoint on Proxyman for the POST request for registering Woo PN.
4. Log in to the app on the simulator, accept push notification request, and keep the app in the foreground.
5. When the breakpoint on Proxyman pauses, update the response to return success result with a token ID in the body.
6. Drag the above APNS file to the simulator.
7. Confirm that you don't see any notice on the UI for the new order. 
8. Update the APNS file with the blog ID of another store.
9. Confirm that you see a notice on the UI for the new order.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

No UI changes

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
