### PR TITLE
Adding JetpackConnectionService

### DIFF
--- a/WooCommerce/Classes/Authentication/Jetpack Setup/JetpackConnectionService.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/JetpackConnectionService.swift
@@ -2,128 +2,52 @@ import Foundation
 import Yosemite
 import class Networking.AlamofireNetwork
 
-enum JetpackConnectionServiceError: Error {
-    case verificationFailed
-}
-
 /// Performs the native Jetpack/WPCom connection sequence:
-/// register (if needed) → provision → finalize → verify.
+/// register (if needed) → provision → finalize.
 protocol JetpackConnectionServiceProtocol {
     func connect(with connectionData: JetpackConnectionData,
                  siteURL: String,
-                 credentials: Credentials) async throws -> String
-
-    func verifyConnection() async throws -> String
+                 credentials: Credentials) async throws
 }
 
 final class JetpackConnectionService: JetpackConnectionServiceProtocol {
     private let stores: StoresManager
-    private let maxRetryCount: Int
-    private let retryDelay: TimeInterval
 
-    init(stores: StoresManager = ServiceLocator.stores,
-         maxRetryCount: Int = 2,
-         retryDelay: TimeInterval = 0.5) {
+    init(stores: StoresManager = ServiceLocator.stores) {
         self.stores = stores
-        self.maxRetryCount = maxRetryCount
-        self.retryDelay = retryDelay
     }
 
     func connect(with connectionData: JetpackConnectionData,
                  siteURL: String,
-                 credentials: Credentials) async throws -> String {
-        // 1. Determine blogID — register if needed
+                 credentials: Credentials) async throws {
         let blogID: Int64
         if connectionData.isRegistered == true, let existingBlogID = connectionData.blogID {
             blogID = existingBlogID
         } else {
-            blogID = try await registerSite()
+            blogID = try await dispatch(JetpackConnectionAction.registerSite)
         }
 
-        // 2. Provision
-        let provisionResponse = try await provisionConnection()
+        let provisionResponse: JetpackConnectionProvisionResponse = try await dispatch(JetpackConnectionAction.provisionConnection)
 
-        // 3. Finalize
-        try await finalizeConnection(blogID: blogID,
-                                     siteURL: siteURL,
-                                     provisionResponse: provisionResponse,
-                                     credentials: credentials)
-
-        // 4. Verify with retry
-        return try await verifyConnection()
-    }
-
-    func verifyConnection() async throws -> String {
-        try await verifyConnection(retryCount: 0)
-    }
-}
-
-// MARK: - Private steps
-private extension JetpackConnectionService {
-    func registerSite() async throws -> Int64 {
-        try await withCheckedThrowingContinuation { continuation in
-            stores.dispatch(JetpackConnectionAction.registerSite { result in
-                continuation.resume(with: result)
-            })
-        }
-    }
-
-    func provisionConnection() async throws -> JetpackConnectionProvisionResponse {
-        try await withCheckedThrowingContinuation { continuation in
-            stores.dispatch(JetpackConnectionAction.provisionConnection { result in
-                continuation.resume(with: result)
-            })
-        }
-    }
-
-    func finalizeConnection(blogID: Int64,
-                            siteURL: String,
-                            provisionResponse: JetpackConnectionProvisionResponse,
-                            credentials: Credentials) async throws {
         let network = AlamofireNetwork(credentials: credentials, selectedSite: nil, appPasswordSupportState: nil)
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            stores.dispatch(JetpackConnectionAction.finalizeConnection(
+        try await dispatch { completion in
+            JetpackConnectionAction.finalizeConnection(
                 siteID: blogID,
                 siteURL: siteURL,
                 provisionResponse: provisionResponse,
-                network: network
-            ) { result in
-                continuation.resume(with: result)
-            })
+                network: network,
+                completion: completion
+            )
         }
     }
+}
 
-    func fetchConnectionData() async throws -> JetpackConnectionData {
+private extension JetpackConnectionService {
+    func dispatch<T>(_ actionBuilder: @escaping (@escaping (Result<T, Error>) -> Void) -> Action) async throws -> T {
         try await withCheckedThrowingContinuation { continuation in
-            stores.dispatch(JetpackConnectionAction.fetchJetpackConnectionData { result in
+            stores.dispatch(actionBuilder { result in
                 continuation.resume(with: result)
             })
         }
-    }
-
-    func verifyConnection(retryCount: Int) async throws -> String {
-        let data: JetpackConnectionData
-        do {
-            data = try await fetchConnectionData()
-        } catch {
-            if retryCount < maxRetryCount {
-                try await Task.sleep(nanoseconds: UInt64(retryDelay * 1_000_000_000))
-                return try await verifyConnection(retryCount: retryCount + 1)
-            }
-            throw error
-        }
-
-        if let email = data.currentUser.wpcomUser?.email {
-            DDLogDebug("📱 JetpackConnectionService: Successfully connected (\(email))")
-            return email
-        }
-
-        DDLogWarn("⚠️ JetpackConnectionService: Cannot find connected WPCom user")
-        if retryCount < maxRetryCount {
-            try await Task.sleep(nanoseconds: UInt64(retryDelay * 1_000_000_000))
-            return try await verifyConnection(retryCount: retryCount + 1)
-        }
-
-        throw JetpackConnectionServiceError.verificationFailed
     }
 }

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/JetpackConnectionService.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/JetpackConnectionService.swift
@@ -1,25 +1,128 @@
+import CocoaLumberjackSwift
 import Foundation
 import Yosemite
 import class Networking.AlamofireNetwork
+import enum Networking.NetworkError
 
-/// Performs the native Jetpack/WPCom connection sequence:
-/// register (if needed) → provision → finalize.
+enum JetpackConnectionOutcome {
+    /// The site was already connected with this email.
+    case alreadyConnected(email: String)
+    /// The connection was newly established, verified with this email.
+    case connected(email: String)
+    /// The site uses an outdated Jetpack version; consumer should use web view.
+    case webViewRequired
+}
+
+enum JetpackConnectionServiceError: Error, CustomNSError {
+    case verificationFailed
+
+    static let errorDomain = "JetpackConnectionService"
+    var errorCode: Int {
+        switch self {
+        case .verificationFailed: return 99
+        }
+    }
+}
+
+/// Encapsulates the full Jetpack/WPCom connection decision tree:
+/// fetch data → decide native/webview → connect → verify.
+/// Ref: pe5sF9-401-p2
 protocol JetpackConnectionServiceProtocol {
-    func connect(with connectionData: JetpackConnectionData,
-                 siteURL: String,
-                 credentials: Credentials) async throws
+    /// Full decision tree: evaluate connection data, perform native connection if possible,
+    /// or return `.webViewRequired` if the site uses outdated Jetpack.
+    func evaluateAndConnect(siteURL: String,
+                            credentials: Credentials) async throws -> JetpackConnectionOutcome
+
+    /// Verify a connected WPCom user exists (used after webview auth).
+    /// Retries internally. Returns the connected email or throws.
+    func verifyConnection() async throws -> String
 }
 
 final class JetpackConnectionService: JetpackConnectionServiceProtocol {
     private let stores: StoresManager
+    private let maxRetryCount: Int
+    private let delayBeforeRetry: TimeInterval
 
-    init(stores: StoresManager = ServiceLocator.stores) {
+    init(stores: StoresManager = ServiceLocator.stores,
+         maxRetryCount: Int = 2,
+         delayBeforeRetry: TimeInterval = 0.5) {
         self.stores = stores
+        self.maxRetryCount = maxRetryCount
+        self.delayBeforeRetry = delayBeforeRetry
     }
 
-    func connect(with connectionData: JetpackConnectionData,
-                 siteURL: String,
-                 credentials: Credentials) async throws {
+    func evaluateAndConnect(siteURL: String,
+                            credentials: Credentials) async throws -> JetpackConnectionOutcome {
+        let data: JetpackConnectionData
+        do {
+            data = try await fetchConnectionData()
+        } catch {
+            DDLogError("⛔️ Error fetching Jetpack connection data: \(error)")
+            throw error
+        }
+
+        // Branch A: Already connected
+        if let email = data.currentUser.wpcomUser?.email {
+            return .alreadyConnected(email: email)
+        }
+
+        // Branch B: isRegistered available (Jetpack >= 14.4) → native path
+        if data.isRegistered != nil {
+            try await nativeConnect(with: data, siteURL: siteURL, credentials: credentials)
+            let email = try await verifyConnection()
+            return .connected(email: email)
+        }
+
+        // Branch C: isRegistered == nil (Jetpack < 14.4)
+        let pluginResult = await checkJetpackPluginInstalled()
+        switch pluginResult {
+        case .installed:
+            return .webViewRequired
+        case .notFound:
+            // Jetpack CP plugin: infer isRegistered from connectionOwner
+            let inferred = data.copy(isRegistered: data.connectionOwner != nil)
+            try await nativeConnect(with: inferred, siteURL: siteURL, credentials: credentials)
+            let email = try await verifyConnection()
+            return .connected(email: email)
+        case .error(let error):
+            throw error
+        }
+    }
+
+    func verifyConnection() async throws -> String {
+        for attempt in 0...maxRetryCount {
+            do {
+                let data = try await fetchConnectionData()
+                if let email = data.currentUser.wpcomUser?.email {
+                    return email
+                }
+            } catch {
+                DDLogError("⛔️ Error verifying Jetpack connection (attempt \(attempt + 1)): \(error)")
+                if attempt == maxRetryCount { throw error }
+            }
+            if attempt < maxRetryCount {
+                try await Task.sleep(nanoseconds: UInt64(delayBeforeRetry * 1_000_000_000))
+            }
+        }
+        DDLogWarn("⚠️ Cannot find connected WPCom user after \(maxRetryCount + 1) attempts")
+        throw JetpackConnectionServiceError.verificationFailed
+    }
+}
+
+private extension JetpackConnectionService {
+    enum PluginCheckResult {
+        case installed
+        case notFound
+        case error(Error)
+    }
+
+    func fetchConnectionData() async throws -> JetpackConnectionData {
+        try await dispatch(JetpackConnectionAction.fetchJetpackConnectionData)
+    }
+
+    func nativeConnect(with connectionData: JetpackConnectionData,
+                       siteURL: String,
+                       credentials: Credentials) async throws {
         let blogID: Int64
         if connectionData.isRegistered == true, let existingBlogID = connectionData.blogID {
             blogID = existingBlogID
@@ -27,7 +130,8 @@ final class JetpackConnectionService: JetpackConnectionServiceProtocol {
             blogID = try await dispatch(JetpackConnectionAction.registerSite)
         }
 
-        let provisionResponse: JetpackConnectionProvisionResponse = try await dispatch(JetpackConnectionAction.provisionConnection)
+        let provisionResponse: JetpackConnectionProvisionResponse =
+            try await dispatch(JetpackConnectionAction.provisionConnection)
 
         let network = AlamofireNetwork(credentials: credentials, selectedSite: nil, appPasswordSupportState: nil)
         try await dispatch { completion in
@@ -40,9 +144,20 @@ final class JetpackConnectionService: JetpackConnectionServiceProtocol {
             )
         }
     }
-}
 
-private extension JetpackConnectionService {
+    func checkJetpackPluginInstalled() async -> PluginCheckResult {
+        do {
+            let _: SitePlugin = try await dispatch(JetpackConnectionAction.retrieveJetpackPluginDetails)
+            return .installed
+        } catch {
+            let code = (error as? NetworkError)?.responseCode ?? (error as NSError).code
+            if code == 404 {
+                return .notFound
+            }
+            return .error(error)
+        }
+    }
+
     func dispatch<T>(_ actionBuilder: @escaping (@escaping (Result<T, Error>) -> Void) -> Action) async throws -> T {
         let stores = self.stores
         return try await withCheckedThrowingContinuation { continuation in

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/JetpackConnectionService.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/JetpackConnectionService.swift
@@ -5,6 +5,7 @@ import class Networking.AlamofireNetwork
 /// Performs the native Jetpack/WPCom connection sequence:
 /// register (if needed) → provision → finalize.
 protocol JetpackConnectionServiceProtocol {
+    @MainActor
     func connect(with connectionData: JetpackConnectionData,
                  siteURL: String,
                  credentials: Credentials) async throws

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/JetpackConnectionService.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/JetpackConnectionService.swift
@@ -5,7 +5,6 @@ import class Networking.AlamofireNetwork
 /// Performs the native Jetpack/WPCom connection sequence:
 /// register (if needed) → provision → finalize.
 protocol JetpackConnectionServiceProtocol {
-    @MainActor
     func connect(with connectionData: JetpackConnectionData,
                  siteURL: String,
                  credentials: Credentials) async throws
@@ -45,10 +44,14 @@ final class JetpackConnectionService: JetpackConnectionServiceProtocol {
 
 private extension JetpackConnectionService {
     func dispatch<T>(_ actionBuilder: @escaping (@escaping (Result<T, Error>) -> Void) -> Action) async throws -> T {
-        try await withCheckedThrowingContinuation { continuation in
-            stores.dispatch(actionBuilder { result in
+        let stores = self.stores
+        return try await withCheckedThrowingContinuation { continuation in
+            let action = actionBuilder { result in
                 continuation.resume(with: result)
-            })
+            }
+            Task { @MainActor in
+                stores.dispatch(action)
+            }
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/JetpackConnectionService.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/JetpackConnectionService.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Yosemite
+import class Networking.AlamofireNetwork
+
+enum JetpackConnectionServiceError: Error {
+    case verificationFailed
+}
+
+/// Performs the native Jetpack/WPCom connection sequence:
+/// register (if needed) → provision → finalize → verify.
+protocol JetpackConnectionServiceProtocol {
+    func connect(with connectionData: JetpackConnectionData,
+                 siteURL: String,
+                 credentials: Credentials) async throws -> String
+
+    func verifyConnection() async throws -> String
+}
+
+final class JetpackConnectionService: JetpackConnectionServiceProtocol {
+    private let stores: StoresManager
+    private let maxRetryCount: Int
+    private let retryDelay: TimeInterval
+
+    init(stores: StoresManager = ServiceLocator.stores,
+         maxRetryCount: Int = 2,
+         retryDelay: TimeInterval = 0.5) {
+        self.stores = stores
+        self.maxRetryCount = maxRetryCount
+        self.retryDelay = retryDelay
+    }
+
+    func connect(with connectionData: JetpackConnectionData,
+                 siteURL: String,
+                 credentials: Credentials) async throws -> String {
+        // 1. Determine blogID — register if needed
+        let blogID: Int64
+        if connectionData.isRegistered == true, let existingBlogID = connectionData.blogID {
+            blogID = existingBlogID
+        } else {
+            blogID = try await registerSite()
+        }
+
+        // 2. Provision
+        let provisionResponse = try await provisionConnection()
+
+        // 3. Finalize
+        try await finalizeConnection(blogID: blogID,
+                                     siteURL: siteURL,
+                                     provisionResponse: provisionResponse,
+                                     credentials: credentials)
+
+        // 4. Verify with retry
+        return try await verifyConnection()
+    }
+
+    func verifyConnection() async throws -> String {
+        try await verifyConnection(retryCount: 0)
+    }
+}
+
+// MARK: - Private steps
+private extension JetpackConnectionService {
+    func registerSite() async throws -> Int64 {
+        try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(JetpackConnectionAction.registerSite { result in
+                continuation.resume(with: result)
+            })
+        }
+    }
+
+    func provisionConnection() async throws -> JetpackConnectionProvisionResponse {
+        try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(JetpackConnectionAction.provisionConnection { result in
+                continuation.resume(with: result)
+            })
+        }
+    }
+
+    func finalizeConnection(blogID: Int64,
+                            siteURL: String,
+                            provisionResponse: JetpackConnectionProvisionResponse,
+                            credentials: Credentials) async throws {
+        let network = AlamofireNetwork(credentials: credentials, selectedSite: nil, appPasswordSupportState: nil)
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            stores.dispatch(JetpackConnectionAction.finalizeConnection(
+                siteID: blogID,
+                siteURL: siteURL,
+                provisionResponse: provisionResponse,
+                network: network
+            ) { result in
+                continuation.resume(with: result)
+            })
+        }
+    }
+
+    func fetchConnectionData() async throws -> JetpackConnectionData {
+        try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(JetpackConnectionAction.fetchJetpackConnectionData { result in
+                continuation.resume(with: result)
+            })
+        }
+    }
+
+    func verifyConnection(retryCount: Int) async throws -> String {
+        let data: JetpackConnectionData
+        do {
+            data = try await fetchConnectionData()
+        } catch {
+            if retryCount < maxRetryCount {
+                try await Task.sleep(nanoseconds: UInt64(retryDelay * 1_000_000_000))
+                return try await verifyConnection(retryCount: retryCount + 1)
+            }
+            throw error
+        }
+
+        if let email = data.currentUser.wpcomUser?.email {
+            DDLogDebug("📱 JetpackConnectionService: Successfully connected (\(email))")
+            return email
+        }
+
+        DDLogWarn("⚠️ JetpackConnectionService: Cannot find connected WPCom user")
+        if retryCount < maxRetryCount {
+            try await Task.sleep(nanoseconds: UInt64(retryDelay * 1_000_000_000))
+            return try await verifyConnection(retryCount: retryCount + 1)
+        }
+
+        throw JetpackConnectionServiceError.verificationFailed
+    }
+}

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
@@ -401,7 +401,7 @@ private extension JetpackSetupViewModel {
     func startNativeConnection(with data: JetpackConnectionData) {
         currentSetupStep = .connection
         trackSetup()
-        Task { [weak self] in
+        Task { @MainActor [weak self] in
             guard let self else { return }
             do {
                 try await self.connectionService.connect(

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
@@ -136,30 +136,14 @@ final class JetpackSetupViewModel: ObservableObject {
 
     func startSetup() {
         if connectionOnly {
-            checkJetpackConnection()
+            checkJetpackConnection(afterConnection: false)
         } else {
             retrieveJetpackPluginDetails()
         }
     }
 
     func didAuthorizeJetpackConnection() {
-        currentConnectionStep = .inProgress
-        Task { [weak self] in
-            guard let self else { return }
-            do {
-                let email = try await self.connectionService.verifyConnection()
-                self.didCompleteJetpackConnection(connectedEmail: email)
-            } catch is JetpackConnectionServiceError {
-                let missingWpcomUserError = NSError(
-                    domain: Constants.errorDomain,
-                    code: Constants.errorCodeNoWPComUser,
-                    userInfo: [Constants.errorUserInfoReason: Constants.errorUserInfoNoWPComUser]
-                )
-                self.didFailJetpackConnection(with: missingWpcomUserError)
-            } catch {
-                self.didFailJetpackConnection(with: error)
-            }
-        }
+        checkJetpackConnection(afterConnection: true)
     }
 
     func didEncounterErrorDuringConnection(code: Int?) {
@@ -189,7 +173,7 @@ final class JetpackSetupViewModel: ObservableObject {
     /// LoginJetpackSetupInterruptedView
     func didTapContinueConnectionButton() {
         trackSetup(tap: .continueSetup)
-        checkJetpackConnection()
+        checkJetpackConnection(afterConnection: false)
     }
 
     /// Tracks events if the current flow is Jetpack setup after login with site credentials
@@ -215,7 +199,7 @@ private extension JetpackSetupViewModel {
                 if plugin.status == .inactive {
                     self.activateJetpack()
                 } else {
-                    self.checkJetpackConnection()
+                    self.checkJetpackConnection(afterConnection: false)
                 }
             case .failure(let error):
                 DDLogError("⛔️ Error retrieving Jetpack: \(error)")
@@ -264,7 +248,7 @@ private extension JetpackSetupViewModel {
             switch result {
             case .success:
                 isPluginActivated = true
-                self.checkJetpackConnection()
+                self.checkJetpackConnection(afterConnection: false)
             case .failure(let error):
                 self.trackSetup(failure: error)
                 DDLogError("⛔️ Error activating Jetpack: \(error)")
@@ -334,23 +318,49 @@ private extension JetpackSetupViewModel {
 // MARK: Handle connection steps
 // Ref: pe5sF9-401-p2
 private extension JetpackSetupViewModel {
-    func checkJetpackConnection(retryCount: Int = 0) {
+    func checkJetpackConnection(afterConnection: Bool, retryCount: Int = 0) {
+        if afterConnection {
+            currentConnectionStep = .inProgress
+        }
         let action = JetpackConnectionAction.fetchJetpackConnectionData { [weak self] result in
             guard let self else { return }
             switch result {
             case .success(let connectionData):
-                handleJetpackConnectionData(connectionData)
+                if afterConnection {
+                    checkConnectedUser(data: connectionData, retryCount: retryCount)
+                } else {
+                    handleJetpackConnectionData(connectionData)
+                }
             case .failure(let error):
                 DDLogError("⛔️ Error checking Jetpack connection: \(error)")
                 if retryCount == Constants.maxRetryCount {
                     return didFailJetpackConnection(with: error)
                 }
                 DispatchQueue.main.asyncAfter(deadline: .now() + delayBeforeRetry) { [weak self] in
-                    self?.checkJetpackConnection(retryCount: retryCount + 1)
+                    self?.checkJetpackConnection(afterConnection: afterConnection, retryCount: retryCount + 1)
                 }
             }
         }
         stores.dispatch(action)
+    }
+
+    func checkConnectedUser(data: JetpackConnectionData, retryCount: Int = 0) {
+        let connectedEmail = data.currentUser.wpcomUser?.email
+        if let connectedEmail {
+            return didCompleteJetpackConnection(connectedEmail: connectedEmail)
+        }
+
+        DDLogWarn("⚠️ Cannot find connected WPcom user")
+        let missingWpcomUserError = NSError(domain: Constants.errorDomain,
+                                            code: Constants.errorCodeNoWPComUser,
+                                            userInfo: [Constants.errorUserInfoReason: Constants.errorUserInfoNoWPComUser])
+        if retryCount == Constants.maxRetryCount {
+            return didFailJetpackConnection(with: missingWpcomUserError)
+        }
+        // Retry fetching user in case Jetpack sync takes some time.
+        DispatchQueue.main.asyncAfter(deadline: .now() + delayBeforeRetry) { [weak self] in
+            self?.checkJetpackConnection(afterConnection: true, retryCount: retryCount + 1)
+        }
     }
 
     func handleJetpackConnectionData(_ data: JetpackConnectionData) {
@@ -400,19 +410,12 @@ private extension JetpackSetupViewModel {
         Task { [weak self] in
             guard let self else { return }
             do {
-                let email = try await self.connectionService.connect(
+                try await self.connectionService.connect(
                     with: data,
                     siteURL: self.siteURL,
                     credentials: self.wpcomCredentials
                 )
-                self.didCompleteJetpackConnection(connectedEmail: email)
-            } catch is JetpackConnectionServiceError {
-                let missingWpcomUserError = NSError(
-                    domain: Constants.errorDomain,
-                    code: Constants.errorCodeNoWPComUser,
-                    userInfo: [Constants.errorUserInfoReason: Constants.errorUserInfoNoWPComUser]
-                )
-                self.didFailJetpackConnection(with: missingWpcomUserError)
+                self.checkJetpackConnection(afterConnection: true)
             } catch {
                 self.didFailJetpackConnection(with: error)
             }

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
@@ -98,7 +98,7 @@ final class JetpackSetupViewModel: ObservableObject {
          wpcomCredentials: Credentials,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
-         connectionService: JetpackConnectionServiceProtocol = ServiceLocator.jetpackConnectionService,
+         connectionService: JetpackConnectionServiceProtocol = JetpackConnectionService(),
          delayBeforeRetry: Double = Constants.delayBeforeRetry,
          onStoreNavigation: @escaping (String?) -> Void = { _ in}) {
         self.siteURL = siteURL
@@ -389,13 +389,7 @@ private extension JetpackSetupViewModel {
                     if error.errorCode == 404 {
                         /// For Jetpack-connected sites, if `isRegistered` is not returned,
                         /// check for `connectionOwner` instead.
-                        let syntheticData = JetpackConnectionData(
-                            currentUser: data.currentUser,
-                            isRegistered: data.connectionOwner != nil,
-                            connectionOwner: data.connectionOwner,
-                            blogID: data.blogID
-                        )
-                        startNativeConnection(with: syntheticData)
+                        startNativeConnection(with: data.copy(isRegistered: data.connectionOwner != nil))
                     } else {
                         didFailJetpackConnection(with: error)
                     }

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
@@ -3,7 +3,6 @@ import UIKit
 import Yosemite
 import enum Alamofire.AFError
 import enum Networking.NetworkError
-import class Networking.AlamofireNetwork
 import protocol WooFoundation.Analytics
 
 /// View model for `JetpackSetupView`.
@@ -92,12 +91,14 @@ final class JetpackSetupViewModel: ObservableObject {
 
     private let analytics: Analytics
     private let delayBeforeRetry: Double
+    private let connectionService: JetpackConnectionServiceProtocol
 
     init(siteURL: String,
          connectionOnly: Bool,
          wpcomCredentials: Credentials,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
+         connectionService: JetpackConnectionServiceProtocol = ServiceLocator.jetpackConnectionService,
          delayBeforeRetry: Double = Constants.delayBeforeRetry,
          onStoreNavigation: @escaping (String?) -> Void = { _ in}) {
         self.siteURL = siteURL
@@ -109,6 +110,7 @@ final class JetpackSetupViewModel: ObservableObject {
         self.storeNavigationHandler = onStoreNavigation
         self.siteConnectionURL = URL(string: String(format: Constants.jetpackInstallString, siteURL))
         self.delayBeforeRetry = delayBeforeRetry
+        self.connectionService = connectionService
     }
 
     func isSetupStepFailed(_ step: JetpackInstallStep) -> Bool {
@@ -134,14 +136,30 @@ final class JetpackSetupViewModel: ObservableObject {
 
     func startSetup() {
         if connectionOnly {
-            checkJetpackConnection(afterConnection: false)
+            checkJetpackConnection()
         } else {
             retrieveJetpackPluginDetails()
         }
     }
 
     func didAuthorizeJetpackConnection() {
-        checkJetpackConnection(afterConnection: true)
+        currentConnectionStep = .inProgress
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let email = try await self.connectionService.verifyConnection()
+                self.didCompleteJetpackConnection(connectedEmail: email)
+            } catch is JetpackConnectionServiceError {
+                let missingWpcomUserError = NSError(
+                    domain: Constants.errorDomain,
+                    code: Constants.errorCodeNoWPComUser,
+                    userInfo: [Constants.errorUserInfoReason: Constants.errorUserInfoNoWPComUser]
+                )
+                self.didFailJetpackConnection(with: missingWpcomUserError)
+            } catch {
+                self.didFailJetpackConnection(with: error)
+            }
+        }
     }
 
     func didEncounterErrorDuringConnection(code: Int?) {
@@ -171,7 +189,7 @@ final class JetpackSetupViewModel: ObservableObject {
     /// LoginJetpackSetupInterruptedView
     func didTapContinueConnectionButton() {
         trackSetup(tap: .continueSetup)
-        checkJetpackConnection(afterConnection: false)
+        checkJetpackConnection()
     }
 
     /// Tracks events if the current flow is Jetpack setup after login with site credentials
@@ -197,7 +215,7 @@ private extension JetpackSetupViewModel {
                 if plugin.status == .inactive {
                     self.activateJetpack()
                 } else {
-                    self.checkJetpackConnection(afterConnection: false)
+                    self.checkJetpackConnection()
                 }
             case .failure(let error):
                 DDLogError("⛔️ Error retrieving Jetpack: \(error)")
@@ -246,7 +264,7 @@ private extension JetpackSetupViewModel {
             switch result {
             case .success:
                 isPluginActivated = true
-                self.checkJetpackConnection(afterConnection: false)
+                self.checkJetpackConnection()
             case .failure(let error):
                 self.trackSetup(failure: error)
                 DDLogError("⛔️ Error activating Jetpack: \(error)")
@@ -316,49 +334,23 @@ private extension JetpackSetupViewModel {
 // MARK: Handle connection steps
 // Ref: pe5sF9-401-p2
 private extension JetpackSetupViewModel {
-    func checkJetpackConnection(afterConnection: Bool, retryCount: Int = 0) {
-        if afterConnection {
-            currentConnectionStep = .inProgress
-        }
+    func checkJetpackConnection(retryCount: Int = 0) {
         let action = JetpackConnectionAction.fetchJetpackConnectionData { [weak self] result in
             guard let self else { return }
             switch result {
             case .success(let connectionData):
-                if afterConnection {
-                    checkConnectedUser(data: connectionData, retryCount: retryCount)
-                } else {
-                    handleJetpackConnectionData(connectionData)
-                }
+                handleJetpackConnectionData(connectionData)
             case .failure(let error):
                 DDLogError("⛔️ Error checking Jetpack connection: \(error)")
                 if retryCount == Constants.maxRetryCount {
                     return didFailJetpackConnection(with: error)
                 }
                 DispatchQueue.main.asyncAfter(deadline: .now() + delayBeforeRetry) { [weak self] in
-                    self?.checkJetpackConnection(afterConnection: afterConnection, retryCount: retryCount + 1)
+                    self?.checkJetpackConnection(retryCount: retryCount + 1)
                 }
             }
         }
         stores.dispatch(action)
-    }
-
-    func checkConnectedUser(data: JetpackConnectionData, retryCount: Int = 0) {
-        let connectedEmail = data.currentUser.wpcomUser?.email
-        if let connectedEmail {
-            return didCompleteJetpackConnection(connectedEmail: connectedEmail)
-        }
-
-        DDLogWarn("⚠️ Cannot find connected WPcom user")
-        let missingWpcomUserError = NSError(domain: Constants.errorDomain,
-                                            code: Constants.errorCodeNoWPComUser,
-                                            userInfo: [Constants.errorUserInfoReason: Constants.errorUserInfoNoWPComUser])
-        if retryCount == Constants.maxRetryCount {
-            return didFailJetpackConnection(with: missingWpcomUserError)
-        }
-        // Retry fetching user in case Jetpack sync takes some time.
-        DispatchQueue.main.asyncAfter(deadline: .now() + delayBeforeRetry) { [weak self] in
-            self?.checkJetpackConnection(afterConnection: true, retryCount: retryCount + 1)
-        }
     }
 
     func handleJetpackConnectionData(_ data: JetpackConnectionData) {
@@ -366,8 +358,8 @@ private extension JetpackSetupViewModel {
             return didCompleteJetpackConnection(connectedEmail: connectedEmail)
         }
 
-        if let isRegistered = data.isRegistered {
-            return handleSiteRegisterResult(isRegistered: isRegistered, blogID: data.blogID)
+        if data.isRegistered != nil {
+            return startNativeConnection(with: data)
         }
 
         if isPluginActivated {
@@ -387,7 +379,13 @@ private extension JetpackSetupViewModel {
                     if error.errorCode == 404 {
                         /// For Jetpack-connected sites, if `isRegistered` is not returned,
                         /// check for `connectionOwner` instead.
-                        handleSiteRegisterResult(isRegistered: data.connectionOwner != nil, blogID: data.blogID)
+                        let syntheticData = JetpackConnectionData(
+                            currentUser: data.currentUser,
+                            isRegistered: data.connectionOwner != nil,
+                            connectionOwner: data.connectionOwner,
+                            blogID: data.blogID
+                        )
+                        startNativeConnection(with: syntheticData)
                     } else {
                         didFailJetpackConnection(with: error)
                     }
@@ -396,56 +394,29 @@ private extension JetpackSetupViewModel {
         }
     }
 
-    func handleSiteRegisterResult(isRegistered: Bool, blogID: Int64?) {
-        if let blogID, isRegistered {
-            provisionSiteConnection(blogID: blogID)
-        } else {
-            registerSiteConnection()
-        }
-    }
-
-    func registerSiteConnection() {
-        stores.dispatch(JetpackConnectionAction.registerSite(completion: { [weak self] result in
-            guard let self else { return }
-            switch result {
-            case .success(let blogID):
-                provisionSiteConnection(blogID: blogID)
-            case .failure(let error):
-                didFailJetpackConnection(with: error)
-            }
-        }))
-    }
-
-    func provisionSiteConnection(blogID: Int64) {
+    func startNativeConnection(with data: JetpackConnectionData) {
         currentSetupStep = .connection
         trackSetup()
-        stores.dispatch(JetpackConnectionAction.provisionConnection(completion: { [weak self] result in
+        Task { [weak self] in
             guard let self else { return }
-            switch result {
-            case .success(let response):
-                finalizeSiteConnection(blogID: blogID, provisionResponse: response)
-            case .failure(let error):
-                didFailJetpackConnection(with: error)
+            do {
+                let email = try await self.connectionService.connect(
+                    with: data,
+                    siteURL: self.siteURL,
+                    credentials: self.wpcomCredentials
+                )
+                self.didCompleteJetpackConnection(connectedEmail: email)
+            } catch is JetpackConnectionServiceError {
+                let missingWpcomUserError = NSError(
+                    domain: Constants.errorDomain,
+                    code: Constants.errorCodeNoWPComUser,
+                    userInfo: [Constants.errorUserInfoReason: Constants.errorUserInfoNoWPComUser]
+                )
+                self.didFailJetpackConnection(with: missingWpcomUserError)
+            } catch {
+                self.didFailJetpackConnection(with: error)
             }
-        }))
-    }
-
-    func finalizeSiteConnection(blogID: Int64, provisionResponse: JetpackConnectionProvisionResponse) {
-        let network = AlamofireNetwork(credentials: wpcomCredentials, selectedSite: nil, appPasswordSupportState: nil)
-        stores.dispatch(JetpackConnectionAction.finalizeConnection(
-            siteID: blogID,
-            siteURL: siteURL,
-            provisionResponse: provisionResponse,
-            network: network
-        ) { [weak self] result in
-            guard let self else { return }
-            switch result {
-            case .success:
-                checkJetpackConnection(afterConnection: true)
-            case .failure(let error):
-                didFailJetpackConnection(with: error)
-            }
-        })
+        }
     }
 
     func didCompleteJetpackConnection(connectedEmail: String) {

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
@@ -15,7 +15,6 @@ final class JetpackSetupViewModel: ObservableObject {
     private let stores: StoresManager
     private let storeNavigationHandler: (_ connectedEmail: String?) -> Void
     private let wpcomCredentials: Credentials
-    private var isPluginActivated = false
     private var connectionType = WooAnalyticsEvent.JetpackSetup.ConnectionType.native
 
     @Published private(set) var setupSteps: [JetpackInstallStep]
@@ -90,7 +89,6 @@ final class JetpackSetupViewModel: ObservableObject {
     }()
 
     private let analytics: Analytics
-    private let delayBeforeRetry: Double
     private let connectionService: JetpackConnectionServiceProtocol
 
     init(siteURL: String,
@@ -98,8 +96,7 @@ final class JetpackSetupViewModel: ObservableObject {
          wpcomCredentials: Credentials,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
-         connectionService: JetpackConnectionServiceProtocol = JetpackConnectionService(),
-         delayBeforeRetry: Double = Constants.delayBeforeRetry,
+         connectionService: JetpackConnectionServiceProtocol? = nil,
          onStoreNavigation: @escaping (String?) -> Void = { _ in}) {
         self.siteURL = siteURL
         self.connectionOnly = connectionOnly
@@ -109,8 +106,7 @@ final class JetpackSetupViewModel: ObservableObject {
         self.setupSteps = connectionOnly ? [.connection, .done] : JetpackInstallStep.allCases
         self.storeNavigationHandler = onStoreNavigation
         self.siteConnectionURL = URL(string: String(format: Constants.jetpackInstallString, siteURL))
-        self.delayBeforeRetry = delayBeforeRetry
-        self.connectionService = connectionService
+        self.connectionService = connectionService ?? JetpackConnectionService(stores: stores)
     }
 
     func isSetupStepFailed(_ step: JetpackInstallStep) -> Bool {
@@ -247,7 +243,6 @@ private extension JetpackSetupViewModel {
             guard let self else { return }
             switch result {
             case .success:
-                isPluginActivated = true
                 self.checkJetpackConnection(afterConnection: false)
             case .failure(let error):
                 self.trackSetup(failure: error)
@@ -318,98 +313,33 @@ private extension JetpackSetupViewModel {
 // MARK: Handle connection steps
 // Ref: pe5sF9-401-p2
 private extension JetpackSetupViewModel {
-    func checkJetpackConnection(afterConnection: Bool, retryCount: Int = 0) {
-        if afterConnection {
-            currentConnectionStep = .inProgress
-        }
-        let action = JetpackConnectionAction.fetchJetpackConnectionData { [weak self] result in
-            guard let self else { return }
-            switch result {
-            case .success(let connectionData):
-                if afterConnection {
-                    checkConnectedUser(data: connectionData, retryCount: retryCount)
-                } else {
-                    handleJetpackConnectionData(connectionData)
-                }
-            case .failure(let error):
-                DDLogError("⛔️ Error checking Jetpack connection: \(error)")
-                if retryCount == Constants.maxRetryCount {
-                    return didFailJetpackConnection(with: error)
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + delayBeforeRetry) { [weak self] in
-                    self?.checkJetpackConnection(afterConnection: afterConnection, retryCount: retryCount + 1)
-                }
-            }
-        }
-        stores.dispatch(action)
-    }
-
-    func checkConnectedUser(data: JetpackConnectionData, retryCount: Int = 0) {
-        let connectedEmail = data.currentUser.wpcomUser?.email
-        if let connectedEmail {
-            return didCompleteJetpackConnection(connectedEmail: connectedEmail)
-        }
-
-        DDLogWarn("⚠️ Cannot find connected WPcom user")
-        let missingWpcomUserError = NSError(domain: Constants.errorDomain,
-                                            code: Constants.errorCodeNoWPComUser,
-                                            userInfo: [Constants.errorUserInfoReason: Constants.errorUserInfoNoWPComUser])
-        if retryCount == Constants.maxRetryCount {
-            return didFailJetpackConnection(with: missingWpcomUserError)
-        }
-        // Retry fetching user in case Jetpack sync takes some time.
-        DispatchQueue.main.asyncAfter(deadline: .now() + delayBeforeRetry) { [weak self] in
-            self?.checkJetpackConnection(afterConnection: true, retryCount: retryCount + 1)
-        }
-    }
-
-    func handleJetpackConnectionData(_ data: JetpackConnectionData) {
-        if let connectedEmail = data.currentUser.wpcomUser?.email {
-            return didCompleteJetpackConnection(connectedEmail: connectedEmail)
-        }
-
-        if data.isRegistered != nil {
-            return startNativeConnection(with: data)
-        }
-
-        if isPluginActivated {
-            /// Skips plugin check if plugin has just got activated.
-            /// `isRegistered` is unavailable due to outdated Jetpack. Proceed with web flow.
-            startConnectionWithWebView()
-        } else {
-            /// Fetch plugin details to check
-            stores.dispatch(JetpackConnectionAction.retrieveJetpackPluginDetails { [weak self] result in
-                guard let self else { return }
-                switch result {
-                case .success:
-                    /// Plugin is available but`isRegistered` is unavailable due to outdated version.
-                    /// Proceed with web flow.
-                    startConnectionWithWebView()
-                case .failure(let error):
-                    if error.errorCode == 404 {
-                        /// For Jetpack-connected sites, if `isRegistered` is not returned,
-                        /// check for `connectionOwner` instead.
-                        startNativeConnection(with: data.copy(isRegistered: data.connectionOwner != nil))
-                    } else {
-                        didFailJetpackConnection(with: error)
-                    }
-                }
-            })
-        }
-    }
-
-    func startNativeConnection(with data: JetpackConnectionData) {
+    func checkJetpackConnection(afterConnection: Bool) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        if afterConnection { currentConnectionStep = .inProgress }
+        // Set synchronously so the UI immediately reflects the connection step.
+        // For .alreadyConnected, this transitions to .done in the next run-loop tick.
         currentSetupStep = .connection
-        trackSetup()
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                try await self.connectionService.connect(
-                    with: data,
-                    siteURL: self.siteURL,
-                    credentials: self.wpcomCredentials
-                )
-                self.checkJetpackConnection(afterConnection: true)
+                if afterConnection {
+                    let email = try await self.connectionService.verifyConnection()
+                    self.didCompleteJetpackConnection(connectedEmail: email)
+                } else {
+                    let outcome = try await self.connectionService.evaluateAndConnect(
+                        siteURL: self.siteURL,
+                        credentials: self.wpcomCredentials
+                    )
+                    switch outcome {
+                    case .alreadyConnected(let email):
+                        self.didCompleteJetpackConnection(connectedEmail: email)
+                    case .connected(let email):
+                        self.trackSetup()
+                        self.didCompleteJetpackConnection(connectedEmail: email)
+                    case .webViewRequired:
+                        self.startConnectionWithWebView()
+                    }
+                }
             } catch {
                 self.didFailJetpackConnection(with: error)
             }
@@ -518,12 +448,6 @@ extension JetpackSetupViewModel {
     }
 
     private enum Constants {
-        static let maxRetryCount: Int = 2
-        static let delayBeforeRetry: Double = 0.5
-        static let errorDomain = "LoginJetpackSetup"
-        static let errorCodeNoWPComUser = 99
-        static let errorUserInfoReason = "reason"
-        static let errorUserInfoNoWPComUser = "No connected WP.com user found"
         static let jetpackInstallString = "%@/wp-admin/admin.php?page=jetpack"
         static let accountConnectionURL = "https://jetpack.wordpress.com/jetpack.authorize"
     }

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -135,6 +135,8 @@ final class ServiceLocator {
 
     /// Age rating change detector
     ///
+    private static var _jetpackConnectionService: JetpackConnectionServiceProtocol = JetpackConnectionService()
+
     private static var _ageRatingChangeDetector: AgeRatingChangeDetector = AgeRatingChangeDetector(
         defaults: .standard,
         provider: StoreKitAgeRatingProvider()
@@ -344,6 +346,10 @@ final class ServiceLocator {
 
     static var ageRangeVerificationService: AgeRangeVerificationServiceProtocol {
         _ageRangeVerificationService
+    }
+
+    static var jetpackConnectionService: JetpackConnectionServiceProtocol {
+        _jetpackConnectionService
     }
 
     static var ageRatingChangeDetector: AgeRatingChangeDetector {

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -135,8 +135,6 @@ final class ServiceLocator {
 
     /// Age rating change detector
     ///
-    private static var _jetpackConnectionService: JetpackConnectionServiceProtocol = JetpackConnectionService()
-
     private static var _ageRatingChangeDetector: AgeRatingChangeDetector = AgeRatingChangeDetector(
         defaults: .standard,
         provider: StoreKitAgeRatingProvider()
@@ -346,10 +344,6 @@ final class ServiceLocator {
 
     static var ageRangeVerificationService: AgeRangeVerificationServiceProtocol {
         _ageRangeVerificationService
-    }
-
-    static var jetpackConnectionService: JetpackConnectionServiceProtocol {
-        _jetpackConnectionService
     }
 
     static var ageRatingChangeDetector: AgeRatingChangeDetector {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -410,6 +410,7 @@
 		31FE28C225E6D338003519F2 /* LearnMoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FE28C125E6D338003519F2 /* LearnMoreTableViewCell.swift */; };
 		31FE28C825E6D384003519F2 /* LearnMoreTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 31FE28C725E6D384003519F2 /* LearnMoreTableViewCell.xib */; };
 		3D94B7D5A94E3515D4B9BB4D /* MockWPComConnectionSetupHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FEE9D30367FFF0ADEE1F5B /* MockWPComConnectionSetupHandler.swift */; };
+		71E7782632CC7D5213733333 /* MockJetpackConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1A903713867FCD550D32AD /* MockJetpackConnectionService.swift */; };
 		3F0904092D26A40800D8ACCE /* WordPressAuthenticator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F0904012D26A40700D8ACCE /* WordPressAuthenticator.framework */; };
 		3F0904142D26A40800D8ACCE /* WordPressAuthenticator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F0904012D26A40700D8ACCE /* WordPressAuthenticator.framework */; };
 		3F0904152D26A40800D8ACCE /* WordPressAuthenticator.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3F0904012D26A40700D8ACCE /* WordPressAuthenticator.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -951,17 +952,6 @@
 		DE279BAD26E9CBEA002BA963 /* ShippingLabelPackagesFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BAC26E9CBEA002BA963 /* ShippingLabelPackagesFormViewModelTests.swift */; };
 		DE279BAF26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BAE26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift */; };
 		DE2FE5882925DD950018040A /* JetpackInstallHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FE5872925DD950018040A /* JetpackInstallHeaderView.swift */; };
-		DE2FE58A2925EAAE0018040A /* LoginJetpackSetupCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FE5892925EAAE0018040A /* LoginJetpackSetupCoordinator.swift */; };
-		DE2FE58D292617C30018040A /* SiteCredentialLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FE58C292617C30018040A /* SiteCredentialLoginViewModel.swift */; };
-		DE2FE59029261DED0018040A /* SiteCredentialLoginViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FE58F29261DED0018040A /* SiteCredentialLoginViewModelTests.swift */; };
-		DE2FE595292737330018040A /* JetpackSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FE594292737330018040A /* JetpackSetupView.swift */; };
-		DE2FE597292737630018040A /* JetpackSetupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FE596292737630018040A /* JetpackSetupViewModel.swift */; };
-		F51BF8AF43A912AAA0E09F6E /* JetpackConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4F3DE2E082ADBAD89A2C291 /* JetpackConnectionService.swift */; };
-		983521AFF082F78FC8D7BA5C /* JetpackConnectionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E140965C8B468705DCA051ED /* JetpackConnectionServiceTests.swift */; };
-		71E7782632CC7D5213733333 /* MockJetpackConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1A903713867FCD550D32AD /* MockJetpackConnectionService.swift */; };
-		DE3144862C5780250015F089 /* UnavailableAnalyticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3144852C5780250015F089 /* UnavailableAnalyticsView.swift */; };
-		DE3404E828B4B96800CF0D97 /* NonAtomicSiteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404E728B4B96800CF0D97 /* NonAtomicSiteViewModel.swift */; };
-		DE3404EA28B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404E928B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift */; };
 		DE34771327F174C8009CA300 /* StatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34771227F174C8009CA300 /* StatusView.swift */; };
 		DE36E09C2A89EEA400B98496 /* StoreNameSetupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE36E09B2A89EEA400B98496 /* StoreNameSetupViewModelTests.swift */; };
 		DE4B3B2C2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4B3B2B2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift */; };
@@ -2181,17 +2171,9 @@
 		DE279BAC26E9CBEA002BA963 /* ShippingLabelPackagesFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackagesFormViewModelTests.swift; sourceTree = "<group>"; };
 		DE279BAE26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelSinglePackageViewModelTests.swift; sourceTree = "<group>"; };
 		DE2FE5872925DD950018040A /* JetpackInstallHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackInstallHeaderView.swift; sourceTree = "<group>"; };
-		DE2FE5892925EAAE0018040A /* LoginJetpackSetupCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginJetpackSetupCoordinator.swift; sourceTree = "<group>"; };
-		DE2FE594292737330018040A /* JetpackSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupView.swift; sourceTree = "<group>"; };
-		DE2FE596292737630018040A /* JetpackSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupViewModel.swift; sourceTree = "<group>"; };
-		A4F3DE2E082ADBAD89A2C291 /* JetpackConnectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackConnectionService.swift; sourceTree = "<group>"; };
-		E140965C8B468705DCA051ED /* JetpackConnectionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackConnectionServiceTests.swift; sourceTree = "<group>"; };
-		5E1A903713867FCD550D32AD /* MockJetpackConnectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockJetpackConnectionService.swift; sourceTree = "<group>"; };
-		DE3144852C5780250015F089 /* UnavailableAnalyticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnavailableAnalyticsView.swift; sourceTree = "<group>"; };
-		DE3404E728B4B96800CF0D97 /* NonAtomicSiteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAtomicSiteViewModel.swift; sourceTree = "<group>"; };
-		DE3404E928B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAtomicSiteViewModelTests.swift; sourceTree = "<group>"; };
 		DE34771227F174C8009CA300 /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
 		DE36E09B2A89EEA400B98496 /* StoreNameSetupViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreNameSetupViewModelTests.swift; sourceTree = "<group>"; };
+		DE4B3B2B2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewModelTests.swift; sourceTree = "<group>"; };
 		DE4B3B2D269455D400EEF2D8 /* MockShipmentActionStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShipmentActionStoresManager.swift; sourceTree = "<group>"; };
 		DE4B3B5726A7041800EEF2D8 /* EdgeInsets+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EdgeInsets+Woo.swift"; sourceTree = "<group>"; };
 		DE4C23B82EA09AFA0079240D /* Booking+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Booking+Helpers.swift"; sourceTree = "<group>"; };
@@ -2327,6 +2309,7 @@
 		EEEA41F12869A5F400AEFC4B /* MockProductImagesProductIDUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductImagesProductIDUpdater.swift; sourceTree = "<group>"; };
 		EEF5C14F2BBAFA5900535C86 /* StoreOnboardingTaskViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreOnboardingTaskViewModelTests.swift; sourceTree = "<group>"; };
 		F1FEE9D30367FFF0ADEE1F5B /* MockWPComConnectionSetupHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MockWPComConnectionSetupHandler.swift; sourceTree = "<group>"; };
+		5E1A903713867FCD550D32AD /* MockJetpackConnectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockJetpackConnectionService.swift; sourceTree = "<group>"; };
 		F997170223DBB97500592D8E /* WooCommerceScreenshots.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WooCommerceScreenshots.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE28F6F3268477C1004465C7 /* RoleEligibilityUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoleEligibilityUseCase.swift; sourceTree = "<group>"; };
 		FE3E427626A8545B00C596CE /* MockRoleEligibilityUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRoleEligibilityUseCase.swift; sourceTree = "<group>"; };
@@ -5104,67 +5087,6 @@
 			path = "Multi-package";
 			sourceTree = "<group>";
 		};
-		DE2FE5842925D9040018040A /* Jetpack Setup */ = {
-			isa = PBXGroup;
-			children = (
-				DE2FE593292736F90018040A /* Native Jetpack Setup */,
-				DE2FE58B2926179A0018040A /* Site Credential Login */,
-				DE2FE5892925EAAE0018040A /* LoginJetpackSetupCoordinator.swift */,
-				A4F3DE2E082ADBAD89A2C291 /* JetpackConnectionService.swift */,
-			);
-			path = "Jetpack Setup";
-			sourceTree = "<group>";
-		};
-		DE2FE58B2926179A0018040A /* Site Credential Login */ = {
-			isa = PBXGroup;
-			children = (
-				DE2FE5852925DA050018040A /* SiteCredentialLoginView.swift */,
-				DE2FE58C292617C30018040A /* SiteCredentialLoginViewModel.swift */,
-			);
-			path = "Site Credential Login";
-			sourceTree = "<group>";
-		};
-		DE2FE58E29261DCE0018040A /* Jetpack Setup */ = {
-			isa = PBXGroup;
-			children = (
-				DE2FE58F29261DED0018040A /* SiteCredentialLoginViewModelTests.swift */,
-				DEE183EC292BD900008818AB /* JetpackSetupViewModelTests.swift */,
-				EEC2D27E292CF60E0072132E /* JetpackSetupHostingControllerTests.swift */,
-				EEC2D280292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift */,
-				E140965C8B468705DCA051ED /* JetpackConnectionServiceTests.swift */,
-			);
-			path = "Jetpack Setup";
-			sourceTree = "<group>";
-		};
-		DE2FE593292736F90018040A /* Native Jetpack Setup */ = {
-			isa = PBXGroup;
-			children = (
-				DE2FE594292737330018040A /* JetpackSetupView.swift */,
-				DE2FE596292737630018040A /* JetpackSetupViewModel.swift */,
-				DEE183F0292E0ED0008818AB /* JetpackSetupInterruptedView.swift */,
-			);
-			path = "Native Jetpack Setup";
-			sourceTree = "<group>";
-		};
-		DE3650642B512864001569A7 /* TargetLocations */ = {
-			isa = PBXGroup;
-			children = (
-				DE3650652B512889001569A7 /* BlazeTargetLocationPickerView.swift */,
-				DE02ABAC2B55288D008E0AC4 /* BlazeTargetLocationSearchView.swift */,
-				DE3650672B5128CE001569A7 /* BlazeTargetLocationPickerViewModel.swift */,
-			);
-			path = TargetLocations;
-			sourceTree = "<group>";
-		};
-		DE36E0962A8634DB00B98496 /* StoreName */ = {
-			isa = PBXGroup;
-			children = (
-				DE36E0972A8634FF00B98496 /* StoreNameSetupView.swift */,
-				DE36E0992A86351100B98496 /* StoreNameSetupViewModel.swift */,
-			);
-			path = StoreName;
-			sourceTree = "<group>";
-		};
 		DE4B3B2A2692DBF200EEF2D8 /* Review Order */ = {
 			isa = PBXGroup;
 			children = (
@@ -6708,10 +6630,6 @@
 				DEEDA239298A11FB0088256B /* SiteCredentialLoginUseCase.swift in Sources */,
 				744F00D221B582A9007EFA93 /* StarRatingView.swift in Sources */,
 				45F627B9253603AE00894B86 /* ProductDownloadSettingsViewModel.swift in Sources */,
-				031B10E3274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift in Sources */,
-				DE2FE597292737630018040A /* JetpackSetupViewModel.swift in Sources */,
-				F51BF8AF43A912AAA0E09F6E /* JetpackConnectionService.swift in Sources */,
-				4572641727F1EB0D004E1F95 /* AddEditCoupon.swift in Sources */,
 				318109E825E5B8D600EE0BE7 /* NumberedListItemTableViewCell.swift in Sources */,
 				DE9F2D292A1B1AB2004E5957 /* FirstProductCreatedView.swift in Sources */,
 				02D29A9229F7C39200473D6D /* UIImage+Text.swift in Sources */,
@@ -7060,16 +6978,9 @@
 				B56C721421B5BBC000E5E85B /* MockStoresManager.swift in Sources */,
 				EE2A57D929E39A9C009F61E1 /* CaseIterable+HelpersTests.swift in Sources */,
 				D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */,
-				EEBDF7E72A31A59F00EFEF47 /* FirstProductCreatedViewModelTests.swift in Sources */,
-				8697AFBD2B60F56A00EFAF21 /* BlazeAdDestinationSettingViewModelTests.swift in Sources */,
-				D8025496265530E0001B2CC1 /* CardPresentModalFoundReaderTests.swift in Sources */,
-				DEE183ED292BD900008818AB /* JetpackSetupViewModelTests.swift in Sources */,
-				983521AFF082F78FC8D7BA5C /* JetpackConnectionServiceTests.swift in Sources */,
-				71E7782632CC7D5213733333 /* MockJetpackConnectionService.swift in Sources */,
-				028E19BC2805BD22001C36E0 /* RefundSubmissionUseCaseTests.swift in Sources */,
-				02645D8C27BA342D0065DC68 /* InboxNoteRowViewModelTests.swift in Sources */,
 				D85136D5231E40B500DD0539 /* ProductReviewTableViewCellTests.swift in Sources */,
 				021125B82578ECF10075AD2A /* BoldableTextParserTests.swift in Sources */,
+				4569D3F425DC1BFF00CDC3E2 /* ShippingLabelFormViewModelTests.swift in Sources */,
 				57F2C6CD246DECC10074063B /* SummaryTableViewCellViewModelTests.swift in Sources */,
 				DEDA8DC02B19CDC50076BF0F /* ThemeSettingViewModelTests.swift in Sources */,
 				CE7CEC2D2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift in Sources */,
@@ -7214,6 +7125,7 @@
 				57F42E40253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift in Sources */,
 				DE0BE0C12F333BC0009CE891 /* NotificationServiceSuppressionTests.swift in Sources */,
 				3D94B7D5A94E3515D4B9BB4D /* MockWPComConnectionSetupHandler.swift in Sources */,
+				71E7782632CC7D5213733333 /* MockJetpackConnectionService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -951,6 +951,17 @@
 		DE279BAD26E9CBEA002BA963 /* ShippingLabelPackagesFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BAC26E9CBEA002BA963 /* ShippingLabelPackagesFormViewModelTests.swift */; };
 		DE279BAF26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BAE26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift */; };
 		DE2FE5882925DD950018040A /* JetpackInstallHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FE5872925DD950018040A /* JetpackInstallHeaderView.swift */; };
+		DE2FE58A2925EAAE0018040A /* LoginJetpackSetupCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FE5892925EAAE0018040A /* LoginJetpackSetupCoordinator.swift */; };
+		DE2FE58D292617C30018040A /* SiteCredentialLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FE58C292617C30018040A /* SiteCredentialLoginViewModel.swift */; };
+		DE2FE59029261DED0018040A /* SiteCredentialLoginViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FE58F29261DED0018040A /* SiteCredentialLoginViewModelTests.swift */; };
+		DE2FE595292737330018040A /* JetpackSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FE594292737330018040A /* JetpackSetupView.swift */; };
+		DE2FE597292737630018040A /* JetpackSetupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FE596292737630018040A /* JetpackSetupViewModel.swift */; };
+		F51BF8AF43A912AAA0E09F6E /* JetpackConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4F3DE2E082ADBAD89A2C291 /* JetpackConnectionService.swift */; };
+		983521AFF082F78FC8D7BA5C /* JetpackConnectionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E140965C8B468705DCA051ED /* JetpackConnectionServiceTests.swift */; };
+		71E7782632CC7D5213733333 /* MockJetpackConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1A903713867FCD550D32AD /* MockJetpackConnectionService.swift */; };
+		DE3144862C5780250015F089 /* UnavailableAnalyticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3144852C5780250015F089 /* UnavailableAnalyticsView.swift */; };
+		DE3404E828B4B96800CF0D97 /* NonAtomicSiteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404E728B4B96800CF0D97 /* NonAtomicSiteViewModel.swift */; };
+		DE3404EA28B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404E928B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift */; };
 		DE34771327F174C8009CA300 /* StatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34771227F174C8009CA300 /* StatusView.swift */; };
 		DE36E09C2A89EEA400B98496 /* StoreNameSetupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE36E09B2A89EEA400B98496 /* StoreNameSetupViewModelTests.swift */; };
 		DE4B3B2C2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4B3B2B2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift */; };
@@ -2170,9 +2181,17 @@
 		DE279BAC26E9CBEA002BA963 /* ShippingLabelPackagesFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackagesFormViewModelTests.swift; sourceTree = "<group>"; };
 		DE279BAE26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelSinglePackageViewModelTests.swift; sourceTree = "<group>"; };
 		DE2FE5872925DD950018040A /* JetpackInstallHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackInstallHeaderView.swift; sourceTree = "<group>"; };
+		DE2FE5892925EAAE0018040A /* LoginJetpackSetupCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginJetpackSetupCoordinator.swift; sourceTree = "<group>"; };
+		DE2FE594292737330018040A /* JetpackSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupView.swift; sourceTree = "<group>"; };
+		DE2FE596292737630018040A /* JetpackSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupViewModel.swift; sourceTree = "<group>"; };
+		A4F3DE2E082ADBAD89A2C291 /* JetpackConnectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackConnectionService.swift; sourceTree = "<group>"; };
+		E140965C8B468705DCA051ED /* JetpackConnectionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackConnectionServiceTests.swift; sourceTree = "<group>"; };
+		5E1A903713867FCD550D32AD /* MockJetpackConnectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockJetpackConnectionService.swift; sourceTree = "<group>"; };
+		DE3144852C5780250015F089 /* UnavailableAnalyticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnavailableAnalyticsView.swift; sourceTree = "<group>"; };
+		DE3404E728B4B96800CF0D97 /* NonAtomicSiteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAtomicSiteViewModel.swift; sourceTree = "<group>"; };
+		DE3404E928B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAtomicSiteViewModelTests.swift; sourceTree = "<group>"; };
 		DE34771227F174C8009CA300 /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
 		DE36E09B2A89EEA400B98496 /* StoreNameSetupViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreNameSetupViewModelTests.swift; sourceTree = "<group>"; };
-		DE4B3B2B2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewModelTests.swift; sourceTree = "<group>"; };
 		DE4B3B2D269455D400EEF2D8 /* MockShipmentActionStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShipmentActionStoresManager.swift; sourceTree = "<group>"; };
 		DE4B3B5726A7041800EEF2D8 /* EdgeInsets+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EdgeInsets+Woo.swift"; sourceTree = "<group>"; };
 		DE4C23B82EA09AFA0079240D /* Booking+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Booking+Helpers.swift"; sourceTree = "<group>"; };
@@ -3983,6 +4002,7 @@
 				EE4C75DE2C86D2F500F9D860 /* BlazeLocalNotificationSchedulerSpy.swift */,
 				CEC3CC792C93537B00B93FBE /* MockShippingSettingsService.swift */,
 				F1FEE9D30367FFF0ADEE1F5B /* MockWPComConnectionSetupHandler.swift */,
+				5E1A903713867FCD550D32AD /* MockJetpackConnectionService.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -5082,6 +5102,67 @@
 				DE279BAE26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift */,
 			);
 			path = "Multi-package";
+			sourceTree = "<group>";
+		};
+		DE2FE5842925D9040018040A /* Jetpack Setup */ = {
+			isa = PBXGroup;
+			children = (
+				DE2FE593292736F90018040A /* Native Jetpack Setup */,
+				DE2FE58B2926179A0018040A /* Site Credential Login */,
+				DE2FE5892925EAAE0018040A /* LoginJetpackSetupCoordinator.swift */,
+				A4F3DE2E082ADBAD89A2C291 /* JetpackConnectionService.swift */,
+			);
+			path = "Jetpack Setup";
+			sourceTree = "<group>";
+		};
+		DE2FE58B2926179A0018040A /* Site Credential Login */ = {
+			isa = PBXGroup;
+			children = (
+				DE2FE5852925DA050018040A /* SiteCredentialLoginView.swift */,
+				DE2FE58C292617C30018040A /* SiteCredentialLoginViewModel.swift */,
+			);
+			path = "Site Credential Login";
+			sourceTree = "<group>";
+		};
+		DE2FE58E29261DCE0018040A /* Jetpack Setup */ = {
+			isa = PBXGroup;
+			children = (
+				DE2FE58F29261DED0018040A /* SiteCredentialLoginViewModelTests.swift */,
+				DEE183EC292BD900008818AB /* JetpackSetupViewModelTests.swift */,
+				EEC2D27E292CF60E0072132E /* JetpackSetupHostingControllerTests.swift */,
+				EEC2D280292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift */,
+				E140965C8B468705DCA051ED /* JetpackConnectionServiceTests.swift */,
+			);
+			path = "Jetpack Setup";
+			sourceTree = "<group>";
+		};
+		DE2FE593292736F90018040A /* Native Jetpack Setup */ = {
+			isa = PBXGroup;
+			children = (
+				DE2FE594292737330018040A /* JetpackSetupView.swift */,
+				DE2FE596292737630018040A /* JetpackSetupViewModel.swift */,
+				DEE183F0292E0ED0008818AB /* JetpackSetupInterruptedView.swift */,
+			);
+			path = "Native Jetpack Setup";
+			sourceTree = "<group>";
+		};
+		DE3650642B512864001569A7 /* TargetLocations */ = {
+			isa = PBXGroup;
+			children = (
+				DE3650652B512889001569A7 /* BlazeTargetLocationPickerView.swift */,
+				DE02ABAC2B55288D008E0AC4 /* BlazeTargetLocationSearchView.swift */,
+				DE3650672B5128CE001569A7 /* BlazeTargetLocationPickerViewModel.swift */,
+			);
+			path = TargetLocations;
+			sourceTree = "<group>";
+		};
+		DE36E0962A8634DB00B98496 /* StoreName */ = {
+			isa = PBXGroup;
+			children = (
+				DE36E0972A8634FF00B98496 /* StoreNameSetupView.swift */,
+				DE36E0992A86351100B98496 /* StoreNameSetupViewModel.swift */,
+			);
+			path = StoreName;
 			sourceTree = "<group>";
 		};
 		DE4B3B2A2692DBF200EEF2D8 /* Review Order */ = {
@@ -6627,6 +6708,10 @@
 				DEEDA239298A11FB0088256B /* SiteCredentialLoginUseCase.swift in Sources */,
 				744F00D221B582A9007EFA93 /* StarRatingView.swift in Sources */,
 				45F627B9253603AE00894B86 /* ProductDownloadSettingsViewModel.swift in Sources */,
+				031B10E3274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift in Sources */,
+				DE2FE597292737630018040A /* JetpackSetupViewModel.swift in Sources */,
+				F51BF8AF43A912AAA0E09F6E /* JetpackConnectionService.swift in Sources */,
+				4572641727F1EB0D004E1F95 /* AddEditCoupon.swift in Sources */,
 				318109E825E5B8D600EE0BE7 /* NumberedListItemTableViewCell.swift in Sources */,
 				DE9F2D292A1B1AB2004E5957 /* FirstProductCreatedView.swift in Sources */,
 				02D29A9229F7C39200473D6D /* UIImage+Text.swift in Sources */,
@@ -6975,9 +7060,16 @@
 				B56C721421B5BBC000E5E85B /* MockStoresManager.swift in Sources */,
 				EE2A57D929E39A9C009F61E1 /* CaseIterable+HelpersTests.swift in Sources */,
 				D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */,
+				EEBDF7E72A31A59F00EFEF47 /* FirstProductCreatedViewModelTests.swift in Sources */,
+				8697AFBD2B60F56A00EFAF21 /* BlazeAdDestinationSettingViewModelTests.swift in Sources */,
+				D8025496265530E0001B2CC1 /* CardPresentModalFoundReaderTests.swift in Sources */,
+				DEE183ED292BD900008818AB /* JetpackSetupViewModelTests.swift in Sources */,
+				983521AFF082F78FC8D7BA5C /* JetpackConnectionServiceTests.swift in Sources */,
+				71E7782632CC7D5213733333 /* MockJetpackConnectionService.swift in Sources */,
+				028E19BC2805BD22001C36E0 /* RefundSubmissionUseCaseTests.swift in Sources */,
+				02645D8C27BA342D0065DC68 /* InboxNoteRowViewModelTests.swift in Sources */,
 				D85136D5231E40B500DD0539 /* ProductReviewTableViewCellTests.swift in Sources */,
 				021125B82578ECF10075AD2A /* BoldableTextParserTests.swift in Sources */,
-				4569D3F425DC1BFF00CDC3E2 /* ShippingLabelFormViewModelTests.swift in Sources */,
 				57F2C6CD246DECC10074063B /* SummaryTableViewCellViewModelTests.swift in Sources */,
 				DEDA8DC02B19CDC50076BF0F /* ThemeSettingViewModelTests.swift in Sources */,
 				CE7CEC2D2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackConnectionServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackConnectionServiceTests.swift
@@ -19,49 +19,53 @@ final class JetpackConnectionServiceTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Tests
+    // MARK: - evaluateAndConnect
 
-    func test_connect_completes_full_flow() async throws {
+    func test_evaluateAndConnect_returns_alreadyConnected_when_user_has_email() async throws {
         // Given
-        let service = JetpackConnectionService(stores: stores)
-        let connectionData = JetpackConnectionData.fake().copy(isRegistered: false)
+        let service = JetpackConnectionService(stores: stores, delayBeforeRetry: 0)
+        let data = JetpackConnectionData.fake().copy(
+            currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "user@example.com"))
+        )
 
-        var triggeredRegister = false
-        var triggeredProvision = false
-        var triggeredFinalize = false
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
-            case .registerSite(let completion):
-                triggeredRegister = true
-                completion(.success(123))
-            case .provisionConnection(let completion):
-                triggeredProvision = true
-                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
-            case let .finalizeConnection(_, _, _, _, completion):
-                triggeredFinalize = true
-                completion(.success(()))
+            case .fetchJetpackConnectionData(let completion):
+                completion(.success(data))
             default:
                 break
             }
         }
 
         // When
-        try await service.connect(with: connectionData, siteURL: testURL, credentials: credentials)
+        let outcome = try await service.evaluateAndConnect(siteURL: testURL, credentials: credentials)
 
         // Then
-        XCTAssertTrue(triggeredRegister)
-        XCTAssertTrue(triggeredProvision)
-        XCTAssertTrue(triggeredFinalize)
+        guard case .alreadyConnected(let email) = outcome else {
+            return XCTFail("Expected .alreadyConnected, got \(outcome)")
+        }
+        XCTAssertEqual(email, "user@example.com")
     }
 
-    func test_connect_skips_register_when_registered_with_blogID() async throws {
+    func test_evaluateAndConnect_performs_native_connect_when_isRegistered_is_true() async throws {
         // Given
-        let service = JetpackConnectionService(stores: stores)
-        let connectionData = JetpackConnectionData.fake().copy(isRegistered: true, blogID: 456)
+        let service = JetpackConnectionService(stores: stores, delayBeforeRetry: 0)
+        let initialData = JetpackConnectionData.fake().copy(isRegistered: true, blogID: 123)
+        let verifiedData = JetpackConnectionData.fake().copy(
+            currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "user@example.com"))
+        )
 
         var triggeredRegister = false
+        var fetchCount = 0
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
+            case .fetchJetpackConnectionData(let completion):
+                fetchCount += 1
+                if fetchCount == 1 {
+                    completion(.success(initialData))
+                } else {
+                    completion(.success(verifiedData))
+                }
             case .registerSite:
                 triggeredRegister = true
             case .provisionConnection(let completion):
@@ -74,22 +78,135 @@ final class JetpackConnectionServiceTests: XCTestCase {
         }
 
         // When
-        try await service.connect(with: connectionData, siteURL: testURL, credentials: credentials)
+        let outcome = try await service.evaluateAndConnect(siteURL: testURL, credentials: credentials)
 
         // Then
+        guard case .connected(let email) = outcome else {
+            return XCTFail("Expected .connected, got \(outcome)")
+        }
+        XCTAssertEqual(email, "user@example.com")
         XCTAssertFalse(triggeredRegister)
     }
 
-    func test_connect_throws_on_provision_failure() async {
+    func test_evaluateAndConnect_registers_site_when_isRegistered_is_false() async throws {
         // Given
-        let service = JetpackConnectionService(stores: stores)
-        let connectionData = JetpackConnectionData.fake().copy(isRegistered: true, blogID: 123)
-        let expectedError = NSError(domain: "Test", code: 500)
+        let service = JetpackConnectionService(stores: stores, delayBeforeRetry: 0)
+        let initialData = JetpackConnectionData.fake().copy(isRegistered: false)
+        let verifiedData = JetpackConnectionData.fake().copy(
+            currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "user@example.com"))
+        )
+
+        var triggeredRegister = false
+        var fetchCount = 0
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .fetchJetpackConnectionData(let completion):
+                fetchCount += 1
+                if fetchCount == 1 {
+                    completion(.success(initialData))
+                } else {
+                    completion(.success(verifiedData))
+                }
+            case .registerSite(let completion):
+                triggeredRegister = true
+                completion(.success(456))
+            case .provisionConnection(let completion):
+                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
+            case let .finalizeConnection(_, _, _, _, completion):
+                completion(.success(()))
+            default:
+                break
+            }
+        }
+
+        // When
+        let outcome = try await service.evaluateAndConnect(siteURL: testURL, credentials: credentials)
+
+        // Then
+        guard case .connected(let email) = outcome else {
+            return XCTFail("Expected .connected, got \(outcome)")
+        }
+        XCTAssertEqual(email, "user@example.com")
+        XCTAssertTrue(triggeredRegister)
+    }
+
+    func test_evaluateAndConnect_returns_webViewRequired_when_isRegistered_nil_and_plugin_installed() async throws {
+        // Given
+        let service = JetpackConnectionService(stores: stores, delayBeforeRetry: 0)
+        let data = JetpackConnectionData.fake().copy(isRegistered: nil)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
+            case .fetchJetpackConnectionData(let completion):
+                completion(.success(data))
+            case .retrieveJetpackPluginDetails(let completion):
+                completion(.success(.fake()))
+            default:
+                break
+            }
+        }
+
+        // When
+        let outcome = try await service.evaluateAndConnect(siteURL: testURL, credentials: credentials)
+
+        // Then
+        guard case .webViewRequired = outcome else {
+            return XCTFail("Expected .webViewRequired, got \(outcome)")
+        }
+    }
+
+    func test_evaluateAndConnect_performs_native_connect_when_isRegistered_nil_and_plugin_not_found() async throws {
+        // Given
+        let service = JetpackConnectionService(stores: stores, delayBeforeRetry: 0)
+        let initialData = JetpackConnectionData.fake().copy(isRegistered: nil, connectionOwner: "owner")
+        let verifiedData = JetpackConnectionData.fake().copy(
+            currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "user@example.com"))
+        )
+
+        var fetchCount = 0
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .fetchJetpackConnectionData(let completion):
+                fetchCount += 1
+                if fetchCount == 1 {
+                    completion(.success(initialData))
+                } else {
+                    completion(.success(verifiedData))
+                }
+            case .retrieveJetpackPluginDetails(let completion):
+                completion(.failure(NSError(domain: "Test", code: 404)))
+            case .registerSite(let completion):
+                completion(.success(789))
             case .provisionConnection(let completion):
-                completion(.failure(expectedError))
+                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
+            case let .finalizeConnection(_, _, _, _, completion):
+                completion(.success(()))
+            default:
+                break
+            }
+        }
+
+        // When
+        let outcome = try await service.evaluateAndConnect(siteURL: testURL, credentials: credentials)
+
+        // Then
+        guard case .connected(let email) = outcome else {
+            return XCTFail("Expected .connected, got \(outcome)")
+        }
+        XCTAssertEqual(email, "user@example.com")
+    }
+
+    func test_evaluateAndConnect_throws_when_plugin_check_fails_with_non_404() async {
+        // Given
+        let service = JetpackConnectionService(stores: stores, delayBeforeRetry: 0)
+        let data = JetpackConnectionData.fake().copy(isRegistered: nil)
+
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .fetchJetpackConnectionData(let completion):
+                completion(.success(data))
+            case .retrieveJetpackPluginDetails(let completion):
+                completion(.failure(NSError(domain: "Test", code: 500)))
             default:
                 break
             }
@@ -97,11 +214,102 @@ final class JetpackConnectionServiceTests: XCTestCase {
 
         // When
         do {
-            try await service.connect(with: connectionData, siteURL: testURL, credentials: credentials)
+            _ = try await service.evaluateAndConnect(siteURL: testURL, credentials: credentials)
             XCTFail("Expected error to be thrown")
         } catch {
             // Then
             XCTAssertEqual((error as NSError).code, 500)
         }
+    }
+
+    // MARK: - verifyConnection
+
+    func test_verifyConnection_retries_then_succeeds() async throws {
+        // Given
+        let service = JetpackConnectionService(stores: stores, maxRetryCount: 2, delayBeforeRetry: 0)
+        let noEmailData = JetpackConnectionData.fake().copy(
+            currentUser: .fake().copy(isConnected: true, wpcomUser: nil)
+        )
+        let emailData = JetpackConnectionData.fake().copy(
+            currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "user@example.com"))
+        )
+
+        var fetchCount = 0
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .fetchJetpackConnectionData(let completion):
+                fetchCount += 1
+                if fetchCount <= 2 {
+                    completion(.success(noEmailData))
+                } else {
+                    completion(.success(emailData))
+                }
+            default:
+                break
+            }
+        }
+
+        // When
+        let email = try await service.verifyConnection()
+
+        // Then
+        XCTAssertEqual(email, "user@example.com")
+        XCTAssertEqual(fetchCount, 3)
+    }
+
+    func test_verifyConnection_throws_after_max_retries() async {
+        // Given
+        let service = JetpackConnectionService(stores: stores, maxRetryCount: 2, delayBeforeRetry: 0)
+        let noEmailData = JetpackConnectionData.fake().copy(
+            currentUser: .fake().copy(isConnected: true, wpcomUser: nil)
+        )
+
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .fetchJetpackConnectionData(let completion):
+                completion(.success(noEmailData))
+            default:
+                break
+            }
+        }
+
+        // When
+        do {
+            _ = try await service.verifyConnection()
+            XCTFail("Expected error to be thrown")
+        } catch {
+            // Then
+            XCTAssertTrue(error is JetpackConnectionServiceError)
+        }
+    }
+
+    func test_verifyConnection_retries_on_fetch_error_then_succeeds() async throws {
+        // Given
+        let service = JetpackConnectionService(stores: stores, maxRetryCount: 2, delayBeforeRetry: 0)
+        let emailData = JetpackConnectionData.fake().copy(
+            currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "user@example.com"))
+        )
+
+        var fetchCount = 0
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .fetchJetpackConnectionData(let completion):
+                fetchCount += 1
+                if fetchCount == 1 {
+                    completion(.failure(NSError(domain: "Test", code: -1001)))
+                } else {
+                    completion(.success(emailData))
+                }
+            default:
+                break
+            }
+        }
+
+        // When
+        let email = try await service.verifyConnection()
+
+        // Then
+        XCTAssertEqual(email, "user@example.com")
+        XCTAssertEqual(fetchCount, 2)
     }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackConnectionServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackConnectionServiceTests.swift
@@ -21,42 +21,42 @@ final class JetpackConnectionServiceTests: XCTestCase {
 
     // MARK: - Tests
 
-    func test_connect_returns_email_on_success() async throws {
+    func test_connect_completes_full_flow() async throws {
         // Given
-        let service = JetpackConnectionService(stores: stores, maxRetryCount: 2, retryDelay: 0)
+        let service = JetpackConnectionService(stores: stores)
         let connectionData = JetpackConnectionData.fake().copy(isRegistered: false)
 
-        var fetchCount = 0
+        var triggeredRegister = false
+        var triggeredProvision = false
+        var triggeredFinalize = false
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .registerSite(let completion):
+                triggeredRegister = true
                 completion(.success(123))
             case .provisionConnection(let completion):
+                triggeredProvision = true
                 completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
             case let .finalizeConnection(_, _, _, _, completion):
+                triggeredFinalize = true
                 completion(.success(()))
-            case .fetchJetpackConnectionData(let completion):
-                fetchCount += 1
-                let data = JetpackConnectionData.fake().copy(
-                    currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@mail.com"))
-                )
-                completion(.success(data))
             default:
                 break
             }
         }
 
         // When
-        let email = try await service.connect(with: connectionData, siteURL: testURL, credentials: credentials)
+        try await service.connect(with: connectionData, siteURL: testURL, credentials: credentials)
 
         // Then
-        XCTAssertEqual(email, "test@mail.com")
-        XCTAssertEqual(fetchCount, 1) // Verify step fetched once
+        XCTAssertTrue(triggeredRegister)
+        XCTAssertTrue(triggeredProvision)
+        XCTAssertTrue(triggeredFinalize)
     }
 
     func test_connect_skips_register_when_registered_with_blogID() async throws {
         // Given
-        let service = JetpackConnectionService(stores: stores, maxRetryCount: 2, retryDelay: 0)
+        let service = JetpackConnectionService(stores: stores)
         let connectionData = JetpackConnectionData.fake().copy(isRegistered: true, blogID: 456)
 
         var triggeredRegister = false
@@ -68,27 +68,21 @@ final class JetpackConnectionServiceTests: XCTestCase {
                 completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
             case let .finalizeConnection(_, _, _, _, completion):
                 completion(.success(()))
-            case .fetchJetpackConnectionData(let completion):
-                let data = JetpackConnectionData.fake().copy(
-                    currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@mail.com"))
-                )
-                completion(.success(data))
             default:
                 break
             }
         }
 
         // When
-        let email = try await service.connect(with: connectionData, siteURL: testURL, credentials: credentials)
+        try await service.connect(with: connectionData, siteURL: testURL, credentials: credentials)
 
         // Then
-        XCTAssertEqual(email, "test@mail.com")
         XCTAssertFalse(triggeredRegister)
     }
 
     func test_connect_throws_on_provision_failure() async {
         // Given
-        let service = JetpackConnectionService(stores: stores, maxRetryCount: 2, retryDelay: 0)
+        let service = JetpackConnectionService(stores: stores)
         let connectionData = JetpackConnectionData.fake().copy(isRegistered: true, blogID: 123)
         let expectedError = NSError(domain: "Test", code: 500)
 
@@ -103,43 +97,11 @@ final class JetpackConnectionServiceTests: XCTestCase {
 
         // When
         do {
-            _ = try await service.connect(with: connectionData, siteURL: testURL, credentials: credentials)
+            try await service.connect(with: connectionData, siteURL: testURL, credentials: credentials)
             XCTFail("Expected error to be thrown")
         } catch {
             // Then
             XCTAssertEqual((error as NSError).code, 500)
-        }
-    }
-
-    func test_connect_throws_verificationFailed_after_max_retries() async {
-        // Given
-        let service = JetpackConnectionService(stores: stores, maxRetryCount: 2, retryDelay: 0)
-        let connectionData = JetpackConnectionData.fake().copy(isRegistered: true, blogID: 123)
-
-        var fetchCount = 0
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .provisionConnection(let completion):
-                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
-            case let .finalizeConnection(_, _, _, _, completion):
-                completion(.success(()))
-            case .fetchJetpackConnectionData(let completion):
-                fetchCount += 1
-                // Always return no wpcomUser
-                completion(.success(.fake().copy(currentUser: .fake().copy(isConnected: true, wpcomUser: nil))))
-            default:
-                break
-            }
-        }
-
-        // When
-        do {
-            _ = try await service.connect(with: connectionData, siteURL: testURL, credentials: credentials)
-            XCTFail("Expected verificationFailed error")
-        } catch {
-            // Then
-            XCTAssertTrue(error is JetpackConnectionServiceError)
-            XCTAssertEqual(fetchCount, 3) // initial + 2 retries
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackConnectionServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackConnectionServiceTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+@MainActor
+final class JetpackConnectionServiceTests: XCTestCase {
+    private let testURL = "https://example.com"
+    private let credentials = Credentials.wpcom(username: "test", authToken: "secret", siteAddress: "https://example.com")
+
+    private var stores: MockStoresManager!
+
+    override func setUp() {
+        super.setUp()
+        stores = MockStoresManager(sessionManager: .makeForTesting())
+    }
+
+    override func tearDown() {
+        stores = nil
+        super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    func test_connect_returns_email_on_success() async throws {
+        // Given
+        let service = JetpackConnectionService(stores: stores, maxRetryCount: 2, retryDelay: 0)
+        let connectionData = JetpackConnectionData.fake().copy(isRegistered: false)
+
+        var fetchCount = 0
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .registerSite(let completion):
+                completion(.success(123))
+            case .provisionConnection(let completion):
+                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
+            case let .finalizeConnection(_, _, _, _, completion):
+                completion(.success(()))
+            case .fetchJetpackConnectionData(let completion):
+                fetchCount += 1
+                let data = JetpackConnectionData.fake().copy(
+                    currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@mail.com"))
+                )
+                completion(.success(data))
+            default:
+                break
+            }
+        }
+
+        // When
+        let email = try await service.connect(with: connectionData, siteURL: testURL, credentials: credentials)
+
+        // Then
+        XCTAssertEqual(email, "test@mail.com")
+        XCTAssertEqual(fetchCount, 1) // Verify step fetched once
+    }
+
+    func test_connect_skips_register_when_registered_with_blogID() async throws {
+        // Given
+        let service = JetpackConnectionService(stores: stores, maxRetryCount: 2, retryDelay: 0)
+        let connectionData = JetpackConnectionData.fake().copy(isRegistered: true, blogID: 456)
+
+        var triggeredRegister = false
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .registerSite:
+                triggeredRegister = true
+            case .provisionConnection(let completion):
+                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
+            case let .finalizeConnection(_, _, _, _, completion):
+                completion(.success(()))
+            case .fetchJetpackConnectionData(let completion):
+                let data = JetpackConnectionData.fake().copy(
+                    currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@mail.com"))
+                )
+                completion(.success(data))
+            default:
+                break
+            }
+        }
+
+        // When
+        let email = try await service.connect(with: connectionData, siteURL: testURL, credentials: credentials)
+
+        // Then
+        XCTAssertEqual(email, "test@mail.com")
+        XCTAssertFalse(triggeredRegister)
+    }
+
+    func test_connect_throws_on_provision_failure() async {
+        // Given
+        let service = JetpackConnectionService(stores: stores, maxRetryCount: 2, retryDelay: 0)
+        let connectionData = JetpackConnectionData.fake().copy(isRegistered: true, blogID: 123)
+        let expectedError = NSError(domain: "Test", code: 500)
+
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .provisionConnection(let completion):
+                completion(.failure(expectedError))
+            default:
+                break
+            }
+        }
+
+        // When
+        do {
+            _ = try await service.connect(with: connectionData, siteURL: testURL, credentials: credentials)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            // Then
+            XCTAssertEqual((error as NSError).code, 500)
+        }
+    }
+
+    func test_connect_throws_verificationFailed_after_max_retries() async {
+        // Given
+        let service = JetpackConnectionService(stores: stores, maxRetryCount: 2, retryDelay: 0)
+        let connectionData = JetpackConnectionData.fake().copy(isRegistered: true, blogID: 123)
+
+        var fetchCount = 0
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .provisionConnection(let completion):
+                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
+            case let .finalizeConnection(_, _, _, _, completion):
+                completion(.success(()))
+            case .fetchJetpackConnectionData(let completion):
+                fetchCount += 1
+                // Always return no wpcomUser
+                completion(.success(.fake().copy(currentUser: .fake().copy(isConnected: true, wpcomUser: nil))))
+            default:
+                break
+            }
+        }
+
+        // When
+        do {
+            _ = try await service.connect(with: connectionData, siteURL: testURL, credentials: credentials)
+            XCTFail("Expected verificationFailed error")
+        } catch {
+            // Then
+            XCTAssertTrue(error is JetpackConnectionServiceError)
+            XCTAssertEqual(fetchCount, 3) // initial + 2 retries
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackConnectionServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackConnectionServiceTests.swift
@@ -5,9 +5,15 @@ import Yosemite
 @MainActor
 final class JetpackConnectionServiceTests: XCTestCase {
     private let testURL = "https://example.com"
+    private let testEmail = "user@example.com"
     private let credentials = Credentials.wpcom(username: "test", authToken: "secret", siteAddress: "https://example.com")
 
     private var stores: MockStoresManager!
+
+    /// Connection data representing a fully-connected user with email.
+    private var connectedData: JetpackConnectionData {
+        .fake().copy(currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: testEmail)))
+    }
 
     override func setUp() {
         super.setUp()
@@ -23,17 +29,10 @@ final class JetpackConnectionServiceTests: XCTestCase {
 
     func test_evaluateAndConnect_returns_alreadyConnected_when_user_has_email() async throws {
         // Given
-        let service = JetpackConnectionService(stores: stores, delayBeforeRetry: 0)
-        let data = JetpackConnectionData.fake().copy(
-            currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "user@example.com"))
-        )
-
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .fetchJetpackConnectionData(let completion):
-                completion(.success(data))
-            default:
-                break
+        let service = makeService()
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { [connectedData] action in
+            if case .fetchJetpackConnectionData(let completion) = action {
+                completion(.success(connectedData))
             }
         }
 
@@ -44,101 +43,30 @@ final class JetpackConnectionServiceTests: XCTestCase {
         guard case .alreadyConnected(let email) = outcome else {
             return XCTFail("Expected .alreadyConnected, got \(outcome)")
         }
-        XCTAssertEqual(email, "user@example.com")
+        XCTAssertEqual(email, testEmail)
     }
 
     func test_evaluateAndConnect_performs_native_connect_when_isRegistered_is_true() async throws {
-        // Given
-        let service = JetpackConnectionService(stores: stores, delayBeforeRetry: 0)
-        let initialData = JetpackConnectionData.fake().copy(isRegistered: true, blogID: 123)
-        let verifiedData = JetpackConnectionData.fake().copy(
-            currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "user@example.com"))
+        try await assertNativeConnect(
+            initialData: .fake().copy(isRegistered: true, blogID: 123),
+            expectsRegister: false
         )
-
-        var triggeredRegister = false
-        var fetchCount = 0
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .fetchJetpackConnectionData(let completion):
-                fetchCount += 1
-                if fetchCount == 1 {
-                    completion(.success(initialData))
-                } else {
-                    completion(.success(verifiedData))
-                }
-            case .registerSite:
-                triggeredRegister = true
-            case .provisionConnection(let completion):
-                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
-            case let .finalizeConnection(_, _, _, _, completion):
-                completion(.success(()))
-            default:
-                break
-            }
-        }
-
-        // When
-        let outcome = try await service.evaluateAndConnect(siteURL: testURL, credentials: credentials)
-
-        // Then
-        guard case .connected(let email) = outcome else {
-            return XCTFail("Expected .connected, got \(outcome)")
-        }
-        XCTAssertEqual(email, "user@example.com")
-        XCTAssertFalse(triggeredRegister)
     }
 
     func test_evaluateAndConnect_registers_site_when_isRegistered_is_false() async throws {
-        // Given
-        let service = JetpackConnectionService(stores: stores, delayBeforeRetry: 0)
-        let initialData = JetpackConnectionData.fake().copy(isRegistered: false)
-        let verifiedData = JetpackConnectionData.fake().copy(
-            currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "user@example.com"))
+        try await assertNativeConnect(
+            initialData: .fake().copy(isRegistered: false),
+            expectsRegister: true
         )
