### PR TITLE
[POS Refunds] Use abs to account negative values from backend

### DIFF
--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
@@ -170,11 +170,12 @@ public final class POSRefundsService: POSRefundsServiceProtocol {
         refunds: [Refund]
     ) -> Bool {
         // Aggregate refunded quantities by product/variation ID
+        // Note: API returns negative quantities for refunds, so we use abs()
         var refundedQuantities: [Int64: Decimal] = [:]
         for refund in refunds {
             for item in refund.items {
                 let id = item.variationID != 0 ? item.variationID : item.productID
-                refundedQuantities[id, default: 0] += item.quantity
+                refundedQuantities[id, default: 0] += abs(item.quantity)
             }
         }
 

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSRefundsServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSRefundsServiceTests.swift
@@ -180,6 +180,66 @@ struct POSRefundsServiceTests {
         #expect(result.supportsAutomaticRefund == true)
     }
 
+    // MARK: - isFullyRefunded Tests
+
+    @Test func providePointOfSaleRefunds_when_all_items_refunded_with_negative_quantities_then_isFullyRefunded_is_true() async throws {
+        // Given: Order has 2 units of product 111
+        let remote = MockPOSRefundsRemote()
+        let sut = makeSUT(remote: remote)
+
+        // API returns negative quantities for refunds (-2 means 2 items refunded)
+        let refundItem = MockRefunds.sampleRefundItem(productID: 111, variationID: 0, quantity: -2)
+        let refund = MockRefunds.sampleRefund(items: [refundItem])
+        remote.result = .success([refund])
+
+        let order = makeOrder(lineItemQuantitiesByProductOrVariationID: [111: 2])
+
+        // When
+        let result = try await sut.providePointOfSaleRefunds(for: order)
+
+        // Then
+        #expect(result.isFullyRefunded == true)
+    }
+
+    @Test func providePointOfSaleRefunds_when_partial_items_refunded_then_isFullyRefunded_is_false() async throws {
+        // Given: Order has 3 units of product 111
+        let remote = MockPOSRefundsRemote()
+        let sut = makeSUT(remote: remote)
+
+        // Only 2 items refunded (negative quantity from API)
+        let refundItem = MockRefunds.sampleRefundItem(productID: 111, variationID: 0, quantity: -2)
+        let refund = MockRefunds.sampleRefund(items: [refundItem])
+        remote.result = .success([refund])
+
+        let order = makeOrder(lineItemQuantitiesByProductOrVariationID: [111: 3])
+
+        // When
+        let result = try await sut.providePointOfSaleRefunds(for: order)
+
+        // Then
+        #expect(result.isFullyRefunded == false)
+    }
+
+    @Test func providePointOfSaleRefunds_when_variation_fully_refunded_then_isFullyRefunded_is_true() async throws {
+        // Given: Order has 1 unit of variation 222 (of product 111)
+        let remote = MockPOSRefundsRemote()
+        let sut = makeSUT(remote: remote)
+
+        // Variation refunded (negative quantity from API)
+        let refundItem = MockRefunds.sampleRefundItem(productID: 111, variationID: 222, quantity: -1)
+        let refund = MockRefunds.sampleRefund(items: [refundItem])
+        remote.result = .success([refund])
+
+        // Key is variationID when variation exists
+        let order = makeOrder(lineItemQuantitiesByProductOrVariationID: [222: 1])
+
+        // When
+        let result = try await sut.providePointOfSaleRefunds(for: order)
+
+        // Then
+        #expect(result.isFullyRefunded == true)
+    }
+
     // MARK: - createRefund Tests
 
     @Test func createRefund_then_calls_calculator_with_correct_parameters() async throws {
@@ -341,7 +401,12 @@ struct POSRefundsServiceTests {
         }
     }
 
-    private func makeOrder(id: Int64 = 1, paymentMethodID: String = "woocommerce_payments", refunds: [POSOrderRefund] = []) -> POSOrder {
+    private func makeOrder(
+        id: Int64 = 1,
+        paymentMethodID: String = "woocommerce_payments",
+        refunds: [POSOrderRefund] = [],
+        lineItemQuantitiesByProductOrVariationID: [Int64: Decimal] = [:]
+    ) -> POSOrder {
         POSOrder(
             id: id,
             number: "1001",
@@ -357,7 +422,8 @@ struct POSRefundsServiceTests {
             formattedDiscountTotal: nil,
             formattedTotalTax: "$0.00",
             formattedPaymentTotal: "$10.00",
-            formattedNetAmount: nil
+            formattedNetAmount: nil,
+            lineItemQuantitiesByProductOrVariationID: lineItemQuantitiesByProductOrVariationID
         )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

  <!-- Id number of the Linear issue this PR addresses. -->
  <!-- Part of: # -> use this if your PR is one of many related to one issue -->

  ## Description
  <!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing "See original issue" – clarify what the problem was and how you've fixed it. -->

  Fixes `isFullyRefunded` calculation to handle negative quantities returned by the API for refunded items.

  The WooCommerce API returns negative quantities for refund line items (e.g., `-2` means 2 items were refunded). The previous implementation compared these directly against positive ordered quantities, causing
  the check to always fail (e.g., `-2 >= 2` is `false`).

  **Fix:** Use `abs()` when aggregating refunded quantities to normalize the comparison.

  ## Test Steps
  <!-- Describe how to test your changes. Include only what's needed for the reviewer to validate the behavior.
  For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
  If applicable, mention key devices, scenarios, or edge cases to verify. -->

  1. Create an order with multiple items in POS
  2. Complete a full refund for all items
  3. Navigate back to the order details
  4. **Expected:** Refund button should NOT be visible (order is fully refunded)

  **Partial refund scenario:**
  1. Create an order with 3 units of the same product
  2. Refund only 2 units
  3. Navigate back to the order details
  4. **Expected:** Refund button should still be visible (order is partially refunded)

  ## Screenshots
  <!-- Include before and after images or gifs when appropriate. -->

  N/A - logic change only

  ---
  - [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.