### PR TITLE
[POS FTS] 3: Add inline FTS indexing to catalog persistence

### DIFF
--- a/Modules/Sources/Storage/GRDB/FTS/POSSearchIndexBuilder.swift
+++ b/Modules/Sources/Storage/GRDB/FTS/POSSearchIndexBuilder.swift
@@ -40,6 +40,11 @@ public struct POSSearchIndexBuilder {
     }
 
     /// Returns the total count of results matching the search term.
+    /// - Parameters:
+    ///   - siteID: The site ID to search within
+    ///   - term: The search term
+    ///   - db: The database to search in
+    /// - Returns: Total count of matching results
     public static func searchCount(siteID: Int64, term: String, in db: Database) throws -> Int {
         let ftsQuery = buildFTSQuery(from: term)
         guard !ftsQuery.isEmpty else { return 0 }
@@ -54,6 +59,10 @@ public struct POSSearchIndexBuilder {
 
     /// Checks if the FTS index needs to be rebuilt for a site.
     /// Compares the index entry count against the total eligible products and variations.
+    /// - Parameters:
+    ///   - siteID: The site ID to check
+    ///   - db: The database to check in
+    /// - Returns: True if rebuild is needed
     public static func needsRebuild(for siteID: Int64, in db: Database) throws -> Bool {
         let productCount = try PersistedProduct
             .posEligibleProductsRequest(siteID: siteID)
@@ -72,14 +81,85 @@ public struct POSSearchIndexBuilder {
         return indexCount < productCount + variationCount
     }
 
+    // MARK: - Inline Indexing (same transaction)
+
     /// Clears the FTS index for a site.
+    /// - Parameters:
+    ///   - siteID: The site ID to clear
+    ///   - db: The database (must be called within a write transaction)
     public static func clearIndex(for siteID: Int64, in db: Database) throws {
         try db.execute(sql: "DELETE FROM pos_search_fts WHERE siteID = ?", arguments: [siteID])
+    }
+
+    /// Indexes a product inline within an existing transaction.
+    /// - Parameters:
+    ///   - product: The persisted product to index
+    ///   - siteID: The site ID
+    ///   - db: The database (must be called within a write transaction)
+    public static func indexProduct(_ product: PersistedProduct, siteID: Int64, in db: Database) throws {
+        guard ["simple", "variable"].contains(product.productTypeKey),
+              !product.downloadable,
+              !["trash", "draft", "pending"].contains(product.statusKey) else {
+            return
+        }
+
+        let searchableText = buildSearchableText(
+            name: product.name,
+            sku: product.sku,
+            globalUniqueID: product.globalUniqueID,
+            attributes: nil
+        )
+
+        try db.execute(
+            sql: "INSERT INTO pos_search_fts (searchable_text, siteID, itemType, itemID, parentProductID) VALUES (?, ?, ?, ?, ?)",
+            arguments: [searchableText, siteID, POSSearchIndex.ItemType.product.rawValue, product.id, nil as Int64?]
+        )
+    }
+
+    /// Indexes a variation inline within an existing transaction.
+    /// - Parameters:
+    ///   - variation: The persisted variation to index
+    ///   - parentProductName: The name of the parent product
+    ///   - attributes: The variation's attribute options (e.g., ["Red", "Large"])
+    ///   - siteID: The site ID
+    ///   - db: The database (must be called within a write transaction)
+    public static func indexVariation(_ variation: PersistedProductVariation,
+                                      parentProductName: String?,
+                                      attributes: [String],
+                                      siteID: Int64,
+                                      in db: Database) throws {
+        guard !variation.downloadable else { return }
+
+        let searchableText = buildSearchableText(
+            name: parentProductName,
+            sku: variation.sku,
+            globalUniqueID: variation.globalUniqueID,
+            attributes: attributes.joined(separator: " ")
+        )
+
+        try db.execute(
+            sql: "INSERT INTO pos_search_fts (searchable_text, siteID, itemType, itemID, parentProductID) VALUES (?, ?, ?, ?, ?)",
+            arguments: [searchableText, siteID, POSSearchIndex.ItemType.variation.rawValue, variation.id, variation.productID]
+        )
+    }
+
+    /// Removes a product or variation from the FTS index.
+    /// - Parameters:
+    ///   - itemID: The ID of the item to remove
+    ///   - itemType: Whether this is a product or variation
+    ///   - siteID: The site ID
+    ///   - db: The database (must be called within a write transaction)
+    public static func removeFromIndex(itemID: Int64, itemType: POSSearchIndex.ItemType, siteID: Int64, in db: Database) throws {
+        try db.execute(
+            sql: "DELETE FROM pos_search_fts WHERE siteID = ? AND itemType = ? AND itemID = ?",
+            arguments: [siteID, itemType.rawValue, itemID]
+        )
     }
 
     // MARK: - Private
 
     private static func buildFTSQuery(from term: String) -> String {
+        // Split on non-alphanumeric characters to match FTS5's unicode61 tokenizer behavior
         let words = term.components(separatedBy: CharacterSet.alphanumerics.inverted)
             .filter { !$0.isEmpty }
 
@@ -99,17 +179,7 @@ public struct POSSearchIndexBuilder {
             .fetchAll(db)
 
         for product in products {
-            let searchableText = buildSearchableText(
-                name: product.name,
-                sku: product.sku,
-                globalUniqueID: product.globalUniqueID,
-                attributes: nil
-            )
-
-            try db.execute(
-                sql: "INSERT INTO pos_search_fts (searchable_text, siteID, itemType, itemID, parentProductID) VALUES (?, ?, ?, ?, ?)",
-                arguments: [searchableText, siteID, POSSearchIndex.ItemType.product.rawValue, product.id, nil as Int64?]
-            )
+            try indexProduct(product, siteID: siteID, in: db)
         }
     }
 
@@ -127,17 +197,11 @@ public struct POSSearchIndexBuilder {
                 .fetchAll(db)
                 .map(\.option)
 
-            let searchableText = buildSearchableText(
-                name: parentProduct?.name,
-                sku: variation.sku,
-                globalUniqueID: variation.globalUniqueID,
-                attributes: attributes.joined(separator: " ")
-            )
-
-            try db.execute(
-                sql: "INSERT INTO pos_search_fts (searchable_text, siteID, itemType, itemID, parentProductID) VALUES (?, ?, ?, ?, ?)",
-                arguments: [searchableText, siteID, POSSearchIndex.ItemType.variation.rawValue, variation.id, variation.productID]
-            )
+            try indexVariation(variation,
+                               parentProductName: parentProduct?.name,
+                               attributes: attributes,
+                               siteID: siteID,
+                               in: db)
         }
     }
 

--- a/Modules/Sources/Storage/GRDB/FTS/POSSearchIndexBuilder.swift
+++ b/Modules/Sources/Storage/GRDB/FTS/POSSearchIndexBuilder.swift
@@ -156,6 +156,19 @@ public struct POSSearchIndexBuilder {
         )
     }
 
+    /// Removes all variations of a product from the FTS index.
+    /// Use this when deleting a product to ensure its cascade-deleted variations are also removed from the index.
+    /// - Parameters:
+    ///   - parentProductID: The ID of the parent product whose variations should be removed
+    ///   - siteID: The site ID
+    ///   - db: The database (must be called within a write transaction)
+    public static func removeVariationsFromIndex(parentProductID: Int64, siteID: Int64, in db: Database) throws {
+        try db.execute(
+            sql: "DELETE FROM pos_search_fts WHERE siteID = ? AND parentProductID = ?",
+            arguments: [siteID, parentProductID]
+        )
+    }
+
     // MARK: - Private
 
     private static func buildFTSQuery(from term: String) -> String {

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
@@ -66,11 +66,12 @@ final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
                                                          in: db)
             }
 
-            // Insert images
+            // Insert actual image data first (shared by products and variations)
             for image in catalog.imagesToPersist {
                 try image.insert(db, onConflict: .replace)
             }
 
+            // Then insert join table entries
             for productImage in catalog.productImagesToPersist {
                 try productImage.insert(db, onConflict: .replace)
             }

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
@@ -205,6 +205,21 @@ final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
         }
 
         DDLogInfo("✅ Incremental catalog persistence complete with inline FTS updates")
