### PR TITLE
Push notifications: Add remote flag and eligibility check for M1

### DIFF
--- a/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
+++ b/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
@@ -32,6 +32,7 @@ public enum RemoteFeatureFlag: CaseIterable, Hashable, Decodable {
     case appPasswordsForJetpackSites
     case posLocalCatalogM1
     case wooPosTabletPromoBanner
+    case selfDrivenPushNotificationsM1
 
     init?(rawValue: String) {
         switch rawValue {
@@ -45,6 +46,8 @@ public enum RemoteFeatureFlag: CaseIterable, Hashable, Decodable {
             self = .posLocalCatalogM1
         case "woo_pos_tablet_promo_banner":
             self = .wooPosTabletPromoBanner
+        case "woo_self_driven_push_notifications_m1":
+            self = .selfDrivenPushNotificationsM1
         default:
             return nil
         }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -295,7 +295,7 @@ extension PushNotificationsManager {
                     analytics.track(.wooPushTokenRegisterSuccess)
                 }
             }
-        } else {
+        } else if !stores.isAuthenticatedWithoutWPCom {
             registerForWPComPushNotifications()
         }
     }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -113,7 +113,9 @@ final class PushNotificationsManager: PushNotesManager {
     private let analytics: Analytics
 
     private let backgroundSynchronizerFactory: PushNotificationBackgroundSynchronizerFactoryProtocol
-    private let selfDrivenPushNotificationEnabled: Bool
+    private let selfDriventPNEligiblityChecker: WooPushNotificationEligibilityCheck
+    private var selfDrivenPushNotificationEnabled: Bool?
+    private var pendingTokenData: Data?
 
     /// Initializes the PushNotificationsManager.
     ///
@@ -127,13 +129,11 @@ final class PushNotificationsManager: PushNotesManager {
         self.registrationState = PushNotificationRegistrationState(defaults: configuration.defaults, log: { DDLogInfo($0) })
         self.backgroundSynchronizerFactory = backgroundSynchronizerFactory
         self.analytics = analytics
-        self.selfDrivenPushNotificationEnabled = {
-            if configuration.storesManager.isAuthenticatedWithoutWPCom {
-                return featureFlagService.isFeatureFlagEnabled(.selfDrivenPushTokenAppPasswords)
-            } else {
-                return featureFlagService.isFeatureFlagEnabled(.selfDrivenPushTokenWPCom)
-            }
-        }()
+        self.selfDriventPNEligiblityChecker = WooPushNotificationEligibilityCheck(
+            featureFlagService: featureFlagService,
+            stores: configuration.storesManager
+        )
+        checkSelfDrivenPushNotificationsEligibility()
     }
 }
 
