### PR TITLE
POS: Add POSPaymentModel with shared payment logic

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -1,0 +1,398 @@
+import CocoaLumberjackSwift
+import Foundation
+import Combine
+
+import struct Yosemite.Order
+import enum Yosemite.CardReaderSoftwareUpdateState
+import protocol Yosemite.PaymentCaptureCelebrationProtocol
+
+/// Shared payment model that owns all payment state and logic.
+@Observable
+final class POSPaymentModel {
+    // MARK: - State (read by views)
+    private(set) var paymentState: PointOfSalePaymentState
+    var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
+    private(set) var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType?
+    private(set) var cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus = .disconnected
+    private(set) var cardReaderUpdateState: CardReaderSoftwareUpdateState = .none
+    var cardPresentPaymentOnboardingViewContainer: CardPresentPaymentOnboardingViewContainer?
+    var isZeroTotal: Bool {
+        guard let total = currentOrder?.total, let decimal = Decimal(string: total) else { return false }
+        return decimal == 0
+    }
+
+    var isCardReaderUpdateAvailable: Bool {
+        if case .available = cardReaderUpdateState {
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Dependencies
+    private let cardPresentPaymentService: CardPresentPaymentFacade
+    private let orderProvider: POSPaymentOrderProviding
+    private let cashPaymentHandler: POSCashPaymentHandling
+    private let receiptSender: POSReceiptSending
+    private let postPaymentStep: (() async throws -> Void)?
+    let configuration: POSPaymentFlowConfiguration
+    private let analytics: POSAnalyticsProviding
+    private let collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking
+    private let celebration: PaymentCaptureCelebrationProtocol
+
+    // MARK: - Internal
+    private var startPaymentOnCardReaderConnection: AnyCancellable?
+    private var cardReaderDisconnection: AnyCancellable?
+    private var onOnboardingCancellation: (() -> Void)?
+    private var cancellables: Set<AnyCancellable> = []
+    private var currentOrder: Order?
+    private var formattedOrderTotalPrice: String?
+
+    init(cardPresentPaymentService: CardPresentPaymentFacade,
+         orderProvider: POSPaymentOrderProviding,
+         cashPaymentHandler: POSCashPaymentHandling,
+         receiptSender: POSReceiptSending,
+         postPaymentStep: (() async throws -> Void)? = nil,
+         configuration: POSPaymentFlowConfiguration,
+         analytics: POSAnalyticsProviding,
+         collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking,
+         celebration: PaymentCaptureCelebrationProtocol,
+         paymentState: PointOfSalePaymentState = .idle) {
+        self.cardPresentPaymentService = cardPresentPaymentService
+        self.orderProvider = orderProvider
+        self.cashPaymentHandler = cashPaymentHandler
+        self.receiptSender = receiptSender
+        self.postPaymentStep = postPaymentStep
+        self.configuration = configuration
+        self.analytics = analytics
+        self.collectOrderPaymentAnalyticsTracker = collectOrderPaymentAnalyticsTracker
+        self.celebration = celebration
+        self.paymentState = paymentState
+
+        publishCardReaderConnectionStatus()
+        publishCardReaderUpdateState()
+        publishPaymentMessages()
+    }
+}
+
+// MARK: - Card Payment Methods
+extension POSPaymentModel {
+    /// Cancels any existing payment on the shared reader, then starts a new payment.
+    /// Collects immediately if a reader is connected; otherwise waits for connection.
+    func startPayment() async {
+        try? await cardPresentPaymentService.cancelPayment()
+        guard case .connected = cardReaderConnectionStatus else {
+            return startPaymentOnCardReaderConnection = cardPresentPaymentService.readerConnectionStatusPublisher
+                .filter { status in
+                    switch status {
+                    case .connected:
+                        return true
+                    case .disconnected, .disconnecting, .cancellingConnection:
+                        return false
+                    }
+                }
+                .removeDuplicates()
+                .sink { [weak self] _ in
+                    Task { @MainActor [weak self] in
+                        await self?.collectCardPayment()
+                    }
+                }
+        }
+        await collectCardPayment()
+    }
+
+    private func collectCardPayment() async {
+        do {
+            let order = try await orderProvider.provideOrder()
+            currentOrder = order
+            guard let total = Decimal(string: order.total), total > 0 else { return }
+            try await collectPayment(for: order)
+        } catch {
+            DDLogError("Error taking payment: \(error)")
+        }
+    }
+
+    private func collectPayment(for order: Order) async throws {
+        _ = try await cardPresentPaymentService.collectPayment(for: order, using: .bluetooth, channel: .pos)
+    }
+
+    func cancelThenCollectPayment() {
+        Task { [weak self] in
+            guard let self else { return }
+            await cancelThenCollectPayment()
+        }
+    }
+
+    func cancelThenCollectPayment() async {
+        try? await cardPresentPaymentService.cancelPayment()
+        await collectCardPayment()
+    }
+
+    func connectCardReader() {
+        analytics.track(.pointOfSaleCardReaderConnectionTapped)
+        Task { @MainActor [weak self] in
+            _ = try await self?.cardPresentPaymentService.connectReader(using: .bluetooth)
+        }
+    }
+
+    func disconnectCardReader() {
+        analytics.track(.cardReaderDisconnectTapped)
+        Task { @MainActor [weak self] in
+            await self?.cardPresentPaymentService.disconnectReader()
+        }
+    }
+
+    func updateCardReaderSoftware() {
+        Task { @MainActor [weak self] in
+            try? await self?.cardPresentPaymentService.updateCardReaderSoftware()
+        }
+    }
+
+    func cancelCardPaymentsOnboarding() {
+        guard let onboardingViewContainer = cardPresentPaymentOnboardingViewContainer else {
+            return
+        }
+        analytics.track(event: .PointOfSale.paymentsOnboardingDismissed(onboardingState: onboardingViewContainer.configuration.state))
+        cardPresentPaymentOnboardingViewContainer = nil
+        onOnboardingCancellation?()
+    }
+
+    func trackCardPaymentsOnboardingShown() {
+        analytics.track(event: .PointOfSale.paymentsOnboardingShown())
+    }
+}
+
+// MARK: - Cash Payment Methods
+extension POSPaymentModel {
+    func startCashPayment() async {
+        analytics.track(.pointOfSaleCheckoutCashPaymentTapped)
+        try? await cardPresentPaymentService.cancelPayment()
+        paymentState.cash = .collectingCash
+    }
+
+    func cancelCashPayment() async {
+        analytics.track(.pointOfSaleBackToCheckoutFromCashTapped)
+        paymentState.cash = .idle
+        if case .connected = cardReaderConnectionStatus {
+            await collectCardPayment()
+        }
+    }
+
+    func collectCashPayment(changeDueAmount: String?) async throws {
+        let order: Order
+        if let currentOrder {
+            order = currentOrder
+        } else {
+            order = try await orderProvider.provideOrder()
+            currentOrder = order
+        }
+        try await cashPaymentHandler.completeCashPayment(for: order, changeDueAmount: changeDueAmount)
+        try? await postPaymentStep?()
+        cashPaymentSuccess()
+    }
+
+    private func cashPaymentSuccess() {
+        paymentState.cash = .paymentSuccess
+        collectOrderPaymentAnalyticsTracker.trackSuccessfulCashPayment()
+        celebration.celebrate()
+    }
+}
+
+// MARK: - Receipt
+extension POSPaymentModel {
+    func sendReceipt(to emailAddress: String) async throws {
+        guard let order = currentOrder else {
+            throw POSPaymentError.noOrder
+        }
+        try await receiptSender.sendReceipt(orderID: order.orderID, recipientEmail: emailAddress)
+    }
+}
+
+// MARK: - Reset
+extension POSPaymentModel {
+    func reset() {
+        paymentState = .idle
+        cardPresentPaymentInlineMessage = nil
+        currentOrder = nil
+        formattedOrderTotalPrice = nil
+        cancelReaderPreparation()
+    }
+
+    private func cancelReaderPreparation() {
+        cardPresentPaymentService.cancelPayment()
+        resetCardReaderObservation()
+    }
+
+    private func resetCardReaderObservation() {
+        startPaymentOnCardReaderConnection?.cancel()
+        startPaymentOnCardReaderConnection = nil
+        cardReaderDisconnection?.cancel()
+        cardReaderDisconnection = nil
+    }
+}
+
+// MARK: - Reader Reconnection
+extension POSPaymentModel {
+    func observeReaderReconnection() {
+        cardReaderDisconnection = cardPresentPaymentService.readerConnectionStatusPublisher
+            .filter({ $0 == .disconnected })
+            .sink { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    await self?.startPayment()
+                }
+            }
+    }
+
+    func cancelReaderReconnectionObservation() {
+        cancelReaderPreparation()
+    }
+}
+
+// MARK: - Combine Subscriptions
+private extension POSPaymentModel {
+    func publishCardReaderConnectionStatus() {
+        cardPresentPaymentService.readerConnectionStatusPublisher
+            .sink(receiveValue: { [weak self] connectionStatus in
+                self?.cardReaderConnectionStatus = connectionStatus
+            })
+            .store(in: &cancellables)
+    }
+
+    func publishCardReaderUpdateState() {
+        cardPresentPaymentService.cardReaderUpdateStatePublisher
+            .sink(receiveValue: { [weak self] updateState in
+                self?.cardReaderUpdateState = updateState
+            })
+            .store(in: &cancellables)
+    }
+
+    func publishPaymentMessages() {
+        // Chain 1: Payment events -> alert view model (modal alerts for reader connection)
+        cardPresentPaymentService.paymentEventPublisher
+            .map { [weak self] event -> PointOfSaleCardPresentPaymentAlertType? in
+                guard let self else { return nil }
+                guard case let .show(eventDetails) = event,
+                      case let .alert(alertType) = presentationStyle(for: eventDetails)
+                else {
+                    return nil
+                }
+
+                // Filter connection success alerts when we're immediately starting a payment
+                if case .connectionSuccess = eventDetails,
+                   startPaymentOnCardReaderConnection != nil {
+                    return nil
+                }
+
+                return alertType
+            }
+            .sink(receiveValue: { [weak self] alertType in
+                self?.cardPresentPaymentAlertViewModel = alertType
+            })
+            .store(in: &cancellables)
+
+        // Chain 2: Payment events -> inline message (payment status in the totals view)
+        cardPresentPaymentService.paymentEventPublisher
+            .map { [weak self] event -> PointOfSaleCardPresentPaymentMessageType? in
+                self?.mapCardPresentPaymentEventToMessageType(event)
+            }
+            .sink(receiveValue: { [weak self] message in
+                self?.cardPresentPaymentInlineMessage = message
+            })
+            .store(in: &cancellables)
+
+        // Chain 3: Payment events -> card payment state
+        cardPresentPaymentService.paymentEventPublisher
+            .compactMap { [weak self] paymentEvent -> PointOfSaleCardPaymentState? in
+                guard let self else { return nil }
+
+                let newCardPaymentState = PointOfSaleCardPaymentState(from: paymentEvent,
+                                                                      using: presentationStyleDeterminerDependencies)
+
+                if case .acceptingCard = newCardPaymentState {
+                    collectOrderPaymentAnalyticsTracker.trackCardReaderReady()
+                }
+
+                if case .processingPayment = newCardPaymentState {
+                    collectOrderPaymentAnalyticsTracker.trackCardReaderTapped()
+                }
+
+                return newCardPaymentState
+            }
+            .sink(receiveValue: { [weak self] cardPaymentState in
+                self?.paymentState.card = cardPaymentState
+            })
+            .store(in: &cancellables)
+
+        // Chain 4: Payment events -> onboarding view (card reader setup)
+        cardPresentPaymentService.paymentEventPublisher
+            .map { [weak self] event -> CardPresentPaymentOnboardingViewContainer? in
+                guard let self else { return nil }
+                guard case let .showOnboarding(factory, onCancel) = event else {
+                    return nil
+                }
+                onOnboardingCancellation = onCancel
+                return factory
+            }
+            .sink(receiveValue: { [weak self] factory in
+                self?.cardPresentPaymentOnboardingViewContainer = factory
+            })
+            .store(in: &cancellables)
+    }
+
+    func mapCardPresentPaymentEventToMessageType(_ event: CardPresentPaymentEvent) -> PointOfSaleCardPresentPaymentMessageType? {
+        guard case let .show(eventDetails) = event,
+              case let .message(messageType) = presentationStyle(for: eventDetails) else {
+            return nil
+        }
+        return messageType
+    }
+
+    func presentationStyle(for eventDetails: CardPresentPaymentEventDetails) -> PointOfSaleCardPresentPaymentEventPresentationStyle? {
+        PointOfSaleCardPresentPaymentEventPresentationStyle(
+            for: eventDetails,
+            dependencies: presentationStyleDeterminerDependencies)
+    }
+
+    var presentationStyleDeterminerDependencies: PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies {
+        let cancelThenCollectPaymentAction: () -> Void = { [weak self] in
+            self?.cancelThenCollectPayment()
+        }
+
+        return PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies(
+            tryPaymentAgainBackToCheckoutAction: cancelThenCollectPaymentAction,
+            nonRetryableErrorExitAction: cancelThenCollectPaymentAction,
+            formattedOrderTotalPrice: formattedOrderTotalPrice,
+            paymentCaptureErrorTryAgainAction: cancelThenCollectPaymentAction,
+            paymentCaptureErrorNewOrderAction: { [weak self] in
+                self?.configuration.captureErrorExitAction.action()
+            },
+            paymentIntentCreationErrorEditOrderAction: { [weak self] in
+                self?.configuration.intentCreationErrorExitAction.action()
+            },
+            dismissReaderConnectionModal: { [weak self] in
+                self?.cardPresentPaymentAlertViewModel = nil
+            }
+        )
+    }
+}
+
+// MARK: - Cleanup
+extension POSPaymentModel {
+    /// Cancels any in-progress payment and cleans up subscriptions.
+    /// We cancel payments to prevent the reader from remaining live and awaiting a card tap.
+    /// Otherwise, it would wait until the timeout (30-45 minutes), using more battery
+    /// and risking a shopper paying for the wrong order.
+    func tearDown() {
+        cardPresentPaymentService.cancelPayment()
+        resetCardReaderObservation()
+        cancellables.forEach { $0.cancel() }
+    }
+}
+
+#if DEBUG
+extension POSPaymentModel {
+    func setPreviewState(paymentState: PointOfSalePaymentState, inlineMessage: PointOfSaleCardPresentPaymentMessageType?) {
+        self.paymentState = paymentState
+        self.cardPresentPaymentInlineMessage = inlineMessage
+    }
+}
+#endif

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
@@ -1,0 +1,328 @@
+import Testing
+import Foundation
+import Combine
+import struct Yosemite.Order
+import protocol Yosemite.PaymentCaptureCelebrationProtocol
+@testable import PointOfSale
+
+struct POSPaymentModelTests {
+
+    // MARK: - Init
+
+    @Test("init sets payment state to idle by default")
+    @MainActor
+    func init_sets_paymentState_to_idle() {
+        let sut = makePaymentController()
+        #expect(sut.paymentState == .idle)
+    }
+
+    // MARK: - Start Payment
+
+    @Test("startPayment collects card payment when reader is connected")
+    @MainActor
+    func startPayment_whenReaderConnected_collectsCardPayment() async {
+        let service = MockCardPresentPaymentService()
+        let orderProvider = MockPOSPaymentOrderProvider()
+        orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
+
+        service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
+
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            orderProvider: orderProvider)
+
+        await sut.startPayment()
+
+        #expect(service.collectPaymentWasCalled == true)
+    }
+
+    @Test("startPayment collects on reader connect when reader is disconnected")
+    @MainActor
+    func startPayment_whenReaderDisconnected_collectsOnConnect() async {
+        let service = MockCardPresentPaymentService()
+        let orderProvider = MockPOSPaymentOrderProvider()
+        orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
+
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            orderProvider: orderProvider)
+
+        await sut.startPayment()
+
+        // Not called yet since reader is disconnected
+        #expect(service.collectPaymentWasCalled == false)
+
+        // Connect the reader and wait for the Combine chain to trigger collectPayment
+        await withCheckedContinuation { continuation in
+            service.onCollectPaymentCalled = {
+                continuation.resume()
+            }
+            service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
+        }
+
+        #expect(service.collectPaymentWasCalled == true)
+    }
+
+    // MARK: - Cash Payment
+
+    @Test("startCashPayment cancels card payment and transitions to cash")
+    @MainActor
+    func startCashPayment_cancelsCardAndTransitionsToCash() async {
+        let service = MockCardPresentPaymentService()
+        let sut = makePaymentController(cardPresentPaymentService: service)
+
+        await sut.startCashPayment()
+
+        #expect(service.cancelPaymentCalled == true)
+        #expect(sut.paymentState == PointOfSalePaymentState(card: .idle, cash: .collectingCash))
+    }
+
+    @Test("cancelCashPayment resets to idle")
+    @MainActor
+    func cancelCashPayment_resetsToIdle() async {
+        let sut = makePaymentController()
+
+        await sut.startCashPayment()
+        #expect(sut.paymentState.cash == .collectingCash)
+
+        await sut.cancelCashPayment()
+        #expect(sut.paymentState.cash == .idle)
+    }
+
+    @Test("collectCashPayment calls handler and transitions to success")
+    @MainActor
+    func collectCashPayment_callsHandlerAndTransitionsToSuccess() async throws {
+        let cashHandler = MockPOSCashPaymentHandler()
+        let orderProvider = MockPOSPaymentOrderProvider()
+        orderProvider.orderToReturn = Order.fake()
+        let celebration = MockPaymentCaptureCelebration()
+
+        let sut = makePaymentController(
+            orderProvider: orderProvider,
+            cashPaymentHandler: cashHandler,
+            celebration: celebration)
+
+        try await sut.collectCashPayment(changeDueAmount: "$5.00")
+
+        #expect(cashHandler.completeCashPaymentCalled == true)
+        #expect(cashHandler.completeCashPaymentReceivedChangeDue == "$5.00")
+        #expect(sut.paymentState.cash == .paymentSuccess)
+        #expect(celebration.celebrationWasCalled == true)
+    }
+
+    @Test("collectCashPayment runs post-payment step")
+    @MainActor
+    func collectCashPayment_runsPostPaymentStep() async throws {
+        let orderProvider = MockPOSPaymentOrderProvider()
+        orderProvider.orderToReturn = Order.fake()
+        var postPaymentStepCalled = false
+
+        let sut = makePaymentController(
+            orderProvider: orderProvider,
+            postPaymentStep: { postPaymentStepCalled = true })
+
+        try await sut.collectCashPayment(changeDueAmount: nil)
+
+        #expect(postPaymentStepCalled == true)
+    }
+
+    // MARK: - Receipt
+
+    @Test("sendReceipt sends to receipt sender with current order")
+    @MainActor
+    func sendReceipt_sendsToReceiptSender() async throws {
+        let receiptSender = MockPOSReceiptSender()
+        let orderProvider = MockPOSPaymentOrderProvider()
+        let order = Order.fake().copy(orderID: 123, total: "10.00")
+        orderProvider.orderToReturn = order
+
+        let service = MockCardPresentPaymentService()
+        service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
+
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            orderProvider: orderProvider,
+            receiptSender: receiptSender)
+
+        // Collect a payment to set the currentOrder
+        await sut.startPayment()
+
+        try await sut.sendReceipt(to: "test@example.com")
+
+        #expect(receiptSender.sendReceiptWasCalled == true)
+        #expect(receiptSender.sendReceiptCalledWithOrderID == 123)
+        #expect(receiptSender.sendReceiptCalledWithEmail == "test@example.com")
+    }
+
+    @Test("sendReceipt throws when no current order")
+    @MainActor
+    func sendReceipt_throwsWhenNoCurrentOrder() async {
+        let sut = makePaymentController()
+
+        await #expect(throws: POSPaymentError.self) {
+            try await sut.sendReceipt(to: "test@example.com")
+        }
+    }
+
+    // MARK: - Reset
+
+    @Test("reset clears all state")
+    @MainActor
+    func reset_clearsAllState() async {
+        let service = MockCardPresentPaymentService()
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            paymentState: PointOfSalePaymentState(card: .cardPaymentSuccessful, cash: .idle))
+
+        // Set up some inline message
+        service.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
+
+        sut.reset()
+
+        #expect(sut.paymentState == .idle)
+        #expect(sut.cardPresentPaymentInlineMessage == nil)
+    }
+
+    // MARK: - Combine Chains
+
+    @Test("payment event publisher updates card payment state")
+    @MainActor
+    func paymentEventPublisher_updatesCardPaymentState() {
+        let service = MockCardPresentPaymentService()
+        let sut = makePaymentController(cardPresentPaymentService: service)
+
+        service.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
+
+        #expect(sut.paymentState.card == .cardPaymentSuccessful)
+    }
+
+    @Test("payment event publisher updates inline message")
+    @MainActor
+    func paymentEventPublisher_updatesInlineMessage() {
+        let service = MockCardPresentPaymentService()
+        let sut = makePaymentController(cardPresentPaymentService: service)
+
+        service.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
+
+        guard case .paymentSuccess = sut.cardPresentPaymentInlineMessage else {
+            Issue.record("Expected paymentSuccess inline message")
+            return
+        }
+    }
+
+    @Test("reader connection publisher updates connection status")
+    @MainActor
+    func readerConnectionPublisher_updatesConnectionStatus() {
+        let service = MockCardPresentPaymentService()
+        let sut = makePaymentController(cardPresentPaymentService: service)
+
+        #expect(sut.cardReaderConnectionStatus == .disconnected)
+
+        service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.85)
+
+        #expect(sut.cardReaderConnectionStatus != .disconnected)
+    }
+
+    // MARK: - Configuration Actions
+
+    @Test("capture error exit action uses configuration")
+    @MainActor
+    func captureErrorExitAction_usesConfiguration() async {
+        var exitActionCalled = false
+        let service = MockCardPresentPaymentService()
+
+        let config = POSPaymentFlowConfiguration.cart(
+            onNewOrder: { exitActionCalled = true },
+            onEditOrder: {})
+
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            configuration: config)
+
+        // Trigger a capture error event
+        service.paymentEvent = .show(eventDetails: .paymentCaptureError(cancelPayment: {}))
+
+        // Find the capture error message and trigger the exit action
+        guard case .paymentCaptureError(let viewModel) = sut.cardPresentPaymentInlineMessage else {
+            Issue.record("Expected paymentCaptureError inline message")
+            return
+        }
+        viewModel.newOrderButtonViewModel.actionHandler()
+        // Yield to let the Task { @MainActor in } enqueued by the action handler execute.
+        await Task.yield()
+        #expect(exitActionCalled == true)
+        _ = sut // prevent sut from being released before the yield
+    }
+
+    @Test("connection success alert is filtered when waiting to start payment on connect")
+    @MainActor
+    func connectionSuccessAlert_isFiltered_whenWaitingToStartPayment() async {
+        let service = MockCardPresentPaymentService()
+        let orderProvider = MockPOSPaymentOrderProvider()
+        orderProvider.orderToReturn = Order.fake()
+
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            orderProvider: orderProvider)
+
+        // Start payment while disconnected — sets up the subscription
+        await sut.startPayment()
+
+        // Emit a connection success event
+        service.paymentEvent = .show(eventDetails: .connectionSuccess(done: {}))
+
+        // Alert should be filtered
+        #expect(sut.cardPresentPaymentAlertViewModel == nil)
+    }
+
+    @Test("connection success alert is shown when not waiting to start payment")
+    @MainActor
+    func connectionSuccessAlert_isShown_whenNotWaitingToStartPayment() async {
+        let service = MockCardPresentPaymentService()
+        service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
+
+        let orderProvider = MockPOSPaymentOrderProvider()
+        orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
+
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            orderProvider: orderProvider)
+
+        // Start and complete a payment — clears the subscription
+        await sut.startPayment()
+
+        // Emit a connection success event
+        service.paymentEvent = .show(eventDetails: .connectionSuccess(done: {}))
+
+        // Alert should be shown
+        #expect(sut.cardPresentPaymentAlertViewModel != nil)
+    }
+}
+
+// MARK: - Factory
+
+@MainActor
+private func makePaymentController(
+    cardPresentPaymentService: CardPresentPaymentFacade = MockCardPresentPaymentService(),
+    orderProvider: POSPaymentOrderProviding = MockPOSPaymentOrderProvider(),
+    cashPaymentHandler: POSCashPaymentHandling = MockPOSCashPaymentHandler(),
+    receiptSender: POSReceiptSending = MockPOSReceiptSender(),
+    postPaymentStep: (() async throws -> Void)? = nil,
+    configuration: POSPaymentFlowConfiguration = .cart(onNewOrder: {}, onEditOrder: {}),
+    analytics: POSAnalyticsProviding = MockPOSAnalytics(),
+    collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking = MockPOSCollectOrderPaymentAnalyticsTracker(),
+    celebration: PaymentCaptureCelebrationProtocol = MockPaymentCaptureCelebration(),
+    paymentState: PointOfSalePaymentState = .idle
+) -> POSPaymentModel {
+    POSPaymentModel(
+        cardPresentPaymentService: cardPresentPaymentService,
+        orderProvider: orderProvider,
+        cashPaymentHandler: cashPaymentHandler,
+        receiptSender: receiptSender,
+        postPaymentStep: postPaymentStep,
+        configuration: configuration,
+        analytics: analytics,
+        collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker,
+        celebration: celebration,
+        paymentState: paymentState)
+}


### PR DESCRIPTION
Part of: WOOMOB-2155
Merge after: #16655

## Description

Extract payment state management and card/cash payment flows from `PointOfSaleAggregateModel` into a dedicated `POSPaymentModel` (`@Observable`).

`POSPaymentModel` owns:
- Card payment lifecycle (start, collect, cancel, retry)
- Cash payment flow (start, collect, cancel)
- Receipt sending
- Card reader connection/disconnection/update state
- Reader reconnection observation
- Payment event → alert/message/state mapping

Dependencies are injected via protocols (`POSPaymentOrderProviding`, `POSCashPaymentHandling`, `POSReceiptSending`) and configured through `POSPaymentFlowConfiguration`, enabling reuse across cart and bookings flows.

Includes comprehensive tests for all payment flows and state transitions.

This is PR 2 of 6 in the POS payment extraction series.

## Test Steps

1. Build the project — new files only, no integration with existing views yet.
2. Run `PointOfSaleTests` — all existing tests pass, plus the new `POSPaymentModelTests`.

## Screenshots

N/A — no visual changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.