### PR TITLE
Add ClientSideBannerProvider for non-Jetpack stores

### DIFF
--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ClientSideBannerProvider.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ClientSideBannerProvider.swift
@@ -1,0 +1,157 @@
+import Foundation
+import UIKit
+import Yosemite
+import protocol WooFoundation.Analytics
+import protocol Experiments.FeatureFlagService
+import enum Networking.RemoteFeatureFlag
+import enum WooFoundation.CountryCode
+
+/// Provides client-side promotional banners for stores that cannot receive server-side JITMs.
+@MainActor
+final class ClientSideBannerProvider {
+
+    private let stores: StoresManager
+    private let analytics: Analytics
+    private let featureFlagService: FeatureFlagService
+    private let siteSettings: SelectedSiteSettingsProtocol
+    private let userInterfaceIdiom: UIUserInterfaceIdiom
+
+    init(stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         siteSettings: SelectedSiteSettingsProtocol = ServiceLocator.selectedSiteSettings,
+         userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+        self.stores = stores
+        self.analytics = analytics
+        self.featureFlagService = featureFlagService
+        self.siteSettings = siteSettings
+        self.userInterfaceIdiom = userInterfaceIdiom
+    }
+
+    /// Returns a banner view model if the store is eligible for client-side banners.
+    /// - Parameter site: The current site to check eligibility for.
+    /// - Returns: A `FeatureAnnouncementCardViewModel` if eligible, `nil` otherwise.
+    func loadBanner(for site: Site) async -> FeatureAnnouncementCardViewModel? {
+        // POS promo is only shown on phones
+        guard userInterfaceIdiom == .phone else {
+            return nil
+        }
+
+        guard isNonJetpackSite(site) else {
+            return nil
+        }
+
+        guard featureFlagService.isFeatureFlagEnabled(.clientSideDashboardBanner) else {
+            return nil
+        }
+
+        let isRemoteFlagEnabled = await isRemoteFeatureFlagEnabled()
+        guard isRemoteFlagEnabled else {
+            return nil
+        }
+
+        // Check dismissal before potentially slow operations
+        let campaign = POSPromoOnPhonesCampaign()
+        guard await isBannerVisible(for: campaign.configuration.campaign) else {
+            return nil
+        }
+
+        guard await isEligibleCountry(siteID: site.siteID) else {
+            return nil
+        }
+
+        return FeatureAnnouncementCardViewModel(
+            analytics: analytics,
+            configuration: campaign.configuration,
+            stores: stores
+        )
+    }
+
+    private func isNonJetpackSite(_ site: Site) -> Bool {
+        let connectionType = SiteConnectionType(site: site)
+        return connectionType == .nonJetpack
+    }
+
+    private func isRemoteFeatureFlagEnabled() async -> Bool {
+        await withCheckedContinuation { [weak self] continuation in
+            guard let self else {
+                return continuation.resume(returning: false)
+            }
+            let action = FeatureFlagAction.isRemoteFeatureFlagEnabled(
+                .wooPosTabletPromoBanner,
+                defaultValue: false
+            ) { isEnabled in
+                continuation.resume(returning: isEnabled)
+            }
+            self.stores.dispatch(action)
+        }
+    }
+
+    private func isBannerVisible(for campaign: FeatureAnnouncementCampaign) async -> Bool {
+        await withCheckedContinuation { [weak self] continuation in
+            guard let self else {
+                return continuation.resume(returning: false)
+            }
+            let action = AppSettingsAction.getFeatureAnnouncementVisibility(campaign: campaign) { result in
+                switch result {
+                case .success(let isVisible):
+                    continuation.resume(returning: isVisible)
+                case .failure:
+                    continuation.resume(returning: false)
+                }
+            }
+            self.stores.dispatch(action)
+        }
+    }
+
+    private func isEligibleCountry(siteID: Int64?) async -> Bool {
+        guard let siteID else {
+            return false
+        }
+
+        let currentSettings = siteSettings.siteSettings
+        if currentSettings.isNotEmpty {
+            let countryCode = SiteAddress(siteSettings: currentSettings).countryCode
+            return countryCode == .US || countryCode == .GB
+        }
+
+        // Wait for settings with a timeout
+        let settings = await waitForSiteSettings(siteID: siteID)
+        guard settings.isNotEmpty else {
+            return false
+        }
+
+        let countryCode = SiteAddress(siteSettings: settings).countryCode
+        return countryCode == .US || countryCode == .GB
+    }
+
+    private func waitForSiteSettings(siteID: Int64) async -> [SiteSetting] {
+        let settingsTask = Task { () -> [SiteSetting] in
+            for await settingsUpdate in siteSettings.settingsStream.values {
+                guard settingsUpdate.siteID == siteID,
+                      settingsUpdate.settings.isNotEmpty else {
+                    continue
+                }
+                return settingsUpdate.settings
+            }
+            return []
+        }
+
+        let timeoutTask = Task { () -> [SiteSetting] in
+            try? await Task.sleep(nanoseconds: 10 * NSEC_PER_SEC)
+            return []
+        }
+
+        return await withTaskGroup(of: [SiteSetting].self) { group in
+            group.addTask { await settingsTask.value }
+            group.addTask { await timeoutTask.value }
+
+            if let result = await group.next() {
+                group.cancelAll()
+                return result
+            }
+            return []
+        }
+    }
+
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -745,6 +745,7 @@
 		20D3D4462F197B00004CE6E3 /* POSPromotionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D3D4472F197B00004CE6E3 /* POSPromotionViewModelTests.swift */; };
 		20D5CB512AFCF856009A39C3 /* PaymentsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D5CB502AFCF856009A39C3 /* PaymentsRow.swift */; };
 		20D5CB532AFCF8E7009A39C3 /* PaymentsToggleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D5CB522AFCF8E7009A39C3 /* PaymentsToggleRow.swift */; };