@@ -185,7 +185,7 @@ extension PushNotificationsManager {
 
         let group = DispatchGroup()
 
-        if selfDrivenPushNotificationEnabled {
+        if selfDrivenPushNotificationEnabled == true  {
             group.enter()
             unregisterFromWooPushNotificationsIfPossible { result in
                 switch result {
@@ -252,6 +252,10 @@ extension PushNotificationsManager {
     ///     - defaultStoreID: Default WooCommerce Store ID
     ///
     func registerDeviceToken(with tokenData: Data) {
+        guard let selfDrivenPushNotificationEnabled else {
+            pendingTokenData = tokenData
+            return
+        }
         let newToken = tokenData.hexString
 
         registrationState.applyNewDeviceToken(newToken)
@@ -610,6 +614,19 @@ private extension PushNotificationsManager {
 // MARK: - Dotcom Device Registration
 //
 private extension PushNotificationsManager {
+
+    func checkSelfDrivenPushNotificationsEligibility() {
+        Task { @MainActor in
+            let isEnabled = await selfDriventPNEligiblityChecker.checkM1Eligibility()
+            if selfDrivenPushNotificationEnabled != isEnabled {
+                selfDrivenPushNotificationEnabled = isEnabled
+                if let pendingTokenData {
+                    self.pendingTokenData = nil
+                    registerDeviceToken(with: pendingTokenData)
+                }
+            }
+        }
+    }
 
     /// Registers an APNS DeviceToken in the WordPress.com backend.
     ///

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -185,7 +185,7 @@ extension PushNotificationsManager {
 
         let group = DispatchGroup()
 
-        if selfDrivenPushNotificationEnabled == true  {
+        if selfDrivenPushNotificationEnabled == true {
             group.enter()
             unregisterFromWooPushNotificationsIfPossible { result in
                 switch result {

--- a/WooCommerce/Classes/Notifications/WooPushNotificationEligibilityCheck.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationEligibilityCheck.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Yosemite
+import Experiments
+
+/// Helper to check whether self-driven push notifications should be enabled.
+final class WooPushNotificationEligibilityCheck {
+    private let featureFlagService: FeatureFlagService
+    private let stores: StoresManager
+
+    init(featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         stores: StoresManager = ServiceLocator.stores) {
+        self.featureFlagService = featureFlagService
+        self.stores = stores
+    }
+
+    @MainActor
+    func checkM1Eligibility() async -> Bool {
+        let defaultM1Value = featureFlagService.isFeatureFlagEnabled(.selfDrivenPushTokenWPCom)
+
+        return await withCheckedContinuation { continuation in
+            stores.dispatch(FeatureFlagAction.isRemoteFeatureFlagEnabled(
+                .selfDrivenPushNotificationsM1,
+                defaultValue: defaultM1Value,
+                useCache: true,
+                completion: { value in
+                    continuation.resume(returning: value)
+                })
+            )
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -410,7 +410,6 @@
 		31FE28C225E6D338003519F2 /* LearnMoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FE28C125E6D338003519F2 /* LearnMoreTableViewCell.swift */; };
 		31FE28C825E6D384003519F2 /* LearnMoreTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 31FE28C725E6D384003519F2 /* LearnMoreTableViewCell.xib */; };
 		3D94B7D5A94E3515D4B9BB4D /* MockWPComConnectionSetupHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FEE9D30367FFF0ADEE1F5B /* MockWPComConnectionSetupHandler.swift */; };
-		71E7782632CC7D5213733333 /* MockJetpackConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1A903713867FCD550D32AD /* MockJetpackConnectionService.swift */; };
 		3F0904092D26A40800D8ACCE /* WordPressAuthenticator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F0904012D26A40700D8ACCE /* WordPressAuthenticator.framework */; };
 		3F0904142D26A40800D8ACCE /* WordPressAuthenticator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F0904012D26A40700D8ACCE /* WordPressAuthenticator.framework */; };
 		3F0904152D26A40800D8ACCE /* WordPressAuthenticator.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3F0904012D26A40700D8ACCE /* WordPressAuthenticator.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -587,6 +586,7 @@
 		68A5221B2BA1804900A6A584 /* PluginDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A5221A2BA1804900A6A584 /* PluginDetailsViewModelTests.swift */; };
 		68B6F22B2ADE7ED500D171FC /* TooltipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B6F22A2ADE7ED500D171FC /* TooltipView.swift */; };
 		68ED2BD62ADD2C8C00ECA88D /* LineDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68ED2BD52ADD2C8C00ECA88D /* LineDetailView.swift */; };
+		71E7782632CC7D5213733333 /* MockJetpackConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1A903713867FCD550D32AD /* MockJetpackConnectionService.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
 		740987B321B87760000E4C80 /* FancyAnimatedButton+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740987B221B87760000E4C80 /* FancyAnimatedButton+Woo.swift */; };
@@ -936,6 +936,7 @@
 		DE0A2EAF281BA278007A8015 /* ProductCategorySelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A2EAE281BA278007A8015 /* ProductCategorySelectorViewModel.swift */; };
 		DE0BE0C12F333BC0009CE891 /* NotificationServiceSuppressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0BE0C02F333BC0009CE891 /* NotificationServiceSuppressionTests.swift */; };
 		DE0CDC942B1ECFF000C98800 /* LocalFileUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0CDC932B1ECFF000C98800 /* LocalFileUploader.swift */; };
+		DE1152822F3C8EC30058F51B /* WooPushNotificationEligibilityCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1152812F3C8EC30058F51B /* WooPushNotificationEligibilityCheckTests.swift */; };
 		DE126D0B26CA2331007F901D /* ValidationErrorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */; };
 		DE126D0D26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */; };
 		DE126D0F26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */; };
