### PR TITLE
[Tooling] Add fastlane lane for AI-generated translation context

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'fastlane-plugin-firebase_app_distribution', '~> 0.10'
 gem 'fastlane-plugin-sentry', '~> 1.0'
 # gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit', branch: ''
 gem 'fastlane-plugin-wpmreleasetoolkit', '~> 14.0'
+gem 'txcontext', git: 'https://github.com/iangmaia/txcontext'
 # To avoid errors like:
 #
 # SSL_connect returned=1 errno=0 peeraddr=3.5.132.155:443 state=error: certificate verify failed (unable to get certificate CRL)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: https://github.com/iangmaia/txcontext
+  revision: c19f9620e6e1e37eb8d8cec5e1d37d639d816f99
+  specs:
+    txcontext (0.1.0)
+      concurrent-ruby (~> 1.2)
+      dotstrings (~> 0.6)
+      httpx (~> 1.0)
+      oj (~> 3.16)
+      rexml (~> 3.2)
+      thor (~> 1.3)
+      tty-progressbar (~> 0.18)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -90,6 +103,7 @@ GEM
       rake (>= 12.0.0, < 14.0.0)
     domain_name (0.6.20240107)
     dotenv (2.8.1)
+    dotstrings (0.6.0)
     drb (2.2.3)
     emoji_regex (3.2.3)
     erubi (1.13.1)
@@ -250,10 +264,13 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     highline (2.0.3)
+    http-2 (1.1.1)
     http-cookie (1.0.8)
       domain_name (~> 0.5)
     httpclient (2.9.0)
       mutex_m
+    httpx (1.7.2)
+      http-2 (>= 1.0.0)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     java-properties (0.3.0)
@@ -287,11 +304,15 @@ GEM
     octokit (6.1.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
+    oj (3.16.13)
+      bigdecimal (>= 3.0)
+      ostruct (>= 0.2)
     open4 (1.3.4)
     openssl (4.0.0)
     options (2.3.2)
     optparse (0.8.1)
     os (1.1.4)
+    ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.10.0)
       ast (~> 2.4.1)
@@ -355,13 +376,20 @@ GEM
       CFPropertyList
       naturally
     singleton (0.3.0)
