### PR TITLE
Add missing localizable string key

### DIFF
--- a/Modules/Sources/Yosemite/Tools/ProductVariations/VariationAttributeViewModel.swift
+++ b/Modules/Sources/Yosemite/Tools/ProductVariations/VariationAttributeViewModel.swift
@@ -55,7 +55,7 @@ extension VariationAttributeViewModel {
         )
 
         static let namedAttributeFormat = NSLocalizedString(
-            "",
+            "variationAttributeView.namedAttributeFormat",
             value: "%1$@: %2$@",
             comment: "Format of a named variation attribute description. %1$@ is the attribute name, and %2$@ is the " +
             "attribute value. Displayed in a whole variation of a Coffee beans/grounds product, it could look like: +" +


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
Part of: AINFRA-1887

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is a follow-up PR for [[Tooling] Fix missing localization paths for GlotPress string extraction](https://github.com/woocommerce/woocommerce-ios/pull/16603)
- Fixes the missing key for localizable string. Addresses the following error:
```
+------------------------------------------------------------+
|                        Lane Context                        |
+------------------+-----------------------------------------+
| DEFAULT_PLATFORM | ios                                     |
| PLATFORM_NAME    | ios                                     |
| LANE_NAME        | ios generate_strings_file_for_glotpress |
+------------------+-----------------------------------------+
[12:06:13]: Called from Fastfile at line 1279
[12:06:13]: ```
[12:06:13]:     1277:	  lane :generate_strings_file_for_glotpress do |options|
[12:06:13]:     1278:	    en_lproj_path = File.join(RESOURCES_FOLDER, 'en.lproj')
[12:06:13]:  => 1279:	    ios_generate_strings_file_from_code(
[12:06:13]:     1280:	      paths: [
[12:06:13]:     1281:	        'WooCommerce/',
[12:06:13]: ```
[12:06:13]: genstrings: error: bad entry in file Modules/Sources/Yosemite/Tools/ProductVariations/VariationAttributeViewModel.swift (line = 57): Argument is not a literal string.
```

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Run bundle exec fastlane generate_strings_file_for_glotpress skip_commit:true
- Verify WooCommerce/Resources/en.lproj/Localizable.strings now contains the previously missing strings (e.g., orderStatusEnum.localizedName.processing)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
