### PR TITLE
[Woo POS][Refunds] Handle refund preparation error

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -521,6 +521,7 @@ private extension POSOrderDetailsView {
 enum RefundModalState: Identifiable, Equatable {
     case loading
     case loadingError
+    case preparationError
     case nothingToRefund
     case itemSelection
     case review(POSRefundReviewData)
@@ -534,6 +535,7 @@ enum RefundModalState: Identifiable, Equatable {
         switch self {
         case .loading: return "loading"
         case .loadingError: return "loadingError"
+        case .preparationError: return "preparationError"
         case .nothingToRefund: return "nothingToRefund"
         case .itemSelection: return "itemSelection"
         case .review: return "review"
@@ -559,6 +561,14 @@ private extension POSOrderDetailsView {
                 title: Localization.loadRefundErrorTitle,
                 subtitle: Localization.loadRefundErrorSubtitle,
                 onRetry: { initiateRefundFlow() },
+                onCancel: { refundModalState = nil },
+                onClose: { refundModalState = nil }
+            )
+        case .preparationError:
+            POSRefundErrorView(
+                title: Localization.prepareRefundErrorTitle,
+                subtitle: Localization.prepareRefundErrorSubtitle,
+                onRetry: { refundModalState = .itemSelection },
                 onCancel: { refundModalState = nil },
                 onClose: { refundModalState = nil }
             )
@@ -667,7 +677,10 @@ private extension POSOrderDetailsView {
     }
 
     func navigateToRefundReview() {
-        guard let reviewData = orderListModel.ordersController.preparePOSRefundReviewData() else { return }
+        guard let reviewData = orderListModel.ordersController.preparePOSRefundReviewData() else {
+            refundModalState = .preparationError
+            return
+        }
         refundModalState = .review(reviewData)
     }
 
@@ -931,6 +944,18 @@ private enum Localization {
         "pos.orderDetailsView.loadRefundError.subtitle",
         value: "Please try again.",
         comment: "Subtitle shown when loading refund information has failed"
+    )
+
+    static let prepareRefundErrorTitle = NSLocalizedString(
+        "pos.orderDetailsView.prepareRefundError.title",
+        value: "Couldn't prepare refund",
+        comment: "Title shown when refund data preparation fails"
+    )
+
+    static let prepareRefundErrorSubtitle = NSLocalizedString(
+        "pos.orderDetailsView.prepareRefundError.subtitle",
+        value: "Please try again.",
+        comment: "Subtitle shown when refund data preparation fails"
     )
 }
 


### PR DESCRIPTION
Closes WOOMOB-1782

## Description
If `preparePOSRefundReviewData` fails to prepare `POSRefundReviewData` (for example due to a currency formatting error), this would be unhandled when navigating to the refund view, making the refund detail view to be non-responsive (cannot proceed with the refund, with no error message of why)

Instead we present a new error through the existing modal pattern with _"Couldn't prepare refund"_ message, and a retry option.

## Test Steps
1. In `POSOrderListController.preparePOSRefundReviewData`, return nil to force the error:
```diff
func preparePOSRefundReviewData() -> POSRefundReviewData? {
+  return nil
```
2. Select a completed order → Tap "Issue Refund" → Select items → Tap "Continue"
3. Verify error modal appears with "Couldn't prepare refund"
4. Test "Retry" → should return to item selection
5. Test "Cancel" → should dismiss modal

## Screenshots

https://github.com/user-attachments/assets/51589184-1f8d-482b-89d4-f409ce37ef04
