### PR TITLE
[POS Refunds] Success Screen

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -426,7 +426,7 @@ enum RefundActionAvailability {
         )
 
         clearRefundSelection()
-        await refreshOrders()
+        try? await updateOrder(orderID: order.id)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -426,6 +426,7 @@ enum RefundActionAvailability {
         )
 
         clearRefundSelection()
+        await refreshOrders()
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
@@ -45,7 +45,7 @@ struct PointOfSalePaymentSuccessView: View {
             VStack(alignment: .center, spacing: POSSpacing.none) {
                 Spacer()
 
-                successIcon
+                POSSuccessIcon()
                     .renderedIf(!dynamicTypeSize.isAccessibilitySize)
                     .scaleEffect(isViewLoaded ? 1 : 0)
                     .opacity(isViewLoaded ? 1 : 0)
@@ -84,28 +84,10 @@ struct PointOfSalePaymentSuccessView: View {
         }
     }
 
-    private var successIcon: some View {
-        ZStack {
-            Circle()
-                .frame(width: Constants.imageSize.width, height: Constants.imageSize.height)
-                .foregroundColor(.posSuccess)
-            PointOfSaleAssets.successCheck.image
-                .renderingMode(.template)
-                .foregroundColor(checkmarkColor)
-                .frame(width: Constants.checkmarkSize)
-                .accessibilityHidden(true)
-        }
-    }
-
-    private var checkmarkColor: Color {
-        .posOnSuccess
-    }
 }
 
 private extension PointOfSalePaymentSuccessView {
     enum Constants {
-        static let imageSize: CGSize = .init(width: 165, height: 165)
-        static let checkmarkSize: CGFloat = 52
         static let textSpacing: CGFloat = POSSpacing.small
         static let animationOffset: CGFloat = 100
     }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -598,7 +598,10 @@ private extension POSOrderDetailsView {
                     refundModalState = nil
                 },
                 onEmailReceipt: {
-                    // TODO: Implement email receipt for refund
+                    refundModalState = nil
+                    Task { @MainActor in
+                        isShowingEmailReceiptView = true
+                    }
                 },
                 onClose: {
                     refundModalState = nil

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -504,6 +504,7 @@ enum RefundModalState: Identifiable, Equatable {
     case reasonInput(POSRefundReviewData)
     case confirmation(POSRefundReviewData)
     case processing(POSRefundReviewData)
+    case success(POSRefundReviewData)
 
     var id: String {
         switch self {
@@ -512,6 +513,7 @@ enum RefundModalState: Identifiable, Equatable {
         case .reasonInput: return "reasonInput"
         case .confirmation: return "confirmation"
         case .processing: return "processing"
+        case .success: return "success"
         }
     }
 }
@@ -588,6 +590,20 @@ private extension POSOrderDetailsView {
                 onConfirm: {},
                 onBack: {}
             )
+        case .success(let reviewData):
+            POSRefundSuccessView(
+                formattedRefundTotal: reviewData.formattedRefundTotal,
+                paymentMethodDescription: reviewData.paymentMethodDescription,
+                onDone: {
+                    refundModalState = nil
+                },
+                onEmailReceipt: {
+                    // TODO: Implement email receipt for refund
+                },
+                onClose: {
+                    refundModalState = nil
+                }
+            )
         }
     }
 
@@ -600,7 +616,7 @@ private extension POSOrderDetailsView {
     func processRefund(reviewData: POSRefundReviewData) async {
         do {
             try await orderListModel.ordersController.processRefund(reason: reviewData.refundReason)
-            refundModalState = nil
+            refundModalState = .success(reviewData)
         } catch {
             // TODO: Handle error - show error state
             refundModalState = .confirmation(reviewData)

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSuccessView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSuccessView.swift
@@ -108,7 +108,7 @@ private extension POSRefundSuccessView {
         static let messageFormat = NSLocalizedString(
             "pos.refundSuccessView.messageFormat",
             value: "You refunded %1$@ %2$@.",
-            comment: "Message shown after successful refund. %1$@ is the formatted amount, %2$@ is the payment method description (e.g., 'via payment card ••••1456')."
+            comment: "Message shown after successful refund. %1$@ is the formatted amount, %2$@ is the payment method description."
         )
 
         static let closeButtonAccessibilityLabel = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSuccessView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSuccessView.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+
+struct POSRefundSuccessView: View {
+    let formattedRefundTotal: String
+    let paymentMethodDescription: String
+    let onDone: () -> Void
+    let onEmailReceipt: () -> Void
+    let onClose: () -> Void
+
+    @Environment(\.posModalParentSize) private var parentSize
+    @State private var isViewLoaded: Bool = false
+
+    var body: some View {
+        VStack(spacing: POSSpacing.none) {
+            headerView
+            contentView
+            buttonsSection
+        }
+        .background(Color.posSurfaceBright)
+        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
+        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding * 2))
+        .onAppear {
+            withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
+                isViewLoaded = true
+            }
+        }
+    }
+}
+
+// MARK: - Subviews
+
+private extension POSRefundSuccessView {
+    var headerView: some View {
+        HStack {
+            Spacer()
+            Button {
+                onClose()
+            } label: {
+                Text(Image(systemName: "xmark"))
+                    .font(.posButtonSymbolLarge)
+            }
+            .accessibilityLabel(Localization.closeButtonAccessibilityLabel)
+        }
+        .foregroundColor(Color.posOnSurface)
+        .padding(POSPadding.xLarge)
+    }
+
+    var contentView: some View {
+        VStack(spacing: POSSpacing.xLarge) {
+            POSSuccessIcon()
+                .scaleEffect(isViewLoaded ? 1 : 0)
+                .opacity(isViewLoaded ? 1 : 0)
+
+            VStack(spacing: POSSpacing.small) {
+                Text(Localization.title)
+                    .font(.posHeadingBold)
+                    .foregroundColor(Color.posOnSurface)
+                    .accessibilityAddTraits(.isHeader)
+                    .offset(y: isViewLoaded ? 0 : Constants.animationOffset)
+                    .opacity(isViewLoaded ? 1 : 0)
+
+                Text(String(format: Localization.messageFormat, formattedRefundTotal, paymentMethodDescription))
+                    .font(.posBodyLargeRegular())
+                    .foregroundColor(Color.posOnSurface)
+                    .offset(y: isViewLoaded ? 0 : Constants.animationOffset)
+                    .opacity(isViewLoaded ? 1 : 0)
+            }
+            .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, POSPadding.xLarge)
+        .padding(.bottom, POSSpacing.xLarge)
+    }
+
+
+    var buttonsSection: some View {
+        VStack(spacing: POSSpacing.medium) {
+            Button(Localization.doneButton, action: onDone)
+                .buttonStyle(POSFilledButtonStyle(size: .normal))
+
+            Button(Localization.emailReceiptButton, action: onEmailReceipt)
+                .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+        }
+        .padding(POSPadding.xLarge)
+        .offset(y: isViewLoaded ? 0 : -Constants.animationOffset)
+        .opacity(isViewLoaded ? 1 : 0)
+    }
+}
+
+
+// MARK: - Constants
+
+private extension POSRefundSuccessView {
+    enum Constants {
+        static let animationOffset: CGFloat = 100
+    }
+}
+
+// MARK: - Localization
+
+private extension POSRefundSuccessView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pos.refundSuccessView.title",
+            value: "Refund complete",
+            comment: "Title shown when a refund has been successfully processed"
+        )
+
+        static let messageFormat = NSLocalizedString(
+            "pos.refundSuccessView.messageFormat",
+            value: "You refunded %1$@ %2$@.",
+            comment: "Message shown after successful refund. %1$@ is the formatted amount, %2$@ is the payment method description (e.g., 'via payment card ••••1456')."
+        )
+
+        static let closeButtonAccessibilityLabel = NSLocalizedString(
+            "pos.refundSuccessView.closeButton.accessibilityLabel",
+            value: "Close",
+            comment: "Accessibility label for close button on refund success screen"
+        )
+
+        static let doneButton = NSLocalizedString(
+            "pos.refundSuccessView.doneButton",
+            value: "Done",
+            comment: "Button to dismiss the refund success screen"
+        )
+
+        static let emailReceiptButton = NSLocalizedString(
+            "pos.refundSuccessView.emailReceiptButton",
+            value: "Email receipt",
+            comment: "Button to email a receipt for the refund"
+        )
+    }
+}
+
+#if DEBUG
+#Preview("POSRefundSuccessView") {
+    POSRefundSuccessView(
+        formattedRefundTotal: "$132.60",
+        paymentMethodDescription: "via payment card ••••1456",
+        onDone: {},
+        onEmailReceipt: {},
+        onClose: {}
+    )
+    .environment(\.posModalParentSize, CGSize(width: 1192, height: 822))
+}
+#endif

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSSuccessIcon.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSSuccessIcon.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct POSSuccessIcon: View {
+    var body: some View {
+        ZStack {
+            Circle()
+                .frame(width: Constants.iconSize, height: Constants.iconSize)
+                .foregroundColor(.posSuccess)
+            PointOfSaleAssets.successCheck.image
+                .renderingMode(.template)
+                .foregroundColor(.posOnSuccess)
+                .frame(width: Constants.checkmarkSize)
+                .accessibilityHidden(true)
+        }
+    }
+}
+
+private extension POSSuccessIcon {
+    enum Constants {
+        static let iconSize: CGFloat = 165
+        static let checkmarkSize: CGFloat = 52
+    }
+}
+
+#if DEBUG
+#Preview {
+    POSSuccessIcon()
+}
+#endif

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -1287,6 +1287,40 @@ final class POSOrderListControllerTests {
         // Then
         #expect(refundsService.spyCreateRefundAutomaticRefund == false)
     }
