### PR TITLE
[POS Refunds] Cash Refunds

### DIFF
--- a/Modules/Sources/Networking/Remote/POSPaymentGatewayRemoteProtocol.swift
+++ b/Modules/Sources/Networking/Remote/POSPaymentGatewayRemoteProtocol.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol POSPaymentGatewayRemoteProtocol {
+    func loadAllPaymentGateways(siteID: Int64, completion: @escaping (Result<[PaymentGateway], Error>) -> Void)
+}

--- a/Modules/Sources/Networking/Remote/PaymentGatewayRemote.swift
+++ b/Modules/Sources/Networking/Remote/PaymentGatewayRemote.swift
@@ -57,3 +57,6 @@ private extension PaymentGatewayRemote {
         static let path = "payment_gateways"
     }
 }
+
+// MARK: - POSPaymentGatewayRemoteProtocol
+extension PaymentGatewayRemote: POSPaymentGatewayRemoteProtocol {}

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -422,7 +422,7 @@ enum RefundActionAvailability {
             orderID: order.id,
             items: refundableItems,
             reason: reason,
-            automaticRefund: refundsResult.supportsAutomaticRefund
+            isAutomaticRefund: refundsResult.supportsAutomaticRefund
         )
 
         clearRefundSelection()

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -398,6 +398,11 @@ enum RefundActionAvailability {
             return
         }
 
