### PR TITLE
[Woo POS][Catalog i2] Update networking

### DIFF
--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -471,17 +471,48 @@ public struct POSCatalogRequestResponse: Decodable {
     public let status: POSCatalogStatus
     /// Download URL when it is already available.
     public let downloadURL: String?
+    /// Timestamp when the job was scheduled.
+    public let scheduledAt: String?
+    /// Timestamp when the job completed.
+    public let completedAt: String?
+    /// Progress percentage (0-100)
+    public let progress: Int?
+    /// Number of items processed so far
+    public let processed: Int?
+    /// Total number of items to process
+    public let total: Int?
 
     private enum CodingKeys: String, CodingKey {
         case status = "state"
         case downloadURL = "url"
+        case scheduledAt = "scheduled_at"
+        case completedAt = "completed_at"
+        case progress
+        case processed
+        case total
+    }
+
+    public init(status: POSCatalogStatus,
+                downloadURL: String? = nil,
+                scheduledAt: String? = nil,
+                completedAt: String? = nil,
+                progress: Int? = nil,
+                processed: Int? = nil,
+                total: Int? = nil) {
+        self.status = status
+        self.downloadURL = downloadURL
+        self.scheduledAt = scheduledAt
+        self.completedAt = completedAt
+        self.progress = progress
+        self.processed = processed
+        self.total = total
     }
 }
 
 /// Catalog generation status.
 public enum POSCatalogStatus: String, Decodable {
     case scheduled
-    case processing
+    case inProgress = "in_progress"
     case completed
     case failed
 }

