### PR TITLE
POS: Update historical orders empty search state copy

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListEmptyViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListEmptyViewModel.swift
@@ -13,7 +13,7 @@ struct POSOrderListEmptyViewModel: POSListEmptyViewModelProtocol {
     }
 
     var hint: String? {
-        isSearching ? Localization.emptyOrdersSearchHint : nil
+        nil
     }
 
     var buttonTitle: String? {
@@ -51,14 +51,8 @@ private enum Localization {
     )
 
     static let emptyOrdersSearchSubtitle = NSLocalizedString(
-        "pos.orderListView.emptyOrdersSearchSubtitle.1",
-        value: "We couldn't find any orders with that name.",
+        "pos.orderListView.emptyOrdersSearchSubtitle.2",
+        value: "We couldn't find any orders with that name. Try adjusting your search term.",
         comment: "Subtitle appearing when order search returns no results."
-    )
-
-    static let emptyOrdersSearchHint = NSLocalizedString(
-        "pos.orderListView.emptyOrdersSearchHint",
-        value: "Try adjusting your search term.",
-        comment: "Hint text suggesting to modify search terms when no orders are found."
     )
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListEmptyViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListEmptyViewModel.swift
@@ -12,10 +12,6 @@ struct POSOrderListEmptyViewModel: POSListEmptyViewModelProtocol {
         isSearching ? Localization.emptyOrdersSearchSubtitle : Localization.emptyOrdersSubtitle
     }
 
-    var hint: String? {
-        nil
-    }
-
     var buttonTitle: String? {
         isSearching ? nil : Localization.emptyOrdersButtonTitle
     }

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSListEmptyView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSListEmptyView.swift
@@ -9,6 +9,10 @@ protocol POSListEmptyViewModelProtocol {
     var icon: Image { get }
 }
 
+extension POSListEmptyViewModelProtocol {
+    var hint: String? { nil }
+}
+
 struct POSListEmptyView: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize


### PR DESCRIPTION
## Description

WOOMOB-1555

Update the empty search state for POS historical orders view to combine the subtitle and hint into a single subtitle message per design.

**Changes:**
- Combined subtitle and hint into a single subtitle: "We couldn't find any orders with that name. Try adjusting your search term."
- Removed the separate hint text that was displayed with different styling

## Test Steps

1. Open the POS mode
2. Navigate to the Orders list
3. Search for a term that returns no results
4. Verify the empty state shows:
   - Title: "No orders found"
   - Subtitle: "We couldn't find any orders with that name. Try adjusting your search term."
   - No separate hint text below the subtitle

## Screenshots

Now matches Android:

### Android
<img width="955" height="534" alt="android2" src="https://github.com/user-attachments/assets/fae020e1-37d2-4b07-80d9-2e659f05291b" />

### iOS

<img width="2732" height="2048" alt="image" src="https://github.com/user-attachments/assets/01bba2be-94b1-4645-8ad7-859b5879124c" />

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.