### PR TITLE
POS: Decouple payment views from aggregate model for reuse

### DIFF
--- a/Modules/Sources/PointOfSale/Models/POSPaymentFlowConfiguration.swift
+++ b/Modules/Sources/PointOfSale/Models/POSPaymentFlowConfiguration.swift
@@ -1,4 +1,5 @@
 import Foundation
+import enum WooFoundationCore.WooAnalyticsStat
 
 /// Configures the view-level differences between payment flow callers.
 struct POSPaymentFlowConfiguration {
@@ -19,13 +20,14 @@ struct POSPaymentFlowConfiguration {
     /// Optional barcode scan handler for the success screen.
     /// When provided, barcode scanning is enabled after a successful payment
     /// (automatically disabled during receipt email entry).
-    let onBarcodeScanned: ((Result<String, HIDBarcodeParserError>) -> Void)?
+    let onSuccessScreenBarcodeScanned: ((Result<String, HIDBarcodeParserError>) -> Void)?
 }
 
 /// A labeled action used by the payment flow configuration.
 struct PaymentFlowAction {
     let title: String
     let action: () -> Void
+    let analyticsEvent: WooAnalyticsStat?
 }
 
 // MARK: - Cart
@@ -33,19 +35,22 @@ struct PaymentFlowAction {
 extension POSPaymentFlowConfiguration {
     static func cart(onNewOrder: @escaping () -> Void,
                      onEditOrder: @escaping () -> Void,
-                     onBarcodeScanned: ((Result<String, HIDBarcodeParserError>) -> Void)? = nil) -> Self {
+                     onSuccessScreenBarcodeScanned: ((Result<String, HIDBarcodeParserError>) -> Void)? = nil) -> Self {
         POSPaymentFlowConfiguration(
             successAction: PaymentFlowAction(
                 title: Localization.Cart.newOrder,
-                action: onNewOrder),
+                action: onNewOrder,
+                analyticsEvent: .pointOfSaleCreateNewOrderTapped),
             captureErrorExitAction: PaymentFlowAction(
                 title: Localization.Cart.newOrder,
-                action: onNewOrder),
+                action: onNewOrder,
+                analyticsEvent: nil),
             intentCreationErrorExitAction: PaymentFlowAction(
                 title: Localization.Cart.editOrder,
-                action: onEditOrder),
+                action: onEditOrder,
+                analyticsEvent: nil),
             showInitialCloseButton: false,
-            onBarcodeScanned: onBarcodeScanned
+            onSuccessScreenBarcodeScanned: onSuccessScreenBarcodeScanned
         )
     }
 }
@@ -57,15 +62,18 @@ extension POSPaymentFlowConfiguration {
         POSPaymentFlowConfiguration(
             successAction: PaymentFlowAction(
                 title: Localization.Bookings.done,
-                action: onDismiss),
+                action: onDismiss,
+                analyticsEvent: nil),
             captureErrorExitAction: PaymentFlowAction(
                 title: Localization.Bookings.backToBooking,
-                action: onDismiss),
+                action: onDismiss,
+                analyticsEvent: nil),
             intentCreationErrorExitAction: PaymentFlowAction(
                 title: Localization.Bookings.backToBooking,
-                action: onDismiss),
+                action: onDismiss,
+                analyticsEvent: nil),
             showInitialCloseButton: true,
-            onBarcodeScanned: nil
+            onSuccessScreenBarcodeScanned: nil
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Models/POSPaymentFlowConfiguration.swift
+++ b/Modules/Sources/PointOfSale/Models/POSPaymentFlowConfiguration.swift
@@ -15,6 +15,11 @@ struct POSPaymentFlowConfiguration {
 
     /// Whether to show a close (x) button on the initial payment screen.
     let showInitialCloseButton: Bool
+
+    /// Optional barcode scan handler for the success screen.
+    /// When provided, barcode scanning is enabled after a successful payment
+    /// (automatically disabled during receipt email entry).
+    let onBarcodeScanned: ((Result<String, HIDBarcodeParserError>) -> Void)?
 }
 
 /// A labeled action used by the payment flow configuration.