+
+        try await grdbManager.databaseConnection.read { db in
+            let productCount = try PersistedProduct.filter { $0.siteID == siteID }.fetchCount(db)
+            let productImageCount = try PersistedProductImage.filter { $0.siteID == siteID }.fetchCount(db)
+            let productAttributeCount = try PersistedProductAttribute.filter { $0.siteID == siteID }.fetchCount(db)
+            let variationCount = try PersistedProductVariation.filter { $0.siteID == siteID }.fetchCount(db)
+            let variationImageCount = try PersistedProductVariationImage.filter { $0.siteID == siteID }.fetchCount(db)
+            let variationAttributeCount = try PersistedProductVariationAttribute.filter { $0.siteID == siteID }.fetchCount(db)
+            let indexCount = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM pos_search_fts WHERE siteID = ?", arguments: [siteID]) ?? 0
+
+            DDLogInfo("Total after incremental update: \(productCount) products, \(productImageCount) product images, " +
+                      "\(productAttributeCount) product attributes, \(variationCount) variations, " +
+                      "\(variationImageCount) variation images, \(variationAttributeCount) variation attributes, " +
+                      "\(indexCount) FTS entries")
+        }
     }
 
     func deleteProducts(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws {

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
@@ -232,6 +232,11 @@ final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
                                                           itemType: .product,
                                                           siteID: siteID,
                                                           in: db)
+                // Also remove any variations of this product from the index.
+                // This handles cascade-deleted variations whose IDs we don't have.
+                try POSSearchIndexBuilder.removeVariationsFromIndex(parentProductID: productID,
+                                                                    siteID: siteID,
+                                                                    in: db)
             }
 
             for variationID in variationIDs {

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogPersistenceService.swift
@@ -3,7 +3,7 @@ import Foundation
 import Storage
 import GRDB
 
-protocol POSCatalogPersistenceServiceProtocol {
+public protocol POSCatalogPersistenceServiceProtocol {
     /// Clears existing data and persists new catalog data
     /// - Parameters:
     ///   - catalog: The catalog to persist
@@ -24,39 +24,53 @@ protocol POSCatalogPersistenceServiceProtocol {
     func deleteProducts(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws
 }
 
-final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
+public final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
     private let grdbManager: GRDBManagerProtocol
 
-    init(grdbManager: GRDBManagerProtocol) {
+    public init(grdbManager: GRDBManagerProtocol) {
         self.grdbManager = grdbManager
     }
 
-    func replaceAllCatalogData(_ catalog: POSCatalog, siteID: Int64) async throws {
+    public func replaceAllCatalogData(_ catalog: POSCatalog, siteID: Int64) async throws {
         DDLogInfo("💾 Persisting catalog with \(catalog.products.count) products and \(catalog.variations.count) variations")
 
         let catalog = filterOrphanedVariations(from: catalog)
 
         try await grdbManager.databaseConnection.write { db in
             DDLogInfo("🗑️ Clearing catalog data for site \(siteID)")
+
+            try POSSearchIndexBuilder.clearIndex(for: siteID, in: db)
+
             try PersistedSite.deleteOne(db, key: siteID)
 
             let site = PersistedSite(id: siteID, lastCatalogFullSyncDate: catalog.syncDate)
             try site.insert(db)
 
+            let productNameLookup = Dictionary(uniqueKeysWithValues: catalog.products.map { ($0.productID, $0.name) })
+            let variationAttributesLookup = Dictionary(grouping: catalog.variationAttributesToPersist) { $0.productVariationID }
+
             for product in catalog.productsToPersist {
                 try product.insert(db, onConflict: .replace)
+                // Filters by eligibility internally
+                try POSSearchIndexBuilder.indexProduct(product, siteID: siteID, in: db)
             }
 
             for variation in catalog.variationsToPersist {
                 try variation.insert(db, onConflict: .replace)
+                let parentName = productNameLookup[variation.productID]
+                let attributes = variationAttributesLookup[variation.id]?.map { $0.option } ?? []
+                try POSSearchIndexBuilder.indexVariation(variation,
+                                                         parentProductName: parentName,
+                                                         attributes: attributes,
+                                                         siteID: siteID,
+                                                         in: db)
             }
 
-            // Insert actual image data first (shared by products and variations)
+            // Insert images
             for image in catalog.imagesToPersist {
                 try image.insert(db, onConflict: .replace)
             }
 
-            // Then insert join table entries
             for productImage in catalog.productImagesToPersist {
                 try productImage.insert(db, onConflict: .replace)
             }
@@ -65,6 +79,7 @@ final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
                 try variationImage.insert(db, onConflict: .replace)
             }
 
+            // Insert attributes
             for var attribute in catalog.productAttributesToPersist {
                 try attribute.insert(db)
             }
@@ -74,35 +89,41 @@ final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
             }
         }
 
-        DDLogInfo("✅ Catalog persistence complete")
+        DDLogInfo("✅ Catalog persistence complete with inline FTS indexing")
 
         try await grdbManager.databaseConnection.read { db in
             let productCount = try PersistedProduct.filter { $0.siteID == siteID }.fetchCount(db)
-            let productImageCount = try PersistedProductImage.filter { $0.siteID == siteID }.fetchCount(db)
-            let productAttributeCount = try PersistedProductAttribute.filter { $0.siteID == siteID }.fetchCount(db)
             let variationCount = try PersistedProductVariation.filter { $0.siteID == siteID }.fetchCount(db)
-            let variationImageCount = try PersistedProductVariationImage.filter { $0.siteID == siteID }.fetchCount(db)
-            let variationAttributeCount = try PersistedProductVariationAttribute.filter { $0.siteID == siteID }.fetchCount(db)
-
-            DDLogInfo("Persisted \(productCount) products, \(productImageCount) product images, " +
-                      "\(productAttributeCount) product attributes, \(variationCount) variations, " +
-                      "\(variationImageCount) variation images, \(variationAttributeCount) variation attributes")
+            let indexCount = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM pos_search_fts WHERE siteID = ?", arguments: [siteID]) ?? 0
+            DDLogInfo("Persisted \(productCount) products, \(variationCount) variations, \(indexCount) FTS entries")
         }
     }
 
-    func persistIncrementalCatalogData(_ catalog: POSCatalog, siteID: Int64) async throws {
+    public func persistIncrementalCatalogData(_ catalog: POSCatalog, siteID: Int64) async throws {
         DDLogInfo("💾 Persisting incremental catalog with \(catalog.products.count) updated products, " +
                   "\(catalog.variations.count) updated variations, " +
                   "\(catalog.productsToRemove.count) products to remove")
 
+        let productNameLookup = Dictionary(uniqueKeysWithValues: catalog.products.map { ($0.productID, $0.name) })
+        let variationAttributesLookup = Dictionary(grouping: catalog.variationAttributesToPersist) { $0.productVariationID }
+
         try await grdbManager.databaseConnection.write { db in
             for product in catalog.products {
-                // Delete attributes for updated products, the remaining set will be recreated later in the save
+                // Remove old FTS entry before updating
+                try POSSearchIndexBuilder.removeFromIndex(itemID: product.productID,
+                                                          itemType: .product,
+                                                          siteID: siteID,
+                                                          in: db)
+
+                // Delete attributes for updated products
                 try PersistedProductAttribute
                     .filter(PersistedProductAttribute.Columns.productID == product.productID)
                     .deleteAll(db)
 
-                try PersistedProduct(from: product).save(db)
+                let persistedProduct = PersistedProduct(from: product)
+                try persistedProduct.save(db)
+
+                try POSSearchIndexBuilder.indexProduct(persistedProduct, siteID: siteID, in: db)
 
                 // Delete variations that are no longer associated with this product
                 let existingVariations = try PersistedProductVariation
@@ -112,26 +133,43 @@ final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
 
                 for variation in existingVariations {
                     if !product.variationIDs.contains(variation.id) {
+                        try POSSearchIndexBuilder.removeFromIndex(itemID: variation.id,
+                                                                  itemType: .variation,
+                                                                  siteID: siteID,
+                                                                  in: db)
                         try variation.delete(db)
                     }
                 }
             }
 
             for variation in catalog.variationsToPersist {
-                // Delete attributes for updated variations, the remaining set will be recreated later in the save
+                // Remove old FTS entry before updating
+                try POSSearchIndexBuilder.removeFromIndex(itemID: variation.id,
+                                                          itemType: .variation,
+                                                          siteID: siteID,
+                                                          in: db)
+
+                // Delete attributes for updated variations
                 try PersistedProductVariationAttribute
                     .filter(PersistedProductVariationAttribute.Columns.productVariationID == variation.id)
                     .deleteAll(db)
 
                 try variation.save(db)
+
+                let parentName = productNameLookup[variation.productID]
+                let attributes = variationAttributesLookup[variation.id]?.map { $0.option } ?? []
+                try POSSearchIndexBuilder.indexVariation(variation,
+                                                         parentProductName: parentName,
+                                                         attributes: attributes,
+                                                         siteID: siteID,
+                                                         in: db)
             }
 
-            // Upsert actual image data (shared by products and variations)
+            // Upsert images
             for image in catalog.imagesToPersist {
                 try image.save(db)
             }
 
-            // Upsert new join table entries
             for image in catalog.productImagesToPersist {
                 try image.save(db)
             }
@@ -140,6 +178,7 @@ final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
                 try image.save(db)
             }
 
+            // Insert attributes
             for var attribute in catalog.productAttributesToPersist {
                 try attribute.insert(db)
             }
@@ -152,34 +191,32 @@ final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
             try site?.updateChanges(db) { $0.lastCatalogIncrementalSyncDate = catalog.syncDate }
         }
 
-        // Delete products hidden from POS when detected during incremental sync
-        // Variations are not tracked separately, they cascade delete in GRDB when their parent product is removed,
-        // so there is no need to pass their IDs here.
+        // Delete products hidden from POS (FTS entries removed inline via deleteProducts)
         if !catalog.productsToRemove.isEmpty {
             try await deleteProducts(catalog.productsToRemove, variationIDs: [], siteID: siteID)
         }
 
-        DDLogInfo("✅ Incremental catalog persistence complete")
-
-        try await grdbManager.databaseConnection.read { db in
-            let productCount = try PersistedProduct.filter { $0.siteID == siteID }.fetchCount(db)
-            let productImageCount = try PersistedProductImage.filter { $0.siteID == siteID }.fetchCount(db)
-            let productAttributeCount = try PersistedProductAttribute.filter { $0.siteID == siteID }.fetchCount(db)
-            let variationCount = try PersistedProductVariation.filter { $0.siteID == siteID }.fetchCount(db)
-            let variationImageCount = try PersistedProductVariationImage.filter { $0.siteID == siteID }.fetchCount(db)
-            let variationAttributeCount = try PersistedProductVariationAttribute.filter { $0.siteID == siteID }.fetchCount(db)
-
-            DDLogInfo("Total after incremental update: \(productCount) products, \(productImageCount) product images, " +
-                      "\(productAttributeCount) product attributes, \(variationCount) variations, " +
-                      "\(variationImageCount) variation images, \(variationAttributeCount) variation attributes")
-        }
+        DDLogInfo("✅ Incremental catalog persistence complete with inline FTS updates")
     }
 
-    func deleteProducts(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws {
+    public func deleteProducts(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws {
         DDLogInfo("🗑️ Deleting \(productIDs.count) products and \(variationIDs.count) variations from catalog")
 
         try await grdbManager.databaseConnection.write { db in
-            // Batch delete products using filter
+            for productID in productIDs {
+                try POSSearchIndexBuilder.removeFromIndex(itemID: productID,
+                                                          itemType: .product,
+                                                          siteID: siteID,
+                                                          in: db)
+            }
+
+            for variationID in variationIDs {
+                try POSSearchIndexBuilder.removeFromIndex(itemID: variationID,
+                                                          itemType: .variation,
+                                                          siteID: siteID,
+                                                          in: db)
+            }
+
             if !productIDs.isEmpty {
                 let deletedProductsCount = try PersistedProduct
                     .filter(PersistedProduct.Columns.siteID == siteID)
@@ -188,7 +225,6 @@ final class POSCatalogPersistenceService: POSCatalogPersistenceServiceProtocol {
                 DDLogInfo("Deleted \(deletedProductsCount) products from catalog")
             }
 
-            // Batch delete variations using filter
             if !variationIDs.isEmpty {
                 let deletedVariationsCount = try PersistedProductVariation
                     .filter(PersistedProductVariation.Columns.siteID == siteID)

--- a/Modules/Tests/StorageTests/GRDB/POSSearchIndexBuilderTests.swift
+++ b/Modules/Tests/StorageTests/GRDB/POSSearchIndexBuilderTests.swift
@@ -535,6 +535,48 @@ struct POSSearchIndexBuilderTests {
         #expect(afterResults.first?.itemID == 2001)
     }
 
+    @Test("removeVariationsFromIndex removes all variations of a product")
+    func test_removeVariationsFromIndex_removes_all_variations_of_product() async throws {
+        // Given: A variable product with multiple variations in the FTS index
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 3000, name: "Variable Shirt", productTypeKey: "variable", in: db)
+            try insertVariation(id: 3001, productID: 3000, sku: "SHIRT-S", in: db)
+            try insertVariation(id: 3002, productID: 3000, sku: "SHIRT-M", in: db)
+            try insertVariation(id: 3003, productID: 3000, sku: "SHIRT-L", in: db)
+            // Also add another product's variation to ensure we only remove the right ones
+            try insertProduct(id: 3100, name: "Variable Pants", productTypeKey: "variable", in: db)
+            try insertVariation(id: 3101, productID: 3100, sku: "PANTS-S", in: db)
+        }
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // Verify all variations are indexed
+        let shirtResults = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "SHIRT", in: db)
+        }
+        #expect(shirtResults.count == 3)
+
+        let pantsResults = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "PANTS", in: db)
+        }
+        #expect(pantsResults.count == 1)
+
+        // When: Remove all variations of the shirt product
+        try await grdbManager.databaseConnection.write { db in
+            try POSSearchIndexBuilder.removeVariationsFromIndex(parentProductID: 3000, siteID: siteID, in: db)
+        }
+
+        // Then: Shirt variations are gone, pants variation remains
+        let shirtResultsAfter = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "SHIRT", in: db)
+        }
+        #expect(shirtResultsAfter.count == 0)
+
+        let pantsResultsAfter = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "PANTS", in: db)
+        }
+        #expect(pantsResultsAfter.count == 1)
+    }
+
     // MARK: - Tokenization Tests
 
     @Test("search tokenization matches FTS5 unicode61 behavior")

--- a/Modules/Tests/StorageTests/GRDB/POSSearchIndexBuilderTests.swift
+++ b/Modules/Tests/StorageTests/GRDB/POSSearchIndexBuilderTests.swift
@@ -505,4 +505,33 @@ struct POSSearchIndexBuilderTests {
         #expect(needsRebuild == false)
     }
 
+    // MARK: - removeFromIndex Tests
+
+    @Test("removeFromIndex removes specific item from FTS index")
+    func test_removeFromIndex_removes_specific_item() async throws {
+        // Given: Two products in the FTS index
+        try await grdbManager.databaseConnection.write { db in
+            try insertProduct(id: 2000, name: "Product One", productTypeKey: "simple", in: db)
+            try insertProduct(id: 2001, name: "Product Two", productTypeKey: "simple", in: db)
+        }
+        try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+
+        // Verify both are searchable
+        let beforeResults = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "Product", in: db)
+        }
+        #expect(beforeResults.count == 2)
+
+        // When: Remove one product from index
+        try await grdbManager.databaseConnection.write { db in
+            try POSSearchIndexBuilder.removeFromIndex(itemID: 2000, itemType: .product, siteID: siteID, in: db)
+        }
+
+        // Then: Only the other product is searchable
+        let afterResults = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "Product", in: db)
+        }
+        #expect(afterResults.count == 1)
+        #expect(afterResults.first?.itemID == 2001)
+    }
 }