@@ -1529,7 +1530,6 @@
 		203AB2A72D01B97D001D989C /* OrderCustomAmountsSectionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomAmountsSectionViewModelTests.swift; sourceTree = "<group>"; };
 		204C9C732B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIUserInterfaceSizeClass+Helpers.swift"; sourceTree = "<group>"; };
 		204CB80D2C0F8A5E000C9773 /* MockViewControllerPresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockViewControllerPresenting.swift; sourceTree = "<group>"; };
-		20716F332D9DA289008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPointOfSalePurchasableItemFetchStrategy.swift; sourceTree = "<group>"; };
 		209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperatingSystemVersion+Localization.swift"; sourceTree = "<group>"; };
 		20A3AFE02B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift; sourceTree = "<group>"; };
 		20B0D65D2AD45BDE0059735A /* TapToPayEducationContactlessLimitViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPayEducationContactlessLimitViewModelTests.swift; sourceTree = "<group>"; };
@@ -1772,6 +1772,7 @@
 		57CFCD292488496F003F51EC /* PrimarySectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PrimarySectionHeaderView.xib; sourceTree = "<group>"; };
 		57F2C6CC246DECC10074063B /* SummaryTableViewCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryTableViewCellViewModelTests.swift; sourceTree = "<group>"; };
 		57F42E3F253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndEditableValueTableViewCellViewModelTests.swift; sourceTree = "<group>"; };
+		5E1A903713867FCD550D32AD /* MockJetpackConnectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockJetpackConnectionService.swift; sourceTree = "<group>"; };
 		640DA3472E97DE4F00317FB2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		6489B8142EF3EB5D001E0343 /* MockError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockError.swift; sourceTree = "<group>"; };
 		6489DFFE2EA78E0D00D96802 /* MockProductDetailCoordinatorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductDetailCoordinatorFactory.swift; sourceTree = "<group>"; };
@@ -2155,6 +2156,7 @@
 		DE0A2EAE281BA278007A8015 /* ProductCategorySelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategorySelectorViewModel.swift; sourceTree = "<group>"; };
 		DE0BE0C02F333BC0009CE891 /* NotificationServiceSuppressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceSuppressionTests.swift; sourceTree = "<group>"; };
 		DE0CDC932B1ECFF000C98800 /* LocalFileUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFileUploader.swift; sourceTree = "<group>"; };
+		DE1152812F3C8EC30058F51B /* WooPushNotificationEligibilityCheckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPushNotificationEligibilityCheckTests.swift; sourceTree = "<group>"; };
 		DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationErrorRow.swift; sourceTree = "<group>"; };
 		DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInputViewModelTests.swift; sourceTree = "<group>"; };
@@ -2309,7 +2311,6 @@
 		EEEA41F12869A5F400AEFC4B /* MockProductImagesProductIDUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductImagesProductIDUpdater.swift; sourceTree = "<group>"; };
 		EEF5C14F2BBAFA5900535C86 /* StoreOnboardingTaskViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreOnboardingTaskViewModelTests.swift; sourceTree = "<group>"; };
 		F1FEE9D30367FFF0ADEE1F5B /* MockWPComConnectionSetupHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MockWPComConnectionSetupHandler.swift; sourceTree = "<group>"; };
-		5E1A903713867FCD550D32AD /* MockJetpackConnectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockJetpackConnectionService.swift; sourceTree = "<group>"; };
 		F997170223DBB97500592D8E /* WooCommerceScreenshots.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WooCommerceScreenshots.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE28F6F3268477C1004465C7 /* RoleEligibilityUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoleEligibilityUseCase.swift; sourceTree = "<group>"; };
 		FE3E427626A8545B00C596CE /* MockRoleEligibilityUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRoleEligibilityUseCase.swift; sourceTree = "<group>"; };
@@ -4437,6 +4438,7 @@
 		B5718D6321B56B3F0026C9F0 /* Notifications */ = {
 			isa = PBXGroup;
 			children = (
+				DE1152812F3C8EC30058F51B /* WooPushNotificationEligibilityCheckTests.swift */,
 				DE0BE0C02F333BC0009CE891 /* NotificationServiceSuppressionTests.swift */,
 				2D5389252F27BF59006A6618 /* PushNotificationRegistrationStateTests.swift */,
 				B5718D6421B56B3F0026C9F0 /* PushNotificationsManagerTests.swift */,
@@ -4444,8 +4446,6 @@
 				26132B3D2C3DA989004C157F /* PushNotificationBackgroundSynchronizerTests.swift */,
 				026D684A2A0E0A9600D8C22C /* LocalNotificationSchedulerTests.swift */,
 				26A280D52B45F00F00ACEE87 /* OrderNotificationViewModelTests.swift */,
-				DE0B20752F35E7D0009CE891 /* WooPushNotificationEligibilityCheckTests.swift */,
-				20716F332D9DA289008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift */,
 			);
 			path = Notifications;
 			sourceTree = "<group>";
@@ -6827,6 +6827,7 @@
 				02FADAA52A607CEE00FE8683 /* MockImageTextScanner.swift in Sources */,
 				CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */,
 				EEB4E2D329B2047700371C3C /* StoreOnboardingViewHostingControllerTests.swift in Sources */,
+				DE1152822F3C8EC30058F51B /* WooPushNotificationEligibilityCheckTests.swift in Sources */,
 				B57C745120F56EE900EEFC87 /* UITableViewCellHelpersTests.swift in Sources */,
 				D85136C9231E12B600DD0539 /* ReviewViewModelTests.swift in Sources */,
 				024EB5812B21A981009BC2D9 /* ProductWithQuantityStepperViewModelTests.swift in Sources */,
@@ -6933,7 +6934,6 @@
 				FE3E427726A8545B00C596CE /* MockRoleEligibilityUseCase.swift in Sources */,
 				02F67FF525806E0100C3BAD2 /* ShippingLabelTrackingURLGeneratorTests.swift in Sources */,
 				CE29FEF62C009F5F007679C2 /* ShippingLineRowViewModelTests.swift in Sources */,
-				DE0B20762F35E7D0009CE891 /* WooPushNotificationEligibilityCheckTests.swift in Sources */,
 				20CCBF212B0E15C0003102E6 /* WooPaymentsPayoutsCurrencyOverviewViewModelTests.swift in Sources */,
 				2602A64227BD89CE00B347F1 /* NewOrderInitialStatusResolverTests.swift in Sources */,
 				DE6D84A52C3B8C9C0014FBFF /* GoogleAdsDashboardCardViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -4444,6 +4444,7 @@
 				26132B3D2C3DA989004C157F /* PushNotificationBackgroundSynchronizerTests.swift */,
 				026D684A2A0E0A9600D8C22C /* LocalNotificationSchedulerTests.swift */,
 				26A280D52B45F00F00ACEE87 /* OrderNotificationViewModelTests.swift */,
+				DE0B20752F35E7D0009CE891 /* WooPushNotificationEligibilityCheckTests.swift */,
 				20716F332D9DA289008D9915 /* MockPointOfSalePurchasableItemFetchStrategy.swift */,
 			);
 			path = Notifications;