-
-        var triggeredRegister = false
-        var fetchCount = 0
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .fetchJetpackConnectionData(let completion):
-                fetchCount += 1
-                if fetchCount == 1 {
-                    completion(.success(initialData))
-                } else {
-                    completion(.success(verifiedData))
-                }
-            case .registerSite(let completion):
-                triggeredRegister = true
-                completion(.success(456))
-            case .provisionConnection(let completion):
-                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
-            case let .finalizeConnection(_, _, _, _, completion):
-                completion(.success(()))
-            default:
-                break
-            }
-        }
-
-        // When
-        let outcome = try await service.evaluateAndConnect(siteURL: testURL, credentials: credentials)
-
-        // Then
-        guard case .connected(let email) = outcome else {
-            return XCTFail("Expected .connected, got \(outcome)")
-        }
-        XCTAssertEqual(email, "user@example.com")
-        XCTAssertTrue(triggeredRegister)
     }
 
     func test_evaluateAndConnect_returns_webViewRequired_when_isRegistered_nil_and_plugin_installed() async throws {
         // Given
-        let service = JetpackConnectionService(stores: stores, delayBeforeRetry: 0)
-        let data = JetpackConnectionData.fake().copy(isRegistered: nil)
-
+        let service = makeService()
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .fetchJetpackConnectionData(let completion):
-                completion(.success(data))
+                completion(.success(.fake().copy(isRegistered: nil)))
             case .retrieveJetpackPluginDetails(let completion):
                 completion(.success(.fake()))
             default:
@@ -156,55 +84,23 @@ final class JetpackConnectionServiceTests: XCTestCase {
     }
 
     func test_evaluateAndConnect_performs_native_connect_when_isRegistered_nil_and_plugin_not_found() async throws {
-        // Given
-        let service = JetpackConnectionService(stores: stores, delayBeforeRetry: 0)
-        let initialData = JetpackConnectionData.fake().copy(isRegistered: nil, connectionOwner: "owner")
-        let verifiedData = JetpackConnectionData.fake().copy(
-            currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "user@example.com"))
-        )
-
-        var fetchCount = 0
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .fetchJetpackConnectionData(let completion):
-                fetchCount += 1
-                if fetchCount == 1 {
-                    completion(.success(initialData))
-                } else {
-                    completion(.success(verifiedData))
-                }
-            case .retrieveJetpackPluginDetails(let completion):
+        try await assertNativeConnect(
+            initialData: .fake().copy(isRegistered: nil, connectionOwner: "owner"),
+            expectsRegister: true
+        ) { action in
+            if case .retrieveJetpackPluginDetails(let completion) = action {
                 completion(.failure(NSError(domain: "Test", code: 404)))
-            case .registerSite(let completion):
-                completion(.success(789))
-            case .provisionConnection(let completion):
-                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
-            case let .finalizeConnection(_, _, _, _, completion):
-                completion(.success(()))
-            default:
-                break
             }
         }