@@ -27,7 +32,8 @@ struct PaymentFlowAction {
 
 extension POSPaymentFlowConfiguration {
     static func cart(onNewOrder: @escaping () -> Void,
-                     onEditOrder: @escaping () -> Void) -> Self {
+                     onEditOrder: @escaping () -> Void,
+                     onBarcodeScanned: ((Result<String, HIDBarcodeParserError>) -> Void)? = nil) -> Self {
         POSPaymentFlowConfiguration(
             successAction: PaymentFlowAction(
                 title: Localization.Cart.newOrder,
@@ -38,7 +44,8 @@ extension POSPaymentFlowConfiguration {
             intentCreationErrorExitAction: PaymentFlowAction(
                 title: Localization.Cart.editOrder,
                 action: onEditOrder),
-            showInitialCloseButton: false
+            showInitialCloseButton: false,
+            onBarcodeScanned: onBarcodeScanned
         )
     }
 }
@@ -57,7 +64,8 @@ extension POSPaymentFlowConfiguration {
             intentCreationErrorExitAction: PaymentFlowAction(
                 title: Localization.Bookings.backToBooking,
                 action: onDismiss),
-            showInitialCloseButton: true
+            showInitialCloseButton: true,
+            onBarcodeScanned: nil
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -151,7 +151,11 @@ protocol PointOfSaleAggregateModelProtocol {
             receiptSender: receiptSender,
             configuration: .cart(
                 onNewOrder: { weakSelf?.startNewCart() },
-                onEditOrder: { weakSelf?.addMoreToCart() }),
+                onEditOrder: { weakSelf?.addMoreToCart() },
+                onBarcodeScanned: { barcode in
+                    weakSelf?.startNewCart()
+                    weakSelf?.barcodeScanned(barcode)
+                }),
             analytics: analytics,
             collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker,
             celebration: celebration,

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -149,7 +149,7 @@ protocol PointOfSaleAggregateModelProtocol {
             configuration: .cart(
                 onNewOrder: { weakSelf?.startNewCart() },
                 onEditOrder: { weakSelf?.addMoreToCart() },
-                onBarcodeScanned: { barcode in
+                onSuccessScreenBarcodeScanned: { barcode in
                     weakSelf?.startNewCart()
                     weakSelf?.barcodeScanned(barcode)
                 }),

--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentInLineMessage.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentInLineMessage.swift
@@ -29,7 +29,7 @@ struct PointOfSaleCardPresentPaymentInLineMessage: View {
                 viewModel: viewModel,
                 onSendReceipt: { email in try await paymentModel.sendReceipt(to: email) },
                 successAction: paymentModel.configuration.successAction,
-                onBarcodeScanned: paymentModel.configuration.onBarcodeScanned)
+                onSuccessScreenBarcodeScanned: paymentModel.configuration.onSuccessScreenBarcodeScanned)
         case .paymentError(let viewModel):
             PointOfSaleCardPresentPaymentErrorMessageView(viewModel: viewModel, animation: animation)
         case .paymentErrorNonRetryable(let viewModel):

--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentInLineMessage.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentInLineMessage.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct PointOfSaleCardPresentPaymentInLineMessage: View {
     private let messageType: PointOfSaleCardPresentPaymentMessageType
+    @Environment(POSPaymentModel.self) private var paymentModel
 
     init(messageType: PointOfSaleCardPresentPaymentMessageType) {
         self.messageType = messageType
@@ -24,7 +25,11 @@ struct PointOfSaleCardPresentPaymentInLineMessage: View {
         case .displayReaderMessage(let viewModel):
             PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView(viewModel: viewModel, animation: animation)
         case .paymentSuccess(let viewModel):
-            PointOfSalePaymentSuccessView(viewModel: viewModel)
+            PointOfSalePaymentSuccessView(
+                viewModel: viewModel,
+                onSendReceipt: { email in try await paymentModel.sendReceipt(to: email) },
+                successAction: paymentModel.configuration.successAction,
+                onBarcodeScanned: paymentModel.configuration.onBarcodeScanned)
         case .paymentError(let viewModel):
             PointOfSaleCardPresentPaymentErrorMessageView(viewModel: viewModel, animation: animation)
         case .paymentErrorNonRetryable(let viewModel):
@@ -47,10 +52,14 @@ struct PointOfSaleCardPresentPaymentInLineMessage: View {
     private var animation: POSCardPresentPaymentInLineMessageAnimation { .init(namespace: namespace) }
 }
 
+#if DEBUG
 #Preview {
+    let model = POSPreviewHelpers.makePreviewAggregateModel()
     PointOfSaleCardPresentPaymentInLineMessage(messageType: .processing(
         viewModel: PointOfSaleCardPresentPaymentProcessingMessageViewModel()))
+    .environment(model.paymentModel)
 }
+#endif
 
 struct POSCardPresentPaymentInLineMessageAnimation {
     let namespace: Namespace.ID

--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
@@ -4,7 +4,7 @@ struct PointOfSalePaymentSuccessView: View {
     let viewModel: PointOfSalePaymentSuccessViewModel
     let onSendReceipt: (String) async throws -> Void
     let successAction: PaymentFlowAction
-    let onBarcodeScanned: ((Result<String, HIDBarcodeParserError>) -> Void)?
+    let onSuccessScreenBarcodeScanned: ((Result<String, HIDBarcodeParserError>) -> Void)?
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
 
     @State private var isShowingSendReceiptView: Bool = false
@@ -29,8 +29,8 @@ struct PointOfSalePaymentSuccessView: View {
                 .background(Color.posSurfaceBright)
             }
         }
-        .barcodeScanning(enabled: .constant(onBarcodeScanned != nil && !isShowingSendReceiptView)) { barcode in
-            onBarcodeScanned?(barcode)
+        .barcodeScanning(enabled: .constant(onSuccessScreenBarcodeScanned != nil && !isShowingSendReceiptView)) { barcode in
+            onSuccessScreenBarcodeScanned?(barcode)
         }
         .accessibilityIdentifier("pos-payment-success-view")
         .onAppear {
@@ -101,8 +101,8 @@ private extension PointOfSalePaymentSuccessView {
         viewModel: PointOfSalePaymentSuccessViewModel(formattedOrderTotal: "$3.00",
                                                       paymentMethod: .card),
         onSendReceipt: { _ in },
-        successAction: PaymentFlowAction(title: "New order", action: {}),
-        onBarcodeScanned: nil
+        successAction: PaymentFlowAction(title: "New order", action: {}, analyticsEvent: nil),
+        onSuccessScreenBarcodeScanned: nil
     )
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
@@ -2,8 +2,10 @@ import SwiftUI
 
 struct PointOfSalePaymentSuccessView: View {
     let viewModel: PointOfSalePaymentSuccessViewModel
+    let onSendReceipt: (String) async throws -> Void
+    let successAction: PaymentFlowAction
+    let onBarcodeScanned: ((Result<String, HIDBarcodeParserError>) -> Void)?
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
-    @Environment(PointOfSaleAggregateModel.self) private var posModel
 
     @State private var isShowingSendReceiptView: Bool = false
     @State private var isViewLoaded: Bool = false
@@ -12,7 +14,7 @@ struct PointOfSalePaymentSuccessView: View {
         VStack {
             if isShowingSendReceiptView {
                 POSSendReceiptView(isShowingSendReceiptView: $isShowingSendReceiptView) { email in
-                    try await posModel.sendReceipt(to: email)
+                    try await onSendReceipt(email)
                 }
                 .transition(.asymmetric(
                     insertion: .move(edge: .trailing).combined(with: .opacity),
@@ -25,11 +27,10 @@ struct PointOfSalePaymentSuccessView: View {
                 }
                 .padding([.leading, .trailing], dynamicTypeSize.isAccessibilitySize ? nil : POSPadding.small)
                 .background(Color.posSurfaceBright)
-                .barcodeScanning { barcode in
-                    posModel.startNewCart()
-                    posModel.barcodeScanned(barcode)
-                }
             }
+        }
+        .barcodeScanning(enabled: .constant(onBarcodeScanned != nil && !isShowingSendReceiptView)) { barcode in
+            onBarcodeScanned?(barcode)
         }
         .accessibilityIdentifier("pos-payment-success-view")
         .onAppear {
@@ -71,7 +72,8 @@ struct PointOfSalePaymentSuccessView: View {
 
                 Spacer().frame(height: POSSpacing.xxLarge)
 
-                PaymentsActionButtons(isShowingSendReceiptView: $isShowingSendReceiptView)
+                PaymentsActionButtons(successAction: successAction,
+                                      isShowingSendReceiptView: $isShowingSendReceiptView)
                     .containerRelativeFrame(.horizontal, count: 2, span: 1, spacing: POSSpacing.none)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .offset(y: isViewLoaded ? 0 : -Constants.animationOffset)
@@ -97,8 +99,10 @@ private extension PointOfSalePaymentSuccessView {
 #Preview {
     PointOfSalePaymentSuccessView(
         viewModel: PointOfSalePaymentSuccessViewModel(formattedOrderTotal: "$3.00",
-                                                      paymentMethod: .card)
+                                                      paymentMethod: .card),
+        onSendReceipt: { _ in },
+        successAction: PaymentFlowAction(title: "New order", action: {}),
+        onBarcodeScanned: nil
     )
-    .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
@@ -1,0 +1,319 @@
+import SwiftUI
+
+// MARK: - Shared Payment Content View
+
+/// Shared payment content view used by the bookings flow.
+/// Handles close button, payment state rendering, static totals fields, cash button,
+/// background color, and payment modal bindings.
+///
+/// The cart flow (TotalsView) uses the shared sub-components directly
+/// because it has additional complexity (shimmering, order errors, layout padding).
+struct POSPaymentContentView: View {
+    let formattedSubtotal: String
+    let formattedTax: String
+    let formattedTotal: String
+    let onDismiss: (() -> Void)?
+
+    @Environment(POSPaymentModel.self) private var paymentModel
+    private let viewHelper = TotalsViewHelper()
+
+    var body: some View {
+        @Bindable var paymentModel = paymentModel
+
+        VStack(spacing: POSSpacing.none) {
+            Spacer()
+
+            paymentContentView
+
+            if shouldShowTotalsFields {
+                totalsFieldsView
+            }
+
+            Spacer()
+                .renderedIf(viewHelper.shouldApplyPadding(paymentState: paymentModel.paymentState))
+
+            cashPaymentButtonView
+        }
+        .background(viewHelper.paymentBackgroundColor(for: paymentModel.paymentState))
+        .animation(.default, value: paymentModel.paymentState)
+        .overlay(alignment: .topTrailing) {
+            closeButton
+        }
+        .posModal(item: $paymentModel.cardPresentPaymentAlertViewModel, onDismiss: {
+            paymentModel.cardPresentPaymentAlertViewModel?.onDismiss?()
+        }) { alertType in
+            PointOfSaleCardPresentPaymentAlert(alertType: alertType)
+                .posInteractiveDismissDisabled(alertType.isDismissDisabled)
+        }
+        .posModal(item: $paymentModel.cardPresentPaymentOnboardingViewContainer, onDismiss: {
+            paymentModel.cancelCardPaymentsOnboarding()
+        }) { factory in
+            PointOfSaleCardPresentPaymentOnboardingView(viewModel: .init(
+                onboardingViewContainer: factory,
+                onDismissTap: {
+                    paymentModel.cancelCardPaymentsOnboarding()
+                }))
+            .onAppear {
+                paymentModel.trackCardPaymentsOnboardingShown()
+            }
+        }
+    }
+
+    // MARK: - Close Button
+
+    @ViewBuilder
+    private var closeButton: some View {
+        if let onDismiss,
+           paymentModel.configuration.showInitialCloseButton,
+           !paymentModel.paymentState.shownFullScreen {
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.posBodyLargeBold)
+                    .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                    .foregroundColor(.posOnSurface)
+                    .padding(POSPadding.small)
+            }
+            .padding(POSPadding.medium)
+        }
+    }
+
+    // MARK: - Payment Content
+
+    @ViewBuilder
+    private var paymentContentView: some View {
+        switch paymentModel.paymentState.activePaymentMethod {
+        case .cash:
+            POSCashPaymentContentView(
+                cashPaymentState: paymentModel.paymentState.cash,
+                formattedOrderTotal: formattedTotal)
+        case .card:
+            POSCardPaymentContentView(
+                cardReaderConnectionStatus: paymentModel.cardReaderConnectionStatus,
+                paymentState: paymentModel.paymentState,
+                cardPresentPaymentInlineMessage: paymentModel.cardPresentPaymentInlineMessage,
+                connectCardReaderAction: paymentModel.connectCardReader,
+                showLoadingWhenIdle: true)
+        }
+    }
+
+    // MARK: - Totals Fields
+
+    private var shouldShowTotalsFields: Bool {
+        viewHelper.shouldShowTotalsFields(for: paymentModel.paymentState)
+    }
+
+    @ViewBuilder
+    private var totalsFieldsView: some View {
+        HStack(alignment: .center) {
+            Spacer()
+            VStack {
+                subtotalRow(
+                    title: Localization.subtotal,
+                    formattedPrice: formattedSubtotal)
+
+                Spacer().frame(height: POSSpacing.medium)
+
+                subtotalRow(
+                    title: Localization.taxes,
+                    formattedPrice: formattedTax)
+
+                Spacer().frame(height: POSSpacing.medium)
+
+                Divider()
+                    .overlay(Color.posOutlineVariant)
+
+                Spacer().frame(height: POSSpacing.medium)
+
+                HStack(alignment: .top, spacing: .zero) {
+                    Text(Localization.total)
+                        .font(.posHeadingBold)
+                        .fontWeight(.semibold)
+                    Spacer(minLength: POSSpacing.large)
+                    Text(formattedTotal)
+                        .font(.posHeadingBold)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityAddTraits(.isHeader)
+                .foregroundColor(Color.posOnSurface)
+            }
+            .padding(EdgeInsets(
+                top: POSPadding.medium,
+                leading: POSPadding.large,
+                bottom: POSPadding.medium,
+                trailing: POSPadding.large))
+            .frame(minWidth: 382)
+            .fixedSize(horizontal: true, vertical: false)
+            Spacer()
+        }
+        .transition(.opacity)
+        .layoutPriority(1)
+        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+    }
+
+    @ViewBuilder
+    private func subtotalRow(title: String, formattedPrice: String) -> some View {
+        HStack(alignment: .top, spacing: .zero) {
+            Text(title)
+                .font(.posBodyLargeRegular())
+            Spacer()
+            Text(formattedPrice)
+                .font(.posBodyLargeRegular())
+        }
+        .accessibilityElement(children: .combine)
+        .foregroundColor(Color.posOnSurface)
+    }
+
+    // MARK: - Cash Payment Button
+
+    @ViewBuilder
+    private var cashPaymentButtonView: some View {
+        if viewHelper.shouldShowCashPaymentButton(
+            paymentState: paymentModel.paymentState,
+            cardReaderConnectionStatus: paymentModel.cardReaderConnectionStatus,
+            isZeroTotal: paymentModel.isZeroTotal) {
+            Button(action: {
+                Task { @MainActor in
+                    await paymentModel.startCashPayment()
+                }
+            }) {
+                Text(Localization.cashPaymentButton)
+                    .font(POSFontStyle.posBodyLargeBold)
+            }
+            .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+            .padding(.horizontal, POSPadding.medium)
+            .safeAreaPadding(.bottom, POSPadding.medium)
+        }
+    }
+}
+
+// MARK: - Localization
+
+private extension POSPaymentContentView {
+    enum Localization {
+        static let subtotal = NSLocalizedString(
+            "pointOfSale.paymentContent.subtotal",
+            value: "Subtotal",
+            comment: "Label for the subtotal amount in the payment content view"
+        )
+
+        static let taxes = NSLocalizedString(
+            "pointOfSale.paymentContent.taxes",
+            value: "Taxes",
+            comment: "Label for the taxes amount in the payment content view"
+        )
+
+        static let total = NSLocalizedString(
+            "pointOfSale.paymentContent.total",
+            value: "Total",
+            comment: "Label for the total amount in the payment content view"
+        )
+
+        static let cashPaymentButton = NSLocalizedString(
+            "pointOfSale.paymentContent.cashPaymentButton",
+            value: "Cash payment",
+            comment: "Button to start a cash payment in the payment flow"
+        )
+    }
+}
+
+// MARK: - Shared Card Payment Content
+
+/// Shared card payment content rendering used by both cart and bookings flows.
+/// Handles reader disconnected message, inline payment messages, and optional loading state.
+struct POSCardPaymentContentView: View {
+    let cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus
+    let paymentState: PointOfSalePaymentState
+    let cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType?
+    let connectCardReaderAction: () -> Void
+    var showLoadingWhenIdle: Bool = false
+
+    private let viewHelper = TotalsViewHelper()
+
+    @ViewBuilder
+    var body: some View {
+        if viewHelper.shouldShowDisconnectedMessage(readerConnectionStatus: cardReaderConnectionStatus,
+                                                    paymentState: paymentState) {
+            PointOfSaleCardPresentPaymentReaderDisconnectedMessageView {
+                connectCardReaderAction()
+            }
+        } else if let inlineMessage = cardPresentPaymentInlineMessage {
+            switch inlineMessage {
+            case .paymentSuccess:
+                PointOfSaleCardPresentPaymentInLineMessage(messageType: inlineMessage)
+            default:
+                HStack(alignment: .center) {
+                    Spacer()
+                    PointOfSaleCardPresentPaymentInLineMessage(messageType: inlineMessage)
+                    Spacer()
+                }
+            }
+        } else if showLoadingWhenIdle,
+                  case .idle = paymentState.card,
+                  case .connected = cardReaderConnectionStatus {
+            POSPaymentLoadingView()
+        }
+    }
+}
+
+// MARK: - Shared Cash Payment Content
+
+/// Shared cash payment content rendering used by both cart and bookings flows.
+struct POSCashPaymentContentView: View {
+    let cashPaymentState: PointOfSaleCashPaymentState
+    let formattedOrderTotal: String
+    @Environment(\.posCurrencyProvider) private var currencyProvider
+
+    var body: some View {
+        switch cashPaymentState {
+        case .collectingCash:
+            PointOfSaleCollectCashView(orderTotal: formattedOrderTotal,
+                                       currencySettings: currencyProvider.currencySettings)
+                .transition(.move(edge: .trailing))
+        case .paymentSuccess:
+            PointOfSaleCardPresentPaymentInLineMessage(
+                messageType: .paymentSuccess(
+                    viewModel: .init(formattedOrderTotal: formattedOrderTotal,
+                                     paymentMethod: .cash)))
+        case .idle:
+            EmptyView()
+        }
+    }
+}
+
+// MARK: - Payment Loading View
+
+/// Loading spinner shown while waiting for order data during payment.
+struct POSPaymentLoadingView: View {
+    var body: some View {
+        VStack(alignment: .center, spacing: POSSpacing.xLarge) {
+            ProgressView()
+                .progressViewStyle(POSProgressViewStyle())
+                .frame(width: 160, height: 160)
+
+            VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
+                Text(Localization.title)
+                    .foregroundStyle(Color.posOnSurfaceVariantHighest)
+                    .font(.posBodyLargeRegular())
+
+                Text(Localization.message)
+                    .font(.posHeadingBold)
+                    .foregroundStyle(Color.posOnSurface)
+            }
+        }
+        .multilineTextAlignment(.center)
+    }
+
+    private enum Localization {
+        static let title = NSLocalizedString(
+            "pointOfSale.payment.loading.title",
+            value: "Getting ready",
+            comment: "Title shown while loading the order for a payment in Point of Sale"
+        )
+
+        static let message = NSLocalizedString(
+            "pointOfSale.payment.loading.message",
+            value: "Loading order",
+            comment: "Message shown while loading the order for a payment in Point of Sale"
+        )
+    }
+}

--- a/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
@@ -15,7 +15,7 @@ struct POSPaymentContentView: View {
     let onDismiss: (() -> Void)?
 
     @Environment(POSPaymentModel.self) private var paymentModel
-    private let viewHelper = TotalsViewHelper()
+    private let viewHelper = POSPaymentViewHelper()
 
     var body: some View {
         @Bindable var paymentModel = paymentModel
@@ -227,7 +227,7 @@ struct POSCardPaymentContentView: View {
     let connectCardReaderAction: () -> Void
     var showLoadingWhenIdle: Bool = false
 
-    private let viewHelper = TotalsViewHelper()
+    private let viewHelper = POSPaymentViewHelper()
 
     @ViewBuilder
     var body: some View {

--- a/Modules/Sources/PointOfSale/Presentation/PaymentButtons.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PaymentButtons.swift
@@ -30,7 +30,9 @@ private extension PaymentsActionButtons {
 
     var successButton: some View {
         Button(action: {
-            analytics.track(.pointOfSaleCreateNewOrderTapped)
+            if let event = successAction.analyticsEvent {
+                analytics.track(event)
+            }
             successAction.action()
         }, label: {
             HStack(spacing: Constants.buttonSpacing) {
@@ -60,7 +62,8 @@ private extension PaymentsActionButtons {
     PaymentsActionButtons(
         successAction: PaymentFlowAction(
             title: "New order",
-            action: {}),
+            action: {},
+            analyticsEvent: nil),
         isShowingSendReceiptView: .constant(false))
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/PaymentButtons.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PaymentButtons.swift
@@ -1,14 +1,14 @@
 import SwiftUI
 
 struct PaymentsActionButtons: View {
-    @Environment(PointOfSaleAggregateModel.self) private var posModel
+    let successAction: PaymentFlowAction
     @Environment(\.posAnalytics) private var analytics
     @Binding var isShowingSendReceiptView: Bool
 
     var body: some View {
         ZStack {
             VStack {
-                newOrderButton
+                successButton
                 sendReceiptButton
             }
         }
@@ -28,13 +28,13 @@ private extension PaymentsActionButtons {
         .buttonStyle(POSOutlinedButtonStyle(size: .normal))
     }
 
-    var newOrderButton: some View {
+    var successButton: some View {
         Button(action: {
             analytics.track(.pointOfSaleCreateNewOrderTapped)
-            posModel.startNewCart()
+            successAction.action()
         }, label: {
             HStack(spacing: Constants.buttonSpacing) {
-                Text(Localization.newOrder)
+                Text(successAction.title)
             }
         })
         .buttonStyle(POSFilledButtonStyle(size: .normal))
@@ -48,10 +48,6 @@ private extension PaymentsActionButtons {
     }
 
     enum Localization {
-        static let newOrder = NSLocalizedString(
-            "pos.totalsView.button.newOrder",
-            value: "New order",
-            comment: "Button title for new order button")
         static let sendReceipt = NSLocalizedString(
             "pos.totalsView.button.sendReceipt",
             value: "Email receipt",
@@ -61,7 +57,10 @@ private extension PaymentsActionButtons {
 
 #if DEBUG
 #Preview {
-    PaymentsActionButtons(isShowingSendReceiptView: .constant(false))
-        .environment(POSPreviewHelpers.makePreviewAggregateModel())
+    PaymentsActionButtons(
+        successAction: PaymentFlowAction(
+            title: "New order",
+            action: {}),
+        isShowingSendReceiptView: .constant(false))
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleCollectCashView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleCollectCashView.swift
@@ -7,7 +7,7 @@ struct PointOfSaleCollectCashView: View {
     @Environment(\.posAnalytics) private var analytics
     @Environment(\.posExternalViews) private var externalViews
     @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
-    @Environment(PointOfSaleAggregateModel.self) private var posModel
+    @Environment(POSPaymentModel.self) private var paymentModel
     @FocusState private var isTextFieldFocused: Bool
 
     private let viewHelper: CollectCashViewHelper
@@ -47,7 +47,7 @@ struct PointOfSaleCollectCashView: View {
                                       backButtonConfiguration: .init(state: isLoading ? .disabled: .enabled,
                                                                      action: {
                         Task { @MainActor in
-                            await posModel.cancelCashPayment()
+                            await paymentModel.cancelCashPayment()
                             isTextFieldFocused = false
                         }
                     }))
@@ -129,7 +129,7 @@ struct PointOfSaleCollectCashView: View {
     private func markComplete() async throws {
         let changeDueAmount = viewHelper.formattedChangeDueAmount(orderTotal: orderTotal,
                                                                   textFieldAmountInput: textFieldAmountInput)
-        try await posModel.collectCashPayment(changeDueAmount: changeDueAmount)
+        try await paymentModel.collectCashPayment(changeDueAmount: changeDueAmount)
     }
 }
 
@@ -194,7 +194,8 @@ private extension PointOfSaleCollectCashView {
 
 #if DEBUG
 #Preview {
+    let model = POSPreviewHelpers.makePreviewAggregateModel()
     PointOfSaleCollectCashView(orderTotal: "$1.23", currencySettings: CurrencySettings())
-        .environment(POSPreviewHelpers.makePreviewAggregateModel())
+        .environment(model.paymentModel)
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -166,6 +166,7 @@ public struct PointOfSaleEntryPointView: View {
             if let posModel {
                 PointOfSaleDashboardView()
                     .environment(posModel)
+                    .environment(posModel.paymentModel)
             } else {
                 PointOfSaleLoadingView()
             }

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -4,7 +4,7 @@ import WooFoundation
 struct TotalsView: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(POSPaymentModel.self) private var paymentModel
-    private let viewHelper = TotalsViewHelper()
+    private let viewHelper = POSPaymentViewHelper()
 
     /// Used together with .matchedGeometryEffect to synchronize the animations of shimmeringLineView and text fields.
     /// This makes SwiftUI treat these views as a single entity in the context of animation.
@@ -183,7 +183,7 @@ private extension TotalsView {
                     .validatingOrder,
                     .preparingReader,
                     .processingPayment:
-                if TotalsViewHelper().shouldShowDisconnectedMessage(readerConnectionStatus: paymentModel.cardReaderConnectionStatus,
+                if POSPaymentViewHelper().shouldShowDisconnectedMessage(readerConnectionStatus: paymentModel.cardReaderConnectionStatus,
                                                                     paymentState: paymentModel.paymentState) {
                     return .outlined
                 }
@@ -274,6 +274,7 @@ private struct TotalsFieldsContent: View {
     let paymentState: PointOfSalePaymentState
     let cart: Cart
     let totalsFieldAnimation: Namespace.ID
+    private let paymentViewHelper = POSPaymentViewHelper()
     private let viewHelper = TotalsViewHelper()
 
     /// Used for synchronizing animations of shimmeringLine and textField
@@ -292,7 +293,7 @@ private struct TotalsFieldsContent: View {
         }
         .transition(.opacity)
         .animation(.default, value: orderState.isSyncing)
-        .opacity(viewHelper.shouldShowTotalsFields(for: paymentState) ? 1 : 0)
+        .opacity(paymentViewHelper.shouldShowTotalsFields(for: paymentState) ? 1 : 0)
         .layoutPriority(1)
         .dynamicTypeSize(...DynamicTypeSize.accessibility1)
     }
@@ -427,7 +428,7 @@ private struct PaymentViewContent: View {
     let cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType?
     let connectCardReaderAction: () -> Void
 
-    private let viewHelper = TotalsViewHelper()
+    private let viewHelper = POSPaymentViewHelper()
 
     var body: some View {
         paymentView

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -3,6 +3,7 @@ import WooFoundation
 
 struct TotalsView: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
+    @Environment(POSPaymentModel.self) private var paymentModel
     private let viewHelper = TotalsViewHelper()
 
     /// Used together with .matchedGeometryEffect to synchronize the animations of shimmeringLineView and text fields.
@@ -16,7 +17,7 @@ struct TotalsView: View {
     // Default true so totals fields would be included in the view hiearchy on first render and animate with TotalsView
     @State private var isShowingTotalsFields: Bool = true
     private var shouldShowTotalsFields: Bool {
-        viewHelper.shouldShowTotalsFields(for: posModel.paymentState)
+        viewHelper.shouldShowTotalsFields(for: paymentModel.paymentState)
     }
 
     var body: some View {
@@ -30,21 +31,21 @@ struct TotalsView: View {
                     VStack(alignment: .center, spacing: 0) {
                         if isShowingPaymentView {
                             PaymentViewContent(
-                                paymentState: posModel.paymentState,
+                                paymentState: paymentModel.paymentState,
                                 cardReaderViewLayout: cardReaderViewLayout,
                                 isShowingTotalsFields: isShowingTotalsFields,
                                 backgroundColor: backgroundColor,
                                 orderState: posModel.orderState,
-                                cardReaderConnectionStatus: posModel.cardReaderConnectionStatus,
-                                cardPresentPaymentInlineMessage: posModel.cardPresentPaymentInlineMessage,
-                                connectCardReaderAction: posModel.connectCardReader
+                                cardReaderConnectionStatus: paymentModel.cardReaderConnectionStatus,
+                                cardPresentPaymentInlineMessage: paymentModel.cardPresentPaymentInlineMessage,
+                                connectCardReaderAction: paymentModel.connectCardReader
                             )
                         }
 
                         if isShowingTotalsFields {
                             TotalsFieldsContent(
                                 orderState: posModel.orderState,
-                                paymentState: posModel.paymentState,
+                                paymentState: paymentModel.paymentState,
                                 cart: posModel.cart,
                                 totalsFieldAnimation: totalsFieldAnimation
                             )
@@ -53,13 +54,13 @@ struct TotalsView: View {
                     }
 
                     Spacer()
-                        .renderedIf(viewHelper.shouldApplyPadding(paymentState: posModel.paymentState))
+                        .renderedIf(viewHelper.shouldApplyPadding(paymentState: paymentModel.paymentState))
 
                     CashPaymentButton(
                         orderState: posModel.orderState,
-                        paymentState: posModel.paymentState,
-                        cardReaderConnectionStatus: posModel.cardReaderConnectionStatus,
-                        startCashPaymentAction: { await posModel.startCashPayment() }
+                        paymentState: paymentModel.paymentState,
+                        cardReaderConnectionStatus: paymentModel.cardReaderConnectionStatus,
+                        startCashPaymentAction: { await paymentModel.startCashPayment() }
                     )
                 }
                 .animation(.default, value: isShowingPaymentView)
@@ -77,7 +78,7 @@ struct TotalsView: View {
             }
         }
         .background(backgroundColor)
-        .animation(.default, value: posModel.paymentState)
+        .animation(.default, value: paymentModel.paymentState)
         .animation(.default, value: posModel.orderState.isError)
         .onAppear {
             isShowingTotalsFields = shouldShowTotalsFields
@@ -89,28 +90,13 @@ struct TotalsView: View {
     }
 
     private var backgroundColor: Color {
-        switch posModel.paymentState.activePaymentMethod {
-        case .cash:
-            switch posModel.paymentState.cash {
-            case .collectingCash:
-                return .posSurfaceBright
-            default:
-                return .clear
-            }
-        case .card:
-            switch posModel.paymentState.card {
-            case .processingPayment:
-                return .posPrimary
-            default:
-                return .clear
-            }
-        }
+        viewHelper.paymentBackgroundColor(for: paymentModel.paymentState)
     }
 }
 
 private extension TotalsView {
     private func hideTotalsFieldsWithDelay(_ isShowing: Bool) {
-        guard !isShowing && posModel.paymentState.card == .processingPayment else {
+        guard !isShowing && paymentModel.paymentState.card == .processingPayment else {
             self.isShowingTotalsFields = isShowing
             return
         }
@@ -148,19 +134,19 @@ private extension TotalsView {
     private var isShowingPaymentView: Bool {
         guard posModel.orderState.isLoaded else {
             // When the order's being created or synced, we only show the shimmering totals.
-            // Before the order exists, we don’t want to show the card payment status, as it will
+            // Before the order exists, we don't want to show the card payment status, as it will
             // show for a second initially, then disappear the moment we start syncing the order.
             return false
         }
 
-        switch posModel.cardReaderConnectionStatus {
+        switch paymentModel.cardReaderConnectionStatus {
         case .connected, .disconnecting, .cancellingConnection:
             // Show card payment UI if there's a message, or cash payment UI when not idle
-            switch posModel.paymentState.activePaymentMethod {
+            switch paymentModel.paymentState.activePaymentMethod {
             case .cash:
                 return true
             case .card:
-                return posModel.cardPresentPaymentInlineMessage != nil
+                return paymentModel.cardPresentPaymentInlineMessage != nil
             }
         case .disconnected:
             // Since the reader is disconnected, this will show the "Connect your reader" CTA button view.
@@ -173,13 +159,13 @@ private extension TotalsView {
             return .primary
         }
 
-        switch posModel.paymentState.activePaymentMethod {
+        switch paymentModel.paymentState.activePaymentMethod {
         case .cash:
             return PaymentViewLayout(topPadding: POSPadding.none,
-                                     bottomPadding: posModel.paymentState.cash == .collectingCash ? nil : POSPadding.none,
+                                     bottomPadding: paymentModel.paymentState.cash == .collectingCash ? nil : POSPadding.none,
                                      sidePadding: POSPadding.none)
         case .card:
-            switch posModel.paymentState.card {
+            switch paymentModel.paymentState.card {
             case .validatingOrderError,
                     .paymentIntentCreationError:
                 return .outlined
@@ -197,8 +183,8 @@ private extension TotalsView {
                     .validatingOrder,
                     .preparingReader,
                     .processingPayment:
-                if TotalsViewHelper().shouldShowDisconnectedMessage(readerConnectionStatus: posModel.cardReaderConnectionStatus,
-                                                                    paymentState: posModel.paymentState) {
+                if TotalsViewHelper().shouldShowDisconnectedMessage(readerConnectionStatus: paymentModel.cardReaderConnectionStatus,
+                                                                    paymentState: paymentModel.paymentState) {
                     return .outlined
                 }
             }
@@ -460,71 +446,17 @@ private struct PaymentViewContent: View {
     @ViewBuilder private var paymentView: some View {
         switch paymentState.activePaymentMethod {
         case .cash:
-            CashPaymentView(
-                cashPaymentState: paymentState.cash,
-                orderState: orderState
-            )
+            if case .loaded(let total) = orderState {
+                POSCashPaymentContentView(
+                    cashPaymentState: paymentState.cash,
+                    formattedOrderTotal: total.orderTotal)
+            }
         case .card:
-            CardPaymentView(
+            POSCardPaymentContentView(
                 cardReaderConnectionStatus: cardReaderConnectionStatus,
                 paymentState: paymentState,
                 cardPresentPaymentInlineMessage: cardPresentPaymentInlineMessage,
-                connectCardReaderAction: connectCardReaderAction
-            )
-        }
-    }
-}
-
-private struct CashPaymentView: View {
-    let cashPaymentState: PointOfSaleCashPaymentState
-    let orderState: PointOfSaleOrderState
-    @Environment(\.posCurrencyProvider) private var currencyProvider
-
-    var body: some View {
-        switch cashPaymentState {
-        case .collectingCash:
-            if case .loaded(let total) = orderState {
-                PointOfSaleCollectCashView(orderTotal: total.orderTotal, currencySettings: currencyProvider.currencySettings)
-                    .transition(.move(edge: .trailing))
-            }
-        case .paymentSuccess:
-            if case .loaded(let total) = orderState {
-                PointOfSaleCardPresentPaymentInLineMessage(
-                    messageType: .paymentSuccess(
-                        viewModel: .init(formattedOrderTotal: total.orderTotal,
-                                         paymentMethod: PointOfSalePaymentMethod.cash)))
-            }
-        case .idle:
-            EmptyView()
-        }
-    }
-}
-
-private struct CardPaymentView: View {
-    let cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus
-    let paymentState: PointOfSalePaymentState
-    let cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType?
-    let connectCardReaderAction: () -> Void
-
-    private let viewHelper = TotalsViewHelper()
-
-    var body: some View {
-        if viewHelper.shouldShowDisconnectedMessage(readerConnectionStatus: cardReaderConnectionStatus,
-                                                    paymentState: paymentState) {
-            PointOfSaleCardPresentPaymentReaderDisconnectedMessageView {
-                connectCardReaderAction()
-            }
-        } else if let inlinePaymentMessage = cardPresentPaymentInlineMessage {
-            switch inlinePaymentMessage {
-            case .paymentSuccess:
-                PointOfSaleCardPresentPaymentInLineMessage(messageType: inlinePaymentMessage)
-            default:
-                HStack(alignment: .center) {
-                    Spacer()
-                    PointOfSaleCardPresentPaymentInLineMessage(messageType: inlinePaymentMessage)
-                    Spacer()
-                }
-            }
+                connectCardReaderAction: connectCardReaderAction)
         }
     }
 }
@@ -562,109 +494,118 @@ private struct CashPaymentButton: View {
 
 #if DEBUG
 #Preview("Card Reader Not Connected") {
+    let model = POSPreviewHelpers.makePreviewAggregateModel(
+        cardPresentPaymentService: CardPresentPaymentPreviewService(connectionStatus: .disconnected)
+    )
     TotalsView()
-        .environment(POSPreviewHelpers.makePreviewAggregateModel(
-            cardPresentPaymentService: CardPresentPaymentPreviewService(connectionStatus: .disconnected)
-        ))
+        .environment(model)
+        .environment(model.paymentModel)
 }
 
 #Preview("Card Reader Connected") {
+    let model = POSPreviewHelpers.makePreviewAggregateModel(
+        cardPresentPaymentService: CardPresentPaymentPreviewService(
+            connectionStatus: .connected(CardPresentPaymentCardReader(name: "Reader", batteryLevel: 0.85))
+        )
+    )
     TotalsView()
-        .environment(POSPreviewHelpers.makePreviewAggregateModel(
-            cardPresentPaymentService: CardPresentPaymentPreviewService(
-                connectionStatus: .connected(CardPresentPaymentCardReader(name: "Reader", batteryLevel: 0.85))
-            )
-        ))
+        .environment(model)
+        .environment(model.paymentModel)
 }
 
 #Preview("Validating Order") {
-    let aggregateModel = POSPreviewHelpers.makePreviewAggregateModel(
+    let model = POSPreviewHelpers.makePreviewAggregateModel(
         cardPresentPaymentService: CardPresentPaymentPreviewService(
             connectionStatus: .connected(CardPresentPaymentCardReader(name: "Reader", batteryLevel: 0.85))
         )
     )
     Task { @MainActor in
-        aggregateModel.setPreviewState(
+        model.setPreviewState(
             paymentState: PointOfSalePaymentState(card: .validatingOrder, cash: .idle),
             inlineMessage: .validatingOrder(viewModel: PointOfSaleCardPresentPaymentValidatingOrderMessageViewModel())
         )
     }
     return TotalsView()
-        .environment(aggregateModel)
+        .environment(model)
+        .environment(model.paymentModel)
 }
 
 #Preview("Accepting Card") {
-    let aggregateModel = POSPreviewHelpers.makePreviewAggregateModel(
+    let model = POSPreviewHelpers.makePreviewAggregateModel(
         cardPresentPaymentService: CardPresentPaymentPreviewService(
             connectionStatus: .connected(CardPresentPaymentCardReader(name: "Reader", batteryLevel: 0.85))
         )
     )
     Task { @MainActor in
-        aggregateModel.setPreviewState(
+        model.setPreviewState(
             paymentState: PointOfSalePaymentState(card: .acceptingCard, cash: .idle),
             inlineMessage: .tapSwipeOrInsertCard(viewModel: PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel(inputMethods: []))
         )
     }
     return TotalsView()
-        .environment(aggregateModel)
+        .environment(model)
+        .environment(model.paymentModel)
 }
 
 #Preview("Processing Payment") {
-    let aggregateModel = POSPreviewHelpers.makePreviewAggregateModel(
+    let model = POSPreviewHelpers.makePreviewAggregateModel(
         cardPresentPaymentService: CardPresentPaymentPreviewService(
             connectionStatus: .connected(CardPresentPaymentCardReader(name: "Reader", batteryLevel: 0.85))
         )
     )
     Task { @MainActor in
-        aggregateModel.setPreviewState(
+        model.setPreviewState(
             paymentState: PointOfSalePaymentState(card: .processingPayment, cash: .idle),
             inlineMessage: .processing(viewModel: PointOfSaleCardPresentPaymentProcessingMessageViewModel())
         )
     }
     return TotalsView()
-        .environment(aggregateModel)
+        .environment(model)
+        .environment(model.paymentModel)
 }
 
 #Preview("Card Payment Successful") {
-    let aggregateModel = POSPreviewHelpers.makePreviewAggregateModel(
+    let model = POSPreviewHelpers.makePreviewAggregateModel(
         cardPresentPaymentService: CardPresentPaymentPreviewService(
             connectionStatus: .connected(CardPresentPaymentCardReader(name: "Reader", batteryLevel: 0.85))
         )
     )
     Task { @MainActor in
-        aggregateModel.setPreviewState(
+        model.setPreviewState(
             paymentState: PointOfSalePaymentState(card: .cardPaymentSuccessful, cash: .idle),
             inlineMessage: .paymentSuccess(viewModel: PointOfSalePaymentSuccessViewModel(formattedOrderTotal: "$12.00", paymentMethod: .card))
         )
     }
     return TotalsView()
-        .environment(aggregateModel)
+        .environment(model)
+        .environment(model.paymentModel)
 }
 
 #Preview("Display Reader Message") {
-    let aggregateModel = POSPreviewHelpers.makePreviewAggregateModel(
+    let model = POSPreviewHelpers.makePreviewAggregateModel(
         cardPresentPaymentService: CardPresentPaymentPreviewService(
             connectionStatus: .connected(CardPresentPaymentCardReader(name: "Reader", batteryLevel: 0.85))
         )
     )
     Task { @MainActor in
-        aggregateModel.setPreviewState(
+        model.setPreviewState(
             paymentState: PointOfSalePaymentState(card: .processingPayment, cash: .idle),
             inlineMessage: .displayReaderMessage(viewModel: PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel(message: "Remove card"))
         )
     }
     return TotalsView()
-        .environment(aggregateModel)
+        .environment(model)
+        .environment(model.paymentModel)
 }
 
 #Preview("Payment Error") {
-    let aggregateModel = POSPreviewHelpers.makePreviewAggregateModel(
+    let model = POSPreviewHelpers.makePreviewAggregateModel(
         cardPresentPaymentService: CardPresentPaymentPreviewService(
             connectionStatus: .connected(CardPresentPaymentCardReader(name: "Reader", batteryLevel: 0.85))
         )
     )
     Task { @MainActor in
-        aggregateModel.setPreviewState(
+        model.setPreviewState(
             paymentState: PointOfSalePaymentState(card: .paymentError, cash: .idle),
             inlineMessage: .paymentError(viewModel: PointOfSaleCardPresentPaymentErrorMessageViewModel(
                 error: NSError(domain: "CardPaymentError", code: 1001, userInfo: [NSLocalizedDescriptionKey: "Card declined"]),
@@ -674,7 +615,8 @@ private struct CashPaymentButton: View {
         )
     }
     return TotalsView()
-        .environment(aggregateModel)
+        .environment(model)
+        .environment(model.paymentModel)
 }
 
 #endif

--- a/Modules/Sources/PointOfSale/ViewHelpers/POSPaymentViewHelper.swift
+++ b/Modules/Sources/PointOfSale/ViewHelpers/POSPaymentViewHelper.swift
@@ -1,0 +1,121 @@
+import Foundation
+import SwiftUI
+
+/// Shared view helper methods used by both cart (TotalsView) and bookings (POSPaymentContentView) payment flows.
+struct POSPaymentViewHelper {
+    func paymentBackgroundColor(for paymentState: PointOfSalePaymentState) -> Color {
+        switch paymentState.activePaymentMethod {
+        case .cash:
+            switch paymentState.cash {
+            case .collectingCash, .paymentSuccess:
+                return .posSurfaceBright
+            default:
+                return .clear
+            }
+        case .card:
+            switch paymentState.card {
+            case .processingPayment:
+                return .posPrimary
+            case .cardPaymentSuccessful:
+                return .posSurfaceBright
+            default:
+                return .clear
+            }
+        }
+    }
+
+    func shouldShowCashPaymentButton(paymentState: PointOfSalePaymentState,
+                                     cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus,
+                                     isZeroTotal: Bool = false) -> Bool {
+        if isZeroTotal, case .card = paymentState.activePaymentMethod {
+            return true
+        }
+        switch paymentState.activePaymentMethod {
+        case .cash:
+            return false
+        case .card:
+            if case .disconnected = cardReaderConnectionStatus,
+               case .idle = paymentState.card {
+                return true
+            }
+            switch paymentState.card {
+            case .validatingOrderError,
+                    .paymentIntentCreationError,
+                    .acceptingCard:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+
+    func shouldShowTotalsFields(for paymentState: PointOfSalePaymentState) -> Bool {
+        switch paymentState.activePaymentMethod {
+        case .cash:
+            return false
+        case .card:
+            switch paymentState.card {
+            case .idle,
+                    .acceptingCard,
+                    .cardInserted,
+                    .validatingOrder,
+                    .validatingOrderError,
+                    .paymentIntentCreationError,
+                    .preparingReader:
+                return true
+            case .processingPayment,
+                    .paymentError,
+                    .cardPaymentSuccessful:
+                return false
+            }
+        }
+    }
+
+    func shouldShowDisconnectedMessage(readerConnectionStatus: CardPresentPaymentReaderConnectionStatus,
+                                       paymentState: PointOfSalePaymentState) -> Bool {
+        guard readerConnectionStatus == .disconnected else {
+            return false
+        }
+
+        switch paymentState.activePaymentMethod {
+        case .cash:
+            return false
+        case .card:
+            switch paymentState.card {
+            case .idle,
+                    .acceptingCard,
+                    .preparingReader:
+                return true
+            case .validatingOrder,
+                    .validatingOrderError,
+                    .paymentIntentCreationError,
+                    .processingPayment,
+                    .cardInserted,
+                    .paymentError,
+                    .cardPaymentSuccessful:
+                return false
+            }
+        }
+    }
+
+    func shouldApplyPadding(paymentState: PointOfSalePaymentState) -> Bool {
+        switch paymentState.activePaymentMethod {
+        case .cash:
+            return false
+        case .card:
+            switch paymentState.card {
+            case .cardPaymentSuccessful, .paymentError:
+                return false
+            case .idle,
+                    .acceptingCard,
+                    .cardInserted,
+                    .validatingOrder,
+                    .validatingOrderError,
+                    .paymentIntentCreationError,
+                    .preparingReader,
+                    .processingPayment:
+                return true
+            }
+        }
+    }
+}

--- a/Modules/Sources/PointOfSale/ViewHelpers/TotalsViewHelper.swift
+++ b/Modules/Sources/PointOfSale/ViewHelpers/TotalsViewHelper.swift
@@ -1,104 +1,8 @@
 import Foundation
-import SwiftUI
-import WooFoundation
 
+/// Cart-specific view helper methods used only by TotalsView.
 struct TotalsViewHelper {
-    /// Shared background color for payment views (cart and bookings).
-    func paymentBackgroundColor(for paymentState: PointOfSalePaymentState) -> Color {
-        switch paymentState.activePaymentMethod {
-        case .cash:
-            switch paymentState.cash {
-            case .collectingCash, .paymentSuccess:
-                return .posSurfaceBright
-            default:
-                return .clear
-            }
-        case .card:
-            switch paymentState.card {
-            case .processingPayment:
-                return .posPrimary
-            case .cardPaymentSuccessful:
-                return .posSurfaceBright
-            default:
-                return .clear
-            }
-        }
-    }
-
-    /// Cash payment button visibility. Shows the button for zero-total orders (both cart and bookings)
-    /// and during card payment states where cash is a valid alternative.
-    func shouldShowCashPaymentButton(paymentState: PointOfSalePaymentState,
-                                     cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus,
-                                     isZeroTotal: Bool = false) -> Bool {
-        if isZeroTotal, case .card = paymentState.activePaymentMethod {
-            return true
-        }
-        switch paymentState.activePaymentMethod {
-        case .cash:
-            return false
-        case .card:
-            if case .disconnected = cardReaderConnectionStatus,
-               case .idle = paymentState.card {
-                return true
-            }
-            switch paymentState.card {
-            case .validatingOrderError,
-                    .paymentIntentCreationError,
-                    .acceptingCard:
-                return true
-            default:
-                return false
-            }
-        }
-    }
-    func shouldShowTotalsFields(for paymentState: PointOfSalePaymentState) -> Bool {
-        switch paymentState.activePaymentMethod {
-        case .cash:
-            return false
-        case .card:
-            switch paymentState.card {
-            case .idle,
-                    .acceptingCard,
-                    .cardInserted,
-                    .validatingOrder,
-                    .validatingOrderError,
-                    .paymentIntentCreationError,
-                    .preparingReader:
-                return true
-            case .processingPayment,
-                    .paymentError,
-                    .cardPaymentSuccessful:
-                return false
-            }
-        }
-    }
-
-    func shouldShowDisconnectedMessage(readerConnectionStatus: CardPresentPaymentReaderConnectionStatus,
-                                       paymentState: PointOfSalePaymentState) -> Bool {
-        guard readerConnectionStatus == .disconnected else {
-            return false
-        }
-
-        switch paymentState.activePaymentMethod {
-        case .cash:
-            return false
-        case .card:
-            switch paymentState.card {
-            case .idle,
-                    .acceptingCard,
-                    .preparingReader:
-                return true
-            case .validatingOrder,
-                    .validatingOrderError,
-                    .paymentIntentCreationError,
-                    .processingPayment,
-                    .cardInserted,
-                    .paymentError,
-                    .cardPaymentSuccessful:
-                return false
-            }
-        }
-    }
+    private let paymentViewHelper = POSPaymentViewHelper()
 
     /// Cash payment button visibility for the cart flow (adds order state guards on top of the base check).
     func shouldShowCollectCashPaymentButton(orderState: PointOfSaleOrderState,
@@ -114,30 +18,9 @@ struct TotalsViewHelper {
             false
         }
 
-        return shouldShowCashPaymentButton(paymentState: paymentState,
-                                           cardReaderConnectionStatus: cardReaderConnectionStatus,
-                                           isZeroTotal: isZeroTotal)
-    }
-
-    func shouldApplyPadding(paymentState: PointOfSalePaymentState) -> Bool {
-        switch paymentState.activePaymentMethod {
-        case .cash:
-            return false
-        case .card:
-            switch paymentState.card {
-            case .cardPaymentSuccessful, .paymentError:
-                return false
-            case .idle,
-                    .acceptingCard,
-                    .cardInserted,
-                    .validatingOrder,
-                    .validatingOrderError,
-                    .paymentIntentCreationError,
-                    .preparingReader,
-                    .processingPayment:
-                return true
-            }
-        }
+        return paymentViewHelper.shouldShowCashPaymentButton(paymentState: paymentState,
+                                                             cardReaderConnectionStatus: cardReaderConnectionStatus,
+                                                             isZeroTotal: isZeroTotal)
     }
 
     func shouldShowTotalDiscountField(cart: Cart, orderTotals: PointOfSaleOrderTotals?) -> Bool {

--- a/Modules/Sources/PointOfSale/ViewHelpers/TotalsViewHelper.swift
+++ b/Modules/Sources/PointOfSale/ViewHelpers/TotalsViewHelper.swift
@@ -1,7 +1,56 @@
 import Foundation
+import SwiftUI
 import WooFoundation
 
 struct TotalsViewHelper {
+    /// Shared background color for payment views (cart and bookings).
+    func paymentBackgroundColor(for paymentState: PointOfSalePaymentState) -> Color {
+        switch paymentState.activePaymentMethod {
+        case .cash:
+            switch paymentState.cash {
+            case .collectingCash, .paymentSuccess:
+                return .posSurfaceBright
+            default:
+                return .clear
+            }
+        case .card:
+            switch paymentState.card {
+            case .processingPayment:
+                return .posPrimary
+            case .cardPaymentSuccessful:
+                return .posSurfaceBright
+            default:
+                return .clear
+            }
+        }
+    }
+
+    /// Cash payment button visibility. Shows the button for zero-total orders (both cart and bookings)
+    /// and during card payment states where cash is a valid alternative.
+    func shouldShowCashPaymentButton(paymentState: PointOfSalePaymentState,
+                                     cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus,
+                                     isZeroTotal: Bool = false) -> Bool {
+        if isZeroTotal, case .card = paymentState.activePaymentMethod {
+            return true
+        }
+        switch paymentState.activePaymentMethod {
+        case .cash:
+            return false
+        case .card:
+            if case .disconnected = cardReaderConnectionStatus,
+               case .idle = paymentState.card {
+                return true
+            }
+            switch paymentState.card {
+            case .validatingOrderError,
+                    .paymentIntentCreationError,
+                    .acceptingCard:
+                return true
+            default:
+                return false
+            }
+        }
+    }
     func shouldShowTotalsFields(for paymentState: PointOfSalePaymentState) -> Bool {
         switch paymentState.activePaymentMethod {
         case .cash:
@@ -51,6 +100,7 @@ struct TotalsViewHelper {
         }
     }
 
+    /// Cash payment button visibility for the cart flow (adds order state guards on top of the base check).
     func shouldShowCollectCashPaymentButton(orderState: PointOfSaleOrderState,
                                             paymentState: PointOfSalePaymentState,
                                             cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus) -> Bool {
@@ -58,34 +108,15 @@ struct TotalsViewHelper {
             return false
         }
 
-        switch paymentState.activePaymentMethod {
-        case .cash:
-            return false
-        case .card:
-            if case .disconnected = cardReaderConnectionStatus,
-                case .idle = paymentState.card {
-                return true
-            }
-
-            if case let .loaded(totals) = orderState, totals.orderTotalDecimal.isZero {
-                return true
-            }
-
-            switch paymentState.card {
-            case .validatingOrderError,
-                    .paymentIntentCreationError,
-                    .acceptingCard:
-                return true
-            case .idle,
-                    .cardInserted,
-                    .validatingOrder,
-                    .preparingReader,
-                    .processingPayment,
-                    .paymentError,
-                    .cardPaymentSuccessful:
-                return false
-            }
+        let isZeroTotal: Bool = if case let .loaded(totals) = orderState {
+            totals.orderTotalDecimal.isZero
+        } else {
+            false
         }
+
+        return shouldShowCashPaymentButton(paymentState: paymentState,
+                                           cardReaderConnectionStatus: cardReaderConnectionStatus,
+                                           isZeroTotal: isZeroTotal)
     }
 
     func shouldApplyPadding(paymentState: PointOfSalePaymentState) -> Bool {

--- a/Modules/Tests/PointOfSaleTests/ViewHelpers/POSPaymentViewHelperTests.swift
+++ b/Modules/Tests/PointOfSaleTests/ViewHelpers/POSPaymentViewHelperTests.swift
@@ -1,0 +1,50 @@
+import Testing
+@testable import PointOfSale
+
+struct POSPaymentViewHelperTests {
+
+    @Test(arguments: [
+        (CardPresentPaymentReaderConnectionStatus.disconnected, PointOfSaleCardPaymentState.acceptingCard),
+        (CardPresentPaymentReaderConnectionStatus.disconnected, PointOfSaleCardPaymentState.idle),
+        (CardPresentPaymentReaderConnectionStatus.disconnected, PointOfSaleCardPaymentState.preparingReader)
+    ])
+    func test_shouldShowDisconnectedMessage_returns_true_when_disconnected_and_no_card_payment_ongoing(
+        readerConnectionStatus: CardPresentPaymentReaderConnectionStatus,
+        paymentState: PointOfSaleCardPaymentState) {
+            #expect(POSPaymentViewHelper().shouldShowDisconnectedMessage(readerConnectionStatus: readerConnectionStatus,
+                                                                         paymentState: PointOfSalePaymentState(card: paymentState, cash: .idle)))
+    }
+
+    @Test(arguments: [
+        (CardPresentPaymentReaderConnectionStatus.disconnected, PointOfSaleCardPaymentState.cardPaymentSuccessful),
+        (CardPresentPaymentReaderConnectionStatus.disconnected, PointOfSaleCardPaymentState.paymentError),
+        (CardPresentPaymentReaderConnectionStatus.disconnected, PointOfSaleCardPaymentState.processingPayment),
+        (CardPresentPaymentReaderConnectionStatus.disconnected, PointOfSaleCardPaymentState.validatingOrder),
+        (CardPresentPaymentReaderConnectionStatus.disconnected, PointOfSaleCardPaymentState.validatingOrderError)
+    ])
+    func test_shouldShowDisconnectedMessage_returns_false_when_card_payment_ongoing(
+        readerConnectionStatus: CardPresentPaymentReaderConnectionStatus,
+        paymentState: PointOfSaleCardPaymentState) {
+            #expect(POSPaymentViewHelper().shouldShowDisconnectedMessage(readerConnectionStatus: readerConnectionStatus,
+                                                                         paymentState: PointOfSalePaymentState(card: paymentState, cash: .idle)) == false)
+    }
+
+    @Test(arguments: [
+        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.acceptingCard),
+        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.cardPaymentSuccessful),
+        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.idle),
+        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.paymentError),
+        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.preparingReader),
+        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.processingPayment),
+        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.validatingOrder),
+        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.validatingOrderError),
+        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.paymentIntentCreationError),
+        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.cardInserted)
+    ])
+    func test_shouldShowDisconnectedMessage_returns_false_when_reader_connected(
+        readerConnectionStatus: CardPresentPaymentReaderConnectionStatus,
+        paymentState: PointOfSaleCardPaymentState) {
+            #expect(POSPaymentViewHelper().shouldShowDisconnectedMessage(readerConnectionStatus: readerConnectionStatus,
+                                                                         paymentState: PointOfSalePaymentState(card: paymentState, cash: .idle)) == false)
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/ViewHelpers/TotalsViewHelperTests.swift
+++ b/Modules/Tests/PointOfSaleTests/ViewHelpers/TotalsViewHelperTests.swift
@@ -5,51 +5,6 @@ import struct Yosemite.POSItemIdentifier
 struct TotalsViewHelperTests {
 
     @Test(arguments: [
-        (CardPresentPaymentReaderConnectionStatus.disconnected, PointOfSaleCardPaymentState.acceptingCard),
-        (CardPresentPaymentReaderConnectionStatus.disconnected, PointOfSaleCardPaymentState.idle),
-        (CardPresentPaymentReaderConnectionStatus.disconnected, PointOfSaleCardPaymentState.preparingReader)
-    ])
-    func test_shouldShowDisconnectedMessage_returns_true_when_disconnected_and_no_card_payment_ongoing(
-        readerConnectionStatus: CardPresentPaymentReaderConnectionStatus,
-        paymentState: PointOfSaleCardPaymentState) {
-            #expect(TotalsViewHelper().shouldShowDisconnectedMessage(readerConnectionStatus: readerConnectionStatus,
-                                                                     paymentState: PointOfSalePaymentState(card: paymentState, cash: .idle)))
-    }
-
-    @Test(arguments: [
-        (CardPresentPaymentReaderConnectionStatus.disconnected, PointOfSaleCardPaymentState.cardPaymentSuccessful),
-        (CardPresentPaymentReaderConnectionStatus.disconnected, PointOfSaleCardPaymentState.paymentError),
-        (CardPresentPaymentReaderConnectionStatus.disconnected, PointOfSaleCardPaymentState.processingPayment),
-        (CardPresentPaymentReaderConnectionStatus.disconnected, PointOfSaleCardPaymentState.validatingOrder),
-        (CardPresentPaymentReaderConnectionStatus.disconnected, PointOfSaleCardPaymentState.validatingOrderError)
-    ])
-    func test_shouldShowDisconnectedMessage_returns_false_when_card_payment_ongoing(
-        readerConnectionStatus: CardPresentPaymentReaderConnectionStatus,
-        paymentState: PointOfSaleCardPaymentState) {
-            #expect(TotalsViewHelper().shouldShowDisconnectedMessage(readerConnectionStatus: readerConnectionStatus,
-                                                                     paymentState: PointOfSalePaymentState(card: paymentState, cash: .idle)) == false)
-    }
-
-    @Test(arguments: [
-        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.acceptingCard),
-        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.cardPaymentSuccessful),
-        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.idle),
-        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.paymentError),
-        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.preparingReader),
-        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.processingPayment),
-        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.validatingOrder),
-        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.validatingOrderError),
-        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.paymentIntentCreationError),
-        (CardPresentPaymentReaderConnectionStatus.connected(.init(name: "", batteryLevel: nil)), PointOfSaleCardPaymentState.cardInserted)
-    ])
-    func test_shouldShowDisconnectedMessage_returns_false_when_reader_connected(
-        readerConnectionStatus: CardPresentPaymentReaderConnectionStatus,
-        paymentState: PointOfSaleCardPaymentState) {
-            #expect(TotalsViewHelper().shouldShowDisconnectedMessage(readerConnectionStatus: readerConnectionStatus,
-                                                                     paymentState: PointOfSalePaymentState(card: paymentState, cash: .idle)) == false)
-    }
-
-    @Test(arguments: [
         (PointOfSaleCardPaymentState.validatingOrderError),
         (PointOfSaleCardPaymentState.acceptingCard),
         (PointOfSaleCardPaymentState.cardInserted),


### PR DESCRIPTION
Part of: WOOMOB-2155
Merge after: #16657

## Description

Extract payment UI components so they depend on `POSPaymentModel` instead of `PointOfSaleAggregateModel`, enabling reuse in the upcoming bookings payment flow.

Key changes:
- **`POSPaymentContentView`**: new sharable container for the bookings flow that renders the appropriate payment UI based on the active payment method and state (card states, cash collection, payment success.) It's only used on Bookings at the moment, but is reusable for other places if we need it, and shares sub views with TotalsView.
- **`POSCardPaymentContentView`** and **`POSCashPaymentContentView`**: extracted sub-components shared between cart (`TotalsView`) and bookings (`POSPaymentContentView`)
- **`TotalsViewHelper`**: extracted payment UI logic (background colors, button visibility, field visibility) shared between cart and bookings
- `PaymentButtons`, `PointOfSaleCollectCashView`, `PointOfSaleCardPresentPaymentInLineMessage`, and `PointOfSalePaymentSuccessView` read `POSPaymentModel` from the SwiftUI environment instead of `PointOfSaleAggregateModel`

This is PR 4 of 6 in the POS payment extraction series.

## Test Steps

1. Open POS, add items to cart, proceed to checkout
2. Verify card payment flow renders correctly (reader status, tap prompt, processing, success)
3. Verify cash payment flow renders correctly (collect cash view, change due, success)
4. Verify the receipt email prompt appears after successful payments
5. After a successful payment, scan a barcode — verify it starts a new cart with the scanned item
6. Run `PointOfSaleTests`

N.B. While testing I noticed a bug in barcode scanning. After seeing the payment success screen, barcode scanning breaks until we go to the checkout and back again. I have no idea why, but it's on trunk too. Will investigate separately, but it's unrelated to the changes here. Seems like the viewModifier isn't re-enabled after payment for some reason.

## Screenshots


https://github.com/user-attachments/assets/be532b0c-cdbc-44a2-8730-cc8446a6fc12





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.