### PR TITLE
[POS FTS] 2: Add search index builder with rebuild and search

### DIFF
--- a/Modules/Sources/Storage/GRDB/FTS/POSSearchIndexBuilder.swift
+++ b/Modules/Sources/Storage/GRDB/FTS/POSSearchIndexBuilder.swift
@@ -40,6 +40,11 @@ public struct POSSearchIndexBuilder {
     }
 
     /// Returns the total count of results matching the search term.
+    /// - Parameters:
+    ///   - siteID: The site ID to search within
+    ///   - term: The search term
+    ///   - db: The database to search in
+    /// - Returns: Total count of matching results
     public static func searchCount(siteID: Int64, term: String, in db: Database) throws -> Int {
         let ftsQuery = buildFTSQuery(from: term)
         guard !ftsQuery.isEmpty else { return 0 }
@@ -54,6 +59,10 @@ public struct POSSearchIndexBuilder {
 
     /// Checks if the FTS index needs to be rebuilt for a site.
     /// Compares the index entry count against the total eligible products and variations.
+    /// - Parameters:
+    ///   - siteID: The site ID to check
+    ///   - db: The database to check in
+    /// - Returns: True if rebuild is needed
     public static func needsRebuild(for siteID: Int64, in db: Database) throws -> Bool {
         let productCount = try PersistedProduct
             .posEligibleProductsRequest(siteID: siteID)
@@ -73,6 +82,9 @@ public struct POSSearchIndexBuilder {
     }
 
     /// Clears the FTS index for a site.
+    /// - Parameters:
+    ///   - siteID: The site ID to clear
+    ///   - db: The database (must be called within a write transaction)
     public static func clearIndex(for siteID: Int64, in db: Database) throws {
         try db.execute(sql: "DELETE FROM pos_search_fts WHERE siteID = ?", arguments: [siteID])
     }

--- a/Modules/Sources/Storage/GRDB/FTS/POSSearchIndexBuilder.swift
+++ b/Modules/Sources/Storage/GRDB/FTS/POSSearchIndexBuilder.swift
@@ -77,15 +77,49 @@ public struct POSSearchIndexBuilder {
         try db.execute(sql: "DELETE FROM pos_search_fts WHERE siteID = ?", arguments: [siteID])
     }
 
+    // MARK: - Internal (for testing)
+
+    /// Tokenizes a search term to match FTS5 unicode61 tokenizer behavior.
+    /// - CJK ideographs are split into individual characters
+    /// - Alphanumeric sequences are kept as single tokens
+    /// - Everything else (punctuation, emoji, whitespace) acts as separators
+    static func tokenize(_ term: String) -> [String] {
+        var tokens: [String] = []
+        var currentWord = ""
+
+        for char in term {
+            let scalar = char.unicodeScalars.first!
+            if scalar.properties.isIdeographic {
+                // CJK ideograph - each is its own token (matches FTS5 unicode61 tokenizer)
+                if !currentWord.isEmpty {
+                    tokens.append(currentWord)
+                    currentWord = ""
+                }
+                tokens.append(String(char))
+            } else if CharacterSet.alphanumerics.contains(scalar) {
+                currentWord.append(char)
+            } else {
+                // Separator (space, punctuation, emoji)
+                if !currentWord.isEmpty {
+                    tokens.append(currentWord)
+                    currentWord = ""
+                }
+            }
+        }
+        if !currentWord.isEmpty {
+            tokens.append(currentWord)
+        }
+
+        return tokens
+    }
+
     // MARK: - Private
 
     private static func buildFTSQuery(from term: String) -> String {
-        let words = term.components(separatedBy: CharacterSet.alphanumerics.inverted)
-            .filter { !$0.isEmpty }
+        let tokens = tokenize(term)
+        guard !tokens.isEmpty else { return "" }
 
-        guard !words.isEmpty else { return "" }
-
-        return words
+        return tokens
             .map { word -> String in
                 let escaped = word.replacingOccurrences(of: "\"", with: "\"\"")
                 return "\"\(escaped)\"*"

--- a/Modules/Sources/Storage/GRDB/FTS/POSSearchIndexBuilder.swift
+++ b/Modules/Sources/Storage/GRDB/FTS/POSSearchIndexBuilder.swift
@@ -1,0 +1,150 @@
+import Foundation
+import GRDB
+
+/// Builds and queries the FTS search index for Point of Sale products and variations.
+public struct POSSearchIndexBuilder {
+    /// Rebuilds the FTS search index for a site by clearing existing entries and indexing
+    /// all eligible products and variations.
+    ///
+    /// - Parameters:
+    ///   - siteID: The site ID to rebuild the index for
+    ///   - db: The database writer to use
+    public static func rebuildIndex(for siteID: Int64, in db: any DatabaseWriter) async throws {
+        try await db.write { db in
+            try clearIndex(for: siteID, in: db)
+            try indexAllProducts(siteID: siteID, in: db)
+            try indexAllVariations(siteID: siteID, in: db)
+        }
+    }
+
+    /// Searches the FTS index for products and variations matching the search term.
+    /// - Parameters:
+    ///   - siteID: The site ID to search within
+    ///   - term: The search term
+    ///   - limit: Maximum number of results (default 50)
+    ///   - offset: Number of results to skip (default 0)
+    ///   - db: The database to search in
+    /// - Returns: Array of matching POSSearchIndex entries, ordered by BM25 relevance
+    public static func search(siteID: Int64, term: String, limit: Int = 50, offset: Int = 0, in db: Database) throws -> [POSSearchIndex] {
+        let ftsQuery = buildFTSQuery(from: term)
+        guard !ftsQuery.isEmpty else { return [] }
+
+        return try POSSearchIndex.fetchAll(db, sql: """
+            SELECT siteID, itemType, itemID, parentProductID
+            FROM pos_search_fts
+            WHERE pos_search_fts MATCH ?
+              AND siteID = ?
+            ORDER BY bm25(pos_search_fts)
+            LIMIT ? OFFSET ?
+        """, arguments: [ftsQuery, siteID, limit, offset])
+    }
+
+    /// Returns the total count of results matching the search term.
+    public static func searchCount(siteID: Int64, term: String, in db: Database) throws -> Int {
+        let ftsQuery = buildFTSQuery(from: term)
+        guard !ftsQuery.isEmpty else { return 0 }
+
+        return try Int.fetchOne(db, sql: """
+            SELECT COUNT(*)
+            FROM pos_search_fts
+            WHERE pos_search_fts MATCH ?
+              AND siteID = ?
+        """, arguments: [ftsQuery, siteID]) ?? 0
+    }
+
+    /// Checks if the FTS index needs to be rebuilt for a site.
+    /// Compares the index entry count against the total eligible products and variations.
+    public static func needsRebuild(for siteID: Int64, in db: Database) throws -> Bool {
+        let productCount = try PersistedProduct
+            .posEligibleProductsRequest(siteID: siteID)
+            .fetchCount(db)
+
+        guard productCount > 0 else { return false }
+
+        let variationCount = try PersistedProductVariation
+            .posAllVariationsRequest(siteID: siteID)
+            .fetchCount(db)
+
+        let indexCount = try Int.fetchOne(db, sql: """
+            SELECT COUNT(*) FROM pos_search_fts WHERE siteID = ?
+        """, arguments: [siteID]) ?? 0
+
+        return indexCount < productCount + variationCount
+    }
+
+    /// Clears the FTS index for a site.
+    public static func clearIndex(for siteID: Int64, in db: Database) throws {
+        try db.execute(sql: "DELETE FROM pos_search_fts WHERE siteID = ?", arguments: [siteID])
+    }
+
+    // MARK: - Private
+
+    private static func buildFTSQuery(from term: String) -> String {
+        let words = term.components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+
+        guard !words.isEmpty else { return "" }
+
+        return words
+            .map { word -> String in
+                let escaped = word.replacingOccurrences(of: "\"", with: "\"\"")
+                return "\"\(escaped)\"*"
+            }
+            .joined(separator: " ")
+    }
+
+    private static func indexAllProducts(siteID: Int64, in db: Database) throws {
+        let products = try PersistedProduct
+            .posEligibleProductsRequest(siteID: siteID)
+            .fetchAll(db)
+
+        for product in products {
+            let searchableText = buildSearchableText(
+                name: product.name,
+                sku: product.sku,
+                globalUniqueID: product.globalUniqueID,
+                attributes: nil
+            )
+
+            try db.execute(
+                sql: "INSERT INTO pos_search_fts (searchable_text, siteID, itemType, itemID, parentProductID) VALUES (?, ?, ?, ?, ?)",
+                arguments: [searchableText, siteID, POSSearchIndex.ItemType.product.rawValue, product.id, nil as Int64?]
+            )
+        }
+    }
+
+    private static func indexAllVariations(siteID: Int64, in db: Database) throws {
+        let variations = try PersistedProductVariation
+            .posAllVariationsRequest(siteID: siteID)
+            .fetchAll(db)
+
+        for variation in variations {
+            let parentProduct = try PersistedProduct.fetchOne(db, key: ["siteID": siteID, "id": variation.productID])
+
+            let attributes = try PersistedProductVariationAttribute
+                .filter(PersistedProductVariationAttribute.Columns.siteID == siteID)
+                .filter(PersistedProductVariationAttribute.Columns.productVariationID == variation.id)
+                .fetchAll(db)
+                .map(\.option)
+
+            let searchableText = buildSearchableText(
+                name: parentProduct?.name,
+                sku: variation.sku,
+                globalUniqueID: variation.globalUniqueID,
+                attributes: attributes.joined(separator: " ")
+            )
+
+            try db.execute(
+                sql: "INSERT INTO pos_search_fts (searchable_text, siteID, itemType, itemID, parentProductID) VALUES (?, ?, ?, ?, ?)",
+                arguments: [searchableText, siteID, POSSearchIndex.ItemType.variation.rawValue, variation.id, variation.productID]
+            )
+        }
+    }
+
+    private static func buildSearchableText(name: String?, sku: String?, globalUniqueID: String?, attributes: String?) -> String {
+        [name, sku, globalUniqueID, attributes]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+}

--- a/Modules/Sources/Storage/GRDB/FTS/POSSearchIndexBuilder.swift
+++ b/Modules/Sources/Storage/GRDB/FTS/POSSearchIndexBuilder.swift
@@ -34,7 +34,7 @@ public struct POSSearchIndexBuilder {
             FROM pos_search_fts
             WHERE pos_search_fts MATCH ?
               AND siteID = ?
-            ORDER BY bm25(pos_search_fts)
+            ORDER BY bm25(pos_search_fts), itemID
             LIMIT ? OFFSET ?
         """, arguments: [ftsQuery, siteID, limit, offset])
     }

--- a/Modules/Sources/Storage/GRDB/FTS/POSSearchIndexBuilder.swift
+++ b/Modules/Sources/Storage/GRDB/FTS/POSSearchIndexBuilder.swift
@@ -77,49 +77,15 @@ public struct POSSearchIndexBuilder {
         try db.execute(sql: "DELETE FROM pos_search_fts WHERE siteID = ?", arguments: [siteID])
     }
 
-    // MARK: - Internal (for testing)
-
-    /// Tokenizes a search term to match FTS5 unicode61 tokenizer behavior.
-    /// - CJK ideographs are split into individual characters
-    /// - Alphanumeric sequences are kept as single tokens
-    /// - Everything else (punctuation, emoji, whitespace) acts as separators
-    static func tokenize(_ term: String) -> [String] {
-        var tokens: [String] = []
-        var currentWord = ""
-
-        for char in term {
-            let scalar = char.unicodeScalars.first!
-            if scalar.properties.isIdeographic {
-                // CJK ideograph - each is its own token (matches FTS5 unicode61 tokenizer)
-                if !currentWord.isEmpty {
-                    tokens.append(currentWord)
-                    currentWord = ""
-                }
-                tokens.append(String(char))
-            } else if CharacterSet.alphanumerics.contains(scalar) {
-                currentWord.append(char)
-            } else {
-                // Separator (space, punctuation, emoji)
-                if !currentWord.isEmpty {
-                    tokens.append(currentWord)
-                    currentWord = ""
-                }
-            }
-        }
-        if !currentWord.isEmpty {
-            tokens.append(currentWord)
-        }
-
-        return tokens
-    }
-
     // MARK: - Private
 
     private static func buildFTSQuery(from term: String) -> String {
-        let tokens = tokenize(term)
-        guard !tokens.isEmpty else { return "" }
+        let words = term.components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
 
-        return tokens
+        guard !words.isEmpty else { return "" }
+
+        return words
             .map { word -> String in
                 let escaped = word.replacingOccurrences(of: "\"", with: "\"\"")
                 return "\"\(escaped)\"*"

--- a/Modules/Sources/Storage/GRDB/Model/PersistedProduct.swift
+++ b/Modules/Sources/Storage/GRDB/Model/PersistedProduct.swift
@@ -166,6 +166,14 @@ public extension PersistedProduct {
     }
 }
 
+// MARK: - FTS Indexing Requests
+extension PersistedProduct {
+    /// Returns all eligible POS products for a site (unordered, for indexing/counting)
+    static func posEligibleProductsRequest(siteID: Int64) -> QueryInterfaceRequest<PersistedProduct> {
+        baseQuery(siteID: siteID)
+    }
+}
+
 // periphery:ignore - TODO: remove ignore when populating database
 private extension PersistedProduct {
     enum CodingKeys: String, CodingKey {

--- a/Modules/Sources/Storage/GRDB/Model/PersistedProductVariation.swift
+++ b/Modules/Sources/Storage/GRDB/Model/PersistedProductVariation.swift
@@ -89,15 +89,18 @@ extension PersistedProductVariation: FetchableRecord, PersistableRecord {
 public extension PersistedProductVariation {
     /// Returns a request for non-downloadable variations of a parent product, ordered by ID
     static func posVariationsRequest(siteID: Int64, parentProductID: Int64) -> QueryInterfaceRequest<PersistedProductVariation> {
-        return PersistedProductVariation
-            .filter(Columns.siteID == siteID)
+        return baseQuery(siteID: siteID)
             .filter(Columns.productID == parentProductID)
-            .filter(Columns.downloadable == false)
             .order(Columns.id)
     }
 
     /// Returns a request for all non-downloadable variations for a site
     static func posAllVariationsRequest(siteID: Int64) -> QueryInterfaceRequest<PersistedProductVariation> {
+        return baseQuery(siteID: siteID)
+    }
+
+    /// Base query for POS-supported variations (non-downloadable) for a given site
+    private static func baseQuery(siteID: Int64) -> QueryInterfaceRequest<PersistedProductVariation> {
         return PersistedProductVariation
             .filter(Columns.siteID == siteID)
             .filter(Columns.downloadable == false)

--- a/Modules/Sources/Storage/GRDB/Model/PersistedProductVariation.swift
+++ b/Modules/Sources/Storage/GRDB/Model/PersistedProductVariation.swift
@@ -96,6 +96,13 @@ public extension PersistedProductVariation {
             .order(Columns.id)
     }
 
+    /// Returns a request for all non-downloadable variations for a site
+    static func posAllVariationsRequest(siteID: Int64) -> QueryInterfaceRequest<PersistedProductVariation> {
+        return PersistedProductVariation
+            .filter(Columns.siteID == siteID)
+            .filter(Columns.downloadable == false)
+    }
+
     /// Searches for a POS-supported variation by global unique ID
     /// - Parameters:
     ///   - siteID: The site ID

--- a/Modules/Tests/StorageTests/GRDB/POSSearchIndexBuilderTests.swift
+++ b/Modules/Tests/StorageTests/GRDB/POSSearchIndexBuilderTests.swift
@@ -505,4 +505,90 @@ struct POSSearchIndexBuilderTests {
         #expect(needsRebuild == false)
     }
 
+    // MARK: - tokenize Tests
+
+    @Test("tokenize splits on whitespace")
+    func test_tokenize_splits_on_whitespace() {
+        let result = POSSearchIndexBuilder.tokenize("hello world")
+        #expect(result == ["hello", "world"])
+    }
+
+    @Test("tokenize keeps alphanumeric sequences together")
+    func test_tokenize_keeps_alphanumerics_together() {
+        let result = POSSearchIndexBuilder.tokenize("abc123 def456")
+        #expect(result == ["abc123", "def456"])
+    }
+
+    @Test("tokenize splits on punctuation")
+    func test_tokenize_splits_on_punctuation() {
+        let result = POSSearchIndexBuilder.tokenize("t-shirt men's wi-fi")
+        #expect(result == ["t", "shirt", "men", "s", "wi", "fi"])
+    }
+
+    @Test("tokenize splits CJK ideographs individually")
+    func test_tokenize_splits_cjk_ideographs() {
+        // Chinese characters should be split individually to match FTS5 unicode61
+        let result = POSSearchIndexBuilder.tokenize("中文测试")
+        #expect(result == ["中", "文", "测", "试"])
+    }
+
+    @Test("tokenize handles mixed CJK and Latin")
+    func test_tokenize_handles_mixed_cjk_and_latin() {
+        let result = POSSearchIndexBuilder.tokenize("hello中文world")
+        #expect(result == ["hello", "中", "文", "world"])
+    }
+
+    @Test("tokenize keeps Japanese hiragana and katakana as words")
+    func test_tokenize_keeps_japanese_kana_as_words() {
+        // Hiragana and katakana are NOT ideographic, so they stay together
+        let result = POSSearchIndexBuilder.tokenize("こんにちは カタカナ")
+        #expect(result == ["こんにちは", "カタカナ"])
+    }
+
+    @Test("tokenize splits Japanese kanji individually")
+    func test_tokenize_splits_japanese_kanji() {
+        // Kanji ARE ideographic, so they split
+        let result = POSSearchIndexBuilder.tokenize("日本語")
+        #expect(result == ["日", "本", "語"])
+    }
+
+    @Test("tokenize keeps Korean hangul as words")
+    func test_tokenize_keeps_korean_hangul_as_words() {
+        // Korean hangul is NOT ideographic
+        let result = POSSearchIndexBuilder.tokenize("안녕하세요")
+        #expect(result == ["안녕하세요"])
+    }
+
+    @Test("tokenize treats emoji as separators")
+    func test_tokenize_treats_emoji_as_separators() {
+        let result = POSSearchIndexBuilder.tokenize("hello😀world")
+        #expect(result == ["hello", "world"])
+    }
+
+    @Test("tokenize handles empty string")
+    func test_tokenize_handles_empty_string() {
+        let result = POSSearchIndexBuilder.tokenize("")
+        #expect(result == [])
+    }
+
+    @Test("tokenize handles only separators")
+    func test_tokenize_handles_only_separators() {
+        let result = POSSearchIndexBuilder.tokenize("   ---   ")
+        #expect(result == [])
+    }
+
+    @Test("tokenize handles Arabic script")
+    func test_tokenize_handles_arabic() {
+        // Arabic is alphanumeric, not ideographic
+        let result = POSSearchIndexBuilder.tokenize("مرحبا")
+        #expect(result == ["مرحبا"])
+    }
+
+    @Test("tokenize handles Hebrew script")
+    func test_tokenize_handles_hebrew() {
+        // Hebrew is alphanumeric, not ideographic
+        let result = POSSearchIndexBuilder.tokenize("שלום")
+        #expect(result == ["שלום"])
+    }
+
 }

--- a/Modules/Tests/StorageTests/GRDB/POSSearchIndexBuilderTests.swift
+++ b/Modules/Tests/StorageTests/GRDB/POSSearchIndexBuilderTests.swift
@@ -1,0 +1,508 @@
+import Foundation
+import Testing
+import GRDB
+@testable import Storage
+
+@Suite("POSSearchIndexBuilder Tests")
+struct POSSearchIndexBuilderTests {
+    private let siteID: Int64 = 123
+    private var grdbManager: GRDBManager!
+
+    init() async throws {
+        grdbManager = try GRDBManager()
+        try await grdbManager.databaseConnection.write { db in
+            try PersistedSite(id: 123).insert(db)
+        }
+    }
+
+    // MARK: - Helper Methods
+
+    private func insertProduct(
+        id: Int64,
+        name: String,
+        sku: String? = nil,
+        productTypeKey: String = "simple",
+        downloadable: Bool = false,
+        statusKey: String = "publish",
+        in db: Database
+    ) throws {
+        let product = PersistedProduct(
+            id: id,
+            siteID: siteID,
+            name: name,
+            productTypeKey: productTypeKey,
+            fullDescription: nil,
+            shortDescription: nil,
+            sku: sku,
+            globalUniqueID: nil,
+            price: "10.00",
+            downloadable: downloadable,
+            parentID: 0,
+            manageStock: false,
+            stockQuantity: nil,
+            stockStatusKey: "instock",
+            statusKey: statusKey
+        )
+        try product.insert(db)
+    }
+
+    private func insertVariation(
+        id: Int64,
+        productID: Int64,
+        sku: String? = nil,
+        downloadable: Bool = false,
+        in db: Database
+    ) throws {
+        let variation = PersistedProductVariation(
+            id: id,
+            siteID: siteID,
+            productID: productID,
+            sku: sku,
+            globalUniqueID: nil,
+            price: "10.00",
+            downloadable: downloadable,
+            fullDescription: nil,
+            manageStock: false,
+            stockQuantity: nil,
+            stockStatusKey: "instock"
+        )
+        try variation.insert(db)
+    }
+
+    private func insertVariationAttribute(
+        variationID: Int64,
+        name: String,
+        option: String,
+        in db: Database
+    ) throws {
+        var attribute = PersistedProductVariationAttribute(
+            siteID: siteID,
+            productVariationID: variationID,
+            remoteAttributeID: 1,
+            name: name,
+            option: option
+        )
+        try attribute.insert(db)
+    }
+
+    // MARK: - rebuildIndex Tests
+
+    @Test("rebuildIndex indexes simple products")
+    func test_rebuildIndex_indexes_simple_products() async throws {
+        // Given: A simple product in the database
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 100, name: "Simple Widget", sku: "SKU-100", productTypeKey: "simple", in: db)
+        }
+
+        // When: Rebuild the index
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // Then: The product is indexed
+        let results = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "Widget", in: db)
+        }
+        #expect(results.count == 1)
+        #expect(results.first?.itemType == .product)
+        #expect(results.first?.itemID == 100)
+    }
+
+    @Test("rebuildIndex indexes variable products")
+    func test_rebuildIndex_indexes_variable_products() async throws {
+        // Given: A variable product in the database
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 200, name: "Variable Shirt", sku: "SKU-200", productTypeKey: "variable", in: db)
+        }
+
+        // When: Rebuild the index
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // Then: The product is indexed
+        let results = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "Shirt", in: db)
+        }
+        #expect(results.count == 1)
+        #expect(results.first?.itemType == .product)
+        #expect(results.first?.itemID == 200)
+    }
+
+    @Test("rebuildIndex indexes variations with attributes")
+    func test_rebuildIndex_indexes_variations_with_attributes() async throws {
+        // Given: A variable product with a variation that has attributes
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 300, name: "T-Shirt", productTypeKey: "variable", in: db)
+            try insertVariation(id: 301, productID: 300, sku: "SKU-301", in: db)
+            try insertVariationAttribute(variationID: 301, name: "Color", option: "Blue", in: db)
+            try insertVariationAttribute(variationID: 301, name: "Size", option: "Large", in: db)
+        }
+
+        // When: Rebuild the index
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // Then: The variation is indexed with attributes
+        let results = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "Blue", in: db)
+        }
+        #expect(results.count == 1)
+        #expect(results.first?.itemType == .variation)
+        #expect(results.first?.itemID == 301)
+        #expect(results.first?.parentProductID == 300)
+    }
+
+    @Test("rebuildIndex clears existing index before rebuilding")
+    func test_rebuildIndex_clears_existing_index() async throws {
+        // Given: An existing index entry
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 400, name: "Old Product", productTypeKey: "simple", in: db)
+        }
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // Verify initial index
+        let initialCount = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.searchCount(siteID: siteID, term: "Old", in: db)
+        }
+        #expect(initialCount == 1)
+
+        // When: Delete the product and rebuild
+        try await grdbManager.databaseConnection.write { db in
+            try db.execute(sql: "DELETE FROM product WHERE id = 400 AND siteID = ?", arguments: [siteID])
+        }
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // Then: The index is cleared
+        let finalCount = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.searchCount(siteID: siteID, term: "Old", in: db)
+        }
+        #expect(finalCount == 0)
+    }
+
+    @Test("rebuildIndex excludes downloadable products")
+    func test_rebuildIndex_excludes_downloadable_products() async throws {
+        // Given: A downloadable product
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 500, name: "Digital Download", productTypeKey: "simple", downloadable: true, in: db)
+        }
+
+        // When: Rebuild the index
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // Then: The downloadable product is not indexed
+        let results = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "Digital", in: db)
+        }
+        #expect(results.isEmpty)
+    }
+
+    @Test("rebuildIndex excludes trash/draft/pending products")
+    func test_rebuildIndex_excludes_invalid_status_products() async throws {
+        // Given: Products with invalid statuses
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 600, name: "Trash Product", productTypeKey: "simple", statusKey: "trash", in: db)
+            try insertProduct(id: 601, name: "Draft Product", productTypeKey: "simple", statusKey: "draft", in: db)
+            try insertProduct(id: 602, name: "Pending Product", productTypeKey: "simple", statusKey: "pending", in: db)
+            try insertProduct(id: 603, name: "Published Product", productTypeKey: "simple", statusKey: "publish", in: db)
+        }
+
+        // When: Rebuild the index
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // Then: Only the published product is indexed
+        let allResults = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "Product", in: db)
+        }
+        #expect(allResults.count == 1)
+        #expect(allResults.first?.itemID == 603)
+    }
+
+    // MARK: - search Tests
+
+    @Test("search finds products by name")
+    func test_search_finds_products_by_name() async throws {
+        // Given: A product with a specific name
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 700, name: "Amazing Gadget", productTypeKey: "simple", in: db)
+        }
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // When: Search by name
+        let results = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "Amazing", in: db)
+        }
+
+        // Then: The product is found
+        #expect(results.count == 1)
+        #expect(results.first?.itemID == 700)
+    }
+
+    @Test("search finds products by SKU")
+    func test_search_finds_products_by_sku() async throws {
+        // Given: A product with a specific SKU
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 800, name: "Product", sku: "UNIQUE-SKU-123", productTypeKey: "simple", in: db)
+        }
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // When: Search by SKU
+        let results = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "UNIQUE-SKU-123", in: db)
+        }
+
+        // Then: The product is found
+        #expect(results.count == 1)
+        #expect(results.first?.itemID == 800)
+    }
+
+    @Test("search matches words in any order")
+    func test_search_matches_words_in_any_order() async throws {
+        // Given: A product with multiple words in name
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 900, name: "Blue Cotton Shirt", productTypeKey: "simple", in: db)
+        }
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // When: Search with words in different order
+        let results = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "Shirt Blue", in: db)
+        }
+
+        // Then: The product is found
+        #expect(results.count == 1)
+        #expect(results.first?.itemID == 900)
+    }
+
+    @Test("search uses prefix matching")
+    func test_search_uses_prefix_matching() async throws {
+        // Given: A product with a specific name
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 1000, name: "Comfortable Chair", productTypeKey: "simple", in: db)
+        }
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // When: Search with prefix
+        let results = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "Comf", in: db)
+        }
+
+        // Then: The product is found
+        #expect(results.count == 1)
+        #expect(results.first?.itemID == 1000)
+    }
+
+    @Test("search finds variations by attribute")
+    func test_search_finds_variations_by_attribute() async throws {
+        // Given: A variation with attributes
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 1100, name: "Hoodie", productTypeKey: "variable", in: db)
+            try insertVariation(id: 1101, productID: 1100, in: db)
+            try insertVariationAttribute(variationID: 1101, name: "Color", option: "Crimson", in: db)
+        }
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // When: Search by attribute value
+        let results = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "Crimson", in: db)
+        }
+
+        // Then: The variation is found
+        #expect(results.count == 1)
+        #expect(results.first?.itemType == .variation)
+        #expect(results.first?.itemID == 1101)
+    }
+
+    @Test("search respects limit and offset")
+    func test_search_respects_limit_and_offset() async throws {
+        // Given: Multiple products
+        try await grdbManager.databaseConnection.write { db in
+            for i in 1...10 {
+                try insertProduct(id: Int64(1200 + i), name: "Test Product \(i)", productTypeKey: "simple", in: db)
+            }
+        }
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // When: Search with limit and offset
+        let results = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "Test", limit: 3, offset: 2, in: db)
+        }
+
+        // Then: Only 3 results are returned, skipping first 2
+        #expect(results.count == 3)
+    }
+
+    // MARK: - searchCount Tests
+
+    @Test("searchCount returns correct total")
+    func test_searchCount_returns_correct_total() async throws {
+        // Given: Multiple products matching a term
+        try await grdbManager.databaseConnection.write { db in
+            for i in 1...5 {
+                try insertProduct(id: Int64(1300 + i), name: "Matching Item \(i)", productTypeKey: "simple", in: db)
+            }
+            try insertProduct(id: 1306, name: "Other Thing", productTypeKey: "simple", in: db)
+        }
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // When: Get search count
+        let count = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.searchCount(siteID: siteID, term: "Matching", in: db)
+        }
+
+        // Then: Correct count is returned
+        #expect(count == 5)
+    }
+
+    @Test("search returns empty for no matches")
+    func test_search_returns_empty_for_no_matches() async throws {
+        // Given: Products that don't match the search term
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 1400, name: "Apple", productTypeKey: "simple", in: db)
+        }
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // When: Search for non-matching term
+        let results = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "Banana", in: db)
+        }
+
+        // Then: No results
+        #expect(results.isEmpty)
+    }
+
+    @Test("search only returns results for specified siteID")
+    func test_search_only_returns_results_for_specified_siteID() async throws {
+        // Given: Products for different sites
+        let otherSiteID: Int64 = 456
+        try await grdbManager.databaseConnection.write { db in
+            try PersistedSite(id: otherSiteID).insert(db)
+            try insertProduct(id: 1500, name: "Site 123 Product", productTypeKey: "simple", in: db)
+            // Insert product for other site
+            let otherProduct = PersistedProduct(
+                id: 1501,
+                siteID: otherSiteID,
+                name: "Site 456 Product",
+                productTypeKey: "simple",
+                fullDescription: nil,
+                shortDescription: nil,
+                sku: nil,
+                globalUniqueID: nil,
+                price: "10.00",
+                downloadable: false,
+                parentID: 0,
+                manageStock: false,
+                stockQuantity: nil,
+                stockStatusKey: "instock",
+                statusKey: "publish"
+            )
+            try otherProduct.insert(db)
+        }
+
+        // Rebuild for both sites
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+        try await POSSearchIndexBuilder.rebuildIndex(for: otherSiteID, in: grdbManager.databaseConnection)
+
+        // When: Search for first site
+        let results = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "Product", in: db)
+        }
+
+        // Then: Only site 123 product is returned
+        #expect(results.count == 1)
+        #expect(results.first?.siteID == siteID)
+        #expect(results.first?.itemID == 1500)
+    }
+
+    @Test("search finds products with hyphenated names using hyphenated query")
+    func test_search_finds_products_with_hyphenated_names() async throws {
+        // Given: A product with a hyphenated name
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 1600, name: "T-Shirt", productTypeKey: "simple", in: db)
+        }
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // When: Search with hyphenated term
+        let results = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "t-shirt", in: db)
+        }
+
+        // Then: The product is found
+        #expect(results.count == 1)
+        #expect(results.first?.itemID == 1600)
+    }
+
+    @Test("search finds products when query contains special characters")
+    func test_search_handles_special_characters_in_query() async throws {
+        // Given: Products with various names
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 1700, name: "Men's T-Shirt", productTypeKey: "simple", in: db)
+            try insertProduct(id: 1701, name: "Wi-Fi Router", productTypeKey: "simple", in: db)
+        }
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // When: Search with apostrophe
+        let mensResults = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "Men's", in: db)
+        }
+
+        // Then: Product is found (apostrophe splits into "Men" and "s")
+        #expect(mensResults.count == 1)
+        #expect(mensResults.first?.itemID == 1700)
+
+        // When: Search with hyphen
+        let wifiResults = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "Wi-Fi", in: db)
+        }
+
+        // Then: Product is found
+        #expect(wifiResults.count == 1)
+        #expect(wifiResults.first?.itemID == 1701)
+    }
+
+    // MARK: - needsRebuild Tests
+
+    @Test("needsRebuild returns true when products exist but FTS index is empty")
+    func test_needsRebuild_returns_true_when_index_empty_but_products_exist() async throws {
+        // Given: Products exist but FTS index is empty
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 1800, name: "Unindexed Product", productTypeKey: "simple", in: db)
+        }
+        // Note: rebuildIndex NOT called
+
+        // When: Check if rebuild is needed
+        let needsRebuild = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.needsRebuild(for: siteID, in: db)
+        }
+
+        // Then: Rebuild is needed
+        #expect(needsRebuild == true)
+    }
+
+    @Test("needsRebuild returns false when FTS index has entries")
+    func test_needsRebuild_returns_false_when_index_populated() async throws {
+        // Given: Products exist and FTS index is populated
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 1900, name: "Indexed Product", productTypeKey: "simple", in: db)
+        }
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // When: Check if rebuild is needed
+        let needsRebuild = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.needsRebuild(for: siteID, in: db)
+        }
+
+        // Then: Rebuild is not needed
+        #expect(needsRebuild == false)
+    }
+
+    @Test("needsRebuild returns false when no products exist")
+    func test_needsRebuild_returns_false_when_no_products() async throws {
+        // Given: No products exist
+        // (site exists from init but no products)
+
+        // When: Check if rebuild is needed
+        let needsRebuild = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.needsRebuild(for: siteID, in: db)
+        }
+
+        // Then: Rebuild is not needed (nothing to index)
+        #expect(needsRebuild == false)
+    }
+
+}

--- a/Modules/Tests/StorageTests/GRDB/POSSearchIndexBuilderTests.swift
+++ b/Modules/Tests/StorageTests/GRDB/POSSearchIndexBuilderTests.swift
@@ -505,90 +505,84 @@ struct POSSearchIndexBuilderTests {
         #expect(needsRebuild == false)
     }
 
-    // MARK: - tokenize Tests
+    // MARK: - Tokenization Tests
 
-    @Test("tokenize splits on whitespace")
-    func test_tokenize_splits_on_whitespace() {
-        let result = POSSearchIndexBuilder.tokenize("hello world")
-        #expect(result == ["hello", "world"])
-    }
+    @Test("search tokenization matches FTS5 unicode61 behavior")
+    func test_search_tokenization_matches_fts5_unicode61() async throws {
+        // Given: A product with complex text matching FTS5 unicode61 docs example
+        // FTS5 unicode61 tokenizes this as: v1, 2, grey, ⅲ, colour, don, t, jump, 你好世界, straße, ...
+        // Key behaviors: CJK kept together, splits on punctuation/apostrophe, case-insensitive
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 2100,
+                              name: "🤦🏼‍♂️ v1.2 Grey Ⅲ ColOUR! Don't jump - 🇫🇮你好世界 Straße",
+                              productTypeKey: "simple",
+                              in: db)
+        }
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
 
-    @Test("tokenize keeps alphanumeric sequences together")
-    func test_tokenize_keeps_alphanumerics_together() {
-        let result = POSSearchIndexBuilder.tokenize("abc123 def456")
-        #expect(result == ["abc123", "def456"])
-    }
+        // Then: Searching for individual tokens finds the product
+        // "v1" - alphanumeric sequence before decimal
+        var count = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.searchCount(siteID: siteID, term: "v1", in: db)
+        }
+        #expect(count == 1)
 
-    @Test("tokenize splits on punctuation")
-    func test_tokenize_splits_on_punctuation() {
-        let result = POSSearchIndexBuilder.tokenize("t-shirt men's wi-fi")
-        #expect(result == ["t", "shirt", "men", "s", "wi", "fi"])
-    }
+        // "2" - number after decimal (separate token)
+        count = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.searchCount(siteID: siteID, term: "2", in: db)
+        }
+        #expect(count == 1)
 
-    @Test("tokenize splits CJK ideographs individually")
-    func test_tokenize_splits_cjk_ideographs() {
-        // Chinese characters should be split individually to match FTS5 unicode61
-        let result = POSSearchIndexBuilder.tokenize("中文测试")
-        #expect(result == ["中", "文", "测", "试"])
-    }
+        // "colour" - case insensitive
+        count = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.searchCount(siteID: siteID, term: "colour", in: db)
+        }
+        #expect(count == 1)
 
-    @Test("tokenize handles mixed CJK and Latin")
-    func test_tokenize_handles_mixed_cjk_and_latin() {
-        let result = POSSearchIndexBuilder.tokenize("hello中文world")
-        #expect(result == ["hello", "中", "文", "world"])
-    }
+        count = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.searchCount(siteID: siteID, term: "COLOUR", in: db)
+        }
+        #expect(count == 1)
 
-    @Test("tokenize keeps Japanese hiragana and katakana as words")
-    func test_tokenize_keeps_japanese_kana_as_words() {
-        // Hiragana and katakana are NOT ideographic, so they stay together
-        let result = POSSearchIndexBuilder.tokenize("こんにちは カタカナ")
-        #expect(result == ["こんにちは", "カタカナ"])
-    }
+        // "don" and "t" - apostrophe splits words
+        count = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.searchCount(siteID: siteID, term: "don", in: db)
+        }
+        #expect(count == 1)
 
-    @Test("tokenize splits Japanese kanji individually")
-    func test_tokenize_splits_japanese_kanji() {
-        // Kanji ARE ideographic, so they split
-        let result = POSSearchIndexBuilder.tokenize("日本語")
-        #expect(result == ["日", "本", "語"])
-    }
+        count = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.searchCount(siteID: siteID, term: "t", in: db)
+        }
+        #expect(count == 1)
 
-    @Test("tokenize keeps Korean hangul as words")
-    func test_tokenize_keeps_korean_hangul_as_words() {
-        // Korean hangul is NOT ideographic
-        let result = POSSearchIndexBuilder.tokenize("안녕하세요")
-        #expect(result == ["안녕하세요"])
-    }
+        // "你好世界" - CJK characters kept together as single token
+        count = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.searchCount(siteID: siteID, term: "你好世界", in: db)
+        }
+        #expect(count == 1)
 
-    @Test("tokenize treats emoji as separators")
-    func test_tokenize_treats_emoji_as_separators() {
-        let result = POSSearchIndexBuilder.tokenize("hello😀world")
-        #expect(result == ["hello", "world"])
-    }
+        // "你好" - prefix of CJK token works
+        count = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.searchCount(siteID: siteID, term: "你好", in: db)
+        }
+        #expect(count == 1)
 
-    @Test("tokenize handles empty string")
-    func test_tokenize_handles_empty_string() {
-        let result = POSSearchIndexBuilder.tokenize("")
-        #expect(result == [])
-    }
+        // "好世" - middle of CJK token does NOT match (not a prefix)
+        count = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.searchCount(siteID: siteID, term: "好世", in: db)
+        }
+        #expect(count == 0)
 
-    @Test("tokenize handles only separators")
-    func test_tokenize_handles_only_separators() {
-        let result = POSSearchIndexBuilder.tokenize("   ---   ")
-        #expect(result == [])
-    }
+        // "straße" - German with ß kept together
+        count = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.searchCount(siteID: siteID, term: "straße", in: db)
+        }
+        #expect(count == 1)
 
-    @Test("tokenize handles Arabic script")
-    func test_tokenize_handles_arabic() {
-        // Arabic is alphanumeric, not ideographic
-        let result = POSSearchIndexBuilder.tokenize("مرحبا")
-        #expect(result == ["مرحبا"])
-    }
-
-    @Test("tokenize handles Hebrew script")
-    func test_tokenize_handles_hebrew() {
-        // Hebrew is alphanumeric, not ideographic
-        let result = POSSearchIndexBuilder.tokenize("שלום")
-        #expect(result == ["שלום"])
+        count = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.searchCount(siteID: siteID, term: "strasse", in: db)
+        }
+        #expect(count == 0) // no ß normalization
     }
 
 }


### PR DESCRIPTION
Part of: WOOMOB-2109
Merge after #16594

## Description
This PR introduces `POSSearchIndexBuilder`, which populates of the index tables in bulk (this will be used for migration), and provides the search query capability.

- `rebuildIndex`: clears and re-indexes all eligible products and variations for a site
- `search` / `searchCount`: FTS5 queries with prefix matching and BM25 ranking
- `needsRebuild`: detects when the index is stale by comparing entry count to eligible items
- `clearIndex`: removes all FTS entries for a site
- `buildFTSQuery`: splits search terms on non-alphanumeric characters and wraps each word as a quoted prefix query

Also adds `posEligibleProductsRequest` on `PersistedProduct` and `posAllVariationsRequest` on `PersistedProductVariation` for index population queries.

## Test Steps

- Run `POSSearchIndexBuilderTests` — all tests should pass

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.