### PR TITLE
POS: Add payment flow protocols and configuration

### DIFF
--- a/Modules/Sources/PointOfSale/Card Present Payments/POSCartCashPaymentHandler.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/POSCartCashPaymentHandler.swift
@@ -1,0 +1,10 @@
+import struct Yosemite.Order
+
+/// Handles cash payment completion for the POS cart flow by delegating to the order controller.
+struct POSCartCashPaymentHandler: POSCashPaymentHandling {
+    let orderController: PointOfSaleOrderControllerProtocol
+
+    func completeCashPayment(for order: Order, changeDueAmount: String?) async throws {
+        try await orderController.collectCashPayment(changeDueAmount: changeDueAmount)
+    }
+}

--- a/Modules/Sources/PointOfSale/Card Present Payments/POSCartPaymentOrderProvider.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/POSCartPaymentOrderProvider.swift
@@ -1,0 +1,13 @@
+import struct Yosemite.Order
+
+/// Provides the already-synced order from the POS cart order controller.
+struct POSCartPaymentOrderProvider: POSPaymentOrderProviding {
+    let orderController: PointOfSaleOrderControllerProtocol
+
+    func provideOrder() async throws -> Order {
+        guard case let .loaded(_, order) = orderController.orderState else {
+            throw POSPaymentError.noOrder
+        }
+        return order
+    }
+}

--- a/Modules/Sources/PointOfSale/Card Present Payments/POSCashPaymentHandling.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/POSCashPaymentHandling.swift
@@ -1,0 +1,6 @@
+import struct Yosemite.Order
+
+/// Handles the "mark order as paid with cash" step during cash payment.
+protocol POSCashPaymentHandling {
+    func completeCashPayment(for order: Order, changeDueAmount: String?) async throws
+}

--- a/Modules/Sources/PointOfSale/Card Present Payments/POSPaymentError.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/POSPaymentError.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum POSPaymentError: Error, LocalizedError {
+    case noOrder
+
+    var errorDescription: String? {
+        switch self {
+        case .noOrder:
+            return NSLocalizedString(
+                "pointOfSale.paymentError.noOrder",
+                value: "No order loaded yet. Start a payment before sending a receipt.",
+                comment: "Error when trying to send a receipt before an order has been loaded in the Point of Sale"
+            )
+        }
+    }
+}

--- a/Modules/Sources/PointOfSale/Card Present Payments/POSPaymentOrderProviding.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/POSPaymentOrderProviding.swift
@@ -1,0 +1,6 @@
+import struct Yosemite.Order
+
+/// Provides an Order for the payment model to collect payment against.
+protocol POSPaymentOrderProviding {
+    func provideOrder() async throws -> Order
+}

