### PR TITLE
[POS FTS] 4: Add background FTS rebuild on POS catalog load

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleObservableItemsController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleObservableItemsController.swift
@@ -1,3 +1,4 @@
+import CocoaLumberjackSwift
 import Foundation
 import Observation
 import class WooFoundation.CurrencySettings
@@ -70,6 +71,12 @@ final class PointOfSaleObservableItemsController: PointOfSaleItemsControllerProt
             }
             dataSource.loadProducts()
             loadingState.productsLoaded = true
+
+            // Start FTS rebuild in background after observation is registered,
+            // so the writer is free for observation setup first.
+            Task {
+                await catalogSyncCoordinator.startBackgroundFTSRebuildIfNeeded(for: siteID)
+            }
 
         case .parent(let parent):
             guard case .variableParentProduct(let parentProduct) = parent else {

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -724,6 +724,10 @@ final class POSPreviewCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol 
     func deleteProductsFromCatalog(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws {
         // no-op
     }
+
+    func startBackgroundFTSRebuildIfNeeded(for siteID: Int64) async {
+        // no-op
+    }
 }
 
 #endif

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -127,6 +127,9 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
     /// Tracks ongoing incremental sync tasks by site ID for cancellation
     private var ongoingIncrementalSyncTasks: [Int64: Task<POSCatalog, Error>] = [:]
 
+    /// Tracks background FTS rebuild tasks by site ID
+    private var backgroundFTSRebuildTasks: [Int64: Task<Void, Never>] = [:]
+
     /// Observable model for full sync state updates
     public nonisolated let fullSyncStateModel: POSCatalogSyncStateModel = .init()
 
@@ -686,7 +689,7 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
 
             DDLogInfo("🔄 POSCatalogSyncCoordinator: Starting background FTS rebuild for site \(siteID)")
 
-            Task {
+            let task = Task {
                 do {
                     try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
                     DDLogInfo("✅ POSCatalogSyncCoordinator: Background FTS rebuild complete for site \(siteID)")
@@ -694,9 +697,18 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
                     DDLogError("⛔️ POSCatalogSyncCoordinator: Background FTS rebuild failed for site \(siteID): \(error)")
                 }
             }
+            backgroundFTSRebuildTasks[siteID] = task
         } catch {
             DDLogError("⛔️ POSCatalogSyncCoordinator: Failed to check FTS rebuild need: \(error)")
         }
+    }
+
+    /// Waits for any pending background FTS rebuild task to complete.
+    /// Primarily used for testing to avoid polling.
+    public func awaitBackgroundFTSRebuild(for siteID: Int64) async {
+        guard let task = backgroundFTSRebuildTasks[siteID] else { return }
+        await task.value
+        backgroundFTSRebuildTasks.removeValue(forKey: siteID)
     }
 
 }

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -690,6 +690,9 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
             DDLogInfo("🔄 POSCatalogSyncCoordinator: Starting background FTS rebuild for site \(siteID)")
 
             let task = Task {
+                defer {
+                    backgroundFTSRebuildTasks.removeValue(forKey: siteID)
+                }
                 do {
                     try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
                     DDLogInfo("✅ POSCatalogSyncCoordinator: Background FTS rebuild complete for site \(siteID)")
@@ -704,11 +707,9 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
     }
 
     /// Waits for any pending background FTS rebuild task to complete.
-    /// Primarily used for testing to avoid polling.
     public func awaitBackgroundFTSRebuild(for siteID: Int64) async {
         guard let task = backgroundFTSRebuildTasks[siteID] else { return }
         await task.value
-        backgroundFTSRebuildTasks.removeValue(forKey: siteID)
     }
 
 }

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -70,6 +70,9 @@ public protocol POSCatalogSyncCoordinatorProtocol {
     ///   - variationIDs: Variation IDs to delete
     ///   - siteID: The site ID
     func deleteProductsFromCatalog(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws
+
+    /// Starts background FTS rebuild if needed (products exist but index empty)
+    func startBackgroundFTSRebuildIfNeeded(for siteID: Int64) async
 }
 
 public extension POSCatalogSyncCoordinatorProtocol {
@@ -667,6 +670,35 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
         let persistenceService = POSCatalogPersistenceService(grdbManager: grdbManager)
         try await persistenceService.deleteProducts(productIDs, variationIDs: variationIDs, siteID: siteID)
     }
+
+    // MARK: - FTS Rebuild
+
+    public func startBackgroundFTSRebuildIfNeeded(for siteID: Int64) async {
+        do {
+            let needsRebuild = try await grdbManager.databaseConnection.read { db in
+                try POSSearchIndexBuilder.needsRebuild(for: siteID, in: db)
+            }
+
+            guard needsRebuild else {
+                DDLogInfo("📋 POSCatalogSyncCoordinator: FTS rebuild not needed for site \(siteID)")
+                return
+            }
+
+            DDLogInfo("🔄 POSCatalogSyncCoordinator: Starting background FTS rebuild for site \(siteID)")
+
+            Task {
+                do {
+                    try await POSSearchIndexBuilder.rebuildIndex(for: siteID, in: grdbManager.databaseConnection)
+                    DDLogInfo("✅ POSCatalogSyncCoordinator: Background FTS rebuild complete for site \(siteID)")
+                } catch {
+                    DDLogError("⛔️ POSCatalogSyncCoordinator: Background FTS rebuild failed for site \(siteID): \(error)")
+                }
+            }
+        } catch {
+            DDLogError("⛔️ POSCatalogSyncCoordinator: Failed to check FTS rebuild need: \(error)")
+        }
+    }
+
 }
 
 // MARK: - Syncing State

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSCatalogSyncCoordinator.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSCatalogSyncCoordinator.swift
@@ -104,4 +104,8 @@ final class MockPOSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
     func deleteProductsFromCatalog(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws {
         // no-op
     }
+
+    func startBackgroundFTSRebuildIfNeeded(for siteID: Int64) async {
+        // no-op
+    }
 }

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
@@ -1534,17 +1534,13 @@ extension POSCatalogSyncCoordinatorTests {
 
         let sut = createSyncCoordinator()
 
-        // When: Start background rebuild
+        // When: Start background rebuild and wait for completion
         await sut.startBackgroundFTSRebuildIfNeeded(for: sampleSiteID)
+        await sut.awaitBackgroundFTSRebuild(for: sampleSiteID)
 
-        // Then: FTS index is eventually populated
-        var results: [POSSearchIndex] = []
-        for _ in 0..<100 {
-            results = try await grdbManager.databaseConnection.read { db in
-                try POSSearchIndexBuilder.search(siteID: sampleSiteID, term: "Test", in: db)
-            }
-            if !results.isEmpty { break }
-            try await Task.sleep(nanoseconds: 10_000_000) // 10ms
+        // Then: FTS index is populated
+        let results = try await grdbManager.databaseConnection.read { db in
+            try POSSearchIndexBuilder.search(siteID: sampleSiteID, term: "Test", in: db)
         }
         #expect(results.count == 1)
     }

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
@@ -1494,6 +1494,62 @@ extension POSCatalogSyncCoordinatorTests {
     }
 }
 