--- a/Modules/Tests/StorageTests/GRDB/POSSearchIndexBuilderTests.swift
+++ b/Modules/Tests/StorageTests/GRDB/POSSearchIndexBuilderTests.swift
@@ -540,25 +540,27 @@ struct POSSearchIndexBuilderTests {
         // Given: A variable product with multiple variations in the FTS index
         try await grdbManager.databaseConnection.write { db in
             try insertProduct(id: 3000, name: "Variable Shirt", productTypeKey: "variable", in: db)
-            try insertVariation(id: 3001, productID: 3000, sku: "SHIRT-S", in: db)
-            try insertVariation(id: 3002, productID: 3000, sku: "SHIRT-M", in: db)
-            try insertVariation(id: 3003, productID: 3000, sku: "SHIRT-L", in: db)
+            try insertVariation(id: 3001, productID: 3000, sku: "VSHIRT-S", in: db)
+            try insertVariation(id: 3002, productID: 3000, sku: "VSHIRT-M", in: db)
+            try insertVariation(id: 3003, productID: 3000, sku: "VSHIRT-L", in: db)
             // Also add another product's variation to ensure we only remove the right ones
             try insertProduct(id: 3100, name: "Variable Pants", productTypeKey: "variable", in: db)
-            try insertVariation(id: 3101, productID: 3100, sku: "PANTS-S", in: db)
+            try insertVariation(id: 3101, productID: 3100, sku: "VPANTS-S", in: db)
         }
         try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
 
-        // Verify all variations are indexed
-        let shirtResults = try await grdbManager.databaseConnection.read { db in
-            try POSSearchIndexBuilder.search(siteID: siteID, term: "SHIRT", in: db)
+        // Verify all variations are indexed (search by SKU prefix to get only variations, not parent products)
+        let shirtVariations = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "VSHIRT", in: db)
         }
