### PR TITLE
Gate hidden settings to local and alpha

### DIFF
--- a/Modules/Sources/WooFoundationCore/BuildConfiguration.swift
+++ b/Modules/Sources/WooFoundationCore/BuildConfiguration.swift
@@ -26,6 +26,15 @@ public enum BuildConfiguration: String {
         }
     }
 
+    public var isProduction: Bool {
+        switch self {
+        case .localDeveloper, .alpha:
+            return false
+        case .appStore:
+            return true
+        }
+    }
+
     static func ~=(a: BuildConfiguration, b: Set<BuildConfiguration>) -> Bool {
         return b.contains(a)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -5,6 +5,7 @@ import SafariServices
 import AutomatticAbout
 import Yosemite
 import SwiftUI
+import WooFoundationCore
 
 protocol SettingsViewPresenter: AnyObject {
     func refreshViewContent()
@@ -524,6 +525,7 @@ private extension SettingsViewController {
     var hiddenSettingsGestureRecognizer: UITapGestureRecognizer {
         let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didInvokeHiddenSettings))
         gestureRecognizer.numberOfTapsRequired = 4
+        gestureRecognizer.isEnabled = !BuildConfiguration.current.isProduction
         return gestureRecognizer
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -524,7 +524,7 @@ private extension SettingsViewController {
 
     var hiddenSettingsGestureRecognizer: UITapGestureRecognizer {
         let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didInvokeHiddenSettings))
-        gestureRecognizer.numberOfTapsRequired = 4
+        gestureRecognizer.numberOfTapsRequired = 2
         gestureRecognizer.isEnabled = !BuildConfiguration.current.isProduction
         return gestureRecognizer
     }


### PR DESCRIPTION
## Description

This PR hides the hidden setting from production. I could not find any info on this, but I don't think we intentionally wanted to allow the hidden settings to be accessed in prod.

It also lowers the required taps to 2 for more convenience. 

## Test Steps

1. Checkout the branch and build locally
2. Navigate to Menu -> Settings
3. Scroll to the bottom
4. Tap ❤️  2x
5. Note hidden setting is displayed
6. Change the scheme to "Release" and build again
7. Navigate the settings again
8. Note hidden menu cannot be opened now.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
