### PR TITLE
[Bookings] Show cancelled bookings in all tab

### DIFF
--- a/WooCommerce/Classes/Bookings/BookingBadgeView.swift
+++ b/WooCommerce/Classes/Bookings/BookingBadgeView.swift
@@ -4,14 +4,17 @@ import enum Yosemite.BookingStatus
 
 struct BookingBadgeView: View {
     let text: String
+    let textColor: Color
     let color: Color
 
     var body: some View {
         BadgeView(text: text,
-                  customizations: .init(textColor: Color(UIColor.label.resolvedColor(with: .init(userInterfaceStyle: .light))),
-                                        backgroundColor: color,
-                                        bordered: false,
-                                        bold: false),
+                  customizations: .init(
+                    textColor: textColor,
+                    backgroundColor: color,
+                    bordered: false,
+                    bold: false
+                  ),
                   backgroundShape: .roundedRectangle(cornerRadius: Layout.cornerRadius))
     }
 }
@@ -24,12 +27,13 @@ private extension BookingBadgeView {
 
 protocol BookingBadgeable {
     var text: String { get }
+    var textColor: Color { get }
     var badgeColor: Color { get }
 }
 
 extension BookingBadgeView {
     init(_ badgeable: BookingBadgeable) {
-        self.init(text: badgeable.text, color: badgeable.badgeColor)
+        self.init(text: badgeable.text, textColor: badgeable.textColor, color: badgeable.badgeColor)
     }
 }
 
@@ -46,11 +50,17 @@ extension BookingAttendanceStatus: BookingBadgeable {
     var text: String {
         self.localizedTitle
     }
+
+    var textColor: Color {
+        BadgeColor.defaultText
+    }
 }
 
 extension BookingStatus: BookingBadgeable {
     var badgeColor: Color {
         switch self {
+        case .cancelled:
+            return BadgeColor.cancelledBackground
         case .unpaid:
             return BadgeColor.info
         default:
@@ -61,9 +71,21 @@ extension BookingStatus: BookingBadgeable {
     var text: String {
         self.localizedTitle
     }
+
+    var textColor: Color {
+        switch self {
+        case .cancelled:
+            return BadgeColor.cancelledText
+        default:
+            return BadgeColor.defaultText
+        }
+    }
 }
 
 fileprivate enum BadgeColor {
     static let `default` = Color(uiColor: .systemGray6.resolvedColor(with: .init(userInterfaceStyle: .light)))
     static let info = try! Color(rgbString: "rgba(255, 227, 101, 1)")
+    static let cancelledBackground = try! Color(rgbString: "rgba(225, 236, 248, 1)")
+    static let cancelledText = try! Color(rgbString: "rgba(0, 23, 88, 1)")
+    static let defaultText = Color(UIColor.label.resolvedColor(with: .init(userInterfaceStyle: .light)))
 }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListView.swift
@@ -182,7 +182,7 @@ private extension BookingListView {
             }
 
             HStack {
-                BookingBadgeView(booking.attendanceStatus)
+                BookingBadgeView(booking.bookingItemHeaderStatusBadge)
                 Spacer()
             }
         }

--- a/WooCommerce/Classes/Bookings/BookingList/BookingStatus+Helpers.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingStatus+Helpers.swift
@@ -25,7 +25,7 @@ extension BookingStatus {
         case .cancelled:
             NSLocalizedString(
                 "bookingStatus.title.canceled",
-                value: "Cancelled",
+                value: "Canceled",
                 comment: "Status of a canceled booking"
             )
         case .pendingConfirmation:

--- a/WooCommerce/Classes/Extensions/Booking+View.swift
+++ b/WooCommerce/Classes/Extensions/Booking+View.swift
@@ -1,0 +1,11 @@
+import Foundation
+import struct Yosemite.Booking
+
+extension Booking {
+    var bookingItemHeaderStatusBadge: BookingBadgeable {
+        if bookingStatus == .cancelled {
+            return bookingStatus
+        }
+        return attendanceStatus
+    }
+}

--- a/WooCommerce/Classes/ViewModels/Booking Details/HeaderContent.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/HeaderContent.swift
@@ -9,9 +9,9 @@ import enum Yosemite.BookingStatus
 extension BookingDetailsViewModel {
     final class HeaderContent: ObservableObject {
         @Published private(set) var bookingDate: String = ""
-        @Published private(set) var attendanceStatus: BookingAttendanceStatus = .unknown
         @Published private(set) var serviceLine: String = ""
         @Published private(set) var customerLine: String = ""
+        @Published private(set) var statusBadge: BookingBadgeable = BookingStatus.unknown
 
         func update(with booking: Booking) {
             bookingDate = booking.startDate.toString(
@@ -21,7 +21,7 @@ extension BookingDetailsViewModel {
             )
             serviceLine = booking.productName ?? ""
             customerLine = booking.customerName
-            attendanceStatus = booking.attendanceStatus
+            statusBadge = booking.bookingItemHeaderStatusBadge
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/HeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/HeaderView.swift
@@ -21,9 +21,7 @@ extension BookingDetailsView {
                         .font(.body)
                         .foregroundColor(.secondary)
                 }
-                HStack {
-                    BookingBadgeView(content.attendanceStatus)
-                }
+                BookingBadgeView(content.statusBadge)
                 .padding(.top, Layout.headerBadgesAdditionalTopPadding)
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -2309,7 +2309,7 @@ which should be translated separately and considered part of this sentence. */
 "bookingsTabViewHostingController.tab.title" = "Bookings";
 
 /* Status of a canceled booking */
-"bookingStatus.title.canceled" = "Cancelled";
+"bookingStatus.title.canceled" = "Canceled";
 
 /* Status of a complete booking */
 "bookingStatus.title.complete" = "Complete";

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -386,6 +386,7 @@
 		26F94E26267A559300DB6CCF /* ProductAddOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F94E25267A559300DB6CCF /* ProductAddOn.swift */; };
 		26F94E2E267A96A000DB6CCF /* ProductAddOnViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F94E2D267A96A000DB6CCF /* ProductAddOnViewModel.swift */; };
 		26FE09DD24D9F3F600B9BDF5 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09DC24D9F3F600B9BDF5 /* LoadingView.swift */; };
+		2D49A8242F3CB63100F7445A /* Booking+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D49A8232F3CB62B00F7445A /* Booking+View.swift */; };
 		2D5389262F27BF59006A6618 /* PushNotificationRegistrationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D5389252F27BF59006A6618 /* PushNotificationRegistrationStateTests.swift */; };
 		2D880B492DFB2F3F00A6FB2C /* OptionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D880B482DFB2F3D00A6FB2C /* OptionalBinding.swift */; };
 		2D88C1112DF883C300A6FB2C /* AttributedString+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D88C1102DF883BD00A6FB2C /* AttributedString+Helpers.swift */; };
@@ -1599,6 +1600,7 @@
 		26F94E25267A559300DB6CCF /* ProductAddOn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAddOn.swift; sourceTree = "<group>"; };
 		26F94E2D267A96A000DB6CCF /* ProductAddOnViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAddOnViewModel.swift; sourceTree = "<group>"; };
 		26FE09DC24D9F3F600B9BDF5 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
+		2D49A8232F3CB62B00F7445A /* Booking+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Booking+View.swift"; sourceTree = "<group>"; };
 		2D5389252F27BF59006A6618 /* PushNotificationRegistrationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationRegistrationStateTests.swift; sourceTree = "<group>"; };
 		2D880B482DFB2F3D00A6FB2C /* OptionalBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalBinding.swift; sourceTree = "<group>"; };
 		2D88C1102DF883BD00A6FB2C /* AttributedString+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Helpers.swift"; sourceTree = "<group>"; };
@@ -4715,6 +4717,7 @@
 		CE1CCB4C20572444000EE3AC /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				2D49A8232F3CB62B00F7445A /* Booking+View.swift */,
 				DE4C23B82EA09AFA0079240D /* Booking+Helpers.swift */,
 				02A239732E811A690067AB38 /* SiteAddress+ServiceLocator.swift */,
 				010F7D8C2E7A8447002B02EA /* ProductImageThumbnail+Extensions.swift */,
@@ -6362,6 +6365,7 @@
 				450C2CB024CF006A00D570DD /* ProductTagsDataSource.swift in Sources */,
 				45F627B8253603AE00894B86 /* ProductDownloadSettingsViewController.swift in Sources */,
 				02162729237965E8000208D2 /* ProductFormTableViewModel.swift in Sources */,
+				2D49A8242F3CB63100F7445A /* Booking+View.swift in Sources */,
 				CE2A9FBF23BFB1BE002BEC1C /* LedgerTableViewCell.swift in Sources */,
 				B5A56BF0219F2CE90065A902 /* VerticalButton.swift in Sources */,
 				204C9C742B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
@@ -357,7 +357,8 @@ final class BookingDetailsViewModelTests: XCTestCase {
             XCTFail("Header section not found")
             return
         }
-        XCTAssertEqual(headerContent.attendanceStatus.localizedTitle, "Checked-in")
+        let badgeStatus = headerContent.statusBadge as? BookingAttendanceStatus
+        XCTAssertEqual(badgeStatus?.localizedTitle, "Checked-in")
     }
 
     func test_init_whenBookingHasAttendanceStatus_updatesAttendanceContentWithCorrectLocalizedString() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingViewTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingViewTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class BookingViewTests: XCTestCase {
+    func test_bookingItemHeaderStatusBadge_returnsBookingStatusWhenCancelled() {
+        let booking = Booking.fake().copy(
+            statusKey: "cancelled",
+            attendanceStatusKey: "booked"
+        )
+
+        let badge = booking.bookingItemHeaderStatusBadge
+
+        XCTAssertEqual(badge as? BookingStatus, .cancelled)
+    }
+
+    func test_bookingItemHeaderStatusBadge_returnsAttendanceStatusWhenNotCancelled() {
+        let booking = Booking.fake().copy(
+            statusKey: "paid",
+            attendanceStatusKey: "no-show"
+        )
+
+        let badge = booking.bookingItemHeaderStatusBadge
+
+        XCTAssertEqual(badge as? BookingAttendanceStatus, .noShow)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-2175

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds a dedicated “Canceled” badge for bookings in both the list and detail header, using the requested info color palette and consistent copy. The badge selection now centralizes around booking status so cancelled entries are visually distinguished while other bookings keep the attendance badge.

- Displays "Canceled" booking badge both in list and details screens.
- Updated `BookingBadgeView` to support per-badge text color and added canceled badge colors (`#E1ECF8` bg, `#001758` text)  
- Updated English localization for the canceled label to “Canceled”  
- Added unit tests to cover badge selection logic (`BookingViewTests`)

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
- Use CIAB store
- Find canceled bookings or create and cancel one
- Locate that canceled booking in booking list
- Make sure the "Canceled" badge is displayed
- Navigate to the booking details
- Make sure the header displays same "Canceled" badge 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before | After
--- | ---
<img width="568" height="183" alt="Screenshot 2026-02-12 at 16 32 06" src="https://github.com/user-attachments/assets/b8deb540-eb98-4568-9ff5-236a3c49e995" /> | <img width="569" height="182" alt="Screenshot 2026-02-12 at 16 32 47" src="https://github.com/user-attachments/assets/76145e3f-f61f-415b-845c-7e4c006be2a0" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