--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -205,8 +205,8 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     public func requestCatalogGeneration(for siteID: Int64, forceGeneration: Bool, allowCellular: Bool) async throws -> POSCatalogRequestResponse {
         let path = "catalog/create"
         var parameters: [String: Any] = [
-            ParameterKey.catalogProductFields: POSProduct.requestFields,
-            ParameterKey.catalogVariationFields: POSProductVariation.requestFields
+            ParameterKey.catalogProductFields: POSProduct.requestFields.joined(separator: ","),
+            ParameterKey.catalogVariationFields: POSProductVariation.requestFields.joined(separator: ",")
         ]
         if forceGeneration {
             parameters[ParameterKey.force] = true
@@ -473,16 +473,16 @@ public struct POSCatalogRequestResponse: Decodable {
     public let downloadURL: String?
 
     private enum CodingKeys: String, CodingKey {
-        case status
-        case downloadURL = "download_url"
+        case status = "state"
+        case downloadURL = "url"
     }
 }
 
 /// Catalog generation status.
 public enum POSCatalogStatus: String, Decodable {
-    case pending
+    case scheduled
     case processing
-    case complete
+    case completed
     case failed
 }
 

--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -203,14 +203,16 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     /// - Returns: Catalog job response with job ID.
     ///
     public func requestCatalogGeneration(for siteID: Int64, forceGeneration: Bool, allowCellular: Bool) async throws -> POSCatalogRequestResponse {
-        let path = "products/catalog"
-        let parameters: [String: Any] = [
-            ParameterKey.fullSyncFields: POSProduct.requestFields,
-            ParameterKey.fullSyncVariationFields: POSProductVariation.requestFields,
-            ParameterKey.forceGenerate: forceGeneration
+        let path = "catalog/create"
+        var parameters: [String: Any] = [
+            ParameterKey.catalogProductFields: POSProduct.requestFields,
+            ParameterKey.catalogVariationFields: POSProductVariation.requestFields
         ]
+        if forceGeneration {
+            parameters[ParameterKey.force] = true
+        }
         let request = JetpackRequest(
-            wooApiVersion: .mark3,
+            wooApiVersion: .wcPosV1,
             method: .post,
             siteID: siteID,
             path: path,
@@ -448,9 +450,9 @@ private extension POSCatalogSyncRemote {
         static let page = "page"
         static let perPage = "per_page"
         static let fields = "_fields"
-        static let fullSyncFields = "fields"
-        static let fullSyncVariationFields = "variation_fields"
-        static let forceGenerate = "force_generate"
+        static let catalogProductFields = "_product_fields"
+        static let catalogVariationFields = "_variation_fields"
+        static let force = "force"
         static let includeStatus = "include_status"
         static let posProductsOnly = "pos_products_only"
     }

--- a/Modules/Sources/NetworkingCore/Settings/WooAPIVersion.swift
+++ b/Modules/Sources/NetworkingCore/Settings/WooAPIVersion.swift
@@ -54,6 +54,10 @@ public enum WooAPIVersion: String {
     ///
     case wcBookings = "wc-bookings/v2"
 
+    /// WooCommerce POS V1.
+    ///
+    case wcPosV1 = "wc/pos/v1"
+
     /// Returns the path for the current API Version
     ///
     var path: String {

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
@@ -241,7 +241,7 @@ private extension POSCatalogFullSyncService {
                     throw POSCatalogSyncError.invalidData
                 }
                 return downloadURL
-            case .scheduled, .processing:
+            case .scheduled, .inProgress:
                 // Only logs every 10th attempt to avoid flooding logs for large catalogs.
                 if attempts % 10 == 0 {
                     DDLogInfo("🟣 Catalog request \(response.status)... (attempt \(attempts + 1)/\(maxAttempts))")

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
@@ -65,7 +65,7 @@ public final class POSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol 
                              appPasswordSupportState: AnyPublisher<Bool, Never>,
                              batchSize: Int = 2,
                              grdbManager: GRDBManagerProtocol,
-                             usesCatalogAPI: Bool = false) {
+                             usesCatalogAPI: Bool) {
         guard let credentials else {
             DDLogError("⛔️ Could not create POSCatalogFullSyncService due missing credentials")
             return nil
@@ -83,7 +83,7 @@ public final class POSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol 
         batchSize: Int,
         retryDelay: TimeInterval = 2.0,
         persistenceService: POSCatalogPersistenceServiceProtocol,
-        usesCatalogAPI: Bool = false
+        usesCatalogAPI: Bool
     ) {
         self.syncRemote = syncRemote
         self.persistenceService = persistenceService
@@ -236,12 +236,12 @@ private extension POSCatalogFullSyncService {
                                                                          allowCellular: allowCellular)
 
             switch response.status {
-            case .complete:
+            case .completed:
                 guard let downloadURL = response.downloadURL else {
                     throw POSCatalogSyncError.invalidData
                 }
                 return downloadURL
-            case .pending, .processing:
+            case .scheduled, .processing:
                 // Only logs every 10th attempt to avoid flooding logs for large catalogs.
                 if attempts % 10 == 0 {
                     DDLogInfo("🟣 Catalog request \(response.status)... (attempt \(attempts + 1)/\(maxAttempts))")

--- a/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
@@ -652,8 +652,9 @@ struct POSCatalogSyncRemoteTests {
 
         // Then
         let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
-        #expect(queryParametersDictionary["fields"] as? [String] == POSProduct.requestFields)
-        #expect(queryParametersDictionary["force_generate"] as? Bool == false)
+        #expect(queryParametersDictionary["_product_fields"] as? [String] == POSProduct.requestFields)
+        #expect(queryParametersDictionary["_variation_fields"] as? [String] == POSProductVariation.requestFields)
+        #expect(queryParametersDictionary["force"] == nil)
     }
 
     @Test func generateCatalog_returns_parsed_response() async throws {
@@ -661,7 +662,7 @@ struct POSCatalogSyncRemoteTests {
         let remote = POSCatalogSyncRemote(network: network)
 
         // When
-        network.simulateResponse(requestUrlSuffix: "catalog", filename: "pos-catalog-generation")
+        network.simulateResponse(requestUrlSuffix: "create", filename: "pos-catalog-generation")
         let response = try await remote.requestCatalogGeneration(for: sampleSiteID, forceGeneration: false, allowCellular: true)
 
         // Then
@@ -944,7 +945,7 @@ struct POSCatalogSyncRemoteTests {
     func requestCatalogGeneration_sets_allowsCellularAccess_on_request(allowCellular: Bool) async throws {
         // Given
         let remote = POSCatalogSyncRemote(network: network)
-        network.simulateResponse(requestUrlSuffix: "catalog", filename: "pos-catalog-generation")
+        network.simulateResponse(requestUrlSuffix: "create", filename: "pos-catalog-generation")
 
         // When
         _ = try await remote.requestCatalogGeneration(for: sampleSiteID, forceGeneration: false, allowCellular: allowCellular)

--- a/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
@@ -652,8 +652,8 @@ struct POSCatalogSyncRemoteTests {
 
         // Then
         let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
-        #expect(queryParametersDictionary["_product_fields"] as? [String] == POSProduct.requestFields)
-        #expect(queryParametersDictionary["_variation_fields"] as? [String] == POSProductVariation.requestFields)
+        #expect(queryParametersDictionary["_product_fields"] as? String == POSProduct.requestFields.joined(separator: ","))
+        #expect(queryParametersDictionary["_variation_fields"] as? String == POSProductVariation.requestFields.joined(separator: ","))
         #expect(queryParametersDictionary["force"] == nil)
     }
 
@@ -666,7 +666,7 @@ struct POSCatalogSyncRemoteTests {
         let response = try await remote.requestCatalogGeneration(for: sampleSiteID, forceGeneration: false, allowCellular: true)
 
         // Then
-        #expect(response.status == .complete)
+        #expect(response.status == .completed)
         #expect(response.downloadURL == "https://example.com/wp-content/uploads/catalog.json")
     }
 

--- a/Modules/Tests/NetworkingTests/Responses/pos-catalog-generation.json
+++ b/Modules/Tests/NetworkingTests/Responses/pos-catalog-generation.json
@@ -1,4 +1,4 @@
 {
-  "status": "complete",
-  "download_url": "https://example.com/wp-content/uploads/catalog.json"
+  "state": "completed",
+  "url": "https://example.com/wp-content/uploads/catalog.json"
 }

--- a/Modules/Tests/NetworkingTests/Responses/pos-catalog-generation.json
+++ b/Modules/Tests/NetworkingTests/Responses/pos-catalog-generation.json
@@ -1,4 +1,9 @@
 {
+  "scheduled_at": "2026-01-23T08:30:25",
+  "completed_at": "2026-01-23T08:31:47",
   "state": "completed",
+  "progress": 100,
+  "processed": 803,
+  "total": 803,
   "url": "https://example.com/wp-content/uploads/catalog.json"
 }

--- a/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogSyncRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogSyncRemote.swift
@@ -12,7 +12,7 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
     // Results returned when posProductsOnly=false (used during dual-request hidden product detection)
     private(set) var allProductResults: [Int: Result<PagedItems<POSProduct>, Error>] = [:]
 
-    var catalogRequestResult: Result<POSCatalogRequestResponse, Error> = .success(.init(status: .complete, downloadURL: "https://example.com/catalog.json"))
+    var catalogRequestResult: Result<POSCatalogRequestResponse, Error> = .success(.init(status: .completed, downloadURL: "https://example.com/catalog.json"))
     var catalogDownloadResult: Result<POSCatalogResponse, Error> = .success(.init(products: [], variations: []))
 
     let loadProductsCallCount = Counter()

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogFullSyncServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogFullSyncServiceTests.swift
@@ -14,7 +14,7 @@ struct POSCatalogFullSyncServiceTests {
     init() {
         self.mockSyncRemote = MockPOSCatalogSyncRemote()
         self.mockPersistenceService = MockPOSCatalogPersistenceService()
-        self.sut = POSCatalogFullSyncService(syncRemote: mockSyncRemote, batchSize: 2, persistenceService: mockPersistenceService)
+        self.sut = POSCatalogFullSyncService(syncRemote: mockSyncRemote, batchSize: 2, persistenceService: mockPersistenceService, usesCatalogAPI: false)
     }
 
     // MARK: - Full Sync Tests
@@ -123,7 +123,11 @@ struct POSCatalogFullSyncServiceTests {
         // Given
         let expectedError = NSError(domain: "network", code: 500, userInfo: [NSLocalizedDescriptionKey: "Network error"])
         mockSyncRemote.setProductResult(pageNumber: 1, result: .failure(expectedError))
-        let sut = POSCatalogFullSyncService(syncRemote: mockSyncRemote, batchSize: 2, retryDelay: 0, persistenceService: mockPersistenceService)
+        let sut = POSCatalogFullSyncService(syncRemote: mockSyncRemote,
+                                            batchSize: 2,
+                                            retryDelay: 0,
+                                            persistenceService: mockPersistenceService,
+                                            usesCatalogAPI: false)
 
         // When/Then
         await #expect(throws: expectedError) {
@@ -143,7 +147,8 @@ struct POSCatalogFullSyncServiceTests {
             credentials: credentials,
             selectedSite: Just(Site.fake()).map { $0.toJetpackSite() }.eraseToAnyPublisher(),
             appPasswordSupportState: Just(false).eraseToAnyPublisher(),
-            grdbManager: grdbManager
+            grdbManager: grdbManager,
+            usesCatalogAPI: false
         )
 
         // Then
@@ -159,7 +164,8 @@ struct POSCatalogFullSyncServiceTests {
             credentials: nil,
             selectedSite: Just(Site.fake()).map { $0.toJetpackSite() }.eraseToAnyPublisher(),
             appPasswordSupportState: Just(false).eraseToAnyPublisher(),
-            grdbManager: grdbManager
+            grdbManager: grdbManager,
+            usesCatalogAPI: false
         )
 
         // Then
@@ -173,7 +179,8 @@ struct POSCatalogFullSyncServiceTests {
         // When
         let service = POSCatalogFullSyncService(syncRemote: mockSyncRemote,
                                                 batchSize: customBatchSize,
-                                                persistenceService: mockPersistenceService)
+                                                persistenceService: mockPersistenceService,
+                                                usesCatalogAPI: false)
         _ = try await service.startFullSync(for: sampleSiteID, allowCellular: true)
 
         // Then
@@ -188,7 +195,7 @@ struct POSCatalogFullSyncServiceTests {
         let expectedProduct = POSProduct.fake().copy(siteID: sampleSiteID, productID: 1)
         let expectedVariation = POSProductVariation.fake().copy(siteID: sampleSiteID, productID: 1, productVariationID: 1)
 
-        mockSyncRemote.catalogRequestResult = .success(.init(status: .complete, downloadURL: "https://example.com/catalog.json"))
+        mockSyncRemote.catalogRequestResult = .success(.init(status: .completed, downloadURL: "https://example.com/catalog.json"))
         mockSyncRemote.catalogDownloadResult = .success(.init(products: [expectedProduct], variations: [expectedVariation]))
 
         let sut = POSCatalogFullSyncService(
@@ -230,7 +237,7 @@ struct POSCatalogFullSyncServiceTests {
     @Test func startFullSync_with_catalog_API_propagates_catalog_download_error() async throws {
         // Given
         let expectedError = NSError(domain: "catalog", code: 404, userInfo: [NSLocalizedDescriptionKey: "Catalog download failed"])
-        mockSyncRemote.catalogRequestResult = .success(.init(status: .complete, downloadURL: "https://example.com/catalog.json"))
+        mockSyncRemote.catalogRequestResult = .success(.init(status: .completed, downloadURL: "https://example.com/catalog.json"))
         mockSyncRemote.catalogDownloadResult = .failure(expectedError)
 
         let sut = POSCatalogFullSyncService(
@@ -249,7 +256,7 @@ struct POSCatalogFullSyncServiceTests {
     @Test func startFullSync_with_catalog_API_propagates_persistence_error() async throws {
         // Given
         let expectedError = NSError(domain: "persistence", code: 1000, userInfo: [NSLocalizedDescriptionKey: "Persistence failed"])
-        mockSyncRemote.catalogRequestResult = .success(.init(status: .complete, downloadURL: "https://example.com/catalog.json"))
+        mockSyncRemote.catalogRequestResult = .success(.init(status: .completed, downloadURL: "https://example.com/catalog.json"))
         mockSyncRemote.catalogDownloadResult = .success(.init(products: [], variations: []))
         mockPersistenceService.replaceAllCatalogDataError = expectedError
 
@@ -269,7 +276,7 @@ struct POSCatalogFullSyncServiceTests {
     @Test(arguments: [true, false])
     func startFullSync_with_catalog_API_passes_regenerateCatalog_to_remote(regenerateCatalog: Bool) async throws {
         // Given
-        mockSyncRemote.catalogRequestResult = .success(.init(status: .complete, downloadURL: "https://example.com/catalog.json"))
+        mockSyncRemote.catalogRequestResult = .success(.init(status: .completed, downloadURL: "https://example.com/catalog.json"))
         mockSyncRemote.catalogDownloadResult = .success(.init(products: [], variations: []))
 
         let sut = POSCatalogFullSyncService(
@@ -289,7 +296,7 @@ struct POSCatalogFullSyncServiceTests {
     @Test(arguments: [true, false])
     func startFullSync_with_catalog_API_passes_allowCellular_to_downloadCatalog(allowCellular: Bool) async throws {
         // Given
-        mockSyncRemote.catalogRequestResult = .success(.init(status: .complete, downloadURL: "https://example.com/catalog.json"))
+        mockSyncRemote.catalogRequestResult = .success(.init(status: .completed, downloadURL: "https://example.com/catalog.json"))
         mockSyncRemote.catalogDownloadResult = .success(.init(products: [], variations: []))
 
         let sut = POSCatalogFullSyncService(


### PR DESCRIPTION
Closes WOOMOB-2050

## Description
This PR updates the networking layer in order to use the core catalog API where needed.

For additional context, seems that when this initial code was added we were expectating to be used through some agentic woo plugin, but ultimately this project was stopped/cancelled and the API was migrated into woo core to the `wc/pos/v1/catalog/create` route [here](https://github.com/woocommerce/woocommerce/blob/b36d3a2660d033285b224a81152b04e36d9c3dcf/plugins/woocommerce/src/Internal/ProductFeed/Integrations/POSCatalog/ApiController.php).

This endpoint is still not used, changes are behind a feature flag and will only download the catalog json file with all products and variations for POS, nothing is persisted to storage just yet.

## Changes
- Updated API version to `wc/pos/v1`, as well as path from `products/catalog` to `catalog/create`, and the required params for products and variations.
- Remove default `usesCatalogAPI: Bool = false` from `POSCatalogFullSyncService` so it relies exclusively in the feature flag to use the paginated or the catalog API approach, injected through `AuthenticatedState`
- Updated tests

## Test Steps
1. Switch `pointOfSaleCatalogAPI` feature flag to to `true`, with this enabled, the `POSCatalogFullSyncService` (only, there are no changes to incremental sync) branches the merchant through loading the catalog from the Catalog API when a full sync is required, rather than through the current paginated approach.
2. Go to POS > `Settings` >`Product Catalog` > tap `Update Catalog`, this will trigger a full sync
3. Observe that sync fails (unable to refresh catalog error on screen), as is not handled yet, but the console will show the file download:
```
🟣 Catalog request scheduled... (attempt 1/1000)
🟣 Catalog ready for download: https://indiemelon.mystagingwebsite.com/wp-content/uploads/product-feeds/pos-catalog-feed-2026-01-28-4437cca0c50be36484d27ed752664d09.json
🟣 Background download completed, file moved to: /Users/iamgabrielma/Library/Developer/CoreSimulator/Devices/4B6ADB99-1B27-4131-AA7F-A183F893B0BD/data/Containers/Data/Application/369DDEBD-9C5B-46BE-ACA8-29C4DF1007F6/tmp/pos-catalog-feed-2026-01-28-4437cca0c50be36484d27ed752664d09.json
```
5. Confirm that the .json file can be found in your site by copy-pasting the URL into the browser.

## Screenshots
N/A