-
-        // When
-        let outcome = try await service.evaluateAndConnect(siteURL: testURL, credentials: credentials)
-
-        // Then
-        guard case .connected(let email) = outcome else {
-            return XCTFail("Expected .connected, got \(outcome)")
-        }
-        XCTAssertEqual(email, "user@example.com")
     }
 
     func test_evaluateAndConnect_throws_when_plugin_check_fails_with_non_404() async {
         // Given
-        let service = JetpackConnectionService(stores: stores, delayBeforeRetry: 0)
-        let data = JetpackConnectionData.fake().copy(isRegistered: nil)
-
+        let service = makeService()
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .fetchJetpackConnectionData(let completion):
-                completion(.success(data))
+                completion(.success(.fake().copy(isRegistered: nil)))
             case .retrieveJetpackPluginDetails(let completion):
                 completion(.failure(NSError(domain: "Test", code: 500)))
             default:
@@ -226,26 +122,14 @@ final class JetpackConnectionServiceTests: XCTestCase {
 
     func test_verifyConnection_retries_then_succeeds() async throws {
         // Given
-        let service = JetpackConnectionService(stores: stores, maxRetryCount: 2, delayBeforeRetry: 0)
-        let noEmailData = JetpackConnectionData.fake().copy(
-            currentUser: .fake().copy(isConnected: true, wpcomUser: nil)
-        )
-        let emailData = JetpackConnectionData.fake().copy(
-            currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "user@example.com"))
-        )
+        let service = makeService()
+        let noEmailData = JetpackConnectionData.fake().copy(currentUser: .fake().copy(isConnected: true, wpcomUser: nil))
 
         var fetchCount = 0
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .fetchJetpackConnectionData(let completion):
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { [connectedData] action in
+            if case .fetchJetpackConnectionData(let completion) = action {
                 fetchCount += 1
-                if fetchCount <= 2 {
-                    completion(.success(noEmailData))
-                } else {
-                    completion(.success(emailData))
-                }
-            default:
-                break
+                completion(.success(fetchCount <= 2 ? noEmailData : connectedData))
             }
         }
 
@@ -253,23 +137,18 @@ final class JetpackConnectionServiceTests: XCTestCase {
         let email = try await service.verifyConnection()
 
         // Then
-        XCTAssertEqual(email, "user@example.com")
+        XCTAssertEqual(email, testEmail)
         XCTAssertEqual(fetchCount, 3)
     }
 
     func test_verifyConnection_throws_after_max_retries() async {
         // Given
-        let service = JetpackConnectionService(stores: stores, maxRetryCount: 2, delayBeforeRetry: 0)
-        let noEmailData = JetpackConnectionData.fake().copy(
-            currentUser: .fake().copy(isConnected: true, wpcomUser: nil)
-        )
+        let service = makeService()
+        let noEmailData = JetpackConnectionData.fake().copy(currentUser: .fake().copy(isConnected: true, wpcomUser: nil))
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .fetchJetpackConnectionData(let completion):
+            if case .fetchJetpackConnectionData(let completion) = action {
                 completion(.success(noEmailData))
-            default:
-                break
             }
         }
 
@@ -285,23 +164,17 @@ final class JetpackConnectionServiceTests: XCTestCase {
 
     func test_verifyConnection_retries_on_fetch_error_then_succeeds() async throws {
         // Given
-        let service = JetpackConnectionService(stores: stores, maxRetryCount: 2, delayBeforeRetry: 0)
-        let emailData = JetpackConnectionData.fake().copy(
-            currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "user@example.com"))
-        )
+        let service = makeService()
 
         var fetchCount = 0
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .fetchJetpackConnectionData(let completion):
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { [connectedData] action in
+            if case .fetchJetpackConnectionData(let completion) = action {
                 fetchCount += 1
                 if fetchCount == 1 {
                     completion(.failure(NSError(domain: "Test", code: -1001)))
                 } else {
-                    completion(.success(emailData))
+                    completion(.success(connectedData))
                 }
-            default:
-                break
             }
         }
 
@@ -309,7 +182,53 @@ final class JetpackConnectionServiceTests: XCTestCase {
         let email = try await service.verifyConnection()
 
         // Then
-        XCTAssertEqual(email, "user@example.com")
+        XCTAssertEqual(email, testEmail)
         XCTAssertEqual(fetchCount, 2)
+    }
+}
+
+// MARK: - Helpers
+private extension JetpackConnectionServiceTests {
+    func makeService(maxRetryCount: Int = 2) -> JetpackConnectionService {
+        JetpackConnectionService(stores: stores, maxRetryCount: maxRetryCount, delayBeforeRetry: 0)
+    }
+
+    /// Asserts that `evaluateAndConnect` performs a full native connection flow.
+    /// - Parameters:
+    ///   - initialData: The connection data returned on the first fetch.
+    ///   - expectsRegister: Whether `registerSite` should be triggered.
+    ///   - extraHandler: Optional handler for additional actions (e.g. `retrieveJetpackPluginDetails`).
+    func assertNativeConnect(
+        initialData: JetpackConnectionData,
+        expectsRegister: Bool,
+        extraHandler: ((JetpackConnectionAction) -> Void)? = nil
+    ) async throws {
+        let service = makeService()
+        var triggeredRegister = false
+        var fetchCount = 0
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { [connectedData] action in
+            switch action {
+            case .fetchJetpackConnectionData(let completion):
+                fetchCount += 1
+                completion(.success(fetchCount == 1 ? initialData : connectedData))
+            case .registerSite(let completion):
+                triggeredRegister = true
+                completion(.success(456))
+            case .provisionConnection(let completion):
+                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
+            case let .finalizeConnection(_, _, _, _, completion):
+                completion(.success(()))
+            default:
+                extraHandler?(action)
+            }
+        }
+
+        let outcome = try await service.evaluateAndConnect(siteURL: testURL, credentials: credentials)
+
+        guard case .connected(let email) = outcome else {
+            return XCTFail("Expected .connected, got \(outcome)")
+        }
+        XCTAssertEqual(email, testEmail)
+        XCTAssertEqual(triggeredRegister, expectsRegister)
     }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupViewModelTests.swift
@@ -234,19 +234,8 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_shouldShowGoToStoreButton_is_correct() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
-
-        let data = JetpackConnectionData.fake().copy(
-            currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@mail.com"))
-        )
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .fetchJetpackConnectionData(let completion):
-                completion(.success(data))
-            default:
-                break
-            }
-        }
+        let mockService = MockJetpackConnectionService()
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, connectionService: mockService, delayBeforeRetry: 0)
 
         // When
         viewModel.startSetup()
