### PR TITLE
[POS FTS] 0: Fix test initializers

### DIFF
--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
@@ -284,7 +284,8 @@ struct POSCatalogSyncCoordinatorTests {
             fullSyncService: mockSyncService,
             incrementalSyncService: mockIncrementalSyncService,
             grdbManager: grdbManager,
-            catalogEligibilityChecker: MockPOSLocalCatalogEligibilityService()
+            catalogEligibilityChecker: MockPOSLocalCatalogEligibilityService(),
+            siteSettings: mockSiteSettings
         )
 
         // When
@@ -305,7 +306,8 @@ struct POSCatalogSyncCoordinatorTests {
             fullSyncService: mockSyncService,
             incrementalSyncService: mockIncrementalSyncService,
             grdbManager: grdbManager,
-            catalogEligibilityChecker: MockPOSLocalCatalogEligibilityService()
+            catalogEligibilityChecker: MockPOSLocalCatalogEligibilityService(),
+            siteSettings: mockSiteSettings
         )
 
         // When
@@ -340,7 +342,8 @@ struct POSCatalogSyncCoordinatorTests {
             fullSyncService: mockSyncService,
             incrementalSyncService: mockIncrementalSyncService,
             grdbManager: grdbManager,
-            catalogEligibilityChecker: MockPOSLocalCatalogEligibilityService()
+            catalogEligibilityChecker: MockPOSLocalCatalogEligibilityService(),
+            siteSettings: mockSiteSettings
         )
 
         // When


### PR DESCRIPTION
Part of: WOOMOB-2109

## Description

Fix flaky tests – some tests were writing to real plists, causing the last sync dates to be held on the simulator and then incorrectly fail tests run later.

This is just a prep PR for the POS FTS search stack. 

Adding the missing `siteSettings` parameter to 3 existing `POSCatalogSyncCoordinator` initializers in tests that were missing it avoids real plist use.

## Test Steps

Tests compile and pass — no behavioral changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.