### PR TITLE
UI Test: Fix check for the Save Password alert in iOS 26.2

### DIFF
--- a/Modules/Sources/UITestsFoundation/Screens/Login/PasswordScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Login/PasswordScreen.swift
@@ -50,7 +50,7 @@ public final class PasswordScreen: ScreenObject {
         continueButton.tap()
 
         // As of Xcode 14.3, the Simulator might ask to save the password which, of course, we don't want to do.
-        if app.buttons["Save Password"].waitForExistence(timeout: 15) {
+        if app.staticTexts["Save Password?"].waitForExistence(timeout: 15) {
             // There should be no need to wait for this button to exist since it's part of the same
             // alert where "Save Password" is.
             let dismissButton = app.buttons["Not Now"]


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Since CI got updated to Xcode 26.2, UI tests have been failing. The issue is that on iOS 26.2, the "Save Password" alert has a different button title than in previous versions, causing tests to be stuck on this alert.

iOS 26.1 | iOS 26.2
--- | ---
<img width="1206" height="2622" alt="Simulator Screenshot - Clone 1 of iPhone 17 - 2026-02-04 at 18 07 15" src="https://github.com/user-attachments/assets/42f4ca2a-2641-40bf-9e73-a670585201cd" /> | <img width="1206" height="2622" alt="Simulator Screenshot - Clone 1 of iPhone 17 - 2026-02-04 at 18 09 14" src="https://github.com/user-attachments/assets/17f825eb-e0b7-46e4-adfe-ad04e2498921" />

The solution is to check for the alert title "Save Password?" which is the same for the iOS versions. This is by no means a reliable check, but I suppose we can live with it until Apple changes the alert again.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Ensure that you have Xcode 26.2 installed.
- Run `rake mocks` in Terminal.
- Run UI tests with iOS 26.2 simulator.
- Confirm that tests pass.
- CI should pass as well.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