@@ -258,6 +247,9 @@ final class JetpackSetupViewModelTests: XCTestCase {
         viewModel.didAuthorizeJetpackConnection()
 
         // Then
+        waitUntil {
+            viewModel.shouldShowGoToStoreButton
+        }
         XCTAssertTrue(viewModel.shouldShowGoToStoreButton)
     }
 
@@ -265,7 +257,8 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_startSetup_triggers_connection_step_if_connectionOnly_is_true() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let mockService = MockJetpackConnectionService()
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores, connectionService: mockService, delayBeforeRetry: 0)
         let testConnectionURL = try XCTUnwrap(URL(string: "https://jetpack.wordpress.com/jetpack.authorize"))
 
         var triggeredRetrieveJetpackPluginDetails = false
@@ -304,12 +297,18 @@ final class JetpackSetupViewModelTests: XCTestCase {
         XCTAssertFalse(triggeredActivation)
         XCTAssertFalse(triggeredConnectionURL)
         XCTAssertTrue(triggeredConnection)
+        waitUntil {
+            mockService.connectCallCount > 0
+        }
+        XCTAssertEqual(mockService.connectCallCount, 1)
+        XCTAssertEqual(mockService.lastConnectionData?.isRegistered, false)
     }
 
     func test_startSetup_triggers_installation_steps_if_connectionOnly_is_false() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let mockService = MockJetpackConnectionService()
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, connectionService: mockService, delayBeforeRetry: 0)
 
         var triggeredRetrieveJetpackPluginDetails = false
         var triggeredInstallation = false
