### PR TITLE
Fix product promotable type filtering

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 24.1
 -----
 - [Internal]: Update Stripe SDK to 5.1.1 [https://github.com/woocommerce/woocommerce-ios/pull/16493]
+- [*] Fix product type filters issue when adding a product to order [https://github.com/woocommerce/woocommerce-ios/pull/16580]
 
 24.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
@@ -84,9 +84,11 @@ final class FilterProductListViewModel: FilterListViewModel {
     /// - Parameters:
     ///   - filters: the filters to be applied initially.
     ///   - siteID: Current selected store's ID
+    ///   - site: Current selected store's Site instance, if available
     ///   - featureFlagService: Feature flag service
     init(filters: Filters,
          siteID: Int64,
+         site: Site? = nil,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
@@ -94,7 +96,13 @@ final class FilterProductListViewModel: FilterListViewModel {
         self.featureFlagService = featureFlagService
         self.stockStatusFilterViewModel = ProductListFilter.stockStatus.createViewModel(filters: filters)
         self.productStatusFilterViewModel = ProductListFilter.productStatus.createViewModel(filters: filters)
-        self.productTypeFilterViewModel = ProductListFilter.productType(siteID: siteID).createViewModel(filters: filters, storageManager: storageManager)
+        self.productTypeFilterViewModel = ProductListFilter
+            .productType(siteID: siteID)
+            .createViewModel(
+                filters: filters,
+                storageManager: storageManager,
+                site: site ?? stores.sessionManager.defaultSite
+            )
         self.productCategoryFilterViewModel = ProductListFilter.productCategory(siteID: siteID).createViewModel(filters: filters)
         self.productFavoriteFilterViewModel = ProductListFilter.favoriteProducts.createViewModel(filters: filters)
         self.shouldShowHistory = featureFlagService.isFeatureFlagEnabled(.filterHistoryOnOrderAndProductLists)
@@ -260,6 +268,7 @@ extension FilterProductListViewModel.ProductListFilter {
 extension FilterProductListViewModel.ProductListFilter {
     func createViewModel(filters: FilterProductListViewModel.Filters,
                          storageManager: StorageManagerType = ServiceLocator.storageManager,
+                         site: Site? = nil,
                          siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker()) -> FilterTypeViewModel {
         switch self {
         case .stockStatus:
@@ -275,6 +284,7 @@ extension FilterProductListViewModel.ProductListFilter {
         case let .productType(siteID):
             let options = buildPromotableTypes(
                 siteID: siteID,
+                site: site,
                 storageManager: storageManager,
                 siteCIABEligibilityChecker: siteCIABEligibilityChecker
             )
@@ -296,43 +306,58 @@ extension FilterProductListViewModel.ProductListFilter {
     ///
     private func buildPromotableTypes(
         siteID: Int64,
+        site: Site?,
         storageManager: StorageManagerType,
         siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol,
     ) -> [PromotableProductType?] {
-        guard let site = fetchStorageSite(
-            siteID: siteID,
-            storageManager: storageManager
-        ) else {
-            assertionFailure("Failed to obtain current Site from local storage.")
-            return []
-        }
-
         let activePlugins = fetchActivePlugins(siteID: siteID, storageManager: storageManager)
         let isSubscriptionsAvailable = activePlugins.contains(.wooSubscriptions)
         let isCompositeProductsAvailable = activePlugins.contains(.wooCompositeProducts)
         let isProductBundlesAvailable = activePlugins.contains(.wooProductBundles)
 
-        let isVariableProductVisible = siteCIABEligibilityChecker.isFeatureSupported(
-            .variableProducts,
-            for: site
+        let isVariableProductVisible: Bool
+        let isGroupedProductVisible: Bool
+        let isBookableProductVisible: Bool
+        let isSubscriptionProductVisible: Bool
+        let isBundleProductVisible: Bool
+        let isCompositeProductVisible: Bool
+
+        let resolvedSite = site ?? fetchStorageSite(
+            siteID: siteID,
+            storageManager: storageManager
         )
-        let isGroupedProductVisible = siteCIABEligibilityChecker.isFeatureSupported(
-            .groupedProducts,
-            for: site
-        )
-        let isBookableProductVisible = siteCIABEligibilityChecker.isSiteCIAB(site)
-        let isSubscriptionProductVisible = siteCIABEligibilityChecker.isFeatureSupported(
-            .subscriptionProducts,
-            for: site
-        )
-        let isBundleProductVisible = siteCIABEligibilityChecker.isFeatureSupported(
-            .bundleProducts,
-            for: site
-        )
-        let isCompositeProductVisible = siteCIABEligibilityChecker.isFeatureSupported(
-            .compositeProducts,
-            for: site
-        )
+
+        if let site = resolvedSite {
+            isVariableProductVisible = siteCIABEligibilityChecker.isFeatureSupported(
+                .variableProducts,
+                for: site
+            )
+            isGroupedProductVisible = siteCIABEligibilityChecker.isFeatureSupported(
+                .groupedProducts,
+                for: site
+            )
+            isBookableProductVisible = siteCIABEligibilityChecker.isSiteCIAB(site)
+            isSubscriptionProductVisible = siteCIABEligibilityChecker.isFeatureSupported(
+                .subscriptionProducts,
+                for: site
+            )
+            isBundleProductVisible = siteCIABEligibilityChecker.isFeatureSupported(
+                .bundleProducts,
+                for: site
+            )
+            isCompositeProductVisible = siteCIABEligibilityChecker.isFeatureSupported(
+                .compositeProducts,
+                for: site
+            )
+        } else {
+            /// Fallback positively if site is absent and there is no way to check CIAB eligibility
+            isVariableProductVisible = true
+            isGroupedProductVisible = true
+            isBookableProductVisible = true
+            isSubscriptionProductVisible = true
+            isBundleProductVisible = true
+            isCompositeProductVisible = true
+        }
 
         let productTypes: [PromotableProductType] = [
             .init(productType: .simple, isAvailable: true, promoteUrl: nil),

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -81,7 +81,13 @@ final class ProductSelectorViewModel: ObservableObject {
     /// View model for the filter list.
     ///
     var filterListViewModel: FilterProductListViewModel {
-        FilterProductListViewModel(filters: filtersSubject.value, siteID: siteID, storageManager: storageManager)
+        FilterProductListViewModel(
+            filters: filtersSubject.value,
+            siteID: siteID,
+            site: stores.sessionManager.defaultSite,
+            stores: stores,
+            storageManager: storageManager
+        )
     }
 
     /// Selected filters for the product list

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -1266,7 +1266,11 @@ private extension ProductsViewController {
 
     @objc func filterButtonTapped() {
         ServiceLocator.analytics.track(event: .ProductListFilter.productListViewFilterOptionsTapped(source: .productsTab))
-        let viewModel = FilterProductListViewModel(filters: filters, siteID: siteID)
+        let viewModel = FilterProductListViewModel(
+            filters: filters,
+            siteID: siteID,
+            site: ServiceLocator.stores.sessionManager.defaultSite
+        )
         let filterProductListViewController = FilterListViewController(viewModel: viewModel, onFilterAction: { [weak self] filters in
             ServiceLocator.analytics.track(event: .ProductListFilter.productFilterListShowProductsButtonTapped(source: .productsTab, filters: filters))
             self?.filters = filters

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
@@ -7,17 +7,14 @@ final class FilterProductListViewModelTests: XCTestCase {
 
     let sampleSiteID: Int64 = 0
     var storageManager: MockStorageManager!
+    var sampleSite: Site!
 
     override func setUp() {
         super.setUp()
 
         storageManager = MockStorageManager()
-        storageManager.insertSampleSite(
-            readOnlySite: Site.fake().copy(
-                siteID: sampleSiteID,
-                isGarden: false,
-            )
-        )
+        sampleSite = Site.fake().copy(siteID: sampleSiteID, isGarden: false)
+        storageManager.insertSampleSite(readOnlySite: sampleSite)
     }
 
     func testCriteriaWithDefaultFilters() {
@@ -193,6 +190,26 @@ final class FilterProductListViewModelTests: XCTestCase {
         XCTAssertEqual(removedSettings?.productCategoryFilter, filters.productCategory)
         XCTAssertEqual(removedSettings?.favoriteProduct, filters.favoriteProduct?.isActive ?? false)
     }
+
+    func test_productTypeFilter_usesStorageSite_whenSiteIsNil() {
+        // Given
+        let checker = CIABEligibilityCheckerSiteCaptureMock()
+        let filters = FilterProductListViewModel.Filters()
+
+        // When
+        let viewModel = FilterProductListViewModel.ProductListFilter
+            .productType(siteID: sampleSiteID)
+            .createViewModel(filters: filters,
+                             storageManager: storageManager,
+                             site: nil,
+                             siteCIABEligibilityChecker: checker)
+
+        // Then
+        guard case .staticOptions = viewModel.listSelectorConfig else {
+            return XCTFail("Expected static options for product type filter.")
+        }
+        XCTAssertEqual(checker.lastSite, sampleSite)
+    }
 }
 
 private extension FilterProductListViewModelTests {
@@ -205,5 +222,25 @@ private extension FilterProductListViewModelTests {
                                            productCategory: filterProductCategory,
                                            favoriteProduct: FavoriteProductsFilter(),
                                            numberOfActiveFilters: 5)
+    }
+}
+
+private final class CIABEligibilityCheckerSiteCaptureMock: CIABEligibilityCheckerProtocol {
+    private(set) var lastSite: Site?
+
+    var isCurrentSiteCIAB: Bool { false }
+
+    func isSiteCIAB(_ site: Site) -> Bool {
+        lastSite = site
+        return false
+    }
+
+    func isFeatureSupportedForCurrentSite(_ feature: CIABAffectedFeature) -> Bool {
+        true
+    }
+
+    func isFeatureSupported(_ feature: CIABAffectedFeature, for site: Site) -> Bool {
+        lastSite = site
+        return true
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-2085

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The issue occurred when filtering product types during order creation after logging in with store credentials. The flow uses a placeholder `siteID` (-1), so the early guard that tried to load a Site from storage failed and triggered an assertionFailure. That wasn’t a crash, but it was still an error caused by the premature fallback when the site wasn’t available in storage.

We now pass the `Site` instance (when available) into the filter view model and fall back to storage to resolve the site before running CIAB eligibility checks. This avoids the assertion in the store‑credentials flow and keeps product type visibility consistent.

 Note: for now we still carry both site and siteID in the context since siteID is required for storage‑keyed operations and site is needed for CIAB checks.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Run from Xcode
- Use non CIAB testing site.
- Login with store credentials.
- Go to Orders -> Create new order -> Add product -> Filter.
- Make sure the `assertionFailure("Failed to obtain current Site from local storage.")` is not triggered.
- Open product type filter. Make sure product type filters entries are in place.

## Screenshots
Before (assertion deleted) | After
--- | ---
<img width="400" height="798" alt="Screenshot 2026-01-29 at 15 28 13" src="https://github.com/user-attachments/assets/c5a4d9f1-3ddf-4a29-99a1-6eb7595299ac" /> | <img width="403" height="457" alt="Screenshot 2026-01-29 at 15 22 47" src="https://github.com/user-attachments/assets/820d0947-b9e9-42ad-ae42-d636cc032426" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
