### PR TITLE
Hide Woo-PN registered sites from Notification Settings

### DIFF
--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -118,7 +118,7 @@ final class PushNotificationsManager: PushNotesManager {
 
     /// Site IDs registered to Woo PN system, separated by commas
     ///
-    private var siteIDsRegisteredForWooPNs: [Int64] {
+    var siteIDsRegisteredForWooPNs: [Int64] {
         get {
             let ids: String? = configuration.defaults.object(forKey: .siteIDsRegisteredForWooPushNotifications)
             return ids?.components(separatedBy: ",")

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -33,6 +33,10 @@ protocol PushNotesManager {
     ///
     var deviceID: String? { get }
 
+    /// Site IDs registered for Woo Push Notifications.
+    ///
+    var siteIDsRegisteredForWooPNs: [Int64] { get }
+
     /// Resets the Badge Count.
     ///
     func resetBadgeCount(type: Note.Kind)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationSettingsViewModel.swift
@@ -33,6 +33,7 @@ final class NotificationSettingsViewModel: ObservableObject {
     private let stores: StoresManager
     private let storageManager: StorageManagerType
     private let analytics: Analytics
+    private let siteIDsRegisteredForWooPNs: Set<Int64>
 
     let currentDeviceID: String?
 
@@ -58,6 +59,7 @@ final class NotificationSettingsViewModel: ObservableObject {
         self.notificationCenter = notificationCenter
         self.stores = stores
         self.storageManager = storageManager
+        self.siteIDsRegisteredForWooPNs = Set(pushNotificationManager.siteIDsRegisteredForWooPNs)
         self.currentDeviceID = pushNotificationManager.deviceID
         self.analytics = analytics
 
@@ -210,7 +212,9 @@ private extension NotificationSettingsViewModel {
     }
 
     func updateSiteList() {
-        sites = siteResultsController.fetchedObjects
+        sites = siteResultsController.fetchedObjects.filter { site in
+            siteIDsRegisteredForWooPNs.contains(site.siteID) == false
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -43,6 +43,7 @@ final class MockPushNotificationsManager: PushNotesManager {
     }
 
     private let mockedDeviceID: String?
+    let siteIDsRegisteredForWooPNs: [Int64]
 
     var deviceID: String? {
         mockedDeviceID
@@ -58,8 +59,9 @@ final class MockPushNotificationsManager: PushNotesManager {
     private(set) var resetBadgeCountKinds: [Note.Kind] = []
     var onRequestLocalNotificationCalled: (() -> Void)?
 
-    init(mockedDeviceID: String? = nil) {
+    init(mockedDeviceID: String? = nil, siteIDsRegisteredForWooPNs: [Int64] = []) {
         self.mockedDeviceID = mockedDeviceID
+        self.siteIDsRegisteredForWooPNs = siteIDsRegisteredForWooPNs
     }
 
     func resetBadgeCount(type: Note.Kind) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/NotificationSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/NotificationSettingsViewModelTests.swift
@@ -71,6 +71,23 @@ struct NotificationSettingsViewModelTests {
     }
 
     @MainActor
+    @Test func sites_excludes_sites_registered_for_woo_pn() async {
+        // Given
+        let storageManager = MockStorageManager()
+        let testSite1 = Site.fake().copy(siteID: 123, name: "Miffy", isWooCommerceActive: true)
+        let testSite2 = Site.fake().copy(siteID: 243, name: "Matsui", isWooCommerceActive: true)
+        storageManager.insertSampleSite(readOnlySite: testSite1)
+        storageManager.insertSampleSite(readOnlySite: testSite2)
+
+        let pushNotificationManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [243])
+        let viewModel = NotificationSettingsViewModel(storageManager: storageManager,
+                                                      pushNotificationManager: pushNotificationManager)
+
+        // Then
+        #expect(viewModel.sites == [testSite1])
+    }
+
+    @MainActor
     @Test func sites_is_updated_when_syncing_succeeds() async throws {
         // Given
         let storageManager = MockStorageManager()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-2018

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In this PR we're hiding Woo-PN-registered sites from Notifications Settings screen.

- Exposes the new `PushNotificationsManager.swiftsiteIDsRegisteredForWooPNs` as public readonly
- Read and store `pushNotificationManager.siteIDsRegisteredForWooPNs` in `NotificationSettingsViewModel` upon initialization.
- In `NotificationSettingsViewModel` filter out sites contained in `PushNotificationsManager.swiftsiteIDsRegisteredForWooPNs`
- Adds a unit test

## Known limitation

Since we only rely on `siteIDsRegisteredForWooPNs` cache to determine if a site is registered for self-driven PNs - we can't know in advance if the site supports new Woo-PNs until we attempt to register PNs with the new `wc-push-notifications/push-tokens` endpoint. (Unless we introduce a new flag for a site or check for Woo plugin specific version).
For example let's say we have A,B,C sites associated with the WP.com account where the "C" is the only one with new Woo-PNs support. After a fresh install a user logs into the site "A" and goes to "Notification Settings" where all 3 sites will be listed including site "C". The site "C" will only disappear from that list after logging into it and registering for new PNs. I.e. when used goes back to site A (or B) - there will be no site "C" in Notifications Settings sites list.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Prepare a set of JP connected sites associated with a same WP.com account. Those sites should run the current prod Woo plugin without new PN support
- Prepare one more site that supports new Woo-PNs + associated with that same WP.com account. Read how here: p91TBi-dyW-p2#comment-14563 
- Test on a physical device
- Turn on the `selfDrivenPushToken` local FF by override tool. Restart the app.
- Log into that last site that supports new Woo-PNs with WP.com credentials.
- Go to app Menu -> Settings -> Application settings section. Make sure the "Notification Settings" option is absent.
- Log into another prepared site without new Woo-PNs support using the same WP.com credentials.
- Go to app Menu -> Settings -> Application settings section. Make sure the "Notification Settings" option is displayed.
- Open "Notification Settings" and make sure all mentioned sites are displayed except the one with new Woo-PNs support.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before / Marked site not yet registered for Woo-PNs | After / Marked site registered for new Woo-PNs
--- | ---
<img width="590" height="1278" alt="FFEnabledBeforeLogin" src="https://github.com/user-attachments/assets/0cebf9ec-2e11-43e4-806b-9f3f8b50c970" /> | <img width="590" height="1278" alt="FFEnabledAfterLogin" src="https://github.com/user-attachments/assets/22d23b47-78ef-48ca-8073-be3b85b20210" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.