@@ -343,6 +342,11 @@ final class JetpackSetupViewModelTests: XCTestCase {
         XCTAssertTrue(triggeredInstallation)
         XCTAssertTrue(triggeredActivation)
         XCTAssertTrue(triggeredConnection)
+        waitUntil {
+            mockService.connectCallCount > 0
+        }
+        XCTAssertEqual(mockService.connectCallCount, 1)
+        XCTAssertEqual(mockService.lastConnectionData?.isRegistered, false)
     }
 
     func test_startSetup_triggers_jetpack_installation_if_retrieving_details_fails_with_404() {
@@ -412,12 +416,12 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_startSetup_triggers_jetpack_connection_if_retrieving_details_returns_active_jetpack() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let mockService = MockJetpackConnectionService()
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, connectionService: mockService, delayBeforeRetry: 0)
         let plugin = SitePlugin.fake().copy(plugin: "Jetpack", status: .active)
 
         var triggeredInstallation = false
         var triggeredActivation = false
-        var triggeredConnection = false
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
@@ -428,8 +432,6 @@ final class JetpackSetupViewModelTests: XCTestCase {
                 triggeredActivation = true
             case .fetchJetpackConnectionData(let completion):
                 completion(.success(.fake().copy(isRegistered: true, blogID: 123)))
-            case .provisionConnection:
-                triggeredConnection = true
             default:
                 break
             }
@@ -445,7 +447,12 @@ final class JetpackSetupViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isSetupStepPending(.done))
         XCTAssertFalse(triggeredInstallation)
         XCTAssertFalse(triggeredActivation)
-        XCTAssertTrue(triggeredConnection)
+        waitUntil {
+            mockService.connectCallCount > 0
+        }
+        XCTAssertEqual(mockService.connectCallCount, 1)
+        XCTAssertEqual(mockService.lastConnectionData?.isRegistered, true)
+        XCTAssertEqual(mockService.lastConnectionData?.blogID, 123)
     }
 
     func test_installation_triggers_activation_when_completing_successfully() {
@@ -486,13 +493,11 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_activation_success_triggers_all_connection_apis_if_isRegistered_is_false() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let mockService = MockJetpackConnectionService()
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, connectionService: mockService, delayBeforeRetry: 0)
 
         var fetchedConnectionData = false
         var triggeredConnectionURL = false
-        var triggeredRegisterSite = false
-        var triggeredProvisionConnection = false
-        var triggeredFinalizeConnection = false
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
@@ -505,15 +510,6 @@ final class JetpackSetupViewModelTests: XCTestCase {
             case .fetchJetpackConnectionData(let completion):
                 fetchedConnectionData = true
                 completion(.success(.fake().copy(isRegistered: false)))
-            case .registerSite(let completion):
-                triggeredRegisterSite = true
-                completion(.success(124))
-            case .provisionConnection(let completion):
-                triggeredProvisionConnection = true
-                completion(.success(JetpackConnectionProvisionResponse(userId: 131, scope: "test", secret: "secret")))
-            case let .finalizeConnection(_, _, _, _, completion):
-                triggeredFinalizeConnection = true
-                completion(.success(()))
             case .fetchJetpackConnectionURL:
                 triggeredConnectionURL = true
             default:
@@ -527,21 +523,21 @@ final class JetpackSetupViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(fetchedConnectionData)
         XCTAssertFalse(triggeredConnectionURL)
-        XCTAssertTrue(triggeredRegisterSite)
-        XCTAssertTrue(triggeredProvisionConnection)
-        XCTAssertTrue(triggeredFinalizeConnection)
+        waitUntil {
+            mockService.connectCallCount > 0
+        }
+        XCTAssertEqual(mockService.connectCallCount, 1)
+        XCTAssertEqual(mockService.lastConnectionData?.isRegistered, false)
     }
 
     func test_activation_success_triggers_all_connection_apis_except_register_if_isRegistered_is_true() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let mockService = MockJetpackConnectionService()
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, connectionService: mockService, delayBeforeRetry: 0)
 
         var fetchedConnectionData = false
         var triggeredConnectionURL = false
-        var triggeredRegisterSite = false
-        var triggeredProvisionConnection = false
-        var triggeredFinalizeConnection = false
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
@@ -554,14 +550,6 @@ final class JetpackSetupViewModelTests: XCTestCase {
             case .fetchJetpackConnectionData(let completion):
                 fetchedConnectionData = true
                 completion(.success(.fake().copy(isRegistered: true, blogID: 124)))
-            case .registerSite:
-                triggeredRegisterSite = true
-            case .provisionConnection(let completion):
-                triggeredProvisionConnection = true
-                completion(.success(JetpackConnectionProvisionResponse(userId: 131, scope: "test", secret: "secret")))
-            case let .finalizeConnection(_, _, _, _, completion):
-                triggeredFinalizeConnection = true
-                completion(.success(()))
             case .fetchJetpackConnectionURL:
                 triggeredConnectionURL = true
             default:
@@ -575,9 +563,12 @@ final class JetpackSetupViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(fetchedConnectionData)
         XCTAssertFalse(triggeredConnectionURL)
-        XCTAssertFalse(triggeredRegisterSite)
-        XCTAssertTrue(triggeredProvisionConnection)
-        XCTAssertTrue(triggeredFinalizeConnection)
+        waitUntil {
+            mockService.connectCallCount > 0
+        }
+        XCTAssertEqual(mockService.connectCallCount, 1)
+        XCTAssertEqual(mockService.lastConnectionData?.isRegistered, true)
+        XCTAssertEqual(mockService.lastConnectionData?.blogID, 124)
     }
 
     func test_activation_triggers_fetching_connection_url_when_site_has_outdated_jetpack() {
@@ -669,52 +660,37 @@ final class JetpackSetupViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.jetpackConnectionURL, URL(string: expectedURL))
     }
 
-    func test_authorizeJetpackConnection_sets_connection_status_to_in_progress_and_triggers_fetching_jetpack_connection() {
+    func test_authorizeJetpackConnection_sets_connection_status_to_in_progress_and_triggers_verifying_connection() {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
-
-        var triggeredFetchingJetpackConnection = false
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .fetchJetpackConnectionData:
-                triggeredFetchingJetpackConnection = true
-            default:
-                break
-            }
-        }
+        let mockService = MockJetpackConnectionService()
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, connectionService: mockService, delayBeforeRetry: 0)
 
         // When
         viewModel.didAuthorizeJetpackConnection()
 
         // Then
-        XCTAssertTrue(triggeredFetchingJetpackConnection)
         XCTAssertEqual(viewModel.currentConnectionStep, .inProgress)
+        waitUntil {
+            mockService.verifyCallCount > 0
+        }
+        XCTAssertEqual(mockService.verifyCallCount, 1)
     }
 