--- a/Modules/Sources/PointOfSale/Models/POSPaymentFlowConfiguration.swift
+++ b/Modules/Sources/PointOfSale/Models/POSPaymentFlowConfiguration.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Configures the view-level differences between payment flow callers.
+struct POSPaymentFlowConfiguration {
+    /// Action shown on the success screen (e.g. "New order" for cart, "Done" for bookings).
+    let successAction: PaymentFlowAction
+
+    /// Action to leave the payment flow from a capture error
+    /// ("New order" for cart, "Back to Booking" for bookings).
+    let captureErrorExitAction: PaymentFlowAction
+
+    /// Action to leave the payment flow from an intent creation error
+    /// ("Edit order" for cart, "Back to Booking" for bookings).
+    let intentCreationErrorExitAction: PaymentFlowAction
+
+    /// Whether to show a close (x) button on the initial payment screen.
+    let showInitialCloseButton: Bool
+}
+
+/// A labeled action used by the payment flow configuration.
+struct PaymentFlowAction {
+    let title: String
+    let action: @MainActor () -> Void
+}
+
+// MARK: - Cart
+
+extension POSPaymentFlowConfiguration {
+    static func cart(onNewOrder: @escaping @MainActor () -> Void,
+                     onEditOrder: @escaping @MainActor () -> Void) -> Self {
+        POSPaymentFlowConfiguration(
+            successAction: PaymentFlowAction(
+                title: Localization.Cart.newOrder,
+                action: onNewOrder),
+            captureErrorExitAction: PaymentFlowAction(
+                title: Localization.Cart.newOrder,
+                action: onNewOrder),
+            intentCreationErrorExitAction: PaymentFlowAction(
+                title: Localization.Cart.editOrder,
+                action: onEditOrder),
+            showInitialCloseButton: false
+        )
+    }
+}
+
+// MARK: - Bookings
+
+extension POSPaymentFlowConfiguration {
+    static func bookings(onDismiss: @escaping @MainActor () -> Void) -> Self {
+        POSPaymentFlowConfiguration(
+            successAction: PaymentFlowAction(
+                title: Localization.Bookings.done,
+                action: onDismiss),
+            captureErrorExitAction: PaymentFlowAction(
+                title: Localization.Bookings.backToBooking,
+                action: onDismiss),
+            intentCreationErrorExitAction: PaymentFlowAction(
+                title: Localization.Bookings.backToBooking,
+                action: onDismiss),
+            showInitialCloseButton: true
+        )
+    }
+}
+
+// MARK: - Localization
+
+private extension POSPaymentFlowConfiguration {
+    enum Localization {
+        enum Cart {
+            static let newOrder = NSLocalizedString(
+                "pointOfSale.paymentFlowConfiguration.cart.newOrder.button.title",
+                value: "New order",
+                comment: "Button title on the payment success and capture error screens " +
+                "in the Point of Sale checkout to start a new order"
+            )
+
+            static let editOrder = NSLocalizedString(
+                "pointOfSale.paymentFlowConfiguration.cart.editOrder.button.title",
+                value: "Edit order",
+                comment: "Button title on the payment intent creation error screen " +
+                "in the Point of Sale checkout to go back and edit the current order"
+            )
+        }
+
+        enum Bookings {
+            static let done = NSLocalizedString(
+                "pointOfSale.paymentFlowConfiguration.bookings.done.button.title",
+                value: "Done",
+                comment: "Button title on the payment success screen " +
+                "in the Point of Sale bookings payment flow to dismiss and return to booking details"
+            )
+
+            static let backToBooking = NSLocalizedString(
+                "pointOfSale.paymentFlowConfiguration.bookings.backToBooking.button.title",
+                value: "Back to Booking",
+                comment: "Button title on payment error screens " +
+                "in the Point of Sale bookings payment flow to dismiss and return to booking details"
+            )
+        }
+    }
+}

