### PR TITLE
[WOOMOB-1582] Update POS order details empty state for search

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsEmptyView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsEmptyView.swift
@@ -11,9 +11,17 @@ struct POSOrderDetailsEmptyView: View {
             VStack {
                 Spacer()
 
-                Text(Localization.noOrderToDisplay)
+                PointOfSaleAssets.noOrders.decorativeImage
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: Constants.iconSize, height: Constants.iconSize)
+                    .foregroundColor(.posOnSurface)
+
+                Spacer().frame(height: POSSpacing.medium)
+
+                Text(Localization.noOrderSelected)
                     .font(.posBodyLargeRegular())
-                    .foregroundStyle(Color.posOnSurfaceVariantHighest)
+                    .foregroundStyle(Color.posOnSurface)
                     .multilineTextAlignment(.center)
 
                 Spacer()
@@ -24,6 +32,10 @@ struct POSOrderDetailsEmptyView: View {
     }
 }
 
+private enum Constants {
+    static let iconSize: CGFloat = 88
+}
+
 private enum Localization {
     static let title = NSLocalizedString(
         "pos.orderDetailsEmptyView.ordersTitle",
@@ -31,10 +43,10 @@ private enum Localization {
         comment: "Title at the header for the Order Details empty view."
     )
 
-    static let noOrderToDisplay = NSLocalizedString(
-        "pos.orderDetailsEmptyView.noOrderToDisplay",
-        value: "No order to display",
-        comment: "Text appearing in the order details pane when there are no orders available."
+    static let noOrderSelected = NSLocalizedString(
+        "pos.orderDetailsEmptyView.noOrderSelected",
+        value: "No order selected.",
+        comment: "Text appearing in the order details pane when no order is selected."
     )
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsEmptyView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsEmptyView.swift
@@ -2,11 +2,14 @@ import SwiftUI
 
 struct POSOrderDetailsEmptyView: View {
     var body: some View {
-        VStack(spacing: 0) {
-            POSPageHeaderView(
-                title: Localization.title,
-                backButtonConfiguration: nil
-            )
+        ZStack {
+            VStack {
+                POSPageHeaderView(
+                    title: Localization.title,
+                    backButtonConfiguration: nil
+                )
+                Spacer()
+            }
 
             VStack {
                 Spacer()

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
@@ -60,6 +60,7 @@ struct POSOrdersView: View {
                 guard horizontalSizeClass == .regular else { return }
 
                 guard let firstOrder = newOrders.first else {
+                    orderListModel.ordersController.selectOrder(nil)
                     return
                 }
 


### PR DESCRIPTION
## Description

Context: WOOMOB-1582

Updates the POS order details empty state view to show an icon with "No order selected." text when no order is selected in the split view. Also fixes selection behavior when search returns no results.

It now matches Android behavior.

### Changes
For empty details view:
- Show orders icon
- Updated text to "No order selected." with proper POS styling
- Clear selection when search returns no results (shows empty state)
- Pre-select first item when search results arrive or search is cleared

## Testing

1. Open POS → tap Orders
2. Verify first order is pre-selected
4. Search for something that returns no results
5. Verify details pane shows empty state with icon and "No order selected."
6. Search for something that returns results → first result should be pre-selected
7. Clear search → top item in list should be pre-selected

## VIdeo

https://github.com/user-attachments/assets/786b9a85-98c4-4e74-9e18-8960d47a2bee

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.