+        guard case .loaded(let refundsResult) = selectedOrderRefundsState else {
+            assertionFailure("processRefund called without loaded refunds state")
+            return
+        }
+
         let selectedItems = refundSelectableItems.filter { $0.isSelected }
         guard !selectedItems.isEmpty else {
             assertionFailure("processRefund called without selected items")
@@ -417,7 +422,7 @@ enum RefundActionAvailability {
             orderID: order.id,
             items: refundableItems,
             reason: reason,
-            paymentMethodID: order.paymentMethodID
+            automaticRefund: refundsResult.supportsAutomaticRefund
         )
 
         clearRefundSelection()

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -416,7 +416,8 @@ enum RefundActionAvailability {
         try await refundsService.createRefund(
             orderID: order.id,
             items: refundableItems,
-            reason: reason
+            reason: reason,
+            paymentMethodID: order.paymentMethodID
         )
 
         clearRefundSelection()

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -559,7 +559,7 @@ final class POSRefundsServicePreview: POSRefundsServiceProtocol {
         POSRefundsResult(refunds: [], isFullyRefunded: false, supportsAutomaticRefund: true)
     }
 
-    func createRefund(orderID: Int64, items: [Yosemite.POSRefundableItem], reason: String?, automaticRefund: Bool) async throws {}
+    func createRefund(orderID: Int64, items: [Yosemite.POSRefundableItem], reason: String?, isAutomaticRefund: Bool) async throws {}
 }
 
 final class POSReceiptServicePreview: POSReceiptServiceProtocol {

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -280,6 +280,7 @@ struct POSPreviewHelpers {
             formattedTotal: "$45.75",
             formattedSubtotal: "$41.99",
             customerEmail: "customer@example.com",
+            paymentMethodID: "cod",
             paymentMethodTitle: "Cash on Delivery",
             lineItems: [
                 POSOrderItem(itemID: 1,
@@ -323,6 +324,7 @@ struct POSPreviewHelpers {
             formattedTotal: "$89.50",
             formattedSubtotal: "$89.96",
             customerEmail: "very.long.customer.email@withverylongdomainname.com",
+            paymentMethodID: "woocommerce_payments",
             paymentMethodTitle: "WooCommerce In-Person Payments",
             lineItems: [
                 POSOrderItem(
@@ -374,6 +376,7 @@ struct POSPreviewHelpers {
             formattedTotal: "$129.99",
             formattedSubtotal: "$120.00",
             customerEmail: nil,
+            paymentMethodID: "woocommerce_payments",
             paymentMethodTitle: "WooCommerce In-Person Payments",
             lineItems: [
                 POSOrderItem(
@@ -407,6 +410,7 @@ struct POSPreviewHelpers {
             formattedTotal: "$24.99",
             formattedSubtotal: "$22.99",
             customerEmail: nil,
+            paymentMethodID: "cod",
             paymentMethodTitle: "Cash on Delivery",
             lineItems: [
                 POSOrderItem(
@@ -438,6 +442,7 @@ struct POSPreviewHelpers {
             formattedTotal: "$156.47",
             formattedSubtotal: "$145.00",
             customerEmail: "john.doe@example.com",
+            paymentMethodID: "woocommerce_payments",
             paymentMethodTitle: "WooCommerce In-Person Payments",
             lineItems: [
                 POSOrderItem(
@@ -554,7 +559,7 @@ final class POSRefundsServicePreview: POSRefundsServiceProtocol {
         POSRefundsResult(refunds: [], isFullyRefunded: false)
     }
 
-    func createRefund(orderID: Int64, items: [Yosemite.POSRefundableItem], reason: String?) async throws {}
+    func createRefund(orderID: Int64, items: [Yosemite.POSRefundableItem], reason: String?, paymentMethodID: String) async throws {}
 }
 
 final class POSReceiptServicePreview: POSReceiptServiceProtocol {

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -556,10 +556,10 @@ final class POSOrderServicePreview: POSOrderServiceProtocol {
 
 final class POSRefundsServicePreview: POSRefundsServiceProtocol {
     func providePointOfSaleRefunds(for order: Yosemite.POSOrder) async throws -> Yosemite.POSRefundsResult {
-        POSRefundsResult(refunds: [], isFullyRefunded: false)
+        POSRefundsResult(refunds: [], isFullyRefunded: false, supportsAutomaticRefund: true)
     }
 
-    func createRefund(orderID: Int64, items: [Yosemite.POSRefundableItem], reason: String?, paymentMethodID: String) async throws {}
+    func createRefund(orderID: Int64, items: [Yosemite.POSRefundableItem], reason: String?, automaticRefund: Bool) async throws {}
 }
 
 final class POSReceiptServicePreview: POSReceiptServiceProtocol {

--- a/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -82,13 +82,15 @@ extension Yosemite.POSOrder {
         formattedTotal: CopiableProp<String> = .copy,
         formattedSubtotal: CopiableProp<String> = .copy,
         customerEmail: NullableCopiableProp<String> = .copy,
+        paymentMethodID: CopiableProp<String> = .copy,
         paymentMethodTitle: CopiableProp<String> = .copy,
         lineItems: CopiableProp<[POSOrderItem]> = .copy,
         refunds: CopiableProp<[POSOrderRefund]> = .copy,
         formattedDiscountTotal: NullableCopiableProp<String> = .copy,
         formattedTotalTax: CopiableProp<String> = .copy,
         formattedPaymentTotal: CopiableProp<String> = .copy,
-        formattedNetAmount: NullableCopiableProp<String> = .copy
+        formattedNetAmount: NullableCopiableProp<String> = .copy,
+        lineItemQuantitiesByProductOrVariationID: CopiableProp<[Int64: Decimal]> = .copy
     ) -> Yosemite.POSOrder {
         let id = id ?? self.id
         let number = number ?? self.number
@@ -97,6 +99,7 @@ extension Yosemite.POSOrder {
         let formattedTotal = formattedTotal ?? self.formattedTotal
         let formattedSubtotal = formattedSubtotal ?? self.formattedSubtotal
         let customerEmail = customerEmail ?? self.customerEmail
+        let paymentMethodID = paymentMethodID ?? self.paymentMethodID
         let paymentMethodTitle = paymentMethodTitle ?? self.paymentMethodTitle
         let lineItems = lineItems ?? self.lineItems
         let refunds = refunds ?? self.refunds
@@ -104,6 +107,7 @@ extension Yosemite.POSOrder {
         let formattedTotalTax = formattedTotalTax ?? self.formattedTotalTax
         let formattedPaymentTotal = formattedPaymentTotal ?? self.formattedPaymentTotal
         let formattedNetAmount = formattedNetAmount ?? self.formattedNetAmount
+        let lineItemQuantitiesByProductOrVariationID = lineItemQuantitiesByProductOrVariationID ?? self.lineItemQuantitiesByProductOrVariationID
 
         return Yosemite.POSOrder(
             id: id,
@@ -113,13 +117,15 @@ extension Yosemite.POSOrder {
             formattedTotal: formattedTotal,
             formattedSubtotal: formattedSubtotal,
             customerEmail: customerEmail,
+            paymentMethodID: paymentMethodID,
             paymentMethodTitle: paymentMethodTitle,
             lineItems: lineItems,
             refunds: refunds,
             formattedDiscountTotal: formattedDiscountTotal,
             formattedTotalTax: formattedTotalTax,
             formattedPaymentTotal: formattedPaymentTotal,
-            formattedNetAmount: formattedNetAmount
+            formattedNetAmount: formattedNetAmount,
+            lineItemQuantitiesByProductOrVariationID: lineItemQuantitiesByProductOrVariationID
         )
     }
 }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrder.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrder.swift
@@ -15,6 +15,7 @@ public struct POSOrder: Equatable, Hashable, GeneratedCopiable {
     public let formattedTotal: String
     public let formattedSubtotal: String
     public let customerEmail: String?
+    public let paymentMethodID: String
     public let paymentMethodTitle: String
     public let lineItems: [POSOrderItem]
     public let refunds: [POSOrderRefund]
@@ -35,6 +36,7 @@ public struct POSOrder: Equatable, Hashable, GeneratedCopiable {
                 formattedTotal: String,
                 formattedSubtotal: String,
                 customerEmail: String? = nil,
+                paymentMethodID: String,
                 paymentMethodTitle: String,
                 lineItems: [POSOrderItem] = [],
                 refunds: [POSOrderRefund] = [],
@@ -50,6 +52,7 @@ public struct POSOrder: Equatable, Hashable, GeneratedCopiable {
         self.formattedTotal = formattedTotal
         self.formattedSubtotal = formattedSubtotal
         self.customerEmail = customerEmail
+        self.paymentMethodID = paymentMethodID
         self.paymentMethodTitle = paymentMethodTitle
         self.lineItems = lineItems
         self.refunds = refunds

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderMapper.swift
@@ -53,6 +53,7 @@ struct POSOrderMapper {
             formattedTotal: currencyFormatter.formatAmount(order.total, with: order.currency) ?? "",
             formattedSubtotal: order.subtotalValue(currencyFormatter: currencyFormatter),
             customerEmail: customerEmail,
+            paymentMethodID: order.paymentMethodID,
             paymentMethodTitle: order.paymentMethodTitle,
             lineItems: posLineItems,
             refunds: posRefunds,

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
@@ -65,7 +65,8 @@ public final class POSRefundsService: POSRefundsServiceProtocol {
                 switch result {
                 case .success(let gateways):
                     continuation.resume(returning: gateways)
-                case .failure:
+                case .failure(let error):
+                    DDLogError("⛔️ Failed to load payment gateways: \(error)")
                     continuation.resume(returning: [])
                 }
             }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
@@ -80,13 +80,13 @@ public final class POSRefundsService: POSRefundsServiceProtocol {
         return paymentMethodID != PaymentGateway.Constants.cashOnDeliveryGatewayID
     }
 
-    public func createRefund(orderID: Int64, items: [POSRefundableItem], reason: String?, automaticRefund: Bool) async throws {
+    public func createRefund(orderID: Int64, items: [POSRefundableItem], reason: String?, isAutomaticRefund: Bool) async throws {
         let request = refundCalculator.buildRefundRequest(
             orderID: orderID,
             selectedItems: items,
             reason: reason
         )
-        let refund = buildRefund(from: request, createAutomated: automaticRefund)
+        let refund = buildRefund(from: request, createAutomated: isAutomaticRefund)
         _ = try await refundsRemote.createRefund(for: siteID, by: orderID, refund: refund)
     }
 

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
@@ -47,17 +47,22 @@ public final class POSRefundsService: POSRefundsServiceProtocol {
         return POSRefundsResult(refunds: mappedRefunds, isFullyRefunded: isFullyRefunded)
     }
 
-    public func createRefund(orderID: Int64, items: [POSRefundableItem], reason: String?) async throws {
+    public func createRefund(orderID: Int64, items: [POSRefundableItem], reason: String?, paymentMethodID: String) async throws {
         let request = refundCalculator.buildRefundRequest(
             orderID: orderID,
             selectedItems: items,
             reason: reason
         )
-        let refund = buildRefund(from: request)
+        let automaticRefundSupported = supportsAutomaticRefund(paymentMethodID: paymentMethodID)
+        let refund = buildRefund(from: request, createAutomated: automaticRefundSupported)
         _ = try await refundsRemote.createRefund(for: siteID, by: orderID, refund: refund)
     }
 
-    private func buildRefund(from request: POSRefundRequest) -> Refund {
+    private func supportsAutomaticRefund(paymentMethodID: String) -> Bool {
+        paymentMethodID != PaymentGateway.Constants.cashOnDeliveryGatewayID
+    }
+
+    private func buildRefund(from request: POSRefundRequest, createAutomated: Bool) -> Refund {
         let items = request.items.map { item in
             OrderItemRefund(
                 itemID: item.itemID,
@@ -86,7 +91,7 @@ public final class POSRefundsService: POSRefundsServiceProtocol {
             reason: request.reason ?? "",
             refundedByUserID: 0,
             isAutomated: nil,
-            createAutomated: true,
+            createAutomated: createAutomated,
             items: items,
             shippingLines: nil
         )

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
@@ -8,6 +8,7 @@ import struct NetworkingCore.OrderItemTaxRefund
 
 public final class POSRefundsService: POSRefundsServiceProtocol {
     private let refundsRemote: POSRefundsRemoteProtocol
+    private let paymentGatewayRemote: POSPaymentGatewayRemoteProtocol
     private let refundCalculator: POSRefundCalculating
     private let siteID: Int64
     private let mapper: POSRefundMapper
@@ -22,44 +23,71 @@ public final class POSRefundsService: POSRefundsServiceProtocol {
                                        selectedSite: selectedSite,
                                        appPasswordSupportState: appPasswordSupportState)
         self.refundsRemote = RefundsRemote(network: network)
+        self.paymentGatewayRemote = PaymentGatewayRemote(network: network)
         self.refundCalculator = POSRefundCalculator()
         self.mapper = POSRefundMapper()
     }
 
     init(siteID: Int64,
          refundsRemote: POSRefundsRemoteProtocol,
+         paymentGatewayRemote: POSPaymentGatewayRemoteProtocol,
          refundCalculator: POSRefundCalculating = POSRefundCalculator()) {
         self.siteID = siteID
         self.refundsRemote = refundsRemote
+        self.paymentGatewayRemote = paymentGatewayRemote
         self.refundCalculator = refundCalculator
         self.mapper = POSRefundMapper()
     }
 
     public func providePointOfSaleRefunds(for order: POSOrder) async throws -> POSRefundsResult {
-        let refunds = try await refundsRemote.loadRefunds(for: siteID, by: order.id, with: order.refunds.map { $0.refundID })
+        async let refundsTask = refundsRemote.loadRefunds(for: siteID, by: order.id, with: order.refunds.map { $0.refundID })
+        async let gatewaysTask = fetchPaymentGateways()
+
+        let refunds = try await refundsTask
+        let gateways = await gatewaysTask
 
         let mappedRefunds = refunds.map { mapper.map(refund: $0) }
         let isFullyRefunded = areAllProductsFullyRefunded(
             orderedQuantities: order.lineItemQuantitiesByProductOrVariationID,
             refunds: refunds
         )
+        let supportsAutomaticRefund = determineAutomaticRefundSupport(
+            paymentMethodID: order.paymentMethodID,
+            gateways: gateways
+        )
 
-        return POSRefundsResult(refunds: mappedRefunds, isFullyRefunded: isFullyRefunded)
+        return POSRefundsResult(refunds: mappedRefunds, isFullyRefunded: isFullyRefunded, supportsAutomaticRefund: supportsAutomaticRefund)
     }
 
-    public func createRefund(orderID: Int64, items: [POSRefundableItem], reason: String?, paymentMethodID: String) async throws {
+    private func fetchPaymentGateways() async -> [PaymentGateway] {
+        await withCheckedContinuation { continuation in
+            paymentGatewayRemote.loadAllPaymentGateways(siteID: siteID) { result in
+                switch result {
+                case .success(let gateways):
+                    continuation.resume(returning: gateways)
+                case .failure:
+                    continuation.resume(returning: [])
+                }
+            }
+        }
+    }
+
+    private func determineAutomaticRefundSupport(paymentMethodID: String, gateways: [PaymentGateway]) -> Bool {
+        if let gateway = gateways.first(where: { $0.gatewayID == paymentMethodID }) {
+            return gateway.features.contains(.refunds)
+        }
+        // Fallback: if gateway not found, use simple check
+        return paymentMethodID != PaymentGateway.Constants.cashOnDeliveryGatewayID
+    }
+
+    public func createRefund(orderID: Int64, items: [POSRefundableItem], reason: String?, automaticRefund: Bool) async throws {
         let request = refundCalculator.buildRefundRequest(
             orderID: orderID,
             selectedItems: items,
             reason: reason
         )
-        let automaticRefundSupported = supportsAutomaticRefund(paymentMethodID: paymentMethodID)
-        let refund = buildRefund(from: request, createAutomated: automaticRefundSupported)
+        let refund = buildRefund(from: request, createAutomated: automaticRefund)
         _ = try await refundsRemote.createRefund(for: siteID, by: orderID, refund: refund)
-    }
-
-    private func supportsAutomaticRefund(paymentMethodID: String) -> Bool {
-        paymentMethodID != PaymentGateway.Constants.cashOnDeliveryGatewayID
     }
 
     private func buildRefund(from request: POSRefundRequest, createAutomated: Bool) -> Refund {

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsServiceProtocol.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsServiceProtocol.swift
@@ -42,5 +42,5 @@ public struct POSRefundRequestItem {
 
 public protocol POSRefundsServiceProtocol {
     func providePointOfSaleRefunds(for order: POSOrder) async throws -> POSRefundsResult
-    func createRefund(orderID: Int64, items: [POSRefundableItem], reason: String?, automaticRefund: Bool) async throws
+    func createRefund(orderID: Int64, items: [POSRefundableItem], reason: String?, isAutomaticRefund: Bool) async throws
 }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsServiceProtocol.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsServiceProtocol.swift
@@ -40,5 +40,5 @@ public struct POSRefundRequestItem {
 
 public protocol POSRefundsServiceProtocol {
     func providePointOfSaleRefunds(for order: POSOrder) async throws -> POSRefundsResult
-    func createRefund(orderID: Int64, items: [POSRefundableItem], reason: String?) async throws
+    func createRefund(orderID: Int64, items: [POSRefundableItem], reason: String?, paymentMethodID: String) async throws
 }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsServiceProtocol.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsServiceProtocol.swift
@@ -3,10 +3,12 @@ import Foundation
 public struct POSRefundsResult {
     public let refunds: [POSRefund]
     public let isFullyRefunded: Bool
+    public let supportsAutomaticRefund: Bool
 
-    public init(refunds: [POSRefund], isFullyRefunded: Bool) {
+    public init(refunds: [POSRefund], isFullyRefunded: Bool, supportsAutomaticRefund: Bool) {
         self.refunds = refunds
         self.isFullyRefunded = isFullyRefunded
+        self.supportsAutomaticRefund = supportsAutomaticRefund
     }
 }
 
@@ -40,5 +42,5 @@ public struct POSRefundRequestItem {
 
 public protocol POSRefundsServiceProtocol {
     func providePointOfSaleRefunds(for order: POSOrder) async throws -> POSRefundsResult
-    func createRefund(orderID: Int64, items: [POSRefundableItem], reason: String?, paymentMethodID: String) async throws
+    func createRefund(orderID: Int64, items: [POSRefundableItem], reason: String?, automaticRefund: Bool) async throws
 }

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -1034,6 +1034,7 @@ final class POSOrderListControllerTests {
 
     // MARK: - Process Refund Tests
 
+    @MainActor
     @Test func processRefund_then_calls_service_with_correct_order_id() async throws {
         // Given
         featureFlags.isPointOfSaleRefundsi1Enabled = true
@@ -1047,13 +1048,13 @@ final class POSOrderListControllerTests {
             makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
         ])
 
-        await sut.selectOrder(order)
+        sut.selectOrder(order)
         _ = await waitForCondition { [weak self] in
             guard let sut = self?.sut else { return false }
             if case .loaded = sut.selectedOrderRefundsState { return true }
             return false
         }
-        await MainActor.run { sut.startRefundFlow() }
+        sut.startRefundFlow()
 
         // When
         try await sut.processRefund(reason: .none)
@@ -1063,6 +1064,7 @@ final class POSOrderListControllerTests {
         #expect(refundsService.spyCreateRefundOrderID == 123)
     }
 
+    @MainActor
     @Test func processRefund_then_calls_service_with_selected_items() async throws {
         // Given
         featureFlags.isPointOfSaleRefundsi1Enabled = true
@@ -1077,16 +1079,14 @@ final class POSOrderListControllerTests {
             makePOSOrderItem(itemID: 2, quantity: 1, price: 5.00, formattedPrice: "$5.00")
         ])
 
-        await sut.selectOrder(order)
+        sut.selectOrder(order)
         _ = await waitForCondition { [weak self] in
             guard let sut = self?.sut else { return false }
             if case .loaded = sut.selectedOrderRefundsState { return true }
             return false
         }
-        await MainActor.run {
-            sut.startRefundFlow()
-            sut.toggleRefundItemSelection(at: 0) // Deselect first item of itemID 1
-        }
+        sut.startRefundFlow()
+        sut.toggleRefundItemSelection(at: 0) // Deselect first item of itemID 1
 
         // When
         try await sut.processRefund(reason: .none)
@@ -1095,6 +1095,7 @@ final class POSOrderListControllerTests {
         #expect(refundsService.spyCreateRefundItems?.count == 2) // 1 from itemID 1, 1 from itemID 2
     }
 
+    @MainActor
     @Test func processRefund_then_calls_service_with_reason() async throws {
         // Given
         featureFlags.isPointOfSaleRefundsi1Enabled = true
@@ -1108,13 +1109,13 @@ final class POSOrderListControllerTests {
             makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
         ])
 
-        await sut.selectOrder(order)
+        sut.selectOrder(order)
         _ = await waitForCondition { [weak self] in
             guard let sut = self?.sut else { return false }
             if case .loaded = sut.selectedOrderRefundsState { return true }
             return false
         }
-        await MainActor.run { sut.startRefundFlow() }
+        sut.startRefundFlow()
 
         // When
         try await sut.processRefund(reason: "Customer changed their mind")
@@ -1123,6 +1124,7 @@ final class POSOrderListControllerTests {
         #expect(refundsService.spyCreateRefundReason == "Customer changed their mind")
     }
 
+    @MainActor
     @Test func processRefund_when_successful_then_clears_selection() async throws {
         // Given
         featureFlags.isPointOfSaleRefundsi1Enabled = true
@@ -1136,26 +1138,24 @@ final class POSOrderListControllerTests {
             makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00")
         ])
 
-        await sut.selectOrder(order)
+        sut.selectOrder(order)
         _ = await waitForCondition { [weak self] in
             guard let sut = self?.sut else { return false }
             if case .loaded = sut.selectedOrderRefundsState { return true }
             return false
         }
-        let initialCount = await MainActor.run {
-            sut.startRefundFlow()
-            return sut.refundSelectableItems.count
-        }
+        sut.startRefundFlow()
+        let initialCount = sut.refundSelectableItems.count
         try #require(initialCount == 2)
 
         // When
         try await sut.processRefund(reason: .none)
 
         // Then
-        let finalCount = await MainActor.run { sut.refundSelectableItems.count }
-        #expect(finalCount == 0)
+        #expect(sut.refundSelectableItems.count == 0)
     }
 
+    @MainActor
     @Test func processRefund_when_service_throws_then_propagates_error() async throws {
         // Given
         featureFlags.isPointOfSaleRefundsi1Enabled = true
@@ -1169,13 +1169,13 @@ final class POSOrderListControllerTests {
             makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
         ])
 
-        await sut.selectOrder(order)
+        sut.selectOrder(order)
         _ = await waitForCondition { [weak self] in
             guard let sut = self?.sut else { return false }
             if case .loaded = sut.selectedOrderRefundsState { return true }
             return false
         }
-        await MainActor.run { sut.startRefundFlow() }
+        sut.startRefundFlow()
 
         struct TestError: Error {}
         refundsService.createRefundErrorToThrow = TestError()
@@ -1191,6 +1191,7 @@ final class POSOrderListControllerTests {
         #expect(thrownError is TestError)
     }
 
+    @MainActor
     @Test func processRefund_then_converts_items_with_correct_properties() async throws {
         // Given
         featureFlags.isPointOfSaleRefundsi1Enabled = true
@@ -1204,13 +1205,13 @@ final class POSOrderListControllerTests {
             makePOSOrderItem(itemID: 42, quantity: 3, price: 15.50, totalTax: 1.55, formattedPrice: "$15.50")
         ])
 
-        await sut.selectOrder(order)
+        sut.selectOrder(order)
         _ = await waitForCondition { [weak self] in
             guard let sut = self?.sut else { return false }
             if case .loaded = sut.selectedOrderRefundsState { return true }
             return false
         }
-        await MainActor.run { sut.startRefundFlow() }
+        sut.startRefundFlow()
 
         // When
         try await sut.processRefund(reason: .none)
@@ -1226,6 +1227,7 @@ final class POSOrderListControllerTests {
         #expect(firstItem.originalQuantity == 3)
     }
 
+    @MainActor
     @Test func processRefund_when_supportsAutomaticRefund_is_true_then_calls_service_with_automatic_refund_true() async throws {
         // Given
         featureFlags.isPointOfSaleRefundsi1Enabled = true
@@ -1239,13 +1241,13 @@ final class POSOrderListControllerTests {
             makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
         ])
 
-        await sut.selectOrder(order)
+        sut.selectOrder(order)
         _ = await waitForCondition { [weak self] in
             guard let sut = self?.sut else { return false }
             if case .loaded = sut.selectedOrderRefundsState { return true }
             return false
         }
-        await MainActor.run { sut.startRefundFlow() }
+        sut.startRefundFlow()
 
         // When
         try await sut.processRefund(reason: .none)
@@ -1254,6 +1256,7 @@ final class POSOrderListControllerTests {
         #expect(refundsService.spyCreateRefundAutomaticRefund == true)
     }
 
+    @MainActor
     @Test func processRefund_when_supportsAutomaticRefund_is_false_then_calls_service_with_automatic_refund_false() async throws {
         // Given
         featureFlags.isPointOfSaleRefundsi1Enabled = true
@@ -1267,13 +1270,13 @@ final class POSOrderListControllerTests {
             makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
         ])
 
-        await sut.selectOrder(order)
+        sut.selectOrder(order)
         _ = await waitForCondition { [weak self] in
             guard let sut = self?.sut else { return false }
             if case .loaded = sut.selectedOrderRefundsState { return true }
             return false
         }
-        await MainActor.run { sut.startRefundFlow() }
+        sut.startRefundFlow()
 
         // When
         try await sut.processRefund(reason: .none)

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -422,7 +422,7 @@ final class POSOrderListControllerTests {
         featureFlags.isPointOfSaleRefundsi1Enabled = true
         let order = MockPOSOrderListService.makeInitialOrders()[0]
 
-        let expectedResult = POSRefundsResult(refunds: [POSRefund(items: [])], isFullyRefunded: false)
+        let expectedResult = POSRefundsResult(refunds: [POSRefund(items: [])], isFullyRefunded: false, supportsAutomaticRefund: true)
         refundsService.providePointOfSaleRefundsResultToReturn = expectedResult
 
         // When
@@ -549,7 +549,8 @@ final class POSOrderListControllerTests {
         // Service returns isFullyRefunded = false (not fully refunded)
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
             refunds: [],
-            isFullyRefunded: false
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
         )
 
         // When
@@ -576,7 +577,8 @@ final class POSOrderListControllerTests {
         // Service returns isFullyRefunded = true (fully refunded)
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
             refunds: [],
-            isFullyRefunded: true
+            isFullyRefunded: true,
+            supportsAutomaticRefund: true
         )
 
         // When
@@ -1034,14 +1036,24 @@ final class POSOrderListControllerTests {
 
     @Test func processRefund_then_calls_service_with_correct_order_id() async throws {
         // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
         let order = makeOrder(id: 123, lineItems: [
             makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
         ])
 
-        await MainActor.run {
-            sut.selectOrder(order)
-            sut.startRefundFlow()
+        await sut.selectOrder(order)
+        _ = await waitForCondition { [weak self] in
+            guard let sut = self?.sut else { return false }
+            if case .loaded = sut.selectedOrderRefundsState { return true }
+            return false
         }
+        await MainActor.run { sut.startRefundFlow() }
 
         // When
         try await sut.processRefund(reason: .none)
@@ -1053,13 +1065,25 @@ final class POSOrderListControllerTests {
 
     @Test func processRefund_then_calls_service_with_selected_items() async throws {
         // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
         let order = makeOrder(lineItems: [
             makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00"),
             makePOSOrderItem(itemID: 2, quantity: 1, price: 5.00, formattedPrice: "$5.00")
         ])
 
+        await sut.selectOrder(order)
+        _ = await waitForCondition { [weak self] in
+            guard let sut = self?.sut else { return false }
+            if case .loaded = sut.selectedOrderRefundsState { return true }
+            return false
+        }
         await MainActor.run {
-            sut.selectOrder(order)
             sut.startRefundFlow()
             sut.toggleRefundItemSelection(at: 0) // Deselect first item of itemID 1
         }
@@ -1073,14 +1097,24 @@ final class POSOrderListControllerTests {
 
     @Test func processRefund_then_calls_service_with_reason() async throws {
         // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
         let order = makeOrder(lineItems: [
             makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
         ])
 
-        await MainActor.run {
-            sut.selectOrder(order)
-            sut.startRefundFlow()
+        await sut.selectOrder(order)
+        _ = await waitForCondition { [weak self] in
+            guard let sut = self?.sut else { return false }
+            if case .loaded = sut.selectedOrderRefundsState { return true }
+            return false
         }
+        await MainActor.run { sut.startRefundFlow() }
 
         // When
         try await sut.processRefund(reason: "Customer changed their mind")
@@ -1091,12 +1125,24 @@ final class POSOrderListControllerTests {
 
     @Test func processRefund_when_successful_then_clears_selection() async throws {
         // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
         let order = makeOrder(lineItems: [
             makePOSOrderItem(itemID: 1, quantity: 2, price: 10.00, formattedPrice: "$10.00")
         ])
 
+        await sut.selectOrder(order)
+        _ = await waitForCondition { [weak self] in
+            guard let sut = self?.sut else { return false }
+            if case .loaded = sut.selectedOrderRefundsState { return true }
+            return false
+        }
         let initialCount = await MainActor.run {
-            sut.selectOrder(order)
             sut.startRefundFlow()
             return sut.refundSelectableItems.count
         }
@@ -1112,14 +1158,24 @@ final class POSOrderListControllerTests {
 
     @Test func processRefund_when_service_throws_then_propagates_error() async throws {
         // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
         let order = makeOrder(lineItems: [
             makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
         ])
 
-        await MainActor.run {
-            sut.selectOrder(order)
-            sut.startRefundFlow()
+        await sut.selectOrder(order)
+        _ = await waitForCondition { [weak self] in
+            guard let sut = self?.sut else { return false }
+            if case .loaded = sut.selectedOrderRefundsState { return true }
+            return false
         }
+        await MainActor.run { sut.startRefundFlow() }
 
         struct TestError: Error {}
         refundsService.createRefundErrorToThrow = TestError()
@@ -1137,14 +1193,24 @@ final class POSOrderListControllerTests {
 
     @Test func processRefund_then_converts_items_with_correct_properties() async throws {
         // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
         let order = makeOrder(lineItems: [
             makePOSOrderItem(itemID: 42, quantity: 3, price: 15.50, totalTax: 1.55, formattedPrice: "$15.50")
         ])
 
-        await MainActor.run {
-            sut.selectOrder(order)
-            sut.startRefundFlow()
+        await sut.selectOrder(order)
+        _ = await waitForCondition { [weak self] in
+            guard let sut = self?.sut else { return false }
+            if case .loaded = sut.selectedOrderRefundsState { return true }
+            return false
         }
+        await MainActor.run { sut.startRefundFlow() }
 
         // When
         try await sut.processRefund(reason: .none)
@@ -1160,22 +1226,60 @@ final class POSOrderListControllerTests {
         #expect(firstItem.originalQuantity == 3)
     }
 
-    @Test func processRefund_then_calls_service_with_payment_method_id() async throws {
+    @Test func processRefund_when_supportsAutomaticRefund_is_true_then_calls_service_with_automatic_refund_true() async throws {
         // Given
-        let order = makeOrder(paymentMethodID: "cod", lineItems: [
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
+        let order = makeOrder(lineItems: [
             makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
         ])
 
-        await MainActor.run {
-            sut.selectOrder(order)
-            sut.startRefundFlow()
+        await sut.selectOrder(order)
+        _ = await waitForCondition { [weak self] in
+            guard let sut = self?.sut else { return false }
+            if case .loaded = sut.selectedOrderRefundsState { return true }
+            return false
         }
+        await MainActor.run { sut.startRefundFlow() }
 
         // When
         try await sut.processRefund(reason: .none)
 
         // Then
-        #expect(refundsService.spyCreateRefundPaymentMethodID == "cod")
+        #expect(refundsService.spyCreateRefundAutomaticRefund == true)
+    }
+
+    @Test func processRefund_when_supportsAutomaticRefund_is_false_then_calls_service_with_automatic_refund_false() async throws {
+        // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: false
+        )
+
+        let order = makeOrder(lineItems: [
+            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+
+        await sut.selectOrder(order)
+        _ = await waitForCondition { [weak self] in
+            guard let sut = self?.sut else { return false }
+            if case .loaded = sut.selectedOrderRefundsState { return true }
+            return false
+        }
+        await MainActor.run { sut.startRefundFlow() }
+
+        // When
+        try await sut.processRefund(reason: .none)
+
+        // Then
+        #expect(refundsService.spyCreateRefundAutomaticRefund == false)
     }
 }
 

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -1296,7 +1296,10 @@ private extension POSOrderListControllerTests {
         )
     }
 
-    func makeOrder(id: Int64 = 1, paymentMethodID: String = "woocommerce_payments", paymentMethodTitle: String = "Cash", lineItems: [POSOrderItem] = []) -> POSOrder {
+    func makeOrder(id: Int64 = 1,
+                   paymentMethodID: String = "woocommerce_payments",
+                   paymentMethodTitle: String = "cod",
+                   lineItems: [POSOrderItem] = []) -> POSOrder {
         POSOrder(
             id: id,
             number: "\(id)",

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -1159,6 +1159,24 @@ final class POSOrderListControllerTests {
         #expect(firstItem.totalTax == 1.55)
         #expect(firstItem.originalQuantity == 3)
     }
+
+    @Test func processRefund_then_calls_service_with_payment_method_id() async throws {
+        // Given
+        let order = makeOrder(paymentMethodID: "cod", lineItems: [
+            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+
+        await MainActor.run {
+            sut.selectOrder(order)
+            sut.startRefundFlow()
+        }
+
+        // When
+        try await sut.processRefund(reason: .none)
+
+        // Then
+        #expect(refundsService.spyCreateRefundPaymentMethodID == "cod")
+    }
 }
 
 private extension POSOrderListControllerTests {
@@ -1174,7 +1192,7 @@ private extension POSOrderListControllerTests {
         )
     }
 
-    func makeOrder(id: Int64 = 1, paymentMethodTitle: String = "Cash", lineItems: [POSOrderItem] = []) -> POSOrder {
+    func makeOrder(id: Int64 = 1, paymentMethodID: String = "woocommerce_payments", paymentMethodTitle: String = "Cash", lineItems: [POSOrderItem] = []) -> POSOrder {
         POSOrder(
             id: id,
             number: "\(id)",
@@ -1183,6 +1201,7 @@ private extension POSOrderListControllerTests {
             formattedTotal: "$25.99",
             formattedSubtotal: "$25.99",
             customerEmail: "customer1@example.com",
+            paymentMethodID: paymentMethodID,
             paymentMethodTitle: paymentMethodTitle,
             lineItems: lineItems,
             refunds: [],

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListService.swift
@@ -149,6 +149,7 @@ extension MockPOSOrderListService {
             formattedTotal: "$25.99",
             formattedSubtotal: "$25.99",
             customerEmail: "customer1@example.com",
+            paymentMethodID: "cod",
             paymentMethodTitle: "Cash",
             lineItems: [
                 POSOrderItem(
@@ -189,6 +190,7 @@ extension MockPOSOrderListService {
             formattedTotal: "$15.50",
             formattedSubtotal: "$15.50",
             customerEmail: "customer2@example.com",
+            paymentMethodID: "woocommerce_payments",
             paymentMethodTitle: "Card",
             lineItems: [
                 POSOrderItem(
@@ -224,6 +226,7 @@ extension MockPOSOrderListService {
             formattedTotal: "$42.75",
             formattedSubtotal: "$42.75",
             customerEmail: "customer3@example.com",
+            paymentMethodID: "cod",
             paymentMethodTitle: "Cash",
             lineItems: [
                 POSOrderItem(
@@ -264,6 +267,7 @@ extension MockPOSOrderListService {
             formattedTotal: "$12.00",
             formattedSubtotal: "$12.00",
             customerEmail: "customer4@example.com",
+            paymentMethodID: "woocommerce_payments",
             paymentMethodTitle: "Card",
             lineItems: [
                 POSOrderItem(
@@ -301,6 +305,7 @@ extension MockPOSOrderListService {
             formattedTotal: "$18.50",
             formattedSubtotal: "$18.50",
             customerEmail: "search@example.com",
+            paymentMethodID: "cod",
             paymentMethodTitle: "Cash",
             lineItems: [
                 POSOrderItem(

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSRefundsService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSRefundsService.swift
@@ -45,12 +45,12 @@ final class MockPOSRefundsService: POSRefundsServiceProtocol {
     var spyCreateRefundAutomaticRefund: Bool?
     var createRefundErrorToThrow: Error?
 
-    func createRefund(orderID: Int64, items: [Yosemite.POSRefundableItem], reason: String?, automaticRefund: Bool) async throws {
+    func createRefund(orderID: Int64, items: [Yosemite.POSRefundableItem], reason: String?, isAutomaticRefund: Bool) async throws {
         createRefundCalled = true
         spyCreateRefundOrderID = orderID
         spyCreateRefundItems = items
         spyCreateRefundReason = reason
-        spyCreateRefundAutomaticRefund = automaticRefund
+        spyCreateRefundAutomaticRefund = isAutomaticRefund
 
         if let error = createRefundErrorToThrow {
             throw error

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSRefundsService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSRefundsService.swift
@@ -2,7 +2,7 @@
 
 final class MockPOSRefundsService: POSRefundsServiceProtocol {
     var spyProvidePointOfSaleRefundsOrder: Yosemite.POSOrder?
-    var providePointOfSaleRefundsResultToReturn: Yosemite.POSRefundsResult = POSRefundsResult(refunds: [], isFullyRefunded: false)
+    var providePointOfSaleRefundsResultToReturn: Yosemite.POSRefundsResult = POSRefundsResult(refunds: [], isFullyRefunded: false, supportsAutomaticRefund: true)
     var errorToThrow: Error?
 
     private var continuation: CheckedContinuation<Yosemite.POSOrder, Never>?
@@ -42,15 +42,15 @@ final class MockPOSRefundsService: POSRefundsServiceProtocol {
     var spyCreateRefundOrderID: Int64?
     var spyCreateRefundItems: [Yosemite.POSRefundableItem]?
     var spyCreateRefundReason: String?
-    var spyCreateRefundPaymentMethodID: String?
+    var spyCreateRefundAutomaticRefund: Bool?
     var createRefundErrorToThrow: Error?
 
-    func createRefund(orderID: Int64, items: [Yosemite.POSRefundableItem], reason: String?, paymentMethodID: String) async throws {
+    func createRefund(orderID: Int64, items: [Yosemite.POSRefundableItem], reason: String?, automaticRefund: Bool) async throws {
         createRefundCalled = true
         spyCreateRefundOrderID = orderID
         spyCreateRefundItems = items
         spyCreateRefundReason = reason
-        spyCreateRefundPaymentMethodID = paymentMethodID
+        spyCreateRefundAutomaticRefund = automaticRefund
 
         if let error = createRefundErrorToThrow {
             throw error

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSRefundsService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSRefundsService.swift
@@ -42,13 +42,15 @@ final class MockPOSRefundsService: POSRefundsServiceProtocol {
     var spyCreateRefundOrderID: Int64?
     var spyCreateRefundItems: [Yosemite.POSRefundableItem]?
     var spyCreateRefundReason: String?
+    var spyCreateRefundPaymentMethodID: String?
     var createRefundErrorToThrow: Error?
 
-    func createRefund(orderID: Int64, items: [Yosemite.POSRefundableItem], reason: String?) async throws {
+    func createRefund(orderID: Int64, items: [Yosemite.POSRefundableItem], reason: String?, paymentMethodID: String) async throws {
         createRefundCalled = true
         spyCreateRefundOrderID = orderID
         spyCreateRefundItems = items
         spyCreateRefundReason = reason
+        spyCreateRefundPaymentMethodID = paymentMethodID
 
         if let error = createRefundErrorToThrow {
             throw error

--- a/Modules/Tests/PointOfSaleTests/Models/POSOrderListModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/POSOrderListModelTests.swift
@@ -74,6 +74,7 @@ final class POSOrderListModelTests {
             formattedTotal: "$10.00",
             formattedSubtotal: "$10.00",
             customerEmail: email,
+            paymentMethodID: "woocommerce_payments",
             paymentMethodTitle: "Test Payment",
             lineItems: [],
             refunds: [],

--- a/Modules/Tests/PointOfSaleTests/Models/POSOrderListStateTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/POSOrderListStateTests.swift
@@ -124,12 +124,12 @@ private extension POSOrderListStateTests {
         [
             POSOrder(id: 1, number: "1001", dateCreated: Date(), status: .completed,
                      formattedTotal: "$10.00", formattedSubtotal: "$10.00", customerEmail: "test1@example.com",
-                     paymentMethodTitle: "Credit Card", lineItems: [],
+                     paymentMethodID: "woocommerce_payments", paymentMethodTitle: "Credit Card", lineItems: [],
                      refunds: [], formattedDiscountTotal: nil, formattedTotalTax: "$0.00",
                      formattedPaymentTotal: "$10.00", formattedNetAmount: nil),
             POSOrder(id: 2, number: "1002", dateCreated: Date(), status: .completed,
                      formattedTotal: "$20.00", formattedSubtotal: "$20.00", customerEmail: "test2@example.com",
-                     paymentMethodTitle: "Cash", lineItems: [],
+                     paymentMethodID: "cod", paymentMethodTitle: "Cash", lineItems: [],
                      refunds: [], formattedDiscountTotal: nil, formattedTotalTax: "$0.00",
                      formattedPaymentTotal: "$20.00", formattedNetAmount: nil)
         ]

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSRefundsServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSRefundsServiceTests.swift
@@ -182,7 +182,7 @@ struct POSRefundsServiceTests {
         let reason = "Customer request"
 
         // When
-        try await sut.createRefund(orderID: orderID, items: items, reason: reason, automaticRefund: true)
+        try await sut.createRefund(orderID: orderID, items: items, reason: reason, isAutomaticRefund: true)
 
         // Then
         #expect(calculator.spyOrderID == orderID)
@@ -201,7 +201,7 @@ struct POSRefundsServiceTests {
         let items = [POSRefundableItem(itemID: 1, price: Decimal(10), totalTax: Decimal(1), originalQuantity: 1)]
 
         // When
-        try await sut.createRefund(orderID: orderID, items: items, reason: nil, automaticRefund: true)
+        try await sut.createRefund(orderID: orderID, items: items, reason: nil, isAutomaticRefund: true)
 
         // Then
         #expect(remote.spyCreateRefundSiteID == siteID)
@@ -221,7 +221,7 @@ struct POSRefundsServiceTests {
         let sut = POSRefundsService(siteID: 123, refundsRemote: remote, paymentGatewayRemote: makeMockPOSPaymentGatewayRemote(), refundCalculator: calculator)
 
         // When
-        try await sut.createRefund(orderID: 456, items: [], reason: "Test reason", automaticRefund: true)
+        try await sut.createRefund(orderID: 456, items: [], reason: "Test reason", isAutomaticRefund: true)
 
         // Then
         #expect(remote.spyCreateRefund?.amount == "132.60")
@@ -234,7 +234,7 @@ struct POSRefundsServiceTests {
         let sut = POSRefundsService(siteID: 123, refundsRemote: remote, paymentGatewayRemote: MockPOSPaymentGatewayRemote())
 
         // When
-        try await sut.createRefund(orderID: 456, items: [], reason: nil, automaticRefund: true)
+        try await sut.createRefund(orderID: 456, items: [], reason: nil, isAutomaticRefund: true)
 
         // Then
         #expect(remote.spyCreateRefund?.createAutomated == true)
@@ -246,7 +246,7 @@ struct POSRefundsServiceTests {
         let sut = POSRefundsService(siteID: 123, refundsRemote: remote, paymentGatewayRemote: MockPOSPaymentGatewayRemote())
 
         // When
-        try await sut.createRefund(orderID: 456, items: [], reason: nil, automaticRefund: false)
+        try await sut.createRefund(orderID: 456, items: [], reason: nil, isAutomaticRefund: false)
 
         // Then
         #expect(remote.spyCreateRefund?.createAutomated == false)
@@ -261,7 +261,7 @@ struct POSRefundsServiceTests {
 
         // Then
         do {
-            try await sut.createRefund(orderID: 456, items: [], reason: nil, automaticRefund: true)
+            try await sut.createRefund(orderID: 456, items: [], reason: nil, isAutomaticRefund: true)
             Issue.record("Expected error to be thrown")
         } catch {
             #expect(error is TestError)

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSRefundsServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSRefundsServiceTests.swift
@@ -2,13 +2,19 @@ import Testing
 import Foundation
 @testable import Yosemite
 import Networking
+@testable import NetworkingCore
 
 struct POSRefundsServiceTests {
+    // MARK: - Mock PaymentGatewayRemote
+
+    private func makeMockPOSPaymentGatewayRemote(gateways: [PaymentGateway] = []) -> MockPOSPaymentGatewayRemote {
+        MockPOSPaymentGatewayRemote(gatewaysToReturn: gateways)
+    }
     @Test func providePointOfSaleRefunds_then_calls_remote_with_expected_params() async throws {
         // Given
         let remote = MockPOSRefundsRemote()
         let siteID: Int64 = 123
-        let sut = POSRefundsService(siteID: siteID, refundsRemote: remote)
+        let sut = POSRefundsService(siteID: siteID, refundsRemote: remote, paymentGatewayRemote: makeMockPOSPaymentGatewayRemote())
         let orderRefunds = [POSOrderRefund(refundID: 10, formattedTotal: "$22"), POSOrderRefund(refundID: 20, formattedTotal: "$22")]
 
         let order = makeOrder(id: 1, refunds: orderRefunds)
@@ -25,7 +31,7 @@ struct POSRefundsServiceTests {
     @Test func providePointOfSaleRefunds_when_remote_fails_then_propagates_remote_error() async throws {
         // Given
         let remote = MockPOSRefundsRemote()
-        let sut = POSRefundsService(siteID: 123, refundsRemote: remote)
+        let sut = POSRefundsService(siteID: 123, refundsRemote: remote, paymentGatewayRemote: makeMockPOSPaymentGatewayRemote())
 
         struct TestError: Error {}
         remote.result = .failure(TestError())
@@ -45,7 +51,7 @@ struct POSRefundsServiceTests {
     @Test func providePointOfSaleRefunds_when_remote_succeeds_then_returns_same_count_as_remote() async throws {
         // Given
         let remote = MockPOSRefundsRemote()
-        let sut = POSRefundsService(siteID: 123, refundsRemote: remote)
+        let sut = POSRefundsService(siteID: 123, refundsRemote: remote, paymentGatewayRemote: makeMockPOSPaymentGatewayRemote())
 
         let r1 = MockRefunds.sampleRefund()
         let r2 = MockRefunds.sampleRefund()
@@ -64,7 +70,7 @@ struct POSRefundsServiceTests {
     @Test func providePointOfSaleRefunds_when_remote_succeeds_then_maps_refund_items_correctly() async throws {
         // Given
         let remote = MockPOSRefundsRemote()
-        let sut = POSRefundsService(siteID: 123, refundsRemote: remote)
+        let sut = POSRefundsService(siteID: 123, refundsRemote: remote, paymentGatewayRemote: makeMockPOSPaymentGatewayRemote())
 
         let item1 = MockRefunds.sampleRefundItem(productID: 111, variationID: 222, quantity: 2)
         let item2 = MockRefunds.sampleRefundItem(productID: 333, variationID: 444, quantity: 5)
@@ -87,6 +93,78 @@ struct POSRefundsServiceTests {
         #expect(mappedItems[1].quantity == item2.quantity)
     }
 
+    // MARK: - supportsAutomaticRefund Tests
+
+    @Test func providePointOfSaleRefunds_when_gateway_supports_refunds_then_supportsAutomaticRefund_is_true() async throws {
+        // Given
+        let remote = MockPOSRefundsRemote()
+        let gateway = PaymentGateway(siteID: 123,
+                                     gatewayID: "woocommerce_payments",
+                                     title: "WooCommerce Payments",
+                                     description: "",
+                                     enabled: true,
+                                     features: [.refunds],
+                                     instructions: nil)
+        let sut = POSRefundsService(siteID: 123, refundsRemote: remote, paymentGatewayRemote: makeMockPOSPaymentGatewayRemote(gateways: [gateway]))
+
+        let order = makeOrder(paymentMethodID: "woocommerce_payments")
+
+        // When
+        let result = try await sut.providePointOfSaleRefunds(for: order)
+
+        // Then
+        #expect(result.supportsAutomaticRefund == true)
+    }
+
+    @Test func providePointOfSaleRefunds_when_gateway_does_not_support_refunds_then_supportsAutomaticRefund_is_false() async throws {
+        // Given
+        let remote = MockPOSRefundsRemote()
+        let gateway = PaymentGateway(siteID: 123,
+                                     gatewayID: "cod",
+                                     title: "Cash on Delivery",
+                                     description: "",
+                                     enabled: true,
+                                     features: [],
+                                     instructions: nil)
+        let sut = POSRefundsService(siteID: 123, refundsRemote: remote, paymentGatewayRemote: makeMockPOSPaymentGatewayRemote(gateways: [gateway]))
+
+        let order = makeOrder(paymentMethodID: "cod")
+
+        // When
+        let result = try await sut.providePointOfSaleRefunds(for: order)
+
+        // Then
+        #expect(result.supportsAutomaticRefund == false)
+    }
+
+    @Test func providePointOfSaleRefunds_when_gateway_not_found_and_payment_method_is_cod_then_supportsAutomaticRefund_is_false() async throws {
+        // Given
+        let remote = MockPOSRefundsRemote()
+        let sut = POSRefundsService(siteID: 123, refundsRemote: remote, paymentGatewayRemote: makeMockPOSPaymentGatewayRemote(gateways: []))
+
+        let order = makeOrder(paymentMethodID: "cod")
+
+        // When
+        let result = try await sut.providePointOfSaleRefunds(for: order)
+
+        // Then
+        #expect(result.supportsAutomaticRefund == false)
+    }
+
+    @Test func providePointOfSaleRefunds_when_gateway_not_found_and_payment_method_is_not_cod_then_supportsAutomaticRefund_is_true() async throws {
+        // Given
+        let remote = MockPOSRefundsRemote()
+        let sut = POSRefundsService(siteID: 123, refundsRemote: remote, paymentGatewayRemote: makeMockPOSPaymentGatewayRemote(gateways: []))
+
+        let order = makeOrder(paymentMethodID: "woocommerce_payments")
+
+        // When
+        let result = try await sut.providePointOfSaleRefunds(for: order)
+
+        // Then
+        #expect(result.supportsAutomaticRefund == true)
+    }
+
     // MARK: - createRefund Tests
 
     @Test func createRefund_then_calls_calculator_with_correct_parameters() async throws {
@@ -94,7 +172,7 @@ struct POSRefundsServiceTests {
         let remote = MockPOSRefundsRemote()
         let calculator = MockPOSRefundCalculator()
         let siteID: Int64 = 123
-        let sut = POSRefundsService(siteID: siteID, refundsRemote: remote, refundCalculator: calculator)
+        let sut = POSRefundsService(siteID: siteID, refundsRemote: remote, paymentGatewayRemote: makeMockPOSPaymentGatewayRemote(), refundCalculator: calculator)
 
         let orderID: Int64 = 456
         let items = [
@@ -104,7 +182,7 @@ struct POSRefundsServiceTests {
         let reason = "Customer request"
 
         // When
-        try await sut.createRefund(orderID: orderID, items: items, reason: reason, paymentMethodID: "woocommerce_payments")
+        try await sut.createRefund(orderID: orderID, items: items, reason: reason, automaticRefund: true)
 
         // Then
         #expect(calculator.spyOrderID == orderID)
@@ -117,13 +195,13 @@ struct POSRefundsServiceTests {
         let remote = MockPOSRefundsRemote()
         let calculator = MockPOSRefundCalculator()
         let siteID: Int64 = 123
-        let sut = POSRefundsService(siteID: siteID, refundsRemote: remote, refundCalculator: calculator)
+        let sut = POSRefundsService(siteID: siteID, refundsRemote: remote, paymentGatewayRemote: makeMockPOSPaymentGatewayRemote(), refundCalculator: calculator)
 
         let orderID: Int64 = 456
         let items = [POSRefundableItem(itemID: 1, price: Decimal(10), totalTax: Decimal(1), originalQuantity: 1)]
 
         // When
-        try await sut.createRefund(orderID: orderID, items: items, reason: nil, paymentMethodID: "woocommerce_payments")
+        try await sut.createRefund(orderID: orderID, items: items, reason: nil, automaticRefund: true)
 
         // Then
         #expect(remote.spyCreateRefundSiteID == siteID)
@@ -140,35 +218,35 @@ struct POSRefundsServiceTests {
             reason: "Test reason",
             items: []
         )
-        let sut = POSRefundsService(siteID: 123, refundsRemote: remote, refundCalculator: calculator)
+        let sut = POSRefundsService(siteID: 123, refundsRemote: remote, paymentGatewayRemote: makeMockPOSPaymentGatewayRemote(), refundCalculator: calculator)
 
         // When
-        try await sut.createRefund(orderID: 456, items: [], reason: "Test reason", paymentMethodID: "woocommerce_payments")
+        try await sut.createRefund(orderID: 456, items: [], reason: "Test reason", automaticRefund: true)
 
         // Then
         #expect(remote.spyCreateRefund?.amount == "132.60")
         #expect(remote.spyCreateRefund?.reason == "Test reason")
     }
 
-    @Test func createRefund_when_card_payment_then_sets_create_automated_to_true() async throws {
+    @Test func createRefund_when_automatic_refund_enabled_then_sets_create_automated_to_true() async throws {
         // Given
         let remote = MockPOSRefundsRemote()
-        let sut = POSRefundsService(siteID: 123, refundsRemote: remote)
+        let sut = POSRefundsService(siteID: 123, refundsRemote: remote, paymentGatewayRemote: MockPOSPaymentGatewayRemote())
 
         // When
-        try await sut.createRefund(orderID: 456, items: [], reason: nil, paymentMethodID: "woocommerce_payments")
+        try await sut.createRefund(orderID: 456, items: [], reason: nil, automaticRefund: true)
 
         // Then
         #expect(remote.spyCreateRefund?.createAutomated == true)
     }
 
-    @Test func createRefund_when_cash_payment_then_sets_create_automated_to_false() async throws {
+    @Test func createRefund_when_automatic_refund_disabled_then_sets_create_automated_to_false() async throws {
         // Given
         let remote = MockPOSRefundsRemote()
-        let sut = POSRefundsService(siteID: 123, refundsRemote: remote)
+        let sut = POSRefundsService(siteID: 123, refundsRemote: remote, paymentGatewayRemote: MockPOSPaymentGatewayRemote())
 
         // When
-        try await sut.createRefund(orderID: 456, items: [], reason: nil, paymentMethodID: "cod")
+        try await sut.createRefund(orderID: 456, items: [], reason: nil, automaticRefund: false)
 
         // Then
         #expect(remote.spyCreateRefund?.createAutomated == false)
@@ -179,18 +257,18 @@ struct POSRefundsServiceTests {
         let remote = MockPOSRefundsRemote()
         struct TestError: Error {}
         remote.createRefundResult = .failure(TestError())
-        let sut = POSRefundsService(siteID: 123, refundsRemote: remote)
+        let sut = POSRefundsService(siteID: 123, refundsRemote: remote, paymentGatewayRemote: makeMockPOSPaymentGatewayRemote())
 
         // Then
         do {
-            try await sut.createRefund(orderID: 456, items: [], reason: nil, paymentMethodID: "woocommerce_payments")
+            try await sut.createRefund(orderID: 456, items: [], reason: nil, automaticRefund: true)
             Issue.record("Expected error to be thrown")
         } catch {
             #expect(error is TestError)
         }
     }
 
-    private func makeOrder(id: Int64 = 1, refunds: [POSOrderRefund] = []) -> POSOrder {
+    private func makeOrder(id: Int64 = 1, paymentMethodID: String = "woocommerce_payments", refunds: [POSOrderRefund] = []) -> POSOrder {
         POSOrder(
             id: id,
             number: "1001",
@@ -199,7 +277,7 @@ struct POSRefundsServiceTests {
             formattedTotal: "$10.00",
             formattedSubtotal: "$10.00",
             customerEmail: "test1@example.com",
-            paymentMethodID: "woocommerce_payments",
+            paymentMethodID: paymentMethodID,
             paymentMethodTitle: "Credit Card",
             lineItems: [],
             refunds: refunds,
@@ -273,5 +351,19 @@ public struct MockRefunds {
                      total: "",
                      totalTax: "",
                      taxes: [ShippingLineTax(taxID: 0, subtotal: "", total: "")])
+    }
+}
+
+// MARK: - MockPOSPaymentGatewayRemote
+
+final class MockPOSPaymentGatewayRemote: POSPaymentGatewayRemoteProtocol {
+    var gatewaysToReturn: [PaymentGateway] = []
+
+    init(gatewaysToReturn: [PaymentGateway] = []) {
+        self.gatewaysToReturn = gatewaysToReturn
+    }
+
+    func loadAllPaymentGateways(siteID: Int64, completion: @escaping (Result<[PaymentGateway], Error>) -> Void) {
+        completion(.success(gatewaysToReturn))
     }
 }

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSRefundsServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSRefundsServiceTests.swift
@@ -104,7 +104,7 @@ struct POSRefundsServiceTests {
         let reason = "Customer request"
 
         // When
-        try await sut.createRefund(orderID: orderID, items: items, reason: reason)
+        try await sut.createRefund(orderID: orderID, items: items, reason: reason, paymentMethodID: "woocommerce_payments")
 
         // Then
         #expect(calculator.spyOrderID == orderID)
@@ -123,7 +123,7 @@ struct POSRefundsServiceTests {
         let items = [POSRefundableItem(itemID: 1, price: Decimal(10), totalTax: Decimal(1), originalQuantity: 1)]
 
         // When
-        try await sut.createRefund(orderID: orderID, items: items, reason: nil)
+        try await sut.createRefund(orderID: orderID, items: items, reason: nil, paymentMethodID: "woocommerce_payments")
 
         // Then
         #expect(remote.spyCreateRefundSiteID == siteID)
@@ -143,23 +143,35 @@ struct POSRefundsServiceTests {
         let sut = POSRefundsService(siteID: 123, refundsRemote: remote, refundCalculator: calculator)
 
         // When
-        try await sut.createRefund(orderID: 456, items: [], reason: "Test reason")
+        try await sut.createRefund(orderID: 456, items: [], reason: "Test reason", paymentMethodID: "woocommerce_payments")
 
         // Then
         #expect(remote.spyCreateRefund?.amount == "132.60")
         #expect(remote.spyCreateRefund?.reason == "Test reason")
     }
 
-    @Test func createRefund_then_sets_create_automated_to_true() async throws {
+    @Test func createRefund_when_card_payment_then_sets_create_automated_to_true() async throws {
         // Given
         let remote = MockPOSRefundsRemote()
         let sut = POSRefundsService(siteID: 123, refundsRemote: remote)
 
         // When
-        try await sut.createRefund(orderID: 456, items: [], reason: nil)
+        try await sut.createRefund(orderID: 456, items: [], reason: nil, paymentMethodID: "woocommerce_payments")
 
         // Then
         #expect(remote.spyCreateRefund?.createAutomated == true)
+    }
+
+    @Test func createRefund_when_cash_payment_then_sets_create_automated_to_false() async throws {
+        // Given
+        let remote = MockPOSRefundsRemote()
+        let sut = POSRefundsService(siteID: 123, refundsRemote: remote)
+
+        // When
+        try await sut.createRefund(orderID: 456, items: [], reason: nil, paymentMethodID: "cod")
+
+        // Then
+        #expect(remote.spyCreateRefund?.createAutomated == false)
     }
 
     @Test func createRefund_when_remote_fails_then_propagates_error() async throws {
@@ -171,7 +183,7 @@ struct POSRefundsServiceTests {
 
         // Then
         do {
-            try await sut.createRefund(orderID: 456, items: [], reason: nil)
+            try await sut.createRefund(orderID: 456, items: [], reason: nil, paymentMethodID: "woocommerce_payments")
             Issue.record("Expected error to be thrown")
         } catch {
             #expect(error is TestError)
@@ -187,6 +199,7 @@ struct POSRefundsServiceTests {
             formattedTotal: "$10.00",
             formattedSubtotal: "$10.00",
             customerEmail: "test1@example.com",
+            paymentMethodID: "woocommerce_payments",
             paymentMethodTitle: "Credit Card",
             lineItems: [],
             refunds: refunds,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Summary

  - Add support for cash payment refunds by determining automatic refund capability from payment gateway features
  - Refunds for payment methods that don't support automatic refunds (like Cash on Delivery) now correctly set api_refund: false

###  Problem

  Cash payment refunds were failing with "The payment gateway for this order does not support automatic refunds" because we were always setting api_refund: true (automatic refund).

 ###  Solution

  When loading refunds for an order, we now also fetch payment gateways to determine if the order's payment method supports automatic refunds. This information is stored in POSRefundsResult.supportsAutomaticRefund and used when creating the refund.

  Logic for determining automatic refund support:
  - If gateway is found with .refunds feature → supportsAutomaticRefund: true
  - If gateway is found without .refunds feature → supportsAutomaticRefund: false
  - Fallback (gateway not found): false for "cod" payment method, true otherwise

 ### Changes

  - Created `POSPaymentGatewayRemoteProtocol` for testability
  - Updated `POSRefundsResult` to include `supportsAutomaticRefund`
  - Updated `POSRefundsService` to fetch payment gateways (in parallel with refunds) and determine automatic refund support
  - Updated `POSRefundsServiceProtocol.createRefund` signature to use `automaticRefund: Bool`
  - Updated `POSOrderListController.processRefund `to pass `supportsAutomaticRefund` from the loaded refunds state
  - Added tests for the new automatic refund determination logic


## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

  - Create an order with card payment, process a refund → should use automatic refund
  - Create an order with cash payment, process a refund → should use manual refund (no "payment gateway does not support automatic refunds" error)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/7ec1534c-9c2d-4079-98f2-addeda442e37


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