+		20D8E3622F1FF8E500AE0FCF /* ClientSideBannerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8E3612F1FF8E500AE0FCF /* ClientSideBannerProvider.swift */; };
 		20DA45652EF975660007FD3B /* CouponCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20DA45642EF975660007FD3B /* CouponCellViewModel.swift */; };
 		20DA6DDB2B681175002AA0FB /* AdaptiveModalContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20DA6DDA2B681175002AA0FB /* AdaptiveModalContainer.swift */; };
 		20E188842AD059A50053E945 /* TapToPayEducationContactlessLimitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E188832AD059A50053E945 /* TapToPayEducationContactlessLimitView.swift */; };
@@ -3682,6 +3683,7 @@
 		20D3D4472F197B00004CE6E3 /* POSPromotionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSPromotionViewModelTests.swift; sourceTree = "<group>"; };
 		20D5CB502AFCF856009A39C3 /* PaymentsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsRow.swift; sourceTree = "<group>"; };
 		20D5CB522AFCF8E7009A39C3 /* PaymentsToggleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsToggleRow.swift; sourceTree = "<group>"; };
+		20D8E3612F1FF8E500AE0FCF /* ClientSideBannerProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientSideBannerProvider.swift; sourceTree = "<group>"; };
 		20DA45642EF975660007FD3B /* CouponCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponCellViewModel.swift; sourceTree = "<group>"; };
 		20DA6DDA2B681175002AA0FB /* AdaptiveModalContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveModalContainer.swift; sourceTree = "<group>"; };
 		20E188832AD059A50053E945 /* TapToPayEducationContactlessLimitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayEducationContactlessLimitView.swift; sourceTree = "<group>"; };
@@ -7200,6 +7202,7 @@
 		0371C36C2876E91500277E2C /* Feature Announcement Cards */ = {
 			isa = PBXGroup;
 			children = (
+				20D8E3612F1FF8E500AE0FCF /* ClientSideBannerProvider.swift */,
 				0371C3672875E47B00277E2C /* FeatureAnnouncementCardViewModel.swift */,
 				0366EAE02909A37800B51755 /* JustInTimeMessageViewModel.swift */,
 				2062D1152F20F7C800D05E28 /* POSPromoOnPhonesCampaign.swift */,
@@ -14695,6 +14698,7 @@
 				B541B226218A412C008FE7C1 /* UIFont+Woo.swift in Sources */,
 				4580BA7723F19D4A00B5F764 /* ProductSettingsViewModel.swift in Sources */,
 				DE4B3B5626A68DD000EEF2D8 /* View+InsetPaddings.swift in Sources */,
+				20D8E3622F1FF8E500AE0FCF /* ClientSideBannerProvider.swift in Sources */,
 				B59D1EEC2190B08B009D1978 /* Age.swift in Sources */,
 				01929C342CEF6354006C79ED /* CardPresentModalErrorWithoutEmail.swift in Sources */,
 				CE27257C21924A8C002B22EB /* HelpAndSupportViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -713,6 +713,7 @@
 		204C9C742B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204C9C732B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift */; };
 		204CB80E2C0F8A5E000C9773 /* MockViewControllerPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204CB80D2C0F8A5E000C9773 /* MockViewControllerPresenting.swift */; };
 		2062D1162F20F7C800D05E28 /* POSPromoOnPhonesCampaign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2062D1152F20F7C800D05E28 /* POSPromoOnPhonesCampaign.swift */; };
