### PR TITLE
Bookings: Display filters on Today and Upcoming tabs

### DIFF
--- a/Modules/Sources/Networking/Remote/BookingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/BookingsRemote.swift
@@ -59,6 +59,40 @@ public struct BookingFilters {
         self.attendanceStatuses = attendanceStatuses
         self.paymentStatuses = paymentStatuses
     }
+
+    /// Returns a new `BookingFilters` by merging user-applied filters with this instance's date constraints.
+    /// Non-date fields come from `userFilters`; date fields are intersected
+    /// (later `startDateAfter`, earlier `startDateBefore`).
+    public func mergingDates(with userFilters: BookingFilters) -> BookingFilters {
+        BookingFilters(
+            productIDs: userFilters.productIDs,
+            customerIDs: userFilters.customerIDs,
+            resourceIDs: userFilters.resourceIDs,
+            startDateBefore: Self.mostRestrictiveDate(date1: startDateBefore,
+                                                      date2: userFilters.startDateBefore,
+                                                      pickEarlier: true),
+            startDateAfter: Self.mostRestrictiveDate(date1: startDateAfter,
+                                                     date2: userFilters.startDateAfter,
+                                                     pickEarlier: false),
+            attendanceStatuses: userFilters.attendanceStatuses
+        )
+    }
+
+    /// Returns the most restrictive of two ISO 8601 date strings.
+    /// - `pickEarlier = true`  → picks `min` (for upper bounds / `startDateBefore`)
+    /// - `pickEarlier = false` → picks `max` (for lower bounds / `startDateAfter`)
+    private static func mostRestrictiveDate(date1: String?, date2: String?, pickEarlier: Bool) -> String? {
+        switch (date1, date2) {
+        case (nil, nil):
+            return nil
+        case (let d, nil):
+            return d
+        case (nil, let d):
+            return d
+        case (let d1?, let d2?):
+            return pickEarlier ? min(d1, d2) : max(d1, d2)
+        }
+    }
 }
 
 /// Booking: Remote Endpoints

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
@@ -88,7 +88,7 @@ private extension BookingListContainerView {
                         .font(.body)
                         .foregroundStyle(Color.accentColor)
                 }
-                .renderedIf(viewModel.selectedTab == .all)
+
             }
             .padding()
             .background(Color(.listForeground(modal: false)))

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
@@ -33,6 +33,12 @@ final class BookingListContainerViewModel: ObservableObject {
         allListViewModel
     ]
 