-    func test_authorizeJetpackConnection_updates_connection_status_and_setup_step_correctly_when_fetching_jetpack_connection_successfully() {
+    func test_authorizeJetpackConnection_updates_connection_status_and_setup_step_correctly_when_verifying_connection_successfully() {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
-
-        let data = JetpackConnectionData.fake().copy(
-            currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@mail.com"))
-        )
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .fetchJetpackConnectionData(let completion):
-                completion(.success(data))
-            default:
-                break
-            }
-        }
+        let mockService = MockJetpackConnectionService()
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, connectionService: mockService, delayBeforeRetry: 0)
 
         // When
         viewModel.didAuthorizeJetpackConnection()
 
         // Then
+        waitUntil {
+            viewModel.currentConnectionStep == .authorized
+        }
         XCTAssertEqual(viewModel.currentConnectionStep, .authorized)
         XCTAssertEqual(viewModel.currentSetupStep, .done)
+        XCTAssertEqual(mockService.verifyCallCount, 1)
     }
 
     func test_navigateToStore_triggers_storeNavigationHandler() {
@@ -842,14 +818,14 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_register_connection_relays_error_when_failed() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let mockService = MockJetpackConnectionService()
+        mockService.connectResult = .failure(NSError(domain: "Test", code: -1001))
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores, connectionService: mockService, delayBeforeRetry: 0)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .fetchJetpackConnectionData(let completion):
                 completion(.success(.fake().copy(isRegistered: false)))
-            case .registerSite(let completion):
-                completion(.failure(NSError(domain: "Test", code: -1001)))
             default:
                 break
             }
@@ -859,6 +835,9 @@ final class JetpackSetupViewModelTests: XCTestCase {
         viewModel.startSetup()
 
         // Then
+        waitUntil {
+            viewModel.setupFailed
+        }
         XCTAssertTrue(viewModel.setupFailed)
         XCTAssertEqual(viewModel.setupErrorDetail, .init(setupErrorMessage: JetpackSetupViewModel.Localization.genericErrorMessage,
                                                          setupErrorSuggestion: JetpackSetupViewModel.Localization.communicationErrorSuggestion,
@@ -868,14 +847,14 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_provision_connection_relays_error_when_failed() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let mockService = MockJetpackConnectionService()
+        mockService.connectResult = .failure(NSError(domain: "Test", code: -1001))
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores, connectionService: mockService, delayBeforeRetry: 0)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .fetchJetpackConnectionData(let completion):
                 completion(.success(.fake().copy(isRegistered: true, blogID: 123)))
-            case .provisionConnection(let completion):
-                completion(.failure(NSError(domain: "Test", code: -1001)))
             default:
                 break
             }
@@ -885,6 +864,9 @@ final class JetpackSetupViewModelTests: XCTestCase {
         viewModel.startSetup()
 
         // Then
+        waitUntil {
+            viewModel.setupFailed
+        }
         XCTAssertTrue(viewModel.setupFailed)
         XCTAssertEqual(viewModel.setupErrorDetail, .init(setupErrorMessage: JetpackSetupViewModel.Localization.genericErrorMessage,
                                                          setupErrorSuggestion: JetpackSetupViewModel.Localization.communicationErrorSuggestion,
@@ -894,16 +876,14 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_finalize_connection_relays_error_when_failed() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let mockService = MockJetpackConnectionService()
+        mockService.connectResult = .failure(NSError(domain: "Test", code: -1001))
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores, connectionService: mockService, delayBeforeRetry: 0)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .fetchJetpackConnectionData(let completion):
                 completion(.success(.fake().copy(isRegistered: true, blogID: 123)))
-            case .provisionConnection(let completion):
-                completion(.success(JetpackConnectionProvisionResponse(userId: 124, scope: "admin", secret: "secret")))
-            case let .finalizeConnection(_, _, _, _, completion):
-                completion(.failure(NSError(domain: "Test", code: -1001)))
             default:
                 break
             }
@@ -913,6 +893,9 @@ final class JetpackSetupViewModelTests: XCTestCase {
         viewModel.startSetup()
 
         // Then
+        waitUntil {
+            viewModel.setupFailed
+        }
         XCTAssertTrue(viewModel.setupFailed)
         XCTAssertEqual(viewModel.setupErrorDetail, .init(setupErrorMessage: JetpackSetupViewModel.Localization.genericErrorMessage,
                                                          setupErrorSuggestion: JetpackSetupViewModel.Localization.communicationErrorSuggestion,
@@ -950,7 +933,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_checkJetpackConnection_hits_fetchJetpackConnection_3_times_when_encountering_error_consistently_and_relays_error() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
         var fetchJetpackConnectionTriggerCount = 0
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -964,7 +947,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         }
 
         // When
-        viewModel.didAuthorizeJetpackConnection()
+        viewModel.startSetup()
 
         // Then
         waitUntil {
@@ -976,21 +959,11 @@ final class JetpackSetupViewModelTests: XCTestCase {
                                                          errorCode: -1001))
     }
 
-    func test_checkJetpackConnection_hits_fetchJetpackConnectionData_3_times_when_failing_to_fetch_connected_wpcom_user() {
+    func test_didAuthorizeJetpackConnection_relays_verification_error() {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
-        var fetchJetpackConnectionTriggerCount = 0
-
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .fetchJetpackConnectionData(let completion):
-                fetchJetpackConnectionTriggerCount += 1
-                completion(.success(JetpackConnectionData.fake().copy(currentUser: .fake().copy(wpcomUser: nil))))
-            default:
-                break
-            }
-        }
+        let mockService = MockJetpackConnectionService()
+        mockService.verifyResult = .failure(JetpackConnectionServiceError.verificationFailed)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, connectionService: mockService, delayBeforeRetry: 0)
 
         // When
         viewModel.didAuthorizeJetpackConnection()
@@ -999,7 +972,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         waitUntil {
             viewModel.setupFailed
         }
-        XCTAssertEqual(fetchJetpackConnectionTriggerCount, 3)
+        XCTAssertEqual(mockService.verifyCallCount, 1)
         XCTAssertEqual(viewModel.setupErrorDetail, .init(setupErrorMessage: JetpackSetupViewModel.Localization.genericErrorMessage,
                                                          setupErrorSuggestion: JetpackSetupViewModel.Localization.communicationErrorSuggestion,
                                                          errorCode: 99))
@@ -1161,17 +1134,17 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let mockService = MockJetpackConnectionService()
         let viewModel = JetpackSetupViewModel(siteURL: testURL,
                                               connectionOnly: true,
                                               wpcomCredentials: credentials,
                                               stores: stores,
                                               analytics: analytics,
+                                              connectionService: mockService,
                                               delayBeforeRetry: 0)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
-            case .retrieveJetpackPluginDetails(let completion):
-                completion(.success(.fake()))
             case .fetchJetpackConnectionData(let completion):
                 completion(.success(.fake().copy(isRegistered: true, blogID: 123)))
             default:
@@ -1193,22 +1166,20 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let mockService = MockJetpackConnectionService()
+        mockService.connectResult = .failure(NSError(domain: "Test", code: 1))
         let viewModel = JetpackSetupViewModel(siteURL: testURL,
                                               connectionOnly: true,
                                               wpcomCredentials: credentials,
                                               stores: stores,
                                               analytics: analytics,
+                                              connectionService: mockService,
                                               delayBeforeRetry: 0)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
-            case .retrieveJetpackPluginDetails(let completion):
-                completion(.success(.fake()))
             case .fetchJetpackConnectionData(let completion):
                 completion(.success(.fake().copy(isRegistered: true, blogID: 123)))
-            case .provisionConnection(let completion):
-                let error = NSError(domain: "Test", code: 1)
-                completion(.failure(error))
             default:
                 break
             }
@@ -1218,6 +1189,9 @@ final class JetpackSetupViewModelTests: XCTestCase {
         viewModel.startSetup()
 
         // Then
+        waitUntil {
+            viewModel.setupFailed
+        }
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(where: { $0 == "jetpack_setup_flow" }))
         XCTAssertEqual(analyticsProvider.receivedProperties[indexOfEvent]["step"] as? String, "connection")
         XCTAssertEqual(analyticsProvider.receivedProperties[indexOfEvent]["error_code"] as? String, "1")
@@ -1265,27 +1239,20 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let mockService = MockJetpackConnectionService()
         let viewModel = JetpackSetupViewModel(siteURL: testURL,
                                               connectionOnly: true,
                                               wpcomCredentials: credentials,
                                               stores: stores,
                                               analytics: analytics,
+                                              connectionService: mockService,
                                               delayBeforeRetry: 0)
-
-        let data = JetpackConnectionData.fake().copy(
-            currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@mail.com"))
-        )
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .fetchJetpackConnectionData(let completion):
-                completion(.success(data))
-            default:
-                break
-            }
-        }
 
         // When
         viewModel.didAuthorizeJetpackConnection()
+        waitUntil {
+            viewModel.currentSetupStep == .done
+        }
 
         // Then
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(where: { $0 == "jetpack_setup_flow" }))
@@ -1297,11 +1264,14 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let mockService = MockJetpackConnectionService()
+        mockService.connectResult = .failure(JetpackConnectionServiceError.verificationFailed)
         let viewModel = JetpackSetupViewModel(siteURL: testURL,
                                               connectionOnly: true,
                                               wpcomCredentials: credentials,
                                               stores: stores,
                                               analytics: analytics,
+                                              connectionService: mockService,
                                               delayBeforeRetry: 0)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -1313,10 +1283,6 @@ final class JetpackSetupViewModelTests: XCTestCase {
                     blogID: 123
                 )
                 completion(.success(data))
-            case .provisionConnection(let completion):
-                completion(.success(JetpackConnectionProvisionResponse(userId: 124, scope: "admin", secret: "secret")))
-            case let .finalizeConnection(_, _, _, _, completion):
-                completion(.success(()))
             default:
                 break
             }

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupViewModelTests.swift
@@ -17,7 +17,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
     func test_title_is_correct_if_jetpack_installation_is_required() {
         // Given
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials)
 
         // Then
         XCTAssertEqual(viewModel.title, JetpackSetupViewModel.Localization.installingJetpack)
@@ -25,7 +25,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
     func test_title_is_correct_if_only_jetpack_connection_is_missing() {
         // Given
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials)
 
         // Then
         XCTAssertEqual(viewModel.title, JetpackSetupViewModel.Localization.connectingJetpack)
@@ -33,7 +33,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
     func test_description_string_is_correct() {
         // Given
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials)
         let description = String(format: JetpackSetupViewModel.Localization.description, testURL.trimHTTPScheme())
 
         // Then
@@ -43,7 +43,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_isSetupStepFailed_is_correct_when_the_current_step_fails() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
         let plugin = SitePlugin.fake().copy(plugin: "Jetpack", status: .inactive)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -69,7 +69,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_title_is_correct_when_retrieveJetpackPluginDetails_fails_with_permission_error() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
@@ -90,7 +90,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_title_and_tryAgainButtonTitle_are_correct_when_installation_step_fails() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
@@ -114,7 +114,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_title_and_tryAgainButtonTitle_are_correct_when_activation_step_fails() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
         let plugin = SitePlugin.fake().copy(plugin: "Jetpack", status: .inactive)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -139,7 +139,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_title_and_tryAgainButtonTitle_are_correct_when_connection_step_fails() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
@@ -156,6 +156,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
+        waitUntil { viewModel.setupFailed }
 
         // Then
         XCTAssertEqual(viewModel.title, JetpackInstallStep.connection.errorTitle)
@@ -165,7 +166,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_shouldShowInitialLoadingIndicator_turns_on_correctly_when_startSetup_then_returns_true() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
 
         // When
         viewModel.startSetup()
@@ -178,7 +179,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_shouldShowInitialLoadingIndicator_turns_off_correctly_when_retrieveJetpackPluginDetails_is_success_then_returns_false() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
         let plugin = SitePlugin.fake().copy(plugin: "Jetpack", status: .inactive)
 
         // When
@@ -200,7 +201,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_shouldShowSetupSteps_when_startSetup_then_returns_false() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
 
         // When
         viewModel.startSetup()
@@ -213,7 +214,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_shouldShowSetupSteps_when_retrieveJetpackPluginDetails_is_success_then_returns_true() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
         let plugin = SitePlugin.fake().copy(plugin: "Jetpack", status: .inactive)
 
         // When
@@ -234,7 +235,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_shouldShowGoToStoreButton_is_correct() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
 
         let data = JetpackConnectionData.fake().copy(
             currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@mail.com"))
@@ -256,6 +257,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.didAuthorizeJetpackConnection()
+        waitUntil { viewModel.shouldShowGoToStoreButton }
 
         // Then
         XCTAssertTrue(viewModel.shouldShowGoToStoreButton)
@@ -265,9 +267,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_startSetup_triggers_connection_step_if_connectionOnly_is_true() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let mockService = MockJetpackConnectionService()
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials,
-                                                      stores: stores, connectionService: mockService, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores)
         let testConnectionURL = try XCTUnwrap(URL(string: "https://jetpack.wordpress.com/jetpack.authorize"))
 
         var triggeredRetrieveJetpackPluginDetails = false
@@ -275,6 +275,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         var triggeredActivation = false
         var triggeredConnectionURL = false
         var triggeredConnection = false
+        var fetchCount = 0
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
@@ -290,8 +291,21 @@ final class JetpackSetupViewModelTests: XCTestCase {
                 completion(.success(testConnectionURL))
                 triggeredConnectionURL = true
             case .fetchJetpackConnectionData(let completion):
-                completion(.success(.fake().copy(isRegistered: false)))
+                fetchCount += 1
                 triggeredConnection = true
+                if fetchCount == 1 {
+                    completion(.success(.fake().copy(isRegistered: false)))
+                } else {
+                    completion(.success(JetpackConnectionData.fake().copy(
+                        currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@example.com"))
+                    )))
+                }
+            case .registerSite(let completion):
+                completion(.success(456))
+            case .provisionConnection(let completion):
+                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
+            case let .finalizeConnection(_, _, _, _, completion):
+                completion(.success(()))
             default:
                 break
             }
@@ -299,6 +313,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
+        waitUntil { triggeredConnection }
 
         // Then
         XCTAssertFalse(triggeredRetrieveJetpackPluginDetails)
@@ -306,24 +321,18 @@ final class JetpackSetupViewModelTests: XCTestCase {
         XCTAssertFalse(triggeredActivation)
         XCTAssertFalse(triggeredConnectionURL)
         XCTAssertTrue(triggeredConnection)
-        waitUntil {
-            mockService.connectCallCount > 0
-        }
-        XCTAssertEqual(mockService.connectCallCount, 1)
-        XCTAssertEqual(mockService.lastConnectionData?.isRegistered, false)
     }
 
     func test_startSetup_triggers_installation_steps_if_connectionOnly_is_false() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let mockService = MockJetpackConnectionService()
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials,
-                                                      stores: stores, connectionService: mockService, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
 
         var triggeredRetrieveJetpackPluginDetails = false
         var triggeredInstallation = false
         var triggeredActivation = false
         var triggeredConnection = false
+        var fetchCount = 0
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
@@ -337,8 +346,21 @@ final class JetpackSetupViewModelTests: XCTestCase {
                 completion(.success(()))
                 triggeredActivation = true
             case .fetchJetpackConnectionData(let completion):
-                completion(.success(.fake().copy(isRegistered: false)))
+                fetchCount += 1
                 triggeredConnection = true
+                if fetchCount == 1 {
+                    completion(.success(.fake().copy(isRegistered: false)))
+                } else {
+                    completion(.success(JetpackConnectionData.fake().copy(
+                        currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@example.com"))
+                    )))
+                }
+            case .registerSite(let completion):
+                completion(.success(456))
+            case .provisionConnection(let completion):
+                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
+            case let .finalizeConnection(_, _, _, _, completion):
+                completion(.success(()))
             default:
                 break
             }
@@ -346,23 +368,19 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
+        waitUntil { triggeredConnection }
 
         // Then
         XCTAssertTrue(triggeredRetrieveJetpackPluginDetails)
         XCTAssertTrue(triggeredInstallation)
         XCTAssertTrue(triggeredActivation)
         XCTAssertTrue(triggeredConnection)
-        waitUntil {
-            mockService.connectCallCount > 0
-        }
-        XCTAssertEqual(mockService.connectCallCount, 1)
-        XCTAssertEqual(mockService.lastConnectionData?.isRegistered, false)
     }
 
     func test_startSetup_triggers_jetpack_installation_if_retrieving_details_fails_with_404() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
 
         var triggeredJetpackInstallation = false
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -390,7 +408,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_startSetup_triggers_jetpack_activation_if_retrieving_details_returns_inactive_jetpack() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
         let plugin = SitePlugin.fake().copy(plugin: "Jetpack", status: .inactive)
 
         var triggeredInstallation = false
@@ -426,13 +444,13 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_startSetup_triggers_jetpack_connection_if_retrieving_details_returns_active_jetpack() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let mockService = MockJetpackConnectionService()
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials,
-                                                      stores: stores, connectionService: mockService, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
         let plugin = SitePlugin.fake().copy(plugin: "Jetpack", status: .active)
 
         var triggeredInstallation = false
         var triggeredActivation = false
+        var triggeredConnection = false
+        var fetchCount = 0
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
@@ -442,7 +460,19 @@ final class JetpackSetupViewModelTests: XCTestCase {
             case .activateJetpackPlugin:
                 triggeredActivation = true
             case .fetchJetpackConnectionData(let completion):
-                completion(.success(.fake().copy(isRegistered: true, blogID: 123)))
+                fetchCount += 1
+                if fetchCount == 1 {
+                    completion(.success(.fake().copy(isRegistered: true, blogID: 123)))
+                } else {
+                    completion(.success(JetpackConnectionData.fake().copy(
+                        currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@example.com"))
+                    )))
+                }
+            case .provisionConnection(let completion):
+                triggeredConnection = true
+                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
+            case let .finalizeConnection(_, _, _, _, completion):
+                completion(.success(()))
             default:
                 break
             }
@@ -451,19 +481,18 @@ final class JetpackSetupViewModelTests: XCTestCase {
         // When
         viewModel.startSetup()
 
-        // Then
+        // Step state is set synchronously before the async Task
         XCTAssertTrue(viewModel.isSetupStepInProgress(.connection))
         XCTAssertFalse(viewModel.isSetupStepPending(.installation))
         XCTAssertFalse(viewModel.isSetupStepPending(.activation))
         XCTAssertTrue(viewModel.isSetupStepPending(.done))
+
+        waitUntil { triggeredConnection }
+
+        // Then
         XCTAssertFalse(triggeredInstallation)
         XCTAssertFalse(triggeredActivation)
-        waitUntil {
-            mockService.connectCallCount > 0
-        }
-        XCTAssertEqual(mockService.connectCallCount, 1)
-        XCTAssertEqual(mockService.lastConnectionData?.isRegistered, true)
-        XCTAssertEqual(mockService.lastConnectionData?.blogID, 123)
+        XCTAssertTrue(triggeredConnection)
     }
 
     func test_installation_triggers_activation_when_completing_successfully() {
@@ -472,8 +501,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let viewModel = JetpackSetupViewModel(siteURL: testURL,
                                               connectionOnly: false,
                                               wpcomCredentials: credentials,
-                                              stores: stores,
-                                              delayBeforeRetry: 0)
+                                              stores: stores)
 
         var triggeredActivation = false
         var triggeredConnection = false
@@ -504,12 +532,13 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_activation_success_triggers_all_connection_apis_if_isRegistered_is_false() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let mockService = MockJetpackConnectionService()
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials,
-                                                      stores: stores, connectionService: mockService, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
 
         var fetchedConnectionData = false
         var triggeredConnectionURL = false
+        var triggeredRegisterSite = false
+        var triggeredProvisionConnection = false
+        var triggeredFinalizeConnection = false
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
@@ -522,6 +551,15 @@ final class JetpackSetupViewModelTests: XCTestCase {
             case .fetchJetpackConnectionData(let completion):
                 fetchedConnectionData = true
                 completion(.success(.fake().copy(isRegistered: false)))
+            case .registerSite(let completion):
+                triggeredRegisterSite = true
+                completion(.success(124))
+            case .provisionConnection(let completion):
+                triggeredProvisionConnection = true
+                completion(.success(JetpackConnectionProvisionResponse(userId: 131, scope: "test", secret: "secret")))
+            case let .finalizeConnection(_, _, _, _, completion):
+                triggeredFinalizeConnection = true
+                completion(.success(()))
             case .fetchJetpackConnectionURL:
                 triggeredConnectionURL = true
             default:
@@ -531,26 +569,26 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
+        waitUntil { triggeredFinalizeConnection }
 
         // Then
         XCTAssertTrue(fetchedConnectionData)
         XCTAssertFalse(triggeredConnectionURL)
-        waitUntil {
-            mockService.connectCallCount > 0
-        }
-        XCTAssertEqual(mockService.connectCallCount, 1)
-        XCTAssertEqual(mockService.lastConnectionData?.isRegistered, false)
+        XCTAssertTrue(triggeredRegisterSite)
+        XCTAssertTrue(triggeredProvisionConnection)
+        XCTAssertTrue(triggeredFinalizeConnection)
     }
 
     func test_activation_success_triggers_all_connection_apis_except_register_if_isRegistered_is_true() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let mockService = MockJetpackConnectionService()
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials,
-                                                      stores: stores, connectionService: mockService, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
 
         var fetchedConnectionData = false
         var triggeredConnectionURL = false
