### PR TITLE
POS Refunds-Bookings: Refactor refund integration using a shared component

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -7,6 +7,7 @@ struct POSBookingDetailView: View {
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(POSOrderListModel.self) private var orderListModel
+    @Environment(POSBookingsModel.self) private var bookingsModel
 
     @State private var navigationPath: [NavigationDestination] = []
     @State private var refundModalState: RefundModalState?
@@ -88,7 +89,29 @@ struct POSBookingDetailView: View {
         .posModal(item: $refundModalState, onDismiss: {
             orderListModel.ordersController.clearRefundSelection()
         }) { state in
-            bookingRefundModalContent(for: state)
+            POSRefundModalContentView(
+                state: state,
+                modalState: $refundModalState,
+                isShowingEmailReceiptView: $isShowingEmailReceiptView,
+                orderListModel: orderListModel,
+                onRetryLoading: { initiateBookingRefundFlow() },
+                onRetryPreparation: { initiateBookingRefundFlow() },
+                onEditRefund: nil,
+                showsItemSelection: false,
+                onRefundSuccess: {
+                    Task {
+                        await bookingsModel.bookingsController.refreshBookings()
+                    }
+                },
+                errorStrings: .init(
+                    loadTitle: Localization.loadRefundErrorTitle,
+                    loadSubtitle: Localization.loadRefundErrorSubtitle,
+                    prepareTitle: Localization.prepareRefundErrorTitle,
+                    prepareSubtitle: Localization.prepareRefundErrorSubtitle,
+                    createTitle: Localization.createRefundErrorTitle,
+                    createSubtitle: Localization.createRefundErrorSubtitle
+                )
+            )
         }
     }
 
@@ -327,128 +350,17 @@ private extension POSBookingDetailView {
             let result = await orderListModel.ordersController.startRefundFlow()
             switch result {
             case .hasItemsToRefund:
-                // Skip item selection state. With POS Bookings we only allow full refunds at the moment
-                navigateToRefundReview()
+                // Skip item selection — go directly to review for full refund
+                guard let reviewData = orderListModel.ordersController.preparePOSRefundReviewData() else {
+                    refundModalState = .preparationError
+                    return
+                }
+                refundModalState = .review(reviewData)
             case .nothingToRefund:
                 refundModalState = .nothingToRefund
             case .failed:
                 refundModalState = .loadingError
             }
-        }
-    }
-
-    func navigateToRefundReview() {
-        guard let reviewData = orderListModel.ordersController.preparePOSRefundReviewData() else {
-            refundModalState = .preparationError
-            return
-        }
-        refundModalState = .review(reviewData)
-    }
-
-    @MainActor
-    func processRefund(reviewData: POSRefundReviewData) async {
-        do {
-            try await orderListModel.ordersController.processRefund(reason: reviewData.refundReason)
-            refundModalState = .success(reviewData)
-        } catch {
-            refundModalState = .error(reviewData)
-        }
-    }
-
-    @ViewBuilder
-    func bookingRefundModalContent(for state: RefundModalState) -> some View {
-        switch state {
-        case .loading:
-            POSRefundLoadingView()
-        case .loadingError:
-            POSRefundErrorView(
-                title: Localization.loadRefundErrorTitle,
-                subtitle: Localization.loadRefundErrorSubtitle,
-                onRetry: { initiateBookingRefundFlow() },
-                onCancel: { refundModalState = nil },
-                onClose: { refundModalState = nil }
-            )
-        case .preparationError:
-            POSRefundErrorView(
-                title: Localization.prepareRefundErrorTitle,
-                subtitle: Localization.prepareRefundErrorSubtitle,
-                onRetry: { initiateBookingRefundFlow() },
-                onCancel: { refundModalState = nil },
-                onClose: { refundModalState = nil }
-            )
-        case .nothingToRefund:
-            POSRefundNothingToRefundView(onClose: { refundModalState = nil })
-        case .itemSelection:
-            // Not used for booking refunds — included for exhaustive switch
-            EmptyView()
-        case .review(let reviewData):
-            POSRefundReviewView(
-                onClose: { refundModalState = nil },
-                itemsCount: reviewData.itemsCount,
-                formattedItemsSubtotal: reviewData.formattedItemsSubtotal,
-                formattedTax: reviewData.formattedTax,
-                formattedRefundTotal: reviewData.formattedRefundTotal,
-                paymentMethodDescription: reviewData.paymentMethodDescription,
-                refundReason: reviewData.refundReason,
-                onAddReason: { refundModalState = .reasonInput(reviewData) },
-                onContinue: { refundModalState = .confirmation(reviewData) },
-                onEditRefund: nil
-            )
-        case .reasonInput(let reviewData):
-            POSRefundReasonView(
-                initialReason: reviewData.refundReason,
-                onSave: { reason in
-                    var updated = reviewData
-                    updated.refundReason = reason
-                    refundModalState = .review(updated)
-                },
-                onBack: { refundModalState = .review(reviewData) },
-                onClose: { refundModalState = nil }
-            )
-        case .confirmation(let reviewData):
-            POSRefundConfirmationView(
-                formattedRefundTotal: reviewData.formattedRefundTotal,
-                paymentMethodDescription: reviewData.paymentMethodDescription,
-                isProcessing: false,
-                onClose: { refundModalState = nil },
-                onConfirm: {
-                    refundModalState = .processing(reviewData)
-                    Task { @MainActor in
-                        await processRefund(reviewData: reviewData)
-                    }
-                },
-                onBack: { refundModalState = .review(reviewData) }
-            )
-        case .processing(let reviewData):
-            POSRefundConfirmationView(
-                formattedRefundTotal: reviewData.formattedRefundTotal,
-                paymentMethodDescription: reviewData.paymentMethodDescription,
-                isProcessing: true,
-                onClose: {},
-                onConfirm: {},
-                onBack: {}
-            )
-        case .success(let reviewData):
-            POSRefundSuccessView(
-                formattedRefundTotal: reviewData.formattedRefundTotal,
-                paymentMethodDescription: reviewData.paymentMethodDescription,
-                onDone: { refundModalState = nil },
-                onEmailReceipt: {
-                    refundModalState = nil
-                    Task { @MainActor in
-                        isShowingEmailReceiptView = true
-                    }
-                },
-                onClose: { refundModalState = nil }
-            )
-        case .error(let reviewData):
-            POSRefundErrorView(
-                title: Localization.createRefundErrorTitle,
-                subtitle: Localization.createRefundErrorSubtitle,
-                onRetry: { refundModalState = .confirmation(reviewData) },
-                onCancel: { refundModalState = nil },
-                onClose: { refundModalState = nil }
-            )
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -1,4 +1,3 @@
-import CocoaLumberjackSwift
 import SwiftUI
 import struct WooFoundation.WooAnalyticsEvent
 import struct Yosemite.POSOrder
@@ -69,7 +68,25 @@ struct POSOrderDetailsView: View {
         .posModal(item: $refundModalState, onDismiss: {
             orderListModel.ordersController.clearRefundSelection()
         }) { state in
-            refundModalContent(for: state)
+            POSRefundModalContentView(
+                state: state,
+                modalState: $refundModalState,
+                isShowingEmailReceiptView: $isShowingEmailReceiptView,
+                orderListModel: orderListModel,
+                onRetryLoading: { initiateRefundFlow() },
+                onRetryPreparation: { refundModalState = .itemSelection },
+                onEditRefund: { refundModalState = .itemSelection },
+                showsItemSelection: true,
+                onRefundSuccess: nil,
+                errorStrings: .init(
+                    loadTitle: Localization.loadRefundErrorTitle,
+                    loadSubtitle: Localization.loadRefundErrorSubtitle,
+                    prepareTitle: Localization.prepareRefundErrorTitle,
+                    prepareSubtitle: Localization.prepareRefundErrorSubtitle,
+                    createTitle: Localization.createRefundErrorTitle,
+                    createSubtitle: Localization.createRefundErrorSubtitle
+                )
+            )
         }
         .onAppear {
             analytics.track(event: WooAnalyticsEvent.PointOfSale.orderDetailsLoaded(
@@ -516,185 +533,6 @@ private extension POSOrderDetailsView {
     }
 }
 
-// MARK: - Refund Modal State
-
-enum RefundModalState: Identifiable, Equatable {
-    case loading
-    case loadingError
-    case preparationError
-    case nothingToRefund
-    case itemSelection
-    case review(POSRefundReviewData)
-    case reasonInput(POSRefundReviewData)
-    case confirmation(POSRefundReviewData)
-    case processing(POSRefundReviewData)
-    case success(POSRefundReviewData)
-    case error(POSRefundReviewData)
-
-    var id: String {
-        switch self {
-        case .loading: return "loading"
-        case .loadingError: return "loadingError"
-        case .preparationError: return "preparationError"
-        case .nothingToRefund: return "nothingToRefund"
-        case .itemSelection: return "itemSelection"
-        case .review: return "review"
-        case .reasonInput: return "reasonInput"
-        case .confirmation: return "confirmation"
-        case .processing: return "processing"
-        case .success: return "success"
-        case .error: return "error"
-        }
-    }
-}
-
-// MARK: - Refund Modal Content
-
-private extension POSOrderDetailsView {
-    @ViewBuilder
-    func refundModalContent(for state: RefundModalState) -> some View {
-        switch state {
-        case .loading:
-            POSRefundLoadingView()
-        case .loadingError:
-            POSRefundErrorView(
-                title: Localization.loadRefundErrorTitle,
-                subtitle: Localization.loadRefundErrorSubtitle,
-                onRetry: { initiateRefundFlow() },
-                onCancel: { refundModalState = nil },
-                onClose: { refundModalState = nil }
-            )
-        case .preparationError:
-            POSRefundErrorView(
-                title: Localization.prepareRefundErrorTitle,
-                subtitle: Localization.prepareRefundErrorSubtitle,
-                onRetry: { refundModalState = .itemSelection },
-                onCancel: { refundModalState = nil },
-                onClose: { refundModalState = nil }
-            )
-        case .nothingToRefund:
-            POSRefundNothingToRefundView(
-                onClose: { refundModalState = nil }
-            )
-        case .itemSelection:
-            POSRefundItemsSelectionView(
-                onClose: { refundModalState = nil },
-                onContinue: { navigateToRefundReview() }
-            )
-        case .review(let reviewData):
-            POSRefundReviewView(
-                onClose: { refundModalState = nil },
-                itemsCount: reviewData.itemsCount,
-                formattedItemsSubtotal: reviewData.formattedItemsSubtotal,
-                formattedTax: reviewData.formattedTax,
-                formattedRefundTotal: reviewData.formattedRefundTotal,
-                paymentMethodDescription: reviewData.paymentMethodDescription,
-                refundReason: reviewData.refundReason,
-                onAddReason: {
-                    refundModalState = .reasonInput(reviewData)
-                },
-                onContinue: {
-                    refundModalState = .confirmation(reviewData)
-                },
-                onEditRefund: {
-                    refundModalState = .itemSelection
-                }
-            )
-        case .reasonInput(let reviewData):
-            POSRefundReasonView(
-                initialReason: reviewData.refundReason,
-                onSave: { reason in
-                    var updatedReviewData = reviewData
-                    updatedReviewData.refundReason = reason
-                    refundModalState = .review(updatedReviewData)
-                },
-                onBack: {
-                    refundModalState = .review(reviewData)
-                },
-                onClose: {
-                    refundModalState = nil
-                }
-            )
-        case .confirmation(let reviewData):
-            POSRefundConfirmationView(
-                formattedRefundTotal: reviewData.formattedRefundTotal,
-                paymentMethodDescription: reviewData.paymentMethodDescription,
-                isProcessing: false,
-                onClose: {
-                    refundModalState = nil
-                },
-                onConfirm: {
-                    refundModalState = .processing(reviewData)
-                    Task { @MainActor in
-                        await processRefund(reviewData: reviewData)
-                    }
-                },
-                onBack: {
-                    refundModalState = .review(reviewData)
-                }
-            )
-        case .processing(let reviewData):
-            POSRefundConfirmationView(
-                formattedRefundTotal: reviewData.formattedRefundTotal,
-                paymentMethodDescription: reviewData.paymentMethodDescription,
-                isProcessing: true,
-                onClose: {},
-                onConfirm: {},
-                onBack: {}
-            )
-        case .success(let reviewData):
-            POSRefundSuccessView(
-                formattedRefundTotal: reviewData.formattedRefundTotal,
-                paymentMethodDescription: reviewData.paymentMethodDescription,
-                onDone: {
-                    refundModalState = nil
-                },
-                onEmailReceipt: {
-                    refundModalState = nil
-                    Task { @MainActor in
-                        isShowingEmailReceiptView = true
-                    }
-                },
-                onClose: {
-                    refundModalState = nil
-                }
-            )
-        case .error(let reviewData):
-            POSRefundErrorView(
-                title: Localization.createRefundErrorTitle,
-                subtitle: Localization.createRefundErrorSubtitle,
-                onRetry: {
-                    refundModalState = .confirmation(reviewData)
-                },
-                onCancel: {
-                    refundModalState = nil
-                },
-                onClose: {
-                    refundModalState = nil
-                }
-            )
-        }
-    }
-
-    func navigateToRefundReview() {
-        guard let reviewData = orderListModel.ordersController.preparePOSRefundReviewData() else {
-            refundModalState = .preparationError
-            return
-        }
-        refundModalState = .review(reviewData)
-    }
-
-    @MainActor
-    func processRefund(reviewData: POSRefundReviewData) async {
-        do {
-            try await orderListModel.ordersController.processRefund(reason: reviewData.refundReason)
-            refundModalState = .success(reviewData)
-        } catch {
-            DDLogError("⛔️ Failed to process refund: \(error)")
-            refundModalState = .error(reviewData)
-        }
-    }
-}
 
 // MARK: - Localization
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -499,10 +499,6 @@ private extension POSOrderDetailsView {
         }
     }
 
-    func emailReceiptAction() {
-        analytics.track(event: WooAnalyticsEvent.PointOfSale.orderDetailsEmailReceiptTapped())
-        isShowingEmailReceiptView = true
-    }
 }
 
 private extension POSOrderDetailsView {

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -73,7 +73,7 @@ struct POSOrderDetailsView: View {
             POSRefundModalContentView(
                 state: state,
                 modalState: $refundModalState,
-                isShowingEmailReceiptView: $isShowingEmailReceiptView,
+                onEmailReceipt: { isShowingEmailReceiptView = true },
                 onRetryLoading: { initiateRefundFlow() },
                 onRetryPreparation: {
                     if autoStartRefund {

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -74,7 +74,6 @@ struct POSOrderDetailsView: View {
                 state: state,
                 modalState: $refundModalState,
                 isShowingEmailReceiptView: $isShowingEmailReceiptView,
-                orderListModel: orderListModel,
                 onRetryLoading: { initiateRefundFlow() },
                 onRetryPreparation: {
                     if autoStartRefund {

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -1,4 +1,3 @@
-import CocoaLumberjackSwift
 import SwiftUI
 
 // MARK: - Refund Modal State
@@ -194,7 +193,6 @@ struct POSRefundModalContentView: View {
             modalState = .success(reviewData)
             onRefundSuccess?()
         } catch {
-            DDLogError("⛔️ Failed to process refund: \(error)")
             modalState = .error(reviewData)
         }
     }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -51,22 +51,10 @@ struct POSRefundModalContentView: View {
     @Binding var isShowingEmailReceiptView: Bool
     let orderListModel: POSOrderListModel
 
-    /// Called when the loading error retry button is tapped.
     let onRetryLoading: () -> Void
-
-    /// Called when the preparation error retry button is tapped.
     let onRetryPreparation: () -> Void
-
-    /// Called when the "Edit refund" button is tapped on the review screen.
-    /// Pass `nil` to hide the button (e.g. for full-refund-only flows like bookings).
     let onEditRefund: (() -> Void)?
-
-    /// Whether to show the item selection view for the `.itemSelection` state.
-    /// Set to `false` for flows that skip item selection (e.g. bookings).
     let showsItemSelection: Bool
-
-    /// Called after a refund is successfully processed.
-    /// Use this to trigger side effects like refreshing a booking list.
     let onRefundSuccess: (() -> Void)?
 
     let errorStrings: POSRefundErrorStrings

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -1,0 +1,201 @@
+import CocoaLumberjackSwift
+import SwiftUI
+
+// MARK: - Refund Modal State
+
+enum RefundModalState: Identifiable, Equatable {
+    case loading
+    case loadingError
+    case preparationError
+    case nothingToRefund
+    case itemSelection
+    case review(POSRefundReviewData)
+    case reasonInput(POSRefundReviewData)
+    case confirmation(POSRefundReviewData)
+    case processing(POSRefundReviewData)
+    case success(POSRefundReviewData)
+    case error(POSRefundReviewData)
+
+    var id: String {
+        switch self {
+        case .loading: return "loading"
+        case .loadingError: return "loadingError"
+        case .preparationError: return "preparationError"
+        case .nothingToRefund: return "nothingToRefund"
+        case .itemSelection: return "itemSelection"
+        case .review: return "review"
+        case .reasonInput: return "reasonInput"
+        case .confirmation: return "confirmation"
+        case .processing: return "processing"
+        case .success: return "success"
+        case .error: return "error"
+        }
+    }
+}
+
+// MARK: - Error Strings
+
+struct POSRefundErrorStrings {
+    let loadTitle: String
+    let loadSubtitle: String
+    let prepareTitle: String
+    let prepareSubtitle: String
+    let createTitle: String
+    let createSubtitle: String
+}
+
+// MARK: - Shared Refund Modal Content
+
+struct POSRefundModalContentView: View {
+    let state: RefundModalState
+    @Binding var modalState: RefundModalState?
+    @Binding var isShowingEmailReceiptView: Bool
+    let orderListModel: POSOrderListModel
+
+    /// Called when the loading error retry button is tapped.
+    let onRetryLoading: () -> Void
+
+    /// Called when the preparation error retry button is tapped.
+    let onRetryPreparation: () -> Void
+
+    /// Called when the "Edit refund" button is tapped on the review screen.
+    /// Pass `nil` to hide the button (e.g. for full-refund-only flows like bookings).
+    let onEditRefund: (() -> Void)?
+
+    /// Whether to show the item selection view for the `.itemSelection` state.
+    /// Set to `false` for flows that skip item selection (e.g. bookings).
+    let showsItemSelection: Bool
+
+    /// Called after a refund is successfully processed.
+    /// Use this to trigger side effects like refreshing a booking list.
+    let onRefundSuccess: (() -> Void)?
+
+    let errorStrings: POSRefundErrorStrings
+
+    var body: some View {
+        content
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch state {
+        case .loading:
+            POSRefundLoadingView()
+        case .loadingError:
+            POSRefundErrorView(
+                title: errorStrings.loadTitle,
+                subtitle: errorStrings.loadSubtitle,
+                onRetry: onRetryLoading,
+                onCancel: { modalState = nil },
+                onClose: { modalState = nil }
+            )
+        case .preparationError:
+            POSRefundErrorView(
+                title: errorStrings.prepareTitle,
+                subtitle: errorStrings.prepareSubtitle,
+                onRetry: onRetryPreparation,
+                onCancel: { modalState = nil },
+                onClose: { modalState = nil }
+            )
+        case .nothingToRefund:
+            POSRefundNothingToRefundView(onClose: { modalState = nil })
+        case .itemSelection:
+            if showsItemSelection {
+                POSRefundItemsSelectionView(
+                    onClose: { modalState = nil },
+                    onContinue: { navigateToRefundReview() }
+                )
+            } else {
+                EmptyView()
+            }
+        case .review(let reviewData):
+            POSRefundReviewView(
+                onClose: { modalState = nil },
+                itemsCount: reviewData.itemsCount,
+                formattedItemsSubtotal: reviewData.formattedItemsSubtotal,
+                formattedTax: reviewData.formattedTax,
+                formattedRefundTotal: reviewData.formattedRefundTotal,
+                paymentMethodDescription: reviewData.paymentMethodDescription,
+                refundReason: reviewData.refundReason,
+                onAddReason: { modalState = .reasonInput(reviewData) },
+                onContinue: { modalState = .confirmation(reviewData) },
+                onEditRefund: onEditRefund
+            )
+        case .reasonInput(let reviewData):
+            POSRefundReasonView(
+                initialReason: reviewData.refundReason,
+                onSave: { reason in
+                    var updated = reviewData
+                    updated.refundReason = reason
+                    modalState = .review(updated)
+                },
+                onBack: { modalState = .review(reviewData) },
+                onClose: { modalState = nil }
+            )
+        case .confirmation(let reviewData):
+            POSRefundConfirmationView(
+                formattedRefundTotal: reviewData.formattedRefundTotal,
+                paymentMethodDescription: reviewData.paymentMethodDescription,
+                isProcessing: false,
+                onClose: { modalState = nil },
+                onConfirm: {
+                    modalState = .processing(reviewData)
+                    Task { @MainActor in
+                        await processRefund(reviewData: reviewData)
+                    }
+                },
+                onBack: { modalState = .review(reviewData) }
+            )
+        case .processing(let reviewData):
+            POSRefundConfirmationView(
+                formattedRefundTotal: reviewData.formattedRefundTotal,
+                paymentMethodDescription: reviewData.paymentMethodDescription,
+                isProcessing: true,
+                onClose: {},
+                onConfirm: {},
+                onBack: {}
+            )
+        case .success(let reviewData):
+            POSRefundSuccessView(
+                formattedRefundTotal: reviewData.formattedRefundTotal,
+                paymentMethodDescription: reviewData.paymentMethodDescription,
+                onDone: { modalState = nil },
+                onEmailReceipt: {
+                    modalState = nil
+                    Task { @MainActor in
+                        isShowingEmailReceiptView = true
+                    }
+                },
+                onClose: { modalState = nil }
+            )
+        case .error(let reviewData):
+            POSRefundErrorView(
+                title: errorStrings.createTitle,
+                subtitle: errorStrings.createSubtitle,
+                onRetry: { modalState = .confirmation(reviewData) },
+                onCancel: { modalState = nil },
+                onClose: { modalState = nil }
+            )
+        }
+    }
+
+    private func navigateToRefundReview() {
+        guard let reviewData = orderListModel.ordersController.preparePOSRefundReviewData() else {
+            modalState = .preparationError
+            return
+        }
+        modalState = .review(reviewData)
+    }
+
+    @MainActor
+    private func processRefund(reviewData: POSRefundReviewData) async {
+        do {
+            try await orderListModel.ordersController.processRefund(reason: reviewData.refundReason)
+            modalState = .success(reviewData)
+            onRefundSuccess?()
+        } catch {
+            DDLogError("⛔️ Failed to process refund: \(error)")
+            modalState = .error(reviewData)
+        }
+    }
+}

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -94,6 +94,7 @@ struct POSRefundModalContentView: View {
                     onContinue: { navigateToRefundReview() }
                 )
             } else {
+                assertionFailure("Unexpected .itemSelection state when showsItemSelection is false")
                 EmptyView()
             }
         case .review(let reviewData):

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -1,3 +1,4 @@
+import CocoaLumberjackSwift
 import SwiftUI
 
 // MARK: - Refund Modal State
@@ -179,6 +180,7 @@ struct POSRefundModalContentView: View {
             modalState = .success(reviewData)
             onRefundSuccess?()
         } catch {
+            DDLogError("⛔️ Failed to process POS refund: \(error)")
             modalState = .error(reviewData)
         }
     }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -94,7 +94,6 @@ struct POSRefundModalContentView: View {
                     onContinue: { navigateToRefundReview() }
                 )
             } else {
-                assertionFailure("Unexpected .itemSelection state when showsItemSelection is false")
                 EmptyView()
             }
         case .review(let reviewData):

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -48,9 +48,9 @@ struct POSRefundErrorStrings {
 struct POSRefundModalContentView: View {
     let state: RefundModalState
     @Binding var modalState: RefundModalState?
-    @Binding var isShowingEmailReceiptView: Bool
     @Environment(POSOrderListModel.self) private var orderListModel
 
+    let onEmailReceipt: () -> Void
     let onRetryLoading: () -> Void
     let onRetryPreparation: () -> Void
     let onEditRefund: (() -> Void)?
@@ -149,9 +149,7 @@ struct POSRefundModalContentView: View {
                 onDone: { modalState = nil },
                 onEmailReceipt: {
                     modalState = nil
-                    Task { @MainActor in
-                        isShowingEmailReceiptView = true
-                    }
+                    onEmailReceipt()
                 },
                 onClose: { modalState = nil }
             )

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -49,7 +49,7 @@ struct POSRefundModalContentView: View {
     let state: RefundModalState
     @Binding var modalState: RefundModalState?
     @Binding var isShowingEmailReceiptView: Bool
-    let orderListModel: POSOrderListModel
+    @Environment(POSOrderListModel.self) private var orderListModel
 
     let onRetryLoading: () -> Void
     let onRetryPreparation: () -> Void


### PR DESCRIPTION
Closes WOOMOB-2198

## Description

This PR extracts the refund modal flow duplication from `POSBookingDetailView` and `POSOrderDetailsView` into a shared `POSRefundModalContentView`

## Changes
- `POSRefundModalContentView` renders the appropriate view for each `RefundModalState`
- `bookingsModel` injected into the bookings detail view.

## Test Steps
1. In POS > Floating Menu > Orders. Refund an Order. This feature is still feature-flagged, is not customer-facing.
2. If the order contains more than 1 item, you should see the item-by-item refund step.

<img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - CIAB - 2026-02-11 at 12 24 23" src="https://github.com/user-attachments/assets/11af694b-abeb-44c1-b1db-b99ad45c5cef" />


3. In POS > Floating Menu > Bookings. Refund a Booking as per https://github.com/woocommerce/woocommerce-ios/pull/16646

<img width="754" height="595" alt="Screenshot 2026-02-11 at 12 41 37" src="https://github.com/user-attachments/assets/8a118931-6e5f-4551-8d69-1c01225ca929" />