-        #expect(shirtResults.count == 3)
+        #expect(shirtVariations.count == 3)
+        #expect(shirtVariations.allSatisfy { $0.itemType == .variation })
 
-        let pantsResults = try await grdbManager.databaseConnection.read { db in
-            try POSSearchIndexBuilder.search(siteID: siteID, term: "PANTS", in: db)
+        let pantsVariations = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "VPANTS", in: db)
         }
-        #expect(pantsResults.count == 1)
+        #expect(pantsVariations.count == 1)
+        #expect(pantsVariations.first?.itemType == .variation)
 
         // When: Remove all variations of the shirt product
         try await grdbManager.databaseConnection.write { db in
@@ -566,15 +568,16 @@ struct POSSearchIndexBuilderTests {
         }
 
         // Then: Shirt variations are gone, pants variation remains
-        let shirtResultsAfter = try await grdbManager.databaseConnection.read { db in
-            try POSSearchIndexBuilder.search(siteID: siteID, term: "SHIRT", in: db)
+        let shirtVariationsAfter = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "VSHIRT", in: db)
         }
-        #expect(shirtResultsAfter.count == 0)
+        #expect(shirtVariationsAfter.count == 0)
 
-        let pantsResultsAfter = try await grdbManager.databaseConnection.read { db in
-            try POSSearchIndexBuilder.search(siteID: siteID, term: "PANTS", in: db)
+        let pantsVariationsAfter = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: siteID, term: "VPANTS", in: db)
         }
