### PR TITLE
Fix failing UI tests on iOS 26.2

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -118,8 +118,6 @@ steps:
   - label: ":microscope: UI Tests (iPhone)"
     command: .buildkite/commands/run-ui-tests.sh UITests "iPhone 17"
     depends_on: build
-    # Only run on `trunk` and `release/*` -- See p91TBi-cBM-p2#comment-13736
-    if: build.branch == "trunk" || build.branch =~ /^release\//
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - fastlane/test_output/*

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -118,6 +118,8 @@ steps:
   - label: ":microscope: UI Tests (iPhone)"
     command: .buildkite/commands/run-ui-tests.sh UITests "iPhone 17"
     depends_on: build
+    # Only run on `trunk` and `release/*` -- See p91TBi-cBM-p2#comment-13736
+    if: build.branch == "trunk" || build.branch =~ /^release\//
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - fastlane/test_output/*

--- a/Modules/Sources/UITestsFoundation/Screens/Login/PasswordScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Login/PasswordScreen.swift
@@ -48,17 +48,53 @@ public final class PasswordScreen: ScreenObject {
     public func proceedWith(password: String) throws {
         passwordField.enterText(text: password)
         continueButton.tap()
+        dismissSavePasswordAlertIfPresent()
+    }
 
-        // As of Xcode 14.3, the Simulator might ask to save the password which, of course, we don't want to do.
-        if app.buttons["Save Password"].waitForExistence(timeout: 15) {
-            // There should be no need to wait for this button to exist since it's part of the same
-            // alert where "Save Password" is.
-            let dismissButton = app.buttons["Not Now"]
-            // Additionally wait for existence of the button to account for animations, even though the test runner should wait for the app
-            // to idle before moving on.
-            XCTAssertTrue(dismissButton.waitForExistence(timeout: 2))
+    private func dismissSavePasswordAlertIfPresent() {
+        // The Simulator may show a system "Save Password?" alert after submitting
+        // the password. This blocks the flow in CI, so dismiss it if it appears.
+        let dismissButtonLabel = "Not Now"
+        let alertTitles = [
+            "Save Password?",
+            "Save Password"
+        ]
+
+        if let dismissButton = findAlertButton(
+            in: app,
+            alertTitles: alertTitles,
+            buttonLabel: dismissButtonLabel,
+            timeout: 3
+        ) {
             dismissButton.tap()
+            return
         }
+    }
+
+    private func findAlertButton(
+        in app: XCUIApplication,
+        alertTitles: [String],
+        buttonLabel: String,
+        timeout: TimeInterval
+    ) -> XCUIElement? {
+        for title in alertTitles {
+            let alert = app.alerts[title]
+            if alert.waitForExistence(timeout: timeout) {
+                let button = alert.buttons[buttonLabel]
+                if button.exists {
+                    return button
+                }
+            }
+
+            let sheet = app.sheets[title]
+            if sheet.waitForExistence(timeout: timeout) {
+                let button = sheet.buttons[buttonLabel]
+                if button.exists {
+                    return button
+                }
+            }
+        }
+        return nil
     }
 
     @discardableResult


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-2132

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Currently UI tests are failing in trunk / blocked by the "Save Password" dialogue that's failed to be identified in iOS 26.2. The PR resolves this issue:

- Performs search for the dialogue alert in `app.alerts` and `app.sheets` instead of `app.buttons`.
- Performs search for the dialogue alert by "Save Password?" term instead of "Save Password" (question mark added).

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Use Xcode
- Run `rake mocks`
- Select `WooCommerceUITests` scheme in Xcode
- Make sure simulator has English language set in settings
- Run these ui tests manually and make sure they pass:
```
test_add_external_product()** in ProductsTests
test_add_grouped_product() in ProductsTests
test_add_simple_physical_product() in ProductsTests
test_add_simple_virtual_product() in ProductsTests
test_add_variable_product() in ProductsTests
test_filter_product() in ProductsTests
test_load_products_screen() in ProductsTests
test_search_product() in ProductsTests
test_load_reviews_screen() in ReviewsTests
test_add_note_to_existing_order() in OrdersTests
test_cancel_order_creation() in OrdersTests
test_create_new_order() in OrdersTests
test_load_existing_order() in OrdersTests
test_load_orders_screen() in OrdersTests
test_load_performance_card() in DashboardTests
test_view_detailed_chart_performance_card() in DashboardTests
test_load_chipper_card_reader_manual() in PaymentsTests
test_load_learn_more_link() in **PaymentsTests
```

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