+        var triggeredRegisterSite = false
+        var triggeredProvisionConnection = false
+        var triggeredFinalizeConnection = false
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
@@ -563,6 +601,14 @@ final class JetpackSetupViewModelTests: XCTestCase {
             case .fetchJetpackConnectionData(let completion):
                 fetchedConnectionData = true
                 completion(.success(.fake().copy(isRegistered: true, blogID: 124)))
+            case .registerSite:
+                triggeredRegisterSite = true
+            case .provisionConnection(let completion):
+                triggeredProvisionConnection = true
+                completion(.success(JetpackConnectionProvisionResponse(userId: 131, scope: "test", secret: "secret")))
+            case let .finalizeConnection(_, _, _, _, completion):
+                triggeredFinalizeConnection = true
+                completion(.success(()))
             case .fetchJetpackConnectionURL:
                 triggeredConnectionURL = true
             default:
@@ -572,30 +618,35 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
+        waitUntil { triggeredFinalizeConnection }
 
         // Then
         XCTAssertTrue(fetchedConnectionData)
         XCTAssertFalse(triggeredConnectionURL)
-        waitUntil {
-            mockService.connectCallCount > 0
-        }
-        XCTAssertEqual(mockService.connectCallCount, 1)
-        XCTAssertEqual(mockService.lastConnectionData?.isRegistered, true)
-        XCTAssertEqual(mockService.lastConnectionData?.blogID, 124)
+        XCTAssertFalse(triggeredRegisterSite)
+        XCTAssertTrue(triggeredProvisionConnection)
+        XCTAssertTrue(triggeredFinalizeConnection)
     }
 
     func test_activation_triggers_fetching_connection_url_when_site_has_outdated_jetpack() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
 
         var fetchedConnectionData = false
         var triggeredConnectionURL = false
+        var retrievePluginCallCount = 0
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
-                let error = NetworkError.notFound(response: nil)
-                completion(.failure(error))
+                retrievePluginCallCount += 1
+                if retrievePluginCallCount == 1 {
+                    // ViewModel's own call: plugin not found → triggers install
+                    completion(.failure(NetworkError.notFound(response: nil)))
+                } else {
+                    // Service's Branch C check: plugin found → webViewRequired
+                    completion(.success(.fake()))
+                }
             case .installJetpackPlugin(let completion):
                 completion(.success(()))
             case .activateJetpackPlugin(let completion):
@@ -612,6 +663,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
+        waitUntil { triggeredConnectionURL }
 
         // Then
         XCTAssertTrue(fetchedConnectionData)
@@ -621,7 +673,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_shouldPresentWebView_is_true_when_fetching_connection_url_returns_account_connection_url() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores)
         let testConnectionURL = try XCTUnwrap(URL(string: "https://jetpack.wordpress.com/jetpack.authorize"))
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -639,6 +691,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
+        waitUntil { viewModel.shouldPresentWebView }
 
         // Then
         XCTAssertTrue(viewModel.shouldPresentWebView)
@@ -648,7 +701,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_shouldPresentWebView_is_true_when_fetching_connection_url_returns_site_connection_url() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores)
         let testConnectionURL = try XCTUnwrap(URL(string: "\(testURL)/plugins/jetpack"))
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -666,6 +719,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
+        waitUntil { viewModel.shouldPresentWebView }
 
         // Then
         XCTAssertTrue(viewModel.shouldPresentWebView)
@@ -676,13 +730,16 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_authorizeJetpackConnection_sets_connection_status_to_in_progress_and_triggers_fetching_jetpack_connection() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
 
         var triggeredFetchingJetpackConnection = false
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
-            case .fetchJetpackConnectionData:
+            case .fetchJetpackConnectionData(let completion):
                 triggeredFetchingJetpackConnection = true
+                completion(.success(JetpackConnectionData.fake().copy(
+                    currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@mail.com"))
+                )))
             default:
                 break
             }
@@ -691,15 +748,19 @@ final class JetpackSetupViewModelTests: XCTestCase {
         // When
         viewModel.didAuthorizeJetpackConnection()
 
+        // Connection step is set synchronously before the async Task
+        XCTAssertEqual(viewModel.currentConnectionStep, .inProgress)
+
+        waitUntil { triggeredFetchingJetpackConnection }
+
         // Then
         XCTAssertTrue(triggeredFetchingJetpackConnection)
-        XCTAssertEqual(viewModel.currentConnectionStep, .inProgress)
     }
 
     func test_authorizeJetpackConnection_updates_connection_status_and_setup_step_correctly_when_fetching_jetpack_connection_successfully() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
 
         let data = JetpackConnectionData.fake().copy(
             currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@mail.com"))
@@ -715,6 +776,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.didAuthorizeJetpackConnection()
+        waitUntil { viewModel.currentConnectionStep == .authorized }
 
         // Then
         XCTAssertEqual(viewModel.currentConnectionStep, .authorized)
@@ -727,7 +789,6 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let viewModel = JetpackSetupViewModel(siteURL: testURL,
                                               connectionOnly: false,
                                               wpcomCredentials: credentials,
-                                              delayBeforeRetry: 0,
                                               onStoreNavigation: { _ in
             storeNavigationTriggered = true
         })
@@ -743,7 +804,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_setupFailed_is_true_when_retrieveJetpackPluginDetails_encounters_permission_error() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
         XCTAssertFalse(viewModel.setupFailed)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -769,7 +830,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_retrieveJetpackPluginDetails_triggers_installJetpack_when_encountering_non_permission_error() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
         var installJetpackTriggered = false
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -793,7 +854,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_installJetpack_relays_error_when_failed() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
@@ -819,7 +880,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_activateJetpack_relays_error_when_failed() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
         let plugin = SitePlugin.fake().copy(plugin: "Jetpack", status: .inactive)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -846,15 +907,14 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_register_connection_relays_error_when_failed() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let mockService = MockJetpackConnectionService()
-        mockService.connectResult = .failure(NSError(domain: "Test", code: -1001))
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials,
-                                                      stores: stores, connectionService: mockService, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .fetchJetpackConnectionData(let completion):
                 completion(.success(.fake().copy(isRegistered: false)))
+            case .registerSite(let completion):
+                completion(.failure(NSError(domain: "Test", code: -1001)))
             default:
                 break
             }
@@ -862,11 +922,9 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
+        waitUntil { viewModel.setupFailed }
 
         // Then
-        waitUntil {
-            viewModel.setupFailed
-        }
         XCTAssertTrue(viewModel.setupFailed)
         XCTAssertEqual(viewModel.setupErrorDetail, .init(setupErrorMessage: JetpackSetupViewModel.Localization.genericErrorMessage,
                                                          setupErrorSuggestion: JetpackSetupViewModel.Localization.communicationErrorSuggestion,
@@ -876,15 +934,14 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_provision_connection_relays_error_when_failed() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let mockService = MockJetpackConnectionService()
-        mockService.connectResult = .failure(NSError(domain: "Test", code: -1001))
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials,
-                                                      stores: stores, connectionService: mockService, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .fetchJetpackConnectionData(let completion):
                 completion(.success(.fake().copy(isRegistered: true, blogID: 123)))
+            case .provisionConnection(let completion):
+                completion(.failure(NSError(domain: "Test", code: -1001)))
             default:
                 break
             }
@@ -892,11 +949,9 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
+        waitUntil { viewModel.setupFailed }
 
         // Then
-        waitUntil {
-            viewModel.setupFailed
-        }
         XCTAssertTrue(viewModel.setupFailed)
         XCTAssertEqual(viewModel.setupErrorDetail, .init(setupErrorMessage: JetpackSetupViewModel.Localization.genericErrorMessage,
                                                          setupErrorSuggestion: JetpackSetupViewModel.Localization.communicationErrorSuggestion,
@@ -906,15 +961,16 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_finalize_connection_relays_error_when_failed() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let mockService = MockJetpackConnectionService()
-        mockService.connectResult = .failure(NSError(domain: "Test", code: -1001))
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials,
-                                                      stores: stores, connectionService: mockService, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .fetchJetpackConnectionData(let completion):
                 completion(.success(.fake().copy(isRegistered: true, blogID: 123)))
+            case .provisionConnection(let completion):
+                completion(.success(JetpackConnectionProvisionResponse(userId: 124, scope: "admin", secret: "secret")))
+            case let .finalizeConnection(_, _, _, _, completion):
+                completion(.failure(NSError(domain: "Test", code: -1001)))
             default:
                 break
             }
@@ -922,11 +978,9 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
+        waitUntil { viewModel.setupFailed }
 
         // Then
-        waitUntil {
-            viewModel.setupFailed
-        }
         XCTAssertTrue(viewModel.setupFailed)
         XCTAssertEqual(viewModel.setupErrorDetail, .init(setupErrorMessage: JetpackSetupViewModel.Localization.genericErrorMessage,
                                                          setupErrorSuggestion: JetpackSetupViewModel.Localization.communicationErrorSuggestion,
@@ -936,7 +990,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_fetchJetpackConnectionURL_relays_error_when_failed() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
@@ -953,6 +1007,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
+        waitUntil { viewModel.setupFailed }
 
         // Then
         XCTAssertTrue(viewModel.setupFailed)
@@ -964,7 +1019,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_checkJetpackConnection_hits_fetchJetpackConnection_3_times_when_encountering_error_consistently_and_relays_error() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
         var fetchJetpackConnectionTriggerCount = 0
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -993,7 +1048,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_checkJetpackConnection_hits_fetchJetpackConnectionData_3_times_when_failing_to_fetch_connected_wpcom_user() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
         var fetchJetpackConnectionTriggerCount = 0
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -1019,6 +1074,26 @@ final class JetpackSetupViewModelTests: XCTestCase {
                                                          errorCode: 99))
     }
 
+    func test_alreadyConnected_completes_setup_without_tracking_connection_step() {
+        // Given
+        let connectionService = MockJetpackConnectionService()
+        connectionService.evaluateAndConnectResult = .success(.alreadyConnected(email: "user@example.com"))
+        let viewModel = JetpackSetupViewModel(siteURL: testURL,
+                                              connectionOnly: true,
+                                              wpcomCredentials: credentials,
+                                              connectionService: connectionService)
+
+        // When
+        viewModel.startSetup()
+        waitUntil { viewModel.currentSetupStep == .done }
+
+        // Then
+        XCTAssertEqual(viewModel.currentSetupStep, .done)
+        XCTAssertEqual(viewModel.currentConnectionStep, .authorized)
+        XCTAssertFalse(viewModel.setupFailed)
+        XCTAssertEqual(connectionService.evaluateAndConnectCallCount, 1)
+    }
+
     // MARK: - Analytics
     func test_it_tracks_when_tapping_go_to_store_button() throws {
         // Given
@@ -1029,8 +1104,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
                                               connectionOnly: false,
                                               wpcomCredentials: credentials,
                                               stores: stores,
-                                              analytics: analytics,
-                                              delayBeforeRetry: 0)
+                                              analytics: analytics)
 
         // When
         // Tapping "Go to Store" button
@@ -1050,8 +1124,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
                                               connectionOnly: false,
                                               wpcomCredentials: credentials,
                                               stores: stores,
-                                              analytics: analytics,
-                                              delayBeforeRetry: 0)
+                                              analytics: analytics)
         let error = NetworkError.notFound(response: nil)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -1081,8 +1154,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
                                               connectionOnly: false,
                                               wpcomCredentials: credentials,
                                               stores: stores,
-                                              analytics: analytics,
-                                              delayBeforeRetry: 0)
+                                              analytics: analytics)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
@@ -1113,8 +1185,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
                                               connectionOnly: false,
                                               wpcomCredentials: credentials,
                                               stores: stores,
-                                              analytics: analytics,
-                                              delayBeforeRetry: 0)
+                                              analytics: analytics)
         let error = NetworkError.notFound(response: nil)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -1148,8 +1219,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
                                               connectionOnly: false,
                                               wpcomCredentials: credentials,
                                               stores: stores,
-                                              analytics: analytics,
-                                              delayBeforeRetry: 0)
+                                              analytics: analytics)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
@@ -1175,19 +1245,28 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let mockService = MockJetpackConnectionService()
         let viewModel = JetpackSetupViewModel(siteURL: testURL,
                                               connectionOnly: true,
                                               wpcomCredentials: credentials,
                                               stores: stores,
-                                              analytics: analytics,
-                                              connectionService: mockService,
-                                              delayBeforeRetry: 0)
+                                              analytics: analytics)
 
+        var fetchCount = 0
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .fetchJetpackConnectionData(let completion):
-                completion(.success(.fake().copy(isRegistered: true, blogID: 123)))
+                fetchCount += 1
+                if fetchCount == 1 {
+                    completion(.success(.fake().copy(isRegistered: true, blogID: 123)))
+                } else {
+                    completion(.success(JetpackConnectionData.fake().copy(
+                        currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@example.com"))
+                    )))
+                }
+            case .provisionConnection(let completion):
+                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
+            case let .finalizeConnection(_, _, _, _, completion):
+                completion(.success(()))
             default:
                 break
             }
@@ -1195,10 +1274,13 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
+        waitUntil { viewModel.currentSetupStep == .done }
 
         // Then
-        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(where: { $0 == "jetpack_setup_flow" }))
-        XCTAssertEqual(analyticsProvider.receivedProperties[indexOfEvent]["step"] as? String, "connection")
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.indices.last(where: {
+            analyticsProvider.receivedEvents[$0] == "jetpack_setup_flow" &&
+            analyticsProvider.receivedProperties[$0]["step"] as? String == "connection"
+        }))
         XCTAssertNil(analyticsProvider.receivedProperties[indexOfEvent]["error_code"])
     }
 
@@ -1207,20 +1289,21 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let mockService = MockJetpackConnectionService()
-        mockService.connectResult = .failure(NSError(domain: "Test", code: 1))
         let viewModel = JetpackSetupViewModel(siteURL: testURL,
                                               connectionOnly: true,
                                               wpcomCredentials: credentials,
                                               stores: stores,
-                                              analytics: analytics,
-                                              connectionService: mockService,
-                                              delayBeforeRetry: 0)
+                                              analytics: analytics)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
+            case .retrieveJetpackPluginDetails(let completion):
+                completion(.success(.fake()))
             case .fetchJetpackConnectionData(let completion):
                 completion(.success(.fake().copy(isRegistered: true, blogID: 123)))
+            case .provisionConnection(let completion):
+                let error = NSError(domain: "Test", code: 1)
+                completion(.failure(error))
             default:
                 break
             }
@@ -1228,11 +1311,9 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
+        waitUntil { viewModel.setupFailed }
 
         // Then
-        waitUntil {
-            viewModel.setupFailed
-        }
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(where: { $0 == "jetpack_setup_flow" }))
         XCTAssertEqual(analyticsProvider.receivedProperties[indexOfEvent]["step"] as? String, "connection")
         XCTAssertEqual(analyticsProvider.receivedProperties[indexOfEvent]["error_code"] as? String, "1")
@@ -1248,8 +1329,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
                                               connectionOnly: true,
                                               wpcomCredentials: credentials,
                                               stores: stores,
-                                              analytics: analytics,
-                                              delayBeforeRetry: 0)
+                                              analytics: analytics)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
@@ -1267,6 +1347,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
+        waitUntil { viewModel.setupFailed }
 
         // Then
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(where: { $0 == "jetpack_setup_flow" }))
@@ -1284,8 +1365,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
                                               connectionOnly: true,
                                               wpcomCredentials: credentials,
                                               stores: stores,
-                                              analytics: analytics,
-                                              delayBeforeRetry: 0)
+                                              analytics: analytics)
 
         let data = JetpackConnectionData.fake().copy(
             currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@mail.com"))
@@ -1301,6 +1381,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.didAuthorizeJetpackConnection()
+        waitUntil { viewModel.currentSetupStep == .done }
 
         // Then
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(where: { $0 == "jetpack_setup_flow" }))
@@ -1312,14 +1393,11 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let mockService = MockJetpackConnectionService()
         let viewModel = JetpackSetupViewModel(siteURL: testURL,
                                               connectionOnly: true,
                                               wpcomCredentials: credentials,
                                               stores: stores,
-                                              analytics: analytics,
-                                              connectionService: mockService,
-                                              delayBeforeRetry: 0)
+                                              analytics: analytics)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
@@ -1330,6 +1408,10 @@ final class JetpackSetupViewModelTests: XCTestCase {
                     blogID: 123
                 )
                 completion(.success(data))
+            case .provisionConnection(let completion):
+                completion(.success(JetpackConnectionProvisionResponse(userId: 124, scope: "admin", secret: "secret")))
+            case let .finalizeConnection(_, _, _, _, completion):
+                completion(.success(()))
             default:
                 break
             }
@@ -1357,8 +1439,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
                                               connectionOnly: false,
                                               wpcomCredentials: credentials,
                                               stores: stores,
-                                              analytics: analytics,
-                                              delayBeforeRetry: 0)
+                                              analytics: analytics)
 
         // When
         viewModel.retryAllSteps()

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupViewModelTests.swift
@@ -234,8 +234,19 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_shouldShowGoToStoreButton_is_correct() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let mockService = MockJetpackConnectionService()
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, connectionService: mockService, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+
+        let data = JetpackConnectionData.fake().copy(
+            currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@mail.com"))
+        )
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .fetchJetpackConnectionData(let completion):
+                completion(.success(data))
+            default:
+                break
+            }
+        }
 
         // When
         viewModel.startSetup()
@@ -247,9 +258,6 @@ final class JetpackSetupViewModelTests: XCTestCase {
         viewModel.didAuthorizeJetpackConnection()
 
         // Then
-        waitUntil {
-            viewModel.shouldShowGoToStoreButton
-        }
         XCTAssertTrue(viewModel.shouldShowGoToStoreButton)
     }
 
@@ -660,37 +668,52 @@ final class JetpackSetupViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.jetpackConnectionURL, URL(string: expectedURL))
     }
 
-    func test_authorizeJetpackConnection_sets_connection_status_to_in_progress_and_triggers_verifying_connection() {
+    func test_authorizeJetpackConnection_sets_connection_status_to_in_progress_and_triggers_fetching_jetpack_connection() {
         // Given
-        let mockService = MockJetpackConnectionService()
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, connectionService: mockService, delayBeforeRetry: 0)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+
+        var triggeredFetchingJetpackConnection = false
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .fetchJetpackConnectionData:
+                triggeredFetchingJetpackConnection = true
+            default:
+                break
+            }
+        }
 
         // When
         viewModel.didAuthorizeJetpackConnection()
 
         // Then
+        XCTAssertTrue(triggeredFetchingJetpackConnection)
         XCTAssertEqual(viewModel.currentConnectionStep, .inProgress)
-        waitUntil {
-            mockService.verifyCallCount > 0
-        }
-        XCTAssertEqual(mockService.verifyCallCount, 1)
     }
 
-    func test_authorizeJetpackConnection_updates_connection_status_and_setup_step_correctly_when_verifying_connection_successfully() {
+    func test_authorizeJetpackConnection_updates_connection_status_and_setup_step_correctly_when_fetching_jetpack_connection_successfully() {
         // Given
-        let mockService = MockJetpackConnectionService()
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, connectionService: mockService, delayBeforeRetry: 0)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+
+        let data = JetpackConnectionData.fake().copy(
+            currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@mail.com"))
+        )
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .fetchJetpackConnectionData(let completion):
+                completion(.success(data))
+            default:
+                break
+            }
+        }
 
         // When
         viewModel.didAuthorizeJetpackConnection()
 
         // Then
-        waitUntil {
-            viewModel.currentConnectionStep == .authorized
-        }
         XCTAssertEqual(viewModel.currentConnectionStep, .authorized)
         XCTAssertEqual(viewModel.currentSetupStep, .done)
-        XCTAssertEqual(mockService.verifyCallCount, 1)
     }
 
     func test_navigateToStore_triggers_storeNavigationHandler() {
@@ -933,7 +956,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_checkJetpackConnection_hits_fetchJetpackConnection_3_times_when_encountering_error_consistently_and_relays_error() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
         var fetchJetpackConnectionTriggerCount = 0
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -947,7 +970,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         }
 
         // When
-        viewModel.startSetup()
+        viewModel.didAuthorizeJetpackConnection()
 
         // Then
         waitUntil {
@@ -959,11 +982,21 @@ final class JetpackSetupViewModelTests: XCTestCase {
                                                          errorCode: -1001))
     }
 
-    func test_didAuthorizeJetpackConnection_relays_verification_error() {
+    func test_checkJetpackConnection_hits_fetchJetpackConnectionData_3_times_when_failing_to_fetch_connected_wpcom_user() {
         // Given
-        let mockService = MockJetpackConnectionService()
-        mockService.verifyResult = .failure(JetpackConnectionServiceError.verificationFailed)
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, connectionService: mockService, delayBeforeRetry: 0)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, delayBeforeRetry: 0)
+        var fetchJetpackConnectionTriggerCount = 0
+
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .fetchJetpackConnectionData(let completion):
+                fetchJetpackConnectionTriggerCount += 1
+                completion(.success(JetpackConnectionData.fake().copy(currentUser: .fake().copy(wpcomUser: nil))))
+            default:
+                break
+            }
+        }
 
         // When
         viewModel.didAuthorizeJetpackConnection()
@@ -972,7 +1005,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         waitUntil {
             viewModel.setupFailed
         }
-        XCTAssertEqual(mockService.verifyCallCount, 1)
+        XCTAssertEqual(fetchJetpackConnectionTriggerCount, 3)
         XCTAssertEqual(viewModel.setupErrorDetail, .init(setupErrorMessage: JetpackSetupViewModel.Localization.genericErrorMessage,
                                                          setupErrorSuggestion: JetpackSetupViewModel.Localization.communicationErrorSuggestion,
                                                          errorCode: 99))