+    private lazy var allSearchViewModels: [BookingSearchViewModel] = [
+        todaySearchViewModel,
+        upcomingSearchViewModel,
+        allSearchViewModel
+    ]
+
     private var filters = BookingFiltersViewModel.Filters()
 
     var filterText: String {
@@ -129,12 +135,8 @@ final class BookingListContainerViewModel: ObservableObject {
     func updateFilters(_ filters: BookingFiltersViewModel.Filters, shouldPersist: Bool = true) {
         self.filters = filters
         self.numberOfActiveFilters = filters.numberOfActiveFilters
-        todayListViewModel.updateFilters(filters)
-        upcomingListViewModel.updateFilters(filters)
-        allListViewModel.updateFilters(filters)
-        todaySearchViewModel.updateFilters(filters)
-        upcomingSearchViewModel.updateFilters(filters)
-        allSearchViewModel.updateFilters(filters)
+        allTabViewModels.forEach { $0.updateFilters(filters) }
+        allSearchViewModels.forEach { $0.updateFilters(filters) }
         if shouldPersist {
             saveFilters(filters)
         }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
@@ -127,10 +127,13 @@ final class BookingListContainerViewModel: ObservableObject {
     }
 
     func updateFilters(_ filters: BookingFiltersViewModel.Filters, shouldPersist: Bool = true) {
-        guard selectedTab == .all else { return }
         self.filters = filters
         self.numberOfActiveFilters = filters.numberOfActiveFilters
+        todayListViewModel.updateFilters(filters)
+        upcomingListViewModel.updateFilters(filters)
         allListViewModel.updateFilters(filters)
+        todaySearchViewModel.updateFilters(filters)
+        upcomingSearchViewModel.updateFilters(filters)
         allSearchViewModel.updateFilters(filters)
         if shouldPersist {
             saveFilters(filters)
@@ -138,7 +141,6 @@ final class BookingListContainerViewModel: ObservableObject {
     }
 
     func clearFilters() {
-        guard selectedTab == .all else { return }
         let filters = BookingFiltersViewModel.Filters()
         updateFilters(filters)
     }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
@@ -35,6 +35,7 @@ final class BookingListViewModel: ObservableObject {
     private let storage: StorageManagerType
     private var currentOrder: SortBy = .newestToOldest
 
+    private let tabDateFilters: BookingFilters
     private var filters: BookingFilters
 
     private static let refreshCacheReason = "refresh-cache"
@@ -79,17 +80,11 @@ final class BookingListViewModel: ObservableObject {
         self.analytics = analytics
         self.paginationTracker = PaginationTracker(pageFirstIndex: pageFirstIndex)
 
-        self.filters = {
-            switch type {
-            case .all:
-                BookingFilters()
-            case .today, .upcoming:
-                BookingFilters(
-                    startDateBefore: type.startDateBefore(currentDate: currentDate)?.ISO8601Format(),
-                    startDateAfter: type.startDateAfter(currentDate: currentDate)?.ISO8601Format()
-                )
-            }
-        }()
+        self.tabDateFilters = BookingFilters(
+            startDateBefore: type.startDateBefore(currentDate: currentDate)?.ISO8601Format(),
+            startDateAfter: type.startDateAfter(currentDate: currentDate)?.ISO8601Format()
+        )
+        self.filters = tabDateFilters
 
         configureResultsController()
         configurePaginationTracker()
@@ -131,10 +126,8 @@ final class BookingListViewModel: ObservableObject {
     }
 
     func updateFilters(_ filters: BookingFiltersViewModel.Filters) {
-        /// Only support filters for All tab
-        guard type == .all else { return }
         hasFilters = filters.numberOfActiveFilters > 0
-        self.filters = filters.bookingFilters
+        self.filters = tabDateFilters.mergingDates(with: filters.bookingFilters)
         resultsController.updatePredicate(siteID: siteID, filters: self.filters)
         paginationTracker.resync(reason: Self.refreshCacheReason) {}
     }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingSearchViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingSearchViewModel.swift
@@ -19,6 +19,7 @@ final class BookingSearchViewModel: ObservableObject {
     private var searchQuerySubscription: AnyCancellable?
     private var currentOrder: BookingListViewModel.SortBy = .newestToOldest
 
+    private let tabDateFilters: BookingFilters
     private var filters: BookingFilters
 
     /// Tracks if the infinite scroll indicator should be displayed.
@@ -41,17 +42,11 @@ final class BookingSearchViewModel: ObservableObject {
         self.stores = stores
         self.searchPaginationTracker = PaginationTracker(pageFirstIndex: pageFirstIndex)
 
-        self.filters = {
-            switch type {
-            case .all:
-                BookingFilters() // TODO: check local storage for persisted filters
-            case .today, .upcoming:
-                BookingFilters(
-                    startDateBefore: type.startDateBefore(currentDate: currentDate)?.ISO8601Format(),
-                    startDateAfter: type.startDateAfter(currentDate: currentDate)?.ISO8601Format()
-                )
-            }
-        }()
+        self.tabDateFilters = BookingFilters(
+            startDateBefore: type.startDateBefore(currentDate: currentDate)?.ISO8601Format(),
+            startDateAfter: type.startDateAfter(currentDate: currentDate)?.ISO8601Format()
+        )
+        self.filters = tabDateFilters
 
         configureSearchPaginationTracker()
         configureSearchQuerySubscription(searchQueryPublisher: searchQueryPublisher)
@@ -83,9 +78,7 @@ final class BookingSearchViewModel: ObservableObject {
     }
 
     func updateFilters(_ filters: BookingFiltersViewModel.Filters) {
-        /// Only support filters for All tab
-        guard type == .all else { return }
-        self.filters = filters.bookingFilters
+        self.filters = tabDateFilters.mergingDates(with: filters.bookingFilters)
         searchPaginationTracker.resync(reason: nil) {}
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListContainerViewModelTests.swift
@@ -159,6 +159,56 @@ class BookingListContainerViewModelTests {
         #expect(analyticsProvider.received(event: "booking_list_sort_by_tapped"))
     }
 
+    // MARK: - Filter propagation
+
+    @Test func updateFilters_propagates_to_all_tabs() {
+        // Given
+        let viewModel = givenViewModel()
+        let filters = BookingFiltersViewModel.Filters(
+            teamMembers: [BookingTeamMemberFilter(resourceID: 1, name: "Alice")],
+            products: [],
+            attendanceStatuses: [],
+            customers: [],
+            dateRange: nil,
+            numberOfActiveFilters: 1
+        )
+
+        // When - on Today tab
+        viewModel.setSelectedTab(to: .today)
+        viewModel.updateFilters(filters)
+
+        // Then - should propagate (no guard blocking non-All tabs)
+        #expect(viewModel.numberOfActiveFilters == 1)
+        #expect(viewModel.listViewModel(for: .today).hasFilters == true)
+        #expect(viewModel.listViewModel(for: .upcoming).hasFilters == true)
+        #expect(viewModel.listViewModel(for: .all).hasFilters == true)
+    }
+
+    @Test func clearFilters_works_on_non_all_tabs() {
+        // Given
+        let viewModel = givenViewModel()
+        let filters = BookingFiltersViewModel.Filters(
+            teamMembers: [BookingTeamMemberFilter(resourceID: 1, name: "Alice")],
+            products: [],
+            attendanceStatuses: [],
+            customers: [],
+            dateRange: nil,
+            numberOfActiveFilters: 1
+        )
+
+        // Apply filters on Today tab
+        viewModel.setSelectedTab(to: .today)
+        viewModel.updateFilters(filters)
+        #expect(viewModel.numberOfActiveFilters == 1)
+
+        // When - clear filters on Today tab
+        viewModel.clearFilters()
+
+        // Then
+        #expect(viewModel.numberOfActiveFilters == 0)
+        #expect(viewModel.listViewModel(for: .today).hasFilters == false)
+    }
+
     @Test func event_fire_when_sortByOptionSelected() {
         // Given
         let viewModel = givenViewModel()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
@@ -561,6 +561,210 @@ class BookingListViewModelTests {
         #expect(viewModel.bookings.first?.siteID == sampleSiteID, "Booking should have the correct site ID")
     }
 
+    // MARK: - Filter merging
+
+    @Test func today_tab_merges_user_date_filters_with_tab_constraints() {
+        // Given
+        let testDate = Date(timeIntervalSince1970: 1609459200) // 2021-01-01 00:00:00 UTC
+        var capturedFilters: BookingFilters?
+
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            guard case let .synchronizeBookings(_, _, _, filters, _, _, onCompletion) = action else {
+                return
+            }
+            capturedFilters = filters
+            onCompletion(.success(false))
+        }
+
+        let viewModel = BookingListViewModel(siteID: sampleSiteID, type: .today, stores: stores, storage: storageManager, currentDate: testDate)
+
+        // User filter with a date range that overlaps today
+        // User wants: after 2020-12-31T12:00:00Z, before 2021-01-01T18:00:00Z
+        let userFilters = BookingFiltersViewModel.Filters(
+            teamMembers: [],
+            products: [],
+            attendanceStatuses: [],
+            customers: [],
+            dateRange: BookingDateRangeFilter(
+                startDate: Date(timeIntervalSince1970: 1609416000), // 2020-12-31T12:00:00Z
+                endDate: Date(timeIntervalSince1970: 1609524000)    // 2021-01-01T18:00:00Z
+            ),
+            numberOfActiveFilters: 1
+        )
+
+        // When
+        viewModel.updateFilters(userFilters)
+        viewModel.loadBookings()
+
+        // Then - startDateAfter should be max(tab, user) = tab's value (later)
+        // Tab startDateAfter = "2020-12-31T23:59:59Z", user startDateAfter = "2020-12-31T12:00:00Z"
+        // max = "2020-12-31T23:59:59Z"
+        #expect(capturedFilters?.startDateAfter == "2020-12-31T23:59:59Z",
+                "Should use tab's startDateAfter since it's later (more restrictive)")
+
+        // startDateBefore should be min(tab, user) = user's value (earlier)
+        // Tab startDateBefore = "2021-01-02T00:00:00Z", user startDateBefore = "2021-01-01T18:00:00Z"
+        // min = "2021-01-01T18:00:00Z"
+        #expect(capturedFilters?.startDateBefore == "2021-01-01T18:00:00Z",
+                "Should use user's startDateBefore since it's earlier (more restrictive)")
+    }
+
+    @Test func upcoming_tab_merges_user_date_filters_with_tab_constraints() {
+        // Given
+        let testDate = Date(timeIntervalSince1970: 1609459200) // 2021-01-01 00:00:00 UTC
+        var capturedFilters: BookingFilters?
+
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            guard case let .synchronizeBookings(_, _, _, filters, _, _, onCompletion) = action else {
+                return
+            }
+            capturedFilters = filters
+            onCompletion(.success(false))
+        }
+
+        let viewModel = BookingListViewModel(siteID: sampleSiteID, type: .upcoming, stores: stores, storage: storageManager, currentDate: testDate)
+
+        // User filter with date range
+        let userFilters = BookingFiltersViewModel.Filters(
+            teamMembers: [],
+            products: [],
+            attendanceStatuses: [],
+            customers: [],
+            dateRange: BookingDateRangeFilter(
+                startDate: Date(timeIntervalSince1970: 1609632000), // 2021-01-03T00:00:00Z
+                endDate: Date(timeIntervalSince1970: 1609804800)    // 2021-01-05T00:00:00Z
+            ),
+            numberOfActiveFilters: 1
+        )
+
+        // When
+        viewModel.updateFilters(userFilters)
+        viewModel.loadBookings()
+
+        // Then - startDateAfter = max(tab, user)
+        // Tab startDateAfter = "2021-01-01T23:59:59Z", user startDateAfter = "2021-01-03T00:00:00Z"
+        // max = "2021-01-03T00:00:00Z"
+        #expect(capturedFilters?.startDateAfter == "2021-01-03T00:00:00Z",
+                "Should use user's startDateAfter since it's later (more restrictive)")
+
+        // startDateBefore = min(tab=nil, user) = user's value
+        #expect(capturedFilters?.startDateBefore == "2021-01-05T00:00:00Z",
+                "Should use user's startDateBefore since tab has no upper bound")
+    }
+
+    @Test func all_tab_passes_user_date_filters_through_unchanged() {
+        // Given
+        let testDate = Date(timeIntervalSince1970: 1609459200)
+        var capturedFilters: BookingFilters?
+
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            guard case let .synchronizeBookings(_, _, _, filters, _, _, onCompletion) = action else {
+                return
+            }
+            capturedFilters = filters
+            onCompletion(.success(false))
+        }
+
+        let viewModel = BookingListViewModel(siteID: sampleSiteID, type: .all, stores: stores, storage: storageManager, currentDate: testDate)
+
+        let userStartDate = Date(timeIntervalSince1970: 1609632000) // 2021-01-03T00:00:00Z
+        let userEndDate = Date(timeIntervalSince1970: 1609804800)   // 2021-01-05T00:00:00Z
+        let userFilters = BookingFiltersViewModel.Filters(
+            teamMembers: [],
+            products: [],
+            attendanceStatuses: [],
+            customers: [],
+            dateRange: BookingDateRangeFilter(startDate: userStartDate, endDate: userEndDate),
+            numberOfActiveFilters: 1
+        )
+
+        // When
+        viewModel.updateFilters(userFilters)
+        viewModel.loadBookings()
+
+        // Then - All tab has no tab constraints, so user dates pass through
+        #expect(capturedFilters?.startDateAfter == userStartDate.ISO8601Format())
+        #expect(capturedFilters?.startDateBefore == userEndDate.ISO8601Format())
+    }
+
+    @Test func non_date_filters_pass_through_on_today_tab() {
+        // Given
+        let testDate = Date(timeIntervalSince1970: 1609459200)
+        var capturedFilters: BookingFilters?
+
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            guard case let .synchronizeBookings(_, _, _, filters, _, _, onCompletion) = action else {
+                return
+            }
+            capturedFilters = filters
+            onCompletion(.success(false))
+        }
+
+        let viewModel = BookingListViewModel(siteID: sampleSiteID, type: .today, stores: stores, storage: storageManager, currentDate: testDate)
+
+        let userFilters = BookingFiltersViewModel.Filters(
+            teamMembers: [BookingTeamMemberFilter(resourceID: 42, name: "Alice")],
+            products: [BookingProductFilter(productID: 100, name: "Massage")],
+            attendanceStatuses: [.booked],
+            customers: [BookingCustomerFilter(customerID: 7, name: "Bob")],
+            dateRange: nil,
+            numberOfActiveFilters: 4
+        )
+
+        // When
+        viewModel.updateFilters(userFilters)
+        viewModel.loadBookings()
+
+        // Then - non-date filters should pass through
+        #expect(capturedFilters?.resourceIDs == [42])
+        #expect(capturedFilters?.productIDs == [100])
+        #expect(capturedFilters?.attendanceStatuses == [BookingAttendanceStatus.booked.rawValue])
+        #expect(capturedFilters?.customerIDs == [7])
+        // Tab date constraints should still be applied
+        #expect(capturedFilters?.startDateAfter == "2020-12-31T23:59:59Z")
+        #expect(capturedFilters?.startDateBefore == "2021-01-02T00:00:00Z")
+    }
+
+    @Test func clearing_filters_on_today_tab_resets_to_tab_date_constraints() {
+        // Given
+        let testDate = Date(timeIntervalSince1970: 1609459200)
+        var capturedFilters: BookingFilters?
+
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            guard case let .synchronizeBookings(_, _, _, filters, _, _, onCompletion) = action else {
+                return
+            }
+            capturedFilters = filters
+            onCompletion(.success(false))
+        }
+
+        let viewModel = BookingListViewModel(siteID: sampleSiteID, type: .today, stores: stores, storage: storageManager, currentDate: testDate)
+
+        // Apply filters first
+        let userFilters = BookingFiltersViewModel.Filters(
+            teamMembers: [BookingTeamMemberFilter(resourceID: 42, name: "Alice")],
+            products: [],
+            attendanceStatuses: [],
+            customers: [],
+            dateRange: nil,
+            numberOfActiveFilters: 1
+        )
+        viewModel.updateFilters(userFilters)
+
+        // When - clear filters
+        let emptyFilters = BookingFiltersViewModel.Filters()
+        viewModel.updateFilters(emptyFilters)
+        viewModel.loadBookings()
+
+        // Then - should be back to tab-only constraints
+        #expect(capturedFilters?.startDateAfter == "2020-12-31T23:59:59Z")
+        #expect(capturedFilters?.startDateBefore == "2021-01-02T00:00:00Z")
+        #expect(capturedFilters?.resourceIDs == [])
+        #expect(capturedFilters?.productIDs == [])
+        #expect(capturedFilters?.attendanceStatuses == [])
+        #expect(capturedFilters?.customerIDs == [])
+    }
+
     // MARK: - Sort order
 
     @Test func update_sort_order_sorts_bookings_from_oldest_to_newest() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingSearchViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingSearchViewModelTests.swift
@@ -325,6 +325,192 @@ struct BookingSearchViewModelTests {
         #expect(capturedFilters?.startDateAfter == nil, "All tab should not have startDateAfter filter")
     }
 
+    // MARK: - Filter merging
+
+    @Test func today_tab_merges_user_date_filters_with_tab_constraints() async throws {
+        // Given
+        let testDate = Date(timeIntervalSince1970: 1609459200) // 2021-01-01 00:00:00 UTC
+        let searchQuerySubject = PassthroughSubject<String, Never>()
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var capturedFilters: BookingFilters?
+
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            guard case let .searchBookings(_, _, _, _, filters, _, onCompletion) = action else {
+                return
+            }
+            capturedFilters = filters
+            onCompletion(.success([]))
+        }
+
+        let viewModel = BookingSearchViewModel(
+            siteID: sampleSiteID,
+            type: .today,
+            searchQueryPublisher: searchQuerySubject.eraseToAnyPublisher(),
+            stores: stores,
+            currentDate: testDate
+        )
+
+        let userFilters = BookingFiltersViewModel.Filters(
+            teamMembers: [],
+            products: [],
+            attendanceStatuses: [],
+            customers: [],
+            dateRange: BookingDateRangeFilter(
+                startDate: Date(timeIntervalSince1970: 1609416000), // 2020-12-31T12:00:00Z
+                endDate: Date(timeIntervalSince1970: 1609524000)    // 2021-01-01T18:00:00Z
+            ),
+            numberOfActiveFilters: 1
+        )
+
+        // When
+        viewModel.updateFilters(userFilters)
+        searchQuerySubject.send("test")
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        // Then
+        #expect(capturedFilters?.startDateAfter == "2020-12-31T23:59:59Z",
+                "Should use tab's startDateAfter since it's later")
+        #expect(capturedFilters?.startDateBefore == "2021-01-01T18:00:00Z",
+                "Should use user's startDateBefore since it's earlier")
+    }
+
+    @Test func upcoming_tab_merges_user_date_filters_with_tab_constraints() async throws {
+        // Given
+        let testDate = Date(timeIntervalSince1970: 1609459200)
+        let searchQuerySubject = PassthroughSubject<String, Never>()
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var capturedFilters: BookingFilters?
+
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            guard case let .searchBookings(_, _, _, _, filters, _, onCompletion) = action else {
+                return
+            }
+            capturedFilters = filters
+            onCompletion(.success([]))
+        }
+
+        let viewModel = BookingSearchViewModel(
+            siteID: sampleSiteID,
+            type: .upcoming,
+            searchQueryPublisher: searchQuerySubject.eraseToAnyPublisher(),
+            stores: stores,
+            currentDate: testDate
+        )
+
+        let userFilters = BookingFiltersViewModel.Filters(
+            teamMembers: [],
+            products: [],
+            attendanceStatuses: [],
+            customers: [],
+            dateRange: BookingDateRangeFilter(
+                startDate: Date(timeIntervalSince1970: 1609632000), // 2021-01-03T00:00:00Z
+                endDate: Date(timeIntervalSince1970: 1609804800)    // 2021-01-05T00:00:00Z
+            ),
+            numberOfActiveFilters: 1
+        )
+
+        // When
+        viewModel.updateFilters(userFilters)
+        searchQuerySubject.send("test")
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        // Then
+        #expect(capturedFilters?.startDateAfter == "2021-01-03T00:00:00Z",
+                "Should use user's startDateAfter since it's later")
+        #expect(capturedFilters?.startDateBefore == "2021-01-05T00:00:00Z",
+                "Should use user's startDateBefore since tab has no upper bound")
+    }
+
+    @Test func all_tab_passes_user_date_filters_through_unchanged() async throws {
+        // Given
+        let testDate = Date(timeIntervalSince1970: 1609459200)
+        let searchQuerySubject = PassthroughSubject<String, Never>()
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var capturedFilters: BookingFilters?
+
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            guard case let .searchBookings(_, _, _, _, filters, _, onCompletion) = action else {
+                return
+            }
+            capturedFilters = filters
+            onCompletion(.success([]))
+        }
+
+        let viewModel = BookingSearchViewModel(
+            siteID: sampleSiteID,
+            type: .all,
+            searchQueryPublisher: searchQuerySubject.eraseToAnyPublisher(),
+            stores: stores,
+            currentDate: testDate
+        )
+
+        let userStartDate = Date(timeIntervalSince1970: 1609632000)
+        let userEndDate = Date(timeIntervalSince1970: 1609804800)
+        let userFilters = BookingFiltersViewModel.Filters(
+            teamMembers: [],
+            products: [],
+            attendanceStatuses: [],
+            customers: [],
+            dateRange: BookingDateRangeFilter(startDate: userStartDate, endDate: userEndDate),
+            numberOfActiveFilters: 1
+        )
+
+        // When
+        viewModel.updateFilters(userFilters)
+        searchQuerySubject.send("test")
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        // Then
+        #expect(capturedFilters?.startDateAfter == userStartDate.ISO8601Format())
+        #expect(capturedFilters?.startDateBefore == userEndDate.ISO8601Format())
+    }
+
+    @Test func non_date_filters_pass_through_on_today_tab() async throws {
+        // Given
+        let testDate = Date(timeIntervalSince1970: 1609459200)
+        let searchQuerySubject = PassthroughSubject<String, Never>()
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var capturedFilters: BookingFilters?
+
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            guard case let .searchBookings(_, _, _, _, filters, _, onCompletion) = action else {
+                return
+            }
+            capturedFilters = filters
+            onCompletion(.success([]))
+        }
+
+        let viewModel = BookingSearchViewModel(
+            siteID: sampleSiteID,
+            type: .today,
+            searchQueryPublisher: searchQuerySubject.eraseToAnyPublisher(),
+            stores: stores,
+            currentDate: testDate
+        )
+
+        let userFilters = BookingFiltersViewModel.Filters(
+            teamMembers: [BookingTeamMemberFilter(resourceID: 42, name: "Alice")],
+            products: [BookingProductFilter(productID: 100, name: "Massage")],
+            attendanceStatuses: [.booked],
+            customers: [BookingCustomerFilter(customerID: 7, name: "Bob")],
+            dateRange: nil,
+            numberOfActiveFilters: 4
+        )
+
+        // When
+        viewModel.updateFilters(userFilters)
+        searchQuerySubject.send("test")
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        // Then
+        #expect(capturedFilters?.resourceIDs == [42])
+        #expect(capturedFilters?.productIDs == [100])
+        #expect(capturedFilters?.attendanceStatuses == [BookingAttendanceStatus.booked.rawValue])
+        #expect(capturedFilters?.customerIDs == [7])
+        #expect(capturedFilters?.startDateAfter == "2020-12-31T23:59:59Z")
+        #expect(capturedFilters?.startDateBefore == "2021-01-02T00:00:00Z")
+    }
+
     // MARK: - Refresh action
 
     @Test func on_refresh_action_resyncs_search_results() async throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-2178

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the Booking list to show the Filters button on Today and Upcoming tabs.

Since these tabs have existing date restrictions, when applying date filters, the filters are updated to intersect and ensure the restrictions are still applied.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

0. Create bookings for Today and Upcoming tabs if needed.
1. Log in to a CIAB store with bookings.
2. Navigate to Bookings tab and confirm that the Filters button is available on both Today and Upcoming tabs.
3. Apply date filters and confirm that the filtered results are valid for the selected tabs.
4. Tap Search icon and enter keywords. Confirm that the filters are applied to search results too.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/afdb4c59-ce90-4643-b1cb-5e8fc10ee767



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