@@ -6932,6 +6933,7 @@
 				FE3E427726A8545B00C596CE /* MockRoleEligibilityUseCase.swift in Sources */,
 				02F67FF525806E0100C3BAD2 /* ShippingLabelTrackingURLGeneratorTests.swift in Sources */,
 				CE29FEF62C009F5F007679C2 /* ShippingLineRowViewModelTests.swift in Sources */,
+				DE0B20762F35E7D0009CE891 /* WooPushNotificationEligibilityCheckTests.swift in Sources */,
 				20CCBF212B0E15C0003102E6 /* WooPaymentsPayoutsCurrencyOverviewViewModelTests.swift in Sources */,
 				2602A64227BD89CE00B347F1 /* NewOrderInitialStatusResolverTests.swift in Sources */,
 				DE6D84A52C3B8C9C0014FBFF /* GoogleAdsDashboardCardViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -123,12 +123,14 @@ final class PushNotificationsManagerTests: XCTestCase {
     }
 
 
-    /// Verifies that `unregisterForRemoteNotifications` does not dispatch any action, whenever the DeviceID is unknown.
+    /// Verifies that `unregisterForRemoteNotifications` does not dispatch any NotificationAction, whenever the DeviceID is unknown.
     ///
     func testUnregisterForRemoteNotificationsDoesNothingWhenThereIsNoDeviceIdStored() {
-        XCTAssert(storesManager.receivedActions.isEmpty)
+        let notificationActionsBefore = storesManager.receivedActions.compactMap { $0 as? NotificationAction }
+        XCTAssert(notificationActionsBefore.isEmpty)
         manager.unregisterForRemoteNotifications {}
-        XCTAssert(storesManager.receivedActions.isEmpty)
+        let notificationActionsAfter = storesManager.receivedActions.compactMap { $0 as? NotificationAction }
+        XCTAssert(notificationActionsAfter.isEmpty)
     }
 
     /// Verifies that `unregisterForRemoteNotifications` does dispatch `.unregisterDevice` Action, whenever the
@@ -139,7 +141,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         manager = makeManager()
         manager.unregisterForRemoteNotifications {}
 
-        guard case let .unregisterDevice(deviceID, _) = storesManager.receivedActions.first as! NotificationAction else {
+        let notificationActions = storesManager.receivedActions.compactMap { $0 as? NotificationAction }
+        guard case let .unregisterDevice(deviceID, _) = notificationActions.first else {
             XCTFail()
             return
         }
@@ -158,7 +161,8 @@ final class PushNotificationsManagerTests: XCTestCase {
 
         manager.unregisterForRemoteNotifications {}
 
-        guard case let .unregisterDevice(_, onCompletion) = storesManager.receivedActions.first as! NotificationAction else {
+        let notificationActions = storesManager.receivedActions.compactMap { $0 as? NotificationAction }
+        guard case let .unregisterDevice(_, onCompletion) = notificationActions.first else {
             XCTFail()
             return
         }
@@ -172,14 +176,28 @@ final class PushNotificationsManagerTests: XCTestCase {
 
     /// Verifies that `registerDeviceToken` effectively stores the Device Token.
     ///
-    func testRegisterForRemoteNotificationsStoresDeviceTokenInUserDefaults() {
+    func testRegisterForRemoteNotificationsStoresDeviceTokenInUserDefaults() async {
+        // Given
+        let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
+        mockRemoteFeatureFlagAction(isEnabled: false, onCompletion: {
+            eligibilityCheckExpectation.fulfill()
+        })
+
+        manager = makeManager()
+
+        // Wait for eligibility check to complete
+        await fulfillment(of: [eligibilityCheckExpectation], timeout: 1.0)
+
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
             XCTFail()
             return
         }
 
+        // When
         XCTAssertNil(defaults.value(forKey: PushNotificationSharedConstants.UserDefaultsKeys.deviceToken))
         manager.registerDeviceToken(with: tokenAsData)
+
+        // Then
         XCTAssertNotNil(defaults.value(forKey: PushNotificationSharedConstants.UserDefaultsKeys.deviceToken))
     }
 
@@ -191,10 +209,10 @@ final class PushNotificationsManagerTests: XCTestCase {
 
         manager.registrationDidFail(with: SampleError.first)
 
-        XCTAssertEqual(storesManager.receivedActions.count, 1)
-        let action = storesManager.receivedActions.first as! NotificationAction
+        let notificationActions = storesManager.receivedActions.compactMap { $0 as? NotificationAction }
+        XCTAssertEqual(notificationActions.count, 1)
 
-        switch action {
+        switch notificationActions.first {
         case .unregisterDevice:
             break
         default:
@@ -657,13 +675,18 @@ final class PushNotificationsManagerTests: XCTestCase {
         XCTAssertTrue(application.presentInAppMessages.isEmpty)
     }
 
-    func test_registerDeviceToken_when_self_driven_gate_enabled_registers_self_driven_token_and_disables_WPCom_notifications() {
+    func test_registerDeviceToken_when_self_driven_gate_enabled_registers_self_driven_token_and_disables_WPCom_notifications() async {
         // Given
         defaults.set("456", forKey: PushNotificationSharedConstants.UserDefaultsKeys.deviceID)
         mockSelfDrivenRegistrationActions(token: 123)
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(99)
         let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+
+        let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
+        mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
+            eligibilityCheckExpectation.fulfill()
+        })
 
         manager = {
             let configuration = PushNotificationsConfiguration(application: self.application,
@@ -675,6 +698,9 @@ final class PushNotificationsManagerTests: XCTestCase {
                                            backgroundSynchronizerFactory: backgroundSynchronizerFactory,
                                             featureFlagService: featureFlagService)
         }()
+
+        // Wait for eligibility check to complete
+        await fulfillment(of: [eligibilityCheckExpectation], timeout: 1.0)
 
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
             XCTFail("Invalid sample token")
@@ -713,12 +739,16 @@ final class PushNotificationsManagerTests: XCTestCase {
         }))
     }
 
-    func test_registerDeviceToken_when_self_driven_gate_enabled_and_self_driven_token_registration_fails_falls_back_to_wpcom() {
+    func test_registerDeviceToken_when_self_driven_gate_enabled_and_self_driven_token_registration_fails_falls_back_to_wpcom() async {
         // Given
-        mockSelfDrivenRegistrationActions(token: 123)
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(99)
         let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+
+        let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
+        mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
+            eligibilityCheckExpectation.fulfill()
+        })
 
         manager = {
             let configuration = PushNotificationsConfiguration(application: self.application,
@@ -730,6 +760,9 @@ final class PushNotificationsManagerTests: XCTestCase {
                                            backgroundSynchronizerFactory: backgroundSynchronizerFactory,
                                            featureFlagService: featureFlagService)
         }()
+
+        // Wait for eligibility check to complete
+        await fulfillment(of: [eligibilityCheckExpectation], timeout: 1.0)
 
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
             XCTFail("Invalid sample token")
@@ -825,6 +858,16 @@ private extension PushNotificationsManagerTests {
 
             default:
                 break
+            }
+        }
+    }
+
+    func mockRemoteFeatureFlagAction(isEnabled: Bool, onCompletion: (() -> Void)? = nil) {
+        storesManager.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            switch action {
+            case .isRemoteFeatureFlagEnabled(_, _, _, let completion):
+                completion(isEnabled)
+                onCompletion?()
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/Notifications/WooPushNotificationEligibilityCheckTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/WooPushNotificationEligibilityCheckTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+@MainActor
+final class WooPushNotificationEligibilityCheckTests: XCTestCase {
+    private var storesManager: MockStoresManager!
+    private var featureFlagService: MockFeatureFlagService!
+
+    override func setUp() {
+        super.setUp()
+        storesManager = MockStoresManager(sessionManager: .testingInstance)
+        featureFlagService = MockFeatureFlagService()
+    }
+
+    override func tearDown() {
+        storesManager = nil
+        featureFlagService = nil
+        super.tearDown()
+    }
+
+    // MARK: - checkM1Eligibility
+
+    func test_checkM1Eligibility_returns_true_when_remote_flag_is_enabled() async {
+        // Given
+        let checker = WooPushNotificationEligibilityCheck(
+            featureFlagService: featureFlagService,
+            stores: storesManager
+        )
+        mockRemoteFeatureFlagAction(isEnabled: true)
+
+        // When
+        let result = await checker.checkM1Eligibility()
+
+        // Then
+        XCTAssertTrue(result)
+    }
+
+    func test_checkM1Eligibility_returns_false_when_remote_flag_is_disabled() async {
+        // Given
+        let checker = WooPushNotificationEligibilityCheck(
+            featureFlagService: featureFlagService,
+            stores: storesManager
+        )
+        mockRemoteFeatureFlagAction(isEnabled: false)
+
+        // When
+        let result = await checker.checkM1Eligibility()
+
+        // Then
+        XCTAssertFalse(result)
+    }
+
+    func test_checkM1Eligibility_passes_local_feature_flag_as_default_value() async {
+        // Given
+        featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        let checker = WooPushNotificationEligibilityCheck(
+            featureFlagService: featureFlagService,
+            stores: storesManager
+        )
+
+        var capturedDefaultValue: Bool?
+        storesManager.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            switch action {
+            case let .isRemoteFeatureFlagEnabled(_, defaultValue, _, completion):
+                capturedDefaultValue = defaultValue
+                completion(defaultValue)
+            }
+        }
+
+        // When
+        _ = await checker.checkM1Eligibility()
+
+        // Then
+        XCTAssertEqual(capturedDefaultValue, true)
+    }
+
+    func test_checkM1Eligibility_passes_correct_remote_feature_flag_key() async {
+        // Given
+        let checker = WooPushNotificationEligibilityCheck(
+            featureFlagService: featureFlagService,
+            stores: storesManager
+        )
+
+        var capturedFeatureFlag: RemoteFeatureFlag?
+        storesManager.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            switch action {
+            case let .isRemoteFeatureFlagEnabled(featureFlag, _, _, completion):
+                capturedFeatureFlag = featureFlag
+                completion(false)
+            }
+        }
+
+        // When
+        _ = await checker.checkM1Eligibility()
+
+        // Then
+        XCTAssertEqual(capturedFeatureFlag, .selfDrivenPushNotificationsM1)
+    }
+
+    func test_checkM1Eligibility_uses_cache() async {
+        // Given
+        let checker = WooPushNotificationEligibilityCheck(
+            featureFlagService: featureFlagService,
+            stores: storesManager
+        )
+
+        var capturedUseCache: Bool?
+        storesManager.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            switch action {
+            case let .isRemoteFeatureFlagEnabled(_, _, useCache, completion):
+                capturedUseCache = useCache
+                completion(false)
+            }
+        }
+
+        // When
+        _ = await checker.checkM1Eligibility()
+
+        // Then
+        XCTAssertEqual(capturedUseCache, true)
+    }
+}
+
+// MARK: - Helpers
+
+private extension WooPushNotificationEligibilityCheckTests {
+    func mockRemoteFeatureFlagAction(isEnabled: Bool) {
+        storesManager.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            switch action {
+            case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
+                completion(isEnabled)
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-2098

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a new eligibility check for M1 of Push notifications project. The check looks for a new remote flag and falls back to the local flag.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Confirm with Xcode console log that after login to a test store with either site credentials or WPCom that:
- If local flag is disabled, registering with Woo PNs is skipped.
- If local flag is enabled, registering with Woo PNs is triggered.
- Using the debug panel to enable remote flag for M1, registering with Woo PNs is triggered.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

No UI updates.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
