### PR TITLE
Push Notifications: Workaround for magic link login

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -40,6 +40,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ///
     private var jetpackSetupCoordinator: JetpackSetupCoordinator?
 
+    /// Coordinates the setup flow for self-driven push notification system
+    private var wooPushNotificationCoordinator: WooPushNotificationSetupCoordinator?
+
     private(set) lazy var requirementsChecker = RequirementsChecker(baseViewController: tabBarController)
 
     /// Handles events to background refresh the app.
@@ -458,9 +461,9 @@ extension AppDelegate {
     }
 
     func handleAuthenticationUrlForNotificationSetup(_ url: URL, rootViewController: UIViewController) -> Bool {
-        // TODO: Handle magic link for notification setup
-        DDLogDebug("📱 Handling magic link for notification setup")
-        return false
+        let coordinator = WooPushNotificationSetupCoordinator(rootViewController: rootViewController)
+        wooPushNotificationCoordinator = coordinator
+        return coordinator.handleAuthenticationUrl(url)
     }
 
     func handleAuthenticationUrlForJetpackSetup(_ url: URL, rootViewController: UIViewController) -> Bool {

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -439,11 +439,28 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 // MARK: - Magic link
 extension AppDelegate {
     func handleAuthenticationUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any], rootViewController: UIViewController) -> Bool {
-        return if ServiceLocator.stores.isAuthenticated {
-            handleAuthenticationUrlForJetpackSetup(url, rootViewController: rootViewController)
+        if ServiceLocator.stores.isAuthenticated {
+            let pendingAuthFlowStorage = PendingAuthFlowStorage()
+            let flow = pendingAuthFlowStorage.current
+            pendingAuthFlowStorage.clear()
+
+            switch flow {
+            case .notificationSetup:
+                return handleAuthenticationUrlForNotificationSetup(url, rootViewController: rootViewController)
+            case .jetpackSetup:
+                return handleAuthenticationUrlForJetpackSetup(url, rootViewController: rootViewController)
+            case .none:
+                return false
+            }
         } else {
-            ServiceLocator.authenticationManager.handleAuthenticationUrl(url, options: options, rootViewController: rootViewController)
+            return ServiceLocator.authenticationManager.handleAuthenticationUrl(url, options: options, rootViewController: rootViewController)
         }
+    }
+
+    func handleAuthenticationUrlForNotificationSetup(_ url: URL, rootViewController: UIViewController) -> Bool {
+        // TODO: Handle magic link for notification setup
+        DDLogDebug("📱 Handling magic link for notification setup")
+        return false
     }
 
     func handleAuthenticationUrlForJetpackSetup(_ url: URL, rootViewController: UIViewController) -> Bool {

--- a/WooCommerce/Classes/Authentication/PendingAuthFlowStorage.swift
+++ b/WooCommerce/Classes/Authentication/PendingAuthFlowStorage.swift
@@ -20,23 +20,18 @@ struct PendingAuthFlowStorage {
     }
 
     var current: PendingAuthFlow? {
-        get {
-            guard let dict = userDefaults.dictionary(forKey: storageKey),
-                  let flowName = dict.keys.first,
-                  let timestamp = dict[flowName] as? Date,
-                  Date().timeIntervalSince(timestamp) < expirationInterval else {
-                clear() // Auto-clear if expired or missing data
-                return nil
-            }
-            return PendingAuthFlow(rawValue: flowName)
+        guard let dict = userDefaults.dictionary(forKey: storageKey),
+              let flowName = dict.keys.first,
+              let timestamp = dict[flowName] as? Date,
+              Date().timeIntervalSince(timestamp) < expirationInterval else {
+            clear() // Auto-clear if expired or missing data
+            return nil
         }
-        set {
-            if let value = newValue {
-                userDefaults.set([value.rawValue: Date()], forKey: storageKey)
-            } else {
-                clear()
-            }
-        }
+        return PendingAuthFlow(rawValue: flowName)
+    }
+
+    func updateCurrentFlow(_ flow: PendingAuthFlow) {
+        userDefaults.set([flow.rawValue: Date()], forKey: storageKey)
     }
 
     func clear() {

--- a/WooCommerce/Classes/Authentication/PendingAuthFlowStorage.swift
+++ b/WooCommerce/Classes/Authentication/PendingAuthFlowStorage.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Tracks which authentication flow is pending when a magic link is sent.
+/// This is used to route the magic link callback to the correct handler when the app
+/// is launched from a cold start via the magic link.
+enum PendingAuthFlow: String {
+    case jetpackSetup
+    case notificationSetup
+}
+
+struct PendingAuthFlowStorage {
+    private let userDefaults: UserDefaults
+    private let storageKey = "pendingAuthFlow"
+
+    /// Magic links typically expire in ~10-15 minutes
+    private let expirationInterval: TimeInterval = 15 * 60
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    var current: PendingAuthFlow? {
+        get {
+            guard let dict = userDefaults.dictionary(forKey: storageKey),
+                  let flowName = dict.keys.first,
+                  let timestamp = dict[flowName] as? Date,
+                  Date().timeIntervalSince(timestamp) < expirationInterval else {
+                clear() // Auto-clear if expired or missing data
+                return nil
+            }
+            return PendingAuthFlow(rawValue: flowName)
+        }
+        set {
+            if let value = newValue {
+                userDefaults.set([value.rawValue: Date()], forKey: storageKey)
+            } else {
+                clear()
+            }
+        }
+    }
+
+    func clear() {
+        userDefaults.removeObject(forKey: storageKey)
+    }
+}

--- a/WooCommerce/Classes/Authentication/PendingAuthFlowStorage.swift
+++ b/WooCommerce/Classes/Authentication/PendingAuthFlowStorage.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Tracks which authentication flow is pending when a magic link is sent.
 /// This is used to route the magic link callback to the correct handler when the app
 /// is launched from a cold start via the magic link.
-enum PendingAuthFlow: String {
+enum PendingAuthFlow: String, Codable {
     case jetpackSetup
     case notificationSetup
 }
@@ -20,21 +20,28 @@ struct PendingAuthFlowStorage {
     }
 
     var current: PendingAuthFlow? {
-        guard let dict = userDefaults.dictionary(forKey: storageKey),
-              let flowName = dict.keys.first,
-              let timestamp = dict[flowName] as? Date,
-              Date().timeIntervalSince(timestamp) < expirationInterval else {
+        guard let object = userDefaults.data(forKey: storageKey),
+              let storedFlow = try? JSONDecoder().decode(StoredFlow.self, from: object),
+              Date().timeIntervalSince(storedFlow.timestamp) < expirationInterval else {
             clear() // Auto-clear if expired or missing data
             return nil
         }
-        return PendingAuthFlow(rawValue: flowName)
+        return storedFlow.flow
     }
 
     func updateCurrentFlow(_ flow: PendingAuthFlow) {
-        userDefaults.set([flow.rawValue: Date()], forKey: storageKey)
+        let stored = StoredFlow(flow: flow, timestamp: Date())
+        userDefaults.set(try? JSONEncoder().encode(stored), forKey: storageKey)
     }
 
     func clear() {
         userDefaults.removeObject(forKey: storageKey)
+    }
+}
+
+extension PendingAuthFlowStorage {
+    struct StoredFlow: Codable {
+        let flow: PendingAuthFlow
+        let timestamp: Date
     }
 }

--- a/WooCommerce/Classes/Authentication/PendingAuthFlowStorage.swift
+++ b/WooCommerce/Classes/Authentication/PendingAuthFlowStorage.swift
@@ -10,7 +10,7 @@ enum PendingAuthFlow: String {
 
 struct PendingAuthFlowStorage {
     private let userDefaults: UserDefaults
-    private let storageKey = "pendingAuthFlow"
+    private let storageKey = UserDefaults.Key.pendingMagicLinkFlow.rawValue
 
     /// Magic links typically expire in ~10-15 minutes
     private let expirationInterval: TimeInterval = 15 * 60

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComLoginCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComLoginCoordinator.swift
@@ -7,6 +7,13 @@ import WooFoundation
 enum WPComLoginFlow {
     case notificationSetup
     case jetpackSetup(requiresConnectionOnly: Bool)
+
+    var pendingAuthFlow: PendingAuthFlow {
+        switch self {
+        case .notificationSetup: .notificationSetup
+        case .jetpackSetup: .jetpackSetup
+        }
+    }
 }
 
 /// Coordinates navigation for the login flow with WPCom accounts.
@@ -153,6 +160,8 @@ private extension WPComLoginCoordinator {
     /// We're letting WPAuthenticator handle the deeplink for now.
     ///
     func showMagicLinkSentUI(email: String) {
+        let storage = PendingAuthFlowStorage()
+        storage.updateCurrentFlow(flow.pendingAuthFlow)
         let viewController = WPComMagicLinkHostingController(email: email,
                                                              title: title,
                                                              flow: flow,

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -81,8 +81,11 @@ extension UserDefaults {
         /// Registered site IDs separated by commas
         case siteIDsRegisteredForWooPushNotifications
 
-        // Whether WPCom connection suggestion for Woo-driven push notifications is hidden
+        /// Whether WPCom connection suggestion for Woo-driven push notifications is hidden
         case hideWPComConnectionOnDashboard
+
+        /// Pending flow for magic link: notification setup or Jetpack setup
+        case pendingMagicLinkFlow
     }
 }
 

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -39,9 +39,33 @@ final class WooPushNotificationSetupCoordinator {
             loginCoordinator.startWithoutEmail()
         }
     }
+
+    func handleAuthenticationUrl(_ url: URL, dotcomAuthScheme: String = ApiCredentials.dotcomAuthScheme) -> Bool {
+        let expectedPrefix = dotcomAuthScheme + "://" + Constants.magicLinkUrlHostname
+        guard url.absoluteString.hasPrefix(expectedPrefix) else {
+            return false
+        }
+
+        guard let queryDictionary = url.query?.dictionaryFromQueryString() else {
+            DDLogError("⛔️ Magic link error: we couldn't retrieve the query dictionary from the sign-in URL.")
+            return false
+        }
+
+        guard let authToken = queryDictionary.string(forKey: "token") else {
+            DDLogError("⛔️ Magic link error: we couldn't retrieve the authentication token from the sign-in URL.")
+            return false
+        }
+
+        // TODO: start Jetpack connection flow with the retrieved authToken.
+        return true
+    }
 }
 
 private extension WooPushNotificationSetupCoordinator {
+    enum Constants {
+        static let magicLinkUrlHostname = "magic-login"
+    }
+
     enum Localization {
         static let flowTitle = NSLocalizedString(
             "wooPushNotificationSetupCoordinator.flowTitle",

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -20,7 +20,7 @@ final class WooPushNotificationSetupCoordinator {
                 flow: .notificationSetup,
                 navigationController: UINavigationController(),
                 completionHandler: { credentials in
-                    // TODO: use credentials for Jetpack setup flow.
+                    // TODO: use credentials for Jetpack connection flow.
                     // Consider reusing JetpackSetupViewModel
                     // Also check JetpackSetupHostingController for more details on what the credentials are for.
                     DDLogDebug("📱 Authentication complete, proceed with Jetpack connection")
@@ -57,6 +57,7 @@ final class WooPushNotificationSetupCoordinator {
         }
 
         // TODO: start Jetpack connection flow with the retrieved authToken.
+        DDLogDebug("📱 Magic link success, now proceed with Jetpack connection")
         return true
     }
 }

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -250,7 +250,7 @@ final class SessionManager: SessionManagerProtocol {
         defaults[.ciabBookingsTabAvailable] = nil
         defaults[.siteIDsRegisteredForWooPushNotifications] = nil
         defaults[.hideWPComConnectionOnDashboard] = nil
-        defaults[.pendingMagicLinkFlow] = nil
+        PendingAuthFlowStorage(userDefaults: defaults).clear()
         resetTimestampsValues()
         imageCache.clearCache()
     }

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -250,6 +250,7 @@ final class SessionManager: SessionManagerProtocol {
         defaults[.ciabBookingsTabAvailable] = nil
         defaults[.siteIDsRegisteredForWooPushNotifications] = nil
         defaults[.hideWPComConnectionOnDashboard] = nil
+        defaults[.pendingMagicLinkFlow] = nil
         resetTimestampsValues()
         imageCache.clearCache()
     }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -386,6 +386,8 @@ private extension JetpackSetupCoordinator {
 
     func showMagicLinkSentUI(email: String, isSignup: Bool) {
         analytics.track(event: .JetpackSetup.loginFlow(step: .magicLink, isSignup: isSignup))
+        let storage = PendingAuthFlowStorage()
+        storage.updateCurrentFlow(.jetpackSetup)
         let viewController = WPComMagicLinkHostingController(email: email,
                                                              title: loginViewTitle,
                                                              flow: loginFlow,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2489,6 +2489,7 @@
 		DE7E5E912B4FD8F0002E28D2 /* BlazeTargetTopicPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E5E902B4FD8F0002E28D2 /* BlazeTargetTopicPickerViewModel.swift */; };
 		DE7E5E932B4FECCA002E28D2 /* BlazeTargetTopicPickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E5E922B4FECCA002E28D2 /* BlazeTargetTopicPickerViewModelTests.swift */; };
 		DE7FF07C2EE809CD00B31E35 /* TechnicalDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7FF07B2EE809CD00B31E35 /* TechnicalDetailsView.swift */; };
+		DE8308B12F2A2B650038C589 /* PendingAuthFlowStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8308B02F2A2B650038C589 /* PendingAuthFlowStorage.swift */; };
 		DE8311C02C6C8D3800A88709 /* BlazeCampaignListItemCustomizationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8311BF2C6C8D3800A88709 /* BlazeCampaignListItemCustomizationsTests.swift */; };
 		DE83FCDA2F29B6F30038C589 /* WooPushNotificationSetupCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE83FCD92F29B6D00038C589 /* WooPushNotificationSetupCoordinator.swift */; };
 		DE85E4ED2AB416F5008789E1 /* AddProductWithAIActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE85E4EC2AB416F5008789E1 /* AddProductWithAIActionSheet.swift */; };
@@ -5452,6 +5453,7 @@
 		DE7E5E902B4FD8F0002E28D2 /* BlazeTargetTopicPickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeTargetTopicPickerViewModel.swift; sourceTree = "<group>"; };
 		DE7E5E922B4FECCA002E28D2 /* BlazeTargetTopicPickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeTargetTopicPickerViewModelTests.swift; sourceTree = "<group>"; };
 		DE7FF07B2EE809CD00B31E35 /* TechnicalDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TechnicalDetailsView.swift; sourceTree = "<group>"; };
+		DE8308B02F2A2B650038C589 /* PendingAuthFlowStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingAuthFlowStorage.swift; sourceTree = "<group>"; };
 		DE8311BF2C6C8D3800A88709 /* BlazeCampaignListItemCustomizationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignListItemCustomizationsTests.swift; sourceTree = "<group>"; };
 		DE83FCD92F29B6D00038C589 /* WooPushNotificationSetupCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPushNotificationSetupCoordinator.swift; sourceTree = "<group>"; };
 		DE85E4EC2AB416F5008789E1 /* AddProductWithAIActionSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddProductWithAIActionSheet.swift; sourceTree = "<group>"; };
@@ -9709,6 +9711,7 @@
 				B5A8F8AB20B88D8400D211DE /* Prologue */,
 				B5D1AFC420BC7B3000DB0E8C /* Epilogue */,
 				B55D4C0520B6027100D7A50F /* AuthenticationManager.swift */,
+				DE8308B02F2A2B650038C589 /* PendingAuthFlowStorage.swift */,
 				DEF13C512963D0B20024A02B /* PostSiteCredentialLoginChecker.swift */,
 				DEEDA238298A11FB0088256B /* SiteCredentialLoginUseCase.swift */,
 				CE16177921B7192A00B82A47 /* AuthenticationConstants.swift */,
@@ -15773,6 +15776,7 @@
 				CEA16F3A20FD0C8C0061B4E1 /* WooAnalytics.swift in Sources */,
 				023053492374528A00487A64 /* AztecBlockquoteFormatBarCommand.swift in Sources */,
 				CE29FEF42C009D7C007679C2 /* ShippingLineRowViewModel.swift in Sources */,
+				DE8308B12F2A2B650038C589 /* PendingAuthFlowStorage.swift in Sources */,
 				0282DD98233CA093006A5FDB /* OrderSearchUICommand.swift in Sources */,
 				B541B21A2189F3A2008FE7C1 /* StringFormatter.swift in Sources */,
 				0250192B2BDF3757009493A5 /* PriceFieldFormatter.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2491,6 +2491,7 @@
 		DE7FF07C2EE809CD00B31E35 /* TechnicalDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7FF07B2EE809CD00B31E35 /* TechnicalDetailsView.swift */; };
 		DE8308B12F2A2B650038C589 /* PendingAuthFlowStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8308B02F2A2B650038C589 /* PendingAuthFlowStorage.swift */; };
 		DE8311C02C6C8D3800A88709 /* BlazeCampaignListItemCustomizationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8311BF2C6C8D3800A88709 /* BlazeCampaignListItemCustomizationsTests.swift */; };
+		DE8320592F2B62220038C589 /* PendingAuthFlowStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8320582F2B62220038C589 /* PendingAuthFlowStorageTests.swift */; };
 		DE83FCDA2F29B6F30038C589 /* WooPushNotificationSetupCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE83FCD92F29B6D00038C589 /* WooPushNotificationSetupCoordinator.swift */; };
 		DE85E4ED2AB416F5008789E1 /* AddProductWithAIActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE85E4EC2AB416F5008789E1 /* AddProductWithAIActionSheet.swift */; };
 		DE86E9272A4BEA2500A89A5B /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE86E9262A4BEA2500A89A5B /* FeedbackView.swift */; };
