### PR TITLE
POS: Migrate aggregate model to delegate to POSPaymentModel

### DIFF
--- a/Modules/Sources/PointOfSale/Card Present Payments/POSCartPaymentOrderProvider.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/POSCartPaymentOrderProvider.swift
@@ -4,10 +4,12 @@ import struct Yosemite.Order
 struct POSCartPaymentOrderProvider: POSPaymentOrderProviding {
     let orderController: PointOfSaleOrderControllerProtocol
 
-    func provideOrder() async throws -> Order {
-        guard case let .loaded(_, order) = orderController.orderState else {
+    func provideOrder() async throws -> POSPaymentOrder {
+        guard case let .loaded(totals, order) = orderController.orderState else {
             throw POSPaymentError.noOrder
         }
-        return order
+        return POSPaymentOrder(order: order,
+                               formattedTotal: totals.orderTotal,
+                               totalDecimal: totals.orderTotalDecimal)
     }
 }

--- a/Modules/Sources/PointOfSale/Card Present Payments/POSPaymentOrderProviding.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/POSPaymentOrderProviding.swift
@@ -1,6 +1,14 @@
+import Foundation
 import struct Yosemite.Order
+
+/// The order data needed by the payment controller.
+struct POSPaymentOrder {
+    let order: Order
+    let formattedTotal: String
+    let totalDecimal: Decimal
+}
 
 /// Provides an Order for the payment model to collect payment against.
 protocol POSPaymentOrderProviding {
-    func provideOrder() async throws -> Order
+    func provideOrder() async throws -> POSPaymentOrder
 }

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -5,6 +5,7 @@ import Combine
 import struct Yosemite.Order
 import enum Yosemite.CardReaderSoftwareUpdateState
 import protocol Yosemite.PaymentCaptureCelebrationProtocol
+import class Yosemite.PaymentCaptureCelebration
 
 /// Shared payment model that owns all payment state and logic.
 @Observable
@@ -55,7 +56,7 @@ final class POSPaymentModel {
          configuration: POSPaymentFlowConfiguration,
          analytics: POSAnalyticsProviding,
          collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking,
-         celebration: PaymentCaptureCelebrationProtocol,
+         celebration: PaymentCaptureCelebrationProtocol = PaymentCaptureCelebration(),
          paymentState: PointOfSalePaymentState = .idle) {
         self.cardPresentPaymentService = cardPresentPaymentService
         self.orderProvider = orderProvider

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -102,10 +102,11 @@ extension POSPaymentModel {
 
     private func collectCardPayment() async {
         do {
-            let order = try await orderProvider.provideOrder()
-            currentOrder = order
-            guard let total = Decimal(string: order.total), total > 0 else { return }
-            try await collectPayment(for: order)
+            let paymentOrder = try await orderProvider.provideOrder()
+            currentOrder = paymentOrder.order
+            formattedOrderTotalPrice = paymentOrder.formattedTotal
+            guard paymentOrder.totalDecimal > 0 else { return }
+            try await collectPayment(for: paymentOrder.order)
         } catch {
             DDLogError("Error taking payment: \(error)")
         }
@@ -182,7 +183,8 @@ extension POSPaymentModel {
         if let currentOrder {
             order = currentOrder
         } else {
-            order = try await orderProvider.provideOrder()
+            let paymentOrder = try await orderProvider.provideOrder()
+            order = paymentOrder.order
             currentOrder = order
         }
         try await cashPaymentHandler.completeCashPayment(for: order, changeDueAmount: changeDueAmount)

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
@@ -5,8 +5,6 @@ import protocol Yosemite.POSOrderServiceProtocol
 import class Yosemite.POSOrderService
 import protocol Yosemite.POSReceiptServiceProtocol
 import protocol Yosemite.PluginsServiceProtocol
-import protocol Yosemite.PaymentCaptureCelebrationProtocol
-import class Yosemite.PaymentCaptureCelebration
 import struct Yosemite.Order
 import struct Yosemite.POSCart
 import struct Yosemite.POSCartItem
@@ -48,19 +46,16 @@ protocol PointOfSaleOrderControllerProtocol {
     init(orderService: POSOrderServiceProtocol,
          receiptSender: POSReceiptSending,
          currencySettingsProvider: POSCurrencySettingsProviding,
-         analytics: POSAnalyticsProviding,
-         celebration: PaymentCaptureCelebrationProtocol = PaymentCaptureCelebration()) {
+         analytics: POSAnalyticsProviding) {
         self.orderService = orderService
         self.receiptSender = receiptSender
         self.currencySettingsProvider = currencySettingsProvider
         self.analytics = analytics
-        self.celebration = celebration
     }
 
     private let orderService: POSOrderServiceProtocol
     private let receiptSender: POSReceiptSending
     private let currencySettingsProvider: POSCurrencySettingsProviding
-    private let celebration: PaymentCaptureCelebrationProtocol
     private let analytics: POSAnalyticsProviding
 
     private(set) var orderState: PointOfSaleInternalOrderState = .idle
@@ -123,10 +118,6 @@ protocol PointOfSaleOrderControllerProtocol {
         orderState = .idle
     }
 
-    private func celebrate() {
-        celebration.celebrate()
-    }
-
     @MainActor
     func collectCashPayment(changeDueAmount: String?) async throws {
         guard let order = order else {
@@ -135,7 +126,6 @@ protocol PointOfSaleOrderControllerProtocol {
 
         do {
             try await orderService.markOrderAsCompletedWithCashPayment(order: order, changeDueAmount: changeDueAmount)
-            celebrate()
         } catch {
             analytics.track(.pointOfSaleCashPaymentFailed)
             throw error

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -4,6 +4,8 @@ import Combine
 import Observation
 
 import protocol Yosemite.POSOrderableItem
+import protocol Yosemite.PaymentCaptureCelebrationProtocol
+import class Yosemite.PaymentCaptureCelebration
 import protocol WooFoundation.Analytics
 import struct Yosemite.Order
 import struct Yosemite.OrderItem
@@ -30,25 +32,27 @@ protocol PointOfSaleAggregateModelProtocol {
 @Observable final class PointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
     private(set) var orderStage: PointOfSaleOrderStage = .building
 
-    private(set) var cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus = .disconnected
-    private(set) var cardReaderUpdateState: CardReaderSoftwareUpdateState = .none
-    private(set) var paymentState: PointOfSalePaymentState
-    var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
-    private(set) var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType?
-    var cardPresentPaymentOnboardingViewContainer: CardPresentPaymentOnboardingViewContainer?
-    private var onOnboardingCancellation: (() -> Void)?
+    let paymentModel: POSPaymentModel
 
-    var isCardReaderUpdateAvailable: Bool {
-        if case .available = cardReaderUpdateState {
-            return true
-        }
-        return false
+    // Temporary forwarding properties for backward compatibility while views are migrated
+    // to read directly from paymentModel via the environment. Remove once migration is complete.
+    var cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus { paymentModel.cardReaderConnectionStatus }
+    var paymentState: PointOfSalePaymentState { paymentModel.paymentState }
+    var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType? {
+        get { paymentModel.cardPresentPaymentAlertViewModel }
+        set { paymentModel.cardPresentPaymentAlertViewModel = newValue }
     }
+    var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType? { paymentModel.cardPresentPaymentInlineMessage }
+    var cardPresentPaymentOnboardingViewContainer: CardPresentPaymentOnboardingViewContainer? {
+        get { paymentModel.cardPresentPaymentOnboardingViewContainer }
+        set { paymentModel.cardPresentPaymentOnboardingViewContainer = newValue }
+    }
+
+    var isCardReaderUpdateAvailable: Bool { paymentModel.isCardReaderUpdateAvailable }
 
     private(set) var cart: Cart = .init()
 
     var orderState: PointOfSaleOrderState { orderController.orderState.externalState }
-    private var internalOrderState: PointOfSaleInternalOrderState { orderController.orderState }
 
     let entryPointController: POSEntryPointController
     let purchasableItemsController: PointOfSaleItemsControllerProtocol
@@ -66,9 +70,6 @@ protocol PointOfSaleAggregateModelProtocol {
     private let barcodeScanService: PointOfSaleBarcodeScanServiceProtocol
     private let siteID: Int64
     private let catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol?
-
-    private var startPaymentOnCardReaderConnection: AnyCancellable?
-    private var cardReaderDisconnection: AnyCancellable?
 
     private let soundPlayer: PointOfSaleSoundPlayerProtocol
 
@@ -115,7 +116,9 @@ protocol PointOfSaleAggregateModelProtocol {
          searchHistoryService: POSSearchHistoryProviding,
          popularPurchasableItemsController: PointOfSaleItemsControllerProtocol,
          barcodeScanService: PointOfSaleBarcodeScanServiceProtocol,
+         receiptSender: POSReceiptSending,
          soundPlayer: PointOfSaleSoundPlayerProtocol = PointOfSaleSoundPlayer(),
+         celebration: PaymentCaptureCelebrationProtocol = PaymentCaptureCelebration(),
          paymentState: PointOfSalePaymentState = .idle,
          siteID: Int64,
          catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol? = nil,
@@ -131,7 +134,6 @@ protocol PointOfSaleAggregateModelProtocol {
         self.analytics = analytics
         self.collectOrderPaymentAnalyticsTracker = collectOrderPaymentAnalyticsTracker
         self.searchHistoryService = searchHistoryService
-        self.paymentState = paymentState
         self.popularPurchasableItemsController = popularPurchasableItemsController
         self.barcodeScanService = barcodeScanService
         self.soundPlayer = soundPlayer
@@ -139,9 +141,23 @@ protocol PointOfSaleAggregateModelProtocol {
         self.catalogSyncCoordinator = catalogSyncCoordinator
         self.isLocalCatalogEligible = isLocalCatalogEligible
 
-        publishCardReaderConnectionStatus()
-        publishCardReaderUpdateState()
-        publishPaymentMessages()
+        // Payment controller is created with cart-specific dependencies.
+        // The weak self captures below are safe because paymentModel is owned by self.
+        weak var weakSelf: PointOfSaleAggregateModel?
+        self.paymentModel = POSPaymentModel(
+            cardPresentPaymentService: cardPresentPaymentService,
+            orderProvider: POSCartPaymentOrderProvider(orderController: orderController),
+            cashPaymentHandler: POSCartCashPaymentHandler(orderController: orderController),
+            receiptSender: receiptSender,
+            configuration: .cart(
+                onNewOrder: { weakSelf?.startNewCart() },
+                onEditOrder: { weakSelf?.addMoreToCart() }),
+            analytics: analytics,
+            collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker,
+            celebration: celebration,
+            paymentState: paymentState)
+        weakSelf = self
+
         setupReaderReconnectionObservation()
         setupPaymentSuccessObservation()
         performInitialSyncIfNeeded()
@@ -192,8 +208,7 @@ extension PointOfSaleAggregateModel {
 
     private func setStateForEditing() {
         orderStage = .building
-        paymentState = .idle
-        cardPresentPaymentInlineMessage = nil
+        paymentModel.reset()
     }
 
     /// Removes missing products from the cart only (catalog is auto-cleaned when errors are detected)
@@ -349,134 +364,50 @@ private extension PointOfSaleAggregateModel {
     }
 }
 
-// MARK: - Card payments
+// MARK: - Payment (delegated to POSPaymentModel)
 extension PointOfSaleAggregateModel {
-    private func publishCardReaderConnectionStatus() {
-        cardPresentPaymentService.readerConnectionStatusPublisher
-            .sink(receiveValue: { [weak self] connectionStatus in
-                self?.cardReaderConnectionStatus = connectionStatus
-            })
-            .store(in: &cancellables)
-    }
-
-    private func publishCardReaderUpdateState() {
-        cardPresentPaymentService.cardReaderUpdateStatePublisher
-            .sink(receiveValue: { [weak self] updateState in
-                self?.cardReaderUpdateState = updateState
-            })
-            .store(in: &cancellables)
-    }
-
     func connectCardReader() {
-        analytics.track(.pointOfSaleCardReaderConnectionTapped)
-        Task { @MainActor [weak self] in
-            _ = try await self?.cardPresentPaymentService.connectReader(using: .bluetooth)
-        }
+        paymentModel.connectCardReader()
     }
 
     func disconnectCardReader() {
-        analytics.track(.cardReaderDisconnectTapped)
-        Task { @MainActor [weak self] in
-            await self?.cardPresentPaymentService.disconnectReader()
-        }
+        paymentModel.disconnectCardReader()
     }
 
     func updateCardReaderSoftware() {
-        //TODO: analytics.track(.cardReaderUpdateTapped)
-        Task { @MainActor [weak self] in
-            try? await self?.cardPresentPaymentService.updateCardReaderSoftware()
-        }
+        paymentModel.updateCardReaderSoftware()
     }
 
-    /// Starts a payment immediately if a reader is connected.
-    /// Otherwise, schedules a payment to start the next time a reader connects.
-    /// Note that any scheduled payments are cancelled by `cancelReaderPreparation`
-    /// e.g. when the TotalsView goes offscreen.
-    private func startPaymentWhenCardReaderConnected() async {
-        guard case .connected = cardReaderConnectionStatus else {
-            return startPaymentOnCardReaderConnection = cardPresentPaymentService.readerConnectionStatusPublisher
-                .filter { status in
-                    switch status {
-                    case .connected:
-                        return true
-                    case .disconnected, .disconnecting, .cancellingConnection:
-                        return false
-                    }
-                }
-                .removeDuplicates()
-                .sink { [weak self] _ in
-                    Task { @MainActor [weak self] in
-                        await self?.collectCardPayment()
-                    }
-                }
-        }
-        await collectCardPayment()
-    }
-
-    @MainActor
-    private func collectCardPayment() async {
-        guard case let .loaded(totals, order) = internalOrderState,
-              totals.orderTotalDecimal > 0.0
-        else {
-            return
-            // Should this throw?
-        }
-        do {
-            try await collectPayment(for: order)
-        } catch {
-            DDLogError("Error taking payment: \(error)")
-        }
-    }
-
-    // Prevents card payments from the moment the merchant decides we start collecting cash
-    // Once we get the callback from the card service, we switch to cash collection state
-    @MainActor
     func startCashPayment() async {
-        analytics.track(.pointOfSaleCheckoutCashPaymentTapped)
-        try? await cardPresentPaymentService.cancelPayment()
-        paymentState.cash = .collectingCash
+        await paymentModel.startCashPayment()
     }
 
-    @MainActor
     func cancelCashPayment() async {
-        analytics.track(.pointOfSaleBackToCheckoutFromCashTapped)
-        paymentState.cash = .idle
-        if case .connected = cardReaderConnectionStatus {
-            await collectCardPayment()
-        }
+        await paymentModel.cancelCashPayment()
     }
 
-    private func cashPaymentSuccess() {
-        paymentState.cash = .paymentSuccess
-        collectOrderPaymentAnalyticsTracker.trackSuccessfulCashPayment()
-    }
-
-    @MainActor
     func collectCashPayment(changeDueAmount: String?) async throws {
-        try await orderController.collectCashPayment(changeDueAmount: changeDueAmount)
-        cashPaymentSuccess()
+        try await paymentModel.collectCashPayment(changeDueAmount: changeDueAmount)
     }
 
-    @MainActor
     func sendReceipt(to emailAddress: String) async throws {
-        try await orderController.sendReceipt(recipientEmail: emailAddress)
-    }
-
-    @MainActor
-    private func collectPayment(for order: Order) async throws {
-        _ = try await cardPresentPaymentService.collectPayment(for: order, using: .bluetooth, channel: .pos)
+        try await paymentModel.sendReceipt(to: emailAddress)
     }
 
     func cancelThenCollectPayment() {
-        Task { [weak self] in
-            guard let self else { return }
-            await cancelThenCollectPayment()
-        }
+        paymentModel.cancelThenCollectPayment()
     }
 
     func cancelThenCollectPayment() async {
-        try? await cardPresentPaymentService.cancelPayment()
-        await collectCardPayment()
+        await paymentModel.cancelThenCollectPayment()
+    }
+
+    func cancelCardPaymentsOnboarding() {
+        paymentModel.cancelCardPaymentsOnboarding()
+    }
+
+    func trackCardPaymentsOnboardingShown() {
+        paymentModel.trackCardPaymentsOnboardingShown()
     }
 
     @Sendable private func setupReaderReconnectionObservation() {
@@ -484,172 +415,14 @@ extension PointOfSaleAggregateModel {
             guard let self else { return }
             switch orderStage {
                 case .building:
-                    cancelCardReaderPreparation()
+                    paymentModel.cancelReaderReconnectionObservation()
                 case .finalizing:
-                    observeReaderReconnection()
+                    paymentModel.observeReaderReconnection()
             }
         } onChange: { [weak self] in
             guard let self else { return }
             DispatchQueue.main.async(execute: setupReaderReconnectionObservation)
         }
-    }
-
-    private func cancelCardReaderPreparation() {
-        cardPresentPaymentService.cancelPayment()
-        resetCardReaderObservation()
-    }
-
-    private func resetCardReaderObservation() {
-        // We set these to nil, so that we can check them when showing `Reader connected` on the Totals screen.
-        startPaymentOnCardReaderConnection?.cancel()
-        startPaymentOnCardReaderConnection = nil
-        cardReaderDisconnection?.cancel()
-        cardReaderDisconnection = nil
-    }
-
-    private func observeReaderReconnection() {
-        cardReaderDisconnection = cardPresentPaymentService.readerConnectionStatusPublisher
-            .filter({ $0 == .disconnected })
-            .sink { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    await self?.startPaymentWhenCardReaderConnected()
-                }
-            }
-    }
-
-    /// Called when the onboarding UI is dismissed.
-    /// For external dismissal (tapping CTA to dismiss), this method is called twice - the first time to dismiss the onboarding UI
-    /// by setting `cardPresentPaymentOnboardingViewContainer` to nil, the second time triggered by internal dismissal.
-    /// For internal dismissal (tapping outside the modal), this method is called once.
-    /// This method is used to reset the internal state of the onboarding UI and track the dismissal event.
-    func cancelCardPaymentsOnboarding() {
-        guard let onboardingViewContainer = cardPresentPaymentOnboardingViewContainer else {
-            return
-        }
-        analytics.track(event: .PointOfSale.paymentsOnboardingDismissed(onboardingState: onboardingViewContainer.configuration.state))
-        cardPresentPaymentOnboardingViewContainer = nil
-        onOnboardingCancellation?()
-    }
-
-    /// Tracks when the onboarding UI is shown.
-    func trackCardPaymentsOnboardingShown() {
-        analytics.track(event: .PointOfSale.paymentsOnboardingShown())
-    }
-}
-
-private extension PointOfSaleAggregateModel {
-    func publishPaymentMessages() {
-        cardPresentPaymentService.paymentEventPublisher
-            .map { [weak self] event -> PointOfSaleCardPresentPaymentAlertType? in
-                guard let self else { return nil }
-                guard case let .show(eventDetails) = event,
-                      case let .alert(alertType) = presentationStyle(for: eventDetails)
-                else {
-                    return nil
-                }
-
-                // Filter connection success alerts when we're immediately starting a payment
-                if case .connectionSuccess = eventDetails,
-                   startPaymentOnCardReaderConnection != nil {
-                    return nil
-                }
-
-                return alertType
-            }
-            .sink(receiveValue: { [weak self] alertType in
-                self?.cardPresentPaymentAlertViewModel = alertType
-            })
-            .store(in: &cancellables)
-
-        cardPresentPaymentService.paymentEventPublisher
-            .map { [weak self] event -> PointOfSaleCardPresentPaymentMessageType? in
-                self?.mapCardPresentPaymentEventToMessageType(event)
-            }
-            .sink(receiveValue: { [weak self] message in
-                self?.cardPresentPaymentInlineMessage = message
-            })
-            .store(in: &cancellables)
-
-        cardPresentPaymentService.paymentEventPublisher
-            .compactMap { [weak self] paymentEvent -> PointOfSaleCardPaymentState? in
-                guard let self else { return nil }
-
-                let newCardPaymentState = PointOfSaleCardPaymentState(from: paymentEvent,
-                                                                      using: presentationStyleDeterminerDependencies)
-
-                if case .acceptingCard = newCardPaymentState {
-                    collectOrderPaymentAnalyticsTracker.trackCardReaderReady()
-                }
-
-                if case .processingPayment = newCardPaymentState {
-                    collectOrderPaymentAnalyticsTracker.trackCardReaderTapped()
-                }
-
-                return newCardPaymentState
-            }
-            .sink(receiveValue: { [weak self] cardPaymentState in
-                self?.paymentState.card = cardPaymentState
-            })
-            .store(in: &cancellables)
-
-        cardPresentPaymentService.paymentEventPublisher
-            .map { [weak self] event -> CardPresentPaymentOnboardingViewContainer? in
-                guard let self else { return nil }
-                guard case let .showOnboarding(factory, onCancel) = event else {
-                    return nil
-                }
-                onOnboardingCancellation = onCancel
-                return factory
-            }
-            .sink(receiveValue: { [weak self] factory in
-                self?.cardPresentPaymentOnboardingViewContainer = factory
-            })
-            .store(in: &cancellables)
-    }
-
-    /// Maps PaymentEvent to POSMessageType and annonates additional information if necessary
-    /// - Parameter event: CardPresentPaymentEvent
-    /// - Returns: PointOfSaleCardPresentPaymentMessageType
-    func mapCardPresentPaymentEventToMessageType(_ event: CardPresentPaymentEvent) -> PointOfSaleCardPresentPaymentMessageType? {
-        guard case let .show(eventDetails) = event,
-              case let .message(messageType) = presentationStyle(for: eventDetails) else {
-            return nil
-        }
-
-        return messageType
-    }
-
-    func presentationStyle(for eventDetails: CardPresentPaymentEventDetails) -> PointOfSaleCardPresentPaymentEventPresentationStyle? {
-        PointOfSaleCardPresentPaymentEventPresentationStyle(
-            for: eventDetails,
-            dependencies: presentationStyleDeterminerDependencies)
-    }
-
-    var presentationStyleDeterminerDependencies: PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies {
-        let cancelThenCollectPaymentWithWeakSelf: () -> Void = { [weak self] in
-            self?.cancelThenCollectPayment()
-        }
-
-        var orderTotal: String?
-        if case .loaded(let totals) = orderState {
-            orderTotal = totals.orderTotal
-        }
-
-        return PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies(
-            tryPaymentAgainBackToCheckoutAction: cancelThenCollectPaymentWithWeakSelf,
-            nonRetryableErrorExitAction: cancelThenCollectPaymentWithWeakSelf,
-            formattedOrderTotalPrice: orderTotal,
-            paymentCaptureErrorTryAgainAction: cancelThenCollectPaymentWithWeakSelf,
-            paymentCaptureErrorNewOrderAction: { [weak self] in
-                self?.startNewCart()
-            },
-            paymentIntentCreationErrorEditOrderAction: { [weak self] in
-                self?.addMoreToCart()
-            },
-            dismissReaderConnectionModal: { [weak self] in
-                self?.cardPresentPaymentAlertViewModel = nil
-            }
-        )
     }
 }
 
@@ -664,7 +437,7 @@ extension PointOfSaleAggregateModel {
         })
         trackOrderSyncState(syncOrderResult)
         await removeMissingProductsFromCatalogAfterSync()
-        await startPaymentWhenCardReaderConnected()
+        await paymentModel.startPayment()
     }
 
     /// Removes unavailable products from the local catalog after detecting them during order sync
@@ -680,20 +453,13 @@ extension PointOfSaleAggregateModel {
 // MARK: - Lifecycle
 extension PointOfSaleAggregateModel {
     func pointOfSaleClosed() {
-        // We cancel any payment to prevent the reader from remaining live and awaiting a card tap. Otherwise, it would
-        // wait until the timeout, which is 30-45 minutes. In that time, it uses more battery, and may result
-        // in a shopper paying for the wrong order.
-        Task { [cardPresentPaymentService] in
-            try await cardPresentPaymentService.cancelPayment()
-        }
-
         // Before exiting Point of Sale, we warn the merchant about losing their in-progress order.
         // We need to clear it down as any accidental retention can cause issues especially when reconnecting card readers.
         orderController.clearOrder()
 
         // Ideally, we could rely on the POS being deallocated to cancel all these. Since we have memory leak issues,
         // cancelling them explicitly helps reduce the risk of user-visible bugs while we work on the memory leaks.
-        resetCardReaderObservation()
+        paymentModel.tearDown()
         cancellables.forEach { $0.cancel() }
     }
 }
@@ -769,8 +535,7 @@ private enum Constants {
 #if DEBUG
 extension PointOfSaleAggregateModel {
     func setPreviewState(paymentState: PointOfSalePaymentState, inlineMessage: PointOfSaleCardPresentPaymentMessageType?) {
-        self.paymentState = paymentState
-        self.cardPresentPaymentInlineMessage = inlineMessage
+        paymentModel.setPreviewState(paymentState: paymentState, inlineMessage: inlineMessage)
     }
 }
 #endif

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -4,8 +4,6 @@ import Combine
 import Observation
 
 import protocol Yosemite.POSOrderableItem
-import protocol Yosemite.PaymentCaptureCelebrationProtocol
-import class Yosemite.PaymentCaptureCelebration
 import protocol WooFoundation.Analytics
 import struct Yosemite.Order
 import struct Yosemite.OrderItem
@@ -118,7 +116,6 @@ protocol PointOfSaleAggregateModelProtocol {
          barcodeScanService: PointOfSaleBarcodeScanServiceProtocol,
          receiptSender: POSReceiptSending,
          soundPlayer: PointOfSaleSoundPlayerProtocol = PointOfSaleSoundPlayer(),
-         celebration: PaymentCaptureCelebrationProtocol = PaymentCaptureCelebration(),
          paymentState: PointOfSalePaymentState = .idle,
          siteID: Int64,
          catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol? = nil,
@@ -154,7 +151,6 @@ protocol PointOfSaleAggregateModelProtocol {
                 onEditOrder: { weakSelf?.addMoreToCart() }),
             analytics: analytics,
             collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker,
-            celebration: celebration,
             paymentState: paymentState)
         weakSelf = self
 

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -43,6 +43,7 @@ public struct PointOfSaleEntryPointView: View {
     private let searchHistoryService: POSSearchHistoryProviding
     private let popularPurchasableItemsController: PointOfSaleItemsControllerProtocol
     private let barcodeScanService: PointOfSaleBarcodeScanServiceProtocol
+    private let receiptSender: POSReceiptSending
     private let siteTimezone: TimeZone
     private let services: POSDependencyProviding
     private let siteID: Int64
@@ -138,6 +139,7 @@ public struct PointOfSaleEntryPointView: View {
             analyticsProvider: services.analytics
         )
         self.barcodeScanService = barcodeScanService
+        self.receiptSender = receiptSender
         self.posEntryPointController = POSEntryPointController(eligibilityChecker: posEligibilityChecker)
         let ordersController = POSOrderListController(orderListFetchStrategyFactory: orderListFetchStrategyFactory,
                                                       refundsService: refundsService,
@@ -186,6 +188,7 @@ public struct PointOfSaleEntryPointView: View {
                 searchHistoryService: searchHistoryService,
                 popularPurchasableItemsController: popularPurchasableItemsController,
                 barcodeScanService: barcodeScanService,
+                receiptSender: receiptSender,
                 siteID: siteID,
                 catalogSyncCoordinator: catalogSyncCoordinator,
                 isLocalCatalogEligible: isLocalCatalogEligible)

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -232,6 +232,7 @@ struct POSPreviewHelpers {
         searchHistoryService: POSSearchHistoryProviding = PointOfSalePreviewHistoryService(),
         popularItemsController: PointOfSaleItemsControllerProtocol = PointOfSalePreviewItemsController(),
         barcodeScanService: PointOfSaleBarcodeScanServiceProtocol = PointOfSalePreviewBarcodeScanService(),
+        receiptSender: POSReceiptSending = POSReceiptSenderPreview(),
         analytics: POSAnalyticsProviding = EmptyPOSAnalytics(),
         siteID: Int64 = 1,
         catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol? = nil,
@@ -251,6 +252,7 @@ struct POSPreviewHelpers {
             searchHistoryService: searchHistoryService,
             popularPurchasableItemsController: popularItemsController,
             barcodeScanService: barcodeScanService,
+            receiptSender: receiptSender,
             siteID: siteID,
             catalogSyncCoordinator: catalogSyncCoordinator,
             isLocalCatalogEligible: isLocalCatalogEligible

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
@@ -24,6 +24,7 @@ struct POSPaymentModelTests {
         let service = MockCardPresentPaymentService()
         let orderProvider = MockPOSPaymentOrderProvider()
         orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
+        orderProvider.totalDecimalToReturn = 10
 
         service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
 
@@ -42,6 +43,7 @@ struct POSPaymentModelTests {
         let service = MockCardPresentPaymentService()
         let orderProvider = MockPOSPaymentOrderProvider()
         orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
+        orderProvider.totalDecimalToReturn = 10
 
         let sut = makePaymentController(
             cardPresentPaymentService: service,
@@ -248,10 +250,7 @@ struct POSPaymentModelTests {
             return
         }
         viewModel.newOrderButtonViewModel.actionHandler()
-        // Yield to let the Task { @MainActor in } enqueued by the action handler execute.
-        await Task.yield()
         #expect(exitActionCalled == true)
-        _ = sut // prevent sut from being released before the yield
     }
 
     @Test("connection success alert is filtered when waiting to start payment on connect")
@@ -283,6 +282,7 @@ struct POSPaymentModelTests {
 
         let orderProvider = MockPOSPaymentOrderProvider()
         orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
+        orderProvider.totalDecimalToReturn = 10
 
         let sut = makePaymentController(
             cardPresentPaymentService: service,

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
@@ -271,8 +271,7 @@ struct PointOfSaleOrderControllerTests {
             let sut = PointOfSaleOrderController(orderService: mockOrderService,
                                                  receiptSender: mockReceiptSender,
                                                  currencySettingsProvider: MockCurrencySettingsProvider(),
-                                                 analytics: MockPOSAnalytics(),
-                                                 celebration: MockPaymentCaptureCelebration())
+                                                 analytics: MockPOSAnalytics())
             try await sut.collectCashPayment(changeDueAmount: nil)
         } catch let error as PointOfSaleOrderController.PointOfSaleOrderControllerError {
             // Then
@@ -280,37 +279,12 @@ struct PointOfSaleOrderControllerTests {
         }
     }
 
-    @MainActor
-    @Test func collectCashPayment_when_successful_calls_celebrate() async throws {
-        // Given
-        let mockPaymentCelebration = MockPaymentCaptureCelebration()
-        let sut = PointOfSaleOrderController(orderService: mockOrderService,
-                                             receiptSender: mockReceiptSender,
-                                             currencySettingsProvider: MockCurrencySettingsProvider(),
-                                             analytics: MockPOSAnalytics(),
-                                             celebration: mockPaymentCelebration)
-
-        let orderItem = OrderItem.fake()
-        let fakeOrder = Order.fake().copy(items: [orderItem])
-        mockOrderService.orderToReturn = fakeOrder
-        await sut.syncOrder(for: Cart(purchasableItems: [makeItem()]), retryHandler: {})
-
-        mockOrderService.resultToReturn = .success(())
-
-        // When
-        try await sut.collectCashPayment(changeDueAmount: nil)
-
-        // Then
-        #expect(mockPaymentCelebration.celebrationWasCalled == true)
-    }
-
     @Test func collectCashPayment_passes_changeDueAmount_to_order_service() async throws {
         // Given
         let sut = PointOfSaleOrderController(orderService: mockOrderService,
                                              receiptSender: mockReceiptSender,
                                              currencySettingsProvider: MockCurrencySettingsProvider(),
-                                             analytics: MockPOSAnalytics(),
-                                             celebration: MockPaymentCaptureCelebration())
+                                             analytics: MockPOSAnalytics())
 
         let orderItem = OrderItem.fake()
         let fakeOrder = Order.fake().copy(items: [orderItem])
@@ -711,8 +685,7 @@ struct PointOfSaleOrderControllerTests {
             let sut = PointOfSaleOrderController(orderService: orderService,
                                                  receiptSender: mockReceiptSender,
                                                  currencySettingsProvider: MockCurrencySettingsProvider(),
-                                                 analytics: analytics,
-                                                 celebration: MockPaymentCaptureCelebration())
+                                                 analytics: analytics)
 
             // In order to test the order controller failure we need to succeed first in creating a successful order:
             let orderItem = OrderItem.fake()

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSPaymentOrderProvider.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSPaymentOrderProvider.swift
@@ -4,13 +4,17 @@ import struct Yosemite.Order
 
 final class MockPOSPaymentOrderProvider: POSPaymentOrderProviding {
     var orderToReturn: Order?
+    var formattedTotalToReturn: String = "$0.00"
+    var totalDecimalToReturn: Decimal = 0
     var errorToThrow: Error?
     var provideOrderCallCount = 0
 
-    func provideOrder() async throws -> Order {
+    func provideOrder() async throws -> POSPaymentOrder {
         provideOrderCallCount += 1
         if let error = errorToThrow { throw error }
         guard let order = orderToReturn else { throw POSPaymentError.noOrder }
-        return order
+        return POSPaymentOrder(order: order,
+                               formattedTotal: formattedTotalToReturn,
+                               totalDecimal: totalDecimalToReturn)
     }
 }

--- a/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
@@ -286,29 +286,57 @@ struct PointOfSaleAggregateModelTests {
             #expect(cardPresentPaymentService.collectPaymentChannel == .pos)
         }
 
-        @Test func sendReceipt_when_invoked_then_calls_controller() async throws {
+        @Test func sendReceipt_when_invoked_then_calls_receiptSender() async throws {
             // Given
-            let orderController = MockPointOfSaleOrderController()
-            let sut = makePointOfSaleAggregateModel(orderController: orderController)
+            let receiptSender = MockPOSReceiptSender()
+            let order = Order.fake().copy(orderID: 42)
+            orderController.orderStateToReturn = makeLoadedOrderState(
+                orderTotal: "$10.00",
+                orderTotalDecimal: 10,
+                order: order)
+            cardPresentPaymentService.connectedReader = .init(name: "Test reader", batteryLevel: 0.7)
+
+            let sut = makePointOfSaleAggregateModel(
+                cardPresentPaymentService: cardPresentPaymentService,
+                orderController: orderController,
+                receiptSender: receiptSender)
+
+            // Trigger checkout to set currentOrder in the payment controller
+            await sut.checkOut()
 
             // When
-            try await sut.sendReceipt(to: "")
+            try await sut.sendReceipt(to: "test@example.com")
 
             // Then
-            #expect(orderController.sendReceiptWasCalled == true)
+            #expect(receiptSender.sendReceiptWasCalled == true)
+            #expect(receiptSender.sendReceiptCalledWithOrderID == 42)
+            #expect(receiptSender.sendReceiptCalledWithEmail == "test@example.com")
         }
 
         @Test func sendReceipt_when_invoked_with_error_then_returns_error() async throws {
             // Given
-            let orderController = MockPointOfSaleOrderController()
+            let receiptSender = MockPOSReceiptSender()
             let expectedError = NSError(domain: "some error", code: -1)
-            orderController.sendReceiptErrorToThrow = expectedError
+            receiptSender.sendReceiptErrorToThrow = expectedError
+            let order = Order.fake().copy(orderID: 42)
+            orderController.orderStateToReturn = makeLoadedOrderState(
+                orderTotal: "$10.00",
+                orderTotalDecimal: 10,
+                order: order)
+            cardPresentPaymentService.connectedReader = .init(name: "Test reader", batteryLevel: 0.7)
 
-            let sut = makePointOfSaleAggregateModel(orderController: orderController)
+            let sut = makePointOfSaleAggregateModel(
+                cardPresentPaymentService: cardPresentPaymentService,
+                orderController: orderController,
+                receiptSender: receiptSender)
+
+            // Trigger checkout to set currentOrder in the payment controller
+            await sut.checkOut()
 
             do {
                 // When
-                try await sut.sendReceipt(to: "")
+                try await sut.sendReceipt(to: "test@example.com")
+                Issue.record("Expected error to be thrown")
             } catch {
                 // Then
                 let nsError = error as NSError
@@ -523,20 +551,21 @@ struct PointOfSaleAggregateModelTests {
         @Test func cardPresentPaymentInlineMessage_when_paymentSuccess_then_total_set() async throws {
             // Given order totals:
             // Note that orderTotal is used, but the Order values are given for test robustness.
-            orderController.orderState = makeLoadedOrderState(
+            orderController.orderStateToReturn = makeLoadedOrderState(
                 orderTotal: "$52.30",
                 orderTotalDecimal: 52.3,
                 order: Order.fake().copy(currency: "$", total: "52.30"))
+            cardPresentPaymentService.connectedReader = .init(name: "Test reader", batteryLevel: 0.7)
             let itemsController = MockPointOfSaleItemsController()
             let sut = makePointOfSaleAggregateModel(
                 itemsController: itemsController,
                 cardPresentPaymentService: cardPresentPaymentService,
                 orderController: orderController)
 
-            // When
-            cardPresentPaymentService.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
+            // Trigger checkout to populate formattedOrderTotalPrice in the payment controller
+            await sut.checkOut()
 
-            // Then
+            // Then — the payment success event is fired by the mock's collectPayment
             guard case .paymentSuccess(let viewModel) = sut.cardPresentPaymentInlineMessage else {
                 Issue.record("Expected cardPresentPaymentInlineMessage to be paymentSuccess")
                 return
@@ -1036,6 +1065,7 @@ private func makePointOfSaleAggregateModel(
     searchHistoryService: POSSearchHistoryProviding = MockPOSSearchHistoryService(),
     popularPurchasableItemsController: PointOfSaleItemsControllerProtocol = MockPointOfSaleItemsController(),
     barcodeScanService: PointOfSaleBarcodeScanServiceProtocol = MockPointOfSaleBarcodeScanService(),
+    receiptSender: POSReceiptSending = MockPOSReceiptSender(),
     soundPlayer: PointOfSaleSoundPlayerProtocol = MockPointOfSaleSoundPlayer(),
     paymentState: PointOfSalePaymentState = .idle,
     siteID: Int64 = 123,
@@ -1055,6 +1085,7 @@ private func makePointOfSaleAggregateModel(
         searchHistoryService: searchHistoryService,
         popularPurchasableItemsController: popularPurchasableItemsController,
         barcodeScanService: barcodeScanService,
+        receiptSender: receiptSender,
         soundPlayer: soundPlayer,
         paymentState: paymentState,
         siteID: siteID,

--- a/Modules/Tests/PointOfSaleTests/Presentation/POSItemActionHandlerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Presentation/POSItemActionHandlerTests.swift
@@ -127,6 +127,7 @@ private func makePointOfSaleAggregateModel(
         searchHistoryService: searchHistoryService,
         popularPurchasableItemsController: popularPurchasableItemsController,
         barcodeScanService: barcodeScanService,
+        receiptSender: MockPOSReceiptSender(),
         siteID: 0
     )
 }


### PR DESCRIPTION
Part of: WOOMOB-2155
Merge after: #16656

## Description

`PointOfSaleAggregateModel` now creates and owns a `POSPaymentModel` instance, delegating all payment state and logic to it instead of managing payments directly. This is the key integration step that wires the new payment model into the existing POS architecture.

Changes:
- `PointOfSaleAggregateModel` creates `POSPaymentModel` with cart-specific protocol implementations (`POSCartPaymentOrderProvider`, `POSCartCashPaymentHandler`)
- Aggregate model forwards payment properties to `POSPaymentModel` for backwards compatibility during the view migration
- `POSPaymentOrderProviding` now returns `POSPaymentOrder` (with `formattedTotal` and `totalDecimal`) instead of raw `Order`
- `POSPaymentModel` injected into SwiftUI environment alongside aggregate model
- Updated aggregate model tests and item action handler tests

This is PR 3 of 6 in the POS payment extraction series.

## Test Steps

1. Open POS, add items to cart, proceed to checkout
2. Complete a card payment — verify the full flow works as before
3. Complete a cash payment — verify change due and success screen
4. Run `PointOfSaleTests` — all tests should pass

## Screenshots

https://github.com/user-attachments/assets/b299c684-7650-4fb1-9dc7-1762f220d461


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.