+    strings-ansi (0.2.0)
     sysrandom (1.0.5)
     terminal-notifier (2.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     text (1.3.1)
+    thor (1.5.0)
     trailblazer-option (0.1.2)
     tty-cursor (0.7.1)
+    tty-progressbar (0.18.3)
+      strings-ansi (~> 0.2)
+      tty-cursor (~> 0.7)
+      tty-screen (~> 0.8)
+      unicode-display_width (>= 1.6, < 3.0)
     tty-screen (0.8.2)
     tty-spinner (0.9.3)
       tty-cursor (~> 0.7)
@@ -401,6 +429,7 @@ DEPENDENCIES
   rmagick (~> 4.1)
   rubocop (~> 1.65)
   rubocop-rake (~> 0.6)
+  txcontext!
   xcode-install
   xcpretty-travis-formatter
 

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -420,7 +420,7 @@ private extension POSOrderListController {
         static let viaPaymentMethodFormat = NSLocalizedString(
             "pos.orderListController.refund.viaPaymentMethodFormat",
             value: "Via %@",
-            comment: "Description for refund via a specific payment method. %@ is the payment method name"
+            comment: "This text appears as a descriptive label in the Point of Sale order list showing how a refund was processed, where %@ is replaced with the specific payment method name (e.g., 'Via Credit Card', 'Via PayPal')."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
@@ -90,7 +90,7 @@ private extension POSRefundConfirmationView {
         static let titleFormat = NSLocalizedString(
             "pos.refundConfirmationView.titleFormat",
             value: "Refund %@",
-            comment: "Title for the refund confirmation modal. %@ is the formatted refund amount."
+            comment: "This text appears as the title of a refund confirmation modal dialog in a point-of-sale app, where %@ is replaced with the formatted refund amount (e.g., 'Refund $25.99'). It serves as the header text that users see when confirming a refund transaction."
         )
 
         static let processingTitleFormat = NSLocalizedString(
@@ -102,13 +102,13 @@ private extension POSRefundConfirmationView {
         static let closeButtonAccessibilityLabel = NSLocalizedString(
             "pos.refundConfirmationView.closeButton.accessibilityLabel",
             value: "Close",
-            comment: "Accessibility label for close button on refund confirmation modal"
+            comment: "This is the accessibility label for a close button on the refund confirmation modal in the point-of-sale system. The label helps screen readers and other assistive technologies identify the button's purpose for users with disabilities."
         )
 
         static let confirmationMessageFormat = NSLocalizedString(
             "pos.refundConfirmationView.confirmationMessageFormat",
             value: "Are you sure you wish to process to refund %1$@ %2$@? This action cannot be undone.",
-            comment: "Confirmation message for the refund. %1$@ is the formatted amount, %2$@ is the payment method description."
+            comment: "Confirmation message displayed in a modal dialog when a user attempts to process a refund in the point-of-sale system. The message warns that the refund action is irreversible and includes placeholders for the refund amount (%1$@) and payment method (%2$@)."
         )
 
         static let processingMessage = NSLocalizedString(
@@ -120,13 +120,13 @@ private extension POSRefundConfirmationView {
         static let confirmButton = NSLocalizedString(
             "pos.refundConfirmationView.confirmButton",
             value: "Yes, proceed",
-            comment: "Button to confirm and process the refund"
+            comment: "This is the label for a confirmation button in the Point of Sale refund confirmation modal that appears when a user wants to process a refund. When tapped, it confirms and processes the refund transaction which cannot be undone."
         )
 
         static let backButton = NSLocalizedString(
             "pos.refundConfirmationView.backButton",
             value: "Back",
-            comment: "Button to go back to the previous screen"
+            comment: "Button label that appears on the refund confirmation modal in the Point of Sale system, allowing users to navigate back to the previous screen without proceeding with the refund action."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemRow.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemRow.swift
@@ -88,32 +88,31 @@ private extension POSRefundItemRow {
         static let selectedState = NSLocalizedString(
             "pos.refundItemRow.selectedState",
             value: "Selected for refund",
-            comment: "Accessibility state when item is selected for refund"
+            comment: "This text serves as an accessibility label that screen readers announce when an item is selected for refund in the Point of Sale refund interface. It's part of the accessibility description that helps visually impaired users understand the selection state of refund items."
         )
 
         static let unselectedState = NSLocalizedString(
             "pos.refundItemRow.unselectedState",
             value: "Not selected for refund",
-            comment: "Accessibility state when item is not selected for refund"
+            comment: "This is an accessibility label used by screen readers in the Point of Sale refund flow to indicate when an item is not selected for refund. It appears as part of the accessibility description for refund item rows to help visually impaired users understand the selection state of each item."
         )
 
         static let attributeFormat = NSLocalizedString(
             "pos.refundItemRow.attributeFormat",
             value: "%1$@: %2$@",
-            comment: "Format for a single attribute in accessibility label. %1$@ is the attribute name, %2$@ is the attribute value. Example: 'Size: Medium'"
+            comment: "Format string used to display product attributes in accessibility labels for refund items in Point of Sale, combining an attribute name and value (e.g., 'Size: Medium'). This formatted text is read by screen readers as part of the complete item description when users navigate refund options."
         )
 
         static let accessibilityLabelFormat = NSLocalizedString(
             "pos.refundItemRow.accessibilityLabelFormat",
             value: "%1$@, %2$@, %3$@",
-            comment: "Accessibility label format for refund item without attributes. %1$@ is the product name, %2$@ is the price, %3$@ is the selection state"
+            comment: "This is an accessibility label format string used to provide screen reader users with information about items in the refund selection screen. It combines three pieces of information (product name, price, and selection state) separated by commas to create a comprehensive audio description for visually impaired users."
         )
 
         static let accessibilityLabelWithAttributesFormat = NSLocalizedString(
             "pos.refundItemRow.accessibilityLabelWithAttributesFormat",
             value: "%1$@, %2$@, %3$@, %4$@",
-            comment:
-                """
+            comment: "This is an accessibility label format string used by screen readers to describe refund items that have product attributes (like size, color) in the Point of Sale refund interface. It combines four pieces of information in order: product name, attribute details, price, and selection status to create a complete audio description for visually impaired users.""
                 Accessibility label format for refund item with attributes.
                 %1$@ is the product name.
                 %2$@ is the attributes list.

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemsSelectionView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemsSelectionView.swift
@@ -131,25 +131,25 @@ private extension POSRefundItemsSelectionView {
         static let title = NSLocalizedString(
             "pos.refundItemsSelectionView.title",
             value: "Select items to refund",
-            comment: "Title for the refund items selection modal"
+            comment: "This text appears as the title of a modal screen in the Point of Sale module where users can select specific items from an order to process a refund."
         )
 
         static let continueButton = NSLocalizedString(
             "pos.refundItemsSelectionView.continueButton",
             value: "Continue",
-            comment: "Button to continue with selected items for refund"
+            comment: "Button label in the Point of Sale refund items selection modal that allows users to proceed to the next step after selecting which items they want to refund from an order."
         )
 
         static let closeButtonAccessibilityLabel = NSLocalizedString(
             "pos.refundItemsSelectionView.closeButton.accessibilityLabel",
             value: "Close",
-            comment: "Accessibility label for close button on refund items selection modal"
+            comment: "Accessibility label for the close button in the refund items selection modal screen within the Point of Sale system. This text is read by screen readers to help visually impaired users understand that the button will close the modal without processing any refunds."
         )
 
         static let itemsHeaderTitle = NSLocalizedString(
             "pos.refundItemsSelectionView.itemsHeaderTitle",
             value: "Select all items",
-            comment: "Header label for items in the refund items selection modal"
+            comment: "A header label that appears at the top of the items list in a Point of Sale refund selection modal, where users can choose which items to refund from an order."
         )
 
         static let itemsSelectedCountFormat = NSLocalizedString(
@@ -161,7 +161,7 @@ private extension POSRefundItemsSelectionView {
         static let selectAllAccessibilityLabel = NSLocalizedString(
             "pos.refundItemsSelectionView.selectAll.accessibilityLabel",
             value: "Select or deselect all items",
-            comment: "Accessibility label for the select-all checkbox in the refund items selection modal"
+            comment: "This is an accessibility label for a checkbox that allows users to select or deselect all items at once in the refund items selection screen of a point-of-sale system. The text is read by screen readers to help visually impaired users understand the purpose of the select-all toggle control."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReasonView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReasonView.swift
@@ -125,31 +125,31 @@ private extension POSRefundReasonView {
         static let title = NSLocalizedString(
             "pos.refundReasonView.title",
             value: "Refund reason",
-            comment: "Title for the refund reason input screen"
+            comment: "This is the screen title displayed at the top of the refund reason input screen in the Point of Sale app, where merchants enter a reason for refunding a customer's order."
         )
 
         static let backButtonAccessibilityLabel = NSLocalizedString(
             "pos.refundReasonView.backButton.accessibilityLabel",
             value: "Back",
-            comment: "Accessibility label for back button on refund reason screen"
+            comment: "This is an accessibility label for the back button on the refund reason input screen in the Point of Sale module. It helps screen readers and assistive technologies identify the navigation button that allows users to return to the previous screen when entering a refund reason."
         )
 
         static let closeButtonAccessibilityLabel = NSLocalizedString(
             "pos.refundReasonView.closeButton.accessibilityLabel",
             value: "Close",
-            comment: "Accessibility label for close button on refund reason screen"
+            comment: "This is the accessibility label for a close button on the refund reason input screen in a point-of-sale system. The button allows users to close/dismiss the refund reason view without completing the refund process."
         )
 
         static let placeholder = NSLocalizedString(
             "pos.refundReasonView.placeholder",
             value: "Reason for refunding order",
-            comment: "Placeholder text for the refund reason text field"
+            comment: "This text appears as placeholder text in a text input field on the refund reason screen in a point-of-sale app, prompting users to enter why they are refunding an order."
         )
 
         static let addButton = NSLocalizedString(
             "pos.refundReasonView.addButton",
             value: "Add",
-            comment: "Button to add the refund reason"
+            comment: "Button label that appears on the Point of Sale refund reason screen, allowing users to add or save the refund reason they've entered in a text field."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
@@ -146,13 +146,13 @@ private extension POSRefundReviewView {
         static let title = NSLocalizedString(
             "pos.refundReviewView.title",
             value: "Review refund",
-            comment: "Title for the refund review modal"
+            comment: "This text appears as the title of a modal screen in the Point of Sale app where merchants review details of a refund before processing it. It's displayed as a header at the top of the refund review interface."
         )
 
         static let closeButtonAccessibilityLabel = NSLocalizedString(
             "pos.refundReviewView.closeButton.accessibilityLabel",
             value: "Close",
-            comment: "Accessibility label for close button on refund review modal"
+            comment: "This is the accessibility label for a close button on the refund review modal in the point-of-sale system. Screen readers will announce this text when users focus on the button that dismisses the refund review screen."
         )
 
         static let itemsSubtotalFormat = NSLocalizedString(
@@ -164,61 +164,61 @@ private extension POSRefundReviewView {
         static let taxLabel = NSLocalizedString(
             "pos.refundReviewView.taxLabel",
             value: "Tax",
-            comment: "Label for tax row in refund review"
+            comment: "A label displayed in the refund review screen of the Point of Sale module, identifying the tax amount line item in the refund breakdown summary."
         )
 
         static let refundTotalLabel = NSLocalizedString(
             "pos.refundReviewView.refundTotalLabel",
             value: "Refund total",
-            comment: "Label for refund total row in refund review"
+            comment: "A label that displays the total amount to be refunded to the customer on the refund review screen in a point-of-sale app. This appears as a row label in a summary breakdown showing the final refund amount before processing the transaction."
         )
 
         static let refundReasonLabel = NSLocalizedString(
             "pos.refundReviewView.refundReasonLabel",
             value: "Refund reason",
-            comment: "Label for refund reason section in refund review"
+            comment: "This is a section label that appears in the refund review screen of a point-of-sale app, identifying the area where users can view or add the reason for processing a refund."
         )
 
         static let addReasonButton = NSLocalizedString(
             "pos.refundReviewView.addReasonButton",
             value: "Add reason",
-            comment: "Button to add a reason for the refund"
+            comment: "Button label that appears in the refund review screen of a point-of-sale app, allowing users to add an optional reason/explanation for why they are processing a refund."
         )
 
         static let editReasonButton = NSLocalizedString(
             "pos.refundReviewView.editReasonButton",
             value: "Edit reason",
-            comment: "Button to edit an existing refund reason"
+            comment: "Button text that appears in the refund review screen of the Point of Sale app, allowing users to modify a refund reason that has already been entered. This button is displayed when a refund reason already exists and needs to be changed."
         )
 
         static let addReasonAccessibilityLabel = NSLocalizedString(
             "pos.refundReviewView.addReason.accessibilityLabel",
             value: "Add refund reason",
-            comment: "Accessibility label for add reason button in refund review"
+            comment: "Accessibility label for a button that allows users to add a reason when processing refunds in the Point of Sale interface. This text is read by screen readers when users with accessibility needs interact with the add reason button during the refund review process."
         )
 
         static let editReasonAccessibilityLabel = NSLocalizedString(
             "pos.refundReviewView.editReason.accessibilityLabel",
             value: "Edit refund reason",
-            comment: "Accessibility label for edit reason button in refund review"
+            comment: "This is an accessibility label for a button in the refund review screen that allows users to edit an existing refund reason. The label is read by screen readers to help visually impaired users understand the purpose of the edit button."
         )
 
         static let reasonPlaceholder = NSLocalizedString(
             "pos.refundReviewView.reasonPlaceholder",
             value: "Reason for refunding order",
-            comment: "Placeholder text when no refund reason has been added"
+            comment: "This text appears as placeholder text in a text input field on the refund review screen, prompting users to enter a reason for refunding an order. It displays when no refund reason has been entered yet and guides users on what information to provide."
         )
 
         static let continueButton = NSLocalizedString(
             "pos.refundReviewView.continueButton",
             value: "Continue",
-            comment: "Button to continue with the refund"
+            comment: "Button label in the Point of Sale refund review screen that allows users to proceed with processing the refund after reviewing the refund details, items, and total amount."
         )
 
         static let editRefundButton = NSLocalizedString(
             "pos.refundReviewView.editRefundButton",
             value: "Edit refund",
-            comment: "Button to go back and edit the refund items"
+            comment: "This text appears as a button label on the refund review screen in a point-of-sale app, allowing users to go back and modify the items selected for refund before finalizing the transaction."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSCheckbox.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSCheckbox.swift
@@ -39,13 +39,13 @@ private extension POSCheckbox {
         static let selectedLabel = NSLocalizedString(
             "pos.checkbox.selected.accessibilityLabel",
             value: "Selected",
-            comment: "Accessibility label for a selected checkbox"
+            comment: "This text serves as an accessibility label for checkboxes in the Point of Sale interface when they are in a selected state, helping screen readers announce the checkbox status to visually impaired users."
         )
 
         static let unselectedLabel = NSLocalizedString(
             "pos.checkbox.unselected.accessibilityLabel",
             value: "Not selected",
-            comment: "Accessibility label for an unselected checkbox"
+            comment: "This is an accessibility label for unselected checkbox controls in the Point of Sale interface, used by screen readers to announce the state of checkboxes that are not currently selected."
         )
     }
 }

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -91,7 +91,7 @@ enum SiteCredentialLoginError: LocalizedError {
         static let invalidLoginResponse = NSLocalizedString(
             "siteCredentialLoginError.invalidLoginResponse.message",
             value: "Unable to login due to an unexpected response from your site.",
-            comment: "Error message explaining login failure due to unexpected response."
+            comment: "This error message appears when the app receives an unexpected response while attempting to log into a WooCommerce store using site credentials. It's displayed as an error notification to inform users that the login failed due to an unusual server response."
         )
         static let unacceptableStatusCode = NSLocalizedString(
             "Unable to login with response status code %1$d.",
@@ -104,7 +104,7 @@ enum SiteCredentialLoginError: LocalizedError {
         static let failedAuthenticationChallenge = NSLocalizedString(
             "siteCredentialLoginError.failedAuthenticationChallenge.message",
             value: "Unable to log in due to an unexpected security measure on your store. Please contact support for troubleshooting.",
-            comment: "Error message explaining login failure due to an unexpected authentication challenge."
+            comment: "Error message displayed to users when login fails due to an unexpected authentication challenge or security measure on their WooCommerce store, directing them to contact support for help."
         )
     }
 }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPCom2FALoginView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPCom2FALoginView.swift
@@ -160,7 +160,7 @@ private extension WPCom2FALoginView {
         static let anotherFormText = NSLocalizedString(
             "wpCom2FALoginView.anotherFormText",
             value: "Or choose another form of authentication.",
-            comment: "Text to suggest another form of 2FA authentication"
+            comment: "This text appears on the WordPress.com two-factor authentication login screen as explanatory text that introduces alternative authentication options like SMS codes or security keys to users."
         )
     }
 }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginView.swift
@@ -155,7 +155,7 @@ private extension WPComEmailLoginView {
         static let enterEmail = NSLocalizedString(
             "wpComEmailLoginView.enterEmail",
             value: "Enter email address or username",
-            comment: "Placeholder text for the email field on the WPCom email login screen of the Jetpack setup flow."
+            comment: "This text appears as placeholder text in an email/username input field on the WordPress.com login screen during the Jetpack setup flow. It guides users on what type of credentials they can enter to authenticate their account."
         )
         static let enterUsername = NSLocalizedString(
             "wpComEmailLoginView.enterUsername",

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComEmailLoginViewModel.swift
@@ -232,22 +232,22 @@ extension WPComEmailLoginViewModel {
             static let title = NSLocalizedString(
                 "wpcomEmailLoginViewModel.connectWPCom.title",
                 value: "Connect to WordPress.com",
-                comment: "Title for the WPCom email login screen for push notification setup"
+                comment: "Title displayed at the top of the WordPress.com email login screen that appears during push notification setup, prompting users to connect their store to WordPress.com."
             )
             static let subtitle = NSLocalizedString(
                 "wpcomEmailLoginViewModel.connectWPCom.subtitle",
                 value: "Log in with your WordPress.com account to connect your store.",
-                comment: "Subtitle for the WPCom email login screen for push notification setup"
+                comment: "This text appears as a subtitle on the WordPress.com email login screen, explaining to users why they need to log in with their WordPress.com account when setting up push notifications for their WooCommerce store."
             )
             static let primaryButtonTitle = NSLocalizedString(
                 "wpcomEmailLoginViewModel.connectWPCom.primaryButtonTitle",
                 value: "Continue",
-                comment: "Button to submit a WPCom email on the login screen for push notification setup"
+                comment: "Primary button text on the WordPress.com email login screen that allows users to proceed with connecting their WooCommerce store to WordPress.com for push notification setup. This button submits the email address entered by the user to continue the authentication process."
             )
             static let termsContent = NSLocalizedString(
                 "wpcomEmailLoginViewModel.connectWPCom.termsContent",
                 value: "By continuing, you agree to our %1$@ and to %2$@ with WordPress.com.",
-                comment: "Content of the label at the end of the Wrong Account screen. " +
+                comment: "This text appears as a terms and conditions disclaimer on the WordPress.com login screen during push notification setup, informing users that by continuing they agree to terms of service and data sharing with WordPress.com. The text contains two placeholder variables (%1$@ and %2$@) that will be replaced with clickable links to the actual terms and privacy policy." +
                 "Reads like: By tapping the Connect Jetpack button, you agree to our Terms of Service and to share details with WordPress.com.")
         }
     }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComPasswordLoginView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComPasswordLoginView.swift
@@ -136,12 +136,12 @@ private extension WPComPasswordLoginView {
         static let passwordLabel = NSLocalizedString(
             "wpcomPasswordLoginView.password",
             value: "Password",
-            comment: "Label for the password field on the WPCom password login screen of the Jetpack setup flow."
+            comment: "Label text for the password input field on the WordPress.com login screen during the Jetpack setup flow in the WooCommerce app."
         )
         static let passwordPlaceholder = NSLocalizedString(
             "wpcomPasswordLoginView.passwordPlaceholder",
             value: "Enter the password for your account",
-            comment: "Placeholder text for the password field on the WPCom password login screen of the Jetpack setup flow."
+            comment: "This text appears as placeholder text inside the password input field on the WordPress.com login screen during the Jetpack setup flow. It provides guidance to users about what to enter in the password field before they start typing."
         )
         static let resetPassword = NSLocalizedString(
             "Reset your password",
@@ -154,7 +154,7 @@ private extension WPComPasswordLoginView {
         static let secondaryAction = NSLocalizedString(
             "wpcomPasswordLoginView.secondaryAction",
             value: "or continue using a magic link",
-            comment: "Button to switch to magic link on the WPCom password login screen of the Jetpack setup flow."
+            comment: "This text appears as a secondary action button on the WordPress.com password login screen during Jetpack setup, allowing users to switch from password authentication to magic link authentication instead."
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/POSPromoOnPhonesCampaign.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/POSPromoOnPhonesCampaign.swift
@@ -29,19 +29,19 @@ extension POSPromoOnPhonesCampaign {
         static let cardTitle = NSLocalizedString(
             "posPromoOnPhonesCampaign.title",
             value: "Run WooCommerce POS on your tablet",
-            comment: "Title for the POS promotional banner on the dashboard"
+            comment: "This text appears as the title of a promotional banner card displayed on the dashboard/My Store screen, promoting the WooCommerce Point of Sale (POS) feature to encourage users to set it up on their tablet device."
         )
 
         static let cardMessage = NSLocalizedString(
             "posPromoOnPhonesCampaign.message",
             value: "Take in‑person payments with WooCommerce POS. Set up on a tablet and start selling today.",
-            comment: "Message for the POS promotional banner on the dashboard"
+            comment: "This text appears as the body message in a promotional banner on the dashboard that advertises WooCommerce POS functionality to encourage users to set up point-of-sale on tablets for in-person payments."
         )
 
         static let cardButtonTitle = NSLocalizedString(
             "posPromoOnPhonesCampaign.buttonTitle",
             value: "Learn more",
-            comment: "Button title for the POS promotional banner on the dashboard"
+            comment: "This is the button text for a promotional banner on the app's dashboard that advertises WooCommerce POS for tablet usage. When tapped, the button leads users to more detailed information about setting up and using WooCommerce POS for in-person payments."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -496,7 +496,7 @@ private extension AppCoordinator {
             static let title = NSLocalizedString(
                 "appCoordinator.ineligibleAgeRangeAlert.title",
                 value: "Access Restricted",
-                comment: "Alert title displayed when user identified as underage and taken to force logout."
+                comment: "This is the title of an alert dialog that appears when the app detects that the user's Apple account age is below the minimum required age for using the WooCommerce app. The alert appears before forcing the underage user to log out of the application."
             )
 
             static let message = NSLocalizedString(
@@ -509,7 +509,7 @@ private extension AppCoordinator {
             static let confirmationButton = NSLocalizedString(
                 "appCoordinator.ineligibleAgeRangeAlert.confirmationButton",
                 value: "Got it",
-                comment: "Alert confirmation button displayed when user identified as underage and taken to force logout."
+                comment: "This text appears on a confirmation button in an age verification alert that is displayed when the user's Apple account age is below the minimum required for the WooCommerce app. The button acknowledges the restriction message and proceeds with the forced logout process."
             )
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -867,7 +867,7 @@ private extension SettingsViewController {
         static let enablePushNotifications = NSLocalizedString(
             "settings.enablePushNotifications",
             value: "Enable Push Notifications",
-            comment: "Settings > Store Settings row that starts the flow to enable push notifications."
+            comment: "This text appears as a row label in the Settings screen that allows users to navigate to a flow for enabling push notifications for their WooCommerce store."
         )
 
         static let privacySettings = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/ConnectWPComCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/ConnectWPComCard.swift
@@ -59,17 +59,17 @@ private extension ConnectWPComCard {
         static let title = NSLocalizedString(
             "dashboardView.connectWPComCard.title",
             value: "Never miss a new order",
-            comment: "Title of the Connect WPCom card on My Store screen"
+            comment: "This is the title text displayed on a promotional card in the My Store dashboard screen that encourages users to connect their WooCommerce store to a WordPress.com account for push notifications about new orders."
         )
         static let subtitle = NSLocalizedString(
             "dashboardView.connectWPComCard.subtitle",
             value: "Connect your store to a WordPress.com account to get alerts for new orders and reviews.",
-            comment: "Subtitle of the Connect WPCom card on My Store screen"
+            comment: "This subtitle text appears on a promotional card in the My Store dashboard screen that encourages users to connect their WooCommerce store to a WordPress.com account for push notifications."
         )
         static let hideButton = NSLocalizedString(
             "dashboardView.connectWPComCard.hideButton",
             value: "Hide this content",
-            comment: "Button to hide the Connect WPCom card from the My Store screen"
+            comment: "This text appears as a button label on a promotional card in the My Store dashboard screen that encourages users to connect their store to WordPress.com for push notifications. When tapped, the button allows users to permanently dismiss this promotional content from their dashboard."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -110,42 +110,42 @@ fileprivate extension WPComPushNotificationsBenefitsView {
     enum Localization {
         static let title = NSLocalizedString("wpcomPushNotificationsBenefitsView.title",
                                              value: "Unlock push notifications with WordPress.com",
-                                             comment: "Title of the WordPress.com Push Notifications Benefits View")
+                                             comment: "This is the main title displayed on a promotional screen that encourages users to connect their WooCommerce store to a WordPress.com account to enable push notifications. It appears as a headline on the WordPress.com Push Notifications Benefits view that explains the advantages of linking accounts.")
 
         static let description = NSLocalizedString(
             "wpcomPushNotificationsBenefitsView.description",
             value: "Connect your store to a WordPress.com account to get access to push notifications for new orders, reviews and more.",
-            comment: "Main description text of the WordPress.com Push Notifications Benefits View"
+            comment: "This text appears as the main description in a benefits view that explains the advantages of connecting a WooCommerce store to a WordPress.com account. It is displayed as body text on a promotional screen encouraging users to enable push notifications for store activities."
         )
 
         static let subdescription = NSLocalizedString(
             "wpcomPushNotificationsBenefitsView.subdescription",
             value: "It only takes a minute.",
-            comment: "Secondary description text of the WordPress.com Push Notifications Benefits View"
+            comment: "This text appears as a secondary description below the main explanation in a benefits screen that encourages users to connect their WooCommerce store to WordPress.com for push notifications. It reassures users that the connection process is quick and easy."
         )
 
         static let whatIsWPCom = NSLocalizedString(
             "wpcomPushNotificationsBenefitsView.whatIsWPCom",
             value: "What is WordPress.com?",
-            comment: "Link text explaining what WordPress.com is in the Push Notifications Benefits View"
+            comment: "Link text that appears on the WordPress.com Push Notifications Benefits screen, allowing users to tap and learn more about what WordPress.com is. This is displayed as a clickable link below the main description explaining the benefits of connecting to WordPress.com for push notifications."
         )
 
         static let continueButton = NSLocalizedString(
             "wpcomPushNotificationsBenefitsView.continueButton",
             value: "Continue",
-            comment: "Continue button title in the WordPress.com Push Notifications Benefits View"
+            comment: "This is the label for a primary action button in the WordPress.com Push Notifications Benefits screen that allows users to proceed with connecting their WooCommerce store to WordPress.com to enable push notifications."
         )
 
         static let notNowButton = NSLocalizedString(
             "wpcomPushNotificationsBenefitsView.notNowButton",
             value: "Not now",
-            comment: "Not now button title in the WordPress.com Push Notifications Benefits View"
+            comment: "This text appears on a button in the WordPress.com Push Notifications Benefits view that allows users to decline or postpone setting up push notifications without completely canceling the process."
         )
 
         static let cancelButton = NSLocalizedString(
             "wpcomPushNotificationsBenefitsView.cancelButton",
             value: "Cancel",
-            comment: "Cancel button title in the WordPress.com Push Notifications Benefits View toolbar"
+            comment: "This is a cancel button displayed in the toolbar of the WordPress.com Push Notifications Benefits View, which appears when users are being introduced to push notification features. The button allows users to dismiss or exit this benefits explanation screen."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionStepsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionStepsFactory.swift
@@ -20,30 +20,30 @@ private enum Localization {
     static let step1Description = NSLocalizedString(
         "posPromotion.step1.description",
         value: "Take payments in person and connect everything back to your store — all through the WooCommerce mobile app.",
-        comment: "Description for the first step of the POS promotion modal"
+        comment: "This text appears as a descriptive step in a POS (Point of Sale) promotion modal that introduces users to the benefits of using WooCommerce's in-person payment features. It's the first step description in a multi-step promotional flow explaining how the mobile app can handle physical store transactions."
     )
 
     static let step2Description = NSLocalizedString(
         "posPromotion.step2.description",
         value: "Real-time syncing for inventory, customer, and order data between your online store and POS.",
-        comment: "Description for the second step of the POS promotion modal"
+        comment: "This text appears as a descriptive label in step 2 of a POS (Point of Sale) promotion modal that introduces users to the benefits of the WooCommerce POS feature. It explains the real-time data synchronization capability between online store and physical point-of-sale systems."
     )
 
     static let step3Description = NSLocalizedString(
         "posPromotion.step3.description",
         value: "Quick and simple to learn.",
-        comment: "Description for the third step of the POS promotion modal"
+        comment: "This text appears as a description for the third step in a POS (Point of Sale) promotional modal that introduces users to the WooCommerce POS feature. It highlights the ease of use as one of the key selling points in a multi-step promotional flow within the mobile app."
     )
 
     static let step4Description = NSLocalizedString(
         "posPromotion.step4.description",
         value: "Built right into the WooCommerce mobile app — no third-party integration required.",
-        comment: "Description for the fourth step of the POS promotion modal"
+        comment: "This text appears as a descriptive label for the fourth step in a POS (Point of Sale) promotion modal that explains the benefits of the WooCommerce POS feature to users. It emphasizes that the POS functionality is integrated directly into the app without requiring external tools."
     )
 
     static let step5Description = NSLocalizedString(
         "posPromotion.step5.description",
         value: "Use with WooPayments or Stripe payment gateways.",
-        comment: "Description for the fifth step of the POS promotion modal"
+        comment: "This text appears as a description for the fifth step in a Point of Sale (POS) promotion modal that introduces users to the WooCommerce POS feature. It specifically explains the payment gateway compatibility requirements for using the POS system."
     )
 }

--- a/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/POS/Promotion/POSPromotionViewModel.swift
@@ -133,18 +133,18 @@ private enum Localization {
     static let title = NSLocalizedString(
         "posPromotion.title",
         value: "Point of Sale from WooCommerce",
-        comment: "Title for the POS promotion modal (shown on all steps)"
+        comment: "This text appears as the title at the top of a promotional modal that introduces users to WooCommerce's Point of Sale feature. The title is displayed across all steps of the promotion flow and helps users understand what product is being promoted."
     )
 
     static let next = NSLocalizedString(
         "posPromotion.button.next",
         value: "Next",
-        comment: "Button to go to the next step in the POS promotion modal"
+        comment: "Button label that advances users to the next step in a multi-step Point of Sale (POS) promotion modal that introduces the WooCommerce POS feature."
     )
 
     static let explorePOS = NSLocalizedString(
         "posPromotion.button.explorePOS",
         value: "Explore WooCommerce POS",
-        comment: "Button to open the POS learn more page in Safari (final step of POS promotion modal)"
+        comment: "This text appears as a button label in the final step of a Point of Sale (POS) promotion modal, which when tapped opens a Safari web page with more information about WooCommerce POS features."
     )
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeatureAnnouncementCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeatureAnnouncementCardView.swift
@@ -120,6 +120,6 @@ extension FeatureAnnouncementCardView {
         static let hideContent = NSLocalizedString(
             "featureAnnouncementCardView.hideContent",
             value: "Hide this content",
-            comment: "Menu item to dismiss a feature announcement card")
+            comment: "This text appears as a menu item in a feature announcement card that allows users to dismiss or hide the entire announcement card from view. It's likely displayed in a context menu or as part of a dismissal action for promotional content or new feature notifications.")
     }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,6 +3,7 @@
 default_platform(:ios)
 fastlane_require 'dotenv'
 fastlane_require 'git'
+fastlane_require 'txcontext'
 
 UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Helper.bundler?
 
@@ -313,6 +314,8 @@ platform :ios do
     UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
 
     update_app_store_strings
+
+    add_translation_context
 
     generate_strings_file_for_glotpress
 
@@ -1266,6 +1269,56 @@ platform :ios do
     configure_validate
   end
 
+  # Adds AI-generated translation context to new/changed strings.
+  #
+  # Uses the txcontext gem to analyze source code usage and generate helpful descriptions
+  # for translators. Context is written back to the Localizable.strings file as comments.
+  #
+  # @param [String] diff_base (default: auto-detected previous release tag) Git ref to compare against for finding changed strings
+  # @param [Boolean] skip_commit (default: false) If true, does not commit the changes made to the `.strings` file
+  #
+  # @example Running the lane
+  #          bundle exec fastlane add_translation_context
+  #          bundle exec fastlane add_translation_context diff_base:9.5
+  #
+  lane :add_translation_context do |diff_base: previous_release_tag, skip_commit: false|
+    UI.user_error!('Could not determine previous release tag. Please specify diff_base parameter.') if diff_base.nil?
+    UI.user_error!('ANTHROPIC_API_KEY environment variable is required.') if ENV['ANTHROPIC_API_KEY'].nil?
+
+    strings_file = File.join(RESOURCES_FOLDER, 'en.lproj', 'Localizable.strings')
+    source_paths = %w[
+      WooCommerce/
+      Modules/Sources/
+    ].map { |p| File.join(PROJECT_ROOT_FOLDER, p) }
+
+    UI.message("Adding translation context for strings changed since #{diff_base}...")
+
+    # Use txcontext Ruby API directly
+    config = Txcontext::Config.new(
+      translations: [strings_file],
+      source_paths: source_paths,
+      diff_base: diff_base,
+      write_back_to_code: true,
+      context_prefix: '',
+      context_mode: 'replace'
+    )
+
+    extractor = Txcontext::ContextExtractor.new(config)
+    extractor.run
+
+    unless skip_commit
+      # Stage source paths modified by write_back_to_code
+      source_paths.each { |path| Actions.sh('git', 'add', path) }
+      git_commit(
+        path: source_paths,
+        message: 'Add AI-generated translation context for new strings',
+        allow_nothing_to_commit: true
+      )
+    end
+
+    UI.success('Translation context added successfully!')
+  end
+
   # Generates the `.strings` file to be imported by GlotPress, by parsing source code (using `genstrings` under the hood).
   #
   #
@@ -1282,9 +1335,9 @@ platform :ios do
         'Modules/Sources/WordPress*/',
         'Modules/Sources/PointOfSale/',
         'Modules/Sources/WPMediaPicker/',
-        'Storage/Storage/',
-        'Networking/Networking/',
-        'Hardware/Hardware/'
+        'Modules/Sources/Storage/',
+        'Modules/Sources/Networking/',
+        'Modules/Sources/Hardware/'
       ],
       exclude: [
         '*Vendor*',
@@ -1474,6 +1527,35 @@ def release_version_next
   next_calculated_release_version = VERSION_CALCULATOR.next_release_version(version: current_version)
   # Return the formatted release version
   VERSION_FORMATTER.release_version(next_calculated_release_version)
+end
+
+# Returns the most recent release tag before the current version.
+# Used for comparing changes between releases (e.g., for translation context).
+#
+# Looks for tags matching the release version pattern (X.Y or X.Y.Z) and returns
+# the most recent one that is numerically less than the current release version.
+#
+def previous_release_tag
+  current_version = release_version_current
+  current_parts = current_version.split('.').map(&:to_i)
+
+  # Fetch tags from remote to ensure we have the latest
+  Actions.sh('git', 'fetch', '--tags', '--force')
+
+  # Get all tags sorted by version (descending), filtering for release-like tags
+  # Release tags are in format X.Y or X.Y.Z (no -rc suffix, no build codes like X.Y.Z.N)
+  tags = Actions.sh('git', 'tag', '--list', '--sort=-v:refname').split("\n")
+
+  # Filter for release tags (X.Y or X.Y.Z format, excluding build codes and RCs)
+  release_tags = tags.select do |tag|
+    tag.match?(/^\d+\.\d+(\.\d+)?$/) && !tag.include?('-')
+  end
+
+  # Find the first tag that's numerically less than the current version
+  release_tags.find do |tag|
+    tag_parts = tag.split('.').map(&:to_i)
+    (tag_parts <=> current_parts) < 0
+  end
 end
 
 # Returns the current build code of the app

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1536,26 +1536,26 @@ end
 # the most recent one that is numerically less than the current release version.
 #
 def previous_release_tag
-  current_version = release_version_current
-  current_parts = current_version.split('.').map(&:to_i)
+  current_parts = release_version_current.split('.').map(&:to_i)
+  release_tags = fetch_release_tags
 
-  # Fetch tags from remote to ensure we have the latest
+  release_tags.find { |tag| version_less_than?(tag, current_parts) }
+end
+
+# Fetches all release tags from the remote, sorted by version descending.
+# Release tags are in format X.Y or X.Y.Z (no -rc suffix, no build codes).
+#
+def fetch_release_tags
   Actions.sh('git', 'fetch', '--tags', '--force')
-
-  # Get all tags sorted by version (descending), filtering for release-like tags
-  # Release tags are in format X.Y or X.Y.Z (no -rc suffix, no build codes like X.Y.Z.N)
   tags = Actions.sh('git', 'tag', '--list', '--sort=-v:refname').split("\n")
+  tags.grep(/^\d+\.\d+(\.\d+)?$/)
+end
 
-  # Filter for release tags (X.Y or X.Y.Z format, excluding build codes and RCs)
-  release_tags = tags.select do |tag|
-    tag.match?(/^\d+\.\d+(\.\d+)?$/) && !tag.include?('-')
-  end
-
-  # Find the first tag that's numerically less than the current version
-  release_tags.find do |tag|
-    tag_parts = tag.split('.').map(&:to_i)
-    (tag_parts <=> current_parts) < 0
-  end
+# Returns true if the tag version is numerically less than the comparison parts.
+#
+def version_less_than?(tag, comparison_parts)
+  tag_parts = tag.split('.').map(&:to_i)
+  (tag_parts <=> comparison_parts).negative?
 end
 
 # Returns the current build code of the app


### PR DESCRIPTION
Fixes AINFRA-1869

See paaHJt-9BZ-p2

## Summary

This PR uses the gem https://github.com/iangmaia/txcontext (name and location are temporary to validate the general idea) within the release process, specifically in the Code Freeze, to include now a step to enhance the context of translation strings using a LLM.

## Changes

- Adds a new `add_translation_context` fastlane lane that uses the `txcontext` gem to generate AI-powered translation context comments for new/changed strings
- Integrates the lane into the code freeze process (`complete_code_freeze` lane)
- Adds `previous_release_tag` helper to automatically detect the comparison base
- Includes example context comments for recently added strings

## Test plan

- [ ] Run `bundle exec fastlane add_translation_context diff_base:<tag>` with `ANTHROPIC_API_KEY` set
- [ ] Verify context comments are added to strings.xml