+		2062DCEB2F20F83600D05E28 /* POSPromoOnPhonesCampaignTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2062DCEA2F20F83600D05E28 /* POSPromoOnPhonesCampaignTests.swift */; };
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsPayoutsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsPayoutsCurrencyOverviewViewModel.swift */; };
 		209AD3D22AC1EDF600825D76 /* WooPaymentsPayoutsCurrencyOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3D12AC1EDF600825D76 /* WooPaymentsPayoutsCurrencyOverviewView.swift */; };
 		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
@@ -746,6 +747,7 @@
 		20D5CB512AFCF856009A39C3 /* PaymentsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D5CB502AFCF856009A39C3 /* PaymentsRow.swift */; };
 		20D5CB532AFCF8E7009A39C3 /* PaymentsToggleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D5CB522AFCF8E7009A39C3 /* PaymentsToggleRow.swift */; };
 		20D8E3622F1FF8E500AE0FCF /* ClientSideBannerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8E3612F1FF8E500AE0FCF /* ClientSideBannerProvider.swift */; };
+		20D8E7572F1FF96A00AE0FCF /* ClientSideBannerProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8E7542F1FF96A00AE0FCF /* ClientSideBannerProviderTests.swift */; };
 		20DA45652EF975660007FD3B /* CouponCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20DA45642EF975660007FD3B /* CouponCellViewModel.swift */; };
 		20DA6DDB2B681175002AA0FB /* AdaptiveModalContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20DA6DDA2B681175002AA0FB /* AdaptiveModalContainer.swift */; };
 		20E188842AD059A50053E945 /* TapToPayEducationContactlessLimitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E188832AD059A50053E945 /* TapToPayEducationContactlessLimitView.swift */; };
