### PR TITLE
POS: Enable email receipt for refunded orders

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -432,25 +432,28 @@ private extension POSOrderDetailsView {
     }
 
     var availableActionsSetup: OrderDetailsActionsSetup {
-        guard order.status == .completed else {
-            return .init(primary: nil, secondary: [])
-        }
-
         let email: OrderDetailsAction = .emailReceipt
 
-        guard featureFlags.isFeatureFlagEnabled(.pointOfSaleRefundsi1) else {
+        switch order.status {
+        case .refunded:
             return .init(primary: email, secondary: [])
-        }
+        case .completed:
+            guard featureFlags.isFeatureFlagEnabled(.pointOfSaleRefundsi1) else {
+                return .init(primary: email, secondary: [])
+            }
 
-        switch orderListModel.ordersController.refundActionAvailability {
-        case .available:
-            return .init(primary: .issueRefund, secondary: [email])
+            switch orderListModel.ordersController.refundActionAvailability {
+            case .available:
+                return .init(primary: .issueRefund, secondary: [email])
 
-        case .unavailable:
-            return .init(primary: email, secondary: [])
+            case .unavailable:
+                return .init(primary: email, secondary: [])
 
-        case .unknown:
-            return .init(primary: nil, secondary: [email])
+            case .unknown:
+                return .init(primary: nil, secondary: [email])
+            }
+        default:
+            return .init(primary: nil, secondary: [])
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing "See original issue" – clarify what the problem was and how you've fixed it. -->

WOOMOB-2044

Previously, the email receipt action in the POS order details screen was only available for orders with `completed` status. This change extends that functionality to also include `refunded` status, allowing merchants to send receipts for orders that have been refunded.

The email will temporarily use the completed order template to enable the functionality. Completed template still shows refunded items. 

The use of a specific refunded template looks to require some backend changes. More context: https://linear.app/a8c/issue/WOOMOB-2044/woo-posrefunds-enable-sending-receipts-for-refunded-orders#comment-20fdf6b0. This matches Android behavior.

## Test Steps
<!-- Describe how to test your changes. Include only what's needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Open the POS (Point of Sale) mode
2. Navigate to an order with "Refunded" status (You can make an order on POS, and refund in Order Management side of the app)
3. Verify the "Email receipt" button is visible and functional
4. Compare with a "Completed" order to verify email receipt works there too
5. Check that "Issue refund" option is NOT shown for refunded orders

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/b87506a7-6894-47fa-a6f4-2867b57886b1

<img width="598" height="752" alt="image" src="https://github.com/user-attachments/assets/03209d75-a4ea-42d7-890f-c684c08379ac" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.