### PR TITLE
[Tooling] Fix missing localization paths for GlotPress string extraction

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1282,9 +1282,12 @@ platform :ios do
         'Modules/Sources/WordPress*/',
         'Modules/Sources/PointOfSale/',
         'Modules/Sources/WPMediaPicker/',
-        'Storage/Storage/',
-        'Networking/Networking/',
-        'Hardware/Hardware/'
+        'Modules/Sources/Storage/',
+        'Modules/Sources/Networking/',
+        'Modules/Sources/NetworkingCore/',
+        'Modules/Sources/Yosemite/',
+        'Modules/Sources/WooFoundation/',
+        'Modules/Sources/Hardware/'
       ],
       exclude: [
         '*Vendor*',


### PR DESCRIPTION
Fixes AINFRA-1887

## Description
The `generate_strings_file_for_glotpress` lane was not scanning several modules that contain NSLocalizedString calls, causing strings to be missing from Localizable.strings and GlotPress.

- Fix stale paths in `generate_strings_file_for_glotpress` that no longer exist
- Add missing Swift Package modules that contain localized strings

## Testing
- Run `bundle exec fastlane generate_strings_file_for_glotpress skip_commit:true`
- Verify `WooCommerce/Resources/en.lproj/Localizable.strings` now contains the previously missing strings (e.g., orderStatusEnum.localizedName.processing)