@@ -1239,20 +1272,27 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let mockService = MockJetpackConnectionService()
         let viewModel = JetpackSetupViewModel(siteURL: testURL,
                                               connectionOnly: true,
                                               wpcomCredentials: credentials,
                                               stores: stores,
                                               analytics: analytics,
-                                              connectionService: mockService,
                                               delayBeforeRetry: 0)
+
+        let data = JetpackConnectionData.fake().copy(
+            currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@mail.com"))
+        )
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .fetchJetpackConnectionData(let completion):
+                completion(.success(data))
+            default:
+                break
+            }
+        }
 
         // When
         viewModel.didAuthorizeJetpackConnection()
-        waitUntil {
-            viewModel.currentSetupStep == .done
-        }
 
         // Then
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(where: { $0 == "jetpack_setup_flow" }))
@@ -1265,7 +1305,6 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let mockService = MockJetpackConnectionService()
-        mockService.connectResult = .failure(JetpackConnectionServiceError.verificationFailed)
         let viewModel = JetpackSetupViewModel(siteURL: testURL,
                                               connectionOnly: true,
                                               wpcomCredentials: credentials,

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupViewModelTests.swift
@@ -266,7 +266,8 @@ final class JetpackSetupViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let mockService = MockJetpackConnectionService()
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores, connectionService: mockService, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials,
+                                                      stores: stores, connectionService: mockService, delayBeforeRetry: 0)
         let testConnectionURL = try XCTUnwrap(URL(string: "https://jetpack.wordpress.com/jetpack.authorize"))
 
         var triggeredRetrieveJetpackPluginDetails = false
@@ -316,7 +317,8 @@ final class JetpackSetupViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let mockService = MockJetpackConnectionService()
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, connectionService: mockService, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials,
+                                                      stores: stores, connectionService: mockService, delayBeforeRetry: 0)
 
         var triggeredRetrieveJetpackPluginDetails = false
         var triggeredInstallation = false
@@ -425,7 +427,8 @@ final class JetpackSetupViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let mockService = MockJetpackConnectionService()
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, connectionService: mockService, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials,
+                                                      stores: stores, connectionService: mockService, delayBeforeRetry: 0)
         let plugin = SitePlugin.fake().copy(plugin: "Jetpack", status: .active)
 
         var triggeredInstallation = false
@@ -502,7 +505,8 @@ final class JetpackSetupViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let mockService = MockJetpackConnectionService()
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, connectionService: mockService, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials,
+                                                      stores: stores, connectionService: mockService, delayBeforeRetry: 0)
 
         var fetchedConnectionData = false
         var triggeredConnectionURL = false
@@ -542,7 +546,8 @@ final class JetpackSetupViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let mockService = MockJetpackConnectionService()
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores, connectionService: mockService, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials,
+                                                      stores: stores, connectionService: mockService, delayBeforeRetry: 0)
 
         var fetchedConnectionData = false
         var triggeredConnectionURL = false
@@ -843,7 +848,8 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let mockService = MockJetpackConnectionService()
         mockService.connectResult = .failure(NSError(domain: "Test", code: -1001))
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores, connectionService: mockService, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials,
+                                                      stores: stores, connectionService: mockService, delayBeforeRetry: 0)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
@@ -872,7 +878,8 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let mockService = MockJetpackConnectionService()
         mockService.connectResult = .failure(NSError(domain: "Test", code: -1001))
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores, connectionService: mockService, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials,
+                                                      stores: stores, connectionService: mockService, delayBeforeRetry: 0)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
@@ -901,7 +908,8 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let mockService = MockJetpackConnectionService()
         mockService.connectResult = .failure(NSError(domain: "Test", code: -1001))
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores, connectionService: mockService, delayBeforeRetry: 0)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials,
+                                                      stores: stores, connectionService: mockService, delayBeforeRetry: 0)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupViewModelTests.swift
@@ -264,48 +264,27 @@ final class JetpackSetupViewModelTests: XCTestCase {
     }
 
     // MARK: - API calls
-    func test_startSetup_triggers_connection_step_if_connectionOnly_is_true() throws {
+    func test_startSetup_triggers_connection_step_if_connectionOnly_is_true() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials, stores: stores)
-        let testConnectionURL = try XCTUnwrap(URL(string: "https://jetpack.wordpress.com/jetpack.authorize"))
+        let connectionService = MockJetpackConnectionService()
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: true, wpcomCredentials: credentials,
+                                              stores: stores, connectionService: connectionService)
 
         var triggeredRetrieveJetpackPluginDetails = false
         var triggeredInstallation = false
         var triggeredActivation = false
         var triggeredConnectionURL = false
-        var triggeredConnection = false
-        var fetchCount = 0
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
-            case .retrieveJetpackPluginDetails(let completion):
+            case .retrieveJetpackPluginDetails:
                 triggeredRetrieveJetpackPluginDetails = true
-                completion(.success(.fake()))
-            case .installJetpackPlugin(let completion):
-                completion(.success(()))
+            case .installJetpackPlugin:
                 triggeredInstallation = true
-            case .activateJetpackPlugin(let completion):
-                completion(.success(()))
+            case .activateJetpackPlugin:
                 triggeredActivation = true
-            case .fetchJetpackConnectionURL(_, let completion):
-                completion(.success(testConnectionURL))
+            case .fetchJetpackConnectionURL:
                 triggeredConnectionURL = true
-            case .fetchJetpackConnectionData(let completion):
-                fetchCount += 1
-                triggeredConnection = true
-                if fetchCount == 1 {
-                    completion(.success(.fake().copy(isRegistered: false)))
-                } else {
-                    completion(.success(JetpackConnectionData.fake().copy(
-                        currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@example.com"))
-                    )))
-                }
-            case .registerSite(let completion):
-                completion(.success(456))
-            case .provisionConnection(let completion):
-                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
-            case let .finalizeConnection(_, _, _, _, completion):
-                completion(.success(()))
             default:
                 break
             }
@@ -313,53 +292,36 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
-        waitUntil { triggeredConnection }
+        waitUntil { connectionService.evaluateAndConnectCallCount > 0 }
 
         // Then
         XCTAssertFalse(triggeredRetrieveJetpackPluginDetails)
         XCTAssertFalse(triggeredInstallation)
         XCTAssertFalse(triggeredActivation)
         XCTAssertFalse(triggeredConnectionURL)
-        XCTAssertTrue(triggeredConnection)
+        XCTAssertEqual(connectionService.evaluateAndConnectCallCount, 1)
     }
 
-    func test_startSetup_triggers_installation_steps_if_connectionOnly_is_false() throws {
+    func test_startSetup_triggers_installation_steps_if_connectionOnly_is_false() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
+        let connectionService = MockJetpackConnectionService()
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials,
+                                              stores: stores, connectionService: connectionService)
 
         var triggeredRetrieveJetpackPluginDetails = false
         var triggeredInstallation = false
         var triggeredActivation = false
-        var triggeredConnection = false
-        var fetchCount = 0
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
                 triggeredRetrieveJetpackPluginDetails = true
-                let error = NetworkError.notFound(response: nil)
-                completion(.failure(error))
+                completion(.failure(NetworkError.notFound(response: nil)))
             case .installJetpackPlugin(let completion):
-                completion(.success(()))
                 triggeredInstallation = true
-            case .activateJetpackPlugin(let completion):
                 completion(.success(()))
+            case .activateJetpackPlugin(let completion):
                 triggeredActivation = true
-            case .fetchJetpackConnectionData(let completion):
-                fetchCount += 1
-                triggeredConnection = true
-                if fetchCount == 1 {
-                    completion(.success(.fake().copy(isRegistered: false)))
-                } else {
-                    completion(.success(JetpackConnectionData.fake().copy(
-                        currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@example.com"))
-                    )))
-                }
-            case .registerSite(let completion):
-                completion(.success(456))
-            case .provisionConnection(let completion):
-                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
-            case let .finalizeConnection(_, _, _, _, completion):
                 completion(.success(()))
             default:
                 break
@@ -368,13 +330,13 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
-        waitUntil { triggeredConnection }
+        waitUntil { connectionService.evaluateAndConnectCallCount > 0 }
 
         // Then
         XCTAssertTrue(triggeredRetrieveJetpackPluginDetails)
         XCTAssertTrue(triggeredInstallation)
         XCTAssertTrue(triggeredActivation)
-        XCTAssertTrue(triggeredConnection)
+        XCTAssertEqual(connectionService.evaluateAndConnectCallCount, 1)
     }
 
     func test_startSetup_triggers_jetpack_installation_if_retrieving_details_fails_with_404() {
@@ -444,13 +406,13 @@ final class JetpackSetupViewModelTests: XCTestCase {
     func test_startSetup_triggers_jetpack_connection_if_retrieving_details_returns_active_jetpack() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
+        let connectionService = MockJetpackConnectionService()
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials,
+                                              stores: stores, connectionService: connectionService)
         let plugin = SitePlugin.fake().copy(plugin: "Jetpack", status: .active)
 
         var triggeredInstallation = false
         var triggeredActivation = false
-        var triggeredConnection = false
-        var fetchCount = 0
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
@@ -459,20 +421,6 @@ final class JetpackSetupViewModelTests: XCTestCase {
                 triggeredInstallation = true
             case .activateJetpackPlugin:
                 triggeredActivation = true
-            case .fetchJetpackConnectionData(let completion):
-                fetchCount += 1
-                if fetchCount == 1 {
-                    completion(.success(.fake().copy(isRegistered: true, blogID: 123)))
-                } else {
-                    completion(.success(JetpackConnectionData.fake().copy(
-                        currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@example.com"))
-                    )))
-                }
-            case .provisionConnection(let completion):
-                triggeredConnection = true
-                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
-            case let .finalizeConnection(_, _, _, _, completion):
-                completion(.success(()))
             default:
                 break
             }
@@ -487,12 +435,12 @@ final class JetpackSetupViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isSetupStepPending(.activation))
         XCTAssertTrue(viewModel.isSetupStepPending(.done))
 
-        waitUntil { triggeredConnection }
+        waitUntil { connectionService.evaluateAndConnectCallCount > 0 }
 
         // Then
         XCTAssertFalse(triggeredInstallation)
         XCTAssertFalse(triggeredActivation)
-        XCTAssertTrue(triggeredConnection)
+        XCTAssertEqual(connectionService.evaluateAndConnectCallCount, 1)
     }
 
     func test_installation_triggers_activation_when_completing_successfully() {
@@ -529,39 +477,21 @@ final class JetpackSetupViewModelTests: XCTestCase {
         XCTAssertFalse(triggeredConnection)
     }
 
-    func test_activation_success_triggers_all_connection_apis_if_isRegistered_is_false() {
+    func test_activation_success_triggers_connection_service() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
+        let connectionService = MockJetpackConnectionService()
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials,
+                                              stores: stores, connectionService: connectionService)
 
-        var fetchedConnectionData = false
-        var triggeredConnectionURL = false
-        var triggeredRegisterSite = false
-        var triggeredProvisionConnection = false
-        var triggeredFinalizeConnection = false
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
-                let error = NetworkError.notFound(response: nil)
-                completion(.failure(error))
+                completion(.failure(NetworkError.notFound(response: nil)))
             case .installJetpackPlugin(let completion):
                 completion(.success(()))
             case .activateJetpackPlugin(let completion):
                 completion(.success(()))
-            case .fetchJetpackConnectionData(let completion):
-                fetchedConnectionData = true
-                completion(.success(.fake().copy(isRegistered: false)))
-            case .registerSite(let completion):
-                triggeredRegisterSite = true
-                completion(.success(124))
-            case .provisionConnection(let completion):
-                triggeredProvisionConnection = true
-                completion(.success(JetpackConnectionProvisionResponse(userId: 131, scope: "test", secret: "secret")))
-            case let .finalizeConnection(_, _, _, _, completion):
-                triggeredFinalizeConnection = true
-                completion(.success(()))
-            case .fetchJetpackConnectionURL:
-                triggeredConnectionURL = true
             default:
                 break
             }
@@ -569,91 +499,29 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
-        waitUntil { triggeredFinalizeConnection }
+        waitUntil { connectionService.evaluateAndConnectCallCount > 0 }
 
         // Then
-        XCTAssertTrue(fetchedConnectionData)
-        XCTAssertFalse(triggeredConnectionURL)
-        XCTAssertTrue(triggeredRegisterSite)
-        XCTAssertTrue(triggeredProvisionConnection)
-        XCTAssertTrue(triggeredFinalizeConnection)
-    }
-
-    func test_activation_success_triggers_all_connection_apis_except_register_if_isRegistered_is_true() {
-        // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
-
-        var fetchedConnectionData = false
-        var triggeredConnectionURL = false
-        var triggeredRegisterSite = false
-        var triggeredProvisionConnection = false
-        var triggeredFinalizeConnection = false
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .retrieveJetpackPluginDetails(let completion):
-                let error = NetworkError.notFound(response: nil)
-                completion(.failure(error))
-            case .installJetpackPlugin(let completion):
-                completion(.success(()))
-            case .activateJetpackPlugin(let completion):
-                completion(.success(()))
-            case .fetchJetpackConnectionData(let completion):
-                fetchedConnectionData = true
-                completion(.success(.fake().copy(isRegistered: true, blogID: 124)))
-            case .registerSite:
-                triggeredRegisterSite = true
-            case .provisionConnection(let completion):
-                triggeredProvisionConnection = true
-                completion(.success(JetpackConnectionProvisionResponse(userId: 131, scope: "test", secret: "secret")))
-            case let .finalizeConnection(_, _, _, _, completion):
-                triggeredFinalizeConnection = true
-                completion(.success(()))
-            case .fetchJetpackConnectionURL:
-                triggeredConnectionURL = true
-            default:
-                break
-            }
-        }
-
-        // When
-        viewModel.startSetup()
-        waitUntil { triggeredFinalizeConnection }
-
-        // Then
-        XCTAssertTrue(fetchedConnectionData)
-        XCTAssertFalse(triggeredConnectionURL)
-        XCTAssertFalse(triggeredRegisterSite)
-        XCTAssertTrue(triggeredProvisionConnection)
-        XCTAssertTrue(triggeredFinalizeConnection)
+        XCTAssertEqual(connectionService.evaluateAndConnectCallCount, 1)
     }
 
     func test_activation_triggers_fetching_connection_url_when_site_has_outdated_jetpack() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials, stores: stores)
+        let connectionService = MockJetpackConnectionService()
+        connectionService.evaluateAndConnectResult = .success(.webViewRequired)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials,
+                                              stores: stores, connectionService: connectionService)
 
-        var fetchedConnectionData = false
         var triggeredConnectionURL = false
-        var retrievePluginCallCount = 0
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
-                retrievePluginCallCount += 1
-                if retrievePluginCallCount == 1 {
-                    // ViewModel's own call: plugin not found → triggers install
-                    completion(.failure(NetworkError.notFound(response: nil)))
-                } else {
-                    // Service's Branch C check: plugin found → webViewRequired
-                    completion(.success(.fake()))
-                }
+                completion(.failure(NetworkError.notFound(response: nil)))
             case .installJetpackPlugin(let completion):
                 completion(.success(()))
             case .activateJetpackPlugin(let completion):
                 completion(.success(()))
-            case .fetchJetpackConnectionData(let completion):
-                fetchedConnectionData = true
-                completion(.success(.fake().copy(isRegistered: nil)))
             case .fetchJetpackConnectionURL:
                 triggeredConnectionURL = true
             default:
@@ -666,7 +534,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         waitUntil { triggeredConnectionURL }
 
         // Then
-        XCTAssertTrue(fetchedConnectionData)
+        XCTAssertEqual(connectionService.evaluateAndConnectCallCount, 1)
         XCTAssertTrue(triggeredConnectionURL)
     }
 
@@ -1242,35 +1110,14 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
     func test_it_tracks_correct_event_when_connection_step_starts() throws {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let connectionService = MockJetpackConnectionService()
         let viewModel = JetpackSetupViewModel(siteURL: testURL,
                                               connectionOnly: true,
                                               wpcomCredentials: credentials,
-                                              stores: stores,
-                                              analytics: analytics)
-
-        var fetchCount = 0
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .fetchJetpackConnectionData(let completion):
-                fetchCount += 1
-                if fetchCount == 1 {
-                    completion(.success(.fake().copy(isRegistered: true, blogID: 123)))
-                } else {
-                    completion(.success(JetpackConnectionData.fake().copy(
-                        currentUser: .fake().copy(isConnected: true, wpcomUser: DotcomUser.fake().copy(email: "test@example.com"))
-                    )))
-                }
-            case .provisionConnection(let completion):
-                completion(.success(JetpackConnectionProvisionResponse(userId: 1, scope: "admin", secret: "secret")))
-            case let .finalizeConnection(_, _, _, _, completion):
-                completion(.success(()))
-            default:
-                break
-            }
-        }
+                                              analytics: analytics,
+                                              connectionService: connectionService)
 
         // When
         viewModel.startSetup()

--- a/WooCommerce/WooCommerceTests/Mocks/MockJetpackConnectionService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockJetpackConnectionService.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Yosemite
+@testable import WooCommerce
+
+final class MockJetpackConnectionService: JetpackConnectionServiceProtocol {
+    var connectResult: Result<String, Error> = .success("test@mail.com")
+    private(set) var connectCallCount = 0
+    private(set) var lastConnectionData: JetpackConnectionData?
+
+    var verifyResult: Result<String, Error> = .success("test@mail.com")
+    private(set) var verifyCallCount = 0
+
+    func connect(with connectionData: JetpackConnectionData,
+                 siteURL: String,
+                 credentials: Credentials) async throws -> String {
+        connectCallCount += 1
+        lastConnectionData = connectionData
+        return try connectResult.get()
+    }
+
+    func verifyConnection() async throws -> String {
+        verifyCallCount += 1
+        return try verifyResult.get()
+    }
+}

--- a/WooCommerce/WooCommerceTests/Mocks/MockJetpackConnectionService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockJetpackConnectionService.swift
@@ -3,23 +3,15 @@ import Yosemite
 @testable import WooCommerce
 
 final class MockJetpackConnectionService: JetpackConnectionServiceProtocol {
-    var connectResult: Result<String, Error> = .success("test@mail.com")
+    var connectResult: Result<Void, Error> = .success(())
     private(set) var connectCallCount = 0
     private(set) var lastConnectionData: JetpackConnectionData?
 
-    var verifyResult: Result<String, Error> = .success("test@mail.com")
-    private(set) var verifyCallCount = 0
-
     func connect(with connectionData: JetpackConnectionData,
                  siteURL: String,
-                 credentials: Credentials) async throws -> String {
+                 credentials: Credentials) async throws {
         connectCallCount += 1
         lastConnectionData = connectionData
-        return try connectResult.get()
-    }
-
-    func verifyConnection() async throws -> String {
-        verifyCallCount += 1
-        return try verifyResult.get()
+        try connectResult.get()
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockJetpackConnectionService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockJetpackConnectionService.swift
@@ -3,15 +3,19 @@ import Yosemite
 @testable import WooCommerce
 
 final class MockJetpackConnectionService: JetpackConnectionServiceProtocol {
-    var connectResult: Result<Void, Error> = .success(())
-    private(set) var connectCallCount = 0
-    private(set) var lastConnectionData: JetpackConnectionData?
+    var evaluateAndConnectResult: Result<JetpackConnectionOutcome, Error> = .success(.connected(email: "test@example.com"))
+    private(set) var evaluateAndConnectCallCount = 0
 
-    func connect(with connectionData: JetpackConnectionData,
-                 siteURL: String,
-                 credentials: Credentials) async throws {
-        connectCallCount += 1
-        lastConnectionData = connectionData
-        try connectResult.get()
+    var verifyConnectionResult: Result<String, Error> = .success("test@example.com")
+    private(set) var verifyConnectionCallCount = 0
+
+    func evaluateAndConnect(siteURL: String, credentials: Credentials) async throws -> JetpackConnectionOutcome {
+        evaluateAndConnectCallCount += 1
+        return try evaluateAndConnectResult.get()
+    }
+
+    func verifyConnection() async throws -> String {
+        verifyConnectionCallCount += 1
+        return try verifyConnectionResult.get()
     }
 }


### PR DESCRIPTION
Follow up on #16614

## Description

Extracts the native Jetpack connection logic (register → provision → finalize) from JetpackSetupViewModel into a reusable JetpackConnectionService. This reduces duplication ahead of reusing the same sequence in the push notification WPCom connection flow in an upcoming PR.

Changes
- New JetpackConnectionService  that wraps the 3-step connection sequence
- JetpackSetupViewModel replaces 4 internal methods (handleSiteRegisterResult, registerSiteConnection, provisionSiteConnection, finalizeSiteConnection) with a single startNativeConnection(with:) that delegates to the service
- No behavioral changes, the ViewModel's UI state, analytics, and verify/retry logic remain untouched

## Test Steps

1. Create a site with just WooCommerce on JN (no Jetpack plugin)
1. Log in with application password: Log In → enter site address → enter wp-admin credentials
1. Tap the Jetpack benefits banner on the My Store tab
1. Tap Log In to Continue and enter WPCom credentials
1. The Jetpack install/activate/connect steps should all succeed
2. Verify on the sites's dashboard that the jetpack plugin is setup

## Screenshots
![ScreenRecording_02-09-2026 15-25-01_1](https://github.com/user-attachments/assets/96db3bd3-20d7-4f8b-be2d-ff9477dfc039)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