-        #expect(pantsResultsAfter.count == 1)
+        #expect(pantsVariationsAfter.count == 1)
+        #expect(pantsVariationsAfter.first?.itemType == .variation)
     }
 
     // MARK: - Tokenization Tests

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogPersistenceServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogPersistenceServiceTests.swift
@@ -895,6 +895,51 @@ struct POSCatalogPersistenceServiceTests {
         }
     }
 
+    @Test func deleteProducts_removes_cascade_deleted_variations_from_fts_index() async throws {
+        // Given - A variable product with variations (all FTS-eligible)
+        let product = POSProduct.fake().copy(
+            siteID: sampleSiteID,
+            productID: 100,
+            name: "Variable Shirt",
+            productTypeKey: "variable",
+            statusKey: "publish"
+        )
+        let variation1 = POSProductVariation.fake().copy(
+            siteID: sampleSiteID,
+            productID: 100,
+            productVariationID: 501,
+            sku: "SHIRT-S"
+        )
+        let variation2 = POSProductVariation.fake().copy(
+            siteID: sampleSiteID,
+            productID: 100,
+            productVariationID: 502,
+            sku: "SHIRT-M"
+        )
+        let catalog = POSCatalog(
+            products: [product],
+            variations: [variation1, variation2],
+            syncDate: .now
+        )
+        try await sut.replaceAllCatalogData(catalog, siteID: sampleSiteID)
+
+        // Verify FTS index has product and variations
+        let initialIndexCount = try await db.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM pos_search_fts WHERE siteID = ?", arguments: [sampleSiteID]) ?? 0
+        }
+        #expect(initialIndexCount == 3) // 1 product + 2 variations
+
+        // When - Delete the product without specifying variation IDs
+        // (simulates cascade delete scenario where variations are deleted by GRDB cascade)
+        try await sut.deleteProducts([100], variationIDs: [], siteID: sampleSiteID)
+
+        // Then - FTS index should also have the variations removed
+        let finalIndexCount = try await db.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM pos_search_fts WHERE siteID = ?", arguments: [sampleSiteID]) ?? 0
+        }
+        #expect(finalIndexCount == 0) // All entries removed
+    }
+
     // MARK: - FTS Index Rebuild Tests
 
     @Test func replaceAllCatalogData_rebuilds_fts_index() async throws {

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogPersistenceServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogPersistenceServiceTests.swift
@@ -894,6 +894,41 @@ struct POSCatalogPersistenceServiceTests {
             #expect(products.first?.id == 100)
         }
     }
