### PR TITLE
Shipping Labels: Send email to purchase requests

### DIFF
--- a/Modules/Sources/Fakes/Networking.generated.swift
+++ b/Modules/Sources/Fakes/Networking.generated.swift
@@ -760,39 +760,6 @@ extension Networking.Media {
         )
     }
 }
-extension Networking.OrderItemRefund {
-    /// Returns a "ready to use" type filled with fake values.
-    ///
-    public static func fake() -> Networking.OrderItemRefund {
-        .init(
-            itemID: .fake(),
-            name: .fake(),
-            productID: .fake(),
-            variationID: .fake(),
-            refundedItemID: .fake(),
-            quantity: .fake(),
-            price: .fake(),
-            sku: .fake(),
-            subtotal: .fake(),
-            subtotalTax: .fake(),
-            taxClass: .fake(),
-            taxes: .fake(),
-            total: .fake(),
-            totalTax: .fake()
-        )
-    }
-}
-extension Networking.OrderItemTaxRefund {
-    /// Returns a "ready to use" type filled with fake values.
-    ///
-    public static func fake() -> Networking.OrderItemTaxRefund {
-        .init(
-            taxID: .fake(),
-            subtotal: .fake(),
-            total: .fake()
-        )
-    }
-}
 extension Networking.POSProduct {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -1422,25 +1389,6 @@ extension Networking.Receipt {
         )
     }
 }
-extension Networking.Refund {
-    /// Returns a "ready to use" type filled with fake values.
-    ///
-    public static func fake() -> Networking.Refund {
-        .init(
-            refundID: .fake(),
-            orderID: .fake(),
-            siteID: .fake(),
-            dateCreated: .fake(),
-            amount: .fake(),
-            reason: .fake(),
-            refundedByUserID: .fake(),
-            isAutomated: .fake(),
-            createAutomated: .fake(),
-            items: .fake(),
-            shippingLines: .fake()
-        )
-    }
-}
 extension Networking.RemoteReaderLocation {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -1798,40 +1746,6 @@ extension Networking.ShippingLabelStoreOptions {
         )
     }
 }