@@ -3650,6 +3652,7 @@
 		204C9C732B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIUserInterfaceSizeClass+Helpers.swift"; sourceTree = "<group>"; };
 		204CB80D2C0F8A5E000C9773 /* MockViewControllerPresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockViewControllerPresenting.swift; sourceTree = "<group>"; };
 		2062D1152F20F7C800D05E28 /* POSPromoOnPhonesCampaign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSPromoOnPhonesCampaign.swift; sourceTree = "<group>"; };
+		2062DCEA2F20F83600D05E28 /* POSPromoOnPhonesCampaignTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSPromoOnPhonesCampaignTests.swift; sourceTree = "<group>"; };
 		20716F332D9DA289008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPointOfSalePurchasableItemFetchStrategy.swift; sourceTree = "<group>"; };
 		209AD3CF2AC1EDDA00825D76 /* WooPaymentsPayoutsCurrencyOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsCurrencyOverviewViewModel.swift; sourceTree = "<group>"; };
 		209AD3D12AC1EDF600825D76 /* WooPaymentsPayoutsCurrencyOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsPayoutsCurrencyOverviewView.swift; sourceTree = "<group>"; };
@@ -3684,6 +3687,7 @@
 		20D5CB502AFCF856009A39C3 /* PaymentsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsRow.swift; sourceTree = "<group>"; };
 		20D5CB522AFCF8E7009A39C3 /* PaymentsToggleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsToggleRow.swift; sourceTree = "<group>"; };
 		20D8E3612F1FF8E500AE0FCF /* ClientSideBannerProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientSideBannerProvider.swift; sourceTree = "<group>"; };
+		20D8E7542F1FF96A00AE0FCF /* ClientSideBannerProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientSideBannerProviderTests.swift; sourceTree = "<group>"; };
 		20DA45642EF975660007FD3B /* CouponCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponCellViewModel.swift; sourceTree = "<group>"; };
 		20DA6DDA2B681175002AA0FB /* AdaptiveModalContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveModalContainer.swift; sourceTree = "<group>"; };
 		20E188832AD059A50053E945 /* TapToPayEducationContactlessLimitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayEducationContactlessLimitView.swift; sourceTree = "<group>"; };
@@ -7214,7 +7218,9 @@
 		0371C36F2876ED3A00277E2C /* Feature Announcement Cards */ = {
 			isa = PBXGroup;
 			children = (
+				20D8E7542F1FF96A00AE0FCF /* ClientSideBannerProviderTests.swift */,
 				0371C3692876DBCA00277E2C /* FeatureAnnouncementCardViewModelTests.swift */,
+				2062DCEA2F20F83600D05E28 /* POSPromoOnPhonesCampaignTests.swift */,
 				035BA3A7291000E90056F0AD /* JustInTimeMessageViewModelTests.swift */,
 			);
 			path = "Feature Announcement Cards";
@@ -16053,6 +16059,7 @@
 				EEB221A729B9B5B300662A12 /* CouponLineDetailsViewModelTests.swift in Sources */,
 				20134CE62D4D1BDF00076A80 /* LearnMoreViewModelTests.swift in Sources */,
 				026D684B2A0E0A9600D8C22C /* LocalNotificationSchedulerTests.swift in Sources */,
+				20D8E7572F1FF96A00AE0FCF /* ClientSideBannerProviderTests.swift in Sources */,
 				02038C612AF222D600CD36D9 /* ConfigurableVariableBundleAttributePickerViewModelTests.swift in Sources */,
 				CE56C01E2D2431C000EBDE24 /* WooShippingOriginAddressListViewModelTests.swift in Sources */,
 				DA3F99BA2C92F6D30034BDA5 /* MarkOrderAsReadUseCaseTests.swift in Sources */,
@@ -16237,6 +16244,7 @@
 				CE7CEC2D2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift in Sources */,
 				03EF250028C0E9EE006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift in Sources */,
 				01F067ED2D0C5D59001C5805 /* MockLocationService.swift in Sources */,
+				2062DCEB2F20F83600D05E28 /* POSPromoOnPhonesCampaignTests.swift in Sources */,
 				86B3E2572C6B249C0002420B /* HelpAndSupportViewModelTests.swift in Sources */,
 				DE2FE5832924DA2F0018040A /* JetpackSetupRequiredViewModelTests.swift in Sources */,
 				AEB4DB99290AE8F300AE4340 /* MockCookieJar.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/ClientSideBannerProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/ClientSideBannerProviderTests.swift
@@ -1,0 +1,262 @@
+import XCTest
+import Combine
+import Fakes
+import UIKit
+@testable import WooCommerce
+@testable import Yosemite
+import enum Networking.RemoteFeatureFlag
+
+@MainActor
+final class ClientSideBannerProviderTests: XCTestCase {
+
+    private let testSiteID: Int64 = 123
+    private var stores: MockStoresManager!
+    private var analytics: MockAnalyticsProvider!
+    private var featureFlagService: MockFeatureFlagService!
+    private var siteSettings: MockSelectedSiteSettings!
+
+    override func setUp() {
+        super.setUp()
+        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        analytics = MockAnalyticsProvider()
+        featureFlagService = MockFeatureFlagService()
+        siteSettings = MockSelectedSiteSettings()
+
+        // Set up mock handlers for actions dispatched during the provider's operations
+        setUpBasicMocks()
+    }
+
+    override func tearDown() {
+        stores = nil
+        analytics = nil
+        featureFlagService = nil
+        siteSettings = nil
+        super.tearDown()
+    }
+
+    private func setUpBasicMocks() {
+        // Default: remote feature flag disabled
+        stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            switch action {
+            case let .isRemoteFeatureFlagEnabled(_, _, onCompletion):
+                onCompletion(false)
+            }
+        }
+
+        // Default: banner not dismissed (visible)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .getFeatureAnnouncementVisibility(_, onCompletion):
+                onCompletion(.success(true))
+            default:
+                break
+            }
+        }
+    }
+
+    // MARK: - Device Type Tests
+
+    func test_loadBanner_returns_nil_on_iPad() async {
+        // Given
+        let site = Site.fake().copy(siteID: testSiteID, isJetpackThePluginInstalled: false, isJetpackConnected: false)
+        featureFlagService.isFeatureFlagEnabledReturnValue[.clientSideDashboardBanner] = true
+        enableRemoteFeatureFlag()
+        setUpUSCountrySettings()
+
+        let sut = makeSUT(userInterfaceIdiom: .pad)
+
+        // When
+        let result = await sut.loadBanner(for: site)
+
+        // Then
+        XCTAssertNil(result, "Banner should not be shown on iPad")
+    }
+
+    // MARK: - Connection Type Tests
+
+    func test_loadBanner_returns_nil_for_fullJetpack_site() async {
+        // Given
+        let site = Site.fake().copy(siteID: testSiteID, isJetpackThePluginInstalled: true, isJetpackConnected: true)
+        featureFlagService.isFeatureFlagEnabledReturnValue[.clientSideDashboardBanner] = true
+        enableRemoteFeatureFlag()
+        setUpUSCountrySettings()
+
+        let sut = makeSUT()
+
+        // When
+        let result = await sut.loadBanner(for: site)
+
+        // Then
+        XCTAssertNil(result, "Banner should not be shown for full Jetpack sites")
+    }
+
+    func test_loadBanner_returns_nil_for_jetpackConnectionPackage_site() async {
+        // Given
+        let site = Site.fake().copy(siteID: testSiteID, isJetpackThePluginInstalled: false, isJetpackConnected: true)
+        featureFlagService.isFeatureFlagEnabledReturnValue[.clientSideDashboardBanner] = true
+        enableRemoteFeatureFlag()
+        setUpUSCountrySettings()
+
+        let sut = makeSUT()
+
+        // When
+        let result = await sut.loadBanner(for: site)
+
+        // Then
+        XCTAssertNil(result, "Banner should not be shown for JCP sites")
+    }
+
+    // MARK: - Feature Flag Tests
+
+    func test_loadBanner_returns_nil_when_local_feature_flag_disabled() async {
+        // Given
+        let site = Site.fake().copy(siteID: testSiteID, isJetpackThePluginInstalled: false, isJetpackConnected: false)
+        featureFlagService.isFeatureFlagEnabledReturnValue[.clientSideDashboardBanner] = false
+        enableRemoteFeatureFlag()
+        setUpUSCountrySettings()
+
+        let sut = makeSUT()
+
+        // When
+        let result = await sut.loadBanner(for: site)
+
+        // Then
+        XCTAssertNil(result, "Banner should not be shown when local feature flag is disabled")
+    }
+
+    func test_loadBanner_returns_nil_when_remote_feature_flag_disabled() async {
+        // Given
+        let site = Site.fake().copy(siteID: testSiteID, isJetpackThePluginInstalled: false, isJetpackConnected: false)
+        featureFlagService.isFeatureFlagEnabledReturnValue[.clientSideDashboardBanner] = true
+        // Remote flag is disabled by default in setUpBasicMocks()
+        setUpUSCountrySettings()
+
+        let sut = makeSUT()
+
+        // When
+        let result = await sut.loadBanner(for: site)
+
+        // Then
+        XCTAssertNil(result, "Banner should not be shown when remote feature flag is disabled")
+    }
+
+    // MARK: - Country Targeting Tests
+
+    func test_loadBanner_returns_nil_when_store_country_is_not_US_or_GB() async {
+        // Given
+        let site = Site.fake().copy(siteID: testSiteID, isJetpackThePluginInstalled: false, isJetpackConnected: false)
+        featureFlagService.isFeatureFlagEnabledReturnValue[.clientSideDashboardBanner] = true
+        enableRemoteFeatureFlag()
+        setUpCountrySettings(countryCode: "CA") // Canada
+
+        let sut = makeSUT()
+
+        // When
+        let result = await sut.loadBanner(for: site)
+
+        // Then
+        XCTAssertNil(result, "Banner should not be shown for stores outside US/GB")
+    }
+
+    func test_loadBanner_returns_banner_for_US_store() async {
+        // Given
+        let site = Site.fake().copy(siteID: testSiteID, isJetpackThePluginInstalled: false, isJetpackConnected: false)
+        featureFlagService.isFeatureFlagEnabledReturnValue[.clientSideDashboardBanner] = true
+        enableRemoteFeatureFlag()
+        setUpUSCountrySettings()
+
+        let sut = makeSUT()
+
+        // When
+        let result = await sut.loadBanner(for: site)
+
+        // Then
+        XCTAssertNotNil(result, "Banner should be shown for non-Jetpack US stores with both flags enabled")
+    }
+
+    func test_loadBanner_returns_banner_for_GB_store() async {
+        // Given
+        let site = Site.fake().copy(siteID: testSiteID, isJetpackThePluginInstalled: false, isJetpackConnected: false)
+        featureFlagService.isFeatureFlagEnabledReturnValue[.clientSideDashboardBanner] = true
+        enableRemoteFeatureFlag()
+        setUpCountrySettings(countryCode: "GB")
+
+        let sut = makeSUT()
+
+        // When
+        let result = await sut.loadBanner(for: site)
+
+        // Then
+        XCTAssertNotNil(result, "Banner should be shown for non-Jetpack GB stores with both flags enabled")
+    }
+
+    // MARK: - Dismissal Tests
+
+    func test_loadBanner_returns_nil_when_banner_previously_dismissed() async {
+        // Given
+        let site = Site.fake().copy(siteID: testSiteID, isJetpackThePluginInstalled: false, isJetpackConnected: false)
+        featureFlagService.isFeatureFlagEnabledReturnValue[.clientSideDashboardBanner] = true
+        enableRemoteFeatureFlag()
+        setUpUSCountrySettings()
+
+        // Override to return false (banner was dismissed)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .getFeatureAnnouncementVisibility(_, onCompletion):
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
+
+        let sut = makeSUT()
+
+        // When
+        let result = await sut.loadBanner(for: site)
+
+        // Then
+        XCTAssertNil(result, "Banner should not be shown when previously dismissed")
+    }
+
+    // MARK: - Helpers
+
+    private func makeSUT(userInterfaceIdiom: UIUserInterfaceIdiom = .phone) -> ClientSideBannerProvider {
+        ClientSideBannerProvider(
+            stores: stores,
+            analytics: WooAnalytics(analyticsProvider: analytics),
+            featureFlagService: featureFlagService,
+            siteSettings: siteSettings,
+            userInterfaceIdiom: userInterfaceIdiom
+        )
+    }
+
+    private func enableRemoteFeatureFlag() {
+        stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            switch action {
+            case let .isRemoteFeatureFlagEnabled(flag, _, onCompletion):
+                if flag == .wooPosTabletPromoBanner {
+                    onCompletion(true)
+                } else {
+                    onCompletion(false)
+                }
+            }
+        }
+    }
+
+    private func setUpUSCountrySettings() {
+        setUpCountrySettings(countryCode: "US")
+    }
+
+    private func setUpCountrySettings(countryCode: String) {
+        let countrySetting = SiteSetting.fake().copy(
+            settingID: "woocommerce_default_country",
+            value: countryCode
+        )
+        // Set the siteSettings property directly for the fast path
+        siteSettings.siteSettings = [countrySetting]
+        // Also set up the stream as a fallback
+        siteSettings.mockSettingsStream = [
+            (siteID: testSiteID, settings: [countrySetting], source: .refresh)
+        ].publisher.eraseToAnyPublisher()
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/POSPromoOnPhonesCampaignTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/POSPromoOnPhonesCampaignTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import WooCommerce
+
+final class POSPromoOnPhonesCampaignTests: XCTestCase {
+
+    func test_configuration_has_correct_source() {
+        // Given
+        let sut = POSPromoOnPhonesCampaign()
+
+        // When
+        let configuration = sut.configuration
+
+        // Then
+        XCTAssertEqual(configuration.source, .myStore)
+    }
+
+    func test_configuration_has_correct_campaign() {
+        // Given
+        let sut = POSPromoOnPhonesCampaign()
+
+        // When
+        let configuration = sut.configuration
+
+        // Then
+        XCTAssertEqual(configuration.campaign, .posPromoOnPhones)
+    }
+
+    func test_configuration_has_non_empty_title() {
+        // Given
+        let sut = POSPromoOnPhonesCampaign()
+
+        // When
+        let configuration = sut.configuration
+
+        // Then
+        XCTAssertFalse(configuration.title.isEmpty)
+    }
+
+    func test_configuration_has_non_empty_message() {
+        // Given
+        let sut = POSPromoOnPhonesCampaign()
+
+        // When
+        let configuration = sut.configuration
+
+        // Then
+        XCTAssertFalse(configuration.message.isEmpty)
+    }
+
+    func test_configuration_has_non_empty_button_title() {
+        // Given
+        let sut = POSPromoOnPhonesCampaign()
+
+        // When
+        let configuration = sut.configuration
+
+        // Then
+        XCTAssertNotNil(configuration.buttonTitle)
+        XCTAssertFalse(configuration.buttonTitle?.isEmpty ?? true)
+    }
+
+    func test_ctaURL_is_valid() {
+        // Then
+        XCTAssertEqual(POSPromoOnPhonesCampaign.ctaURL.absoluteString, "https://woocommerce.com/in-person-payments/")
+    }
+
+    func test_configuration_does_not_show_dividers() {
+        // Given
+        let sut = POSPromoOnPhonesCampaign()
+
+        // When
+        let configuration = sut.configuration
+
+        // Then
+        XCTAssertFalse(configuration.showDividers)
+    }
+
+    func test_configuration_does_not_show_dismiss_confirmation() {
+        // Given
+        let sut = POSPromoOnPhonesCampaign()
+
+        // When
+        let configuration = sut.configuration
+
+        // Then
+        XCTAssertFalse(configuration.showDismissConfirmation)
+    }
+}


### PR DESCRIPTION
Part of: WOOMOB-1974
Merge after #16539 

## Description

This PR adds `ClientSideBannerProvider`, which decides whether we should show client-side promotional banners on non-Jetpack stores. These stores can't receive server-side JITMs, so we need client-side logic.

The provider checks:
- Site is non-Jetpack (not connected via Jetpack plugin or connection package)
- Local feature flag is enabled
- Remote feature flag is enabled
- Banner hasn't been dismissed
- Store country is US or GB

There's some complexity here – the site gets updated a few times on launch/login/switching sites. Some of these updates don't include the details we need, so we wait for them to come through fully, e.g. when the connection type is unknown.

The country check uses a fast path (checking already-loaded settings) with a fallback to waiting for settings with a 10-second timeout. This does not block other actions though.

Includes unit tests for eligibility scenarios.

## Test Steps

1. Verify the app builds successfully and all unit tests pass on CI

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.