### PR TITLE
Use cache for remote feature flags

### DIFF
--- a/Modules/Sources/Yosemite/Actions/FeatureFlagAction.swift
+++ b/Modules/Sources/Yosemite/Actions/FeatureFlagAction.swift
@@ -3,5 +3,5 @@ import Foundation
 /// Defines the `actions` supported by the `FeatureFlagStore`.
 ///
 public enum FeatureFlagAction: Action {
-    case isRemoteFeatureFlagEnabled(_ featureFlag: RemoteFeatureFlag, defaultValue: Bool, completion: (Bool) -> Void)
+    case isRemoteFeatureFlagEnabled(_ featureFlag: RemoteFeatureFlag, defaultValue: Bool, useCache: Bool = true, completion: (Bool) -> Void)
 }

--- a/Modules/Sources/Yosemite/Model/Mocks/MockStoresManager.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/MockStoresManager.swift
@@ -165,7 +165,7 @@ public class MockStoresManager: StoresManager {
             couponActionHandler.handle(action: action)
         case let action as FeatureFlagAction:
             switch action {
-            case let .isRemoteFeatureFlagEnabled(_, _, completion):
+            case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 completion(true)
             }
         default:

--- a/Modules/Sources/Yosemite/Stores/FeatureFlagStore.swift
+++ b/Modules/Sources/Yosemite/Stores/FeatureFlagStore.swift
@@ -1,15 +1,23 @@
+import Foundation
 import Networking
 import Storage
 
 public final class FeatureFlagStore: Store {
     private let remote: FeatureFlagRemoteProtocol
     private var cachedFeatureFlags: [RemoteFeatureFlag: Bool]?
+    private var cacheTimestamp: Date?
+    private let cacheMaxAge: TimeInterval
+    private let currentDate: () -> Date
 
     init(dispatcher: Dispatcher,
          storageManager: StorageManagerType,
          network: Network,
-         remote: FeatureFlagRemoteProtocol) {
+         remote: FeatureFlagRemoteProtocol,
+         cacheMaxAge: TimeInterval = 24 * 60 * 60,
+         currentDate: @escaping () -> Date = { Date() }) {
         self.remote = remote
+        self.cacheMaxAge = cacheMaxAge
+        self.currentDate = currentDate
         super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
     }
 
@@ -50,11 +58,16 @@ public final class FeatureFlagStore: Store {
 // MARK: - Services
 //
 private extension FeatureFlagStore {
+    var isCacheExpired: Bool {
+        guard let cacheTimestamp else { return true }
+        return currentDate().timeIntervalSince(cacheTimestamp) >= cacheMaxAge
+    }
+
     func isRemoteFeatureFlagEnabled(_ featureFlag: RemoteFeatureFlag,
                                     defaultValue: Bool,
                                     useCache: Bool,
                                     completion: @escaping (Bool) -> Void) {
-        if useCache, let cachedFlags = cachedFeatureFlags {
+        if useCache, let cachedFlags = cachedFeatureFlags, !isCacheExpired {
             completion(cachedFlags[featureFlag] ?? defaultValue)
             return
         }
@@ -64,6 +77,7 @@ private extension FeatureFlagStore {
                 let featureFlags = try await remote.loadAllFeatureFlags()
                 await MainActor.run {
                     self.cachedFeatureFlags = featureFlags
+                    self.cacheTimestamp = self.currentDate()
                     completion(featureFlags[featureFlag] ?? defaultValue)
                 }
             } catch {

--- a/Modules/Sources/Yosemite/Stores/FeatureFlagStore.swift
+++ b/Modules/Sources/Yosemite/Stores/FeatureFlagStore.swift
@@ -3,6 +3,7 @@ import Storage
 
 public final class FeatureFlagStore: Store {
     private let remote: FeatureFlagRemoteProtocol
+    private var cachedFeatureFlags: [RemoteFeatureFlag: Bool]?
 
     init(dispatcher: Dispatcher,
          storageManager: StorageManagerType,
@@ -40,8 +41,8 @@ public final class FeatureFlagStore: Store {
         }
 
         switch action {
-        case let .isRemoteFeatureFlagEnabled(featureFlag, defaultValue, completion):
-            isRemoteFeatureFlagEnabled(featureFlag, defaultValue: defaultValue, completion: completion)
+        case let .isRemoteFeatureFlagEnabled(featureFlag, defaultValue, useCache, completion):
+            isRemoteFeatureFlagEnabled(featureFlag, defaultValue: defaultValue, useCache: useCache, completion: completion)
         }
     }
 }
@@ -49,11 +50,20 @@ public final class FeatureFlagStore: Store {
 // MARK: - Services
 //
 private extension FeatureFlagStore {
-    func isRemoteFeatureFlagEnabled(_ featureFlag: RemoteFeatureFlag, defaultValue: Bool, completion: @escaping (Bool) -> Void) {
+    func isRemoteFeatureFlagEnabled(_ featureFlag: RemoteFeatureFlag,
+                                    defaultValue: Bool,
+                                    useCache: Bool,
+                                    completion: @escaping (Bool) -> Void) {
+        if useCache, let cachedFlags = cachedFeatureFlags {
+            completion(cachedFlags[featureFlag] ?? defaultValue)
+            return
+        }
+
         Task { @MainActor in
             do {
                 let featureFlags = try await remote.loadAllFeatureFlags()
                 await MainActor.run {
+                    self.cachedFeatureFlags = featureFlags
                     completion(featureFlags[featureFlag] ?? defaultValue)
                 }
             } catch {

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockFeatureFlagRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockFeatureFlagRemote.swift
@@ -7,6 +7,9 @@ final class MockFeatureFlagRemote {
     /// The results to return in `loadAllFeatureFlags`.
     private var loadAllFeatureFlagsResult: Result<[RemoteFeatureFlag: Bool], Error>?
 
+    /// The number of times `loadAllFeatureFlags` has been called.
+    private(set) var loadAllFeatureFlagsCallCount = 0
+
     /// Returns the value when `loadAllFeatureFlags` is called.
     func whenLoadingAllFeatureFlags(thenReturn result: Result<[RemoteFeatureFlag: Bool], Error>) {
         loadAllFeatureFlagsResult = result
@@ -15,6 +18,7 @@ final class MockFeatureFlagRemote {
 
 extension MockFeatureFlagRemote: FeatureFlagRemoteProtocol {
     func loadAllFeatureFlags() async throws -> [RemoteFeatureFlag: Bool] {
+        loadAllFeatureFlagsCallCount += 1
         guard let result = loadAllFeatureFlagsResult else {
             XCTFail("Could not find result for loading all feature flags.")
             throw NetworkError.notFound()

--- a/Modules/Tests/YosemiteTests/Stores/FeatureFlagStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/FeatureFlagStoreTests.swift
@@ -43,7 +43,7 @@ final class FeatureFlagStoreTests: XCTestCase {
         // When
         let isEnabled = waitFor { promise in
             self.store.onAction(FeatureFlagAction
-                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: false) { result in
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: false, useCache: true) { result in
                 promise(result)
             })
         }
@@ -59,12 +59,102 @@ final class FeatureFlagStoreTests: XCTestCase {
         // When
         let isEnabled = waitFor { promise in
             self.store.onAction(FeatureFlagAction
-                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: false) { result in
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: false, useCache: true) { result in
                     promise(result)
                 })
         }
 
         // Then
         XCTAssertFalse(isEnabled)
+    }
+
+    func test_isRemoteFeatureFlagEnabled_when_useCache_is_true_returns_cached_value_without_remote_call() throws {
+        // Given
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: true]))
+
+        // First call to populate the cache
+        waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: false, useCache: true) { _ in
+                    promise(())
+                })
+        }
+
+        // Change the remote response to verify cache is used
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: false]))
+
+        // When
+        let isEnabled = waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: false, useCache: true) { result in
+                    promise(result)
+                })
+        }
+
+        // Then - should return cached value (true), not the new remote value (false)
+        XCTAssertTrue(isEnabled)
+        XCTAssertEqual(remote.loadAllFeatureFlagsCallCount, 1)
+    }
+
+    func test_isRemoteFeatureFlagEnabled_when_useCache_is_false_fetches_from_remote() throws {
+        // Given
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: true]))
+
+        // First call to populate the cache
+        waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: false, useCache: true) { _ in
+                    promise(())
+                })
+        }
+
+        // Change the remote response
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: false]))
+
+        // When - use useCache: false to force remote fetch
+        let isEnabled = waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: true, useCache: false) { result in
+                    promise(result)
+                })
+        }
+
+        // Then - should return the new remote value (false)
+        XCTAssertFalse(isEnabled)
+        XCTAssertEqual(remote.loadAllFeatureFlagsCallCount, 2)
+    }
+
+    func test_isRemoteFeatureFlagEnabled_when_useCache_is_false_updates_cache() throws {
+        // Given
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: true]))
+
+        // First call to populate the cache
+        waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: false, useCache: true) { _ in
+                    promise(())
+                })
+        }
+
+        // Change the remote response and fetch with useCache: false
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: false]))
+        waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: true, useCache: false) { _ in
+                    promise(())
+                })
+        }
+
+        // When - fetch with useCache: true, should use updated cache
+        let isEnabled = waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: true, useCache: true) { result in
+                    promise(result)
+                })
+        }
+
+        // Then - should return the updated cached value (false)
+        XCTAssertFalse(isEnabled)
+        XCTAssertEqual(remote.loadAllFeatureFlagsCallCount, 2)
     }
 }