-extension Networking.Site {
-    /// Returns a "ready to use" type filled with fake values.
-    ///
-    public static func fake() -> Networking.Site {
-        .init(
-            siteID: .fake(),
-            name: .fake(),
-            description: .fake(),
-            url: .fake(),
-            adminURL: .fake(),
-            loginURL: .fake(),
-            isSiteOwner: .fake(),
-            frameNonce: .fake(),
-            plan: .fake(),
-            isAIAssistantFeatureActive: .fake(),
-            isJetpackThePluginInstalled: .fake(),
-            isJetpackConnected: .fake(),
-            isWooCommerceActive: .fake(),
-            isWordPressComStore: .fake(),
-            jetpackConnectionActivePlugins: .fake(),
-            timezone: .fake(),
-            gmtOffset: .fake(),
-            visibility: .fake(),
-            canBlaze: .fake(),
-            isAdmin: .fake(),
-            wasEcommerceTrial: .fake(),
-            hasSSOEnabled: .fake(),
-            applicationPasswordAvailable: .fake(),
-            isGarden: .fake(),
-            gardenName: .fake(),
-            gardenPartner: .fake()
-        )
-    }
-}
 extension Networking.SiteAPI {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -1901,13 +1815,6 @@ extension Networking.SiteSettingGroup {
     ///
     public static func fake() -> Networking.SiteSettingGroup {
         .general
-    }
-}
-extension Networking.SiteVisibility {
-    /// Returns a "ready to use" type filled with fake values.
-    ///
-    public static func fake() -> Networking.SiteVisibility {
-        .privateSite
     }
 }
 extension Networking.StateOfACountry {
@@ -2327,6 +2234,7 @@ extension Networking.WooShippingAddress {
         .init(
             company: .fake(),
             name: .fake(),
+            email: .fake(),
             phone: .fake(),
             country: .fake(),
             state: .fake(),
@@ -2418,6 +2326,7 @@ extension Networking.WooShippingNormalizedAddress {
             company: .fake(),
             firstName: .fake(),
             lastName: .fake(),
+            email: .fake(),
             phone: .fake(),
             country: .fake(),
             state: .fake(),

--- a/Modules/Sources/Fakes/NetworkingCore.generated.swift
+++ b/Modules/Sources/Fakes/NetworkingCore.generated.swift
@@ -314,10 +314,43 @@ extension NetworkingCore.OrderItemProductAddOn {
         )
     }
 }
+extension NetworkingCore.OrderItemRefund {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> NetworkingCore.OrderItemRefund {
+        .init(
+            itemID: .fake(),
+            name: .fake(),
+            productID: .fake(),
+            variationID: .fake(),
+            refundedItemID: .fake(),
+            quantity: .fake(),
+            price: .fake(),
+            sku: .fake(),
+            subtotal: .fake(),
+            subtotalTax: .fake(),
+            taxClass: .fake(),
+            taxes: .fake(),
+            total: .fake(),
+            totalTax: .fake()
+        )
+    }
+}
 extension NetworkingCore.OrderItemTax {
     /// Returns a "ready to use" type filled with fake values.
     ///
     public static func fake() -> NetworkingCore.OrderItemTax {
+        .init(
+            taxID: .fake(),
+            subtotal: .fake(),
+            total: .fake()
+        )
+    }
+}
+extension NetworkingCore.OrderItemTaxRefund {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> NetworkingCore.OrderItemTaxRefund {
         .init(
             taxID: .fake(),
             subtotal: .fake(),
@@ -433,6 +466,25 @@ extension NetworkingCore.ProductVariationAttribute {
         )
     }
 }
+extension NetworkingCore.Refund {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> NetworkingCore.Refund {
+        .init(
+            refundID: .fake(),
+            orderID: .fake(),
+            siteID: .fake(),
+            dateCreated: .fake(),
+            amount: .fake(),
+            reason: .fake(),
+            refundedByUserID: .fake(),
+            isAutomated: .fake(),
+            createAutomated: .fake(),
+            items: .fake(),
+            shippingLines: .fake()
+        )
+    }
+}
 extension NetworkingCore.ShippingLabel {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -529,6 +581,40 @@ extension NetworkingCore.ShippingLineTax {
         )
     }
 }
+extension NetworkingCore.Site {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> NetworkingCore.Site {
+        .init(
+            siteID: .fake(),
+            name: .fake(),
+            description: .fake(),
+            url: .fake(),
+            adminURL: .fake(),
+            loginURL: .fake(),
+            isSiteOwner: .fake(),
+            frameNonce: .fake(),
+            plan: .fake(),
+            isAIAssistantFeatureActive: .fake(),
+            isJetpackThePluginInstalled: .fake(),
+            isJetpackConnected: .fake(),
+            isWooCommerceActive: .fake(),
+            isWordPressComStore: .fake(),
+            jetpackConnectionActivePlugins: .fake(),
+            timezone: .fake(),
+            gmtOffset: .fake(),
+            visibility: .fake(),
+            canBlaze: .fake(),
+            isAdmin: .fake(),
+            wasEcommerceTrial: .fake(),
+            hasSSOEnabled: .fake(),
+            applicationPasswordAvailable: .fake(),
+            isGarden: .fake(),
+            gardenName: .fake(),
+            gardenPartner: .fake()
+        )
+    }
+}
 extension NetworkingCore.SiteSummaryStats {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -540,6 +626,13 @@ extension NetworkingCore.SiteSummaryStats {
             visitors: .fake(),
             views: .fake()
         )
+    }
+}
+extension NetworkingCore.SiteVisibility {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> NetworkingCore.SiteVisibility {
+        .privateSite
     }
 }
 extension NetworkingCore.SiteVisitStats {

--- a/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -5,7 +5,6 @@ import Codegen
 import Foundation
 import WooFoundation
 import struct Alamofire.JSONEncoding
-import struct NetworkingCore.JetpackSite
 
 // swiftlint:disable line_length
 
@@ -1302,57 +1301,6 @@ extension Networking.NotificationSettings.Device {
     }
 }
 
-extension Networking.OrderItemRefund {
-    public func copy(
-        itemID: CopiableProp<Int64> = .copy,
-        name: CopiableProp<String> = .copy,
-        productID: CopiableProp<Int64> = .copy,
-        variationID: CopiableProp<Int64> = .copy,
-        refundedItemID: NullableCopiableProp<String> = .copy,
-        quantity: CopiableProp<Decimal> = .copy,
-        price: CopiableProp<NSDecimalNumber> = .copy,
-        sku: NullableCopiableProp<String> = .copy,
-        subtotal: CopiableProp<String> = .copy,
-        subtotalTax: CopiableProp<String> = .copy,
-        taxClass: CopiableProp<String> = .copy,
-        taxes: CopiableProp<[OrderItemTaxRefund]> = .copy,
-        total: CopiableProp<String> = .copy,
-        totalTax: CopiableProp<String> = .copy
-    ) -> Networking.OrderItemRefund {
-        let itemID = itemID ?? self.itemID
-        let name = name ?? self.name
-        let productID = productID ?? self.productID
-        let variationID = variationID ?? self.variationID
-        let refundedItemID = refundedItemID ?? self.refundedItemID
-        let quantity = quantity ?? self.quantity
-        let price = price ?? self.price
-        let sku = sku ?? self.sku
-        let subtotal = subtotal ?? self.subtotal
-        let subtotalTax = subtotalTax ?? self.subtotalTax
-        let taxClass = taxClass ?? self.taxClass
-        let taxes = taxes ?? self.taxes
-        let total = total ?? self.total
-        let totalTax = totalTax ?? self.totalTax
-
-        return Networking.OrderItemRefund(
-            itemID: itemID,
-            name: name,
-            productID: productID,
-            variationID: variationID,
-            refundedItemID: refundedItemID,
-            quantity: quantity,
-            price: price,
-            sku: sku,
-            subtotal: subtotal,
-            subtotalTax: subtotalTax,
-            taxClass: taxClass,
-            taxes: taxes,
-            total: total,
-            totalTax: totalTax
-        )
-    }
-}
-
 extension Networking.POSProduct {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,
@@ -2436,48 +2384,6 @@ extension Networking.Receipt {
     }
 }
 
-extension Networking.Refund {
-    public func copy(
-        refundID: CopiableProp<Int64> = .copy,
-        orderID: CopiableProp<Int64> = .copy,
-        siteID: CopiableProp<Int64> = .copy,
-        dateCreated: CopiableProp<Date> = .copy,
-        amount: CopiableProp<String> = .copy,
-        reason: CopiableProp<String> = .copy,
-        refundedByUserID: CopiableProp<Int64> = .copy,
-        isAutomated: NullableCopiableProp<Bool> = .copy,
-        createAutomated: NullableCopiableProp<Bool> = .copy,
-        items: CopiableProp<[OrderItemRefund]> = .copy,
-        shippingLines: NullableCopiableProp<[ShippingLine]> = .copy
-    ) -> Networking.Refund {
-        let refundID = refundID ?? self.refundID
-        let orderID = orderID ?? self.orderID
-        let siteID = siteID ?? self.siteID
-        let dateCreated = dateCreated ?? self.dateCreated
-        let amount = amount ?? self.amount
-        let reason = reason ?? self.reason
-        let refundedByUserID = refundedByUserID ?? self.refundedByUserID
-        let isAutomated = isAutomated ?? self.isAutomated
-        let createAutomated = createAutomated ?? self.createAutomated
-        let items = items ?? self.items
-        let shippingLines = shippingLines ?? self.shippingLines
-
-        return Networking.Refund(
-            refundID: refundID,
-            orderID: orderID,
-            siteID: siteID,
-            dateCreated: dateCreated,
-            amount: amount,
-            reason: reason,
-            refundedByUserID: refundedByUserID,
-            isAutomated: isAutomated,
-            createAutomated: createAutomated,
-            items: items,
-            shippingLines: shippingLines
-        )
-    }
-}
-
 extension Networking.RemoteReaderLocation {
     public func copy(
         locationID: CopiableProp<String> = .copy,
@@ -2837,93 +2743,6 @@ extension Networking.ShippingLabelPurchase {
             productNames: productNames,
             shipmentID: shipmentID,
             refund: refund
-        )
-    }
-}
-
-extension Networking.Site {
-    public func copy(
-        siteID: CopiableProp<Int64> = .copy,
-        name: CopiableProp<String> = .copy,
-        description: CopiableProp<String> = .copy,
-        url: CopiableProp<String> = .copy,
-        adminURL: CopiableProp<String> = .copy,
-        loginURL: CopiableProp<String> = .copy,
-        isSiteOwner: CopiableProp<Bool> = .copy,
-        frameNonce: CopiableProp<String> = .copy,
-        plan: CopiableProp<String> = .copy,
-        isAIAssistantFeatureActive: CopiableProp<Bool> = .copy,
-        isJetpackThePluginInstalled: CopiableProp<Bool> = .copy,
-        isJetpackConnected: CopiableProp<Bool> = .copy,
-        isWooCommerceActive: CopiableProp<Bool> = .copy,
-        isWordPressComStore: CopiableProp<Bool> = .copy,
-        jetpackConnectionActivePlugins: CopiableProp<[String]> = .copy,
-        timezone: CopiableProp<String> = .copy,
-        gmtOffset: CopiableProp<Double> = .copy,
-        visibility: CopiableProp<SiteVisibility> = .copy,
-        canBlaze: CopiableProp<Bool> = .copy,
-        isAdmin: CopiableProp<Bool> = .copy,
-        wasEcommerceTrial: CopiableProp<Bool> = .copy,
-        hasSSOEnabled: CopiableProp<Bool> = .copy,
-        applicationPasswordAvailable: CopiableProp<Bool> = .copy,
-        isGarden: CopiableProp<Bool> = .copy,
-        gardenName: NullableCopiableProp<String> = .copy,
-        gardenPartner: NullableCopiableProp<String> = .copy
-    ) -> Networking.Site {
-        let siteID = siteID ?? self.siteID
-        let name = name ?? self.name
-        let description = description ?? self.description
-        let url = url ?? self.url
-        let adminURL = adminURL ?? self.adminURL
-        let loginURL = loginURL ?? self.loginURL
-        let isSiteOwner = isSiteOwner ?? self.isSiteOwner
-        let frameNonce = frameNonce ?? self.frameNonce
-        let plan = plan ?? self.plan
-        let isAIAssistantFeatureActive = isAIAssistantFeatureActive ?? self.isAIAssistantFeatureActive
-        let isJetpackThePluginInstalled = isJetpackThePluginInstalled ?? self.isJetpackThePluginInstalled
-        let isJetpackConnected = isJetpackConnected ?? self.isJetpackConnected
-        let isWooCommerceActive = isWooCommerceActive ?? self.isWooCommerceActive
-        let isWordPressComStore = isWordPressComStore ?? self.isWordPressComStore
-        let jetpackConnectionActivePlugins = jetpackConnectionActivePlugins ?? self.jetpackConnectionActivePlugins
-        let timezone = timezone ?? self.timezone
-        let gmtOffset = gmtOffset ?? self.gmtOffset
-        let visibility = visibility ?? self.visibility
-        let canBlaze = canBlaze ?? self.canBlaze
-        let isAdmin = isAdmin ?? self.isAdmin
-        let wasEcommerceTrial = wasEcommerceTrial ?? self.wasEcommerceTrial
-        let hasSSOEnabled = hasSSOEnabled ?? self.hasSSOEnabled
-        let applicationPasswordAvailable = applicationPasswordAvailable ?? self.applicationPasswordAvailable
-        let isGarden = isGarden ?? self.isGarden
-        let gardenName = gardenName ?? self.gardenName
-        let gardenPartner = gardenPartner ?? self.gardenPartner
-
-        return Networking.Site(
-            siteID: siteID,
-            name: name,
-            description: description,
-            url: url,
-            adminURL: adminURL,
-            loginURL: loginURL,
-            isSiteOwner: isSiteOwner,
-            frameNonce: frameNonce,
-            plan: plan,
-            isAIAssistantFeatureActive: isAIAssistantFeatureActive,
-            isJetpackThePluginInstalled: isJetpackThePluginInstalled,
-            isJetpackConnected: isJetpackConnected,
-            isWooCommerceActive: isWooCommerceActive,
-            isWordPressComStore: isWordPressComStore,
-            jetpackConnectionActivePlugins: jetpackConnectionActivePlugins,
-            timezone: timezone,
-            gmtOffset: gmtOffset,
-            visibility: visibility,
-            canBlaze: canBlaze,
-            isAdmin: isAdmin,
-            wasEcommerceTrial: wasEcommerceTrial,
-            hasSSOEnabled: hasSSOEnabled,
-            applicationPasswordAvailable: applicationPasswordAvailable,
-            isGarden: isGarden,
-            gardenName: gardenName,
-            gardenPartner: gardenPartner
         )
     }
 }
@@ -3562,6 +3381,7 @@ extension Networking.WooShippingAddress {
     public func copy(
         company: CopiableProp<String> = .copy,
         name: CopiableProp<String> = .copy,
+        email: NullableCopiableProp<String> = .copy,
         phone: CopiableProp<String> = .copy,
         country: CopiableProp<String> = .copy,
         state: CopiableProp<String> = .copy,
@@ -3572,6 +3392,7 @@ extension Networking.WooShippingAddress {
     ) -> Networking.WooShippingAddress {
         let company = company ?? self.company
         let name = name ?? self.name
+        let email = email ?? self.email
         let phone = phone ?? self.phone
         let country = country ?? self.country
         let state = state ?? self.state
@@ -3583,6 +3404,7 @@ extension Networking.WooShippingAddress {
         return Networking.WooShippingAddress(
             company: company,
             name: name,
+            email: email,
             phone: phone,
             country: country,
             state: state,
@@ -3713,6 +3535,7 @@ extension Networking.WooShippingNormalizedAddress {
         company: CopiableProp<String> = .copy,
         firstName: CopiableProp<String> = .copy,
         lastName: CopiableProp<String> = .copy,
+        email: NullableCopiableProp<String> = .copy,
         phone: CopiableProp<String> = .copy,
         country: CopiableProp<String> = .copy,
         state: CopiableProp<String> = .copy,
@@ -3724,6 +3547,7 @@ extension Networking.WooShippingNormalizedAddress {
         let company = company ?? self.company
         let firstName = firstName ?? self.firstName
         let lastName = lastName ?? self.lastName
+        let email = email ?? self.email
         let phone = phone ?? self.phone
         let country = country ?? self.country
         let state = state ?? self.state
@@ -3736,6 +3560,7 @@ extension Networking.WooShippingNormalizedAddress {
             company: company,
             firstName: firstName,
             lastName: lastName,
+            email: email,
             phone: phone,
             country: country,
             state: state,

--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingNormalizedAddress.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingNormalizedAddress.swift
@@ -13,6 +13,9 @@ public struct WooShippingNormalizedAddress: Equatable, GeneratedFakeable, Genera
     /// The last name of the sender/receiver at the address.
     public let lastName: String
 
+    /// Email of the sender/receiver
+    public let email: String?
+
     /// The contact phone number at the address.
     public let phone: String
 
@@ -37,6 +40,7 @@ public struct WooShippingNormalizedAddress: Equatable, GeneratedFakeable, Genera
     public init(company: String,
                 firstName: String,
                 lastName: String,
+                email: String?,
                 phone: String,
                 country: String,
                 state: String,
@@ -47,6 +51,7 @@ public struct WooShippingNormalizedAddress: Equatable, GeneratedFakeable, Genera
         self.company = company
         self.firstName = firstName
         self.lastName = lastName
+        self.email = email
         self.phone = phone
         self.country = country
         self.state = state
@@ -64,6 +69,7 @@ extension WooShippingNormalizedAddress: Decodable {
         let firstName = try container.decodeIfPresent(String.self, forKey: .firstName) ?? ""
         let lastName = try container.decodeIfPresent(String.self, forKey: .lastName) ?? ""
         let company = try container.decode(String.self, forKey: .company)
+        let email = try container.decodeIfPresent(String.self, forKey: .email)
         let phone = try container.decode(String.self, forKey: .phone)
         let country = try container.decode(String.self, forKey: .country)
         let state = try container.decode(String.self, forKey: .state)
@@ -75,6 +81,7 @@ extension WooShippingNormalizedAddress: Decodable {
         self.init(company: company,
                   firstName: firstName,
                   lastName: lastName,
+                  email: email,
                   phone: phone,
                   country: country,
                   state: state,
@@ -88,6 +95,7 @@ extension WooShippingNormalizedAddress: Decodable {
         case company
         case firstName = "first_name"
         case lastName = "last_name"
+        case email
         case phone
         case country
         case state

--- a/Modules/Sources/Networking/Model/ShippingLabel/WooShippingAddress.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/WooShippingAddress.swift
@@ -10,6 +10,9 @@ public struct WooShippingAddress: Equatable, Hashable, GeneratedFakeable, Genera
     /// The name of the sender/receiver at the address.
     public let name: String
 
+    /// Email of the sender/receiver
+    public let email: String?
+
     /// The contact phone number at the address.
     public let phone: String
 
@@ -33,6 +36,7 @@ public struct WooShippingAddress: Equatable, Hashable, GeneratedFakeable, Genera
 
     public init(company: String,
                 name: String,
+                email: String?,
                 phone: String,
                 country: String,
                 state: String,
@@ -42,6 +46,7 @@ public struct WooShippingAddress: Equatable, Hashable, GeneratedFakeable, Genera
                 postcode: String) {
         self.company = company
         self.name = name
+        self.email = email
         self.phone = phone
         self.country = country
         self.state = state
@@ -59,6 +64,7 @@ extension WooShippingAddress: Codable {
         // If no name is sent to validation address request, no name will be received in response.
         // So make sure to decode it only if it's present.
         let name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        let email = try container.decodeIfPresent(String.self, forKey: .email)
         let company = try container.decodeIfPresent(String.self, forKey: .company) ?? ""
         let phone = try container.decodeIfPresent(String.self, forKey: .phone) ?? ""
         let country = try container.decode(String.self, forKey: .country)
@@ -70,6 +76,7 @@ extension WooShippingAddress: Codable {
 
         self.init(company: company,
                   name: name,
+                  email: email,
                   phone: phone,
                   country: country,
                   state: state,
@@ -89,6 +96,9 @@ extension WooShippingAddress: Codable {
         if !name.isEmpty {
             try container.encode(name, forKey: .name)
         }
+        if let email {
+            try container.encode(email, forKey: .email)
+        }
         try container.encode(phone, forKey: .phone)
         try container.encode(country, forKey: .country)
         try container.encode(state, forKey: .state)
@@ -101,6 +111,7 @@ extension WooShippingAddress: Codable {
     private enum CodingKeys: String, CodingKey {
         case company
         case name
+        case email
         case phone
         case country
         case state
@@ -116,7 +127,7 @@ extension WooShippingAddress {
     /// This empty initializer is used when parsing the API response for shipping labels, because the origin/destination addresses are not available in each
     /// shipping label response and we have to manually populate them later.
     init() {
-        self.init(company: "", name: "", phone: "", country: "", state: "", address1: "", address2: "", city: "", postcode: "")
+        self.init(company: "", name: "", email: nil, phone: "", country: "", state: "", address1: "", address2: "", city: "", postcode: "")
     }
 }
 

--- a/Modules/Sources/NetworkingCore/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/NetworkingCore/Model/Copiable/Models+Copiable.generated.swift
@@ -2,6 +2,7 @@
 // DO NOT EDIT
 import Codegen
 import Foundation
+import struct NetworkingCore.JetpackSite
 
 // swiftlint:disable line_length
 
@@ -554,6 +555,57 @@ extension NetworkingCore.OrderItemProductAddOn {
     }
 }
 
+extension NetworkingCore.OrderItemRefund {
+    public func copy(
+        itemID: CopiableProp<Int64> = .copy,
+        name: CopiableProp<String> = .copy,
+        productID: CopiableProp<Int64> = .copy,
+        variationID: CopiableProp<Int64> = .copy,
+        refundedItemID: NullableCopiableProp<String> = .copy,
+        quantity: CopiableProp<Decimal> = .copy,
+        price: CopiableProp<NSDecimalNumber> = .copy,
+        sku: NullableCopiableProp<String> = .copy,
+        subtotal: CopiableProp<String> = .copy,
+        subtotalTax: CopiableProp<String> = .copy,
+        taxClass: CopiableProp<String> = .copy,
+        taxes: CopiableProp<[OrderItemTaxRefund]> = .copy,
+        total: CopiableProp<String> = .copy,
+        totalTax: CopiableProp<String> = .copy
+    ) -> NetworkingCore.OrderItemRefund {
+        let itemID = itemID ?? self.itemID
+        let name = name ?? self.name
+        let productID = productID ?? self.productID
+        let variationID = variationID ?? self.variationID
+        let refundedItemID = refundedItemID ?? self.refundedItemID
+        let quantity = quantity ?? self.quantity
+        let price = price ?? self.price
+        let sku = sku ?? self.sku
+        let subtotal = subtotal ?? self.subtotal
+        let subtotalTax = subtotalTax ?? self.subtotalTax
+        let taxClass = taxClass ?? self.taxClass
+        let taxes = taxes ?? self.taxes
+        let total = total ?? self.total
+        let totalTax = totalTax ?? self.totalTax
+
+        return NetworkingCore.OrderItemRefund(
+            itemID: itemID,
+            name: name,
+            productID: productID,
+            variationID: variationID,
+            refundedItemID: refundedItemID,
+            quantity: quantity,
+            price: price,
+            sku: sku,
+            subtotal: subtotal,
+            subtotalTax: subtotalTax,
+            taxClass: taxClass,
+            taxes: taxes,
+            total: total,
+            totalTax: totalTax
+        )
+    }
+}
+
 extension NetworkingCore.OrderStatsV4 {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,
@@ -695,6 +747,48 @@ extension NetworkingCore.ProductVariationAttribute {
     }
 }
 
+extension NetworkingCore.Refund {
+    public func copy(
+        refundID: CopiableProp<Int64> = .copy,
+        orderID: CopiableProp<Int64> = .copy,
+        siteID: CopiableProp<Int64> = .copy,
+        dateCreated: CopiableProp<Date> = .copy,
+        amount: CopiableProp<String> = .copy,
+        reason: CopiableProp<String> = .copy,
+        refundedByUserID: CopiableProp<Int64> = .copy,
+        isAutomated: NullableCopiableProp<Bool> = .copy,
+        createAutomated: NullableCopiableProp<Bool> = .copy,
+        items: CopiableProp<[OrderItemRefund]> = .copy,
+        shippingLines: NullableCopiableProp<[ShippingLine]> = .copy
+    ) -> NetworkingCore.Refund {
+        let refundID = refundID ?? self.refundID
+        let orderID = orderID ?? self.orderID
+        let siteID = siteID ?? self.siteID
+        let dateCreated = dateCreated ?? self.dateCreated
+        let amount = amount ?? self.amount
+        let reason = reason ?? self.reason
+        let refundedByUserID = refundedByUserID ?? self.refundedByUserID
+        let isAutomated = isAutomated ?? self.isAutomated
+        let createAutomated = createAutomated ?? self.createAutomated
+        let items = items ?? self.items
+        let shippingLines = shippingLines ?? self.shippingLines
+
+        return NetworkingCore.Refund(
+            refundID: refundID,
+            orderID: orderID,
+            siteID: siteID,
+            dateCreated: dateCreated,
+            amount: amount,
+            reason: reason,
+            refundedByUserID: refundedByUserID,
+            isAutomated: isAutomated,
+            createAutomated: createAutomated,
+            items: items,
+            shippingLines: shippingLines
+        )
+    }
+}
+
 extension NetworkingCore.ShippingLabel {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,
@@ -829,6 +923,93 @@ extension NetworkingCore.ShippingLine {
             total: total,
             totalTax: totalTax,
             taxes: taxes
+        )
+    }
+}
+
+extension NetworkingCore.Site {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        name: CopiableProp<String> = .copy,
+        description: CopiableProp<String> = .copy,
+        url: CopiableProp<String> = .copy,
+        adminURL: CopiableProp<String> = .copy,
+        loginURL: CopiableProp<String> = .copy,
+        isSiteOwner: CopiableProp<Bool> = .copy,
+        frameNonce: CopiableProp<String> = .copy,
+        plan: CopiableProp<String> = .copy,
+        isAIAssistantFeatureActive: CopiableProp<Bool> = .copy,
+        isJetpackThePluginInstalled: CopiableProp<Bool> = .copy,
+        isJetpackConnected: CopiableProp<Bool> = .copy,
+        isWooCommerceActive: CopiableProp<Bool> = .copy,
+        isWordPressComStore: CopiableProp<Bool> = .copy,
+        jetpackConnectionActivePlugins: CopiableProp<[String]> = .copy,
+        timezone: CopiableProp<String> = .copy,
+        gmtOffset: CopiableProp<Double> = .copy,
+        visibility: CopiableProp<SiteVisibility> = .copy,
+        canBlaze: CopiableProp<Bool> = .copy,
+        isAdmin: CopiableProp<Bool> = .copy,
+        wasEcommerceTrial: CopiableProp<Bool> = .copy,
+        hasSSOEnabled: CopiableProp<Bool> = .copy,
+        applicationPasswordAvailable: CopiableProp<Bool> = .copy,
+        isGarden: CopiableProp<Bool> = .copy,
+        gardenName: NullableCopiableProp<String> = .copy,
+        gardenPartner: NullableCopiableProp<String> = .copy
+    ) -> NetworkingCore.Site {
+        let siteID = siteID ?? self.siteID
+        let name = name ?? self.name
+        let description = description ?? self.description
+        let url = url ?? self.url
+        let adminURL = adminURL ?? self.adminURL
+        let loginURL = loginURL ?? self.loginURL
+        let isSiteOwner = isSiteOwner ?? self.isSiteOwner
+        let frameNonce = frameNonce ?? self.frameNonce
+        let plan = plan ?? self.plan
+        let isAIAssistantFeatureActive = isAIAssistantFeatureActive ?? self.isAIAssistantFeatureActive
+        let isJetpackThePluginInstalled = isJetpackThePluginInstalled ?? self.isJetpackThePluginInstalled
+        let isJetpackConnected = isJetpackConnected ?? self.isJetpackConnected
+        let isWooCommerceActive = isWooCommerceActive ?? self.isWooCommerceActive
+        let isWordPressComStore = isWordPressComStore ?? self.isWordPressComStore
+        let jetpackConnectionActivePlugins = jetpackConnectionActivePlugins ?? self.jetpackConnectionActivePlugins
+        let timezone = timezone ?? self.timezone
+        let gmtOffset = gmtOffset ?? self.gmtOffset
+        let visibility = visibility ?? self.visibility
+        let canBlaze = canBlaze ?? self.canBlaze
+        let isAdmin = isAdmin ?? self.isAdmin
+        let wasEcommerceTrial = wasEcommerceTrial ?? self.wasEcommerceTrial
+        let hasSSOEnabled = hasSSOEnabled ?? self.hasSSOEnabled
+        let applicationPasswordAvailable = applicationPasswordAvailable ?? self.applicationPasswordAvailable
+        let isGarden = isGarden ?? self.isGarden
+        let gardenName = gardenName ?? self.gardenName
+        let gardenPartner = gardenPartner ?? self.gardenPartner
+
+        return NetworkingCore.Site(
+            siteID: siteID,
+            name: name,
+            description: description,
+            url: url,
+            adminURL: adminURL,
+            loginURL: loginURL,
+            isSiteOwner: isSiteOwner,
+            frameNonce: frameNonce,
+            plan: plan,
+            isAIAssistantFeatureActive: isAIAssistantFeatureActive,
+            isJetpackThePluginInstalled: isJetpackThePluginInstalled,
+            isJetpackConnected: isJetpackConnected,
+            isWooCommerceActive: isWooCommerceActive,
+            isWordPressComStore: isWordPressComStore,
+            jetpackConnectionActivePlugins: jetpackConnectionActivePlugins,
+            timezone: timezone,
+            gmtOffset: gmtOffset,
+            visibility: visibility,
+            canBlaze: canBlaze,
+            isAdmin: isAdmin,
+            wasEcommerceTrial: wasEcommerceTrial,
+            hasSSOEnabled: hasSSOEnabled,
+            applicationPasswordAvailable: applicationPasswordAvailable,
+            isGarden: isGarden,
+            gardenName: gardenName,
+            gardenPartner: gardenPartner
         )
     }
 }

--- a/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -88,7 +88,8 @@ extension Yosemite.POSOrder {
         formattedDiscountTotal: NullableCopiableProp<String> = .copy,
         formattedTotalTax: CopiableProp<String> = .copy,
         formattedPaymentTotal: CopiableProp<String> = .copy,
-        formattedNetAmount: NullableCopiableProp<String> = .copy
+        formattedNetAmount: NullableCopiableProp<String> = .copy,
+        lineItemQuantitiesByProductOrVariationID: CopiableProp<[Int64: Decimal]> = .copy
     ) -> Yosemite.POSOrder {
         let id = id ?? self.id
         let number = number ?? self.number
@@ -104,6 +105,7 @@ extension Yosemite.POSOrder {
         let formattedTotalTax = formattedTotalTax ?? self.formattedTotalTax
         let formattedPaymentTotal = formattedPaymentTotal ?? self.formattedPaymentTotal
         let formattedNetAmount = formattedNetAmount ?? self.formattedNetAmount
+        let lineItemQuantitiesByProductOrVariationID = lineItemQuantitiesByProductOrVariationID ?? self.lineItemQuantitiesByProductOrVariationID
 
         return Yosemite.POSOrder(
             id: id,
@@ -119,7 +121,8 @@ extension Yosemite.POSOrder {
             formattedDiscountTotal: formattedDiscountTotal,
             formattedTotalTax: formattedTotalTax,
             formattedPaymentTotal: formattedPaymentTotal,
-            formattedNetAmount: formattedNetAmount
+            formattedNetAmount: formattedNetAmount,
+            lineItemQuantitiesByProductOrVariationID: lineItemQuantitiesByProductOrVariationID
         )
     }
 }
@@ -186,7 +189,7 @@ extension Yosemite.POSSite {
 
 extension Yosemite.ProductReviewFromNoteParcel {
     public func copy(
-        note: CopiableProp<Note> = .copy,
+        note: NullableCopiableProp<Note> = .copy,
         review: CopiableProp<ProductReview> = .copy,
         product: CopiableProp<Networking.Product> = .copy
     ) -> Yosemite.ProductReviewFromNoteParcel {

--- a/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -394,12 +394,15 @@ final class WooShippingRemoteTests: XCTestCase {
         )
         let markOrderComplete = true
 
+        let originEmail = "origin@example.com"
+        let destinationEmail = "destination@example.com"
+
         // When
         let result: Result<[ShippingLabelPurchase], Error> = waitFor { promise in
             remote.purchaseShippingLabel(siteID: self.sampleSiteID,
                                          orderID: self.sampleOrderID,
-                                         originAddress: WooShippingAddress.fake(),
-                                         destinationAddress: WooShippingAddress.fake(),
+                                         originAddress: WooShippingAddress.fake().copy(email: originEmail),
+                                         destinationAddress: WooShippingAddress.fake().copy(email: destinationEmail),
                                          package: package,
                                          markOrderComplete: markOrderComplete) { result in
                 promise(result)
@@ -442,6 +445,12 @@ final class WooShippingRemoteTests: XCTestCase {
         XCTAssertEqual(firstPackage["non_delivery_option"] as? String, "return")
         XCTAssertEqual(firstPackage["restriction_comments"] as? String, "")
         XCTAssertEqual(firstPackage["contents_explanation"] as? String, "")
+
+        let originParam = try XCTUnwrap(request.parameters["origin"] as? [String: Any])
+        XCTAssertEqual(originParam["email"] as? String, originEmail)
+
+        let destinationParam = try XCTUnwrap(request.parameters["destination"] as? [String: Any])
+        XCTAssertEqual(destinationParam["email"] as? String, destinationEmail)
 
         let selectedRateParam = try XCTUnwrap(request.parameters["selected_rate"] as? [String: Any])
         let parentValue = try XCTUnwrap(selectedRateParam["parent"] as? [String: Any])

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
@@ -5,6 +5,13 @@ extension WooAnalyticsEvent {
     enum BookingsDetail {
         private enum Properties {
             static let bookingStatus = "booking_status"
+            static let action = "action"
+        }
+
+        enum Action: String {
+            case cancelBooking = "cancel_booking"
+            case updateAttendance = "update_attendance"
+            case markAsPaid = "mark_as_paid"
         }
 
         static func bookingCancelled() -> WooAnalyticsEvent {
@@ -32,26 +39,11 @@ extension WooAnalyticsEvent {
 
         static func failedToUpdateBookingDetails(action: Action, error: Error) -> WooAnalyticsEvent {
             let properties: [String: WooAnalyticsEventPropertyType] = [
-                BookingProperties.action: action.rawValue
+                Properties.action: action.rawValue
             ]
             return  WooAnalyticsEvent(statName: .bookingListFailedToUpdateBookingDetails,
                                       properties: properties,
                                       error: error)
         }
-    }
-}
-
-fileprivate extension WooAnalyticsEvent.BookingsDetail {
-    enum BookingProperties {
-        static let bookingStatus = "booking_status"
-        static let action = "action"
-    }
-}
-
-extension WooAnalyticsEvent.BookingsDetail {
-    enum Action: String {
-        case cancelBooking = "cancel_booking"
-        case updateAttendance = "update_attendance"
-        case markAsPaid = "mark_as_paid"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -232,11 +232,16 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
                                                          package: package,
                                                          selectedRate: selectedRate,
                                                          productIDs: shipment.items.map(\.productOrVariationID))
+
+        // Avoid sending email for destination address as that crashes the purchase API at the moment.
+        // TODO: remove this workaround when backend fixes this and adoption rate is high enough.
+        let destinationAddressWithoutEmail = destinationAddress.copy(email: nil)
+
         let purchasedLabel = try await withCheckedThrowingContinuation { continuation in
             let action = WooShippingAction.purchaseShippingLabel(siteID: order.siteID,
                                                                  orderID: order.orderID,
                                                                  originAddress: originAddress,
-                                                                 destinationAddress: destinationAddress,
+                                                                 destinationAddress: destinationAddressWithoutEmail,
                                                                  package: packagePurchase,
                                                                  markOrderComplete: markOrderComplete) { [weak self] result in
                 switch result {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTOS/UPSTermsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/UPSTOS/UPSTermsView.swift
@@ -220,6 +220,7 @@ private extension UPSTermsView {
     UPSTermsView(viewModel: UPSTermsViewModel(siteID: 123,
                                               originAddress: .init(company: "A8C",
                                                                    name: "John Doe",
+                                                                   email: "test@mail.com",
                                                                    phone: "09381734543",
                                                                    country: "US",
                                                                    state: "New York",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingDestinationAddress+Woo.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingDestinationAddress+Woo.swift
@@ -22,6 +22,7 @@ extension WooShippingDestinationAddress {
     func toWooShippingAddress() -> WooShippingAddress {
         WooShippingAddress(company: company,
                            name: name.isNotEmpty ? name : fullName,
+                           email: email,
                            phone: phone,
                            country: country,
                            state: state,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -353,6 +353,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     func proceedWithInputAddress() {
         let address = WooShippingAddress(company: company.value,
                                          name: name.value,
+                                         email: email.value,
                                          phone: phone.value,
                                          country: country.value,
                                          state: state.value,
@@ -368,6 +369,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     func remotelyValidateAddress() async {
         let addressToValidate = WooShippingAddress(company: company.value,
                                                    name: name.value,
+                                                   email: email.value,
                                                    phone: phone.value,
                                                    country: country.value,
                                                    state: state.value,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -4,6 +4,7 @@ import Yosemite
 import protocol Storage.StorageManagerType
 import protocol WooFoundation.Analytics
 import Combine
+import class WordPressShared.EmailFormatValidator
 
 /// View model for editing an address in the Woo Shipping label flow.
 final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
@@ -235,7 +236,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
             newPostalCode.isEmpty ? Localization.Validation.postalCode : nil
         })
         self.email = WooShippingAddressField(type: .email, value: email, required: true, validate: { newEmail in
-            newEmail.isEmpty ? Localization.Validation.email : nil
+            (newEmail.isEmpty || !EmailFormatValidator.validate(string: newEmail)) ? Localization.Validation.email : nil
         })
         let phoneNumberRequired = Self.phoneNumberRequired(addressType: type,
                                                            selectedCountryCode: country,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizeAddressViewModel.swift
@@ -45,6 +45,7 @@ extension WooShippingNormalizeAddressViewModel {
     static var sampleEnteredAddress: WooShippingAddress {
         WooShippingAddress(company: "",
                            name: "",
+                           email: "",
                            phone: "",
                            country: "US",
                            state: "NY",
@@ -57,6 +58,7 @@ extension WooShippingNormalizeAddressViewModel {
     static var sampleSuggestedAddress: WooShippingAddress {
         WooShippingAddress(company: "",
                            name: "",
+                           email: "",
                            phone: "",
                            country: "US",
                            state: "NY",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizedAddress+Woo.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingNormalizedAddress+Woo.swift
@@ -23,6 +23,7 @@ extension WooShippingNormalizedAddress {
     func toWooShippingAddress() -> WooShippingAddress {
         WooShippingAddress(company: company,
                            name: fullName,
+                           email: email,
                            phone: phone,
                            country: country,
                            state: state,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -846,6 +846,7 @@ extension WooShippingOriginAddress {
     func toWooShippingAddress() -> WooShippingAddress {
         WooShippingAddress(company: company,
                            name: fullName,
+                           email: email,
                            phone: phone,
                            country: country,
                            state: state,
@@ -864,6 +865,7 @@ private extension ShippingLabelAddress {
     func toWooShippingAddress() -> WooShippingAddress {
         WooShippingAddress(company: company,
                            name: name,
+                           email: nil, // ignoring as we don't display email on UI for purchased labels
                            phone: phone,
                            country: country,
                            state: state,
@@ -882,6 +884,7 @@ private extension Address {
     func toWooShippingAddress() -> WooShippingAddress {
         return WooShippingAddress(company: company ?? "",
                                   name: fullName,
+                                  email: email,
                                   phone: phone ?? "",
                                   country: country,
                                   state: state,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/UPSTermsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/UPSTermsViewModelTests.swift
@@ -8,6 +8,7 @@ struct UPSTermsViewModelTests {
         // Given
         let originAddress = WooShippingAddress(company: "A8C",
                                                name: "Teddy Bear",
+                                               email: nil,
                                                phone: "0985728394",
                                                country: "US",
                                                state: "New York",
@@ -37,6 +38,7 @@ struct UPSTermsViewModelTests {
         // Given
         let originAddress = WooShippingAddress(company: "A8C",
                                                name: "Teddy Bear",
+                                               email: nil,
                                                phone: "0985728394",
                                                country: "US",
                                                state: "New York",
@@ -59,6 +61,7 @@ struct UPSTermsViewModelTests {
         // Given
         let originAddress = WooShippingAddress(company: "A8C",
                                                name: "Teddy Bear",
+                                               email: nil,
                                                phone: "0985728394",
                                                country: "US",
                                                state: "New York",
@@ -82,6 +85,7 @@ struct UPSTermsViewModelTests {
         // Given
         let originAddress = WooShippingAddress(company: "A8C",
                                                name: "Teddy Bear",
+                                               email: nil,
                                                phone: "0985728394",
                                                country: "US",
                                                state: "New York",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -110,8 +110,10 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let state = StateOfACountry(code: "NY", name: "New York")
         let countries = [Country(code: "US", name: "United States", states: [state]), Country(code: "CA", name: "Canada", states: [])]
         storageManager.insertSampleCountries(readOnlyCountries: countries)
+        let email = "TEST@EXAMPLE.COM"
         let address = WooShippingAddress(company: "HEADQUARTERS",
                                          name: "JANE DOE",
+                                         email: email,
                                          phone: "223-456-7890",
                                          country: "US",
                                          state: "NY",
@@ -119,7 +121,6 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                          address2: "STE 100",
                                          city: "TICONDEROGA",
                                          postcode: "12883-1487")
-        let email = "TEST@EXAMPLE.COM"
 
         // When
         let viewModel = WooShippingEditAddressViewModel(address: address,
@@ -257,6 +258,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         // Given
         let address = WooShippingAddress(company: "HEADQUARTERS",
                                          name: "JANE DOE",
+                                         email: "",
                                          phone: "223-456-7890",
                                          country: "US",
                                          state: "NY",
@@ -281,6 +283,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         // Given
         let address = WooShippingAddress(company: "HEADQUARTERS",
                                          name: "JANE DOE",
+                                         email: "",
                                          phone: "223-456-7890",
                                          country: "US",
                                          state: "NY",
@@ -780,6 +783,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         // Given
         let expectedAddress = WooShippingAddress(company: "HEADQUARTERS",
                                                  name: "JANE DOE",
+                                                 email: "",
                                                  phone: "1-234-456-7890",
                                                  country: "US",
                                                  state: "NY",
@@ -937,6 +941,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let suggestedAddress = WooShippingNormalizedAddress(company: "HEADQUARTERS",
                                                             firstName: "JANE",
                                                             lastName: "DOE",
+                                                            email: "TEXT@EXAMPLE.COM",
                                                             phone: "123-456-7890",
                                                             country: "US",
                                                             state: "NY",
@@ -1020,6 +1025,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let suggestedAddress = WooShippingNormalizedAddress(company: "HEADQUARTERS",
                                                             firstName: "JANE",
                                                             lastName: "DOE",
+                                                            email: "TEXT@EXAMPLE.COM",
                                                             phone: "123-456-7890",
                                                             country: "US",
                                                             state: "NY",
@@ -1075,6 +1081,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         let sampleOrderID: Int64 = 123
         let normalizedAddress = WooShippingNormalizedAddress.fake().copy(firstName: "JANE",
                                                                          lastName: "DOE",
+                                                                         email: "TEXT@EXAMPLE.COM",
                                                                          phone: "123-456-7890")
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let result: (WooShippingDestinationAddressUpdate, String?) = await waitForAsync { promise in
@@ -1614,6 +1621,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
         let testAddress = WooShippingAddress(company: "TEST COMPANY",
                                              name: "TEST NAME",
+                                             email: "test@example.com",
                                              phone: "555-123-4567",
                                              country: "US",
                                              state: "CA",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -545,6 +545,7 @@ private extension WooShippingServiceViewModelTests {
     func sampleDestinationAddress() -> WooShippingAddress {
         WooShippingAddress(company: "HEADQUARTERS",
                            name: "JANE DOE",
+                           email: nil,
                            phone: "1-234-456-7890",
                            country: "US",
                            state: "NY",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
@@ -991,6 +991,7 @@ private extension WooShippingShipmentDetailsViewModelTests {
     func sampleOriginAddress(country: String, state: String) -> WooShippingAddress {
         WooShippingAddress(company: "HEADQUARTERS",
                            name: "John Doe",
+                           email: nil,
                            phone: "",
                            country: country,
                            state: state,
@@ -1004,6 +1005,7 @@ private extension WooShippingShipmentDetailsViewModelTests {
     func sampleDestinationAddress(country: String, state: String) -> WooShippingAddress {
         WooShippingAddress(company: "",
                            name: "",
+                           email: nil,
                            phone: "",
                            country: country,
                            state: state,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-2090

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR follows a recent requirement for email in origin address for shipping label purchase requests. More info can be found in p1769606745065859-slack-C05VBLKHHV1.

The solution is to add a new field `email` to `WooShippingAddress` and `WooShippingNormalizedAddress`. I'm skipping the similar change to `ShippingLabelAddress` as this model is for addresses from purchased labels, and we're not displaying emails for those. Also, skipping that saves us from a Core Data migration.

Most of the changes come from generated code for Copiable and Fakeable. I also updated some analytics code of Booking because the structure causes an assertion failure in Sourcery.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Log in to a test store with WooShipping plugin setup.
2. Create a complete order with physical products or open an existing one.
3. Select Create shipping label and fill in the details. Ensure to fill in email address for both origin and destination addresses.
4. Proceed to purchase a label.
5. Confirm with Proxyman that your purchase request includes the input email addresses.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

No UI changes.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.