### PR TITLE
[WOOMOB-2140] POS Bookings entry point visibility

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
@@ -15,6 +15,7 @@ struct POSFloatingControlView: View {
     @State private var showBarcodeScanningModal: Bool = false
     @State private var showOrders: Bool = false
     @State private var showBookings: Bool = false
+    @Environment(\.posBookingsEligible) private var isBookingsEligible
 
     init(showExitPOSModal: Binding<Bool>,
          showSupport: Binding<Bool>,
@@ -106,7 +107,7 @@ private extension POSFloatingControlView {
             }
         }
 
-        if featureFlags.isFeatureFlagEnabled(.pointOfSaleBookings) {
+        if featureFlags.isFeatureFlagEnabled(.pointOfSaleBookings) && isBookingsEligible {
             Button {
                 showBookings = true
             } label: {

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -48,6 +48,7 @@ public struct PointOfSaleEntryPointView: View {
     private let siteID: Int64
     private let catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol?
     private let isLocalCatalogEligible: Bool
+    private let isBookingsEligible: Bool
 
     /// periphery: ignore - public in preparation of move to POS module
     public init(siteID: Int64,
@@ -57,6 +58,7 @@ public struct PointOfSaleEntryPointView: View {
          couponFetchStrategyFactory: PointOfSaleCouponFetchStrategyFactoryProtocol,
          orderListFetchStrategyFactory: POSOrderListFetchStrategyFactoryProtocol,
          bookingListFetchStrategyFactory: POSBookingListFetchStrategyFactoryProtocol?,
+         isBookingsEligible: Bool,
          orderService: POSOrderServiceProtocol,
          refundsService: POSRefundsServiceProtocol,
          onPointOfSaleModeActiveStateChange: @escaping ((Bool) -> Void),
@@ -154,6 +156,7 @@ public struct PointOfSaleEntryPointView: View {
         self.siteID = siteID
         self.catalogSyncCoordinator = catalogSyncCoordinator
         self.isLocalCatalogEligible = isLocalCatalogEligible
+        self.isBookingsEligible = isBookingsEligible
     }
 
     public var body: some View {
@@ -193,6 +196,7 @@ public struct PointOfSaleEntryPointView: View {
         .environment(\.posConnectivityProvider, services.connectivity)
         .environment(\.posExternalNavigation, services.externalNavigation)
         .environment(\.posExternalViews, services.externalViews)
+        .environment(\.posBookingsEligible, isBookingsEligible)
         .environmentObject(posModalManager)
         .environmentObject(posSheetManager)
         .environmentObject(posCoverManager)
@@ -223,6 +227,7 @@ public struct PointOfSaleEntryPointView: View {
         couponFetchStrategyFactory: PointOfSaleCouponFetchStrategyFactoryPreview(),
         orderListFetchStrategyFactory: POSOrderListFetchStrategyFactoryPreview(),
         bookingListFetchStrategyFactory: nil,
+        isBookingsEligible: true,
         orderService: POSOrderServicePreview(),
         refundsService: POSRefundsServicePreview(),
         onPointOfSaleModeActiveStateChange: { _ in },

--- a/Modules/Sources/PointOfSale/Utils/POSEnvironmentKeys.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSEnvironmentKeys.swift
@@ -33,6 +33,11 @@ struct POSFeatureFlagsKey: EnvironmentKey {
     static let defaultValue: POSFeatureFlagProviding = EmptyPOSFeatureFlags()
 }
 
+/// Environment key for POS bookings eligibility (true if the site supports bookings)
+struct POSBookingsEligibilityKey: EnvironmentKey {
+    static let defaultValue: Bool = false
+}
+
 /// Environment key for POS connectivity
 struct POSConnectivityKey: EnvironmentKey {
     static let defaultValue: POSConnectivityProviding = EmptyPOSConnectivityProvider()
@@ -67,6 +72,11 @@ extension EnvironmentValues {
     var posFeatureFlags: POSFeatureFlagProviding {
         get { self[POSFeatureFlagsKey.self] }
         set { self[POSFeatureFlagsKey.self] = newValue }
+    }
+
+    var posBookingsEligible: Bool {
+        get { self[POSBookingsEligibilityKey.self] }
+        set { self[POSBookingsEligibilityKey.self] = newValue }
     }
 
     var posConnectivityProvider: POSConnectivityProviding {

--- a/WooCommerce/Classes/Bookings/BookingsTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/Bookings/BookingsTabEligibilityChecker.swift
@@ -15,35 +15,51 @@ final class BookingsTabEligibilityChecker: BookingsTabEligibilityCheckerProtocol
     private let featureFlagService: FeatureFlagService
     private let ciabEligibilityChecker: CIABEligibilityCheckerProtocol
     private let userDefaults: UserDefaults
+    private let isPOSTabVisible: () -> Bool
 
     init(site: Site,
          stores: StoresManager = ServiceLocator.stores,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          ciabEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker(),
-         userDefaults: UserDefaults = .standard) {
+         userDefaults: UserDefaults = .standard,
+         isPOSTabVisible: @escaping () -> Bool = { false }) {
         self.site = site
         self.stores = stores
         self.featureFlagService = featureFlagService
         self.ciabEligibilityChecker = ciabEligibilityChecker
         self.userDefaults = userDefaults
+        self.isPOSTabVisible = isPOSTabVisible
     }
 
     /// Checks the initial visibility of the Bookings tab using cached result.
     func checkInitialVisibility() -> Bool {
-        userDefaults.loadCachedBookingsTabVisibility(siteID: site.siteID)
+        if featureFlagService.isFeatureFlagEnabled(.pointOfSaleBookings) && isPOSTabVisible() {
+            return false
+        }
+        return userDefaults.loadCachedBookingsTabVisibility(siteID: site.siteID)
     }
 
     /// Checks the initial visibility without the `BookingsTabEligibilityChecker` instsance
     /// Used for the initial state check when a site instance hasn't been loaded but a `siteID` is available
     static func checkInitialVisibility(
         for siteID: Int64,
+        isPOSTabVisible: Bool = false,
+        featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
         in userDefaults: UserDefaults = .standard
     ) -> Bool {
+        if featureFlagService.isFeatureFlagEnabled(.pointOfSaleBookings) && isPOSTabVisible {
+            return false
+        }
         return userDefaults.loadCachedBookingsTabVisibility(siteID: siteID)
     }
 
     /// Checks the final visibility of the Bookings tab.
     func checkVisibility() async -> Bool {
+        // When POS bookings is enabled and POS tab is visible, bookings are accessed through POS
+        if featureFlagService.isFeatureFlagEnabled(.pointOfSaleBookings) && isPOSTabVisible() {
+            return false
+        }
+
         // Check feature flag
         guard featureFlagService.isFeatureFlagEnabled(.ciabBookings) else {
             return false

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -266,6 +266,9 @@ private extension POSTabCoordinator {
                     itemProvider = PointOfSaleItemServiceScreenshotMock()
                 }
 
+                let isBookingsEligible = storesManager.sessionManager.defaultSite
+                    .map { CIABEligibilityChecker().isSiteCIAB($0) } ?? false
+
                 let bookingListFetchStrategyFactory: POSBookingListFetchStrategyFactory? =
                     ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleBookings)
                     ? POSBookingListFetchStrategyFactory(
@@ -291,6 +294,7 @@ private extension POSTabCoordinator {
                         analytics: POSOrderListFetchAnalytics(analytics: serviceAdaptor.analytics)
                     ),
                     bookingListFetchStrategyFactory: bookingListFetchStrategyFactory,
+                    isBookingsEligible: isBookingsEligible,
                     orderService: orderService,
                     refundsService: refundsService,
                     onPointOfSaleModeActiveStateChange: { [weak self] isEnabled in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
@@ -56,8 +56,10 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
 
     /// Checks the final visibility of the POS tab.
     func checkVisibility() async -> Bool {
-        guard siteCIABEligibilityChecker.isFeatureSupported(.pointOfSale, for: site) else {
-            return false
+        if !featureFlagService.isFeatureFlagEnabled(.pointOfSaleBookings) {
+            guard siteCIABEligibilityChecker.isFeatureSupported(.pointOfSale, for: site) else {
+                return false
+            }
         }
 
         guard userInterfaceIdiom == .pad else {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -146,7 +146,7 @@ final class MainTabBarController: UITabBarController {
     private let analytics: Analytics
     private let posTabVisibilityCheckerFactory: ((_ site: Site) -> POSTabVisibilityCheckerProtocol)
     private let posEligibilityService: POSEligibilityServiceProtocol
-    private let bookingsEligibilityCheckerFactory: ((_ site: Site) -> BookingsTabEligibilityCheckerProtocol)
+    private let bookingsEligibilityCheckerFactory: ((_ site: Site, _ isPOSTabVisible: @escaping () -> Bool) -> BookingsTabEligibilityCheckerProtocol)
     private let userDefaults: UserDefaults
 
     private var productImageUploadErrorsSubscription: AnyCancellable?
@@ -172,7 +172,7 @@ final class MainTabBarController: UITabBarController {
           stores: StoresManager = ServiceLocator.stores,
           posTabVisibilityCheckerFactory: ((Site) -> POSTabVisibilityCheckerProtocol)? = nil,
           posEligibilityService: POSEligibilityServiceProtocol = POSEligibilityService(),
-          bookingsEligibilityCheckerFactory: ((Site) -> BookingsTabEligibilityCheckerProtocol)? = nil,
+          bookingsEligibilityCheckerFactory: ((_ site: Site, _ isPOSTabVisible: @escaping () -> Bool) -> BookingsTabEligibilityCheckerProtocol)? = nil,
           userDefaults: UserDefaults = .standard) {
         self.featureFlagService = featureFlagService
         self.noticePresenter = noticePresenter
@@ -183,8 +183,8 @@ final class MainTabBarController: UITabBarController {
             POSTabVisibilityChecker(site: site)
         }
         self.posEligibilityService = posEligibilityService
-        self.bookingsEligibilityCheckerFactory = bookingsEligibilityCheckerFactory ?? { site in
-            BookingsTabEligibilityChecker(site: site)
+        self.bookingsEligibilityCheckerFactory = bookingsEligibilityCheckerFactory ?? { site, isPOSTabVisible in
+            BookingsTabEligibilityChecker(site: site, isPOSTabVisible: isPOSTabVisible)
         }
         self.userDefaults = userDefaults
         super.init(coder: coder)
@@ -201,8 +201,8 @@ final class MainTabBarController: UITabBarController {
             POSTabVisibilityChecker(site: site)
         }
         self.posEligibilityService = POSEligibilityService()
-        self.bookingsEligibilityCheckerFactory = { site in
-            BookingsTabEligibilityChecker(site: site)
+        self.bookingsEligibilityCheckerFactory = { site, isPOSTabVisible in
+            BookingsTabEligibilityChecker(site: site, isPOSTabVisible: isPOSTabVisible)
         }
         self.userDefaults = .standard
         super.init(coder: coder)
@@ -355,6 +355,7 @@ final class MainTabBarController: UITabBarController {
         )
         let isBookingsTabVisible = BookingsTabEligibilityChecker.checkInitialVisibility(
             for: siteID,
+            isPOSTabVisible: isPOSTabVisible,
             in: userDefaults
         )
 
@@ -902,7 +903,7 @@ private extension MainTabBarController {
     }
 
     func observeBookingsEligibilityForBookingsTabVisibility(site: Site) {
-        let bookingsEligibilityChecker = bookingsEligibilityCheckerFactory(site)
+        let bookingsEligibilityChecker = bookingsEligibilityCheckerFactory(site, { [weak self] in self?.isPOSTabVisible ?? false })
         self.bookingsEligibilityChecker = bookingsEligibilityChecker
 
         // Sets Bookings tab initial visibility based on cached value if available.

--- a/WooCommerce/WooCommerceTests/Bookings/BookingsTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/Bookings/BookingsTabEligibilityCheckerTests.swift
@@ -285,6 +285,108 @@ struct BookingsTabEligibilityCheckerTests {
         #expect(result == false)
     }
 
+    // MARK: - POS Bookings Interaction Tests
+
+    @Test func checkInitialVisibility_returns_false_when_pos_bookings_enabled_and_pos_tab_visible() async throws {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        userDefaults[.ciabBookingsTabAvailable] = [siteID.description: true]
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleBookings] = true
+        let checker = BookingsTabEligibilityChecker(site: site,
+                                                    stores: stores,
+                                                    featureFlagService: featureFlagService,
+                                                    ciabEligibilityChecker: ciabEligibilityChecker,
+                                                    userDefaults: userDefaults,
+                                                    isPOSTabVisible: { true })
+
+        // When
+        let result = checker.checkInitialVisibility()
+
+        // Then
+        #expect(result == false)
+    }
+
+    @Test func checkInitialVisibility_returns_cached_value_when_pos_bookings_not_enabled() async throws {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        userDefaults[.ciabBookingsTabAvailable] = [siteID.description: true]
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleBookings] = false
+        let checker = BookingsTabEligibilityChecker(site: site,
+                                                    stores: stores,
+                                                    featureFlagService: featureFlagService,
+                                                    ciabEligibilityChecker: ciabEligibilityChecker,
+                                                    userDefaults: userDefaults,
+                                                    isPOSTabVisible: { true })
+
+        // When
+        let result = checker.checkInitialVisibility()
+
+        // Then
+        #expect(result == true)
+    }
+
+    @Test func checkInitialVisibility_returns_cached_value_when_pos_tab_not_visible() async throws {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        userDefaults[.ciabBookingsTabAvailable] = [siteID.description: true]
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleBookings] = true
+        let checker = BookingsTabEligibilityChecker(site: site,
+                                                    stores: stores,
+                                                    featureFlagService: featureFlagService,
+                                                    ciabEligibilityChecker: ciabEligibilityChecker,
+                                                    userDefaults: userDefaults,
+                                                    isPOSTabVisible: { false })
+
+        // When
+        let result = checker.checkInitialVisibility()
+
+        // Then
+        #expect(result == true)
+    }
+
+    @Test func checkVisibility_returns_false_when_pos_bookings_enabled_and_pos_tab_visible() async throws {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        let featureFlagService = MockFeatureFlagService(isCIABBookingsEnabled: true)
+        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleBookings] = true
+        setupStoreHasBookableProducts(hasProducts: true)
+        let checker = BookingsTabEligibilityChecker(site: site,
+                                                    stores: stores,
+                                                    featureFlagService: featureFlagService,
+                                                    ciabEligibilityChecker: ciabEligibilityChecker,
+                                                    userDefaults: userDefaults,
+                                                    isPOSTabVisible: { true })
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == false)
+    }
+
+    @Test func checkVisibility_returns_true_when_pos_bookings_enabled_but_pos_tab_not_visible() async throws {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        let featureFlagService = MockFeatureFlagService(isCIABBookingsEnabled: true)
+        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleBookings] = true
+        setupStoreHasBookableProducts(hasProducts: true)
+        let checker = BookingsTabEligibilityChecker(site: site,
+                                                    stores: stores,
+                                                    featureFlagService: featureFlagService,
+                                                    ciabEligibilityChecker: ciabEligibilityChecker,
+                                                    userDefaults: userDefaults,
+                                                    isPOSTabVisible: { false })
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == true)
+    }
+
     // MARK: - UserDefaults Extension Tests
 
     @Test func userDefaults_loadCachedBookingsTabVisibility_returns_false_when_no_cache() async throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarController+TabsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarController+TabsTests.swift
@@ -169,7 +169,7 @@ final class MainTabBarController_TabsTests: XCTestCase {
             return MainTabBarController(coder: coder,
                                         featureFlagService: MockFeatureFlagService(),
                                         stores: storesManager,
-                                        bookingsEligibilityCheckerFactory: { _ in mockBookingsEligibilityChecker })
+                                        bookingsEligibilityCheckerFactory: { _, _ in mockBookingsEligibilityChecker })
         }) else {
             return
         }
@@ -227,7 +227,7 @@ final class MainTabBarController_TabsTests: XCTestCase {
             return MainTabBarController(coder: coder,
                                         featureFlagService: MockFeatureFlagService(),
                                         stores: storesManager,
-                                        bookingsEligibilityCheckerFactory: { _ in mockBookingsEligibilityChecker })
+                                        bookingsEligibilityCheckerFactory: { _, _ in mockBookingsEligibilityChecker })
         }) else {
             return
         }
@@ -280,7 +280,7 @@ final class MainTabBarController_TabsTests: XCTestCase {
             return MainTabBarController(coder: coder,
                                         featureFlagService: MockFeatureFlagService(),
                                         stores: storesManager,
-                                        bookingsEligibilityCheckerFactory: { _ in mockBookingsEligibilityChecker })
+                                        bookingsEligibilityCheckerFactory: { _, _ in mockBookingsEligibilityChecker })
         }) else {
             return
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -634,8 +634,8 @@ final class MainTabBarControllerTests: XCTestCase {
                                      POSTabVisibilityChecker(site: site, eligibilityService: mockPOSEligibilityService)
                                  },
                                  posEligibilityService: mockPOSEligibilityService,
-                                 bookingsEligibilityCheckerFactory: { site in
-                                     BookingsTabEligibilityChecker(site: site, userDefaults: userDefaults)
+                                 bookingsEligibilityCheckerFactory: { site, isPOSTabVisible in
+                                     BookingsTabEligibilityChecker(site: site, userDefaults: userDefaults, isPOSTabVisible: isPOSTabVisible)
                                  },
                                  userDefaults: userDefaults)
         }))
@@ -680,7 +680,7 @@ final class MainTabBarControllerTests: XCTestCase {
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
             return MainTabBarController(coder: coder,
                                         stores: stores,
-                                        bookingsEligibilityCheckerFactory: { _ in mockBookingsEligibilityChecker })
+                                        bookingsEligibilityCheckerFactory: { _, _ in mockBookingsEligibilityChecker })
         }) else {
             return
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
@@ -207,6 +207,29 @@ struct POSTabVisibilityCheckerTests {
         #expect(result == false)
     }
 
+    @Test func is_visible_when_site_is_CIAB_and_pos_bookings_enabled() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleBookings] = true
+        setupCountry(country: .us, currency: .USD)
+        accountWhitelistedInBackend(true)
+        let ciabEligibilityChecker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: true,
+                                                                mockedCIABSites: [site],
+                                                                mockedCIABDisabledFeatures: [.pointOfSale])
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .pad,
+                                              siteSettings: siteSettings,
+                                              stores: stores,
+                                              featureFlagService: featureFlagService,
+                                              siteCIABEligibilityChecker: ciabEligibilityChecker)
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == true)
+    }
+
     @Test func checkVisibility_returns_expected_result_after_site_settings_available() async throws {
         // Given - no site settings are immediately available (empty stream that will emit values later)
         let featureFlagService = MockFeatureFlagService()


### PR DESCRIPTION
## Description

WOOMOB-2140

Wires POS bookings entry point visibility so the Bookings menu item in POS and the Bookings tab in the main tab bar are mutually exclusive, gated by the `.pointOfSaleBookings` feature flag and CIAB site eligibility.

> **Note:** `isSiteCIAB` only returns `true` when the store is logged in through Jetpack.

### Changes

**POS floating menu**
- `posBookingsEligible` environment key injected from `POSTabCoordinator` via `CIABEligibilityChecker().isSiteCIAB()`
- Bookings button shown only when `.pointOfSaleBookings` flag is on AND site is CIAB-eligible

**Tab mutual exclusivity**
- `POSTabVisibilityChecker`: bypasses CIAB `isFeatureSupported(.pointOfSale)` guard when `.pointOfSaleBookings` is enabled — POS becomes visible on CIAB sites
- `BookingsTabEligibilityChecker`: returns `false` (both initial and async) when `.pointOfSaleBookings` is on AND POS tab is visible
- `isPOSTabVisible` closure passed through the checker factory from `MainTabBarController`

## Testing

| # | Scenario | Expected |
|---|----------|----------|
| 1 | CIAB store + `.pointOfSaleBookings` enabled | POS tab visible, Bookings option in POS menu, no Bookings tab |
| 2 | CIAB store + `.pointOfSaleBookings` disabled | Bookings tab visible, no POS tab |
| 3 | Non-CIAB store | POS tab visible (if eligible), no Bookings tab |
| 4 | iPhone + CIAB store + `.pointOfSaleBookings` enabled | Bookings tab visible (POS requires iPad) |

## Video

### POS and Bookings entry point based on the feature flag

https://github.com/user-attachments/assets/86a5a240-7559-4b0b-83e7-69d892fe9c33

### iPhone with feature flag enabled

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-09 at 15 13 33" src="https://github.com/user-attachments/assets/13afa958-cfe6-4f50-a4dd-8d712a0c4666" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.