### PR TITLE
[CIAB] Filter cancelled bookings from Today and Upcoming tabs

### DIFF
--- a/Modules/Sources/Networking/Remote/BookingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/BookingsRemote.swift
@@ -41,6 +41,7 @@ public struct BookingFilters {
     public let startDateAfter: String?
     public let attendanceStatuses: [String]
     public let paymentStatuses: [String]
+    public let bookingStatusExclude: [String]
 
     public init(
         productIDs: [Int64] = [],
@@ -49,7 +50,8 @@ public struct BookingFilters {
         startDateBefore: String? = nil,
         startDateAfter: String? = nil,
         attendanceStatuses: [String] = [],
-        paymentStatuses: [String] = []
+        paymentStatuses: [String] = [],
+        bookingStatusExclude: [String] = []
     ) {
         self.productIDs = productIDs
         self.customerIDs = customerIDs
@@ -58,6 +60,7 @@ public struct BookingFilters {
         self.startDateAfter = startDateAfter
         self.attendanceStatuses = attendanceStatuses
         self.paymentStatuses = paymentStatuses
+        self.bookingStatusExclude = bookingStatusExclude
     }
 
     /// Returns a new `BookingFilters` by merging user-applied filters with this instance's date constraints.
@@ -74,7 +77,8 @@ public struct BookingFilters {
             startDateAfter: Self.mostRestrictiveDate(date1: startDateAfter,
                                                      date2: userFilters.startDateAfter,
                                                      pickEarlier: false),
-            attendanceStatuses: userFilters.attendanceStatuses
+            attendanceStatuses: userFilters.attendanceStatuses,
+            bookingStatusExclude: bookingStatusExclude
         )
     }
 
@@ -157,6 +161,10 @@ public final class BookingsRemote: Remote, BookingsRemoteProtocol {
 
             if filters.paymentStatuses.isNotEmpty {
                 parameters[ParameterKey.paymentStatus] = filters.paymentStatuses
+            }
+
+            if filters.bookingStatusExclude.isNotEmpty {
+                parameters[ParameterKey.bookingStatusExclude] = filters.bookingStatusExclude
             }
         }
 
@@ -304,6 +312,7 @@ public extension BookingsRemote {
         static let resource: String        = "resource"
         static let attendanceStatus        = "attendance_status"
         static let paymentStatus           = "booking_status" // to be updated later when payment filtering is supported
+        static let bookingStatusExclude    = "booking_status_exclude"
         static let status: String          = "status"
         static let note: String            = "note"
     }

--- a/Modules/Sources/Yosemite/Tools/Bookings/ResultsController+FilterBookings.swift
+++ b/Modules/Sources/Yosemite/Tools/Bookings/ResultsController+FilterBookings.swift
@@ -26,6 +26,9 @@ extension NSPredicate {
         let attendanceStatusesPredicate = filters.attendanceStatuses.isNotEmpty ?
         NSPredicate(format: "attendanceStatusKey IN %@", filters.attendanceStatuses) : nil
 
+        let bookingStatusExcludePredicate = filters.bookingStatusExclude.isNotEmpty ?
+        NSPredicate(format: "NOT (statusKey IN %@)", filters.bookingStatusExclude) : nil
+
         let subpredicates = [
             siteIDPredicate,
             productIDsPredicate,
@@ -34,7 +37,8 @@ extension NSPredicate {
             startDateBeforePredicate,
             startDateAfterPredicate,
             paymentStatusesPredicate,
-            attendanceStatusesPredicate
+            attendanceStatusesPredicate,
+            bookingStatusExcludePredicate
         ].compactMap({ $0 })
 
         return NSCompoundPredicate(andPredicateWithSubpredicates: subpredicates)

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
@@ -307,21 +307,21 @@ enum BookingListTab: Int, CaseIterable {
         }
     }
 
-    /// Filters sent to the remote API (date range boundaries per tab).
+    /// Filters sent to the remote API (date range boundaries and status exclusions per tab).
     func remoteFilters(currentDate: Date) -> BookingFilters {
         BookingFilters(
             startDateBefore: startDateBefore(currentDate: currentDate)?.ISO8601Format(),
-            startDateAfter: startDateAfter(currentDate: currentDate)?.ISO8601Format()
+            startDateAfter: startDateAfter(currentDate: currentDate)?.ISO8601Format(),
+            bookingStatusExclude: bookingStatusExclude
         )
     }
 
-    /// Additional local-only predicate for Core Data filtering that is not sent to the API.
-    var localPredicate: NSPredicate? {
+    private var bookingStatusExclude: [String] {
         switch self {
         case .today, .upcoming:
-            NSPredicate(format: "statusKey != %@", BookingStatus.cancelled.rawValue)
+            [BookingStatus.cancelled.rawValue]
         case .all:
-            nil
+            []
         }
     }
 

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
@@ -307,14 +307,32 @@ enum BookingListTab: Int, CaseIterable {
         }
     }
 
-    func startDateBefore(currentDate: Date) -> Date? {
+    /// Filters sent to the remote API (date range boundaries per tab).
+    func remoteFilters(currentDate: Date) -> BookingFilters {
+        BookingFilters(
+            startDateBefore: startDateBefore(currentDate: currentDate)?.ISO8601Format(),
+            startDateAfter: startDateAfter(currentDate: currentDate)?.ISO8601Format()
+        )
+    }
+
+    /// Additional local-only predicate for Core Data filtering that is not sent to the API.
+    var localPredicate: NSPredicate? {
+        switch self {
+        case .today, .upcoming:
+            NSPredicate(format: "statusKey != %@", BookingStatus.cancelled.rawValue)
+        case .all:
+            nil
+        }
+    }
+
+    private func startDateBefore(currentDate: Date) -> Date? {
         switch self {
         case .today: currentDate.endOfDay(timezone: Self.utcTimeZone).addingTimeInterval(1)
         case .upcoming, .all: nil
         }
     }
 
-    func startDateAfter(currentDate: Date) -> Date? {
+    private func startDateAfter(currentDate: Date) -> Date? {
         switch self {
         case .today: currentDate.startOfDay(timezone: Self.utcTimeZone).addingTimeInterval(-1)
         case .upcoming: currentDate.endOfDay(timezone: Self.utcTimeZone)

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
@@ -58,13 +58,9 @@ final class BookingListViewModel: ObservableObject {
 
     /// Booking ResultsController.
     private lazy var resultsController: ResultsController<StorageBooking> = {
-        var predicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: filters)
-        if let localPredicate = type.localPredicate {
-            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, localPredicate])
-        }
         let sortDescriptorByDate = NSSortDescriptor(key: "startDate", ascending: false)
         let resultsController = ResultsController<StorageBooking>(storageManager: storage,
-                                                                  matching: predicate,
+                                                                  matching: currentPredicate,
                                                                   sortedBy: [sortDescriptorByDate])
         return resultsController
     }()
@@ -128,17 +124,19 @@ final class BookingListViewModel: ObservableObject {
     func updateFilters(_ filters: BookingFiltersViewModel.Filters) {
         hasFilters = filters.numberOfActiveFilters > 0
         self.filters = tabDateFilters.mergingDates(with: filters.bookingFilters)
-        var predicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: self.filters)
-        if let localPredicate = type.localPredicate {
-            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, localPredicate])
-        }
-        resultsController.predicate = predicate
+        resultsController.predicate = currentPredicate
         paginationTracker.resync(reason: Self.refreshCacheReason) {}
     }
 
     /// Converts SortBy to BookingsRemote.Order
     private func remoteOrder(from sortBy: SortBy) -> BookingsRemote.Order {
         sortBy == .oldestToNewest ? .ascending : .descending
+    }
+
+    private var currentPredicate: NSPredicate {
+        let predicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: filters)
+        guard let localPredicate = type.localPredicate else { return predicate }
+        return NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, localPredicate])
     }
 }
 

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
@@ -128,7 +128,11 @@ final class BookingListViewModel: ObservableObject {
     func updateFilters(_ filters: BookingFiltersViewModel.Filters) {
         hasFilters = filters.numberOfActiveFilters > 0
         self.filters = tabDateFilters.mergingDates(with: filters.bookingFilters)
-        resultsController.updatePredicate(siteID: siteID, filters: self.filters)
+        var predicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: self.filters)
+        if let localPredicate = type.localPredicate {
+            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, localPredicate])
+        }
+        resultsController.predicate = predicate
         paginationTracker.resync(reason: Self.refreshCacheReason) {}
     }
 

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
@@ -134,9 +134,7 @@ final class BookingListViewModel: ObservableObject {
     }
 
     private var currentPredicate: NSPredicate {
-        let predicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: filters)
-        guard let localPredicate = type.localPredicate else { return predicate }
-        return NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, localPredicate])
+        NSPredicate.createBookingPredicate(siteID: siteID, filters: filters)
     }
 }
 

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
@@ -58,10 +58,13 @@ final class BookingListViewModel: ObservableObject {
 
     /// Booking ResultsController.
     private lazy var resultsController: ResultsController<StorageBooking> = {
-        let combinedPredicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: filters)
+        var predicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: filters)
+        if let localPredicate = type.localPredicate {
+            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, localPredicate])
+        }
         let sortDescriptorByDate = NSSortDescriptor(key: "startDate", ascending: false)
         let resultsController = ResultsController<StorageBooking>(storageManager: storage,
-                                                                  matching: combinedPredicate,
+                                                                  matching: predicate,
                                                                   sortedBy: [sortDescriptorByDate])
         return resultsController
     }()
