### PR TITLE
Push Notifications: Handle connection step for setup

### DIFF
--- a/WooCommerce/Classes/Authentication/Jetpack Setup/JetpackConnectionService.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/JetpackConnectionService.swift
@@ -36,6 +36,9 @@ protocol JetpackConnectionServiceProtocol {
     /// Verify a connected WPCom user exists (used after webview auth).
     /// Retries internally. Returns the connected email or throws.
     func verifyConnection() async throws -> String
+
+    /// Fetches the URL used for setting up Jetpack connection via web view.
+    func fetchJetpackConnectionURL(authenticatedWithWPCom: Bool) async throws -> URL
 }
 
 final class JetpackConnectionService: JetpackConnectionServiceProtocol {
@@ -86,6 +89,15 @@ final class JetpackConnectionService: JetpackConnectionServiceProtocol {
             return .connected(email: email)
         case .error(let error):
             throw error
+        }
+    }
+
+    func fetchJetpackConnectionURL(authenticatedWithWPCom: Bool) async throws -> URL {
+        try await dispatch { completion in
+            JetpackConnectionAction.fetchJetpackConnectionURL(
+                authenticatedWithWPCom: authenticatedWithWPCom,
+                completion: completion
+            )
         }
     }
 

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/JetpackConnectionService.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/JetpackConnectionService.swift
@@ -33,7 +33,7 @@ protocol JetpackConnectionServiceProtocol {
     func evaluateAndConnect(siteURL: String,
                             credentials: Credentials) async throws -> JetpackConnectionOutcome
 
-    /// Verify a connected WPCom user exists (used after webview auth).
+    /// Verify a connected WPCom user exists.
     /// Retries internally. Returns the connected email or throws.
     func verifyConnection() async throws -> String
 

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
@@ -262,10 +262,10 @@ private extension JetpackSetupViewModel {
         connectionType = .web
         trackSetup()
         let authenticatedWithWPCom = !stores.isAuthenticatedWithoutWPCom
-        let action = JetpackConnectionAction.fetchJetpackConnectionURL(authenticatedWithWPCom: authenticatedWithWPCom) { [weak self] result in
+        Task { @MainActor [weak self] in
             guard let self else { return }
-            switch result {
-            case .success(let url):
+            do {
+                let url = try await self.connectionService.fetchJetpackConnectionURL(authenticatedWithWPCom: authenticatedWithWPCom)
                 /// Checks if the fetch URL is for account connection;
                 /// if not, use the web view solution to avoid the need for cookie-nonce.
                 /// Reference: pe5sF9-1le-p2#comment-1942.
@@ -275,14 +275,13 @@ private extension JetpackSetupViewModel {
                     self.jetpackConnectionURL = self.siteConnectionURL
                 }
                 self.shouldPresentWebView = true
-            case .failure(let error):
+            } catch {
                 self.trackSetup(failure: error)
                 DDLogError("⛔️ Error fetching Jetpack connection URL: \(error)")
                 self.setupError = error
                 self.setupFailed = true
             }
         }
-        stores.dispatch(action)
     }
 
     func updateErrorMessage() {

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
@@ -35,16 +35,19 @@ final class WPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol {
 
     private let siteURL: String
     private let credentials: Credentials?
+    private let stores: StoresManager
     private let jetpackConnectionService: JetpackConnectionServiceProtocol
     private let pluginVersionChecker: PluginVersionCheckerProtocol
 
     init(siteID: Int64,
          siteURL: String,
          credentials: Credentials?,
+         stores: StoresManager = ServiceLocator.stores,
          jetpackConnectionService: JetpackConnectionServiceProtocol = JetpackConnectionService(),
          pluginVersionChecker: PluginVersionCheckerProtocol? = nil) {
         self.siteURL = siteURL
         self.credentials = credentials
+        self.stores = stores
         self.jetpackConnectionService = jetpackConnectionService
         self.pluginVersionChecker = pluginVersionChecker ?? PluginVersionChecker(
             siteID: siteID,
@@ -137,10 +140,11 @@ private extension WPComConnectionSetupHandler {
 
     @MainActor
     func startConnectionWithWebView() {
+        let authenticatedWithWPCom = !stores.isAuthenticatedWithoutWPCom
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                let url = try await self.jetpackConnectionService.fetchJetpackConnectionURL(authenticatedWithWPCom: true)
+                let url = try await jetpackConnectionService.fetchJetpackConnectionURL(authenticatedWithWPCom: authenticatedWithWPCom)
                 let connectionURL: URL
                 if url.absoluteString.hasPrefix(Constants.accountConnectionURL) {
                     connectionURL = url
@@ -148,10 +152,10 @@ private extension WPComConnectionSetupHandler {
                     let fallback = String(format: Constants.siteConnectionURLFormat, self.siteURL)
                     connectionURL = URL(string: fallback) ?? url
                 }
-                self.delegate?.setupDidRequireWebView(url: connectionURL, siteURL: self.siteURL)
+                delegate?.setupDidRequireWebView(url: connectionURL, siteURL: self.siteURL)
             } catch {
                 DDLogError("⛔️ Error fetching Jetpack connection URL: \(error)")
-                self.delegate?.stepDidUpdate(.connect, status: .failure(reason: error.localizedDescription))
+                delegate?.stepDidUpdate(.connect, status: .failure(reason: error.localizedDescription))
             }
         }
     }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
@@ -11,6 +11,7 @@ enum SetupStep: Int, CaseIterable {
 protocol WPComConnectionSetupHandlerDelegate: AnyObject {
     func stepDidUpdate(_ step: SetupStep, status: WPComConnectionSetupStep.Status)
     func setupDidComplete()
+    func setupDidRequireWebView(url: URL, siteURL: String)
 }
 
 @MainActor
@@ -19,6 +20,9 @@ protocol WPComConnectionSetupHandlerProtocol: AnyObject {
     func start()
     func retry()
     func cancel()
+    func didAuthorizeWebViewConnection()
+    func didEncounterWebViewError(code: Int?)
+    func didCancelWebView()
 }
 
 /// Stub implementation for the handler protocol.
@@ -26,6 +30,8 @@ protocol WPComConnectionSetupHandlerProtocol: AnyObject {
 @MainActor
 final class WPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol {
     weak var delegate: WPComConnectionSetupHandlerDelegate?
+
+    private var currentStep: SetupStep?
 
     private let siteURL: String
     private let credentials: Credentials?
@@ -48,38 +54,106 @@ final class WPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol {
     }
 
     func start() {
-        Task { @MainActor in
-            /// Step 1 (optional): check Jetpack connection
-            if let credentials {
-                do {
-                    delegate?.stepDidUpdate(.connect, status: .running)
-                    try await checkJetpackConnection(with: credentials)
-                    delegate?.stepDidUpdate(.connect, status: .success)
-                } catch {
-                    delegate?.stepDidUpdate(.connect, status: .failure(reason: error.localizedDescription)) // TODO: update msg
-                }
-            }
-
-            /// Step 2: TODO: Check plugin version
-
-            /// Step 3: Enable push notification
-            /// TODO: Inject PushNotificationManager to trigger Woo PN registration
+        /// Step 1 (optional): check Jetpack connection
+        if credentials != nil {
+            currentStep = .connect
+            startJetpackConnection()
         }
+
+        /// Step 2: TODO: Check plugin version
+
+        /// Step 3: Enable push notification
+        /// TODO: Inject PushNotificationManager to trigger Woo PN registration
     }
 
     func retry() {
-        // TODO: Implement in follow-up PR
+        switch currentStep {
+        case .connect:
+            startJetpackConnection()
+        case .checkPlugin, .enablePush, .none:
+            // TODO
+            break
+        }
     }
 
     func cancel() {
         // TODO: Implement in follow-up PR
     }
+
+    func didAuthorizeWebViewConnection() {
+        Task { @MainActor in
+            do {
+                let _ = try await jetpackConnectionService.verifyConnection()
+                delegate?.stepDidUpdate(.connect, status: .success)
+                // TODO: continue to next steps
+            } catch {
+                delegate?.stepDidUpdate(.connect, status: .failure(reason: error.localizedDescription))
+            }
+        }
+    }
+
+    func didEncounterWebViewError(code: Int?) {
+        let reason = code.map { "Web view error (code: \($0))" } ?? "Web view error"
+        delegate?.stepDidUpdate(.connect, status: .failure(reason: reason))
+    }
+
+    func didCancelWebView() {
+        delegate?.stepDidUpdate(.connect, status: .failure(reason: "Connection cancelled"))
+    }
 }
 
 private extension WPComConnectionSetupHandler {
+    func startJetpackConnection() {
+        guard let credentials else { return }
+        Task { @MainActor in
+            do {
+                delegate?.stepDidUpdate(.connect, status: .running)
+                let completed = try await checkJetpackConnection(with: credentials)
+                if completed {
+                    delegate?.stepDidUpdate(.connect, status: .success)
+                }
+                // When `completed` is false, the web view flow has been triggered
+                // and the flow will resume via didAuthorizeWebViewConnection().
+            } catch {
+                delegate?.stepDidUpdate(.connect, status: .failure(reason: error.localizedDescription)) // TODO: update msg
+            }
+        }
+
+    }
+
+    /// Returns `true` when the connection step completed (already connected or just connected).
+    /// Returns `false` when a web view is required — the flow pauses until the web view finishes.
     @MainActor
-    func checkJetpackConnection(with credentials: Credentials) async throws {
+    func checkJetpackConnection(with credentials: Credentials) async throws -> Bool {
         let result = try await jetpackConnectionService.evaluateAndConnect(siteURL: siteURL, credentials: credentials)
+        switch result {
+        case .alreadyConnected, .connected:
+            return true
+        case .webViewRequired:
+            startConnectionWithWebView()
+            return false
+        }
+    }
+
+    @MainActor
+    func startConnectionWithWebView() {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let url = try await self.jetpackConnectionService.fetchJetpackConnectionURL(authenticatedWithWPCom: true)
+                let connectionURL: URL
+                if url.absoluteString.hasPrefix(Constants.accountConnectionURL) {
+                    connectionURL = url
+                } else {
+                    let fallback = String(format: Constants.siteConnectionURLFormat, self.siteURL)
+                    connectionURL = URL(string: fallback) ?? url
+                }
+                self.delegate?.setupDidRequireWebView(url: connectionURL, siteURL: self.siteURL)
+            } catch {
+                DDLogError("⛔️ Error fetching Jetpack connection URL: \(error)")
+                self.delegate?.stepDidUpdate(.connect, status: .failure(reason: error.localizedDescription))
+            }
+        }
     }
 }
 
@@ -87,5 +161,7 @@ private extension WPComConnectionSetupHandler {
     enum Constants {
         static let wooPluginPath = "woocommerce/woocommerce.php"
         static let minimumWooVersion = "10.5.3" // This is for testing
+        static let accountConnectionURL = "https://jetpack.wordpress.com/jetpack.authorize"
+        static let siteConnectionURLFormat = "%@/wp-admin/admin.php?page=jetpack"
     }
 }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
@@ -90,18 +90,18 @@ final class WPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol {
                 delegate?.stepDidUpdate(.connect, status: .success)
                 // TODO: continue to next steps
             } catch {
-                delegate?.stepDidUpdate(.connect, status: .failure(reason: error.localizedDescription))
+                didFailConnection(with: error)
             }
         }
     }
 
     func didEncounterWebViewError(code: Int?) {
-        let reason = code.map { "Web view error (code: \($0))" } ?? "Web view error"
-        delegate?.stepDidUpdate(.connect, status: .failure(reason: reason))
+        DDLogError("⛔️ Web view error (code: \(String(describing: code)))")
+        delegate?.stepDidUpdate(.connect, status: .failure(reason: Localization.ConnectionStep.genericError))
     }
 
     func didCancelWebView() {
-        delegate?.stepDidUpdate(.connect, status: .failure(reason: "Connection cancelled"))
+        delegate?.stepDidUpdate(.connect, status: .failure(reason: Localization.ConnectionStep.canceled))
     }
 }
 
@@ -118,7 +118,7 @@ private extension WPComConnectionSetupHandler {
                 // When `completed` is false, the web view flow has been triggered
                 // and the flow will resume via didAuthorizeWebViewConnection().
             } catch {
-                delegate?.stepDidUpdate(.connect, status: .failure(reason: error.localizedDescription)) // TODO: update msg
+                didFailConnection(with: error)
             }
         }
 
@@ -155,9 +155,14 @@ private extension WPComConnectionSetupHandler {
                 delegate?.setupDidRequireWebView(url: connectionURL, siteURL: self.siteURL)
             } catch {
                 DDLogError("⛔️ Error fetching Jetpack connection URL: \(error)")
-                delegate?.stepDidUpdate(.connect, status: .failure(reason: error.localizedDescription))
+                didFailConnection(with: error)
             }
         }
+    }
+
+    func didFailConnection(with error: Error) {
+        DDLogError("⛔️ WPCom connection fails: \(error)")
+        delegate?.stepDidUpdate(.connect, status: .failure(reason: Localization.ConnectionStep.genericError))
     }
 }
 
@@ -167,5 +172,20 @@ private extension WPComConnectionSetupHandler {
         static let minimumWooVersion = "10.5.3" // This is for testing
         static let accountConnectionURL = "https://jetpack.wordpress.com/jetpack.authorize"
         static let siteConnectionURLFormat = "%@/wp-admin/admin.php?page=jetpack"
+    }
+
+    enum Localization {
+        enum ConnectionStep {
+            static let genericError = NSLocalizedString(
+                "wpcomConnectionSetupHandler.ConnectionStep.genericError",
+                value: "There was an error completing your request. Please try again or contact support if this error continues.",
+                comment: "Generic error message when the connection step fails during push notification setup"
+            )
+            static let canceled = NSLocalizedString(
+                "wpcomConnectionSetupHandler.ConnectionStep.canceled",
+                value: "Connection canceled.",
+                comment: "Error message when the connection step is canceled during push notification setup"
+            )
+        }
     }
 }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Yosemite
 
 enum SetupStep: Int, CaseIterable {
     case connect = 0
@@ -26,8 +27,44 @@ protocol WPComConnectionSetupHandlerProtocol: AnyObject {
 final class WPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol {
     weak var delegate: WPComConnectionSetupHandlerDelegate?
 
+    private let siteURL: String
+    private let credentials: Credentials?
+    private let jetpackConnectionService: JetpackConnectionServiceProtocol
+    private let pluginVersionChecker: PluginVersionCheckerProtocol
+
+    init(siteID: Int64,
+         siteURL: String,
+         credentials: Credentials?,
+         jetpackConnectionService: JetpackConnectionServiceProtocol = JetpackConnectionService(),
+         pluginVersionChecker: PluginVersionCheckerProtocol? = nil) {
+        self.siteURL = siteURL
+        self.credentials = credentials
+        self.jetpackConnectionService = jetpackConnectionService
+        self.pluginVersionChecker = pluginVersionChecker ?? PluginVersionChecker(
+            siteID: siteID,
+            pluginPath: Constants.wooPluginPath,
+            minimumVersion: Constants.minimumWooVersion
+        )
+    }
+
     func start() {
-        // TODO: Implement in follow-up PR
+        Task { @MainActor in
+            /// Step 1 (optional): check Jetpack connection
+            if let credentials {
+                do {
+                    delegate?.stepDidUpdate(.connect, status: .running)
+                    try await checkJetpackConnection(with: credentials)
+                    delegate?.stepDidUpdate(.connect, status: .success)
+                } catch {
+                    delegate?.stepDidUpdate(.connect, status: .failure(reason: error.localizedDescription)) // TODO: update msg
+                }
+            }
+
+            /// Step 2: TODO: Check plugin version
+
+            /// Step 3: Enable push notification
+            /// TODO: Inject PushNotificationManager to trigger Woo PN registration
+        }
     }
 
     func retry() {
@@ -36,5 +73,19 @@ final class WPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol {
 
     func cancel() {
         // TODO: Implement in follow-up PR
+    }
+}
+
+private extension WPComConnectionSetupHandler {
+    @MainActor
+    func checkJetpackConnection(with credentials: Credentials) async throws {
+        let result = try await jetpackConnectionService.evaluateAndConnect(siteURL: siteURL, credentials: credentials)
+    }
+}
+
+private extension WPComConnectionSetupHandler {
+    enum Constants {
+        static let wooPluginPath = "woocommerce/woocommerce.php"
+        static let minimumWooVersion = "10.5.3" // This is for testing
     }
 }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupView.swift
@@ -1,10 +1,19 @@
 import SwiftUI
 import UIKit
+import Combine
+import Yosemite
 
 /// Hosting controller for `WPComConnectionSetupView`
 final class WPComConnectionSetupHostingController: UIHostingController<WPComConnectionSetupView> {
 
-    init(viewModel: WPComConnectionSetupViewModel) {
+    private let viewModel: WPComConnectionSetupViewModel
+    private let credentials: Credentials?
+    private var connectionWebView: UINavigationController?
+    private var cancellables = Set<AnyCancellable>()
+
+    init(viewModel: WPComConnectionSetupViewModel, credentials: Credentials? = nil) {
+        self.viewModel = viewModel
+        self.credentials = credentials
         super.init(rootView: WPComConnectionSetupView(viewModel: viewModel))
     }
 
@@ -16,11 +25,78 @@ final class WPComConnectionSetupHostingController: UIHostingController<WPComConn
     override func viewDidLoad() {
         super.viewDidLoad()
         configureTransparentNavigationBar()
+        observeWebViewPresentation()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: animated)
+    }
+}
+
+// MARK: - Web View Presentation
+private extension WPComConnectionSetupHostingController {
+    func observeWebViewPresentation() {
+        viewModel.$webViewPresentation
+            .compactMap { $0 }
+            .sink { [weak self] presentation in
+                self?.presentJetpackConnectionWebView(with: presentation.url, siteURL: presentation.siteURL)
+            }
+            .store(in: &cancellables)
+    }
+
+    func presentJetpackConnectionWebView(with url: URL, siteURL: String) {
+        let webViewModel = JetpackConnectionWebViewModel(
+            initialURL: url,
+            siteURL: siteURL,
+            completion: { [weak self] in
+                guard let self else { return }
+                self.dismissWebView()
+                self.viewModel.didAuthorizeWebViewConnection()
+            },
+            onAuthorization: { [weak self] url in
+                self?.presentJetpackConnectionWebView(with: url, siteURL: siteURL)
+            },
+            onFailure: { [weak self] errorCode in
+                guard let self else { return }
+                self.dismissWebView()
+                self.viewModel.didEncounterWebViewError(code: errorCode)
+            },
+            onDismissal: { [weak self] in
+                self?.viewModel.didCancelWebView()
+            }
+        )
+
+        let webView = AuthenticatedWebViewController(viewModel: webViewModel, extraCredentials: credentials)
+        webView.navigationItem.leftBarButtonItem = UIBarButtonItem(
+            title: Localization.cancel,
+            style: .plain,
+            target: self,
+            action: #selector(dismissWebView)
+        )
+
+        if let connectionWebView {
+            connectionWebView.viewControllers = [webView]
+        } else {
+            let navigationController = UINavigationController(rootViewController: webView)
+            present(navigationController, animated: true)
+            connectionWebView = navigationController
+        }
+    }
+
+    @objc func dismissWebView() {
+        connectionWebView?.dismiss(animated: true)
+        connectionWebView = nil
+    }
+}
+
+private extension WPComConnectionSetupHostingController {
+    enum Localization {
+        static let cancel = NSLocalizedString(
+            "wpComConnectionSetupHostingController.cancel",
+            value: "Cancel",
+            comment: "Cancel button in the Jetpack connection web view."
+        )
     }
 }
 

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupView.swift
@@ -115,7 +115,7 @@ private extension WPComConnectionSetupView {
 #Preview {
     let viewModel = WPComConnectionSetupViewModel(
         storeName: "coffeebeans.com",
-        handler: WPComConnectionSetupHandler(),
+        handler: WPComConnectionSetupHandler(siteID: 123, siteURL: "https://example.com", credentials: nil),
         onDismiss: {},
         onGoToStore: {},
         onUpdatePlugin: {}

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
@@ -5,6 +5,11 @@ import SwiftUI
 @MainActor
 final class WPComConnectionSetupViewModel: ObservableObject {
 
+    struct WebViewPresentation: Equatable {
+        let url: URL
+        let siteURL: String
+    }
+
     enum CheckPluginError: Equatable {
         case outdated
         case other
@@ -18,6 +23,7 @@ final class WPComConnectionSetupViewModel: ObservableObject {
 
     @Published private(set) var steps: [WPComConnectionSetupStep] = []
     @Published private var setupState: SetupState = .inProgress
+    @Published var webViewPresentation: WebViewPresentation?
 
     let subtitleAttributedString: AttributedString
 
@@ -124,6 +130,21 @@ final class WPComConnectionSetupViewModel: ObservableObject {
         onDismiss()
     }
 
+    func didAuthorizeWebViewConnection() {
+        webViewPresentation = nil
+        handler.didAuthorizeWebViewConnection()
+    }
+
+    func didEncounterWebViewError(code: Int?) {
+        webViewPresentation = nil
+        handler.didEncounterWebViewError(code: code)
+    }
+
+    func didCancelWebView() {
+        webViewPresentation = nil
+        handler.didCancelWebView()
+    }
+
     private func retrySetup() {
         setupState = .inProgress
         handler.retry()
@@ -164,6 +185,10 @@ extension WPComConnectionSetupViewModel: WPComConnectionSetupHandlerDelegate {
 
     func setupDidComplete() {
         setupState = .completed
+    }
+
+    func setupDidRequireWebView(url: URL, siteURL: String) {
+        webViewPresentation = WebViewPresentation(url: url, siteURL: siteURL)
     }
 }
 

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -97,7 +97,7 @@ private extension WooPushNotificationSetupCoordinator {
                 // TODO: Implement plugin update flow in follow-up PR
             }
         )
-        let connectionSetupController = WPComConnectionSetupHostingController(viewModel: viewModel)
+        let connectionSetupController = WPComConnectionSetupHostingController(viewModel: viewModel, credentials: credentials)
         navigationController.viewControllers = [connectionSetupController]
 
         // Dismiss current modal (login or benefits) and present connection setup

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -23,13 +23,9 @@ final class WooPushNotificationSetupCoordinator {
                 flow: .notificationSetup,
                 navigationController: UINavigationController(),
                 completionHandler: { [weak self] credentials in
-                    // TODO: use credentials for Jetpack connection flow.
-                    // Consider reusing JetpackSetupViewModel
-                    // Also check JetpackSetupHostingController for more details on what the credentials are for.
-
                     DDLogDebug("📱 Authentication complete, proceed with Jetpack connection")
                     DispatchQueue.main.async {
-                        self?.showConnectionSetup()
+                        self?.showConnectionSetup(with: credentials)
                     }
             })
         }()
@@ -66,9 +62,8 @@ final class WooPushNotificationSetupCoordinator {
             return false
         }
 
-        // TODO: start Jetpack connection flow with the retrieved authToken.
         DDLogDebug("📱 Magic link success, now proceed with Jetpack connection")
-        showConnectionSetup()
+        showConnectionSetup(with: Credentials(authToken: authToken))
         return true
     }
 }
@@ -78,10 +73,17 @@ private extension WooPushNotificationSetupCoordinator {
         static let magicLinkUrlHostname = "magic-login"
     }
 
-    func showConnectionSetup() {
-        let storeName = stores.sessionManager.defaultSite?.name ?? stores.sessionManager.defaultSite?.url ?? ""
+    func showConnectionSetup(with credentials: Credentials? = nil) {
+        guard let site = stores.sessionManager.defaultSite else {
+            fatalError("❌ No default site found for Woo push notification setup!")
+        }
+        let storeName = site.name
         let navigationController = WooNavigationController()
-        let handler = WPComConnectionSetupHandler()
+        let handler = WPComConnectionSetupHandler(
+            siteID: site.siteID,
+            siteURL: site.url,
+            credentials: credentials
+        )
         let viewModel = WPComConnectionSetupViewModel(
             storeName: storeName,
             handler: handler,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/DebugPanelView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/DebugPanelView.swift
@@ -20,15 +20,21 @@ struct DebugPanelView: View {
                 Text("Override Feature Flags")
             }
 
-            DebugSheetPresenter("Present WPComConnectionSetupView") { dismiss in
-                let viewModel = WPComConnectionSetupViewModel(
-                    storeName: "nicestore.com",
-                    handler: WPComConnectionSetupHandler(),
-                    onDismiss: dismiss,
-                    onGoToStore: dismiss,
-                    onUpdatePlugin: {}
-                )
-                WPComConnectionSetupView(viewModel: viewModel)
+            if let site = ServiceLocator.stores.sessionManager.defaultSite {
+                DebugSheetPresenter("Present WPComConnectionSetupView") { dismiss in
+                    let viewModel = WPComConnectionSetupViewModel(
+                        storeName: "nicestore.com",
+                        handler: WPComConnectionSetupHandler(
+                            siteID: site.siteID,
+                            siteURL: site.url,
+                            credentials: nil
+                        ),
+                        onDismiss: dismiss,
+                        onGoToStore: dismiss,
+                        onUpdatePlugin: {}
+                    )
+                    WPComConnectionSetupView(viewModel: viewModel)
+                }
             }
         }
         .contentMargins(20)

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupViewModelTests.swift
@@ -513,7 +513,6 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, wpcomCredentials: credentials,
                                               stores: stores, connectionService: connectionService)
 
-        var triggeredConnectionURL = false
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
@@ -522,8 +521,6 @@ final class JetpackSetupViewModelTests: XCTestCase {
                 completion(.success(()))
             case .activateJetpackPlugin(let completion):
                 completion(.success(()))
-            case .fetchJetpackConnectionURL:
-                triggeredConnectionURL = true
             default:
                 break
             }
@@ -531,11 +528,11 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // When
         viewModel.startSetup()
-        waitUntil { triggeredConnectionURL }
+        waitUntil { connectionService.fetchJetpackConnectionURLCallCount > 0 }
 
         // Then
         XCTAssertEqual(connectionService.evaluateAndConnectCallCount, 1)
-        XCTAssertTrue(triggeredConnectionURL)
+        XCTAssertEqual(connectionService.fetchJetpackConnectionURLCallCount, 1)
     }
 
     func test_shouldPresentWebView_is_true_when_fetching_connection_url_returns_account_connection_url() throws {

--- a/WooCommerce/WooCommerceTests/Mocks/MockJetpackConnectionService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockJetpackConnectionService.swift
@@ -9,6 +9,10 @@ final class MockJetpackConnectionService: JetpackConnectionServiceProtocol {
     var verifyConnectionResult: Result<String, Error> = .success("test@example.com")
     private(set) var verifyConnectionCallCount = 0
 
+    var fetchJetpackConnectionURLResult: Result<URL, Error> = .success(URL(string: "https://jetpack.wordpress.com/jetpack.authorize")!)
+    private(set) var fetchJetpackConnectionURLCallCount = 0
+    private(set) var lastAuthenticatedWithWPCom: Bool?
+
     func evaluateAndConnect(siteURL: String, credentials: Credentials) async throws -> JetpackConnectionOutcome {
         evaluateAndConnectCallCount += 1
         return try evaluateAndConnectResult.get()
@@ -17,5 +21,11 @@ final class MockJetpackConnectionService: JetpackConnectionServiceProtocol {
     func verifyConnection() async throws -> String {
         verifyConnectionCallCount += 1
         return try verifyConnectionResult.get()
+    }
+
+    func fetchJetpackConnectionURL(authenticatedWithWPCom: Bool) async throws -> URL {
+        fetchJetpackConnectionURLCallCount += 1
+        lastAuthenticatedWithWPCom = authenticatedWithWPCom
+        return try fetchJetpackConnectionURLResult.get()
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockWPComConnectionSetupHandler.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockWPComConnectionSetupHandler.swift
@@ -8,6 +8,9 @@ final class MockWPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol
     private(set) var startCallCount = 0
     private(set) var retryCallCount = 0
     private(set) var cancelCallCount = 0
+    private(set) var didAuthorizeWebViewConnectionCallCount = 0
+    private(set) var didEncounterWebViewErrorCallCount = 0
+    private(set) var didCancelWebViewCallCount = 0
 
     func start() {
         startCallCount += 1
@@ -21,6 +24,18 @@ final class MockWPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol
         cancelCallCount += 1
     }
 
+    func didAuthorizeWebViewConnection() {
+        didAuthorizeWebViewConnectionCallCount += 1
+    }
+
+    func didEncounterWebViewError(code: Int?) {
+        didEncounterWebViewErrorCallCount += 1
+    }
+
+    func didCancelWebView() {
+        didCancelWebViewCallCount += 1
+    }
+
     // MARK: - Test helpers
 
     func simulateStepUpdate(_ step: SetupStep, status: WPComConnectionSetupStep.Status) {
@@ -29,5 +44,9 @@ final class MockWPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol
 
     func simulateSetupComplete() {
         delegate?.setupDidComplete()
+    }
+
+    func simulateWebViewRequired(url: URL, siteURL: String) {
+        delegate?.setupDidRequireWebView(url: url, siteURL: siteURL)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerTests.swift
@@ -1,0 +1,321 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+@MainActor
+final class WPComConnectionSetupHandlerTests: XCTestCase {
+
+    private let testSiteURL = "https://example.com"
+
+    private var mockConnectionService: MockJetpackConnectionService!
+    private var mockPluginVersionChecker: MockPluginVersionChecker!
+    private var delegateSpy: MockWPComConnectionSetupHandlerDelegate!
+
+    override func setUp() {
+        super.setUp()
+        mockConnectionService = MockJetpackConnectionService()
+        mockPluginVersionChecker = MockPluginVersionChecker()
+        delegateSpy = MockWPComConnectionSetupHandlerDelegate()
+    }
+
+    override func tearDown() {
+        mockConnectionService = nil
+        mockPluginVersionChecker = nil
+        delegateSpy = nil
+        super.tearDown()
+    }
+
+    // MARK: - start() Tests
+
+    func test_start_with_alreadyConnected_marks_connect_step_as_success() async throws {
+        // Given
+        mockConnectionService.evaluateAndConnectResult = .success(.alreadyConnected(email: "test@example.com"))
+        let handler = makeHandler()
+
+        // When
+        handler.start()
+        await delegateSpy.waitForStepUpdate(count: 2)
+
+        // Then
+        XCTAssertEqual(delegateSpy.stepUpdates.count, 2)
+        XCTAssertEqual(delegateSpy.stepUpdates[0].step, .connect)
+        XCTAssertEqual(delegateSpy.stepUpdates[0].status, .running)
+        XCTAssertEqual(delegateSpy.stepUpdates[1].step, .connect)
+        XCTAssertEqual(delegateSpy.stepUpdates[1].status, .success)
+    }
+
+    func test_start_with_connected_marks_connect_step_as_success() async throws {
+        // Given
+        mockConnectionService.evaluateAndConnectResult = .success(.connected(email: "test@example.com"))
+        let handler = makeHandler()
+
+        // When
+        handler.start()
+        await delegateSpy.waitForStepUpdate(count: 2)
+
+        // Then
+        XCTAssertEqual(delegateSpy.stepUpdates.count, 2)
+        XCTAssertEqual(delegateSpy.stepUpdates[1].status, .success)
+    }
+
+    func test_start_with_webViewRequired_triggers_web_view_with_account_connection_url() async throws {
+        // Given
+        mockConnectionService.evaluateAndConnectResult = .success(.webViewRequired)
+        let accountURL = URL(string: "https://jetpack.wordpress.com/jetpack.authorize/123")!
+        mockConnectionService.fetchJetpackConnectionURLResult = .success(accountURL)
+        let handler = makeHandler()
+
+        // When
+        handler.start()
+        await delegateSpy.waitForWebViewRequired()
+
+        // Then
+        XCTAssertEqual(delegateSpy.webViewURLs.count, 1)
+        XCTAssertEqual(delegateSpy.webViewURLs.first?.url, accountURL)
+        XCTAssertEqual(delegateSpy.webViewURLs.first?.siteURL, testSiteURL)
+    }
+
+    func test_start_with_webViewRequired_uses_fallback_url_when_not_account_connection() async throws {
+        // Given
+        mockConnectionService.evaluateAndConnectResult = .success(.webViewRequired)
+        let nonAccountURL = URL(string: "https://other.example.com/connect")!
+        mockConnectionService.fetchJetpackConnectionURLResult = .success(nonAccountURL)
+        let handler = makeHandler()
+
+        // When
+        handler.start()
+        await delegateSpy.waitForWebViewRequired()
+
+        // Then
+        let expectedFallback = URL(string: "\(testSiteURL)/wp-admin/admin.php?page=jetpack")!
+        XCTAssertEqual(delegateSpy.webViewURLs.first?.url, expectedFallback)
+    }
+
+    func test_start_without_credentials_does_not_run_connect_step() async throws {
+        // Given
+        let handler = makeHandler(credentials: .none)
+
+        // When
+        handler.start()
+        // Give a moment for any async work to run
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then
+        XCTAssertTrue(delegateSpy.stepUpdates.isEmpty)
+        XCTAssertEqual(mockConnectionService.evaluateAndConnectCallCount, 0)
+    }
+
+    func test_start_with_evaluateAndConnect_failure_marks_connect_step_as_failure() async throws {
+        // Given
+        mockConnectionService.evaluateAndConnectResult = .failure(NSError(domain: "Test", code: -1))
+        let handler = makeHandler()
+
+        // When
+        handler.start()
+        await delegateSpy.waitForStepUpdate(count: 2)
+
+        // Then
+        XCTAssertEqual(delegateSpy.stepUpdates.count, 2)
+        XCTAssertEqual(delegateSpy.stepUpdates[0].status, .running)
+        assertFailureStatus(delegateSpy.stepUpdates[1].status)
+    }
+
+    func test_start_with_fetchURL_failure_marks_connect_step_as_failure() async throws {
+        // Given
+        mockConnectionService.evaluateAndConnectResult = .success(.webViewRequired)
+        mockConnectionService.fetchJetpackConnectionURLResult = .failure(NSError(domain: "Test", code: -1))
+        let handler = makeHandler()
+
+        // When
+        handler.start()
+        await delegateSpy.waitForStepUpdate(count: 2)
+
+        // Then
+        XCTAssertEqual(delegateSpy.stepUpdates.count, 2)
+        assertFailureStatus(delegateSpy.stepUpdates[1].status)
+    }
+
+    // MARK: - didAuthorizeWebViewConnection() Tests
+
+    func test_didAuthorizeWebViewConnection_verifies_connection_and_marks_success() async throws {
+        // Given
+        mockConnectionService.verifyConnectionResult = .success("test@example.com")
+        let handler = makeHandler()
+
+        // When
+        handler.didAuthorizeWebViewConnection()
+        await delegateSpy.waitForStepUpdate(count: 1)
+
+        // Then
+        XCTAssertEqual(mockConnectionService.verifyConnectionCallCount, 1)
+        XCTAssertEqual(delegateSpy.stepUpdates.first?.status, .success)
+    }
+
+    func test_didAuthorizeWebViewConnection_on_verification_failure_marks_failure() async throws {
+        // Given
+        mockConnectionService.verifyConnectionResult = .failure(NSError(domain: "Test", code: -1))
+        let handler = makeHandler()
+
+        // When
+        handler.didAuthorizeWebViewConnection()
+        await delegateSpy.waitForStepUpdate(count: 1)
+
+        // Then
+        XCTAssertEqual(mockConnectionService.verifyConnectionCallCount, 1)
+        assertFailureStatus(delegateSpy.stepUpdates.first?.status)
+    }
+
+    // MARK: - didEncounterWebViewError() Tests
+
+    func test_didEncounterWebViewError_marks_connect_step_as_failure() {
+        // Given
+        let handler = makeHandler()
+
+        // When
+        handler.didEncounterWebViewError(code: 404)
+
+        // Then
+        XCTAssertEqual(delegateSpy.stepUpdates.count, 1)
+        XCTAssertEqual(delegateSpy.stepUpdates.first?.step, .connect)
+        assertFailureStatus(delegateSpy.stepUpdates.first?.status)
+    }
+
+    // MARK: - didCancelWebView() Tests
+
+    func test_didCancelWebView_marks_connect_step_as_failure() {
+        // Given
+        let handler = makeHandler()
+
+        // When
+        handler.didCancelWebView()
+
+        // Then
+        XCTAssertEqual(delegateSpy.stepUpdates.count, 1)
+        XCTAssertEqual(delegateSpy.stepUpdates.first?.step, .connect)
+        assertFailureStatus(delegateSpy.stepUpdates.first?.status)
+    }
+
+    // MARK: - retry() Tests
+
+    func test_retry_after_connection_failure_restarts_connection() async throws {
+        // Given
+        mockConnectionService.evaluateAndConnectResult = .failure(NSError(domain: "Test", code: -1))
+        let handler = makeHandler()
+        handler.start()
+        await delegateSpy.waitForStepUpdate(count: 2)
+
+        // Reset for retry
+        mockConnectionService.evaluateAndConnectResult = .success(.alreadyConnected(email: "test@example.com"))
+        delegateSpy.stepUpdates.removeAll()
+
+        // When
+        handler.retry()
+        await delegateSpy.waitForStepUpdate(count: 2)
+
+        // Then
+        XCTAssertEqual(delegateSpy.stepUpdates.count, 2)
+        XCTAssertEqual(delegateSpy.stepUpdates[0].status, .running)
+        XCTAssertEqual(delegateSpy.stepUpdates[1].status, .success)
+    }
+
+    // MARK: - Helpers
+
+    private enum CredentialsOption {
+        case `default`
+        case none
+        case custom(Credentials)
+
+        var value: Credentials? {
+            switch self {
+            case .default:
+                return Credentials.wpcom(username: "test", authToken: "secret", siteAddress: "https://example.com")
+            case .none:
+                return nil
+            case .custom(let creds):
+                return creds
+            }
+        }
+    }
+
+    private func makeHandler(credentials: CredentialsOption = .default) -> WPComConnectionSetupHandler {
+        let handler = WPComConnectionSetupHandler(
+            siteID: 123,
+            siteURL: testSiteURL,
+            credentials: credentials.value,
+            stores: MockStoresManager(sessionManager: .makeForTesting()),
+            jetpackConnectionService: mockConnectionService,
+            pluginVersionChecker: mockPluginVersionChecker
+        )
+        handler.delegate = delegateSpy
+        return handler
+    }
+
+    private func assertFailureStatus(_ status: WPComConnectionSetupStep.Status?, file: StaticString = #filePath, line: UInt = #line) {
+        guard let status else {
+            XCTFail("Status is nil", file: file, line: line)
+            return
+        }
+        if case .failure = status {
+            // Expected
+        } else {
+            XCTFail("Expected .failure but got \(status)", file: file, line: line)
+        }
+    }
+}
+
+// MARK: - Mock Delegate
+
+@MainActor
+private final class MockWPComConnectionSetupHandlerDelegate: WPComConnectionSetupHandlerDelegate {
+    struct StepUpdate {
+        let step: SetupStep
+        let status: WPComConnectionSetupStep.Status
+    }
+
+    struct WebViewURL {
+        let url: URL
+        let siteURL: String
+    }
+
+    var stepUpdates: [StepUpdate] = []
+    var setupCompleteCalled = false
+    var webViewURLs: [WebViewURL] = []
+
+    func stepDidUpdate(_ step: SetupStep, status: WPComConnectionSetupStep.Status) {
+        stepUpdates.append(StepUpdate(step: step, status: status))
+    }
+
+    func setupDidComplete() {
+        setupCompleteCalled = true
+    }
+
+    func setupDidRequireWebView(url: URL, siteURL: String) {
+        webViewURLs.append(WebViewURL(url: url, siteURL: siteURL))
+    }
+
+    /// Polls until the expected number of step updates are received.
+    func waitForStepUpdate(count: Int, timeout: TimeInterval = 2.0) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while stepUpdates.count < count, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000) // 10ms
+        }
+    }
+
+    /// Polls until at least one web view URL is received.
+    func waitForWebViewRequired(timeout: TimeInterval = 2.0) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while webViewURLs.isEmpty, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000) // 10ms
+        }
+    }
+}
+
+// MARK: - Mock Plugin Version Checker
+
+private final class MockPluginVersionChecker: PluginVersionCheckerProtocol {
+    var result: Result<PluginVersionResult, Error> = .success(.compatible)
+
+    func checkCompatibility() async throws -> PluginVersionResult {
+        try result.get()
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModelTests.swift
@@ -168,6 +168,63 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
         XCTAssertTrue(dismissCalled)
     }
 
+    // MARK: - Web View Presentation Tests
+
+    func test_setupDidRequireWebView_sets_webViewPresentation() {
+        // Given
+        let viewModel = makeViewModel()
+        let url = URL(string: "https://jetpack.wordpress.com/jetpack.authorize/123")!
+        let siteURL = "https://example.com"
+
+        // When
+        mockHandler.simulateWebViewRequired(url: url, siteURL: siteURL)
+
+        // Then
+        XCTAssertEqual(viewModel.webViewPresentation, WPComConnectionSetupViewModel.WebViewPresentation(url: url, siteURL: siteURL))
+    }
+
+    func test_didAuthorizeWebViewConnection_clears_presentation_and_forwards_to_handler() {
+        // Given
+        let viewModel = makeViewModel()
+        mockHandler.simulateWebViewRequired(url: URL(string: "https://example.com")!, siteURL: "https://example.com")
+        XCTAssertNotNil(viewModel.webViewPresentation)
+
+        // When
+        viewModel.didAuthorizeWebViewConnection()
+
+        // Then
+        XCTAssertNil(viewModel.webViewPresentation)
+        XCTAssertEqual(mockHandler.didAuthorizeWebViewConnectionCallCount, 1)
+    }
+
+    func test_didEncounterWebViewError_clears_presentation_and_forwards_to_handler() {
+        // Given
+        let viewModel = makeViewModel()
+        mockHandler.simulateWebViewRequired(url: URL(string: "https://example.com")!, siteURL: "https://example.com")
+        XCTAssertNotNil(viewModel.webViewPresentation)
+
+        // When
+        viewModel.didEncounterWebViewError(code: 404)
+
+        // Then
+        XCTAssertNil(viewModel.webViewPresentation)
+        XCTAssertEqual(mockHandler.didEncounterWebViewErrorCallCount, 1)
+    }
+
+    func test_didCancelWebView_clears_presentation_and_forwards_to_handler() {
+        // Given
+        let viewModel = makeViewModel()
+        mockHandler.simulateWebViewRequired(url: URL(string: "https://example.com")!, siteURL: "https://example.com")
+        XCTAssertNotNil(viewModel.webViewPresentation)
+
+        // When
+        viewModel.didCancelWebView()
+
+        // Then
+        XCTAssertNil(viewModel.webViewPresentation)
+        XCTAssertEqual(mockHandler.didCancelWebViewCallCount, 1)
+    }
+
     // MARK: - Helpers
 
     private func makeViewModel() -> WPComConnectionSetupViewModel {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of WOOMOB-1928

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR implements the connection step for push notification setup. Changes include:
- Extracts `fetchJetpackConnectionURL` to `JetpackConnectionService` for reusability.
- Injects `JetpackConnectionService` to `WPComConnectionSetupHandler` and implement connection step similarly to what we did in `JetpackSetupViewModel`.
- Updates `WPComConnectionSetupHostingController` and view model to support the web view connection case.
- Adds tests.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

### TC1: Native connection supported
1. Enable feature flags for M1 and M2.
2. Log in to a JN site with no Jetpack plugin and no JP connection and doesn't support Woo PN.
3. Tap on the WPCom connection dashboard card to start the PN setup flow.
4. Proceed to log in to a WPCom account (using password or magic link).
5. After login completes, confirm that the connection step starts then completes.
6. Check your JN site's admin to confirm that the site Jetpack is connected to the logged in account correctly.

### TC2: Web view connection flow
1. Use Proxyman to put a break point to the response of `GET */jetpack/v4/connection/data`.
2. Repeat steps 1-4 in TC1.
3. When the breakpoint pauses, remove the `isRegistered` field from the response body and proceed.
4. Confirm that a web view is displayed. Follow the instruction to complete the connection.
5. Confirm that the connection step completes and JN site is connected on the admin page.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/e0a302e6-8510-449e-907c-4043eb571598



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