--- a/Modules/Tests/YosemiteTests/Stores/FeatureFlagStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/FeatureFlagStoreTests.swift
@@ -14,6 +14,7 @@ final class FeatureFlagStoreTests: XCTestCase {
 
     private var remote: MockFeatureFlagRemote!
     private var store: FeatureFlagStore!
+    private var currentDate: Date!
 
     override func setUp() {
         super.setUp()
@@ -21,10 +22,12 @@ final class FeatureFlagStoreTests: XCTestCase {
         storageManager = MockStorageManager()
         network = MockNetwork()
         remote = MockFeatureFlagRemote()
+        currentDate = Date()
         store = FeatureFlagStore(dispatcher: dispatcher,
                                  storageManager: storageManager,
                                  network: network,
-                                 remote: remote)
+                                 remote: remote,
+                                 currentDate: { self.currentDate })
     }
 
     override func tearDown() {
@@ -33,6 +36,7 @@ final class FeatureFlagStoreTests: XCTestCase {
         network = nil
         storageManager = nil
         dispatcher = nil
+        currentDate = nil
         super.tearDown()
     }
 
@@ -122,6 +126,70 @@ final class FeatureFlagStoreTests: XCTestCase {
         // Then - should return the new remote value (false)
         XCTAssertFalse(isEnabled)
         XCTAssertEqual(remote.loadAllFeatureFlagsCallCount, 2)
+    }
+
+    func test_isRemoteFeatureFlagEnabled_when_cache_is_expired_fetches_from_remote() throws {
+        // Given
+        let cacheMaxAge: TimeInterval = 24 * 60 * 60
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: true]))
+
+        // First call to populate the cache
+        waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: false, useCache: true) { _ in
+                    promise(())
+                })
+        }
+
+        // Advance time past the 24-hour limit
+        currentDate = currentDate.addingTimeInterval(cacheMaxAge + 1)
+
+        // Change the remote response
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: false]))
+
+        // When - useCache is true but cache is expired
+        let isEnabled = waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: true, useCache: true) { result in
+                    promise(result)
+                })
+        }
+
+        // Then - should fetch from remote and return the new value (false)
+        XCTAssertFalse(isEnabled)
+        XCTAssertEqual(remote.loadAllFeatureFlagsCallCount, 2)
+    }
+
+    func test_isRemoteFeatureFlagEnabled_when_cache_is_not_expired_returns_cached_value() throws {
+        // Given
+        let cacheMaxAge: TimeInterval = 24 * 60 * 60
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: true]))
+
+        // First call to populate the cache
+        waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: false, useCache: true) { _ in
+                    promise(())
+                })
+        }
+
+        // Advance time but stay within the 24-hour limit
+        currentDate = currentDate.addingTimeInterval(cacheMaxAge - 1)
+
+        // Change the remote response
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: false]))
+
+        // When
+        let isEnabled = waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: false, useCache: true) { result in
+                    promise(result)
+                })
+        }
+
+        // Then - should return cached value (true), not the new remote value (false)
+        XCTAssertTrue(isEnabled)
+        XCTAssertEqual(remote.loadAllFeatureFlagsCallCount, 1)
     }
 
     func test_isRemoteFeatureFlagEnabled_when_useCache_is_false_updates_cache() throws {

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationSchedulerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationSchedulerTests.swift
@@ -22,7 +22,7 @@ final class LocalNotificationSchedulerTests: XCTestCase {
         let scheduler = LocalNotificationScheduler(pushNotesManager: pushNotesManager, stores: stores)
         stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
             switch action {
-            case let .isRemoteFeatureFlagEnabled(_, _, completion):
+            case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 // Remote feature flag is enabled.
                 completion(true)
             }
@@ -42,7 +42,7 @@ final class LocalNotificationSchedulerTests: XCTestCase {
         let scheduler = LocalNotificationScheduler(pushNotesManager: pushNotesManager, stores: stores)
         stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
             switch action {
-            case let .isRemoteFeatureFlagEnabled(_, _, completion):
+            case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 // Remote feature flag is disabled.
                 completion(false)
             }
@@ -75,7 +75,7 @@ final class LocalNotificationSchedulerTests: XCTestCase {
         let scheduler = LocalNotificationScheduler(pushNotesManager: pushNotesManager, stores: stores)
         stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
             switch action {
-            case let .isRemoteFeatureFlagEnabled(_, _, completion):
+            case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 // Remote feature flag is enabled.
                 completion(true)
             }

--- a/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/ClientSideBannerProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/ClientSideBannerProviderTests.swift
@@ -38,7 +38,7 @@ final class ClientSideBannerProviderTests: XCTestCase {
         // Default: remote feature flag disabled
         stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
             switch action {
-            case let .isRemoteFeatureFlagEnabled(_, _, onCompletion):
+            case let .isRemoteFeatureFlagEnabled(_, _, _, onCompletion):
                 onCompletion(false)
             }
         }
@@ -233,7 +233,7 @@ final class ClientSideBannerProviderTests: XCTestCase {
     private func enableRemoteFeatureFlag() {
         stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
             switch action {
-            case let .isRemoteFeatureFlagEnabled(flag, _, onCompletion):
+            case let .isRemoteFeatureFlagEnabled(flag, _, _, onCompletion):
                 if flag == .wooPosTabletPromoBanner {
                     onCompletion(true)
                 } else {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -89,7 +89,7 @@ final class DashboardViewModelTests: XCTestCase {
         // FeatureFlagAction - dispatched by child view models checking feature availability
         storesManager.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
             switch action {
-            case let .isRemoteFeatureFlagEnabled(_, _, onCompletion):
+            case let .isRemoteFeatureFlagEnabled(_, _, _, onCompletion):
                 onCompletion(false)
             }
         }
@@ -1145,7 +1145,7 @@ private extension DashboardViewModelTests {
 
         stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
             switch action {
-            case let .isRemoteFeatureFlagEnabled(_, _, onCompletion):
+            case let .isRemoteFeatureFlagEnabled(_, _, _, onCompletion):
                 onCompletion(false)
             }
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/ApplicationPasswordsExperimentAvailabilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/ApplicationPasswordsExperimentAvailabilityCheckerTests.swift
@@ -65,7 +65,7 @@ final class ApplicationPasswordsExperimentAvailabilityCheckerTests: XCTestCase {
         )
         stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
             switch action {
-            case .isRemoteFeatureFlagEnabled(_, _, let completion):
+            case .isRemoteFeatureFlagEnabled(_, _, _, let completion):
                 completion(true)
             }
         }
@@ -96,7 +96,7 @@ final class ApplicationPasswordsExperimentAvailabilityCheckerTests: XCTestCase {
         )
         stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
             switch action {
-            case .isRemoteFeatureFlagEnabled(_, _, let completion):
+            case .isRemoteFeatureFlagEnabled(_, _, _, let completion):
                 completion(false)
             }
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
@@ -293,7 +293,7 @@ private extension POSTabVisibilityCheckerTests {
     func accountWhitelistedInBackend(_ isAllowed: Bool = false) {
         stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
             switch action {
-            case .isRemoteFeatureFlagEnabled(_, _, completion: let completion):
+            case .isRemoteFeatureFlagEnabled(_, _, _, completion: let completion):
                 completion(isAllowed)
             }
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of WOOMOB-2123

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously we fetch remote feature flags every time checking for a specific flag.

This PR optimizes the logic by using a local cache for the flags. A new param `useCache` is also introduced in case we need to get some value straight from the remote and refresh the cache.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Just CI passing should be enough.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

No UI update.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