@@ -80,10 +83,7 @@ final class BookingListViewModel: ObservableObject {
         self.analytics = analytics
         self.paginationTracker = PaginationTracker(pageFirstIndex: pageFirstIndex)
 
-        self.tabDateFilters = BookingFilters(
-            startDateBefore: type.startDateBefore(currentDate: currentDate)?.ISO8601Format(),
-            startDateAfter: type.startDateAfter(currentDate: currentDate)?.ISO8601Format()
-        )
+        self.tabDateFilters = type.remoteFilters(currentDate: currentDate)
         self.filters = tabDateFilters
 
         configureResultsController()

--- a/WooCommerce/Classes/Bookings/BookingList/BookingSearchViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingSearchViewModel.swift
@@ -42,10 +42,7 @@ final class BookingSearchViewModel: ObservableObject {
         self.stores = stores
         self.searchPaginationTracker = PaginationTracker(pageFirstIndex: pageFirstIndex)
 
-        self.tabDateFilters = BookingFilters(
-            startDateBefore: type.startDateBefore(currentDate: currentDate)?.ISO8601Format(),
-            startDateAfter: type.startDateAfter(currentDate: currentDate)?.ISO8601Format()
-        )
+        self.tabDateFilters = type.remoteFilters(currentDate: currentDate)
         self.filters = tabDateFilters
 
         configureSearchPaginationTracker()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
@@ -336,6 +336,8 @@ class BookingListViewModelTests {
         // Then
         #expect(capturedFilters?.startDateAfter == "2020-12-31T23:59:59Z", "Today tab should filter after start of day")
         #expect(capturedFilters?.startDateBefore == "2021-01-02T00:00:00Z", "Today tab should filter before end of day")
+        #expect(capturedFilters?.bookingStatusExclude == [BookingStatus.cancelled.rawValue],
+                "Today tab should exclude cancelled bookings via API")
     }
 
     @Test func upcoming_tab_passes_correct_date_filters_to_booking_action() {
@@ -362,6 +364,8 @@ class BookingListViewModelTests {
         // Then
         #expect(capturedFilters?.startDateBefore == nil, "Upcoming tab should not have startDateBefore filter")
         #expect(capturedFilters?.startDateAfter == "2021-01-01T23:59:59Z", "Upcoming tab should filter after end of day")
+        #expect(capturedFilters?.bookingStatusExclude == [BookingStatus.cancelled.rawValue],
+                "Upcoming tab should exclude cancelled bookings via API")
     }
 
     @Test func all_tab_passes_no_date_filters_to_booking_action() {
@@ -385,6 +389,7 @@ class BookingListViewModelTests {
         // Then
         #expect(capturedFilters?.startDateBefore == nil, "All tab should not have startDateBefore filter")
         #expect(capturedFilters?.startDateAfter == nil, "All tab should not have startDateAfter filter")
+        #expect(capturedFilters?.bookingStatusExclude == [], "All tab should not exclude any booking statuses")
     }
 
     // MARK: - Cache clearing logic
@@ -818,6 +823,8 @@ class BookingListViewModelTests {
         // Tab date constraints should still be applied
         #expect(capturedFilters?.startDateAfter == "2020-12-31T23:59:59Z")
         #expect(capturedFilters?.startDateBefore == "2021-01-02T00:00:00Z")
+        // Tab status exclusion should be preserved after merging user filters
+        #expect(capturedFilters?.bookingStatusExclude == [BookingStatus.cancelled.rawValue])
     }
 
     @Test func clearing_filters_on_today_tab_resets_to_tab_date_constraints() {
@@ -858,6 +865,7 @@ class BookingListViewModelTests {
         #expect(capturedFilters?.productIDs == [])
         #expect(capturedFilters?.attendanceStatuses == [])
         #expect(capturedFilters?.customerIDs == [])
+        #expect(capturedFilters?.bookingStatusExclude == [BookingStatus.cancelled.rawValue])
     }
 
     // MARK: - Sort order

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
@@ -561,6 +561,101 @@ class BookingListViewModelTests {
         #expect(viewModel.bookings.first?.siteID == sampleSiteID, "Booking should have the correct site ID")
     }
 
+    // MARK: - Cancelled booking filtering
+
+    @Test func today_tab_excludes_cancelled_bookings() {
+        // Given
+        let testDate = Date(timeIntervalSince1970: 1609459200) // 2021-01-01 00:00:00 UTC
+        let confirmedBooking = createBooking(id: 1, startDate: testDate, status: .confirmed)
+        let cancelledBooking = createBooking(id: 2, startDate: testDate, status: .cancelled)
+        let paidBooking = createBooking(id: 3, startDate: testDate, status: .paid)
+
+        insertBookings([confirmedBooking, cancelledBooking, paidBooking])
+
+        let viewModel = BookingListViewModel(siteID: sampleSiteID,
+                                             type: .today,
+                                             stores: MockStoresManager(sessionManager: .testingInstance),
+                                             storage: storageManager,
+                                             currentDate: testDate)
+
+        // Then
+        let bookingIDs = Set(viewModel.bookings.map { $0.bookingID })
+        #expect(bookingIDs.contains(confirmedBooking.bookingID))
+        #expect(!bookingIDs.contains(cancelledBooking.bookingID), "Cancelled bookings should be excluded from Today tab")
+        #expect(bookingIDs.contains(paidBooking.bookingID))
+    }
+
+    @Test func upcoming_tab_excludes_cancelled_bookings() {
+        // Given
+        let testDate = Date(timeIntervalSince1970: 1609459200) // 2021-01-01 00:00:00 UTC
+        let futureDate = testDate.addingTimeInterval(86400 * 2) // 2 days later
+        let confirmedBooking = createBooking(id: 1, startDate: futureDate, status: .confirmed)
+        let cancelledBooking = createBooking(id: 2, startDate: futureDate, status: .cancelled)
+
+        insertBookings([confirmedBooking, cancelledBooking])
+
+        let viewModel = BookingListViewModel(siteID: sampleSiteID,
+                                             type: .upcoming,
+                                             stores: MockStoresManager(sessionManager: .testingInstance),
+                                             storage: storageManager,
+                                             currentDate: testDate)
+
+        // Then
+        let bookingIDs = Set(viewModel.bookings.map { $0.bookingID })
+        #expect(bookingIDs.contains(confirmedBooking.bookingID))
+        #expect(!bookingIDs.contains(cancelledBooking.bookingID), "Cancelled bookings should be excluded from Upcoming tab")
+    }
+
+    @Test func all_tab_includes_cancelled_bookings() {
+        // Given
+        let testDate = Date(timeIntervalSince1970: 1609459200) // 2021-01-01 00:00:00 UTC
+        let confirmedBooking = createBooking(id: 1, startDate: testDate, status: .confirmed)
+        let cancelledBooking = createBooking(id: 2, startDate: testDate, status: .cancelled)
+
+        insertBookings([confirmedBooking, cancelledBooking])
+
+        let viewModel = BookingListViewModel(siteID: sampleSiteID,
+                                             type: .all,
+                                             stores: MockStoresManager(sessionManager: .testingInstance),
+                                             storage: storageManager,
+                                             currentDate: testDate)
+
+        // Then
+        let bookingIDs = Set(viewModel.bookings.map { $0.bookingID })
+        #expect(bookingIDs.contains(confirmedBooking.bookingID))
+        #expect(bookingIDs.contains(cancelledBooking.bookingID), "Cancelled bookings should be included in All tab")
+    }
+
+    @Test func today_tab_excludes_cancelled_bookings_after_applying_filters() {
+        // Given
+        let testDate = Date(timeIntervalSince1970: 1609459200) // 2021-01-01 00:00:00 UTC
+        let confirmedBooking = createBooking(id: 1, startDate: testDate, status: .confirmed)
+        let cancelledBooking = createBooking(id: 2, startDate: testDate, status: .cancelled)
+
+        insertBookings([confirmedBooking, cancelledBooking])
+
+        let viewModel = BookingListViewModel(siteID: sampleSiteID,
+                                             type: .today,
+                                             stores: MockStoresManager(sessionManager: .testingInstance),
+                                             storage: storageManager,
+                                             currentDate: testDate)
+
+        // When — apply a filter (e.g. team member)
+        let userFilters = BookingFiltersViewModel.Filters(
+            teamMembers: [BookingTeamMemberFilter(resourceID: 0, name: "Any")],
+            products: [],
+            attendanceStatuses: [],
+            customers: [],
+            dateRange: nil,
+            numberOfActiveFilters: 1
+        )
+        viewModel.updateFilters(userFilters)
+
+        // Then — cancelled bookings should still be excluded
+        let bookingIDs = Set(viewModel.bookings.map { $0.bookingID })
+        #expect(!bookingIDs.contains(cancelledBooking.bookingID), "Cancelled bookings should remain excluded after applying filters")
+    }
+
     // MARK: - Filter merging
 
     @Test func today_tab_merges_user_date_filters_with_tab_constraints() {
@@ -901,8 +996,8 @@ private extension BookingListViewModelTests {
         }, completion: {}, on: .main)
     }
 
-    func createBooking(id: Int64, startDate: Date, siteID: Int64? = nil) -> Booking {
-        return Booking.fake().copy(siteID: siteID ?? self.sampleSiteID, bookingID: id, startDate: startDate)
+    func createBooking(id: Int64, startDate: Date, siteID: Int64? = nil, status: BookingStatus = .confirmed) -> Booking {
+        return Booking.fake().copy(siteID: siteID ?? self.sampleSiteID, bookingID: id, startDate: startDate, statusKey: status.rawValue)
     }
 }
 


### PR DESCRIPTION
Closes [WOOMOB-2201](https://linear.app/a8c/issue/WOOMOB-2201)

## Description

Filters cancelled bookings from Today and Upcoming tabs so they only appear on the All tab.

**Changes**
- `BookingFilters` gains a `bookingStatusExclude` field, sent as `booking_status_exclude` API parameter
- `BookingListTab.remoteFilters` includes the exclude for today/upcoming tabs, preserved through `mergingDates` when user-applied filters are merged
- Core Data predicate (`createBookingPredicate`) also applies the exclude locally for consistency
- `currentPredicate` computed property in `BookingListViewModel` is the single source of truth for predicate construction
- `startDateBefore`/`startDateAfter` are now private to `BookingListTab`

## Test Steps

Prerequiste:
Creata booking for today and upcoming as well.

1. Log in to a CIAB store 
2. Navigate to Bookings
3. On `Today` and `Upcoming` tabs that the bookings appear.
4. Cancel the booking on the `Today` tab and verify that after reloading, the booking disappears.
5. Cancel the booking on the `Upcoming` tab and verify that after reloading, the booking disappears.
7. On the **All** tab, verify cancelled bookings are still shown

## Screenshots
| Today | Upcoming | All |
| --- | --- | --- |
| ![Simulator Screen Recording - iPhone 16 - 2026-02-12 at 09 30 53](https://github.com/user-attachments/assets/003099b0-d7f5-4942-9e8a-59d91b54dbd7) | ![Simulator Screen Recording - iPhone 16 - 2026-02-12 at 09 26 43](https://github.com/user-attachments/assets/36c2ad69-fe4b-458b-a892-db48532c4767) |  <img  height="600" alt="image" src="https://github.com/user-attachments/assets/fc3da19f-a398-4650-a4c3-b314207dd0ea" /> |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