--- a/Modules/Sources/PointOfSale/Models/POSPaymentFlowConfiguration.swift
+++ b/Modules/Sources/PointOfSale/Models/POSPaymentFlowConfiguration.swift
@@ -20,14 +20,14 @@ struct POSPaymentFlowConfiguration {
 /// A labeled action used by the payment flow configuration.
 struct PaymentFlowAction {
     let title: String
-    let action: @MainActor () -> Void
+    let action: () -> Void
 }
 
 // MARK: - Cart
 
 extension POSPaymentFlowConfiguration {
-    static func cart(onNewOrder: @escaping @MainActor () -> Void,
-                     onEditOrder: @escaping @MainActor () -> Void) -> Self {
+    static func cart(onNewOrder: @escaping () -> Void,
+                     onEditOrder: @escaping () -> Void) -> Self {
         POSPaymentFlowConfiguration(
             successAction: PaymentFlowAction(
                 title: Localization.Cart.newOrder,
@@ -46,7 +46,7 @@ extension POSPaymentFlowConfiguration {
 // MARK: - Bookings
 
 extension POSPaymentFlowConfiguration {
-    static func bookings(onDismiss: @escaping @MainActor () -> Void) -> Self {
+    static func bookings(onDismiss: @escaping () -> Void) -> Self {
         POSPaymentFlowConfiguration(
             successAction: PaymentFlowAction(
                 title: Localization.Bookings.done,

--- a/Modules/Sources/PointOfSale/Models/POSPaymentFlowConfiguration.swift
+++ b/Modules/Sources/PointOfSale/Models/POSPaymentFlowConfiguration.swift
@@ -92,7 +92,7 @@ private extension POSPaymentFlowConfiguration {
 
             static let backToBooking = NSLocalizedString(
                 "pointOfSale.paymentFlowConfiguration.bookings.backToBooking.button.title",
-                value: "Back to Booking",
+                value: "Back to booking",
                 comment: "Button title on payment error screens " +
                 "in the Point of Sale bookings payment flow to dismiss and return to booking details"
             )

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSCashPaymentHandler.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSCashPaymentHandler.swift
@@ -1,0 +1,17 @@
+import Foundation
+@testable import PointOfSale
+import struct Yosemite.Order
+
+final class MockPOSCashPaymentHandler: POSCashPaymentHandling {
+    var completeCashPaymentCalled = false
+    var completeCashPaymentReceivedOrder: Order?
+    var completeCashPaymentReceivedChangeDue: String?
+    var errorToThrow: Error?
+
+    func completeCashPayment(for order: Order, changeDueAmount: String?) async throws {
+        completeCashPaymentCalled = true
+        completeCashPaymentReceivedOrder = order
+        completeCashPaymentReceivedChangeDue = changeDueAmount
+        if let error = errorToThrow { throw error }
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSPaymentOrderProvider.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSPaymentOrderProvider.swift
@@ -1,0 +1,16 @@
+import Foundation
+@testable import PointOfSale
+import struct Yosemite.Order
+
+final class MockPOSPaymentOrderProvider: POSPaymentOrderProviding {
+    var orderToReturn: Order?
+    var errorToThrow: Error?
+    var provideOrderCallCount = 0
+
+    func provideOrder() async throws -> Order {
+        provideOrderCallCount += 1
+        if let error = errorToThrow { throw error }
+        guard let order = orderToReturn else { throw POSPaymentError.noOrder }
+        return order
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Models/POSPaymentFlowConfigurationTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/POSPaymentFlowConfigurationTests.swift
@@ -73,7 +73,7 @@ struct POSPaymentFlowConfigurationTests {
     @Test("bookings config has 'Back to Booking' intent creation error exit title")
     func bookings_config_has_back_to_booking_intent_creation_error_exit_title() {
         let config = POSPaymentFlowConfiguration.bookings(onDismiss: {})
-        #expect(config.intentCreationErrorExitAction.title == "Back to Booking")
+        #expect(config.intentCreationErrorExitAction.title == "Back to booking")
     }
 
     @Test("bookings config has close button")

--- a/Modules/Tests/PointOfSaleTests/Models/POSPaymentFlowConfigurationTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/POSPaymentFlowConfigurationTests.swift
@@ -67,7 +67,7 @@ struct POSPaymentFlowConfigurationTests {
     @Test("bookings config has 'Back to Booking' capture error exit title")
     func bookings_config_has_back_to_booking_capture_error_exit_title() {
         let config = POSPaymentFlowConfiguration.bookings(onDismiss: {})
-        #expect(config.captureErrorExitAction.title == "Back to Booking")
+        #expect(config.captureErrorExitAction.title == "Back to booking")
     }
 
     @Test("bookings config has 'Back to Booking' intent creation error exit title")

--- a/Modules/Tests/PointOfSaleTests/Models/POSPaymentFlowConfigurationTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/POSPaymentFlowConfigurationTests.swift
@@ -1,0 +1,97 @@
+import Testing
+@testable import PointOfSale
+
+struct POSPaymentFlowConfigurationTests {
+
+    // MARK: - Cart Configuration
+
+    @Test("cart config has 'New order' success title")
+    func cart_config_has_new_order_success_title() {
+        let config = POSPaymentFlowConfiguration.cart(onNewOrder: {}, onEditOrder: {})
+        #expect(config.successAction.title == "New order")
+    }
+
+    @Test("cart config has 'New order' capture error exit title")
+    func cart_config_has_new_order_capture_error_exit_title() {
+        let config = POSPaymentFlowConfiguration.cart(onNewOrder: {}, onEditOrder: {})
+        #expect(config.captureErrorExitAction.title == "New order")
+    }
+
+    @Test("cart config has 'Edit order' intent creation error exit title")
+    func cart_config_has_edit_order_intent_creation_error_exit_title() {
+        let config = POSPaymentFlowConfiguration.cart(onNewOrder: {}, onEditOrder: {})
+        #expect(config.intentCreationErrorExitAction.title == "Edit order")
+    }
+
+    @Test("cart config has no close button")
+    func cart_config_has_no_close_button() {
+        let config = POSPaymentFlowConfiguration.cart(onNewOrder: {}, onEditOrder: {})
+        #expect(config.showInitialCloseButton == false)
+    }
+
+    @Test("cart config success action calls onNewOrder")
+    @MainActor
+    func cart_config_success_action_calls_onNewOrder() {
+        var called = false
+        let config = POSPaymentFlowConfiguration.cart(onNewOrder: { called = true }, onEditOrder: {})
+        config.successAction.action()
+        #expect(called == true)
+    }
+
+    @Test("cart config capture error exit calls onNewOrder")
+    @MainActor
+    func cart_config_capture_error_exit_calls_onNewOrder() {
+        var called = false
+        let config = POSPaymentFlowConfiguration.cart(onNewOrder: { called = true }, onEditOrder: {})
+        config.captureErrorExitAction.action()
+        #expect(called == true)
+    }
+
+    @Test("cart config intent creation error exit calls onEditOrder")
+    @MainActor
+    func cart_config_intent_creation_error_exit_calls_onEditOrder() {
+        var called = false
+        let config = POSPaymentFlowConfiguration.cart(onNewOrder: {}, onEditOrder: { called = true })
+        config.intentCreationErrorExitAction.action()
+        #expect(called == true)
+    }
+
+    // MARK: - Bookings Configuration
+
+    @Test("bookings config has 'Done' success title")
+    func bookings_config_has_done_success_title() {
+        let config = POSPaymentFlowConfiguration.bookings(onDismiss: {})
+        #expect(config.successAction.title == "Done")
+    }
+
+    @Test("bookings config has 'Back to Booking' capture error exit title")
+    func bookings_config_has_back_to_booking_capture_error_exit_title() {
+        let config = POSPaymentFlowConfiguration.bookings(onDismiss: {})
+        #expect(config.captureErrorExitAction.title == "Back to Booking")
+    }
+
+    @Test("bookings config has 'Back to Booking' intent creation error exit title")
+    func bookings_config_has_back_to_booking_intent_creation_error_exit_title() {
+        let config = POSPaymentFlowConfiguration.bookings(onDismiss: {})
+        #expect(config.intentCreationErrorExitAction.title == "Back to Booking")
+    }
+
+    @Test("bookings config has close button")
+    func bookings_config_has_close_button() {
+        let config = POSPaymentFlowConfiguration.bookings(onDismiss: {})
+        #expect(config.showInitialCloseButton == true)
+    }
+
+    @Test("bookings config all actions call onDismiss")
+    @MainActor
+    func bookings_config_all_actions_call_onDismiss() {
+        var dismissCount = 0
+        let config = POSPaymentFlowConfiguration.bookings(onDismiss: { dismissCount += 1 })
+
+        config.successAction.action()
+        config.captureErrorExitAction.action()
+        config.intentCreationErrorExitAction.action()
+
+        #expect(dismissCount == 3)
+    }
+}


### PR DESCRIPTION
Part of: WOOMOB-2155

## Description

Introduce the protocol layer that enables the upcoming `POSPaymentModel` to work with both cart and bookings payment flows through dependency injection.

New types:
- **`POSPaymentOrderProviding`** — protocol that provides an Order for payment collection. Cart flow returns the already-synced order; bookings flow will fetch by order ID.
- **`POSCashPaymentHandling`** — protocol for completing cash payments. Cart flow marks the order as paid via the order controller; bookings flow will use the order service.
- **`POSPaymentError`** — shared error type for payment operations.
- **`POSPaymentFlowConfiguration`** — configures flow-specific behaviors (exit actions, display options) with `.cart()` and `.bookings()` factory methods.
- **`POSCartPaymentOrderProvider`** / **`POSCartCashPaymentHandler`** — cart-specific protocol implementations.
- Mock implementations and configuration tests.

This is PR 1 of 6 in the POS payment extraction series.

## Test Steps

1. Build the project — all new files, no behavioral changes yet.
2. Run `PointOfSaleTests` — all existing tests should pass, plus the new `POSPaymentFlowConfigurationTests`.

## Screenshots

N/A — no visual changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.