@@ -5455,6 +5456,7 @@
 		DE7FF07B2EE809CD00B31E35 /* TechnicalDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TechnicalDetailsView.swift; sourceTree = "<group>"; };
 		DE8308B02F2A2B650038C589 /* PendingAuthFlowStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingAuthFlowStorage.swift; sourceTree = "<group>"; };
 		DE8311BF2C6C8D3800A88709 /* BlazeCampaignListItemCustomizationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignListItemCustomizationsTests.swift; sourceTree = "<group>"; };
+		DE8320582F2B62220038C589 /* PendingAuthFlowStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingAuthFlowStorageTests.swift; sourceTree = "<group>"; };
 		DE83FCD92F29B6D00038C589 /* WooPushNotificationSetupCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPushNotificationSetupCoordinator.swift; sourceTree = "<group>"; };
 		DE85E4EC2AB416F5008789E1 /* AddProductWithAIActionSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddProductWithAIActionSheet.swift; sourceTree = "<group>"; };
 		DE86E9262A4BEA2500A89A5B /* FeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
@@ -8868,6 +8870,7 @@
 				D8610BDC256F5ABF00A5DF27 /* JetpackErrorViewModelTests.swift */,
 				57C2F6E424C27B1E00131012 /* Epilogue */,
 				D8610BF6256F5F0900A5DF27 /* ULErrorViewControllerTests.swift */,
