### PR TITLE
Remove version overrides from extensions

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -16560,7 +16560,6 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 24.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.storewidgets;
@@ -16592,7 +16591,6 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 24.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.storewidgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -16623,7 +16621,6 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 24.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.alpha.woocommerce.storewidgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -16948,7 +16945,6 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = NotificationServiceExtension/Entitlements/NotificationServiceExtensionDebug.entitlements;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 24.0.0.0;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -16962,7 +16958,6 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 24.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.NotificationServiceExtension;
@@ -16988,7 +16983,6 @@
 				CODE_SIGN_ENTITLEMENTS = NotificationServiceExtension/Entitlements/NotificationServiceExtensionRelease.entitlements;
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 24.0.0.0;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -17002,7 +16996,6 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 24.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.NotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -17026,7 +17019,6 @@
 				CODE_SIGN_ENTITLEMENTS = NotificationServiceExtension/Entitlements/NotificationServiceExtension.entitlements;
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 24.0.0.0;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -17040,7 +17032,6 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 24.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.alpha.woocommerce.NotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## Description

Updated:

- NotificationServiceExtension
- StoreWidgetsExtension

A recent App Store Connect upload gave us this warning:

```
Version 24.1
Build 24.1.0.0
Although delivery was successful, you may want to correct the following issues in your next delivery. Once you've corrected the issues, upload a new binary to App Store Connect.

ITMS-90473: CFBundleVersion Mismatch - The CFBundleVersion value '24.0.0.0' of extension 'WooCommerce.app/PlugIns/NotificationServiceExtension.appex' does not match the CFBundleVersion value '24.1.0.0' of its containing iOS application 'WooCommerce.app'.

ITMS-90473: CFBundleShortVersionString Mismatch - The CFBundleShortVersionString value '24.0' of extension 'WooCommerce.app/PlugIns/NotificationServiceExtension.appex' does not match the CFBundleShortVersionString value '24.1' of its containing iOS application 'WooCommerce.app'.

ITMS-90473: CFBundleShortVersionString Mismatch - The CFBundleShortVersionString value '24.0' of extension 'WooCommerce.app/PlugIns/StoreWidgetsExtension.appex' does not match the CFBundleShortVersionString value '24.1' of its containing iOS application 'WooCommerce.app'.
```

The reason was that, somehow, the version and build for those extensions had been overridden at the time of the 24.0 build, blocking the inheritance from the project that keeps versions across all targets in sync.

## Test Steps
N.A., we'll see what App Store Connect says on the next upload. Alternatively, you could archive the app and verify the versions of each components.

Also notice how the Xcode build settings now resolve the version following from the master config file:

<img width="2574" height="272" alt="image" src="https://github.com/user-attachments/assets/6011657f-13c9-4c26-8b7b-f1e90f7a33dc" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. — N.A.