+
+    @MainActor
+    @Test func processRefund_when_successful_then_updates_order() async throws {
+        // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
+        let order = makeOrder(lineItems: [
+            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+        orderListService.orderPages = [[order]]
+        orderListService.loadOrderResult = order
+
+        await sut.loadOrders()
+
+        sut.selectOrder(order)
+        _ = await waitForCondition { [weak self] in
+            guard let sut = self?.sut else { return false }
+            if case .loaded = sut.selectedOrderRefundsState { return true }
+            return false
+        }
+        sut.startRefundFlow()
+
+        // When
+        try await sut.processRefund(reason: .none)
+
+        // Then
+        #expect(orderListService.loadOrderWasCalled == true)
+        #expect(orderListService.lastLoadOrderID == order.id)
+    }
 }
 
 private extension POSOrderListControllerTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
  Adds a success screen displayed after a refund is successfully processed in POS. The screen shows:
  - A success checkmark icon (reused from payment success)
  - "Refund complete" title
  - Message with the refunded amount and payment method
  - "Done" button to dismiss
  - "Email receipt" button (action implemented)
  - Update order after it is refunded

  Also extracts POSSuccessIcon as a reusable component shared between the payment success and refund success screens.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
  1. Open POS and complete an order
  2. From the order details, tap "Issue refund"
  3. Select items and proceed through the refund flow
  4. Confirm the refund
  5. Verify the success screen appears with the correct refund amount and payment method
  6. Tap "Done" to dismiss

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Done Button

https://github.com/user-attachments/assets/90516fec-ba69-4663-9495-1a81cde7c552

### Receipt Button

https://github.com/user-attachments/assets/2ae2bf27-17d0-4c9b-910d-813108e15062



---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
