### PR TITLE
Experiment - POS bookings refunds

### DIFF
--- a/Modules/Sources/Networking/Remote/BookingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/BookingsRemote.swift
@@ -1,4 +1,5 @@
 // periphery:ignore:all
+import CocoaLumberjackSwift
 import Foundation
 
 /// Protocol for `BookingsRemote` mainly used for mocking.
@@ -134,7 +135,30 @@ public final class BookingsRemote: Remote, BookingsRemoteProtocol {
         let request = JetpackRequest(wooApiVersion: .wcBookings, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
         let mapper = ListMapper<Booking>(siteID: siteID)
 
-        return try await enqueue(request, mapper: mapper)
+        do {
+            let result = try await enqueue(request, mapper: mapper)
+            DDLogInfo("📚 BookingsRemote.loadAllBookings: Successfully decoded \(result.count) bookings")
+            return result
+        } catch {
+            DDLogError("⛔️ BookingsRemote.loadAllBookings FAILED - path: \(path), siteID: \(siteID)")
+            DDLogError("⛔️ BookingsRemote.loadAllBookings error type: \(type(of: error))")
+            DDLogError("⛔️ BookingsRemote.loadAllBookings error: \(error)")
+            if let decodingError = error as? DecodingError {
+                switch decodingError {
+                case .typeMismatch(let type, let context):
+                    DDLogError("⛔️ DecodingError.typeMismatch: expected \(type), path: \(context.codingPath), \(context.debugDescription)")
+                case .valueNotFound(let type, let context):
+                    DDLogError("⛔️ DecodingError.valueNotFound: \(type), path: \(context.codingPath), \(context.debugDescription)")
+                case .keyNotFound(let key, let context):
+                    DDLogError("⛔️ DecodingError.keyNotFound: \(key), path: \(context.codingPath), \(context.debugDescription)")
+                case .dataCorrupted(let context):
+                    DDLogError("⛔️ DecodingError.dataCorrupted: path: \(context.codingPath), \(context.debugDescription)")
+                @unknown default:
+                    DDLogError("⛔️ DecodingError unknown: \(decodingError)")
+                }
+            }
+            throw error
+        }
     }
 
     public func loadBooking(

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -36,7 +36,7 @@ final class POSBookingListController {
                 state = .empty
             } else {
                 let posBookings = result.bookings.map { mapToPOSBooking($0) }
-                    .sorted { $0.startTime < $1.startTime }
+                    .sorted { $0.startTime > $1.startTime }
                 state = .loaded(posBookings)
             }
         } catch {
@@ -60,7 +60,7 @@ final class POSBookingListController {
                 selectedBooking = nil
             } else {
                 let posBookings = result.bookings.map { mapToPOSBooking($0) }
-                    .sorted { $0.startTime < $1.startTime }
+                    .sorted { $0.startTime > $1.startTime }
                 state = .loaded(posBookings)
 
                 // Update selected booking with fresh data

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingRefundController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingRefundController.swift
@@ -1,0 +1,232 @@
+// POSBookingRefundController.swift
+import Foundation
+import Observation
+import Yosemite
+import Networking
+import NetworkingCore
+import class WooFoundation.CurrencyFormatter
+
+/// Manages the refund flow for a booking's linked order.
+///
+/// Fetches the order associated with a booking, converts its line items into selectable items,
+/// and uses `POSRefundsServiceProtocol` for amount calculations and refund creation.
+/// Follows the same patterns as `POSOrderListController`'s refund methods.
+@MainActor
+@Observable
+final class POSBookingRefundController {
+    private(set) var refundSelectableItems: [POSRefundSelectableItem] = []
+    private(set) var isLoadingOrder: Bool = false
+    private(set) var orderLoadError: Error?
+
+    private let siteID: Int64
+    private let orderProvider: POSOrderProviding
+    private let refundsService: POSRefundsServiceProtocol
+    private let currencyFormatter: CurrencyFormatter
+
+    private var fetchedOrder: Order?
+
+    init(siteID: Int64,
+         orderProvider: POSOrderProviding,
+         refundsService: POSRefundsServiceProtocol,
+         currencyFormatter: CurrencyFormatter) {
+        self.siteID = siteID
+        self.orderProvider = orderProvider
+        self.refundsService = refundsService
+        self.currencyFormatter = currencyFormatter
+    }
+
+    /// Fetches the order for a booking and prepares selectable items for the refund flow.
+    func loadOrderForRefund(booking: POSBooking) async {
+        guard let orderID = booking.orderID else {
+            orderLoadError = BookingRefundError.noLinkedOrder
+            return
+        }
+
+        isLoadingOrder = true
+        orderLoadError = nil
+
+        do {
+            let order = try await orderProvider.fetchOrder(siteID: siteID, orderID: orderID)
+            fetchedOrder = order
+            refundSelectableItems = createSelectableItems(from: order)
+        } catch {
+            orderLoadError = error
+        }
+
+        isLoadingOrder = false
+    }
+
+    /// Whether the loaded order is already fully refunded.
+    var isFullyRefunded: Bool {
+        fetchedOrder?.status == .refunded
+    }
+
+    /// Whether the payment gateway likely supports automatic refunds.
+    var supportsAutomaticRefund: Bool {
+        guard let order = fetchedOrder else { return false }
+        return order.paymentMethodID != PaymentGateway.Constants.cashOnDeliveryGatewayID
+    }
+
+    /// A human-readable description of the payment method (e.g. "via Credit Card").
+    var paymentMethodDescription: String {
+        guard let order = fetchedOrder else { return "" }
+        let title = order.paymentMethodTitle
+        if title.isEmpty {
+            return ""
+        }
+        return String(format: Localization.viaPaymentMethod, title)
+    }
+
+    // MARK: - Item Selection
+
+    func toggleRefundItemSelection(at index: Int) {
+        guard refundSelectableItems.indices.contains(index) else { return }
+        refundSelectableItems[index].isSelected.toggle()
+    }
+
+    func toggleAllRefundItemsSelection() {
+        let allSelected = !refundSelectableItems.isEmpty && refundSelectableItems.allSatisfy(\.isSelected)
+        let newSelectionState = !allSelected
+        for index in refundSelectableItems.indices {
+            refundSelectableItems[index].isSelected = newSelectionState
+        }
+    }
+
+    func clearRefundSelection() {
+        refundSelectableItems = []
+        fetchedOrder = nil
+    }
+
+    // MARK: - Refund Data Preparation
+
+    func preparePOSRefundReviewData() -> POSRefundReviewData? {
+        let selectedItems = refundSelectableItems.filter(\.isSelected)
+        guard !selectedItems.isEmpty else { return nil }
+
+        let refundableItems = selectedItems.map {
+            POSRefundableItem(
+                itemID: $0.itemID,
+                lineItemTotal: $0.lineItemTotal,
+                totalTax: $0.totalTax,
+                originalQuantity: $0.originalQuantity
+            )
+        }
+
+        let amounts = refundsService.calculateRefundAmounts(for: refundableItems)
+
+        guard let formattedSubtotal = currencyFormatter.formatAmount(amounts.subtotal),
+              let formattedTax = currencyFormatter.formatAmount(amounts.tax),
+              let formattedTotal = currencyFormatter.formatAmount(amounts.total) else {
+            return nil
+        }
+
+        return POSRefundReviewData(
+            itemsCount: selectedItems.count,
+            formattedItemsSubtotal: formattedSubtotal,
+            formattedTax: formattedTax,
+            formattedRefundTotal: formattedTotal,
+            paymentMethodDescription: paymentMethodDescription,
+            refundReason: nil
+        )
+    }
+
+    // MARK: - Process Refund
+
+    func processRefund(reason: String?) async throws {
+        guard let order = fetchedOrder else {
+            throw BookingRefundError.noOrderLoaded
+        }
+
+        let selectedItems = refundSelectableItems.filter(\.isSelected)
+        guard !selectedItems.isEmpty else {
+            throw BookingRefundError.noItemsSelected
+        }
+
+        let refundableItems = selectedItems.map {
+            POSRefundableItem(
+                itemID: $0.itemID,
+                lineItemTotal: $0.lineItemTotal,
+                totalTax: $0.totalTax,
+                originalQuantity: $0.originalQuantity
+            )
+        }
+
+        try await refundsService.createRefund(
+            orderID: order.orderID,
+            items: refundableItems,
+            reason: reason,
+            isAutomaticRefund: supportsAutomaticRefund
+        )
+
+        clearRefundSelection()
+    }
+
+    // MARK: - Private Helpers
+
+    private func createSelectableItems(from order: Order) -> [POSRefundSelectableItem] {
+        order.items.flatMap { item -> [POSRefundSelectableItem] in
+            let intQuantity = NSDecimalNumber(decimal: item.quantity).intValue
+            guard intQuantity > 0 else { return [] }
+
+            let lineItemTotal = Decimal(string: item.total) ?? 0
+            let totalTax = Decimal(string: item.totalTax) ?? 0
+            let formattedPrice = currencyFormatter.formatAmount(item.price.decimalValue) ?? item.total
+
+            return (0..<intQuantity).map { index in
+                POSRefundSelectableItem(
+                    itemID: item.itemID,
+                    name: item.name,
+                    imageSrc: item.image?.src,
+                    lineItemTotal: lineItemTotal,
+                    totalTax: totalTax,
+                    originalQuantity: item.quantity,
+                    formattedPrice: formattedPrice,
+                    attributes: item.attributes,
+                    isSelected: true,
+                    index: index
+                )
+            }
+        }
+    }
+
+    // MARK: - Localization
+
+    private enum Localization {
+        static let viaPaymentMethod = NSLocalizedString(
+            "posBookingRefundController.viaPaymentMethod",
+            value: "via %@",
+            comment: "Payment method description for refund review. %@ is the payment method title (e.g. 'Credit Card')."
+        )
+    }
+}
+
+// MARK: - Errors
+
+enum BookingRefundError: LocalizedError {
+    case noLinkedOrder
+    case noOrderLoaded
+    case noItemsSelected
+
+    var errorDescription: String? {
+        switch self {
+        case .noLinkedOrder:
+            return NSLocalizedString(
+                "bookingRefundError.noLinkedOrder",
+                value: "This booking has no linked order to refund.",
+                comment: "Error when trying to refund a booking without a linked order"
+            )
+        case .noOrderLoaded:
+            return NSLocalizedString(
+                "bookingRefundError.noOrderLoaded",
+                value: "Order data has not been loaded yet.",
+                comment: "Error when trying to process refund before loading the order"
+            )
+        case .noItemsSelected:
+            return NSLocalizedString(
+                "bookingRefundError.noItemsSelected",
+                value: "No items selected for refund.",
+                comment: "Error when trying to process refund with no items selected"
+            )
+        }
+    }
+}

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingRefundController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingRefundController.swift
@@ -62,9 +62,11 @@ final class POSBookingRefundController {
     }
 
     /// Whether the payment gateway likely supports automatic refunds.
+    /// Returns `false` when no gateway is associated (e.g. order manually marked as completed).
     var supportsAutomaticRefund: Bool {
         guard let order = fetchedOrder else { return false }
-        return order.paymentMethodID != PaymentGateway.Constants.cashOnDeliveryGatewayID
+        let methodID = order.paymentMethodID
+        return !methodID.isEmpty && methodID != PaymentGateway.Constants.cashOnDeliveryGatewayID
     }
 
     /// A human-readable description of the payment method (e.g. "via Credit Card").

--- a/Modules/Sources/PointOfSale/Models/POSBookingsModel.swift
+++ b/Modules/Sources/PointOfSale/Models/POSBookingsModel.swift
@@ -2,6 +2,7 @@
 import Foundation
 import Observation
 import Yosemite
+import class WooFoundation.CurrencyFormatter
 
 @Observable final class POSBookingsModel {
     let bookingListController: POSBookingListController
@@ -10,22 +11,37 @@ import Yosemite
     let cardPaymentFacade: CardPresentPaymentFacade
     let receiptSender: POSReceiptSending
     let orderProvider: POSOrderProviding
+    let refundsService: POSRefundsServiceProtocol
+    let currencyFormatter: CurrencyFormatter
 
     init(bookingListController: POSBookingListController,
          siteID: Int64,
          bookingService: POSBookingServiceProtocol,
          cardPaymentFacade: CardPresentPaymentFacade,
          receiptSender: POSReceiptSending,
-         orderProvider: POSOrderProviding) {
+         orderProvider: POSOrderProviding,
+         refundsService: POSRefundsServiceProtocol,
+         currencyFormatter: CurrencyFormatter) {
         self.bookingListController = bookingListController
         self.siteID = siteID
         self.bookingService = bookingService
         self.cardPaymentFacade = cardPaymentFacade
         self.receiptSender = receiptSender
         self.orderProvider = orderProvider
+        self.refundsService = refundsService
+        self.currencyFormatter = currencyFormatter
     }
 
     func sendReceipt(orderID: Int64, email: String) async throws {
         try await receiptSender.sendReceipt(orderID: orderID, recipientEmail: email)
+    }
+
+    @MainActor func makeRefundController() -> POSBookingRefundController {
+        POSBookingRefundController(
+            siteID: siteID,
+            orderProvider: orderProvider,
+            refundsService: refundsService,
+            currencyFormatter: currencyFormatter
+        )
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -7,17 +7,20 @@ struct POSBookingDetailView: View {
     let onBack: () -> Void
     let onPayByCard: () -> Void
     let onPayByCash: () -> Void
+    let onIssueRefund: (() -> Void)?
 
     init(booking: POSBooking,
          isRefreshing: Bool = false,
          onBack: @escaping () -> Void,
          onPayByCard: @escaping () -> Void,
-         onPayByCash: @escaping () -> Void) {
+         onPayByCash: @escaping () -> Void,
+         onIssueRefund: (() -> Void)? = nil) {
         self.booking = booking
         self.isRefreshing = isRefreshing
         self.onBack = onBack
         self.onPayByCard = onPayByCard
         self.onPayByCash = onPayByCash
+        self.onIssueRefund = onIssueRefund
     }
 
     @Environment(\.siteTimezone) private var siteTimezone
@@ -280,11 +283,20 @@ struct POSBookingDetailView: View {
                 }
 
             case .paid:
-                statusMessage(
-                    icon: "checkmark.circle.fill",
-                    text: Localization.paymentComplete,
-                    color: .posSuccess
-                )
+                VStack(spacing: POSSpacing.medium) {
+                    statusMessage(
+                        icon: "checkmark.circle.fill",
+                        text: Localization.paymentComplete,
+                        color: .posSuccess
+                    )
+
+                    if let onIssueRefund {
+                        Button(Localization.issueRefund) {
+                            onIssueRefund()
+                        }
+                        .buttonStyle(POSFilledButtonStyle(size: .normal))
+                    }
+                }
 
             case .cancelled:
                 statusMessage(
@@ -360,6 +372,11 @@ struct POSBookingDetailView: View {
             "posBookingDetail.paymentComplete",
             value: "Payment Complete",
             comment: "Status for paid booking"
+        )
+        static let issueRefund = NSLocalizedString(
+            "posBookingDetail.issueRefund",
+            value: "Issue Refund",
+            comment: "Button to start the refund flow for a paid booking"
         )
         static let bookingCancelled = NSLocalizedString(
             "posBookingDetail.bookingCancelled",

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -8,19 +8,22 @@ struct POSBookingDetailView: View {
     let onPayByCard: () -> Void
     let onPayByCash: () -> Void
     let onIssueRefund: (() -> Void)?
+    let onViewOrder: (() -> Void)?
 
     init(booking: POSBooking,
          isRefreshing: Bool = false,
          onBack: @escaping () -> Void,
          onPayByCard: @escaping () -> Void,
          onPayByCash: @escaping () -> Void,
-         onIssueRefund: (() -> Void)? = nil) {
+         onIssueRefund: (() -> Void)? = nil,
+         onViewOrder: (() -> Void)? = nil) {
         self.booking = booking
         self.isRefreshing = isRefreshing
         self.onBack = onBack
         self.onPayByCard = onPayByCard
         self.onPayByCash = onPayByCash
         self.onIssueRefund = onIssueRefund
+        self.onViewOrder = onViewOrder
     }
 
     @Environment(\.siteTimezone) private var siteTimezone
@@ -268,9 +271,9 @@ struct POSBookingDetailView: View {
                 .frame(height: 52)
                 .shimmering()
         } else {
-            switch booking.status {
-            case .unpaid:
-                VStack(spacing: POSSpacing.medium) {
+            VStack(spacing: POSSpacing.medium) {
+                switch booking.status {
+                case .unpaid:
                     Button(Localization.payByCard) {
                         onPayByCard()
                     }
@@ -280,10 +283,8 @@ struct POSBookingDetailView: View {
                         onPayByCash()
                     }
                     .buttonStyle(POSOutlinedButtonStyle(size: .normal))
-                }
 
-            case .paid:
-                VStack(spacing: POSSpacing.medium) {
+                case .paid:
                     statusMessage(
                         icon: "checkmark.circle.fill",
                         text: Localization.paymentComplete,
@@ -296,21 +297,28 @@ struct POSBookingDetailView: View {
                         }
                         .buttonStyle(POSFilledButtonStyle(size: .normal))
                     }
+
+                case .cancelled:
+                    statusMessage(
+                        icon: "xmark.circle.fill",
+                        text: Localization.bookingCancelled,
+                        color: .posOnSurfaceVariantHighest
+                    )
+
+                case .noLinkedOrder:
+                    statusMessage(
+                        icon: "exclamationmark.triangle.fill",
+                        text: Localization.noLinkedOrder,
+                        color: .posError
+                    )
                 }
 
-            case .cancelled:
-                statusMessage(
-                    icon: "xmark.circle.fill",
-                    text: Localization.bookingCancelled,
-                    color: .posOnSurfaceVariantHighest
-                )
-
-            case .noLinkedOrder:
-                statusMessage(
-                    icon: "exclamationmark.triangle.fill",
-                    text: Localization.noLinkedOrder,
-                    color: .posError
-                )
+                if let onViewOrder {
+                    Button(Localization.viewOrder) {
+                        onViewOrder()
+                    }
+                    .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+                }
             }
         }
     }
@@ -377,6 +385,11 @@ struct POSBookingDetailView: View {
             "posBookingDetail.issueRefund",
             value: "Issue Refund",
             comment: "Button to start the refund flow for a paid booking"
+        )
+        static let viewOrder = NSLocalizedString(
+            "posBookingDetail.viewOrder",
+            value: "View Order",
+            comment: "Button to navigate to the order details in the main app"
         )
         static let bookingCancelled = NSLocalizedString(
             "posBookingDetail.bookingCancelled",

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -9,6 +9,7 @@ struct POSBookingDetailView: View {
     let onPayByCash: () -> Void
     let onIssueRefund: (() -> Void)?
     let onViewOrder: (() -> Void)?
+    let onViewOrderInPOS: (() -> Void)?
 
     init(booking: POSBooking,
          isRefreshing: Bool = false,
@@ -16,7 +17,8 @@ struct POSBookingDetailView: View {
          onPayByCard: @escaping () -> Void,
          onPayByCash: @escaping () -> Void,
          onIssueRefund: (() -> Void)? = nil,
-         onViewOrder: (() -> Void)? = nil) {
+         onViewOrder: (() -> Void)? = nil,
+         onViewOrderInPOS: (() -> Void)? = nil) {
         self.booking = booking
         self.isRefreshing = isRefreshing
         self.onBack = onBack
@@ -24,6 +26,7 @@ struct POSBookingDetailView: View {
         self.onPayByCash = onPayByCash
         self.onIssueRefund = onIssueRefund
         self.onViewOrder = onViewOrder
+        self.onViewOrderInPOS = onViewOrderInPOS
     }
 
     @Environment(\.siteTimezone) private var siteTimezone
@@ -319,6 +322,13 @@ struct POSBookingDetailView: View {
                     }
                     .buttonStyle(POSOutlinedButtonStyle(size: .normal))
                 }
+
+                if let onViewOrderInPOS {
+                    Button(Localization.viewInPOSOrders) {
+                        onViewOrderInPOS()
+                    }
+                    .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+                }
             }
         }
     }
@@ -388,8 +398,13 @@ struct POSBookingDetailView: View {
         )
         static let viewOrder = NSLocalizedString(
             "posBookingDetail.viewOrder",
-            value: "View Order",
+            value: "View Order in App",
             comment: "Button to navigate to the order details in the main app"
+        )
+        static let viewInPOSOrders = NSLocalizedString(
+            "posBookingDetail.viewInPOSOrders",
+            value: "View in POS Orders",
+            comment: "Button to navigate to the order within the POS orders view"
         )
         static let bookingCancelled = NSLocalizedString(
             "posBookingDetail.bookingCancelled",

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingsContainerView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingsContainerView.swift
@@ -6,6 +6,7 @@ import Yosemite
 struct POSBookingsContainerView: View {
     @Environment(POSBookingsModel.self) private var bookingsModel
     @Environment(\.posAnalytics) private var analytics
+    @Environment(\.posExternalNavigation) private var externalNavigation
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     @Binding var isPresented: Bool
@@ -55,7 +56,10 @@ struct POSBookingsContainerView: View {
                 onBack: { bookingListController.selectBooking(nil) },
                 onPayByCard: { startCardPayment(for: booking) },
                 onPayByCash: { startCashPayment(for: booking) },
-                onIssueRefund: booking.status == .paid ? { startRefundFlow(for: booking) } : nil
+                onIssueRefund: booking.status == .paid ? { startRefundFlow(for: booking) } : nil,
+                onViewOrder: booking.orderID != nil ? {
+                    externalNavigation.navigateToOrderDetails(orderID: booking.orderID!, siteID: bookingsModel.siteID)
+                } : nil
             )
             .id(booking.bookingID)
         } detailPlaceholderView: {

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingsContainerView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingsContainerView.swift
@@ -10,6 +10,7 @@ struct POSBookingsContainerView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     @Binding var isPresented: Bool
+    var onNavigateToPOSOrder: ((Int64) -> Void)?
     @State private var showingCashPayment: Bool = false
     @State private var showingEmailReceipt: Bool = false
     @State private var cardPaymentController: POSBookingPaymentController?
@@ -59,6 +60,9 @@ struct POSBookingsContainerView: View {
                 onIssueRefund: booking.status == .paid ? { startRefundFlow(for: booking) } : nil,
                 onViewOrder: booking.orderID != nil ? {
                     externalNavigation.navigateToOrderDetails(orderID: booking.orderID!, siteID: bookingsModel.siteID)
+                } : nil,
+                onViewOrderInPOS: booking.orderID != nil ? {
+                    onNavigateToPOSOrder?(booking.orderID!)
                 } : nil
             )
             .id(booking.bookingID)

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingsContainerView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingsContainerView.swift
@@ -1,4 +1,5 @@
 // POSBookingsContainerView.swift
+import CocoaLumberjackSwift
 import SwiftUI
 import Yosemite
 
@@ -11,6 +12,8 @@ struct POSBookingsContainerView: View {
     @State private var showingCashPayment: Bool = false
     @State private var showingEmailReceipt: Bool = false
     @State private var cardPaymentController: POSBookingPaymentController?
+    @State private var refundModalState: BookingRefundModalState?
+    @State private var bookingRefundController: POSBookingRefundController?
 
     private var bookingListController: POSBookingListController {
         bookingsModel.bookingListController
@@ -51,7 +54,8 @@ struct POSBookingsContainerView: View {
                 isRefreshing: bookingListController.isRefreshing,
                 onBack: { bookingListController.selectBooking(nil) },
                 onPayByCard: { startCardPayment(for: booking) },
-                onPayByCash: { startCashPayment(for: booking) }
+                onPayByCash: { startCashPayment(for: booking) },
+                onIssueRefund: booking.status == .paid ? { startRefundFlow(for: booking) } : nil
             )
             .id(booking.bookingID)
         } detailPlaceholderView: {
@@ -133,6 +137,11 @@ struct POSBookingsContainerView: View {
                 }
             }
         }
+        .posModal(item: $refundModalState, onDismiss: {
+            bookingRefundController?.clearRefundSelection()
+        }) { state in
+            bookingRefundModalContent(for: state)
+        }
     }
 
     @ViewBuilder
@@ -163,6 +172,8 @@ struct POSBookingsContainerView: View {
         .background(Color.posSurfaceBright)
     }
 
+    // MARK: - Payment Actions
+
     private func startCardPayment(for booking: POSBooking) {
         cardPaymentController = POSBookingPaymentController(
             siteID: bookingsModel.siteID,
@@ -183,11 +194,188 @@ struct POSBookingsContainerView: View {
         }
     }
 
+    // MARK: - Refund Flow
+
+    private func startRefundFlow(for booking: POSBooking) {
+        let controller = bookingsModel.makeRefundController()
+        bookingRefundController = controller
+
+        Task {
+            await controller.loadOrderForRefund(booking: booking)
+
+            if controller.isFullyRefunded {
+                // Order is already fully refunded, don't show item selection
+                bookingRefundController = nil
+                return
+            }
+
+            if controller.orderLoadError != nil {
+                // Failed to load order, don't show refund flow
+                bookingRefundController = nil
+                return
+            }
+
+            refundModalState = .itemSelection
+        }
+    }
+
+    @ViewBuilder
+    private func bookingRefundModalContent(for state: BookingRefundModalState) -> some View {
+        switch state {
+        case .itemSelection:
+            if let controller = bookingRefundController {
+                POSBookingRefundItemsSelectionView(
+                    refundController: controller,
+                    onClose: { refundModalState = nil },
+                    onContinue: { navigateToRefundReview() }
+                )
+            }
+        case .review(let reviewData):
+            POSRefundReviewView(
+                onClose: { refundModalState = nil },
+                itemsCount: reviewData.itemsCount,
+                formattedItemsSubtotal: reviewData.formattedItemsSubtotal,
+                formattedTax: reviewData.formattedTax,
+                formattedRefundTotal: reviewData.formattedRefundTotal,
+                paymentMethodDescription: reviewData.paymentMethodDescription,
+                refundReason: reviewData.refundReason,
+                onAddReason: {
+                    refundModalState = .reasonInput(reviewData)
+                },
+                onContinue: {
+                    refundModalState = .confirmation(reviewData)
+                },
+                onEditRefund: {
+                    refundModalState = .itemSelection
+                }
+            )
+        case .reasonInput(let reviewData):
+            POSRefundReasonView(
+                initialReason: reviewData.refundReason,
+                onSave: { reason in
+                    var updatedReviewData = reviewData
+                    updatedReviewData.refundReason = reason
+                    refundModalState = .review(updatedReviewData)
+                },
+                onBack: {
+                    refundModalState = .review(reviewData)
+                },
+                onClose: {
+                    refundModalState = nil
+                }
+            )
+        case .confirmation(let reviewData):
+            POSRefundConfirmationView(
+                formattedRefundTotal: reviewData.formattedRefundTotal,
+                paymentMethodDescription: reviewData.paymentMethodDescription,
+                isProcessing: false,
+                onClose: {
+                    refundModalState = nil
+                },
+                onConfirm: {
+                    refundModalState = .processing(reviewData)
+                    Task { @MainActor in
+                        await processBookingRefund(reviewData: reviewData)
+                    }
+                },
+                onBack: {
+                    refundModalState = .review(reviewData)
+                }
+            )
+        case .processing(let reviewData):
+            POSRefundConfirmationView(
+                formattedRefundTotal: reviewData.formattedRefundTotal,
+                paymentMethodDescription: reviewData.paymentMethodDescription,
+                isProcessing: true,
+                onClose: {},
+                onConfirm: {},
+                onBack: {}
+            )
+        case .success(let reviewData):
+            POSRefundSuccessView(
+                formattedRefundTotal: reviewData.formattedRefundTotal,
+                paymentMethodDescription: reviewData.paymentMethodDescription,
+                onDone: {
+                    refundModalState = nil
+                    refreshAfterPayment()
+                },
+                onEmailReceipt: {
+                    if let booking = bookingListController.selectedBooking,
+                       let orderID = booking.orderID {
+                        showingEmailReceipt = true
+                        // Email receipt is handled by the sheet already attached to the view
+                        _ = orderID
+                    }
+                },
+                onClose: {
+                    refundModalState = nil
+                    refreshAfterPayment()
+                }
+            )
+        case .error(let reviewData):
+            POSRefundErrorView(
+                onRetry: {
+                    refundModalState = .confirmation(reviewData)
+                },
+                onCancel: {
+                    refundModalState = nil
+                },
+                onClose: {
+                    refundModalState = nil
+                }
+            )
+        }
+    }
+
+    private func navigateToRefundReview() {
+        guard let reviewData = bookingRefundController?.preparePOSRefundReviewData() else { return }
+        refundModalState = .review(reviewData)
+    }
+
+    @MainActor
+    private func processBookingRefund(reviewData: POSRefundReviewData) async {
+        do {
+            try await bookingRefundController?.processRefund(reason: reviewData.refundReason)
+            refundModalState = .success(reviewData)
+        } catch {
+            DDLogError("⛔️ Failed to process booking refund: \(error)")
+            refundModalState = .error(reviewData)
+        }
+    }
+
+    // MARK: - Localization
+
     private enum Localization {
         static let title = NSLocalizedString(
             "posBookingsContainer.title",
             value: "Today's Bookings",
             comment: "Title for bookings screen"
         )
+    }
+}
+
+// MARK: - Booking Refund Modal State
+
+/// State machine for the booking refund modal flow.
+/// Mirrors `RefundModalState` from `POSOrderDetailsView` but scoped to bookings.
+enum BookingRefundModalState: Identifiable, Equatable {
+    case itemSelection
+    case review(POSRefundReviewData)
+    case reasonInput(POSRefundReviewData)
+    case confirmation(POSRefundReviewData)
+    case processing(POSRefundReviewData)
+    case success(POSRefundReviewData)
+    case error(POSRefundReviewData)
+
+    var id: String {
+        switch self {
+        case .itemSelection: return "itemSelection"
+        case .review: return "review"
+        case .reasonInput: return "reasonInput"
+        case .confirmation: return "confirmation"
+        case .processing: return "processing"
+        case .success: return "success"
+        case .error: return "error"
+        }
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/Refund/POSBookingRefundItemsSelectionView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/Refund/POSBookingRefundItemsSelectionView.swift
@@ -1,0 +1,172 @@
+// POSBookingRefundItemsSelectionView.swift
+import SwiftUI
+
+/// Item selection view for booking refunds.
+///
+/// Reads selectable items from `POSBookingRefundController` instead of `POSOrderListModel`,
+/// reusing the same UI pattern as `POSRefundItemsSelectionView`.
+struct POSBookingRefundItemsSelectionView: View {
+    let refundController: POSBookingRefundController
+    let onClose: () -> Void
+    let onContinue: () -> Void
+
+    @Environment(\.posModalParentSize) private var parentSize
+
+    private var refundSelectableItems: [POSRefundSelectableItem] {
+        refundController.refundSelectableItems
+    }
+
+    private var selectedItems: [POSRefundSelectableItem] {
+        refundSelectableItems.filter(\.isSelected)
+    }
+
+    private var hasSelectedItems: Bool {
+        refundSelectableItems.contains(where: \.isSelected)
+    }
+
+    private var allItemsSelected: Bool {
+        !refundSelectableItems.isEmpty &&
+        refundSelectableItems.allSatisfy(\.isSelected)
+    }
+
+    var body: some View {
+        VStack(spacing: POSSpacing.none) {
+            headerView
+            itemsHeaderView
+
+            Divider()
+                .overlay(Color.posOutlineVariant.opacity(0.5))
+
+            itemsList
+
+            continueButton
+        }
+        .padding(POSPadding.xLarge)
+        .background(Color.posSurfaceBright)
+        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
+        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding * 2))
+    }
+}
+
+// MARK: - Subviews
+
+private extension POSBookingRefundItemsSelectionView {
+    var headerView: some View {
+        HStack {
+            Text(Localization.title)
+                .font(.posHeadingBold)
+                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                .lineLimit(1)
+            Spacer()
+            Button {
+                onClose()
+            } label: {
+                Text(Image(systemName: "xmark"))
+                    .font(.posButtonSymbolLarge)
+            }
+            .accessibilityLabel(Localization.closeButtonAccessibilityLabel)
+        }
+        .foregroundColor(Color.posOnSurface)
+        .padding(.bottom, POSPadding.xLarge)
+    }
+
+    var itemsHeaderView: some View {
+        HStack(spacing: POSSpacing.small) {
+            POSCheckbox(
+                isSelected: allItemsSelected,
+                onToggle: {
+                    refundController.toggleAllRefundItemsSelection()
+                }
+            )
+            .accessibilityLabel(Localization.selectAllAccessibilityLabel)
+
+            HStack(spacing: POSSpacing.xSmall) {
+                Text(Localization.itemsHeaderTitle)
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.posOnSurface)
+                    .textCase(.uppercase)
+
+                Text(String(format: Localization.itemsSelectedCountFormat, selectedItems.count))
+                    .font(.caption.weight(.regular))
+                    .foregroundColor(.posOnSurfaceVariantLowest)
+                    .textCase(.uppercase)
+            }
+
+            Spacer()
+        }
+        .padding(.bottom, POSPadding.medium)
+    }
+
+    var itemsList: some View {
+        ScrollView {
+            LazyVStack(spacing: POSSpacing.none) {
+                ForEach(refundSelectableItems.indices, id: \.self) { index in
+                    let item = refundSelectableItems[index]
+
+                    POSRefundItemRow(
+                        item: item,
+                        onToggle: {
+                            refundController.toggleRefundItemSelection(at: index)
+                        }
+                    )
+
+                    if index < refundSelectableItems.count - 1 {
+                        Divider()
+                            .overlay(Color.posOutlineVariant.opacity(0.5))
+                    }
+                }
+            }
+        }
+    }
+
+    var continueButton: some View {
+        Button(Localization.continueButton) {
+            onContinue()
+        }
+        .buttonStyle(POSFilledButtonStyle(size: .normal))
+        .disabled(!hasSelectedItems)
+        .padding(.top, POSPadding.medium)
+    }
+}
+
+// MARK: - Localization
+
+private extension POSBookingRefundItemsSelectionView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pos.bookingRefundItemsSelectionView.title",
+            value: "Select items to refund",
+            comment: "Title for the booking refund items selection modal"
+        )
+
+        static let continueButton = NSLocalizedString(
+            "pos.bookingRefundItemsSelectionView.continueButton",
+            value: "Continue",
+            comment: "Button to continue with selected items for booking refund"
+        )
+
+        static let closeButtonAccessibilityLabel = NSLocalizedString(
+            "pos.bookingRefundItemsSelectionView.closeButton.accessibilityLabel",
+            value: "Close",
+            comment: "Accessibility label for close button on booking refund items selection modal"
+        )
+
+        static let itemsHeaderTitle = NSLocalizedString(
+            "pos.bookingRefundItemsSelectionView.itemsHeaderTitle",
+            value: "Select all items",
+            comment: "Header label for items in the booking refund items selection modal"
+        )
+
+        static let itemsSelectedCountFormat = NSLocalizedString(
+            "pos.bookingRefundItemsSelectionView.itemsSelectedCountFormat",
+            value: "(%d selected)",
+            comment: "Label showing number of selected items in the booking refund items selection modal"
+        )
+
+        static let selectAllAccessibilityLabel = NSLocalizedString(
+            "pos.bookingRefundItemsSelectionView.selectAll.accessibilityLabel",
+            value: "Select or deselect all items",
+            comment: "Accessibility label for the select-all checkbox in the booking refund items selection modal"
+        )
+    }
+}

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
@@ -5,6 +5,7 @@ import struct WooFoundation.SafariView
 
 struct POSOrdersView: View {
     @Binding var isPresented: Bool
+    var initialOrderID: Int64? = nil
     @Environment(POSOrderListModel.self) private var orderListModel
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.posAnalytics) private var analytics
@@ -16,6 +17,10 @@ struct POSOrdersView: View {
         contentView
             .task {
                 await orderListModel.ordersController.loadOrders()
+                if let initialOrderID,
+                   let order = orderListModel.ordersController.ordersViewState.orders.first(where: { $0.id == initialOrderID }) {
+                    orderListModel.ordersController.selectOrder(order)
+                }
             }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
@@ -15,6 +15,8 @@ struct POSFloatingControlView: View {
     @State private var showBarcodeScanningModal: Bool = false
     @State private var showOrders: Bool = false
     @State private var showBookings: Bool = false
+    @State private var pendingPOSOrderID: Int64?
+    @State private var initialOrderIDForOrders: Int64?
 
     init(showExitPOSModal: Binding<Bool>,
          showSupport: Binding<Bool>,
@@ -59,11 +61,25 @@ struct POSFloatingControlView: View {
         .posModal(isPresented: $showBarcodeScanningModal) {
             POSBarcodeScannerSetup(isPresented: $showBarcodeScanningModal, analytics: analytics)
         }
-        .posFullScreenCover(isPresented: $showOrders) {
-            POSOrdersView(isPresented: $showOrders)
+        .posFullScreenCover(isPresented: $showOrders, onDismiss: {
+            initialOrderIDForOrders = nil
+        }) {
+            POSOrdersView(isPresented: $showOrders, initialOrderID: initialOrderIDForOrders)
         }
-        .posFullScreenCover(isPresented: $showBookings) {
-            POSBookingsContainerView(isPresented: $showBookings)
+        .posFullScreenCover(isPresented: $showBookings, onDismiss: {
+            if let orderID = pendingPOSOrderID {
+                pendingPOSOrderID = nil
+                initialOrderIDForOrders = orderID
+                showOrders = true
+            }
+        }) {
+            POSBookingsContainerView(
+                isPresented: $showBookings,
+                onNavigateToPOSOrder: { orderID in
+                    pendingPOSOrderID = orderID
+                    showBookings = false
+                }
+            )
         }
         .frame(height: Constants.size)
         .background(Color.clear)

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -147,10 +147,11 @@ public struct PointOfSaleEntryPointView: View {
 
         // Create bookings model if booking service and order provider are provided
         if let bookingService, let bookingOrderProvider {
+            let currencyFormatter = CurrencyFormatter(currencySettings: services.currency.currencySettings)
             let bookingListController = POSBookingListController(
                 siteID: siteID,
                 bookingService: bookingService,
-                currencyFormatter: CurrencyFormatter(currencySettings: services.currency.currencySettings)
+                currencyFormatter: currencyFormatter
             )
             self.bookingsModel = POSBookingsModel(
                 bookingListController: bookingListController,
@@ -158,7 +159,9 @@ public struct PointOfSaleEntryPointView: View {
                 bookingService: bookingService,
                 cardPaymentFacade: cardPresentPaymentService,
                 receiptSender: receiptSender,
-                orderProvider: bookingOrderProvider
+                orderProvider: bookingOrderProvider,
+                refundsService: refundsService,
+                currencyFormatter: currencyFormatter
             )
         } else {
             self.bookingsModel = nil

--- a/Modules/Sources/PointOfSale/Protocols/POSDependencyProviding.swift
+++ b/Modules/Sources/PointOfSale/Protocols/POSDependencyProviding.swift
@@ -40,6 +40,7 @@ public protocol POSConnectivityProviding {
 /// Protocol that provides main app navigation capabilities for POS
 public protocol POSExternalNavigationProviding {
     func navigateToCreateOrder()
+    func navigateToOrderDetails(orderID: Int64, siteID: Int64)
 }
 
 /// Protocol that provides access to complex Woo application views that depend on a lot of Woo app target dependencies

--- a/Modules/Sources/PointOfSale/Utils/POSEnvironmentKeys.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSEnvironmentKeys.swift
@@ -102,6 +102,7 @@ extension View {
 
 struct EmptyPOSExternalNavigation: POSExternalNavigationProviding {
     func navigateToCreateOrder() {}
+    func navigateToOrderDetails(orderID: Int64, siteID: Int64) {}
     init() {}
 }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSBookingService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSBookingService.swift
@@ -71,14 +71,24 @@ public final class POSBookingService: POSBookingServiceProtocol, @unchecked Send
             startDateAfter: dateFormatter.string(from: startOfDay)
         )
 
-        let bookings = try await bookingsRemote.loadAllBookings(
-            for: siteID,
-            pageNumber: 1,
-            pageSize: 100,
-            filters: filters,
-            searchQuery: nil,
-            order: .ascending
-        )
+        DDLogInfo("📚 POSBookingService: Fetching bookings for siteID=\(siteID), after=\(dateFormatter.string(from: startOfDay)), before=\(dateFormatter.string(from: endOfDay))")
+
+        let bookings: [Booking]
+        do {
+            bookings = try await bookingsRemote.loadAllBookings(
+                for: siteID,
+                pageNumber: 1,
+                pageSize: 100,
+                filters: filters,
+                searchQuery: nil,
+                order: .ascending
+            )
+            DDLogInfo("📚 POSBookingService: Fetched \(bookings.count) bookings successfully")
+        } catch {
+            DDLogError("⛔️ POSBookingService: loadAllBookings failed with error: \(error)")
+            DDLogError("⛔️ POSBookingService: error localizedDescription: \(error.localizedDescription)")
+            throw error
+        }
 
         // Fetch orders for all bookings that have order IDs
         let orderIDs = bookings.compactMap { $0.orderID > 0 ? $0.orderID : nil }

--- a/WooCommerce/Classes/POS/Adaptors/POSServiceLocatorAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/POSServiceLocatorAdaptor.swift
@@ -84,6 +84,10 @@ private struct POSExternalNavigationAdaptor: POSExternalNavigationProviding {
     func navigateToCreateOrder() {
         AppDelegate.shared.tabBarController?.navigate(to: OrdersDestination.createOrder)
     }
+
+    func navigateToOrderDetails(orderID: Int64, siteID: Int64) {
+        MainTabBarController.navigateToOrderDetails(with: orderID, siteID: siteID)
+    }
 }
 
 private struct POSExternalViewAdaptor: POSExternalViewProviding {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -70,15 +70,15 @@ extension WooTab {
     ///   - isBookingsTabVisible: indicates if the Bookings tab is visible.
     /// - Returns: visible tabs in the tab bar.
     static func visibleTabs(isPOSTabVisible: Bool, isBookingsTabVisible: Bool = false) -> [WooTab] {
-        var tabs: [WooTab] = [.myStore, .orders, .products]
+        var tabs: [WooTab] = [.myStore, .orders, .products, .pointOfSale, .bookings]
 
-        if isBookingsTabVisible {
-            tabs.append(.bookings)
-        }
-
-        if isPOSTabVisible {
-            tabs.append(.pointOfSale)
-        }
+//        if isBookingsTabVisible {
+//            tabs.append(.bookings)
+//        }
+//
+//        if isPOSTabVisible {
+//            tabs.append(.pointOfSale)
+//        }
 
         tabs.append(.hubMenu)
         return tabs


### PR DESCRIPTION
WOOMOB-2156

Experimental refund flow for POS bookings


https://github.com/user-attachments/assets/3a1caa6c-041f-468c-8fd9-5bcbd8981af9

2. `View Order Details` in  https://github.com/woocommerce/woocommerce-ios/pull/16638/commits/96c7eca5fe657f03f522e367e964be74832dcddd with additional button to deep-link to order
details as needed.


https://github.com/user-attachments/assets/60954f4c-335f-4061-9937-ff4bd2d07b18

3. `View in POS Orders` in https://github.com/woocommerce/woocommerce-ios/pull/16638/commits/e5eefe9414f5534863b96de9518a5a7e22d1e104



https://github.com/user-attachments/assets/04048a1f-2344-49b2-864e-105eb6527e21