+				DE8320582F2B62220038C589 /* PendingAuthFlowStorageTests.swift */,
 				DEEDA23C298A22180088256B /* SiteCredentialLoginUseCaseTests.swift */,
 				DE2FE5822924DA2F0018040A /* JetpackSetupRequiredViewModelTests.swift */,
 				D85DD1D6257F359800861AA8 /* NotWPErrorViewModelTests.swift */,
@@ -16076,6 +16079,7 @@
 				EE289AEC2C9D7CF7004AB1A6 /* ImageTextScannerTests.swift in Sources */,
 				EE0EE7A828B74EF300F6061E /* CustomHelpCenterContentTests.swift in Sources */,
 				4574745F24EA9ADE00CF49BC /* ProductTypeBottomSheetListSelectorCommandTests.swift in Sources */,
+				DE8320592F2B62220038C589 /* PendingAuthFlowStorageTests.swift in Sources */,
 				26C0D1E52B460EB700F6EDA5 /* WooConstants.swift in Sources */,
 				AEE2611126E6785400B142A0 /* EditOrderAddressFormViewModelTests.swift in Sources */,
 				0212683724C049F000F8A892 /* ProductListMultiSelectorDataSourceTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/PendingAuthFlowStorageTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/PendingAuthFlowStorageTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Testing
+@testable import WooCommerce
+
+struct PendingAuthFlowStorageTests {
+
+    private let storageKey = "pendingMagicLinkFlow"
+
+    private func makeUserDefaults() -> UserDefaults {
+        let suiteName = UUID().uuidString
+        return UserDefaults(suiteName: suiteName)!
+    }
+
+    // MARK: - current
+
+    @Test func current_returns_nil_when_nothing_is_stored() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        let storage = PendingAuthFlowStorage(userDefaults: userDefaults)
+
+        // When
+        let result = storage.current
+
+        // Then
+        #expect(result == nil)
+    }
+
+    @Test func current_returns_jetpackSetup_when_stored() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        let storage = PendingAuthFlowStorage(userDefaults: userDefaults)
+        storage.updateCurrentFlow(.jetpackSetup)
+
+        // When
+        let result = storage.current
+
+        // Then
+        #expect(result == .jetpackSetup)
+    }
+
+    @Test func current_returns_notificationSetup_when_stored() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        let storage = PendingAuthFlowStorage(userDefaults: userDefaults)
+        storage.updateCurrentFlow(.notificationSetup)
+
+        // When
+        let result = storage.current
+
+        // Then
+        #expect(result == .notificationSetup)
+    }
+
+    @Test func current_returns_nil_when_flow_is_expired() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        let storage = PendingAuthFlowStorage(userDefaults: userDefaults)
+
+        // Store an expired flow (16 minutes ago, expiration is 15 minutes)
+        let expiredDate = Date().addingTimeInterval(-16 * 60)
+        userDefaults.set([PendingAuthFlow.jetpackSetup.rawValue: expiredDate], forKey: storageKey)
+
+        // When
+        let result = storage.current
+
+        // Then
+        #expect(result == nil)
+    }
+
+    @Test func current_returns_flow_when_not_expired() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        let storage = PendingAuthFlowStorage(userDefaults: userDefaults)
+
+        // Store a flow that is not expired (5 minutes ago)
+        let recentDate = Date().addingTimeInterval(-5 * 60)
+        userDefaults.set([PendingAuthFlow.notificationSetup.rawValue: recentDate], forKey: storageKey)
+
+        // When
+        let result = storage.current
+
+        // Then
+        #expect(result == .notificationSetup)
+    }
+
+    @Test func current_clears_storage_when_expired() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        let storage = PendingAuthFlowStorage(userDefaults: userDefaults)
+
+        // Store an expired flow
+        let expiredDate = Date().addingTimeInterval(-16 * 60)
+        userDefaults.set([PendingAuthFlow.jetpackSetup.rawValue: expiredDate], forKey: storageKey)
+
+        // When
+        _ = storage.current
+
+        // Then
+        #expect(userDefaults.dictionary(forKey: storageKey) == nil)
+    }
+
+    // MARK: - updateCurrentFlow
+
+    @Test func updateCurrentFlow_stores_flow_with_current_timestamp() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        let storage = PendingAuthFlowStorage(userDefaults: userDefaults)
+        let beforeUpdate = Date()
+
+        // When
+        storage.updateCurrentFlow(.jetpackSetup)
+
+        // Then
+        let afterUpdate = Date()
+        let storedDict = userDefaults.dictionary(forKey: storageKey)
+        #expect(storedDict != nil)
+        #expect(storedDict?.keys.first == PendingAuthFlow.jetpackSetup.rawValue)
+
+        let storedDate = storedDict?[PendingAuthFlow.jetpackSetup.rawValue] as? Date
+        #expect(storedDate != nil)
+        #expect(storedDate! >= beforeUpdate)
+        #expect(storedDate! <= afterUpdate)
+    }
+
+    @Test func updateCurrentFlow_overwrites_previous_flow() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        let storage = PendingAuthFlowStorage(userDefaults: userDefaults)
+        storage.updateCurrentFlow(.jetpackSetup)
+
+        // When
+        storage.updateCurrentFlow(.notificationSetup)
+
+        // Then
+        let result = storage.current
+        #expect(result == .notificationSetup)
+    }
+
+    // MARK: - clear
+
+    @Test func clear_removes_stored_flow() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        let storage = PendingAuthFlowStorage(userDefaults: userDefaults)
+        storage.updateCurrentFlow(.jetpackSetup)
+
+        // When
+        storage.clear()
+
+        // Then
+        #expect(storage.current == nil)
+        #expect(userDefaults.dictionary(forKey: storageKey) == nil)
+    }
+
+    @Test func clear_succeeds_when_nothing_is_stored() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        let storage = PendingAuthFlowStorage(userDefaults: userDefaults)
+
+        // When/Then - should not throw
+        storage.clear()
+
+        #expect(storage.current == nil)
+    }
+}

--- a/WooCommerce/WooCommerceTests/Authentication/PendingAuthFlowStorageTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/PendingAuthFlowStorageTests.swift
@@ -11,6 +11,22 @@ struct PendingAuthFlowStorageTests {
         return UserDefaults(suiteName: suiteName)!
     }
 
+    /// Helper to store a flow with a specific timestamp directly in UserDefaults
+    /// This mirrors the internal StoredFlow structure used by PendingAuthFlowStorage
+    private func storeFlow(_ flow: PendingAuthFlow, timestamp: Date, in userDefaults: UserDefaults) {
+        let stored = PendingAuthFlowStorage.StoredFlow(flow: flow, timestamp: timestamp)
+        userDefaults.set(try? JSONEncoder().encode(stored), forKey: storageKey)
+    }
+
+    /// Helper to read the stored flow data from UserDefaults
+    private func readStoredFlow(from userDefaults: UserDefaults) -> (flow: PendingAuthFlow, timestamp: Date)? {
+        guard let data = userDefaults.data(forKey: storageKey),
+              let stored = try? JSONDecoder().decode(PendingAuthFlowStorage.StoredFlow.self, from: data) else {
+            return nil
+        }
+        return (stored.flow, stored.timestamp)
+    }
+
     // MARK: - current
 
     @Test func current_returns_nil_when_nothing_is_stored() {
@@ -58,7 +74,7 @@ struct PendingAuthFlowStorageTests {
 
         // Store an expired flow (16 minutes ago, expiration is 15 minutes)
         let expiredDate = Date().addingTimeInterval(-16 * 60)
-        userDefaults.set([PendingAuthFlow.jetpackSetup.rawValue: expiredDate], forKey: storageKey)
+        storeFlow(.jetpackSetup, timestamp: expiredDate, in: userDefaults)
 
         // When
         let result = storage.current
@@ -74,7 +90,7 @@ struct PendingAuthFlowStorageTests {
 
         // Store a flow that is not expired (5 minutes ago)
         let recentDate = Date().addingTimeInterval(-5 * 60)
-        userDefaults.set([PendingAuthFlow.notificationSetup.rawValue: recentDate], forKey: storageKey)
+        storeFlow(.notificationSetup, timestamp: recentDate, in: userDefaults)
 
         // When
         let result = storage.current
@@ -90,13 +106,13 @@ struct PendingAuthFlowStorageTests {
 
         // Store an expired flow
         let expiredDate = Date().addingTimeInterval(-16 * 60)
-        userDefaults.set([PendingAuthFlow.jetpackSetup.rawValue: expiredDate], forKey: storageKey)
+        storeFlow(.jetpackSetup, timestamp: expiredDate, in: userDefaults)
 
         // When
         _ = storage.current
 
         // Then
-        #expect(userDefaults.dictionary(forKey: storageKey) == nil)
+        #expect(userDefaults.data(forKey: storageKey) == nil)
     }
 
     // MARK: - updateCurrentFlow
@@ -112,14 +128,11 @@ struct PendingAuthFlowStorageTests {
 
         // Then
         let afterUpdate = Date()
-        let storedDict = userDefaults.dictionary(forKey: storageKey)
-        #expect(storedDict != nil)
-        #expect(storedDict?.keys.first == PendingAuthFlow.jetpackSetup.rawValue)
-
-        let storedDate = storedDict?[PendingAuthFlow.jetpackSetup.rawValue] as? Date
-        #expect(storedDate != nil)
-        #expect(storedDate! >= beforeUpdate)
-        #expect(storedDate! <= afterUpdate)
+        let storedFlow = readStoredFlow(from: userDefaults)
+        #expect(storedFlow != nil)
+        #expect(storedFlow?.flow == .jetpackSetup)
+        #expect(storedFlow!.timestamp >= beforeUpdate)
+        #expect(storedFlow!.timestamp <= afterUpdate)
     }
 
     @Test func updateCurrentFlow_overwrites_previous_flow() {
@@ -149,7 +162,7 @@ struct PendingAuthFlowStorageTests {
 
         // Then
         #expect(storage.current == nil)
-        #expect(userDefaults.dictionary(forKey: storageKey) == nil)
+        #expect(userDefaults.data(forKey: storageKey) == nil)
     }
 
     @Test func clear_succeeds_when_nothing_is_stored() {

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -472,7 +472,8 @@ final class SessionManagerTests: XCTestCase {
         let sut = SessionManager(defaults: defaults, keychainServiceName: Settings.keychainServiceName)
 
         // When
-        defaults[.pendingMagicLinkFlow] = ["jetpackSetup": Date()]
+        let flow = PendingAuthFlowStorage.StoredFlow(flow: .jetpackSetup, timestamp: Date())
+        defaults[.pendingMagicLinkFlow] = try? JSONEncoder().encode(flow)
 
         // Then
         XCTAssertNotNil(defaults[.pendingMagicLinkFlow])

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -465,6 +465,25 @@ final class SessionManagerTests: XCTestCase {
         XCTAssertNil(defaults[.hideWPComConnectionOnDashboard])
     }
 
+    func test_pendingMagicLinkFlow_is_cleared_upon_reset() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let sut = SessionManager(defaults: defaults, keychainServiceName: Settings.keychainServiceName)
+
+        // When
+        defaults[.pendingMagicLinkFlow] = ["jetpackSetup": Date()]
+
+        // Then
+        XCTAssertNotNil(defaults[.pendingMagicLinkFlow])
+
+        // When
+        sut.reset()
+
+        // Then
+        XCTAssertNil(defaults[.pendingMagicLinkFlow])
+    }
+
     /// Verifies that `removeDefaultCredentials` effectively nukes everything from the keychain
     ///
     func testDefaultCredentialsAreEffectivelyNuked() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-2083

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Context

The Woo PN setup flow uses a similar mechanism as what we used for Jetpack setup: we ask users to log in with WPCom then proceed with Jetpack connection handling.

The login flow includes the option to use magic link. Even though the magic link request accepts a source parameter, this field is forced to be either `default` or `jetpack-login`. `jetpack-login` is a custom field made for the Jetpack (WordPress) app. Sending custom values for this field is not accepted, unless we actually update the API endpoint.

### Solution

This PR adds a workaround to differentiate the magic link flow for Jetpack setup and Woo PN setup. The solution is to use a UserDefaults key with an expiration date of 15 minutes. The value is set after a magic link is requested.

`AppDelegate` then uses this key to check for pending flow when a magic link is detected. It will then start a corresponding coordinator to continue the flow with the magic link.

For extra safety, this key is also cleared upon logout.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Pre-requisites: Create a new Jurassic Ninja site with normal Woo version and no Jetpack plugin.

### TC1: Regression check for Jetpack setup.
1. Ensure that feature flags `selfDrivenPushTokenWPCom` and `selfDrivenPushTokenAppPasswords` are disabled.
2. Build and run the app on a physical device.
3. Log in to the test store.
4. Tap on the Jetpack banner on the dashboard and proceed to the setup flow.
5. Enter your email address then select the option to use magic link for login.
6. Open the email for magic link login and tap on Log in.
7. Confirm that the app is opened and Jetpack setup flow is continued.

### TC2: Woo PN setup
1. Ensure that feature flags `selfDrivenPushTokenWPCom` and `selfDrivenPushTokenAppPasswords` are enabled.
2. Build and run the app on a physical device.
3. Log in to the test store.
4. Tap on the Connect WPCom card on the dashboard and proceed to the setup flow.
5. Enter your email address then select the option to use magic link for login.
6. Open the email for magic link login and tap on Log in.
7. Confirm that the app is opened and notice in Xcode console log: `📱 Magic link success, now proceed with Jetpack connection`.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

No UI changes

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