+// MARK: - FTS Rebuild Tests
+
+extension POSCatalogSyncCoordinatorTests {
+    private func createSyncCoordinator() -> POSCatalogSyncCoordinator {
+        POSCatalogSyncCoordinator(
+            fullSyncService: mockSyncService,
+            incrementalSyncService: mockIncrementalSyncService,
+            grdbManager: grdbManager,
+            catalogEligibilityChecker: mockEligibilityChecker,
+            siteSettings: mockSiteSettings
+        )
+    }
+
+    @Test("startBackgroundFTSRebuildIfNeeded starts rebuild when index empty but products exist")
+    func test_startBackgroundFTSRebuildIfNeeded_starts_rebuild_when_needed() async throws {
+        // Given: Products exist but FTS index is empty
+        try await grdbManager.databaseConnection.write { db in
+            try PersistedSite(id: sampleSiteID).insert(db)
+            let product = PersistedProduct(
+                id: 100,
+                siteID: sampleSiteID,
+                name: "Test Product",
+                productTypeKey: "simple",
+                fullDescription: nil,
+                shortDescription: nil,
+                sku: nil,
+                globalUniqueID: nil,
+                price: "10.00",
+                downloadable: false,
+                parentID: 0,
+                manageStock: false,
+                stockQuantity: nil,
+                stockStatusKey: "instock",
+                statusKey: "publish"
+            )
+            try product.insert(db)
+        }
+
+        let sut = createSyncCoordinator()
+
+        // When: Start background rebuild
+        await sut.startBackgroundFTSRebuildIfNeeded(for: sampleSiteID)
+
+        // Then: FTS index is eventually populated
+        var results: [POSSearchIndex] = []
+        for _ in 0..<100 {
+            results = try await grdbManager.databaseConnection.read { db in
+                try POSSearchIndexBuilder.search(siteID: sampleSiteID, term: "Test", in: db)
+            }
+            if !results.isEmpty { break }
+            try await Task.sleep(nanoseconds: 10_000_000) // 10ms
+        }
+        #expect(results.count == 1)
+    }
+}
+
 extension POSCatalogSyncCoordinator {
     func performFullSyncIfApplicable(for siteID: Int64, maxAge: TimeInterval) async throws {
         try await performFullSyncIfApplicable(for: siteID, maxAge: maxAge, regenerateCatalog: false)

--- a/WooCommerce/WooCommerceTests/Tools/ForegroundPOSCatalogSyncDispatcherTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ForegroundPOSCatalogSyncDispatcherTests.swift
@@ -315,4 +315,8 @@ private final class MockPOSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProt
     func deleteProductsFromCatalog(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws {
         // no-op
     }
+
+    func startBackgroundFTSRebuildIfNeeded(for siteID: Int64) async {
+        // no-op
+    }
 }


### PR DESCRIPTION
Part of: WOOMOB-2109
Merge after #16596

## Description

This PR integrates the FTS index rebuilding after a migration to the POS flow. For a large store, this can take some time. With 5k products/12k variations, it takes ~17 seconds on my iPad. 

- During migration, we do the lightweight essentials – adding the FTS tables only. There's no noticable delay.
- If/when the merchant opens POS, and there's fewer records in the index than the main entities, we start the FTS rebuild. The user can still use POS
- During this time, search will only show loading indicators, not results. There's nothing specific to say what it's doing, but it's an edge case. Seeing these requires that someone goes immediately to search and has a large catalog

**N.B. Searches performed using this PR are still SQL `LIKE` queries**, not FTS, even though the index exists and gets populated.

## Test Steps

- Run `POSCatalogSyncCoordinatorTests` — the new FTS rebuild test should pass

### Migration rebuild test

Increase `POSLocalCatalogEligibilityService.defaultCatalogSizeLimit` to work for your store, e.g. 100000

- Delete the app
- Install **from trunk, before the migration PR is merged** (#16594) and log in to a large store (largefuntesting.mystagingwebsite.com is the one I use.)
- Wait for local catalog eligibility to show in the console. Or just wait for the full sync to be done (also console)
- Open POS and wait for full sync to complete
- Install the build from this branch
- Wait for it to determine local catalog eligibility
- Open POS, verify no UI delay from the background rebuild as you open it
- Open search and type a term – observe that you see the skeleton cells, and after a few seconds, search results.
- Observe that subsequent searches do not have this delay. 

You can also (if you want) repeat the whole test to see that if you leave it 20 seconds after opening POS, search works immediately, but don't feel that's essential.

## Screenshots

https://github.com/user-attachments/assets/fb2a07d2-e2a0-4d9f-b9d5-19b24f84c8f1


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.