### PR TITLE
Implement "Unlock push notifications" introduction modal

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -326,35 +326,11 @@ private extension DashboardView {
     }
 
     var connectWPComCard: some View {
-        HStack {
-            Image(uiImage: .connectWPComImage)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(height: Layout.wpcomIconHeight * scale)
-            VStack(alignment: .leading) {
-                Text(Localization.ConnectWPComCard.title)
-                    .font(.body)
-                    .fontWeight(.semibold)
-                Text(Localization.ConnectWPComCard.subtitle)
-                    .font(.callout)
+        ConnectWPComCard(
+            hideAction: {
+                viewModel.hideWPComConnectionSuggestion()
             }
-            VStack {
-                Menu {
-                    Button(Localization.ConnectWPComCard.hideButton) {
-                        viewModel.hideWPComConnectionSuggestion()
-                    }
-                } label: {
-                    Image(systemName: "ellipsis")
-                        .foregroundStyle(Color.secondary)
-                        .padding(.leading, Layout.padding)
-                }
-                Spacer()
-            }
-        }
-        .padding(Layout.padding)
-        .background(Color(.listForeground(modal: false)))
-        .clipShape(RoundedRectangle(cornerSize: Layout.cornerSize))
-        .padding(.horizontal, Layout.padding)
+        )
     }
 
     var newCardsNoticeCard: some View {
@@ -454,8 +430,6 @@ private extension DashboardView {
         static let dotBadgePadding = EdgeInsets(top: 6, leading: 0, bottom: 0, trailing: 2)
         static let dotBadgeSize: CGFloat = 6
         static let dotBadgeOffset = CGSize(width: 7, height: -7)
-        static let wpcomIconHeight: CGFloat = 35
-
     }
     enum Localization {
         static let title = NSLocalizedString(
@@ -519,23 +493,6 @@ private extension DashboardView {
             )
         }
 
-        enum ConnectWPComCard {
-            static let title = NSLocalizedString(
-                "dashboardView.connectWPComCard.title",
-                value: "Never miss a new order",
-                comment: "Title of the Connect WPCom card on My Store screen"
-            )
-            static let subtitle = NSLocalizedString(
-                "dashboardView.connectWPComCard.subtitle",
-                value: "Connect your store to a WordPress.com account to get alerts for new orders and reviews.",
-                comment: "Subtitle of the Connect WPCom card on My Store screen"
-            )
-            static let hideButton = NSLocalizedString(
-                "dashboardView.connectWPComCard.hideButton",
-                value: "Hide this content",
-                comment: "Button to hide the Connect WPCom card from the My Store screen"
-            )
-        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/DebugPanelView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/DebugPanelView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct DebugPanelView: View {
+    var body: some View {
+        List {
+            Button {
+                UserDefaults.standard[.hasSavedPrivacyBannerSettings] = false
+            } label: {
+                Text("Reset Privacy Choice Banner State")
+            }
+
+            Button {
+                ServiceLocator.crashLogging.crash()
+            } label: {
+                Text("Crash Immediately")
+            }
+
+            NavigationLink(destination: OverrideFeatureFlagsView()) {
+                Text("Override Feature Flags")
+            }
+        }
+        .contentMargins(20)
+        .navigationTitle("Debug Panel")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/DebugPanelView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/DebugPanelView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct DebugPanelView: View {
+    @State private var showUnlockPushNotificationsModal: Bool = false
+
     var body: some View {
         List {
             Button {
@@ -18,8 +20,36 @@ struct DebugPanelView: View {
             NavigationLink(destination: OverrideFeatureFlagsView()) {
                 Text("Override Feature Flags")
             }
+
+            DebugSheetPresenter("Force show \"Unlock push notifications WP.com modal\"") {
+                WPComPushNotificationsBenefitsView()
+            }
         }
         .contentMargins(20)
         .navigationTitle("Debug Panel")
+    }
+}
+
+fileprivate struct DebugSheetPresenter<Content: View>: View {
+    private let content: () -> Content
+    private let label: String
+    @State private var isPresented = false
+
+    init(_ label: String,
+        @ViewBuilder content: @escaping () -> Content,
+    ) {
+        self.label = label
+        self.content = content
+    }
+
+    var body: some View {
+        Button {
+            isPresented = true
+        } label: {
+            Text(label)
+        }
+        .sheet(isPresented: $isPresented) {
+            content()
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/DebugPanelView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/DebugPanelView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct DebugPanelView: View {
-    @State private var showUnlockPushNotificationsModal: Bool = false
 
     var body: some View {
         List {
@@ -21,8 +20,9 @@ struct DebugPanelView: View {
                 Text("Override Feature Flags")
             }
 
-            DebugSheetPresenter("Force show \"Unlock push notifications WP.com modal\"") {
-                WPComPushNotificationsBenefitsView()
+            DebugSheetPresenter("Force show \"Unlock push notifications WP.com modal\"") { dismiss in
+                let viewModel = WPComPushNotificationsBenefitsViewModel(onDismiss: dismiss)
+                WPComPushNotificationsBenefitsView(viewModel: viewModel)
             }
         }
         .contentMargins(20)
@@ -31,12 +31,12 @@ struct DebugPanelView: View {
 }
 
 fileprivate struct DebugSheetPresenter<Content: View>: View {
-    private let content: () -> Content
+    private let content: (@escaping () -> Void) -> Content
     private let label: String
     @State private var isPresented = false
 
     init(_ label: String,
-        @ViewBuilder content: @escaping () -> Content,
+        @ViewBuilder content: @escaping (@escaping () -> Void) -> Content
     ) {
         self.label = label
         self.content = content
@@ -49,7 +49,7 @@ fileprivate struct DebugSheetPresenter<Content: View>: View {
             Text(label)
         }
         .sheet(isPresented: $isPresented) {
-            content()
+            content { isPresented = false }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/OverrideFeatureFlagsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/OverrideFeatureFlagsView.swift
@@ -27,7 +27,7 @@ struct OverrideFeatureFlagsView: View {
         }
         .contentMargins(20)
         .id(refreshID)
-        .searchable(text: $searchText, prompt: "Search feature flags")
+        .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search feature flags")
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -530,43 +530,8 @@ private extension SettingsViewController {
     }
 
     @objc func didInvokeHiddenSettings(_ sender: UITapGestureRecognizer? = nil) {
-        let hiddenSettingsMenu = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        hiddenSettingsMenu.addAction(resetPrivacyChoicesAction)
-        hiddenSettingsMenu.addAction(featureOverrideAction)
-        hiddenSettingsMenu.addAction(crashDebugMenuCrashAction)
-        hiddenSettingsMenu.addAction(crashDebugMenuCancelAction)
-
-        if let popoverController = hiddenSettingsMenu.popoverPresentationController {
-            popoverController.sourceView = sender?.view
-            popoverController.sourceRect = sender?.view?.bounds ?? .zero
-        }
-
-        present(hiddenSettingsMenu, animated: true, completion: nil)
-    }
-
-    var resetPrivacyChoicesAction: UIAlertAction {
-        return UIAlertAction(title: Localization.HiddenSettingsMenu.resetPrivacyChoices, style: .default) { _ in
-            UserDefaults.standard[.hasSavedPrivacyBannerSettings] = false
-        }
-    }
-
-    var crashDebugMenuCrashAction: UIAlertAction {
-        return UIAlertAction(title: Localization.HiddenSettingsMenu.crashImmediately, style: .destructive) { _ in
-            ServiceLocator.crashLogging.crash()
-        }
-    }
-
-    var featureOverrideAction: UIAlertAction {
-        return UIAlertAction(title: "Override Feature Flags", style: .default) { [weak self] _ in
-            guard let self else { return }
-
-            let hostingController = UIHostingController(rootView: OverrideFeatureFlagsView())
-            self.navigationController?.pushViewController(hostingController, animated: true)
-        }
-    }
-
-    var crashDebugMenuCancelAction: UIAlertAction {
-        return UIAlertAction(title: Localization.HiddenSettingsMenu.cancel, style: .cancel, handler: nil)
+        let hostingController = UIHostingController(rootView: DebugPanelView())
+        self.navigationController?.pushViewController(hostingController, animated: true)
     }
 }
 
@@ -930,23 +895,6 @@ private extension SettingsViewController {
             "Made with love by Automattic. <a href=\"https://automattic.com/work-with-us/\">We’re hiring!</a>",
             comment: "It reads 'Made with love by Automattic. We’re hiring!'. Place \'We’re hiring!' between `<a>` and `</a>`"
         )
-
-        enum HiddenSettingsMenu {
-            static let resetPrivacyChoices = NSLocalizedString(
-                "Reset Privacy Choice Banner State",
-                comment: "The title for a menu to reset the privacy choice banner presentation"
-            )
-
-            static let crashImmediately = NSLocalizedString(
-                "Crash Immediately",
-                comment: "The title for a button that causes the app to deliberately crash for debugging purposes"
-            )
-
-            static let cancel = NSLocalizedString(
-                "Cancel",
-                comment: "The title for a button that dismisses the crash debug menu"
-            )
-        }
 
         enum LogoutAlert {
             static let alertMessage = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/ConnectWPComCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/ConnectWPComCard.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+/// A card prompting users to connect their store to WordPress.com for push notifications.
+struct ConnectWPComCard: View {
+
+    /// Closure invoked when the hide button is tapped
+    var hideAction: () -> Void
+
+    @ScaledMetric private var scale: CGFloat = 1.0
+    @State private var showingWPComPushNotificationsBenefits = false
+
+    var body: some View {
+        HStack {
+            Image(uiImage: .connectWPComImage)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(height: Layout.iconHeight * scale)
+            VStack(alignment: .leading) {
+                Text(Localization.title)
+                    .font(.body)
+                    .fontWeight(.semibold)
+                Text(Localization.subtitle)
+                    .font(.callout)
+            }
+            VStack {
+                Menu {
+                    Button(Localization.hideButton) {
+                        hideAction()
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .foregroundStyle(Color.secondary)
+                        .padding(.leading, Layout.padding)
+                }
+                Spacer()
+            }
+        }
+        .padding(Layout.padding)
+        .background(Color(.listForeground(modal: false)))
+        .clipShape(RoundedRectangle(cornerSize: Layout.cornerSize))
+        .padding(.horizontal, Layout.padding)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            showingWPComPushNotificationsBenefits = true
+        }
+        .sheet(isPresented: $showingWPComPushNotificationsBenefits) {
+            WPComPushNotificationsBenefitsView(
+                viewModel: WPComPushNotificationsBenefitsViewModel(
+                    onDismiss: { showingWPComPushNotificationsBenefits = false }
+                )
+            )
+        }
+    }
+}
+
+private extension ConnectWPComCard {
+    enum Layout {
+        static let padding: CGFloat = 16
+        static let iconHeight: CGFloat = 35
+        static let cornerSize = CGSize(width: 8.0, height: 8.0)
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString(
+            "dashboardView.connectWPComCard.title",
+            value: "Never miss a new order",
+            comment: "Title of the Connect WPCom card on My Store screen"
+        )
+        static let subtitle = NSLocalizedString(
+            "dashboardView.connectWPComCard.subtitle",
+            value: "Connect your store to a WordPress.com account to get alerts for new orders and reviews.",
+            comment: "Subtitle of the Connect WPCom card on My Store screen"
+        )
+        static let hideButton = NSLocalizedString(
+            "dashboardView.connectWPComCard.hideButton",
+            value: "Hide this content",
+            comment: "Button to hide the Connect WPCom card from the My Store screen"
+        )
+    }
+}
+
+#Preview {
+    ConnectWPComCard(hideAction: {})
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -1,7 +1,9 @@
 import SwiftUI
+import WooFoundation
 
 struct WPComPushNotificationsBenefitsView: View {
     private let viewModel: WPComPushNotificationsBenefitsViewModel
+    @State private var safariURL: URL?
 
     init(viewModel: WPComPushNotificationsBenefitsViewModel) {
         self.viewModel = viewModel
@@ -32,6 +34,12 @@ struct WPComPushNotificationsBenefitsView: View {
         .onAppear {
             viewModel.onAppear()
         }
+        .environment(\.openURL, OpenURLAction { [viewModel] url in
+            viewModel.whatIsWPComTapped()
+            safariURL = url
+            return .handled
+        })
+        .safariSheet(url: $safariURL)
     }
 
     private var stackedImages: some View {
@@ -53,11 +61,9 @@ struct WPComPushNotificationsBenefitsView: View {
                 .font(.body)
             Text(Localization.subdescription)
                 .font(.body)
-            Button(Localization.whatIsWPCom) {
-                viewModel.whatIsWPComTapped()
-            }
-            .font(.body)
-            .foregroundColor(Color(UIColor.accent))
+            Link(Localization.whatIsWPCom, destination: WooConstants.URLs.whatIsWPCom.asURL())
+                .font(.body)
+                .foregroundColor(Color(UIColor.accent))
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -1,18 +1,37 @@
 import SwiftUI
 
 struct WPComPushNotificationsBenefitsView: View {
+    private let viewModel: WPComPushNotificationsBenefitsViewModel
+
+    init(viewModel: WPComPushNotificationsBenefitsViewModel) {
+        self.viewModel = viewModel
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: Layout.contentSpacing) {
-            Spacer()
+        NavigationStack {
             VStack(alignment: .leading, spacing: Layout.contentSpacing) {
-                stackedImages
-                title
-                detail
+                Spacer()
+                VStack(alignment: .leading, spacing: Layout.contentSpacing) {
+                    stackedImages
+                    title
+                    detail
+                }
+                Spacer()
+                footer
             }
-            Spacer()
-            footer
+            .padding([.leading, .bottom, .trailing], Layout.contentPadding)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.cancelButton) {
+                        viewModel.notNowTapped()
+                    }
+                }
+            }
+            .toolbarBackground(.hidden, for: .navigationBar)
         }
-        .padding([.leading, .bottom, .trailing], Layout.contentPadding)
+        .onAppear {
+            viewModel.onAppear()
+        }
     }
 
     private var stackedImages: some View {
@@ -34,21 +53,23 @@ struct WPComPushNotificationsBenefitsView: View {
                 .font(.body)
             Text(Localization.subdescription)
                 .font(.body)
-            Link(Localization.whatIsWPCom, destination: WooConstants.URLs.whatIsWPCom.asURL())
-                .font(.body)
-                .foregroundColor(Color(UIColor.accent))
+            Button(Localization.whatIsWPCom) {
+                viewModel.whatIsWPComTapped()
+            }
+            .font(.body)
+            .foregroundColor(Color(UIColor.accent))
         }
     }
 
     private var footer: some View {
         VStack {
             Button(Localization.continueButton) {
-
+                viewModel.continueTapped()
             }
             .buttonStyle(PrimaryButtonStyle())
 
             Button(Localization.notNowButton) {
-
+                viewModel.notNowTapped()
             }
             .buttonStyle(SecondaryButtonStyle())
         }
@@ -96,9 +117,19 @@ fileprivate extension WPComPushNotificationsBenefitsView {
             value: "Not now",
             comment: "Not now button title in the WordPress.com Push Notifications Benefits View"
         )
+
+        static let cancelButton = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsView.cancelButton",
+            value: "Cancel",
+            comment: "Cancel button title in the WordPress.com Push Notifications Benefits View toolbar"
+        )
     }
 }
 
 #Preview {
-    WPComPushNotificationsBenefitsView()
+    WPComPushNotificationsBenefitsView(
+        viewModel: WPComPushNotificationsBenefitsViewModel(
+            onDismiss: {}
+        )
+    )
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import UIKit
 import protocol WooFoundation.Analytics
 
 final class WPComPushNotificationsBenefitsViewModel {
@@ -24,6 +23,5 @@ final class WPComPushNotificationsBenefitsViewModel {
 
     func whatIsWPComTapped() {
         // TODO: Track link tapped event
-        UIApplication.shared.open(WooConstants.URLs.whatIsWPCom.asURL())
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -1,0 +1,37 @@
+import Foundation
+import UIKit
+import protocol WooFoundation.Analytics
+
+final class WPComPushNotificationsBenefitsViewModel {
+    // MARK: - Callbacks
+    private let onDismiss: () -> Void
+
+    // MARK: - Dependencies
+    private let analytics: Analytics
+
+    // MARK: - Init
+    init(onDismiss: @escaping () -> Void,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.onDismiss = onDismiss
+        self.analytics = analytics
+    }
+
+    // MARK: - Actions
+    func onAppear() {
+        // TODO: Track modal shown event
+    }
+
+    func continueTapped() {
+        // TODO: Track continue tapped event
+    }
+
+    func notNowTapped() {
+        // TODO: Track not now tapped event
+        onDismiss()
+    }
+
+    func whatIsWPComTapped() {
+        // TODO: Track link tapped event
+        UIApplication.shared.open(WooConstants.URLs.whatIsWPCom.asURL())
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -3,20 +3,12 @@ import UIKit
 import protocol WooFoundation.Analytics
 
 final class WPComPushNotificationsBenefitsViewModel {
-    // MARK: - Callbacks
     private let onDismiss: () -> Void
 
-    // MARK: - Dependencies
-    private let analytics: Analytics
-
-    // MARK: - Init
-    init(onDismiss: @escaping () -> Void,
-         analytics: Analytics = ServiceLocator.analytics) {
+    init(onDismiss: @escaping () -> Void) {
         self.onDismiss = onDismiss
-        self.analytics = analytics
     }
 
-    // MARK: - Actions
     func onAppear() {
         // TODO: Track modal shown event
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefitsView.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+
+struct WPComPushNotificationsBenefitsView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            Spacer()
+            VStack(alignment: .leading, spacing: 24) {
+                stackedImages
+                title
+                detail
+            }
+            Spacer()
+            footer
+        }
+        .padding([.leading, .bottom, .trailing], 16)
+    }
+
+    private var stackedImages: some View {
+        Text(Localization.stackedImagesPlaceholder)
+    }
+
+    private var title: some View {
+        Text(Localization.title)
+            .font(.largeTitle)
+            .fontWeight(.bold)
+    }
+
+    private var detail: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            Text(Localization.description)
+                .font(.body)
+            Text(Localization.subdescription)
+                .font(.body)
+            Link(Localization.whatIsWPCom, destination: URL(string: "http://wordpress.com")!)
+                .font(.body)
+                .foregroundColor(Color(UIColor.accent))
+        }
+    }
+
+    private var footer: some View {
+        VStack {
+            Button(Localization.continueButton) {
+
+            }
+            .buttonStyle(PrimaryButtonStyle())
+
+            Button(Localization.notNowButton) {
+
+            }
+            .buttonStyle(SecondaryButtonStyle())
+        }
+    }
+}
+
+fileprivate extension WPComPushNotificationsBenefitsView {
+    enum Localization {
+        static let title = NSLocalizedString("wpcomPushNotificationsBenefitsView.title",
+                                             value: "Unlock push notifications with WordPress.com",
+                                             comment: "Title of the WordPress.com Push Notifications Benefits View")
+
+        static let stackedImagesPlaceholder = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsView.stackedImagesPlaceholder",
+            value: "stackedImages",
+            comment: "Placeholder text for stacked images in the WordPress.com Push Notifications Benefits View"
+        )
+
+        static let description = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsView.description",
+            value: "Connect your store to a WordPress.com account to get access to push notifications for new orders, reviews and more.",
+            comment: "Main description text of the WordPress.com Push Notifications Benefits View"
+        )
+
+        static let subdescription = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsView.subdescription",
+            value: "It only takes a minute.",
+            comment: "Secondary description text of the WordPress.com Push Notifications Benefits View"
+        )
+
+        static let whatIsWPCom = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsView.whatIsWPCom",
+            value: "What is WordPress.com?",
+            comment: "Link text explaining what WordPress.com is in the Push Notifications Benefits View"
+        )
+
+        static let continueButton = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsView.continueButton",
+            value: "Continue",
+            comment: "Continue button title in the WordPress.com Push Notifications Benefits View"
+        )
+
+        static let notNowButton = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsView.notNowButton",
+            value: "Not now",
+            comment: "Not now button title in the WordPress.com Push Notifications Benefits View"
+        )
+    }
+}
+
+#Preview {
+    WPComPushNotificationsBenefitsView()
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefitsView.swift
@@ -2,9 +2,9 @@ import SwiftUI
 
 struct WPComPushNotificationsBenefitsView: View {
     var body: some View {
-        VStack(alignment: .leading, spacing: 24) {
+        VStack(alignment: .leading, spacing: Layout.contentSpacing) {
             Spacer()
-            VStack(alignment: .leading, spacing: 24) {
+            VStack(alignment: .leading, spacing: Layout.contentSpacing) {
                 stackedImages
                 title
                 detail
@@ -12,11 +12,14 @@ struct WPComPushNotificationsBenefitsView: View {
             Spacer()
             footer
         }
-        .padding([.leading, .bottom, .trailing], 16)
+        .padding([.leading, .bottom, .trailing], Layout.contentPadding)
     }
 
     private var stackedImages: some View {
-        Text(Localization.stackedImagesPlaceholder)
+        Image(uiImage: .connectWPComImage)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(height: Layout.logoHeight)
     }
 
     private var title: some View {
@@ -26,12 +29,12 @@ struct WPComPushNotificationsBenefitsView: View {
     }
 
     private var detail: some View {
-        VStack(alignment: .leading, spacing: 24) {
+        VStack(alignment: .leading, spacing: Layout.contentSpacing) {
             Text(Localization.description)
                 .font(.body)
             Text(Localization.subdescription)
                 .font(.body)
-            Link(Localization.whatIsWPCom, destination: URL(string: "http://wordpress.com")!)
+            Link(Localization.whatIsWPCom, destination: WooConstants.URLs.whatIsWPCom.asURL())
                 .font(.body)
                 .foregroundColor(Color(UIColor.accent))
         }
@@ -53,16 +56,16 @@ struct WPComPushNotificationsBenefitsView: View {
 }
 
 fileprivate extension WPComPushNotificationsBenefitsView {
+    enum Layout {
+        static let logoHeight: CGFloat = 64
+        static let contentSpacing: CGFloat = 24
+        static let contentPadding: CGFloat = 16
+    }
+
     enum Localization {
         static let title = NSLocalizedString("wpcomPushNotificationsBenefitsView.title",
                                              value: "Unlock push notifications with WordPress.com",
                                              comment: "Title of the WordPress.com Push Notifications Benefits View")
-
-        static let stackedImagesPlaceholder = NSLocalizedString(
-            "wpcomPushNotificationsBenefitsView.stackedImagesPlaceholder",
-            value: "stackedImages",
-            comment: "Placeholder text for stacked images in the WordPress.com Push Notifications Benefits View"
-        )
 
         static let description = NSLocalizedString(
             "wpcomPushNotificationsBenefitsView.description",

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1356,6 +1356,8 @@
 		643492C42F1A45B30080AEC1 /* OverrideFeatureFlagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 643492C32F1A45A80080AEC1 /* OverrideFeatureFlagsView.swift */; };
 		644EA1542F20CC5C00511C2A /* DebugPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 644EA1532F20CC4F00511C2A /* DebugPanelView.swift */; };
 		644EA9382F20DF7900511C2A /* WPComPushNotificationsBenefitsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 644EA9372F20DF7900511C2A /* WPComPushNotificationsBenefitsView.swift */; };
+		6460A3672F279B03005D3A3E /* WPComPushNotificationsBenefitsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6460A3662F279B03005D3A3E /* WPComPushNotificationsBenefitsViewModel.swift */; };
+		6460A36B2F27A132005D3A3E /* ConnectWPComCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6460A36A2F27A132005D3A3E /* ConnectWPComCard.swift */; };
 		646FEDB82EE827DF00352BFF /* ApplicationLogProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 646FEDB72EE827DF00352BFF /* ApplicationLogProvider.swift */; };
 		647C05FB2ED5D9E800E5FF3F /* NotesContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647C05FA2ED5D9E200E5FF3F /* NotesContent.swift */; };
 		647C05FD2ED5E1C000E5FF3F /* BookingNotesRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647C05FC2ED5E1C000E5FF3F /* BookingNotesRowView.swift */; };
@@ -4275,6 +4277,8 @@
 		643492C32F1A45A80080AEC1 /* OverrideFeatureFlagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverrideFeatureFlagsView.swift; sourceTree = "<group>"; };
 		644EA1532F20CC4F00511C2A /* DebugPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugPanelView.swift; sourceTree = "<group>"; };
 		644EA9372F20DF7900511C2A /* WPComPushNotificationsBenefitsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPushNotificationsBenefitsView.swift; sourceTree = "<group>"; };
+		6460A3662F279B03005D3A3E /* WPComPushNotificationsBenefitsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPushNotificationsBenefitsViewModel.swift; sourceTree = "<group>"; };
+		6460A36A2F27A132005D3A3E /* ConnectWPComCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectWPComCard.swift; sourceTree = "<group>"; };
 		646FEDB72EE827DF00352BFF /* ApplicationLogProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogProvider.swift; sourceTree = "<group>"; };
 		647C05FA2ED5D9E200E5FF3F /* NotesContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesContent.swift; sourceTree = "<group>"; };
 		647C05FC2ED5E1C000E5FF3F /* BookingNotesRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingNotesRowView.swift; sourceTree = "<group>"; };
@@ -8932,6 +8936,16 @@
 			path = TitleAndEditableValueTableViewCell;
 			sourceTree = "<group>";
 		};
+		6460A3692F279B1A005D3A3E /* WPComPushNotificationsBenefits */ = {
+			isa = PBXGroup;
+			children = (
+				6460A36A2F27A132005D3A3E /* ConnectWPComCard.swift */,
+				644EA9372F20DF7900511C2A /* WPComPushNotificationsBenefitsView.swift */,
+				6460A3662F279B03005D3A3E /* WPComPushNotificationsBenefitsViewModel.swift */,
+			);
+			path = WPComPushNotificationsBenefits;
+			sourceTree = "<group>";
+		};
 		682210EB2909664800814E14 /* Customer */ = {
 			isa = PBXGroup;
 			children = (
@@ -11477,7 +11491,6 @@
 		CE85FD5120F677460080B73E /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
-				644EA9372F20DF7900511C2A /* WPComPushNotificationsBenefitsView.swift */,
 				DEB387A12C3647300025256E /* GoogleAds */,
 				EE8B420A2BF9A1E40077C4E7 /* Orders */,
 				DE20045E2BF7090700660A72 /* ProductStock */,
@@ -11501,6 +11514,7 @@
 				DE74A4502BCF86F60009C415 /* TopPerformers */,
 				DEA6BCAD2BC6A9A50017D671 /* StoreStats */,
 				DEC75CC02BC4E4E600763801 /* DashboardCustomization */,
+				6460A3692F279B1A005D3A3E /* WPComPushNotificationsBenefits */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -14539,6 +14553,7 @@
 				20D5CB532AFCF8E7009A39C3 /* PaymentsToggleRow.swift in Sources */,
 				CE22E3F72170E23C005A6BEF /* PrivacySettingsViewController.swift in Sources */,
 				021125482577CC650075AD2A /* ShippingLabelDetailsViewModel.swift in Sources */,
+				6460A3672F279B03005D3A3E /* WPComPushNotificationsBenefitsViewModel.swift in Sources */,
 				68D1BEDD2900E4180074A29E /* CustomerSearchUICommand.swift in Sources */,
 				316837DA25CCA90C00E36B2F /* OrderStatusListDataSource.swift in Sources */,
 				FE28F6F4268477C1004465C7 /* RoleEligibilityUseCase.swift in Sources */,
@@ -14724,6 +14739,7 @@
 				45912FE32526642200982948 /* ProductFormViewController+Helpers.swift in Sources */,
 				B55D4C0620B6027200D7A50F /* AuthenticationManager.swift in Sources */,
 				451A04F02386F7B500E368C9 /* ProductImageCollectionViewCell.swift in Sources */,
+				6460A36B2F27A132005D3A3E /* ConnectWPComCard.swift in Sources */,
 				AEACCB6D2785FF4A000D01F0 /* NavigationRow.swift in Sources */,
 				DE50294928BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift in Sources */,
 				CE4FE7DA2B7E2E9400F66DD5 /* AnalyticsHubCustomizeViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1354,6 +1354,7 @@
 		57F42E40253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F42E3F253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift */; };
 		640DA3482E97DE4F00317FB2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640DA3472E97DE4F00317FB2 /* SceneDelegate.swift */; };
 		643492C42F1A45B30080AEC1 /* OverrideFeatureFlagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 643492C32F1A45A80080AEC1 /* OverrideFeatureFlagsView.swift */; };
+		644EA1542F20CC5C00511C2A /* DebugPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 644EA1532F20CC4F00511C2A /* DebugPanelView.swift */; };
 		646FEDB82EE827DF00352BFF /* ApplicationLogProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 646FEDB72EE827DF00352BFF /* ApplicationLogProvider.swift */; };
 		647C05FB2ED5D9E800E5FF3F /* NotesContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647C05FA2ED5D9E200E5FF3F /* NotesContent.swift */; };
 		647C05FD2ED5E1C000E5FF3F /* BookingNotesRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647C05FC2ED5E1C000E5FF3F /* BookingNotesRowView.swift */; };
@@ -4271,6 +4272,7 @@
 		57F42E3F253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndEditableValueTableViewCellViewModelTests.swift; sourceTree = "<group>"; };
 		640DA3472E97DE4F00317FB2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		643492C32F1A45A80080AEC1 /* OverrideFeatureFlagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverrideFeatureFlagsView.swift; sourceTree = "<group>"; };
+		644EA1532F20CC4F00511C2A /* DebugPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugPanelView.swift; sourceTree = "<group>"; };
 		646FEDB72EE827DF00352BFF /* ApplicationLogProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogProvider.swift; sourceTree = "<group>"; };
 		647C05FA2ED5D9E200E5FF3F /* NotesContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesContent.swift; sourceTree = "<group>"; };
 		647C05FC2ED5E1C000E5FF3F /* BookingNotesRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingNotesRowView.swift; sourceTree = "<group>"; };
@@ -10540,6 +10542,7 @@
 		BAF1B3B32736595A00BA11DC /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				644EA1532F20CC4F00511C2A /* DebugPanelView.swift */,
 				643492C32F1A45A80080AEC1 /* OverrideFeatureFlagsView.swift */,
 				027D4A8B2526FD1700108626 /* SettingsViewController.swift */,
 				BAE4F8422734325C00871344 /* SettingsViewModel.swift */,
@@ -15721,6 +15724,7 @@
 				0250192B2BDF3757009493A5 /* PriceFieldFormatter.swift in Sources */,
 				0279F0DF252DC12D0098D7DE /* ProductLoaderViewControllerModel+Init.swift in Sources */,
 				2D05D1A22E82D235004111FD /* HeaderContent.swift in Sources */,
+				644EA1542F20CC5C00511C2A /* DebugPanelView.swift in Sources */,
 				26B9875D273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift in Sources */,
 				CE6302482BAB60AE00E3325C /* CustomerDetailViewModel.swift in Sources */,
 				DEF36DEA2898D3CF00178AC2 /* AuthenticatedWebViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1355,6 +1355,7 @@
 		640DA3482E97DE4F00317FB2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640DA3472E97DE4F00317FB2 /* SceneDelegate.swift */; };
 		643492C42F1A45B30080AEC1 /* OverrideFeatureFlagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 643492C32F1A45A80080AEC1 /* OverrideFeatureFlagsView.swift */; };
 		644EA1542F20CC5C00511C2A /* DebugPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 644EA1532F20CC4F00511C2A /* DebugPanelView.swift */; };
+		644EA9382F20DF7900511C2A /* WPComPushNotificationsBenefitsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 644EA9372F20DF7900511C2A /* WPComPushNotificationsBenefitsView.swift */; };
 		646FEDB82EE827DF00352BFF /* ApplicationLogProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 646FEDB72EE827DF00352BFF /* ApplicationLogProvider.swift */; };
 		647C05FB2ED5D9E800E5FF3F /* NotesContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647C05FA2ED5D9E200E5FF3F /* NotesContent.swift */; };
 		647C05FD2ED5E1C000E5FF3F /* BookingNotesRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647C05FC2ED5E1C000E5FF3F /* BookingNotesRowView.swift */; };
@@ -4273,6 +4274,7 @@
 		640DA3472E97DE4F00317FB2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		643492C32F1A45A80080AEC1 /* OverrideFeatureFlagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverrideFeatureFlagsView.swift; sourceTree = "<group>"; };
 		644EA1532F20CC4F00511C2A /* DebugPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugPanelView.swift; sourceTree = "<group>"; };
+		644EA9372F20DF7900511C2A /* WPComPushNotificationsBenefitsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPushNotificationsBenefitsView.swift; sourceTree = "<group>"; };
 		646FEDB72EE827DF00352BFF /* ApplicationLogProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogProvider.swift; sourceTree = "<group>"; };
 		647C05FA2ED5D9E200E5FF3F /* NotesContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesContent.swift; sourceTree = "<group>"; };
 		647C05FC2ED5E1C000E5FF3F /* BookingNotesRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingNotesRowView.swift; sourceTree = "<group>"; };
@@ -11475,6 +11477,7 @@
 		CE85FD5120F677460080B73E /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
+				644EA9372F20DF7900511C2A /* WPComPushNotificationsBenefitsView.swift */,
 				DEB387A12C3647300025256E /* GoogleAds */,
 				EE8B420A2BF9A1E40077C4E7 /* Orders */,
 				DE20045E2BF7090700660A72 /* ProductStock */,
@@ -14308,6 +14311,7 @@
 				B541B220218A007C008FE7C1 /* NSMutableParagraphStyle+Helpers.swift in Sources */,
 				45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */,
 				6832C7CA26DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift in Sources */,
+				644EA9382F20DF7900511C2A /* WPComPushNotificationsBenefitsView.swift in Sources */,
 				26838354296F460B00CCF60A /* GenerateVariationsOptionPresenter.swift in Sources */,
 				DED91DFA2AD78A3A00CDCC53 /* BlazeCampaignItemView.swift in Sources */,
 				31FC8CE727B47591004B9456 /* CardReaderSettingsDataSource.swift in Sources */,


### PR DESCRIPTION
Closes [WOOMOB-1924](https://linear.app/a8c/issue/WOOMOB-1924)

## Description
- Added [DebugPanelView](https://github.com/woocommerce/woocommerce-ios/pull/16558/changes#diff-ba17ec2c7390d44dfb16c2bae45d8de3f4a2ed07266b89faff159a891b23e037) as a new helper view instead of the old alert to access debug-related actions. Update [SettingsViewController](https://github.com/woocommerce/woocommerce-ios/pull/16558/changes#diff-21f0d52621503c18fb1f5bd82bbffb89704784df76183b461d4170a22cab819e) according.
- Update [OverrideFeatureFlagView](https://github.com/woocommerce/woocommerce-ios/pull/16558/changes#diff-e424fe506d712c7ac8c89b2b84b3cb8e1298682f02d921f5a5008b90a364ea94) to always display the search bar cc @itsmeichigo 
- Extracted [ConnectWPComCard](https://github.com/woocommerce/woocommerce-ios/pull/16558/changes#diff-0403e90089f07c19ba93312cf3bca4318c6c6152db926fc9e853b5de312d6cb6) from DashboardView to it's own component and update to handle the tap action to open the new modal.
- Added [WPComPushNotificationsBenefitsView](https://github.com/woocommerce/woocommerce-ios/pull/16558/changes#diff-5c3d0ff52c962f173222e81e1a868eb1b91413654088bfef932b4576e64f7a83) and the corresponding [ViewModel](https://github.com/woocommerce/woocommerce-ios/pull/16558/changes#diff-75d0c8a6af03916feffb9095dcfe702bea1869eda6aec61cbd9454f06279c588)

## Test Steps
1. Enable the feature flag selfDrivenPushTokenAppPasswords and build the app to a physical device.
1. Log in to a site without support of new PN with site credentials.
1. Confirm that the new dashboard card is displayed
2. Tap the card to open the modal
3. Close with cancel/not now
4. Open the card again
5. Tap the "What is Wordpress.com?"
6. Validate that webbrowser opens

## Screenshots
![ScreenRecording_01-26-2026 14-58-41_1](https://github.com/user-attachments/assets/a39c5238-1d19-4d09-a5bf-8d1534a1f9f8)

![ScreenRecording_01-26-2026 15-01-23_1](https://github.com/user-attachments/assets/fa3e8d47-facc-457c-bbb3-d9dc51e59575)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
