### PR TITLE
[POS FTS] 1: Add FTS schema, model, and feature flag

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -92,6 +92,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .pointOfSaleLocalCatalogi1:
             return true
+        case .pointOfSaleFTSSearch:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .ciabBookings:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .ciab:

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -192,6 +192,11 @@ public enum FeatureFlag: Int, CaseIterable {
     ///
     case pointOfSaleLocalCatalogi1
 
+    /// Enables FTS (Full-Text Search) for Point of Sale local catalog search.
+    /// Only has effect when pointOfSaleLocalCatalogi1 is also enabled.
+    ///
+    case pointOfSaleFTSSearch
+
     /// Enables a new Bookings tab for CIAB sites
     ///
     case ciabBookings

--- a/Modules/Sources/Storage/GRDB/GRDBManager.swift
+++ b/Modules/Sources/Storage/GRDB/GRDBManager.swift
@@ -36,17 +36,35 @@ public final class GRDBManager: GRDBManagerProtocol {
             // Disable foreign key constraints temporarily to avoid dependency issues
             try db.execute(sql: "PRAGMA foreign_keys = OFF")
 
-            // Get all user tables (excluding sqlite internal tables)
+            // Get all user tables (excluding sqlite internal tables and FTS5 shadow tables)
+            // FTS5 shadow tables have suffixes: _data, _idx, _content, _docsize, _config
             let tableNames = try String.fetchAll(db, sql: """
                 SELECT name FROM sqlite_master
                 WHERE type = 'table'
                 AND name NOT LIKE 'sqlite_%'
                 AND name NOT LIKE 'grdb_%'
+                AND name NOT LIKE '%_data'
+                AND name NOT LIKE '%_idx'
+                AND name NOT LIKE '%_content'
+                AND name NOT LIKE '%_docsize'
+                AND name NOT LIKE '%_config'
             """)
 
             // Delete all data from each table
             for tableName in tableNames {
                 try db.execute(sql: "DELETE FROM \(tableName)")
+            }
+
+            // Clear FTS virtual tables separately (this handles their shadow tables automatically)
+            // FTS5 virtual tables are listed as 'table' type but deleting from them clears shadow tables
+            let ftsTableNames = try String.fetchAll(db, sql: """
+                SELECT name FROM sqlite_master
+                WHERE type = 'table'
+                AND sql LIKE '%USING fts5%'
+            """)
+
+            for ftsTableName in ftsTableNames {
+                try db.execute(sql: "DELETE FROM \(ftsTableName)")
             }
 
             // Re-enable foreign key constraints
@@ -61,6 +79,10 @@ private extension GRDBManager {
 
         migrator.registerMigration("V001InitialSchema") { db in
             try V001InitialSchema.migrate(db)
+        }
+
+        migrator.registerMigration("V002FTSSearch") { db in
+            try V002FTSSearch.migrate(db)
         }
 
         try migrator.migrate(databaseConnection)

--- a/Modules/Sources/Storage/GRDB/Migrations/V002FTSSearch.swift
+++ b/Modules/Sources/Storage/GRDB/Migrations/V002FTSSearch.swift
@@ -9,14 +9,12 @@ struct V002FTSSearch {
     }
 
     private static func createSearchFTSTable(_ db: Database) throws {
-        try db.execute(sql: """
-            CREATE VIRTUAL TABLE pos_search_fts USING fts5(
-                searchable_text,
-                siteID UNINDEXED,
-                itemType UNINDEXED,
-                itemID UNINDEXED,
-                parentProductID UNINDEXED
-            )
-        """)
+        try db.create(virtualTable: "pos_search_fts", using: FTS5()) { t in
+            t.column("searchable_text")
+            t.column("siteID").notIndexed()
+            t.column("itemType").notIndexed()
+            t.column("itemID").notIndexed()
+            t.column("parentProductID").notIndexed()
+        }
     }
 }

--- a/Modules/Sources/Storage/GRDB/Migrations/V002FTSSearch.swift
+++ b/Modules/Sources/Storage/GRDB/Migrations/V002FTSSearch.swift
@@ -1,0 +1,22 @@
+import Foundation
+import GRDB
+
+struct V002FTSSearch {
+    static func migrate(_ db: Database) throws {
+        try createSearchFTSTable(db)
+        // Data population moved to POS open time via POSSearchIndexBuilder.rebuildIndex
+        // This prevents blocking app startup for users with large catalogs
+    }
+
+    private static func createSearchFTSTable(_ db: Database) throws {
+        try db.execute(sql: """
+            CREATE VIRTUAL TABLE pos_search_fts USING fts5(
+                searchable_text,
+                siteID UNINDEXED,
+                itemType UNINDEXED,
+                itemID UNINDEXED,
+                parentProductID UNINDEXED
+            )
+        """)
+    }
+}

--- a/Modules/Sources/Storage/GRDB/Model/POSSearchIndex.swift
+++ b/Modules/Sources/Storage/GRDB/Model/POSSearchIndex.swift
@@ -1,0 +1,26 @@
+import Foundation
+import GRDB
+
+/// Represents a search result from the POS FTS index.
+/// Decoded from raw SQL queries against the pos_search_fts virtual table.
+public struct POSSearchIndex: Codable, Equatable, FetchableRecord {
+    public let siteID: Int64
+    public let itemType: ItemType
+    public let itemID: Int64
+    public let parentProductID: Int64?
+
+    public enum ItemType: String, Codable {
+        case product
+        case variation
+    }
+
+    public init(siteID: Int64,
+                itemType: ItemType,
+                itemID: Int64,
+                parentProductID: Int64?) {
+        self.siteID = siteID
+        self.itemType = itemType
+        self.itemID = itemID
+        self.parentProductID = parentProductID
+    }
+}


### PR DESCRIPTION
Part of: WOOMOB-2109
Merge after #16592

## Description

Full Text Search requires a virtual table to make the reverse index for the search lookups. This PR adds that table and a model for us to fetch results into.

This is our first migration after adding FTS – it's worth installing from trunk, doing a full sync, and then updating to this PR (or a later one) over the top to trigger that migration.

The FTS5 table uses `UNINDEXED` columns for siteID, itemType, itemID, and parentProductID. These are stored and queryable but will not form part of FTS searches, they're just so we can find the correct underlying model. Only `searchable_text` participates in FTS matching.

## Test Steps

- Verify the migration creates the `pos_search_fts` table

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.