### PR TITLE
[Shipping Labels] Make shipping address phone number mandatory

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 -----
 - [Internal]: Update Stripe SDK to 5.1.1 [https://github.com/woocommerce/woocommerce-ios/pull/16493]
 - [*] Fix product type filters issue when adding a product to order [https://github.com/woocommerce/woocommerce-ios/pull/16580]
+- [*] Make phone number mandatory for shipping destination addresses [https://github.com/woocommerce/woocommerce-ios/pull/16625]
 
 24.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -104,6 +104,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
         shippingLabel == nil
         // or if any required fields are missing
         && originAddress != nil && destinationAddress != nil
+        && destinationAddress?.hasValidPhoneNumberForShipping == true
         && selectedPackage != nil
         && selectedRate != nil
         && (!customsFormRequired || customsInformationIsCompleted)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingAddress+Woo.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingAddress+Woo.swift
@@ -22,6 +22,27 @@ extension WooShippingAddress {
     var formattedPostalAddress: String? {
         return postalAddress.formatted(as: .mailingAddress)?.replacingOccurrences(of: "\n", with: ", ")
     }
+
+    /// Digits-only representation of the phone number.
+    var phoneDigits: String {
+        phone.components(separatedBy: .decimalDigits.inverted).joined()
+    }
+
+    /// Whether the phone number is valid for label purchase.
+    /// For US addresses, the phone must be 10 digits (or 11 with leading "1").
+    var hasValidPhoneNumberForShipping: Bool {
+        let digits = phoneDigits
+        guard digits.isNotEmpty else {
+            return false
+        }
+        guard country == "US" else {
+            return true
+        }
+        if digits.hasPrefix("1") {
+            return digits.count == 11
+        }
+        return digits.count == 10
+    }
 }
 
 private extension WooShippingAddress {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingAddress+Woo.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingAddress+Woo.swift
@@ -25,23 +25,14 @@ extension WooShippingAddress {
 
     /// Digits-only representation of the phone number.
     var phoneDigits: String {
-        phone.components(separatedBy: .decimalDigits.inverted).joined()
+        WooShippingPhoneValidator.digits(from: phone)
     }
 
     /// Whether the phone number is valid for label purchase.
     /// For US addresses, the phone must be 10 digits (or 11 with leading "1").
     var hasValidPhoneNumberForShipping: Bool {
-        let digits = phoneDigits
-        guard digits.isNotEmpty else {
-            return false
-        }
-        guard country == "US" else {
-            return true
-        }
-        if digits.hasPrefix("1") {
-            return digits.count == 11
-        }
-        return digits.count == 10
+        WooShippingPhoneValidator.isValid(phone: phone,
+                                          country: country)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -77,11 +77,11 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     }
 
     /// The origin address country code.
-    /// This is used to determine whether the phone number is required when editing a destination address.
+    /// Reserved for future validation rules.
     private let originCountryCode: String?
 
     /// The origin address state code.
-    /// This is used to determine whether the phone number is required when editing a destination address.
+    /// Reserved for future validation rules.
     private let originStateCode: String?
 
     /// Status of the address, based on local validation and remote verification.
@@ -584,10 +584,7 @@ extension WooShippingEditAddressViewModel {
         case .origin:
             return true
         case .destination:
-            return WooShippingCustomsRequirements.isCustomsRequired(originCountry: originCountryCode,
-                                                                    originState: originStateCode,
-                                                                    destinationCountry: selectedCountryCode,
-                                                                    destinationState: selectedState)
+            return true
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -238,12 +238,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
         self.email = WooShippingAddressField(type: .email, value: email, required: true, validate: { newEmail in
             (newEmail.isEmpty || !EmailFormatValidator.validate(string: newEmail)) ? Localization.Validation.email : nil
         })
-        let phoneNumberRequired = Self.phoneNumberRequired(addressType: type,
-                                                           selectedCountryCode: country,
-                                                           selectedState: state,
-                                                           originCountryCode: originCountryCode,
-                                                           originStateCode: originStateCode)
-        self.phone = WooShippingAddressField(type: .phone, value: phone, required: phoneNumberRequired, validate: { _ in return nil})
+        self.phone = WooShippingAddressField(type: .phone, value: phone, required: true, validate: { _ in return nil})
         self.isDefaultAddress = isDefaultAddress
         self.showCompanyField = showCompanyField
         self.originalAddressIsVerified = isVerified
@@ -544,42 +539,10 @@ extension WooShippingEditAddressViewModel {
     /// has length 10 with additional "1" area code for US.
     ///
     private var isPhoneNumberValid: Bool {
-        let isRequired = phoneNumberRequired(for: country.value, and: state.value)
-        if !isRequired {
-            return true
-        }
-        return WooShippingPhoneValidator.isValid(phone: phone.value,
-                                                 country: country.value)
-    }
-
-    /// Whether the phone number is required.
-    ///
-    private func phoneNumberRequired(for country: String?, and state: String?) -> Bool {
-        Self.phoneNumberRequired(addressType: addressType,
-                                    selectedCountryCode: country,
-                                    selectedState: state,
-                                    originCountryCode: originCountryCode,
-                                    originStateCode: originStateCode)
-    }
-
-    /// Whether the phone number is required.
-    /// - Parameters:
-    ///   - addressType: Type of address being edited.
-    ///   - selectedCountryCode: Country code of the selected country for the address being edited.
-    ///   - selectedState: Selected state for the address being edited.
-    ///   - originCountryCode: Country code of the origin address.
-    ///   - originStateCode: State code of the origin address.
-    private static func phoneNumberRequired(addressType: AddressType,
-                                            selectedCountryCode: String?,
-                                            selectedState: String?,
-                                            originCountryCode: String?,
-                                            originStateCode: String?) -> Bool {
-        switch addressType {
-        case .origin:
-            return true
-        case .destination:
-            return true
-        }
+        return WooShippingPhoneValidator.isValid(
+            phone: phone.value,
+            country: country.value
+        )
     }
 }
 
@@ -619,7 +582,7 @@ private extension WooShippingEditAddressViewModel {
                 state.required = stateRequired
 
                 // Update phone number requirement based on selected country.
-                phone.required = phoneNumberRequired(for: selectedCountry.code, and: selectedState?.code)
+                phone.required = true
                 phone.validateField()
             }
             .store(in: &cancellables)
@@ -634,7 +597,7 @@ private extension WooShippingEditAddressViewModel {
                 state.setDisplayValue(selectedState?.name ?? "")
 
                 // Update phone number requirement based on selected state.
-                phone.required = phoneNumberRequired(for: country.value, and: selectedState?.code)
+                phone.required = true
                 phone.validateField()
             }
             .store(in: &cancellables)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -544,18 +544,12 @@ extension WooShippingEditAddressViewModel {
     /// has length 10 with additional "1" area code for US.
     ///
     private var isPhoneNumberValid: Bool {
-        guard phone.value.isNotEmpty else {
-            return !phoneNumberRequired(for: country.value, and: state.value)
-        }
-        guard isUSAddress else {
+        let isRequired = phoneNumberRequired(for: country.value, and: state.value)
+        if !isRequired {
             return true
         }
-        let phoneDigits = phone.value.components(separatedBy: .decimalDigits.inverted).joined()
-        if phoneDigits.hasPrefix("1") {
-            return phoneDigits.count == 11
-        } else {
-            return phoneDigits.count == 10
-        }
+        return WooShippingPhoneValidator.isValid(phone: phone.value,
+                                                 country: country.value)
     }
 
     /// Whether the phone number is required.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingPhoneValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingPhoneValidator.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum WooShippingPhoneValidator {
+    static func digits(from phone: String) -> String {
+        phone.components(separatedBy: .decimalDigits.inverted).joined()
+    }
+
+    static func isValid(phone: String, country: String?) -> Bool {
+        guard phone.isNotEmpty else {
+            return false
+        }
+        guard country == "US" else {
+            return true
+        }
+        let phoneDigits = digits(from: phone)
+        if phoneDigits.hasPrefix("1") {
+            return phoneDigits.count == 11
+        }
+        return phoneDigits.count == 10
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -301,6 +301,20 @@ private extension WooShippingCreateLabelsView {
                                        onTap: {
                         viewModel.editSelectedOriginAddress()
                     })
+                } else if let destinationPhoneNumberNoticeLabel = viewModel.destinationPhoneNumberNoticeLabel {
+                    // Phone number notice for destination address
+                    verificationNotice(
+                        with: destinationPhoneNumberNoticeLabel,
+                        isVerified: false,
+                        onDismiss: {
+                            withAnimation {
+                                viewModel.destinationPhoneNumberNoticeLabel = nil
+                            }
+                        },
+                        onTap: {
+                            viewModel.editDestinationAddress()
+                        }
+                    )
                 } else if let destinationAddressStatusNoticeLabel = viewModel.destinationAddressStatusNoticeLabel {
                     // Verification notice for destination address
                     verificationNotice(with: destinationAddressStatusNoticeLabel,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -137,6 +137,9 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// This property can be set to display a notice with the provided label about the destination address status.
     @Published var destinationAddressStatusNoticeLabel: String?
 
+    /// This property can be set to display a notice with the provided label about the destination phone number.
+    @Published var destinationPhoneNumberNoticeLabel: String?
+
     /// View model for address to edit.
     /// Setting this property will navigate to the address edit screen.
     @Published var addressToEdit: WooShippingEditAddressViewModel?
@@ -380,12 +383,27 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         } catch let DotcomError.unknown(code, _, _) where code == Constants.missingUPSDAPTermsOfServiceAcceptance {
             shouldShowUPSTermsAndConditions = true
         } catch {
-            labelPurchaseErrorNotice = Notice(title: Localization.LabelPurchaseError.title,
-                                              message: Localization.LabelPurchaseError.message,
-                                              feedbackType: .error,
-                                              actionTitle: Localization.LabelPurchaseError.retry) { [weak self] in
-                Task {
-                    await self?.purchaseLabel(shouldRefreshPackageAndRate: shouldRefreshPackageAndRate)
+            if let phoneMessage = invalidPhoneNumberMessage(from: error) {
+                labelPurchaseErrorNotice = Notice(
+                    title: Localization.PhoneNumberError.title,
+                    message: phoneMessage,
+                    feedbackType: .error,
+                    actionTitle: Localization.PhoneNumberError.editAddress
+                ) { [weak self] in
+                    self?.editDestinationAddress()
+                }
+            } else {
+                labelPurchaseErrorNotice = Notice(
+                    title: Localization.LabelPurchaseError.title,
+                    message: Localization.LabelPurchaseError.message,
+                    feedbackType: .error,
+                    actionTitle: Localization.LabelPurchaseError.retry
+                ) { [weak self] in
+                    Task {
+                        await self?.purchaseLabel(
+                            shouldRefreshPackageAndRate: shouldRefreshPackageAndRate
+                        )
+                    }
                 }
             }
             DDLogError("⛔️ Error purchasing shipping label: \(error)")
@@ -640,6 +658,12 @@ private extension WooShippingCreateLabelsViewModel {
             }
             .assign(to: &$destinationAddressStatusNoticeLabel)
 
+        $destinationAddress
+            .map { [weak self] address -> String? in
+                return self?.destinationPhoneNoticeLabel(for: address)
+            }
+            .assign(to: &$destinationPhoneNumberNoticeLabel)
+
         /// Clear the notice after a delay when the address is verified.
         $shouldShowNotices
             .combineLatest($destinationAddressStatusNoticeLabel)
@@ -649,6 +673,19 @@ private extension WooShippingCreateLabelsViewModel {
             .delay(for: .seconds(2), scheduler: RunLoop.current)
             .map { _ in nil }
             .assign(to: &$destinationAddressStatusNoticeLabel)
+    }
+
+    func destinationPhoneNoticeLabel(for address: WooShippingAddress?) -> String? {
+        guard let address else {
+            return nil
+        }
+        if address.phoneDigits.isEmpty {
+            return Localization.DestinationPhoneNumber.missing
+        }
+        if !address.hasValidPhoneNumberForShipping {
+            return Localization.DestinationPhoneNumber.invalid
+        }
+        return nil
     }
 
     /// Ensures that initial notices are only displayed after the view is ready
@@ -796,6 +833,7 @@ private extension WooShippingCreateLabelsViewModel {
 private extension WooShippingCreateLabelsViewModel {
     enum Constants {
         static let missingUPSDAPTermsOfServiceAcceptance = "missing_upsdap_terms_of_service_acceptance"
+        static let serverErrorResponse = "wcc_server_error_response"
     }
     enum Localization {
         enum OriginAddressStatus {
@@ -830,11 +868,49 @@ private extension WooShippingCreateLabelsViewModel {
                                                    comment: "Button to retry label purchase when an error occurs")
         }
 
+        enum DestinationPhoneNumber {
+            static let missing = NSLocalizedString(
+                "wooShipping.createLabels.destinationPhoneNumber.missing",
+                value: "Phone number is required for the destination address.",
+                comment: "Notice when the destination phone number is missing on the shipping label creation screen"
+            )
+            static let invalid = NSLocalizedString(
+                "wooShipping.createLabels.destinationPhoneNumber.invalid",
+                value: "Please enter a valid phone number for the destination address.",
+                comment: "Notice when the destination phone number is invalid"
+            )
+        }
+
+        enum PhoneNumberError {
+            static let title = NSLocalizedString(
+                "wooShipping.createLabels.phoneNumberError.title",
+                value: "Invalid phone number.",
+                comment: "Title for the notice when the label purchase fails due to an invalid destination phone number"
+            )
+            static let editAddress = NSLocalizedString(
+                "wooShipping.createLabels.phoneNumberError.editAddress",
+                value: "Edit address",
+                comment: "Action button title to edit the destination address when phone number is invalid"
+            )
+        }
+
         static let refundNotice = NSLocalizedString(
             "wooShipping.createLabels.refundNotice",
             value: "You have successfully submitted a request for refund. You can purchase a new label.",
             comment: "Notice to display after requesting refund for a shipping label"
         )
+    }
+}
+
+private extension WooShippingCreateLabelsViewModel {
+    func invalidPhoneNumberMessage(from error: Error) -> String? {
+        guard case let DotcomError.unknown(code, message, data) = error,
+              code == Constants.serverErrorResponse else {
+            return nil
+        }
+        let dataMessage = data?["message"]?.value as? String
+        let candidates = [message, dataMessage].compactMap { $0 }
+        return candidates.first { $0.localizedCaseInsensitiveContains("phone number") }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -887,6 +887,11 @@ private extension WooShippingCreateLabelsViewModel {
                 value: "Invalid phone number.",
                 comment: "Title for the notice when the label purchase fails due to an invalid destination phone number"
             )
+            static let message = NSLocalizedString(
+                "wooShipping.createLabels.phoneNumberError.message",
+                value: "Please enter a valid phone number for the destination address.",
+                comment: "Message for the notice when the label purchase fails due to an invalid destination phone number"
+            )
             static let editAddress = NSLocalizedString(
                 "wooShipping.createLabels.phoneNumberError.editAddress",
                 value: "Edit address",
@@ -910,7 +915,10 @@ private extension WooShippingCreateLabelsViewModel {
         }
         let dataMessage = data?["message"]?.value as? String
         let candidates = [message, dataMessage].compactMap { $0 }
-        return candidates.first { $0.localizedCaseInsensitiveContains("phone number") }
+        guard candidates.contains(where: { $0.range(of: "phone", options: .caseInsensitive) != nil }) else {
+            return nil
+        }
+        return Localization.PhoneNumberError.message
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -966,6 +966,8 @@
 		2D200F072ED7245000DD6EBF /* BookingDateTimeFilterViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D200F062ED7245000DD6EBF /* BookingDateTimeFilterViewTests.swift */; };
 		2D205B882EF2B99500E1F7A2 /* AgeRangeVerificationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D205B872EF2B99400E1F7A2 /* AgeRangeVerificationCoordinator.swift */; };
 		2D49C42B2F34A80900F7445A /* WooShippingPhoneValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D49C42A2F34A80900F7445A /* WooShippingPhoneValidator.swift */; };
+		2D49C42E2F34A97C00F7445A /* WooShippingAddressPhoneValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D49C42C2F34A97C00F7445A /* WooShippingAddressPhoneValidationTests.swift */; };
+		2D49C42F2F34A97C00F7445A /* WooShippingPhoneValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D49C42D2F34A97C00F7445A /* WooShippingPhoneValidatorTests.swift */; };
 		2D535DBD2F1924E8006A6618 /* AgeRangeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D535DBC2F1924E8006A6618 /* AgeRangeProvider.swift */; };
 		2D535DBF2F1932FE006A6618 /* AgeRangeVerificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D535DBE2F1932FE006A6618 /* AgeRangeVerificationServiceTests.swift */; };
 		2D5389242F278E17006A6618 /* PushNotificationRegistrationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D5389232F278E17006A6618 /* PushNotificationRegistrationState.swift */; };
@@ -3749,6 +3751,8 @@
 		2D200F062ED7245000DD6EBF /* BookingDateTimeFilterViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingDateTimeFilterViewTests.swift; sourceTree = "<group>"; };
 		2D205B872EF2B99400E1F7A2 /* AgeRangeVerificationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgeRangeVerificationCoordinator.swift; sourceTree = "<group>"; };
 		2D49C42A2F34A80900F7445A /* WooShippingPhoneValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPhoneValidator.swift; sourceTree = "<group>"; };
+		2D49C42C2F34A97C00F7445A /* WooShippingAddressPhoneValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingAddressPhoneValidationTests.swift; sourceTree = "<group>"; };
+		2D49C42D2F34A97C00F7445A /* WooShippingPhoneValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPhoneValidatorTests.swift; sourceTree = "<group>"; };
 		2D535DBC2F1924E8006A6618 /* AgeRangeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgeRangeProvider.swift; sourceTree = "<group>"; };
 		2D535DBE2F1932FE006A6618 /* AgeRangeVerificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgeRangeVerificationServiceTests.swift; sourceTree = "<group>"; };
 		2D5389232F278E17006A6618 /* PushNotificationRegistrationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationRegistrationState.swift; sourceTree = "<group>"; };
@@ -10965,6 +10969,8 @@
 		CEC3CC722C9343BC00B93FBE /* WooShipping Create Shipping Labels */ = {
 			isa = PBXGroup;
 			children = (
+				2D49C42C2F34A97C00F7445A /* WooShippingAddressPhoneValidationTests.swift */,
+				2D49C42D2F34A97C00F7445A /* WooShippingPhoneValidatorTests.swift */,
 				EEBB9B3E2D8FE5AC008D6CE5 /* Split shipments */,
 				B9A5317D2D2FCC3900208304 /* WooShipping Customs */,
 				CE2207032CA5C55100E16D9B /* WooShippingCreateLabelsViewModelTests.swift */,
@@ -15239,6 +15245,8 @@
 				68674D312B6C895D00E93FBD /* ReceiptEligibilityUseCaseTests.swift in Sources */,
 				CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */,
 				DE61979528A25842005E4362 /* StorePickerViewModelTests.swift in Sources */,
+				2D49C42E2F34A97C00F7445A /* WooShippingAddressPhoneValidationTests.swift in Sources */,
+				2D49C42F2F34A97C00F7445A /* WooShippingPhoneValidatorTests.swift in Sources */,
 				EEB4E2D329B2047700371C3C /* StoreOnboardingViewHostingControllerTests.swift in Sources */,
 				B57C745120F56EE900EEFC87 /* UITableViewCellHelpersTests.swift in Sources */,
 				2D054A2A2E953E3C004111FD /* BookingDetailsViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -965,6 +965,7 @@
 		2D09E0D52E65C9B9005C26F3 /* ApplicationPasswordsExperimentStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D09E0D42E65C9B9005C26F3 /* ApplicationPasswordsExperimentStateTests.swift */; };
 		2D200F072ED7245000DD6EBF /* BookingDateTimeFilterViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D200F062ED7245000DD6EBF /* BookingDateTimeFilterViewTests.swift */; };
 		2D205B882EF2B99500E1F7A2 /* AgeRangeVerificationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D205B872EF2B99400E1F7A2 /* AgeRangeVerificationCoordinator.swift */; };
+		2D49C42B2F34A80900F7445A /* WooShippingPhoneValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D49C42A2F34A80900F7445A /* WooShippingPhoneValidator.swift */; };
 		2D535DBD2F1924E8006A6618 /* AgeRangeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D535DBC2F1924E8006A6618 /* AgeRangeProvider.swift */; };
 		2D535DBF2F1932FE006A6618 /* AgeRangeVerificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D535DBE2F1932FE006A6618 /* AgeRangeVerificationServiceTests.swift */; };
 		2D5389242F278E17006A6618 /* PushNotificationRegistrationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D5389232F278E17006A6618 /* PushNotificationRegistrationState.swift */; };
@@ -3747,6 +3748,7 @@
 		2D09E0D42E65C9B9005C26F3 /* ApplicationPasswordsExperimentStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordsExperimentStateTests.swift; sourceTree = "<group>"; };
 		2D200F062ED7245000DD6EBF /* BookingDateTimeFilterViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookingDateTimeFilterViewTests.swift; sourceTree = "<group>"; };
 		2D205B872EF2B99400E1F7A2 /* AgeRangeVerificationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgeRangeVerificationCoordinator.swift; sourceTree = "<group>"; };
+		2D49C42A2F34A80900F7445A /* WooShippingPhoneValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingPhoneValidator.swift; sourceTree = "<group>"; };
 		2D535DBC2F1924E8006A6618 /* AgeRangeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgeRangeProvider.swift; sourceTree = "<group>"; };
 		2D535DBE2F1932FE006A6618 /* AgeRangeVerificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgeRangeVerificationServiceTests.swift; sourceTree = "<group>"; };
 		2D5389232F278E17006A6618 /* PushNotificationRegistrationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationRegistrationState.swift; sourceTree = "<group>"; };
@@ -10821,6 +10823,7 @@
 		CE7FE6922D13249D000F9475 /* WooShippingAddresses */ = {
 			isa = PBXGroup;
 			children = (
+				2D49C42A2F34A80900F7445A /* WooShippingPhoneValidator.swift */,
 				EE5EEDEA2D6F32F200E1EC05 /* WooShippingDestinationAddress+Woo.swift */,
 				EE5EEDE82D6F2F8300E1EC05 /* WooShippingNormalizedAddress+Woo.swift */,
 				CE755F762D4A79C2002539F6 /* WooShippingAddress+Woo.swift */,
@@ -13939,6 +13942,7 @@
 				026CAF802AC2B7FF002D23BB /* ConfigurableBundleProductView.swift in Sources */,
 				640D42342F2B840A00300B0D /* WPComConnectionSetupView.swift in Sources */,
 				DE8C22732EB0AE8500C69F35 /* MultiSelectListView.swift in Sources */,
+				2D49C42B2F34A80900F7445A /* WooShippingPhoneValidator.swift in Sources */,
 				45BBFBC1274FD94300213001 /* HubMenuCoordinator.swift in Sources */,
 				D8652E582630BFF500350F37 /* OrderDetailsPaymentAlerts.swift in Sources */,
 				B5A56BF0219F2CE90065A902 /* VerticalButton.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddressPhoneValidationTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddressPhoneValidationTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+
+final class WooShippingAddressPhoneValidationTests: XCTestCase {
+    func test_hasValidPhoneNumberForShipping_returns_false_for_empty_phone() {
+        let address = makeAddress(phone: "", country: "US")
+
+        XCTAssertFalse(address.hasValidPhoneNumberForShipping)
+    }
+
+    func test_hasValidPhoneNumberForShipping_returns_true_for_non_us_non_empty_phone() {
+        let address = makeAddress(phone: "123", country: "CA")
+
+        XCTAssertTrue(address.hasValidPhoneNumberForShipping)
+    }
+
+    func test_hasValidPhoneNumberForShipping_returns_true_for_us_10_digits() {
+        let address = makeAddress(phone: "234-567-8901", country: "US")
+
+        XCTAssertTrue(address.hasValidPhoneNumberForShipping)
+    }
+
+    func test_hasValidPhoneNumberForShipping_returns_true_for_us_11_digits_with_leading_one() {
+        let address = makeAddress(phone: "1 (234) 567-8901", country: "US")
+
+        XCTAssertTrue(address.hasValidPhoneNumberForShipping)
+    }
+
+    func test_hasValidPhoneNumberForShipping_returns_false_for_us_11_digits_without_leading_one() {
+        let address = makeAddress(phone: "234-567-89012", country: "US")
+
+        XCTAssertFalse(address.hasValidPhoneNumberForShipping)
+    }
+
+    func test_hasValidPhoneNumberForShipping_returns_false_for_us_short_phone() {
+        let address = makeAddress(phone: "123-4567", country: "US")
+
+        XCTAssertFalse(address.hasValidPhoneNumberForShipping)
+    }
+}
+
+private extension WooShippingAddressPhoneValidationTests {
+    func makeAddress(phone: String, country: String) -> WooShippingAddress {
+        WooShippingAddress(company: "HEADQUARTERS",
+                           name: "JANE DOE",
+                           email: "test@example.com",
+                           phone: phone,
+                           country: country,
+                           state: "NY",
+                           address1: "15 ALGONKIN ST",
+                           address2: "",
+                           city: "TICONDEROGA",
+                           postcode: "12883")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -3,6 +3,8 @@ import XCTest
 @testable import Networking
 import WooFoundation
 import Yosemite
+import struct NetworkingCore.AnyDecodable
+import enum NetworkingCore.DotcomError
 import protocol Storage.StorageManagerType
 import protocol Storage.StorageType
 
@@ -542,6 +544,171 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         waitUntil {
             viewModel.hazmatNotice != nil
         }
+    }
+
+    func test_destinationPhoneNumberNoticeLabel_is_missing_when_phone_is_empty() {
+        // Given
+        let labelDestinationAddress = ShippingLabelAddress.fake().copy(phone: "", country: "US")
+        let shippingLabel = ShippingLabel.fake().copy(destinationAddress: labelDestinationAddress)
+        let order = Order.fake().copy(shippingLabels: [shippingLabel])
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(
+            order: order,
+            preselection: .shippingLabel(
+                label: shippingLabel
+            )
+        )
+
+        // Then
+        let expected = NSLocalizedString("wooShipping.createLabels.destinationPhoneNumber.missing",
+                                         value: "Phone number is required for the destination address.",
+                                         comment: "")
+        waitUntil {
+            viewModel.destinationPhoneNumberNoticeLabel != nil
+        }
+        XCTAssertEqual(viewModel.destinationPhoneNumberNoticeLabel, expected)
+    }
+
+    func test_destinationPhoneNumberNoticeLabel_is_invalid_when_phone_is_invalid_for_us() {
+        // Given
+        let labelDestinationAddress = ShippingLabelAddress.fake().copy(phone: "123-4567", country: "US")
+        let shippingLabel = ShippingLabel.fake().copy(destinationAddress: labelDestinationAddress)
+        let order = Order.fake().copy(shippingLabels: [shippingLabel])
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(
+            order: order,
+            preselection: .shippingLabel(
+                label: shippingLabel
+            )
+        )
+
+        // Then
+        let expected = NSLocalizedString("wooShipping.createLabels.destinationPhoneNumber.invalid",
+                                         value: "Please enter a valid phone number for the destination address.",
+                                         comment: "")
+        waitUntil {
+            viewModel.destinationPhoneNumberNoticeLabel != nil
+        }
+        XCTAssertEqual(viewModel.destinationPhoneNumberNoticeLabel, expected)
+    }
+
+    @MainActor
+    func test_purchaseLabel_sets_phoneNumberErrorNotice_with_generic_message() async {
+        // Given
+        let shippingAddress = Address(firstName: "Jane",
+                                      lastName: "Doe",
+                                      company: nil,
+                                      address1: "123 Main Street",
+                                      address2: nil,
+                                      city: "San Francisco",
+                                      state: "CA",
+                                      postcode: "94107",
+                                      country: "US",
+                                      phone: "234-567-8901",
+                                      email: "test@example.com")
+        let originAddress = WooShippingOriginAddress.fake().copy(
+            id: "default",
+            company: "HEADQUARTERS",
+            address1: "15 ALGONKIN ST",
+            address2: "STE 100",
+            city: "TICONDEROGA",
+            state: "NY",
+            postcode: "12883-1487",
+            country: "US",
+            phone: "223-456-7890",
+            defaultAddress: true
+        )
+        insert(originAddress: originAddress)
+
+        let destinationAddress = WooShippingNormalizedAddress.fake().copy(phone: "234-567-8901", country: "US", state: "CA")
+        let order = Order.fake().copy(siteID: siteID, orderID: orderID, shippingAddress: shippingAddress)
+        let paymentMethod = ShippingLabelPaymentMethod.fake().copy(
+            paymentMethodID: 11743265,
+            name: "Example User",
+            cardType: .visa,
+            cardDigits: "4242"
+        )
+        let accountSettings = ShippingLabelAccountSettings.fake().copy(
+            paymentMethods: [paymentMethod],
+            selectedPaymentMethodID: paymentMethod.paymentMethodID
+        )
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .loadOriginAddresses(_, let completion):
+                completion(.success([originAddress]))
+            case .loadAccountSettings(_, let completion):
+                completion(.success(self.settings))
+            case .verifyDestinationAddress(_, _, let completion):
+                completion(.success(WooShippingVerifyDestinationAddressSuccess(normalizedAddress: destinationAddress,
+                                                                               isTrivialNormalization: nil,
+                                                                               isVerified: true)))
+            case let .purchaseShippingLabel(_, _, _, _, _, _, _, _, _, completion):
+                let data: [String: AnyDecodable] = [
+                    "message": AnyDecodable("Please enter a valid phone number.")
+                ]
+                completion(.failure(DotcomError.unknown(code: "wcc_server_error_response",
+                                                        message: "Please enter a valid phone number.",
+                                                        data: data)))
+            case .loadPackages, .loadConfig:
+                break
+            default:
+                break
+            }
+        }
+
+        let viewModel = WooShippingCreateLabelsViewModel(order: order,
+                                                         stores: stores,
+                                                         storageManager: storageManager)
+        await until {
+            viewModel.state == .ready
+        }
+        await until {
+            viewModel.currentShipmentDetailsViewModel.shippingService != nil
+        }
+        viewModel.didUpdateAccountSettings(accountSettings)
+
+        let package = WooShippingPackageData(id: "small_flat_box",
+                                             name: "Small Flat Rate Box",
+                                             length: "21.91",
+                                             width: "13.65",
+                                             height: "4.13",
+                                             weight: ".25",
+                                             source: .predefined(sourceTitle: "usps", sourceID: "usps"),
+                                             packageType: "box")
+        let selectedRate = WooShippingSelectedRate(
+            rate: ShippingLabelCarrierRate(title: "USPS - Parcel Select Mail",
+                                           insurance: "100",
+                                           retailRate: 40.06,
+                                           rate: 40.06,
+                                           rateID: "rate_a8a29d5f34984722942f466c30ea27eh",
+                                           serviceID: "",
+                                           carrierID: "usps",
+                                           shipmentID: "",
+                                           hasTracking: true,
+                                           isSelected: false,
+                                           isPickupFree: true,
+                                           deliveryDays: 2,
+                                           deliveryDateGuaranteed: false),
+            signatureRate: nil,
+            adultSignatureRate: nil,
+            carbonNeutralRate: nil,
+            saturdayDeliveryRate: nil,
+            additionalHandlingRate: nil
+        )
+        viewModel.currentShipmentDetailsViewModel.selectPackage(package)
+        viewModel.currentShipmentDetailsViewModel.shippingService?.onSelectRate?(selectedRate)
+
+        // When
+        await viewModel.purchaseLabel(shouldRefreshPackageAndRate: false)
+
+        // Then
+        let expectedMessage = NSLocalizedString("wooShipping.createLabels.phoneNumberError.message",
+                                                value: "Please enter a valid phone number for the destination address.",
+                                                comment: "")
+        XCTAssertEqual(viewModel.labelPurchaseErrorNotice?.message, expectedMessage)
     }
 
     func test_originAddressLines_is_correct_for_both_purchased_label_and_unfulfilled_shipment() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -254,7 +254,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.phone.required)
     }
 
-    func test_phone_number_not_required_for_destination_address_when_customs_form_not_required() {
+    func test_phone_number_required_for_destination_address() {
         // Given
         let address = WooShippingAddress(company: "HEADQUARTERS",
                                          name: "JANE DOE",
@@ -276,7 +276,7 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
                                                         originStateCode: "CA")
 
         // Then
-        XCTAssertFalse(viewModel.phone.required)
+        XCTAssertTrue(viewModel.phone.required)
     }
 
     func test_phone_number_required_for_destination_address_when_customs_form_required() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingPhoneValidatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingPhoneValidatorTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import WooCommerce
+
+final class WooShippingPhoneValidatorTests: XCTestCase {
+    func test_digits_strips_non_digits() {
+        // When
+        let digits = WooShippingPhoneValidator.digits(from: "+1 (234) 567-8900")
+
+        // Then
+        XCTAssertEqual(digits, "12345678900")
+    }
+
+    func test_isValid_returns_false_for_empty_phone() {
+        XCTAssertFalse(WooShippingPhoneValidator.isValid(phone: "", country: "US"))
+    }
+
+    func test_isValid_returns_true_for_non_us_non_empty_phone() {
+        XCTAssertTrue(WooShippingPhoneValidator.isValid(phone: "123", country: "CA"))
+    }
+
+    func test_isValid_returns_true_for_us_10_digits() {
+        XCTAssertTrue(WooShippingPhoneValidator.isValid(phone: "234-567-8901", country: "US"))
+    }
+
+    func test_isValid_returns_true_for_us_11_digits_with_leading_one() {
+        XCTAssertTrue(WooShippingPhoneValidator.isValid(phone: "1 (234) 567-8901", country: "US"))
+    }
+
+    func test_isValid_returns_false_for_us_11_digits_without_leading_one() {
+        XCTAssertFalse(WooShippingPhoneValidator.isValid(phone: "234-567-89012", country: "US"))
+    }
+
+    func test_isValid_returns_false_for_us_short_phone() {
+        XCTAssertFalse(WooShippingPhoneValidator.isValid(phone: "123-4567", country: "US"))
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingShipmentDetailsViewModelTests.swift
@@ -64,6 +64,26 @@ final class WooShippingShipmentDetailsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isPurchaseButtonEnabled)
     }
 
+    func test_isPurchaseButtonEnabled_false_when_destination_phone_is_invalid() throws {
+        // Given
+        let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
+        let destinationAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(
+            sampleDestinationAddress(country: "US", state: "CA", phone: "123-4567")
+        )
+
+        // When
+        let viewModel = WooShippingShipmentDetailsViewModel(order: Order.fake(),
+                                                            shipment: sampleShipment,
+                                                            shippingLabel: nil,
+                                                            originAddress: originAddressSubject.eraseToAnyPublisher(),
+                                                            destinationAddress: destinationAddressSubject.eraseToAnyPublisher())
+        viewModel.selectPackage(samplePackageData())
+        viewModel.shippingService?.onSelectRate?(sampleSelectedRate())
+
+        // Then
+        XCTAssertFalse(viewModel.isPurchaseButtonEnabled)
+    }
+
     func test_selecting_standard_shipping_rate_sets_expected_shippingRates() throws {
         // Given
         let originAddressSubject = CurrentValueSubject<WooShippingAddress?, Never>(sampleOriginAddress(country: "US", state: "NY"))
@@ -1002,11 +1022,11 @@ private extension WooShippingShipmentDetailsViewModelTests {
         )
     }
 
-    func sampleDestinationAddress(country: String, state: String) -> WooShippingAddress {
+    func sampleDestinationAddress(country: String, state: String, phone: String = "234-567-8901") -> WooShippingAddress {
         WooShippingAddress(company: "",
                            name: "",
                            email: nil,
-                           phone: "",
+                           phone: phone,
                            country: country,
                            state: state,
                            address1: "1 Main Street",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-2131

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
- Makes phone number required both for origin and destination shipping addresses.
- Disables "Purchase" button in case if phone number is missing for destination address.
- Presents "Phone number is required" message in shipment details bottom sheet if phone is invalid.
- Presents a notice in case if "invalid phone" error returned from server.

Generally the system won't let user to save/validate address in case if phone number is missing. Only old addresses will remain with missing phone numbers.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Use site with Shipping plugin
- Create or use a completed order with a physical product
- Navigate to Order Details -> Create Shipping Label
- Update destination address to have empty phone number or input non-digit characters. 
  - Try both US and non-US addresses. 
  - Make sure the phone number field is marked with "Please provide a valid phone number" message. 
  - Make sure the "Validate and save" button is not available. 
- Enter a valid phone number and make sure the "validate and save" button becomes available
- Find an order with destination shipping address that has no phone number. Or switch to `trunk` and update origin/destination addresses to match countries - only international shipments required phone number before. Then switch back to current branch and use this address without phone.
- To unblock label purchasing comment out the `&& destinationAddress?.hasValidPhoneNumberForShipping == true` condition to keep purchase button enabled.
- Proceed to shipping label purchase. And fill in missing fields.
- Select a package by UPS carrier
- Do a purchase
- Make sure there was a purchase error and the "Invalid phone number" toast presented. Tap on "edit address" and make sure the address editing form is presented
- Fill in the missing phone number
- Repeat purchase
- Make sure it's successful

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
|Bottom sheet notice | Server error notice|
--- | ---
<img width="568" height="311" alt="Screenshot 2026-02-05 at 14 27 53" src="https://github.com/user-attachments/assets/4abc4fbe-cc9a-44e6-93f1-3c7ea2858f52" /> | <img width="569" height="318" alt="Screenshot 2026-02-05 at 14 26 49" src="https://github.com/user-attachments/assets/5c9c6685-ac56-4bba-a19c-a802ca51dd89" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
