### PR TITLE
[CIAB MVP] Display bookings tab if POS is absent

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -86,6 +86,7 @@ final class HubMenuViewModel: ObservableObject {
     private let googleAdsEligibilityChecker: GoogleAdsEligibilityChecker
 
     private let siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol
+    private let posEligibilityService: POSEligibilityServiceProtocol
     private let bookingsEligibilityCheckerFactory: (Site) -> BookingsTabEligibilityCheckerProtocol
     private let isPad: Bool
 
@@ -99,6 +100,7 @@ final class HubMenuViewModel: ObservableObject {
     @Published private var isSiteEligibleForGoogleAds = false
     @Published private var isSiteEligibleForInbox = false
     @Published private var isSiteEligibleForBookings = false
+    @Published private var isPOSTabCachedVisible = false
 
     private var cancellables: Set<AnyCancellable> = []
 
@@ -136,6 +138,7 @@ final class HubMenuViewModel: ObservableObject {
          blazeEligibilityChecker: BlazeEligibilityCheckerProtocol = BlazeEligibilityChecker(),
          googleAdsEligibilityChecker: GoogleAdsEligibilityChecker = DefaultGoogleAdsEligibilityChecker(),
          siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker(),
+         posEligibilityService: POSEligibilityServiceProtocol = POSEligibilityService(),
          bookingsEligibilityCheckerFactory: @escaping (Site) -> BookingsTabEligibilityCheckerProtocol = { site in
              BookingsTabEligibilityChecker(site: site)
          },
@@ -153,6 +156,7 @@ final class HubMenuViewModel: ObservableObject {
         self.blazeEligibilityChecker = blazeEligibilityChecker
         self.googleAdsEligibilityChecker = googleAdsEligibilityChecker
         self.siteCIABEligibilityChecker = siteCIABEligibilityChecker
+        self.posEligibilityService = posEligibilityService
         self.bookingsEligibilityCheckerFactory = bookingsEligibilityCheckerFactory
         self.isPad = isPad
         self.cardPresentPaymentsOnboarding = CardPresentPaymentsOnboardingUseCase()
@@ -370,6 +374,7 @@ private extension HubMenuViewModel {
 
     func updateMenuItemEligibility(with site: Yosemite.Site) {
         isSiteEligibleForInbox = inboxEligibilityChecker.isEligibleForInbox(siteID: site.siteID)
+        isPOSTabCachedVisible = posEligibilityService.loadCachedPOSTabVisibility(siteID: site.siteID) ?? false
 
         if shouldShowBookingsInMenu {
             let bookingsEligibilityChecker = bookingsEligibilityCheckerFactory(site)
@@ -444,7 +449,7 @@ private extension HubMenuViewModel {
     }
 
     var shouldShowBookingsInMenu: Bool {
-        isPad
+        isPad && isPOSTabCachedVisible
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -161,6 +161,7 @@ final class MainTabBarController: UITabBarController {
 
     private var isPOSTabVisible: Bool = false
     private var isBookingsTabVisible: Bool = false
+    private var isBookingsFeatureAvailable: Bool = false
 
     private lazy var isProductsSplitViewFeatureFlagOn = featureFlagService.isFeatureFlagEnabled(.splitViewInProductsTab)
 
@@ -362,7 +363,13 @@ final class MainTabBarController: UITabBarController {
             for: siteID,
             in: userDefaults
         )
-        let isBookingsTabVisible = shouldShowBookingsTab && isBookingsFeatureAvailable
+
+        self.isBookingsFeatureAvailable = isBookingsFeatureAvailable
+
+        let isBookingsTabVisible = shouldShowBookingsTab(
+            isPOSTabVisible: isPOSTabVisible,
+            bookingsFeatureAvailable: isBookingsFeatureAvailable
+        )
 
         updateTabViewControllers(
             isPOSTabVisible: isPOSTabVisible,
@@ -753,6 +760,8 @@ private extension MainTabBarController {
 
         // Sets POS tab initial visibility based on cached value if available.
         let initialVisibility = posTabVisibilityChecker.checkInitialVisibility()
+        let isBookingsTabVisible = shouldShowBookingsTab(isPOSTabVisible: initialVisibility,
+                                                         bookingsFeatureAvailable: isBookingsFeatureAvailable)
         updateTabViewControllers(isPOSTabVisible: initialVisibility, isBookingsTabVisible: isBookingsTabVisible)
 
         // Cancels any existing task.
@@ -764,6 +773,8 @@ private extension MainTabBarController {
             let isPOSTabVisible = await posTabVisibilityChecker.checkVisibility()
             analytics.track(.pointOfSaleTabVisibilityChecked, withProperties: ["is_visible": isPOSTabVisible])
             cachePOSTabVisibility(siteID: siteID, isPOSTabVisible: isPOSTabVisible)
+            let isBookingsTabVisible = shouldShowBookingsTab(isPOSTabVisible: isPOSTabVisible,
+                                                             bookingsFeatureAvailable: isBookingsFeatureAvailable)
             updateTabViewControllers(isPOSTabVisible: isPOSTabVisible, isBookingsTabVisible: isBookingsTabVisible)
             viewModel.loadHubMenuTabBadge()
 
@@ -913,7 +924,9 @@ private extension MainTabBarController {
 
         // Sets Bookings tab initial visibility based on cached value if available.
         let initialVisibility = bookingsEligibilityChecker.checkInitialVisibility()
-        let initialBookingsTabVisibility = shouldShowBookingsTab && initialVisibility
+        isBookingsFeatureAvailable = initialVisibility
+        let initialBookingsTabVisibility = shouldShowBookingsTab(isPOSTabVisible: isPOSTabVisible,
+                                                                 bookingsFeatureAvailable: initialVisibility)
         updateTabViewControllers(isPOSTabVisible: isPOSTabVisible, isBookingsTabVisible: initialBookingsTabVisibility)
 
         // Cancels any existing task.
@@ -924,15 +937,20 @@ private extension MainTabBarController {
             guard let self else { return }
             let isBookingsFeatureAvailable = await bookingsEligibilityChecker.checkVisibility()
             // TODO: Add analytics tracking for bookings tab visibility
-            let isBookingsTabVisible = shouldShowBookingsTab && isBookingsFeatureAvailable
+            self.isBookingsFeatureAvailable = isBookingsFeatureAvailable
+            let isBookingsTabVisible = shouldShowBookingsTab(isPOSTabVisible: isPOSTabVisible,
+                                                             bookingsFeatureAvailable: isBookingsFeatureAvailable)
             updateTabViewControllers(isPOSTabVisible: isPOSTabVisible, isBookingsTabVisible: isBookingsTabVisible)
         }
     }
 }
 
 private extension MainTabBarController {
-    var shouldShowBookingsTab: Bool {
-        !isPad
+    func shouldShowBookingsTab(isPOSTabVisible: Bool, bookingsFeatureAvailable: Bool) -> Bool {
+        guard bookingsFeatureAvailable else {
+            return false
+        }
+        return isPad ? !isPOSTabVisible : true
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -496,12 +496,15 @@ final class HubMenuViewModelTests: XCTestCase {
         stores.updateDefaultStore(.fake().copy(siteID: sampleSiteID))
 
         let mockBookingsEligibilityChecker = MockBookingsEligibilityChecker(isEligible: true)
+        let posEligibilityService = MockPOSEligibilityService()
+        posEligibilityService.cachedTabVisibility[sampleSiteID] = true
 
         // When
         let viewModel = HubMenuViewModel(
             siteID: sampleSiteID,
             tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
             stores: stores,
+            posEligibilityService: posEligibilityService,
             bookingsEligibilityCheckerFactory: { _ in mockBookingsEligibilityChecker },
             isPad: true
         )

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -523,6 +523,40 @@ final class HubMenuViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_menuElements_exclude_bookings_on_ipad_when_pos_not_available() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.updateDefaultStore(storeID: sampleSiteID)
+        stores.updateDefaultStore(.fake().copy(siteID: sampleSiteID))
+
+        let mockBookingsEligibilityChecker = MockBookingsEligibilityChecker(isEligible: true)
+        let posEligibilityService = MockPOSEligibilityService()
+        posEligibilityService.cachedTabVisibility[sampleSiteID] = false
+
+        // When
+        let viewModel = HubMenuViewModel(
+            siteID: sampleSiteID,
+            tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
+            stores: stores,
+            posEligibilityService: posEligibilityService,
+            bookingsEligibilityCheckerFactory: { _ in mockBookingsEligibilityChecker },
+            isPad: true
+        )
+        viewModel.setupMenuElements()
+
+        waitUntil {
+            viewModel.generalElements.firstIndex(where: { item in
+                item.id == HubMenuViewModel.Bookings.id
+            }) == nil
+        }
+
+        // Then
+        XCTAssertNil(viewModel.generalElements.firstIndex(where: { item in
+            item.id == HubMenuViewModel.Bookings.id
+        }))
+    }
+
+    @MainActor
     func test_showPayments_replaces_navigationPath_with_payments() {
         // Given
         var navigationPath = NavigationPath(["testPath1", "testPath2"])


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-2194

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Covers the edge case mentioned in [comment](https://github.com/woocommerce/woocommerce-ios/pull/16643#pullrequestreview-3773720746)
The "Bookings" will be displayed as tabbar item instead of menu item in case if POS is not supported by store.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
- Use CIAB site
- Use remote FF debug panel and disable POS remote and local FF.
- Restart the app
- Make sure the POS tab is not displayed in tabbar
- Make sure Bookings tab is displayed in tabbar
- Navigate to menu and make sure the "Bookings" tab is not displayed there.
- Turn on the POS FFs and restart the app
- Make sure the POS tab is displayed in tabbar
- Make sure the Bookings item is displayed in menu.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
POS absent / Bookings in tabbar | POS present / Bookings in menu
--- | ---
<img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2026-02-10 at 15 15 11" src="https://github.com/user-attachments/assets/cf99d6b1-bc3b-44c4-a758-c760246c1cde" /> | <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2026-02-10 at 15 14 16" src="https://github.com/user-attachments/assets/27ccb6fc-1889-42b8-b302-d1c2c69f5585" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