+
+    // MARK: - FTS Index Rebuild Tests
+
+    @Test func replaceAllCatalogData_rebuilds_fts_index() async throws {
+        // Given - product with valid productTypeKey and statusKey for FTS indexing
+        let product = POSProduct.fake().copy(siteID: sampleSiteID, productID: 1, name: "Coffee Beans", productTypeKey: "simple", statusKey: "publish")
+        let catalog = POSCatalog(products: [product], variations: [], syncDate: .now)
+
+        // When
+        try await sut.replaceAllCatalogData(catalog, siteID: sampleSiteID)
+
+        // Then
+        let indexCount = try await db.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM pos_search_fts WHERE siteID = ?", arguments: [sampleSiteID]) ?? 0
+        }
+        #expect(indexCount == 1)
+    }
+
+    @Test func persistIncrementalCatalogData_rebuilds_fts_index() async throws {
+        // Given - products with valid productTypeKey and statusKey for FTS indexing
+        let product1 = POSProduct.fake().copy(siteID: sampleSiteID, productID: 1, name: "Coffee", productTypeKey: "simple", statusKey: "publish")
+        let initialCatalog = POSCatalog(products: [product1], variations: [], syncDate: .now)
+        try await sut.replaceAllCatalogData(initialCatalog, siteID: sampleSiteID)
+
+        // When
+        let product2 = POSProduct.fake().copy(siteID: sampleSiteID, productID: 2, name: "Tea", productTypeKey: "simple", statusKey: "publish")
+        let incrementalCatalog = POSCatalog(products: [product2], variations: [], syncDate: .now)
+        try await sut.persistIncrementalCatalogData(incrementalCatalog, siteID: sampleSiteID)
+
+        // Then
+        let indexCount = try await db.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM pos_search_fts WHERE siteID = ?", arguments: [sampleSiteID]) ?? 0
+        }
+        #expect(indexCount == 2)
+    }
 }
 
 private extension POSCatalogPersistenceServiceTests {


### PR DESCRIPTION
Part of: WOOMOB-2109
Merge after #16595

## Description

This PR populates the index during day to day syncs – in the transactions when we insert/update/delete products and variations, we call the index builder to index each item.

Adds per-item indexing methods to `POSSearchIndexBuilder`:
- `indexProduct`: indexes a single product (filters by eligibility internally)
- `indexVariation`: indexes a single variation with parent product name and attributes
- `removeFromIndex`: removes a specific item from the FTS index

Refactors `indexAllProducts` / `indexAllVariations` to delegate to these methods.

Wires up inline FTS indexing in `POSCatalogPersistenceService`:
- `replaceAllCatalogData` clears and rebuilds the index inline during full sync
- `persistIncrementalCatalogData` removes old entries before re-indexing updated items
- `deleteProducts` removes FTS entries before deleting records

## Test Steps

- Run `POSSearchIndexBuilderTests` and `POSCatalogPersistenceServiceTests` — all tests should pass

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.