### PR TITLE
POS: Add legacy LIKE-based local search fallback

### DIFF
--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemFetchStrategyFactory.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemFetchStrategyFactory.swift
@@ -56,8 +56,18 @@ public final class PointOfSaleItemFetchStrategyFactory: PointOfSaleItemFetchStra
     }
     public func searchStrategy(searchTerm: String,
                                analytics: POSItemFetchAnalyticsTracking) -> PointOfSalePurchasableItemFetchStrategy {
-        // Use local FTS search if both local catalog and FTS search are enabled, and dependencies are available
-        if isLocalCatalogEnabled, isFTSSearchEnabled, let grdbManager = grdbManager, let itemMapper = itemMapper {
+        guard isLocalCatalogEnabled, let grdbManager = grdbManager else {
+            // Remote API search when local catalog is not enabled
+            return PointOfSaleSearchPurchasableItemFetchStrategy(siteID: siteID,
+                                                                searchTerm: searchTerm,
+                                                                productsRemote: productsRemote,
+                                                                variationsRemote: variationsRemote,
+                                                                analytics: analytics,
+                                                                posProductsOnly: posProductsOnlyEnabled)
+        }
+
+        if isFTSSearchEnabled, let itemMapper = itemMapper {
+            // FTS-based local search (returns mixed products and variations)
             return PointOfSaleLocalSearchPurchasableItemFetchStrategy(siteID: siteID,
                                                                       searchTerm: searchTerm,
                                                                       grdbManager: grdbManager,
@@ -65,14 +75,15 @@ public final class PointOfSaleItemFetchStrategyFactory: PointOfSaleItemFetchStra
                                                                       itemMapper: itemMapper,
                                                                       analytics: analytics,
                                                                       posProductsOnly: posProductsOnlyEnabled)
+        } else {
+            // Legacy LIKE-based local search (products only)
+            return PointOfSaleLegacyLocalSearchPurchasableItemFetchStrategy(siteID: siteID,
+                                                                            searchTerm: searchTerm,
+                                                                            grdbManager: grdbManager,
+                                                                            variationsRemote: variationsRemote,
+                                                                            analytics: analytics,
+                                                                            posProductsOnly: posProductsOnlyEnabled)
         }
-        // Fall back to remote API search
-        return PointOfSaleSearchPurchasableItemFetchStrategy(siteID: siteID,
-                                                            searchTerm: searchTerm,
-                                                            productsRemote: productsRemote,
-                                                            variationsRemote: variationsRemote,
-                                                            analytics: analytics,
-                                                            posProductsOnly: posProductsOnlyEnabled)
     }
 
     public func popularStrategy(pageSize: Int = 10) -> PointOfSalePurchasableItemFetchStrategy {

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemService.swift
@@ -27,6 +27,7 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
                                         fetchStrategy: PointOfSalePurchasableItemFetchStrategy) async throws -> PagedItems<POSItem> {
         do {
             // Check if strategy provides mixed items (e.g., FTS search returning products and variations together)
+            // TODO: Simplify this branching once FTS search is fully rolled out and legacy strategies are removed
             if let mixedItems = try await fetchStrategy.fetchMixedItems(pageNumber: pageNumber) {
                 if pageNumber != 1 && mixedItems.items.isEmpty {
                     return .init(items: [], hasMorePages: false, totalItems: 0)

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleLegacyLocalSearchPurchasableItemFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleLegacyLocalSearchPurchasableItemFetchStrategy.swift
@@ -1,0 +1,104 @@
+import Foundation
+import protocol Storage.GRDBManagerProtocol
+import protocol Networking.ProductVariationsRemoteProtocol
+
+/// Fetch strategy for searching products in the local GRDB catalog using SQL LIKE queries.
+/// This is the legacy fallback when FTS search is disabled but local catalog is enabled.
+struct PointOfSaleLegacyLocalSearchPurchasableItemFetchStrategy: PointOfSalePurchasableItemFetchStrategy {
+    private let siteID: Int64
+    private let searchTerm: String
+    private let grdbManager: GRDBManagerProtocol
+    // periphery:ignore - Reserved for future variation fetching from remote when not in local catalog
+    private let variationsRemote: ProductVariationsRemoteProtocol
+    private let analytics: POSItemFetchAnalyticsTracking
+    private let pageSize: Int
+    private let posProductsOnly: Bool
+
+    init(siteID: Int64,
+         searchTerm: String,
+         grdbManager: GRDBManagerProtocol,
+         variationsRemote: ProductVariationsRemoteProtocol,
+         analytics: POSItemFetchAnalyticsTracking,
+         pageSize: Int = 25,
+         posProductsOnly: Bool = false) {
+        self.siteID = siteID
+        self.searchTerm = searchTerm
+        self.grdbManager = grdbManager
+        self.variationsRemote = variationsRemote
+        self.analytics = analytics
+        self.pageSize = pageSize
+        self.posProductsOnly = posProductsOnly
+    }
+
+    var debounceStrategy: SearchDebounceStrategy {
+        // Use simple debouncing for local search: always debounce to prevent excessive queries
+        // even though local searches are fast. 100ms provides responsive feel while preventing
+        // queries on every keystroke. Delay loading indicators by 150ms to avoid flicker for fast queries.
+        .simple(duration: 150 * NSEC_PER_MSEC, loadingDelayThreshold: 300 * NSEC_PER_MSEC)
+    }
+
+    func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct> {
+        let startTime = Date()
+
+        // Get total count and persisted products in one transaction
+        let (persistedProducts, totalCount) = try await grdbManager.databaseConnection.read { db in
+            let totalCount = try PersistedProduct
+                .posProductSearch(siteID: siteID, searchTerm: searchTerm)
+                .fetchCount(db)
+
+            let offset = (pageNumber - 1) * pageSize
+            let persistedProducts = try PersistedProduct
+                .posProductSearch(siteID: siteID, searchTerm: searchTerm)
+                .limit(pageSize, offset: offset)
+                .fetchAll(db)
+
+            return (persistedProducts, totalCount)
+        }
+
+        // Convert to POSProduct outside the read transaction
+        // toPOSProduct(db:) starts its own transaction, so we can't call it inside another transaction
+        let products = try persistedProducts.map { persistedProduct in
+            try persistedProduct.toPOSProduct(db: grdbManager.databaseConnection)
+        }
+
+        let hasMorePages = (pageNumber * pageSize) < totalCount
+
+        if pageNumber == 1 {
+            let milliseconds = Int(Date().timeIntervalSince(startTime) * Double(MSEC_PER_SEC))
+            analytics.trackSearchLocalResultsFetchComplete(millisecondsSinceRequestSent: milliseconds,
+                                                           totalItems: totalCount)
+        }
+
+        return PagedItems(items: products,
+                         hasMorePages: hasMorePages,
+                         totalItems: totalCount)
+    }
+
+    func fetchVariations(parentProductID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
+        // Get total count and persisted variations in one transaction
+        let (persistedVariations, totalCount) = try await grdbManager.databaseConnection.read { db in
+            let totalCount = try PersistedProductVariation
+                .posVariationsRequest(siteID: siteID, parentProductID: parentProductID)
+                .fetchCount(db)
+
+            let offset = (pageNumber - 1) * pageSize
+            let persistedVariations = try PersistedProductVariation
+                .posVariationsRequest(siteID: siteID, parentProductID: parentProductID)
+                .limit(pageSize, offset: offset)
+                .fetchAll(db)
+
+            return (persistedVariations, totalCount)
+        }
+
+        // Convert to POSProductVariation outside the read transaction
+        let variations = try persistedVariations.map { persistedVariation in
+            try persistedVariation.toPOSProductVariation(db: grdbManager.databaseConnection)
+        }
+
+        let hasMorePages = (pageNumber * pageSize) < totalCount
+
+        return PagedItems(items: variations,
+                         hasMorePages: hasMorePages,
+                         totalItems: totalCount)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `PointOfSaleLegacyLocalSearchPurchasableItemFetchStrategy` for LIKE-based local search when FTS is disabled but local catalog is enabled
- Updates `PointOfSaleItemFetchStrategyFactory` to use three-tier fallback: FTS → Legacy local → Remote API
- This provides a fallback path for users who have local catalog but don't have FTS enabled

## Test plan
- [ ] Disable `pointOfSaleFTSSearch` feature flag
- [ ] Enable local catalog
- [ ] Verify search uses LIKE-based queries locally
- [ ] Enable `pointOfSaleFTSSearch` feature flag  
- [ ] Verify search uses FTS queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)