### PR TITLE
Adding PluginVersionChecker

### DIFF
--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/PluginCompatibilityChecker.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/PluginCompatibilityChecker.swift
@@ -1,0 +1,79 @@
+import CocoaLumberjackSwift
+import Foundation
+import Yosemite
+import class WooFoundation.VersionHelpers
+
+enum PluginVersionResult {
+    case compatible
+    case incompatible(currentVersion: String, requiredVersion: String)
+}
+
+protocol PluginVersionCheckerProtocol {
+    func checkCompatibility() async throws -> PluginVersionResult
+}
+
+final class PluginVersionChecker: PluginVersionCheckerProtocol {
+    private let siteID: Int64
+    private let pluginPath: String
+    private let minimumVersion: String
+    private let stores: StoresManager
+
+    init(siteID: Int64,
+         pluginPath: String,
+         minimumVersion: String,
+         stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.pluginPath = pluginPath
+        self.minimumVersion = minimumVersion
+        self.stores = stores
+    }
+
+    func checkCompatibility() async throws -> PluginVersionResult {
+        let plugin = try await fetchPlugin()
+
+        let isSupported = VersionHelpers.isVersionSupported(
+            version: plugin.version,
+            minimumRequired: minimumVersion
+        )
+
+        if isSupported {
+            DDLogDebug("Plugin compatibility: \(pluginPath) \(plugin.version) meets minimum \(minimumVersion)")
+            return .compatible
+        } else {
+            DDLogDebug("Plugin compatibility: \(pluginPath) \(plugin.version) below minimum \(minimumVersion)")
+            return .incompatible(
+                currentVersion: plugin.version,
+                requiredVersion: minimumVersion
+            )
+        }
+    }
+}
+
+private extension PluginVersionChecker {
+    func fetchPlugin() async throws -> SystemPlugin {
+        let systemInfo = try await syncSystemInformation()
+
+        guard let plugin = systemInfo.systemPlugins.first(where: { $0.plugin == pluginPath }) else {
+            throw PluginVersionError.pluginNotFound
+        }
+
+        return plugin
+    }
+
+    func syncSystemInformation() async throws -> SystemInformation {
+        let stores = self.stores
+        let siteID = self.siteID
+        return try await withCheckedThrowingContinuation { continuation in
+            let action = SystemStatusAction.synchronizeSystemInformation(siteID: siteID) { result in
+                continuation.resume(with: result)
+            }
+            Task { @MainActor in
+                stores.dispatch(action)
+            }
+        }
+    }
+}
+
+enum PluginVersionError: Error {
+    case pluginNotFound
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/PluginVersionCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/PluginVersionCheckerTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class PluginVersionCheckerTests: XCTestCase {
+    private var stores: MockStoresManager!
+
+    override func setUp() {
+        super.setUp()
+        stores = MockStoresManager(sessionManager: .makeForTesting())
+    }
+
+    override func tearDown() {
+        stores = nil
+        super.tearDown()
+    }
+
+    func test_compatible_when_plugin_meets_minimum_version() async throws {
+        // Given
+        let plugin = SystemPlugin.fake().copy(
+            plugin: "jetpack/jetpack.php",
+            version: "14.4"
+        )
+        mockSystemInfo(with: [plugin])
+
+        let checker = PluginVersionChecker(
+            siteID: 123,
+            pluginPath: "jetpack/jetpack.php",
+            minimumVersion: "14.4",
+            stores: stores
+        )
+
+        // When
+        let result = try await checker.checkCompatibility()
+
+        // Then
+        guard case .compatible = result else {
+            return XCTFail("Expected .compatible, got \(result)")
+        }
+    }
+
+    func test_incompatible_when_plugin_below_minimum_version() async throws {
+        // Given
+        let plugin = SystemPlugin.fake().copy(
+            plugin: "jetpack/jetpack.php",
+            version: "14.3"
+        )
+        mockSystemInfo(with: [plugin])
+
+        let checker = PluginVersionChecker(
+            siteID: 123,
+            pluginPath: "jetpack/jetpack.php",
+            minimumVersion: "14.4",
+            stores: stores
+        )
+
+        // When
+        let result = try await checker.checkCompatibility()
+
+        // Then
+        guard case let .incompatible(currentVersion, requiredVersion) = result else {
+            return XCTFail("Expected .incompatible, got \(result)")
+        }
+        XCTAssertEqual(currentVersion, "14.3")
+        XCTAssertEqual(requiredVersion, "14.4")
+    }
+
+    func test_throws_pluginNotFound_when_plugin_missing() async {
+        // Given
+        mockSystemInfo(with: [])
+
+        let checker = PluginVersionChecker(
+            siteID: 123,
+            pluginPath: "jetpack/jetpack.php",
+            minimumVersion: "14.4",
+            stores: stores
+        )
+
+        // When / Then
+        do {
+            _ = try await checker.checkCompatibility()
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(error is PluginVersionError)
+        }
+    }
+
+    func test_throws_when_system_info_sync_fails() async {
+        // Given
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .synchronizeSystemInformation(_, onCompletion):
+                onCompletion(.failure(NSError(domain: "test", code: 0)))
+            default:
+                break
+            }
+        }
+
+        let checker = PluginVersionChecker(
+            siteID: 123,
+            pluginPath: "jetpack/jetpack.php",
+            minimumVersion: "14.4",
+            stores: stores
+        )
+
+        // When / Then
+        do {
+            _ = try await checker.checkCompatibility()
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(error is NSError)
+        }
+    }
+}
+
+private extension PluginVersionCheckerTests {
+    func mockSystemInfo(with plugins: [SystemPlugin]) {
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .synchronizeSystemInformation(_, onCompletion):
+                let systemInfo = SystemInformation.fake().copy(systemPlugins: plugins)
+                onCompletion(.success(systemInfo))
+            default:
+                break
+            }
+        }
+    }
+}


### PR DESCRIPTION
Follow up on #16614

## Description

Extracts `PluginVersionChecker` from #16614 into its own PR to reduce the diff size of the parent PR.

**Key changes:**
- `PluginVersionChecker` fetches system information and validates a plugin meets a minimum version
- `PluginVersionCheckerProtocol` for testability

## Test Steps

- No functionality was added so CI should pass as that indicates new unit tests pass.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
