### PR TITLE
Refactor `PushNotificationRegistrationState` publishing and storage

### DIFF
--- a/WooCommerce/Classes/Notifications/PushNotificationRegistrationState.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationRegistrationState.swift
@@ -1,10 +1,22 @@
+import Combine
 import Foundation
 
 final class PushNotificationRegistrationState {
     private let defaults: UserDefaults
+    private let siteIDsRegisteredForWooPNsSubject: CurrentValueSubject<[Int64]?, Never>
 
     init(defaults: UserDefaults) {
         self.defaults = defaults
+
+        let storedSiteIDsString: String? = defaults.object(
+            forKey: .siteIDsRegisteredForWooPushNotifications
+        )
+
+        let storedSiteIDs = storedSiteIDsString?
+            .components(separatedBy: ",")
+            .compactMap { Int64($0) }
+
+        siteIDsRegisteredForWooPNsSubject = CurrentValueSubject(storedSiteIDs)
     }
 
     /// Apple's Push Notifications DeviceToken
@@ -40,16 +52,21 @@ final class PushNotificationRegistrationState {
     /// Site IDs registered to Woo PN system, separated by commas
     private(set) var siteIDsRegisteredForWooPNs: [Int64] {
         get {
-            let ids: String? = defaults.object(forKey: .siteIDsRegisteredForWooPushNotifications)
-            return ids?.components(separatedBy: ",")
-                .compactMap { Int64($0) } ?? []
+            siteIDsRegisteredForWooPNsSubject.value ?? []
         }
         set {
-            defaults.set(
-                newValue.map { "\($0)" }.joined(separator: ","),
-                forKey: .siteIDsRegisteredForWooPushNotifications
-            )
+            updateSiteIDsRegisteredForWooPNs(newValue)
         }
+    }
+
+    var siteIDsRegisteredForWooPNsPublisher: AnyPublisher<[Int64], Never> {
+        siteIDsRegisteredForWooPNsSubject
+            .map { $0 ?? [] }
+            .eraseToAnyPublisher()
+    }
+
+    var hasStoredSiteIDsRegisteredForWooPNs: Bool {
+        siteIDsRegisteredForWooPNsSubject.value != nil
     }
 
     func isSiteRegisteredForWooPNs(_ siteID: Int64) -> Bool {
@@ -104,25 +121,23 @@ extension PushNotificationRegistrationState {
 
 private extension PushNotificationRegistrationState {
     func instantiateRegisteredSiteIDsCollectionIfAbsent() {
-        guard defaults.containsObject(forKey: .siteIDsRegisteredForWooPushNotifications) == false else {
+        if siteIDsRegisteredForWooPNsSubject.value != nil {
             return
         }
+
         siteIDsRegisteredForWooPNs = []
     }
-}
 
-extension UserDefaults {
-    @objc dynamic var wooPushNotificationToken: String? {
-        string(forKey: Key.wooPushNotificationToken.rawValue)
-    }
+    func updateSiteIDsRegisteredForWooPNs(_ newValue: [Int64]) {
+        if siteIDsRegisteredForWooPNsSubject.value == newValue {
+            return
+        }
 
-    @objc dynamic var deviceToken: String? {
-        string(forKey: Key.deviceToken.rawValue)
-    }
+        defaults.set(
+            newValue.map { "\($0)" }.joined(separator: ","),
+            forKey: .siteIDsRegisteredForWooPushNotifications
+        )
 
-    @objc dynamic var siteIDsRegisteredForWooPushNotifications: [Int64]? {
-        string(forKey: Key.siteIDsRegisteredForWooPushNotifications.rawValue)?
-            .components(separatedBy: ",")
-            .compactMap { Int64($0) }
+        siteIDsRegisteredForWooPNsSubject.send(newValue)
     }
 }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -94,6 +94,14 @@ final class PushNotificationsManager: PushNotesManager {
         registrationState.siteIDsRegisteredForWooPNs
     }
 
+    var siteIDsRegisteredForWooPNsPublisher: AnyPublisher<[Int64], Never> {
+        registrationState.siteIDsRegisteredForWooPNsPublisher
+    }
+
+    var hasStoredSiteIDsRegisteredForWooPNs: Bool {
+        registrationState.hasStoredSiteIDsRegisteredForWooPNs
+    }
+
     private var siteID: Int64? {
         stores.sessionManager.defaultStoreID
     }

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -37,6 +37,14 @@ protocol PushNotesManager {
     ///
     var siteIDsRegisteredForWooPNs: [Int64] { get }
 
+    /// Publisher for site IDs registered for Woo Push Notifications.
+    ///
+    var siteIDsRegisteredForWooPNsPublisher: AnyPublisher<[Int64], Never> { get }
+
+    /// Indicates whether the registered site IDs value exists in storage.
+    ///
+    var hasStoredSiteIDsRegisteredForWooPNs: Bool { get }
+
     /// Resets the Badge Count.
     ///
     func resetBadgeCount(type: Note.Kind)

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -248,7 +248,6 @@ final class SessionManager: SessionManagerProtocol {
         defaults[.applicationPasswordUnsupportedList] = nil
         defaults[.applicationPasswordsExperimentRemoteFFValue] = nil
         defaults[.ciabBookingsTabAvailable] = nil
-        defaults[.siteIDsRegisteredForWooPushNotifications] = nil
         defaults[.hideWPComConnectionOnDashboard] = nil
         resetTimestampsValues()
         imageCache.clearCache()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -97,6 +97,7 @@ final class DashboardViewModel: ObservableObject {
     private let analytics: Analytics
     private let justInTimeMessagesManager: JustInTimeMessagesProvider
     private let userDefaults: UserDefaults
+    private let pushNotesManager: PushNotesManager
     private let storageManager: StorageManagerType
     private let inboxEligibilityChecker: InboxEligibilityChecker
     private let siteIsCIABEligibilityChecker: CIABEligibilityCheckerProtocol
@@ -149,6 +150,7 @@ final class DashboardViewModel: ObservableObject {
          featureFlags: FeatureFlagService = ServiceLocator.featureFlagService,
          analytics: Analytics = ServiceLocator.analytics,
          userDefaults: UserDefaults = .standard,
+         pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
          usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter = StoreStatsUsageTracksEventEmitter(),
          blazeEligibilityChecker: BlazeEligibilityCheckerProtocol = BlazeEligibilityChecker(),
          inboxEligibilityChecker: InboxEligibilityChecker = InboxEligibilityUseCase(),
@@ -163,6 +165,7 @@ final class DashboardViewModel: ObservableObject {
         self.featureFlagService = featureFlags
         self.analytics = analytics
         self.userDefaults = userDefaults
+        self.pushNotesManager = pushNotesManager
         self.justInTimeMessagesManager = JustInTimeMessagesProvider(stores: stores, analytics: analytics)
         self.storeOnboardingViewModel = .init(siteID: siteID, isExpanded: false, stores: stores, defaults: userDefaults)
         self.blazeCampaignDashboardViewModel = .init(siteID: siteID,
@@ -657,7 +660,7 @@ private extension DashboardViewModel {
     }
 
     func observeSelfDrivenPushTokenPersistence() {
-        userDefaults.publisher(for: \.siteIDsRegisteredForWooPushNotifications)
+        pushNotesManager.siteIDsRegisteredForWooPNsPublisher
             .combineLatest(userDefaults.publisher(for: \.hideWPComConnectionOnDashboard))
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _, _ in
@@ -928,11 +931,11 @@ private extension DashboardViewModel {
     }
 
     func updateSelfDrivenPushRegistrationStatus() {
-        let registeredSiteIDs = userDefaults.siteIDsRegisteredForWooPushNotifications
-        isSelfDrivenPushNotificationRegistered = registeredSiteIDs?.contains(siteID) == true && stores.isAuthenticatedWithoutWPCom
+        let registeredSiteIDs = pushNotesManager.siteIDsRegisteredForWooPNs
+        isSelfDrivenPushNotificationRegistered = registeredSiteIDs.contains(siteID) && stores.isAuthenticatedWithoutWPCom
         dismissedWPComConnectionSuggestion = userDefaults.hideWPComConnectionOnDashboard
-        shouldSuggestWPComConnection = registeredSiteIDs != nil &&
-            registeredSiteIDs?.contains(siteID) == false &&
+        shouldSuggestWPComConnection = pushNotesManager.hasStoredSiteIDsRegisteredForWooPNs &&
+            registeredSiteIDs.contains(siteID) == false &&
             stores.isAuthenticatedWithoutWPCom &&
             !dismissedWPComConnectionSuggestion &&
             featureFlagService.isFeatureFlagEnabled(.selfDrivenPushTokenAppPasswords)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -105,6 +105,7 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     private let storageManager: StorageManagerType
     private let featureFlagService: FeatureFlagService
     private let defaults: UserDefaults
+    private let pushNotesManager: PushNotesManager
     private let analytics: Analytics
 
     private var subscriptions: Set<AnyCancellable> = []
@@ -117,11 +118,13 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          defaults: UserDefaults = .standard,
+         pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
          analytics: Analytics = ServiceLocator.analytics) {
         self.stores = stores
         self.storageManager = storageManager
         self.featureFlagService = featureFlagService
         self.defaults = defaults
+        self.pushNotesManager = pushNotesManager
         self.analytics = analytics
 
         /// Initialize Sites Results Controller
@@ -210,7 +213,7 @@ private extension SettingsViewModel {
     }
 
     func observeSelfDrivenPushTokenPersistence() {
-        defaults.publisher(for: \.siteIDsRegisteredForWooPushNotifications)
+        pushNotesManager.siteIDsRegisteredForWooPNsPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.reloadSettings()
@@ -310,7 +313,7 @@ private extension SettingsViewModel {
                     return false
                 }
                 return featureFlagService.isFeatureFlagEnabled(.selfDrivenPushTokenWPCom) &&
-                defaults.siteIDsRegisteredForWooPushNotifications?.contains(siteID) == true
+                pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID)
             }()
             if notificationAvailable && !isSelfDrivenPushNotificationsRegistered {
                 rows = [.notifications, .privacy]
@@ -389,7 +392,7 @@ private extension SettingsViewModel {
             return false
         }
 
-        return defaults.siteIDsRegisteredForWooPushNotifications?.contains(siteID) != true
+        return pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID) == false
     }
 
     /// Ask the CardPresentPaymentStore to loadAccounts from the network and update storage

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -44,11 +44,16 @@ final class MockPushNotificationsManager: PushNotesManager {
 
     private let mockedDeviceID: String?
     let siteIDsRegisteredForWooPNs: [Int64]
+    let hasStoredSiteIDsRegisteredForWooPNs: Bool
+    var siteIDsRegisteredForWooPNsPublisher: AnyPublisher<[Int64], Never> {
+        siteIDsRegisteredForWooPNsSubject.eraseToAnyPublisher()
+    }
 
     var deviceID: String? {
         mockedDeviceID
     }
 
+    private let siteIDsRegisteredForWooPNsSubject: CurrentValueSubject<[Int64], Never>
     private let localNotificationResponsesSubject = PassthroughSubject<UNNotificationResponse, Never>()
 
     private(set) var requestedLocalNotifications: [LocalNotification] = []
@@ -59,9 +64,13 @@ final class MockPushNotificationsManager: PushNotesManager {
     private(set) var resetBadgeCountKinds: [Note.Kind] = []
     var onRequestLocalNotificationCalled: (() -> Void)?
 
-    init(mockedDeviceID: String? = nil, siteIDsRegisteredForWooPNs: [Int64] = []) {
+    init(mockedDeviceID: String? = nil,
+         siteIDsRegisteredForWooPNs: [Int64] = [],
+         hasStoredSiteIDsRegisteredForWooPNs: Bool? = nil) {
         self.mockedDeviceID = mockedDeviceID
         self.siteIDsRegisteredForWooPNs = siteIDsRegisteredForWooPNs
+        self.hasStoredSiteIDsRegisteredForWooPNs = hasStoredSiteIDsRegisteredForWooPNs ?? !siteIDsRegisteredForWooPNs.isEmpty
+        self.siteIDsRegisteredForWooPNsSubject = CurrentValueSubject(siteIDsRegisteredForWooPNs)
     }
 
     func resetBadgeCount(type: Note.Kind) {

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationRegistrationStateTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationRegistrationStateTests.swift
@@ -23,10 +23,22 @@ final class PushNotificationRegistrationStateTests: XCTestCase {
         XCTAssertEqual(state.siteIDsRegisteredForWooPNs, [])
     }
 
+    func test_hasStoredSiteIDsRegisteredForWooPNs_is_false_when_missing() {
+        XCTAssertFalse(state.hasStoredSiteIDsRegisteredForWooPNs)
+    }
+
     func test_siteIDsRegisteredForWooPNs_parses_ids_from_string() {
         defaults.set("1,2,3", forKey: .siteIDsRegisteredForWooPushNotifications)
+        state = PushNotificationRegistrationState(defaults: defaults)
 
         XCTAssertEqual(state.siteIDsRegisteredForWooPNs, [1, 2, 3])
+    }
+
+    func test_hasStoredSiteIDsRegisteredForWooPNs_is_true_when_value_exists() {
+        defaults.set("", forKey: .siteIDsRegisteredForWooPushNotifications)
+        state = PushNotificationRegistrationState(defaults: defaults)
+
+        XCTAssertTrue(state.hasStoredSiteIDsRegisteredForWooPNs)
     }
 
     func test_markSiteAsRegisteredForWooPNs_persists_string_value() {
@@ -41,10 +53,12 @@ final class PushNotificationRegistrationStateTests: XCTestCase {
         state.markSiteAsRegisteredForWooPNs(4)
 
         XCTAssertEqual(state.siteIDsRegisteredForWooPNs, [4])
+        XCTAssertTrue(state.hasStoredSiteIDsRegisteredForWooPNs)
     }
 
     func test_unmarkSiteAsRegisteredForWooPNs_removes_site_id() {
         defaults.set("1,2", forKey: .siteIDsRegisteredForWooPushNotifications)
+        state = PushNotificationRegistrationState(defaults: defaults)
 
         state.unmarkSiteAsRegisteredForWooPNs(1)
 

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -57,15 +57,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         userNotificationCenter = MockUserNotificationsCenterAdapter()
         backgroundSynchronizerFactory = MockPushNotificationBackgroundSynchronizerFactory()
 
-        manager = {
-            let configuration = PushNotificationsConfiguration(application: self.application,
-                                                               defaults: self.defaults,
-                                                               storesManager: self.storesManager,
-                                                               userNotificationsCenter: self.userNotificationCenter)
-
-            return PushNotificationsManager(configuration: configuration,
-                                            backgroundSynchronizerFactory: backgroundSynchronizerFactory)
-        }()
+        manager = makeManager()
     }
 
     @MainActor
@@ -144,6 +136,7 @@ final class PushNotificationsManagerTests: XCTestCase {
     ///
     func testUnregisterForRemoteNotificationsEffectivelyDispatchesUnregisterDeviceAction() {
         defaults.set(Sample.deviceID, forKey: .deviceID)
+        manager = makeManager()
         manager.unregisterForRemoteNotifications {}
 
         guard case let .unregisterDevice(deviceID, _) = storesManager.receivedActions.first as! NotificationAction else {
@@ -161,6 +154,7 @@ final class PushNotificationsManagerTests: XCTestCase {
     func testUnregisterForRemoteNotificationsEffectivelyNukesDeviceIdentifierAndTokenOnSuccess() {
         defaults.set(Sample.deviceID, forKey: .deviceID)
         defaults.set(Sample.deviceToken, forKey: .deviceToken)
+        manager = makeManager()
 
         manager.unregisterForRemoteNotifications {}
 
@@ -193,6 +187,7 @@ final class PushNotificationsManagerTests: XCTestCase {
     ///
     func testRegistrationDidFailDispatchesUnregisterDeviceAction() {
         defaults.set(Sample.deviceID, forKey: .deviceID)
+        manager = makeManager()
 
         manager.registrationDidFail(with: SampleError.first)
 
@@ -767,6 +762,17 @@ final class PushNotificationsManagerTests: XCTestCase {
 // MARK: - Private Methods
 //
 private extension PushNotificationsManagerTests {
+    func makeManager(featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) -> PushNotificationsManager {
+        let configuration = PushNotificationsConfiguration(application: self.application,
+                                                           defaults: self.defaults,
+                                                           storesManager: self.storesManager,
+                                                           userNotificationsCenter: self.userNotificationCenter)
+
+        return PushNotificationsManager(configuration: configuration,
+                                        backgroundSynchronizerFactory: backgroundSynchronizerFactory,
+                                        featureFlagService: featureFlagService)
+    }
+
 
     /// Returns a Sample Notification Payload
     ///

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -422,28 +422,6 @@ final class SessionManagerTests: XCTestCase {
         XCTAssertNil(defaults[.ciabBookingsTabAvailable])
     }
 
-    /// Verifies that image cache is cleared upon reset
-    ///
-    func test_siteIDsRegisteredForWooPushNotifications_is_cleared_upon_reset() throws {
-        // Given
-        let siteID: Int64 = 13
-        let uuid = UUID().uuidString
-        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
-        let sut = SessionManager(defaults: defaults, keychainServiceName: Settings.keychainServiceName)
-
-        // When
-        defaults[.siteIDsRegisteredForWooPushNotifications] = siteID.description
-
-        // Then
-        XCTAssertEqual(try XCTUnwrap(defaults[.siteIDsRegisteredForWooPushNotifications] as? String), siteID.description)
-
-        // When
-        sut.reset()
-
-        // Then
-        XCTAssertNil(defaults[.siteIDsRegisteredForWooPushNotifications])
-    }
-
     /// Verifies that flag to hide WPCom connection suggestion is cleared upon reset
     ///
     func test_hideWPComConnectionOnDashboard_is_cleared_upon_reset() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -914,12 +914,14 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_isSelfDrivenPushNotificationRegistered_returns_false_when_site_is_not_registered_with_Woo_PN() async {
         // Given
-        userDefaults.set("", forKey: .siteIDsRegisteredForWooPushNotifications)
         mockReloadingData()
+        let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [],
+                                                            hasStoredSiteIDsRegisteredForWooPNs: true)
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,
                                            storageManager: storageManager,
                                            userDefaults: userDefaults,
+                                           pushNotesManager: pushNotesManager,
                                            blazeEligibilityChecker: blazeEligibilityChecker,
                                            googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
@@ -933,13 +935,15 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_isSelfDrivenPushNotificationRegistered_returns_true_when_site_is_registered_and_not_wpcom_login() async {
         // Given
-        userDefaults.set("\(sampleSiteID)", forKey: .siteIDsRegisteredForWooPushNotifications)
         mockReloadingData()
         stores.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
+        let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [sampleSiteID],
+                                                            hasStoredSiteIDsRegisteredForWooPNs: true)
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,
                                            storageManager: storageManager,
                                            userDefaults: userDefaults,
+                                           pushNotesManager: pushNotesManager,
                                            blazeEligibilityChecker: blazeEligibilityChecker,
                                            googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
@@ -953,14 +957,16 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_isSelfDrivenPushNotificationRegistered_returns_false_when_site_is_registered_and_wpcom_login() async {
         // Given
-        userDefaults.set("\(sampleSiteID)", forKey: .siteIDsRegisteredForWooPushNotifications)
         mockReloadingData()
         stores.authenticate(credentials: SessionSettings.wpcomCredentials)
+        let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [sampleSiteID],
+                                                            hasStoredSiteIDsRegisteredForWooPNs: true)
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,
                                            storageManager: storageManager,
                                            userDefaults: userDefaults,
+                                           pushNotesManager: pushNotesManager,
                                            blazeEligibilityChecker: blazeEligibilityChecker,
                                            googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
@@ -974,16 +980,18 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_shouldSuggestWPComConnection_returns_false_when_site_is_not_registered_and_not_wpcom_login_and_feature_flag_disabled() async {
         // Given
-        userDefaults.set("", forKey: .siteIDsRegisteredForWooPushNotifications)
         mockReloadingData()
         stores.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
         let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenAppPasswords: false)
+        let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [],
+                                                            hasStoredSiteIDsRegisteredForWooPNs: true)
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,
                                            storageManager: storageManager,
                                            featureFlags: featureFlagService,
                                            userDefaults: userDefaults,
+                                           pushNotesManager: pushNotesManager,
                                            blazeEligibilityChecker: blazeEligibilityChecker,
                                            googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
@@ -997,16 +1005,18 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_shouldSuggestWPComConnection_returns_true_when_site_is_not_registered_and_not_wpcom_login_and_feature_flag_enabled() async {
         // Given
-        userDefaults.set("", forKey: .siteIDsRegisteredForWooPushNotifications)
         mockReloadingData()
         stores.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
         let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenAppPasswords: true)
+        let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [],
+                                                            hasStoredSiteIDsRegisteredForWooPNs: true)
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,
                                            storageManager: storageManager,
                                            featureFlags: featureFlagService,
                                            userDefaults: userDefaults,
+                                           pushNotesManager: pushNotesManager,
                                            blazeEligibilityChecker: blazeEligibilityChecker,
                                            googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
@@ -1020,14 +1030,16 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_shouldSuggestWPComConnection_returns_false_when_site_is_registered_with_Woo_PN_and_not_wpcom_login() async {
         // Given
-        userDefaults.set("\(sampleSiteID)", forKey: .siteIDsRegisteredForWooPushNotifications)
         mockReloadingData()
         stores.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
+        let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [sampleSiteID],
+                                                            hasStoredSiteIDsRegisteredForWooPNs: true)
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,
                                            storageManager: storageManager,
                                            userDefaults: userDefaults,
+                                           pushNotesManager: pushNotesManager,
                                            blazeEligibilityChecker: blazeEligibilityChecker,
                                            googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
@@ -1041,14 +1053,16 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_shouldSuggestWPComConnection_returns_false_when_site_is_not_registered_and_wpcom_login() async {
         // Given
-        userDefaults.set("", forKey: .siteIDsRegisteredForWooPushNotifications)
         mockReloadingData()
         stores.authenticate(credentials: SessionSettings.wpcomCredentials)
+        let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [],
+                                                            hasStoredSiteIDsRegisteredForWooPNs: true)
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,
                                            storageManager: storageManager,
                                            userDefaults: userDefaults,
+                                           pushNotesManager: pushNotesManager,
                                            blazeEligibilityChecker: blazeEligibilityChecker,
                                            googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
@@ -1062,14 +1076,16 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_hideWPComConnectionSuggestion_updates_relevant_properties() async {
         // Given
-        userDefaults.set("\(sampleSiteID)", forKey: .siteIDsRegisteredForWooPushNotifications)
         mockReloadingData()
         stores.authenticate(credentials: SessionSettings.wpcomCredentials)
+        let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [sampleSiteID],
+                                                            hasStoredSiteIDsRegisteredForWooPNs: true)
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,
                                            storageManager: storageManager,
                                            userDefaults: userDefaults,
+                                           pushNotesManager: pushNotesManager,
                                            blazeEligibilityChecker: blazeEligibilityChecker,
                                            googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -295,12 +295,13 @@ final class SettingsViewModelTests: XCTestCase {
     func test_sections_contains_does_not_contain_notifications_row_for_selfregisteredtoken() {
         // Given
         let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
-        defaults.set("123", forKey: .siteIDsRegisteredForWooPushNotifications)
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
+        let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [123], hasStoredSiteIDsRegisteredForWooPNs: true)
         let viewModel = SettingsViewModel(stores: stores,
                                           featureFlagService: featureFlagService,
-                                          defaults: defaults)
+                                          defaults: defaults,
+                                          pushNotesManager: pushNotesManager)
 
         // When
         viewModel.onViewDidLoad()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-2038

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is follow-up PR for the [Extract PN related state attributes](https://github.com/woocommerce/woocommerce-ios/pull/16559) addressing the refactor [suggestion](https://github.com/woocommerce/woocommerce-ios/pull/16559#pullrequestreview-3710596557).

- Moves from `UserDefaults publisher` for `siteIDsRegisteredForWooPushNotifications` to an encapsulated local state publisher. `UserDefaults` now function only as a storage/sync layer for the `siteIDsRegisteredForWooPushNotifications` without value observing. Publisher is based on `CurrentSubject` and only emits local state value on change.
- Updates tests.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
The PR doesn't change the behaviour. Just smoke test PN subscribing for both Woo-PNs and WP.com pns.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
