### PR TITLE
Push notifications: Add new coordinator to support setup

### DIFF
--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginView.swift
@@ -22,7 +22,9 @@ final class WPComEmailLoginHostingController: UIHostingController<WPComEmailLogi
         super.viewDidLoad()
         configureTransparentNavigationBar()
         navigationController?.presentationController?.delegate = self
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: Localization.cancel, style: .plain, target: self, action: #selector(dismissView))
+        if navigationController?.viewControllers.first == self {
+            navigationItem.leftBarButtonItem = UIBarButtonItem(title: Localization.cancel, style: .plain, target: self, action: #selector(dismissView))
+        }
     }
 
     @objc

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComLoginCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComLoginCoordinator.swift
@@ -11,11 +11,12 @@ enum WPComLoginFlow {
 
 /// Coordinates navigation for the login flow with WPCom accounts.
 final class WPComLoginCoordinator {
+    let navigationController: UINavigationController
+
     /// Title to display on top of the login views
     private let title: String
 
     private let flow: WPComLoginFlow
-    private let navigationController: UINavigationController
     private let stores: StoresManager
     private let accountService: WordPressComAccountServiceProtocol
     private let completionHandler: (Credentials) -> Void

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComLoginCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComLoginCoordinator.swift
@@ -18,7 +18,7 @@ final class WPComLoginCoordinator {
     private let navigationController: UINavigationController
     private let stores: StoresManager
     private let accountService: WordPressComAccountServiceProtocol
-    private let completionHandler: () -> Void
+    private let completionHandler: (Credentials) -> Void
 
     private lazy var emailLoginViewModel: WPComEmailLoginViewModel = {
         .init(siteURL: stores.sessionManager.defaultSite?.url ?? "",
@@ -38,7 +38,7 @@ final class WPComLoginCoordinator {
          navigationController: UINavigationController,
          stores: StoresManager = ServiceLocator.stores,
          accountService: WordPressComAccountServiceProtocol = WordPressComAccountService(),
-         completionHandler: @escaping () -> Void) {
+         completionHandler: @escaping (Credentials) -> Void) {
         self.title = title
         self.flow = flow
         self.navigationController = navigationController
@@ -100,7 +100,7 @@ private extension WPComLoginCoordinator {
                 self.showAlert(message: message)
             },
             onLoginSuccess: { [weak self] authToken in
-                await self?.authenticateUserAndComplete(username: email, authToken: authToken)
+                self?.completeLogin(username: email, authToken: authToken)
             })
         let viewController = WPComPasswordLoginHostingController(
             title: title,
@@ -122,8 +122,7 @@ private extension WPComLoginCoordinator {
                 self.showAlert(message: error.errorMessage)
             },
             onLoginSuccess: { [weak self] authToken in
-                await self?.authenticateUserAndComplete(username: loginFields.username,
-                                                        authToken: authToken)
+                self?.completeLogin(username: loginFields.username, authToken: authToken)
             })
         let viewController = WPCom2FALoginHostingController(title: title,
                                                             flow: flow,
@@ -174,17 +173,9 @@ private extension WPComLoginCoordinator {
         }
     }
 
-    @MainActor
-    func authenticateUserAndComplete(username: String, authToken: String) async {
-        await withCheckedContinuation { continuation in
-            let credentials = Credentials(username: username, authToken: authToken)
-            stores.authenticate(credentials: credentials)
-                .synchronizeEntities(onCompletion: { [weak self] in
-                    guard let self else { return }
-                    self.completionHandler()
-                    continuation.resume()
-                })
-        }
+    func completeLogin(username: String, authToken: String) {
+        let credentials = Credentials(username: username, authToken: authToken)
+        completionHandler(credentials)
     }
 }
 

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -19,7 +19,7 @@ final class WooPushNotificationSetupCoordinator: Coordinator {
                 flow: .notificationSetup,
                 navigationController: navigationController,
                 completionHandler: {
-                // TODO
+                DDLogDebug("📱 Authentication complete, proceed with Jetpack connection")
             })
         }()
     }

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -2,15 +2,15 @@ import UIKit
 import Yosemite
 
 /// Coordinator for the setup of self-driven push notifications for ineligible sites
-final class WooPushNotificationSetupCoordinator: Coordinator {
+final class WooPushNotificationSetupCoordinator {
     // Controller to handle navigation between the auth flow and setup steps.
-    let navigationController: UINavigationController
+    let rootViewController: UIViewController
 
     private var loginCoordinator: WPComLoginCoordinator?
 
-    init(navigationController: UINavigationController,
+    init(rootViewController: UIViewController,
          stores: StoresManager = ServiceLocator.stores) {
-        self.navigationController = navigationController
+        self.rootViewController = rootViewController
         self.loginCoordinator = {
             if stores.sessionManager.defaultSite?.isJetpackConnected == true {
                 return nil // no need to connect WPCom
@@ -18,7 +18,7 @@ final class WooPushNotificationSetupCoordinator: Coordinator {
             return WPComLoginCoordinator(
                 title: Localization.flowTitle,
                 flow: .notificationSetup,
-                navigationController: navigationController,
+                navigationController: UINavigationController(),
                 completionHandler: { credentials in
                     // TODO: use credentials for Jetpack setup flow.
                     // Consider reusing JetpackSetupViewModel
@@ -34,7 +34,10 @@ final class WooPushNotificationSetupCoordinator: Coordinator {
             DDLogDebug("📱 Site is connected to Jetpack, now checking plugin version...")
             return
         }
-        loginCoordinator.startWithoutEmail()
+        rootViewController.dismiss(animated: true) {
+            self.rootViewController.present(loginCoordinator.navigationController, animated: true)
+            loginCoordinator.startWithoutEmail()
+        }
     }
 }
 

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -18,8 +18,8 @@ final class WooPushNotificationSetupCoordinator: Coordinator {
                 title: Localization.flowTitle,
                 flow: .notificationSetup,
                 navigationController: navigationController,
-                completionHandler: {
-                DDLogDebug("📱 Authentication complete, proceed with Jetpack connection")
+                completionHandler: { credentials in
+                    DDLogDebug("📱 Authentication complete, proceed with Jetpack connection")
             })
         }()
     }

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -3,6 +3,7 @@ import Yosemite
 
 /// Coordinator for the setup of self-driven push notifications for ineligible sites
 final class WooPushNotificationSetupCoordinator: Coordinator {
+    // Controller to handle navigation between the auth flow and setup steps.
     let navigationController: UINavigationController
 
     private var loginCoordinator: WPComLoginCoordinator?
@@ -19,6 +20,9 @@ final class WooPushNotificationSetupCoordinator: Coordinator {
                 flow: .notificationSetup,
                 navigationController: navigationController,
                 completionHandler: { credentials in
+                    // TODO: use credentials for Jetpack setup flow.
+                    // Consider reusing JetpackSetupViewModel
+                    // Also check JetpackSetupHostingController for more details on what the credentials are for.
                     DDLogDebug("📱 Authentication complete, proceed with Jetpack connection")
             })
         }()

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -1,0 +1,42 @@
+import UIKit
+import Yosemite
+
+/// Coordinator for the setup of self-driven push notifications for ineligible sites
+final class WooPushNotificationSetupCoordinator: Coordinator {
+    let navigationController: UINavigationController
+    var loginCoordinator: WPComLoginCoordinator?
+
+    init(navigationController: UINavigationController,
+         stores: StoresManager = ServiceLocator.stores) {
+        self.navigationController = navigationController
+        self.loginCoordinator = {
+            if let site = stores.sessionManager.defaultSite,
+               site.isJetpackConnected {
+                return nil // no need to connect WPCom
+            }
+            return WPComLoginCoordinator(
+                title: Localization.flowTitle,
+                flow: .notificationSetup,
+                navigationController: navigationController,
+                completionHandler: {
+                // TODO
+            })
+        }()
+    }
+
+    func start() {
+        if let loginCoordinator {
+            loginCoordinator.startWithoutEmail()
+        }
+    }
+}
+
+private extension WooPushNotificationSetupCoordinator {
+    enum Localization {
+        static let flowTitle = NSLocalizedString(
+            "wooPushNotificationSetupCoordinator.flowTitle",
+            value: "Connect to WordPress.com",
+            comment: "Title of the self-driven push notification setup flow"
+        )
+    }
+}

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -4,14 +4,14 @@ import Yosemite
 /// Coordinator for the setup of self-driven push notifications for ineligible sites
 final class WooPushNotificationSetupCoordinator: Coordinator {
     let navigationController: UINavigationController
-    var loginCoordinator: WPComLoginCoordinator?
+
+    private var loginCoordinator: WPComLoginCoordinator?
 
     init(navigationController: UINavigationController,
          stores: StoresManager = ServiceLocator.stores) {
         self.navigationController = navigationController
         self.loginCoordinator = {
-            if let site = stores.sessionManager.defaultSite,
-               site.isJetpackConnected {
+            if stores.sessionManager.defaultSite?.isJetpackConnected == true {
                 return nil // no need to connect WPCom
             }
             return WPComLoginCoordinator(
@@ -25,9 +25,12 @@ final class WooPushNotificationSetupCoordinator: Coordinator {
     }
 
     func start() {
-        if let loginCoordinator {
-            loginCoordinator.startWithoutEmail()
+        guard let loginCoordinator else {
+            // TODO: start plugin check
+            DDLogDebug("📱 Site is connected to Jetpack, now checking plugin version...")
+            return
         }
+        loginCoordinator.startWithoutEmail()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -68,6 +68,9 @@ struct DashboardView: View {
     /// Set externally in the hosting controller.
     var onShowAllGoogleAdsCampaigns: (() -> Void)?
 
+    /// Set externally in the hosting controller.
+    var onConnectWPComSetup: (() -> Void)?
+
     private let storePlanSynchronizer = ServiceLocator.storePlanSynchronizer
     private let connectivityObserver = ServiceLocator.connectivityObserver
 
@@ -327,6 +330,9 @@ private extension DashboardView {
 
     var connectWPComCard: some View {
         ConnectWPComCard(
+            setupAction: {
+                onConnectWPComSetup?()
+            },
             hideAction: {
                 viewModel.hideWPComConnectionSuggestion()
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -372,13 +372,16 @@ private extension DashboardViewHostingController {
         rootView.onConnectWPComSetup = { [weak self] in
             guard let self, let navigationController else { return }
             let viewModel = WPComPushNotificationsBenefitsViewModel()
-            let hostingController = WPComPushNotificationsBenefitsHostingController(viewModel: viewModel, onDismiss: {
-                navigationController.dismiss(animated: true)
-            })
-            navigationController.present(
-                UINavigationController(rootViewController: hostingController),
-                animated: true
+            let rootController = UINavigationController()
+            let hostingController = WPComPushNotificationsBenefitsHostingController(
+                viewModel: viewModel,
+                rootController: rootController,
+                onDismiss: {
+                    navigationController.dismiss(animated: true)
+                }
             )
+            rootController.setViewControllers([hostingController], animated: false)
+            navigationController.present(rootController, animated: true)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -370,18 +370,15 @@ private extension DashboardViewHostingController {
 private extension DashboardViewHostingController {
     func configureConnectWPComCard() {
         rootView.onConnectWPComSetup = { [weak self] in
-            guard let self, let navigationController else { return }
-            let viewModel = WPComPushNotificationsBenefitsViewModel()
-            let rootController = UINavigationController()
+            guard let self else { return }
+            let viewModel = WPComPushNotificationsBenefitsViewModel(onDismiss: {
+                self.dismiss(animated: true)
+            })
             let hostingController = WPComPushNotificationsBenefitsHostingController(
                 viewModel: viewModel,
-                rootController: rootController,
-                onDismiss: {
-                    navigationController.dismiss(animated: true)
-                }
+                rootViewController: self,
             )
-            rootController.setViewControllers([hostingController], animated: false)
-            navigationController.present(rootController, animated: true)
+            present(hostingController, animated: true)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -13,6 +13,7 @@ final class DashboardViewHostingController: UIHostingController<DashboardView> {
     private var blazeCampaignCreationCoordinator: BlazeCampaignCreationCoordinator?
     private var googleAdsCampaignCoordinator: GoogleAdsCampaignCoordinator?
     private var jetpackSetupCoordinator: JetpackSetupCoordinator?
+    private var pushNotificationSetupCoordinator: WooPushNotificationSetupCoordinator?
     private var modalJustInTimeMessageHostingController: ConstraintsUpdatingHostingController<JustInTimeMessageModal_UIKit>?
     private var isAppActive = true
 
@@ -54,6 +55,7 @@ final class DashboardViewHostingController: UIHostingController<DashboardView> {
         configureLastOrdersView()
         configureReviewsCard()
         configureGoogleAdsCard()
+        configureConnectWPComCard()
     }
 
     @available(*, unavailable)
@@ -362,6 +364,18 @@ private extension DashboardViewHostingController {
             type: forCampaignCreation ? .campaignCreation : .dashboard,
             hasCampaigns: hasCampaigns
         ))
+    }
+}
+
+// MARK: Connect WPCom card
+private extension DashboardViewHostingController {
+    func configureConnectWPComCard() {
+        rootView.onConnectWPComSetup = { [weak self] in
+            guard let self, let navigationController else { return }
+            let coordinator = WooPushNotificationSetupCoordinator(navigationController: navigationController)
+            pushNotificationSetupCoordinator = coordinator
+            coordinator.start()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -13,7 +13,6 @@ final class DashboardViewHostingController: UIHostingController<DashboardView> {
     private var blazeCampaignCreationCoordinator: BlazeCampaignCreationCoordinator?
     private var googleAdsCampaignCoordinator: GoogleAdsCampaignCoordinator?
     private var jetpackSetupCoordinator: JetpackSetupCoordinator?
-    private var pushNotificationSetupCoordinator: WooPushNotificationSetupCoordinator?
     private var modalJustInTimeMessageHostingController: ConstraintsUpdatingHostingController<JustInTimeMessageModal_UIKit>?
     private var isAppActive = true
 
@@ -372,9 +371,14 @@ private extension DashboardViewHostingController {
     func configureConnectWPComCard() {
         rootView.onConnectWPComSetup = { [weak self] in
             guard let self, let navigationController else { return }
-            let coordinator = WooPushNotificationSetupCoordinator(navigationController: navigationController)
-            pushNotificationSetupCoordinator = coordinator
-            coordinator.start()
+            let viewModel = WPComPushNotificationsBenefitsViewModel()
+            let hostingController = WPComPushNotificationsBenefitsHostingController(viewModel: viewModel, onDismiss: {
+                navigationController.dismiss(animated: true)
+            })
+            navigationController.present(
+                UINavigationController(rootViewController: hostingController),
+                animated: true
+            )
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/DebugPanelView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/DebugPanelView.swift
@@ -19,11 +19,6 @@ struct DebugPanelView: View {
             NavigationLink(destination: OverrideFeatureFlagsView()) {
                 Text("Override Feature Flags")
             }
-
-            DebugSheetPresenter("Force show \"Unlock push notifications WP.com modal\"") { dismiss in
-                let viewModel = WPComPushNotificationsBenefitsViewModel(onDismiss: dismiss)
-                WPComPushNotificationsBenefitsView(viewModel: viewModel)
-            }
         }
         .contentMargins(20)
         .navigationTitle("Debug Panel")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -433,13 +433,16 @@ private extension SettingsViewController {
     func enablePushNotificationsWasPressed() {
         DDLogInfo("🔔 Settings: Enable Push Notifications tapped")
         let viewModel = WPComPushNotificationsBenefitsViewModel()
+        let rootController = UINavigationController()
         let controller = WPComPushNotificationsBenefitsHostingController(
             viewModel: viewModel,
+            rootController: rootController,
             onDismiss: { [weak self] in
                 self?.dismiss(animated: true)
             }
         )
-        present(UINavigationController(rootViewController: controller), animated: true)
+        rootController.setViewControllers([controller], animated: false)
+        present(rootController, animated: true)
     }
 
     func showThemeSettings() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -432,10 +432,13 @@ private extension SettingsViewController {
 
     func enablePushNotificationsWasPressed() {
         DDLogInfo("🔔 Settings: Enable Push Notifications tapped")
-        let viewModel = WPComPushNotificationsBenefitsViewModel(onDismiss: { [weak self] in
-            self?.dismiss(animated: true)
-        })
-        let controller = UIHostingController(rootView: WPComPushNotificationsBenefitsView(viewModel: viewModel))
+        let viewModel = WPComPushNotificationsBenefitsViewModel()
+        let controller = WPComPushNotificationsBenefitsHostingController(
+            viewModel: viewModel,
+            onDismiss: { [weak self] in
+                self?.dismiss(animated: true)
+            }
+        )
         present(controller, animated: true)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -439,7 +439,7 @@ private extension SettingsViewController {
                 self?.dismiss(animated: true)
             }
         )
-        present(controller, animated: true)
+        present(UINavigationController(rootViewController: controller), animated: true)
     }
 
     func showThemeSettings() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -432,17 +432,14 @@ private extension SettingsViewController {
 
     func enablePushNotificationsWasPressed() {
         DDLogInfo("🔔 Settings: Enable Push Notifications tapped")
-        let viewModel = WPComPushNotificationsBenefitsViewModel()
-        let rootController = UINavigationController()
+        let viewModel = WPComPushNotificationsBenefitsViewModel(onDismiss: { [weak self] in
+            self?.dismiss(animated: true)
+        })
         let controller = WPComPushNotificationsBenefitsHostingController(
             viewModel: viewModel,
-            rootController: rootController,
-            onDismiss: { [weak self] in
-                self?.dismiss(animated: true)
-            }
+            rootViewController: self,
         )
-        rootController.setViewControllers([controller], animated: false)
-        present(rootController, animated: true)
+        present(controller, animated: true)
     }
 
     func showThemeSettings() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/ConnectWPComCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/ConnectWPComCard.swift
@@ -3,11 +3,13 @@ import SwiftUI
 /// A card prompting users to connect their store to WordPress.com for push notifications.
 struct ConnectWPComCard: View {
 
+    /// Closure invoked when the card is tapped
+    var setupAction: () -> Void
+
     /// Closure invoked when the hide button is tapped
     var hideAction: () -> Void
 
     @ScaledMetric private var scale: CGFloat = 1.0
-    @State private var showingWPComPushNotificationsBenefits = false
 
     var body: some View {
         HStack {
@@ -41,14 +43,7 @@ struct ConnectWPComCard: View {
         .padding(.horizontal, Layout.padding)
         .contentShape(Rectangle())
         .onTapGesture {
-            showingWPComPushNotificationsBenefits = true
-        }
-        .sheet(isPresented: $showingWPComPushNotificationsBenefits) {
-            WPComPushNotificationsBenefitsView(
-                viewModel: WPComPushNotificationsBenefitsViewModel(
-                    onDismiss: { showingWPComPushNotificationsBenefits = false }
-                )
-            )
+            setupAction()
         }
     }
 }
@@ -80,5 +75,5 @@ private extension ConnectWPComCard {
 }
 
 #Preview {
-    ConnectWPComCard(hideAction: {})
+    ConnectWPComCard(setupAction: {}, hideAction: {})
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -5,21 +5,12 @@ import WooFoundation
 /// Hosting controller wrapper for `WPComPushNotificationsBenefitsView`
 ///
 final class WPComPushNotificationsBenefitsHostingController: UIHostingController<WPComPushNotificationsBenefitsView> {
-    private let pushNotificationSetupCoordinator: WooPushNotificationSetupCoordinator
 
     init(viewModel: WPComPushNotificationsBenefitsViewModel,
-         rootController: UINavigationController,
-         onDismiss: @escaping () -> Void) {
-        self.pushNotificationSetupCoordinator = WooPushNotificationSetupCoordinator(
-            navigationController: rootController
-        )
-        super.init(rootView: WPComPushNotificationsBenefitsView(
-            viewModel: viewModel,
-            onDismiss: onDismiss
-        ))
-        rootView.onSetup = { [weak self] in
-            self?.pushNotificationSetupCoordinator.start()
-        }
+         rootViewController: UIViewController) {
+        super.init(rootView: WPComPushNotificationsBenefitsView(viewModel: viewModel))
+        let coordinator = WooPushNotificationSetupCoordinator(rootViewController: rootViewController)
+        viewModel.updateCoordinator(coordinator)
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -28,40 +19,36 @@ final class WPComPushNotificationsBenefitsHostingController: UIHostingController
 }
 
 struct WPComPushNotificationsBenefitsView: View {
-    var onSetup: () -> Void = {} // to be set through hosting controller
-
     private let viewModel: WPComPushNotificationsBenefitsViewModel
-    private let onDismiss: () -> Void
 
     @State private var safariURL: URL?
 
-    init(viewModel: WPComPushNotificationsBenefitsViewModel,
-         onDismiss: @escaping () -> Void) {
+    init(viewModel: WPComPushNotificationsBenefitsViewModel) {
         self.viewModel = viewModel
-        self.onDismiss = onDismiss
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Layout.contentSpacing) {
-            Spacer()
+        NavigationStack {
             VStack(alignment: .leading, spacing: Layout.contentSpacing) {
-                stackedImages
-                title
-                detail
+                Spacer()
+                VStack(alignment: .leading, spacing: Layout.contentSpacing) {
+                    stackedImages
+                    title
+                    detail
+                }
+                Spacer()
+                footer
             }
-            Spacer()
-            footer
-        }
-        .padding([.leading, .bottom, .trailing], Layout.contentPadding)
-        .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-                Button(Localization.cancelButton) {
-                    viewModel.notNowTapped()
-                    onDismiss()
+            .padding([.leading, .bottom, .trailing], Layout.contentPadding)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.cancelButton) {
+                        viewModel.notNowTapped()
+                    }
                 }
             }
+            .toolbarBackground(.hidden, for: .navigationBar)
         }
-        .toolbarBackground(.hidden, for: .navigationBar)
         .onAppear {
             viewModel.onAppear()
         }
@@ -102,13 +89,11 @@ struct WPComPushNotificationsBenefitsView: View {
         VStack {
             Button(Localization.continueButton) {
                 viewModel.continueTapped()
-                onSetup()
             }
             .buttonStyle(PrimaryButtonStyle())
 
             Button(Localization.notNowButton) {
                 viewModel.notNowTapped()
-                onDismiss()
             }
             .buttonStyle(SecondaryButtonStyle())
         }
@@ -167,7 +152,6 @@ fileprivate extension WPComPushNotificationsBenefitsView {
 
 #Preview {
     WPComPushNotificationsBenefitsView(
-        viewModel: WPComPushNotificationsBenefitsViewModel(),
-        onDismiss: {}
+        viewModel: WPComPushNotificationsBenefitsViewModel(onDismiss: {})
     )
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -23,7 +23,10 @@ final class WPComPushNotificationsBenefitsHostingController: UIHostingController
     }
 
     private func startPushNotificationSetup() {
-        guard let navigationController else { return }
+        guard let navigationController else {
+            DDLogWarn("⚠️ WooPushNotificationSetupCoordinator cannot start due to an issue with navigation")
+            return
+        }
         let coordinator = WooPushNotificationSetupCoordinator(
             navigationController: navigationController
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -1,54 +1,72 @@
 import SwiftUI
+import UIKit
 import WooFoundation
 
 /// Hosting controller wrapper for `WPComPushNotificationsBenefitsView`
 ///
 final class WPComPushNotificationsBenefitsHostingController: UIHostingController<WPComPushNotificationsBenefitsView> {
+    private var pushNotificationSetupCoordinator: WooPushNotificationSetupCoordinator?
+
     init(viewModel: WPComPushNotificationsBenefitsViewModel,
-         onContinue: @escaping () -> Void) {
+         onDismiss: @escaping () -> Void) {
         super.init(rootView: WPComPushNotificationsBenefitsView(
-            viewModel: viewModel))
-        rootView.onContinue = {
-            // TODO: wire up coordinator
+            viewModel: viewModel,
+            onDismiss: onDismiss
+        ))
+        rootView.onSetup = { [weak self] in
+            self?.startPushNotificationSetup()
         }
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    private func startPushNotificationSetup() {
+        guard let navigationController else { return }
+        let coordinator = WooPushNotificationSetupCoordinator(
+            navigationController: navigationController
+        )
+        pushNotificationSetupCoordinator = coordinator
+        coordinator.start()
+    }
 }
 
 struct WPComPushNotificationsBenefitsView: View {
+    var onSetup: () -> Void = {} // to be set through hosting controller
+
     private let viewModel: WPComPushNotificationsBenefitsViewModel
-    var onContinue: () -> Void = {} // to be set through hosting controller
+    private let onDismiss: () -> Void
+
     @State private var safariURL: URL?
 
-    init(viewModel: WPComPushNotificationsBenefitsViewModel) {
+    init(viewModel: WPComPushNotificationsBenefitsViewModel,
+         onDismiss: @escaping () -> Void) {
         self.viewModel = viewModel
+        self.onDismiss = onDismiss
     }
 
     var body: some View {
-        NavigationStack {
+        VStack(alignment: .leading, spacing: Layout.contentSpacing) {
+            Spacer()
             VStack(alignment: .leading, spacing: Layout.contentSpacing) {
-                Spacer()
-                VStack(alignment: .leading, spacing: Layout.contentSpacing) {
-                    stackedImages
-                    title
-                    detail
-                }
-                Spacer()
-                footer
+                stackedImages
+                title
+                detail
             }
-            .padding([.leading, .bottom, .trailing], Layout.contentPadding)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(Localization.cancelButton) {
-                        viewModel.notNowTapped()
-                    }
-                }
-            }
-            .toolbarBackground(.hidden, for: .navigationBar)
+            Spacer()
+            footer
         }
+        .padding([.leading, .bottom, .trailing], Layout.contentPadding)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(Localization.cancelButton) {
+                    viewModel.notNowTapped()
+                    onDismiss()
+                }
+            }
+        }
+        .toolbarBackground(.hidden, for: .navigationBar)
         .onAppear {
             viewModel.onAppear()
         }
@@ -89,12 +107,13 @@ struct WPComPushNotificationsBenefitsView: View {
         VStack {
             Button(Localization.continueButton) {
                 viewModel.continueTapped()
-                onContinue()
+                onSetup()
             }
             .buttonStyle(PrimaryButtonStyle())
 
             Button(Localization.notNowButton) {
                 viewModel.notNowTapped()
+                onDismiss()
             }
             .buttonStyle(SecondaryButtonStyle())
         }
@@ -153,8 +172,7 @@ fileprivate extension WPComPushNotificationsBenefitsView {
 
 #Preview {
     WPComPushNotificationsBenefitsView(
-        viewModel: WPComPushNotificationsBenefitsViewModel(
-            onDismiss: {}
-        )
+        viewModel: WPComPushNotificationsBenefitsViewModel(),
+        onDismiss: {}
     )
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -1,8 +1,26 @@
 import SwiftUI
 import WooFoundation
 
+/// Hosting controller wrapper for `WPComPushNotificationsBenefitsView`
+///
+final class WPComPushNotificationsBenefitsHostingController: UIHostingController<WPComPushNotificationsBenefitsView> {
+    init(viewModel: WPComPushNotificationsBenefitsViewModel,
+         onContinue: @escaping () -> Void) {
+        super.init(rootView: WPComPushNotificationsBenefitsView(
+            viewModel: viewModel))
+        rootView.onContinue = {
+            // TODO: wire up coordinator
+        }
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 struct WPComPushNotificationsBenefitsView: View {
     private let viewModel: WPComPushNotificationsBenefitsViewModel
+    var onContinue: () -> Void = {} // to be set through hosting controller
     @State private var safariURL: URL?
 
     init(viewModel: WPComPushNotificationsBenefitsViewModel) {
@@ -71,6 +89,7 @@ struct WPComPushNotificationsBenefitsView: View {
         VStack {
             Button(Localization.continueButton) {
                 viewModel.continueTapped()
+                onContinue()
             }
             .buttonStyle(PrimaryButtonStyle())
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -5,33 +5,25 @@ import WooFoundation
 /// Hosting controller wrapper for `WPComPushNotificationsBenefitsView`
 ///
 final class WPComPushNotificationsBenefitsHostingController: UIHostingController<WPComPushNotificationsBenefitsView> {
-    private var pushNotificationSetupCoordinator: WooPushNotificationSetupCoordinator?
+    private let pushNotificationSetupCoordinator: WooPushNotificationSetupCoordinator
 
     init(viewModel: WPComPushNotificationsBenefitsViewModel,
+         rootController: UINavigationController,
          onDismiss: @escaping () -> Void) {
+        self.pushNotificationSetupCoordinator = WooPushNotificationSetupCoordinator(
+            navigationController: rootController
+        )
         super.init(rootView: WPComPushNotificationsBenefitsView(
             viewModel: viewModel,
             onDismiss: onDismiss
         ))
         rootView.onSetup = { [weak self] in
-            self?.startPushNotificationSetup()
+            self?.pushNotificationSetupCoordinator.start()
         }
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    private func startPushNotificationSetup() {
-        guard let navigationController else {
-            DDLogWarn("⚠️ WooPushNotificationSetupCoordinator cannot start due to an issue with navigation")
-            return
-        }
-        let coordinator = WooPushNotificationSetupCoordinator(
-            navigationController: navigationController
-        )
-        pushNotificationSetupCoordinator = coordinator
-        coordinator.start()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -4,9 +4,18 @@ import protocol WooFoundation.Analytics
 final class WPComPushNotificationsBenefitsViewModel {
 
     private let analytics: Analytics
+    private let onDismiss: () -> Void
 
-    init(analytics: Analytics = ServiceLocator.analytics) {
+    private var pushNotificationSetupCoordinator: WooPushNotificationSetupCoordinator?
+
+    init(analytics: Analytics = ServiceLocator.analytics,
+         onDismiss: @escaping () -> Void) {
         self.analytics = analytics
+        self.onDismiss = onDismiss
+    }
+
+    func updateCoordinator(_ coordinator: WooPushNotificationSetupCoordinator) {
+        self.pushNotificationSetupCoordinator = coordinator
     }
 
     func onAppear() {
@@ -15,10 +24,12 @@ final class WPComPushNotificationsBenefitsViewModel {
 
     func continueTapped() {
         // TODO: Track continue tapped event
+        pushNotificationSetupCoordinator?.start()
     }
 
     func notNowTapped() {
         // TODO: Track not now tapped event
+        onDismiss()
     }
 
     func whatIsWPComTapped() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -1,11 +1,12 @@
 import Foundation
 import protocol WooFoundation.Analytics
 
-final class WPComPushNotificationsBenefitsViewModel {
-    private let onDismiss: () -> Void
+final class WPComPushNotificationsBenefitsViewModel: ObservableObject {
 
-    init(onDismiss: @escaping () -> Void) {
-        self.onDismiss = onDismiss
+    private let analytics: Analytics
+
+    init(analytics: Analytics = ServiceLocator.analytics) {
+        self.analytics = analytics
     }
 
     func onAppear() {
@@ -18,7 +19,6 @@ final class WPComPushNotificationsBenefitsViewModel {
 
     func notNowTapped() {
         // TODO: Track not now tapped event
-        onDismiss()
     }
 
     func whatIsWPComTapped() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import protocol WooFoundation.Analytics
 
-final class WPComPushNotificationsBenefitsViewModel: ObservableObject {
+final class WPComPushNotificationsBenefitsViewModel {
 
     private let analytics: Analytics
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1014,9 +1014,9 @@
 		2D09E0D12E61BC7F005C26F3 /* ApplicationPasswordsExperimentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D09E0D02E61BC7D005C26F3 /* ApplicationPasswordsExperimentState.swift */; };
 		2D09E0D52E65C9B9005C26F3 /* ApplicationPasswordsExperimentStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D09E0D42E65C9B9005C26F3 /* ApplicationPasswordsExperimentStateTests.swift */; };
 		2D200F072ED7245000DD6EBF /* BookingDateTimeFilterViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D200F062ED7245000DD6EBF /* BookingDateTimeFilterViewTests.swift */; };
+		2D205B882EF2B99500E1F7A2 /* AgeRangeVerificationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D205B872EF2B99400E1F7A2 /* AgeRangeVerificationCoordinator.swift */; };
 		2D5389242F278E17006A6618 /* PushNotificationRegistrationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D5389232F278E17006A6618 /* PushNotificationRegistrationState.swift */; };
 		2D5389262F27BF59006A6618 /* PushNotificationRegistrationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D5389252F27BF59006A6618 /* PushNotificationRegistrationStateTests.swift */; };
-		2D205B882EF2B99500E1F7A2 /* AgeRangeVerificationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D205B872EF2B99400E1F7A2 /* AgeRangeVerificationCoordinator.swift */; };
 		2D7A3E232E7891DB00C46401 /* CIABEligibilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7A3E222E7891D200C46401 /* CIABEligibilityCheckerTests.swift */; };
 		2D880B492DFB2F3F00A6FB2C /* OptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D880B482DFB2F3D00A6FB2C /* OptionalBinding.swift */; };
 		2D88C1112DF883C300A6FB2C /* AttributedString+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D88C1102DF883BD00A6FB2C /* AttributedString+Helpers.swift */; };
@@ -2490,6 +2490,7 @@
 		DE7E5E932B4FECCA002E28D2 /* BlazeTargetTopicPickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E5E922B4FECCA002E28D2 /* BlazeTargetTopicPickerViewModelTests.swift */; };
 		DE7FF07C2EE809CD00B31E35 /* TechnicalDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7FF07B2EE809CD00B31E35 /* TechnicalDetailsView.swift */; };
 		DE8311C02C6C8D3800A88709 /* BlazeCampaignListItemCustomizationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8311BF2C6C8D3800A88709 /* BlazeCampaignListItemCustomizationsTests.swift */; };
+		DE83FCDA2F29B6F30038C589 /* WooPushNotificationSetupCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE83FCD92F29B6D00038C589 /* WooPushNotificationSetupCoordinator.swift */; };
 		DE85E4ED2AB416F5008789E1 /* AddProductWithAIActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE85E4EC2AB416F5008789E1 /* AddProductWithAIActionSheet.swift */; };
 		DE86E9272A4BEA2500A89A5B /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE86E9262A4BEA2500A89A5B /* FeedbackView.swift */; };
 		DE86E9292A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE86E9282A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift */; };
@@ -3933,9 +3934,9 @@
 		2D09E0D02E61BC7D005C26F3 /* ApplicationPasswordsExperimentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordsExperimentState.swift; sourceTree = "<group>"; };
 		2D09E0D42E65C9B9005C26F3 /* ApplicationPasswordsExperimentStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordsExperimentStateTests.swift; sourceTree = "<group>"; };
 		2D200F062ED7245000DD6EBF /* BookingDateTimeFilterViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingDateTimeFilterViewTests.swift; sourceTree = "<group>"; };
+		2D205B872EF2B99400E1F7A2 /* AgeRangeVerificationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgeRangeVerificationCoordinator.swift; sourceTree = "<group>"; };
 		2D5389232F278E17006A6618 /* PushNotificationRegistrationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationRegistrationState.swift; sourceTree = "<group>"; };
 		2D5389252F27BF59006A6618 /* PushNotificationRegistrationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationRegistrationStateTests.swift; sourceTree = "<group>"; };
-		2D205B872EF2B99400E1F7A2 /* AgeRangeVerificationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgeRangeVerificationCoordinator.swift; sourceTree = "<group>"; };
 		2D7A3E222E7891D200C46401 /* CIABEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIABEligibilityCheckerTests.swift; sourceTree = "<group>"; };
 		2D880B482DFB2F3D00A6FB2C /* OptionalBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalBinding.swift; sourceTree = "<group>"; };
 		2D88C1102DF883BD00A6FB2C /* AttributedString+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Helpers.swift"; sourceTree = "<group>"; };
@@ -5452,6 +5453,7 @@
 		DE7E5E922B4FECCA002E28D2 /* BlazeTargetTopicPickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeTargetTopicPickerViewModelTests.swift; sourceTree = "<group>"; };
 		DE7FF07B2EE809CD00B31E35 /* TechnicalDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TechnicalDetailsView.swift; sourceTree = "<group>"; };
 		DE8311BF2C6C8D3800A88709 /* BlazeCampaignListItemCustomizationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignListItemCustomizationsTests.swift; sourceTree = "<group>"; };
+		DE83FCD92F29B6D00038C589 /* WooPushNotificationSetupCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPushNotificationSetupCoordinator.swift; sourceTree = "<group>"; };
 		DE85E4EC2AB416F5008789E1 /* AddProductWithAIActionSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddProductWithAIActionSheet.swift; sourceTree = "<group>"; };
 		DE86E9262A4BEA2500A89A5B /* FeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
 		DE86E9282A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+AIFeedback.swift"; sourceTree = "<group>"; };
@@ -10137,6 +10139,7 @@
 		B5BBD6DC21B1701F00E3207E /* Notifications */ = {
 			isa = PBXGroup;
 			children = (
+				DE83FCD92F29B6D00038C589 /* WooPushNotificationSetupCoordinator.swift */,
 				2D5389232F278E17006A6618 /* PushNotificationRegistrationState.swift */,
 				01B744E12D2FCA1300AEB3F4 /* PushNotificationBackgroundSynchronizerFactory.swift */,
 				B555530E21B57DE700449E71 /* ApplicationAdapter.swift */,
@@ -15565,6 +15568,7 @@
 				02C1853B27FF0D9C00ABD764 /* RefundSubmissionUseCase.swift in Sources */,
 				02DFD5062B2048C50048CD70 /* ProductStepperViewModel.swift in Sources */,
 				02B334A12BEB712600A46774 /* CollapsibleCustomerCardAddressViewModel.swift in Sources */,
+				DE83FCDA2F29B6F30038C589 /* WooPushNotificationSetupCoordinator.swift in Sources */,
 				26C98F9B29C18ACE00F96503 /* StorePlanBanner.swift in Sources */,
 				E10BD16D27CF890800CE6449 /* InPersonPaymentsCountryNotSupportedStripe.swift in Sources */,
 				26F94E26267A559300DB6CCF /* ProductAddOn.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-2080

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a new coordinator for setting up WPCom connection and Woo PN for eligible sites. Changes include:
- Updates navigation to the benefit modal to use a new hosting controller.
- Create a new coordinator that trigger login flow if site is not connected to Jetpack
- Updates the hosting controller to start the coordinator upon selecting CTA on the view.

The login flow is not fully functional yet, I'll create a separate issue for fixing that. 

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Ensure that both feature flags for self-driven push notifications are enabled.
2. Build and run the app on a physical device.
3. Log in to a store without support for Woo PNs using site credentials.
4. Tap on the dashboard card for connecting WPCom (or go to Menu > Settings > Enable PN).
5. Tap Continue and confirm:
- If the store is not connected to Jetpack, the login flow is displayed.
- If the store is connected to Jetpack, you see in Xcode console log: `📱 Site is connected to Jetpack, now checking plugin version...`.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/0a3bda80-2535-4be6-b8b4-087bb290dce7



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
