### PR TITLE
POS Bookings: Attendance

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -6,6 +6,7 @@ import struct Yosemite.POSBooking
 import class Yosemite.AsyncPaginationTracker
 import enum Yosemite.POSBookingServiceError
 import protocol Yosemite.POSBookingServiceProtocol
+import enum Yosemite.BookingAttendanceStatus
 
 protocol POSBookingListControllerProtocol {
     var bookingsViewState: POSBookingListState { get }
@@ -15,6 +16,7 @@ protocol POSBookingListControllerProtocol {
     func loadNextBookings() async
     func selectBooking(_ booking: POSBooking?)
     func cancelBooking(bookingID: Int64) async throws
+    func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws
 }
 
 protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProtocol {
@@ -87,6 +89,12 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     @MainActor
     func cancelBooking(bookingID: Int64) async throws {
         try await bookingService.cancelBooking(bookingID: bookingID)
+        await refreshBookings()
+    }
+
+    @MainActor
+    func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws {
+        try await bookingService.updateAttendanceStatus(bookingID: bookingID, status: status)
         await refreshBookings()
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/BookingsSpec.md
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/BookingsSpec.md
@@ -95,10 +95,11 @@ Note: Duration, location, customer email/phone/billing address, and customer not
 - More visible time range
 
 **Update Attendance Status**
-- "Mark Attended" button — shown when attendance is `unattended`
-- Requires `.posModal()` confirmation dialog before executing
+- Two inline buttons ("Attended" / "Unattended") in the attendance row trailing area
+- Buttons hidden when booking is cancelled
+- On tap: buttons replaced by inline loading indicator (no confirmation modal)
 - On success: badge updates, list row refreshes
-- On failure: error alert with retry
+- On failure: red error text below attendance row ("Failed to update attendance. Try again.")
 
 **Cancel Booking**
 - "Cancel Booking" button — destructive style, shown when `canCancel` (booking status is NOT cancelled/completed)
@@ -624,10 +625,13 @@ func cancelBooking(booking: POSBooking) async throws
 #### M2-B2. Attendance update UI
 **Modify:** `PointOfSale/Presentation/Bookings/POSBookingDetailView.swift`
 
-- Attendance toggle in the detail view (section 5) — switches between "Attended" / "Unattended"
-- Calls `bookingsModel.markAttended(booking:)` or equivalent on toggle
-- On success: badge updates inline, header status badges update, list row updates via `updateBooking()`
-- On failure: error alert with retry, toggle reverts
+- Inline attendance toggle in the detail view (section 5):
+  - Two compact buttons ("Attended" / "Unattended") in the attendance row trailing area
+  - Buttons hidden when booking is cancelled (shows attendance label text instead)
+- On tap: buttons replaced by inline `ProgressView()` loading indicator (no confirmation modal)
+- Calls `bookingsController.updateAttendanceStatus(bookingID:status:)` directly
+- On success: badge updates inline, header status badges update, list row refreshes via `refreshBookings()`
+- On failure: red error text below attendance row ("Failed to update attendance. Try again.")
 
 #### M2-B3. Cancel booking UI
 **Modify:** `PointOfSale/Presentation/Bookings/POSBookingDetailView.swift`
@@ -876,11 +880,14 @@ M3-C1/C2 ── after all above
 ### M2: Attendance Updates
 | Scenario | Expected |
 |----------|----------|
-| Mark attended on already attended booking | Button hidden (not applicable) |
-| Mark attended on cancelled booking | Button hidden |
-| Network failure on mark attended | Error alert with retry |
-| Two people mark attended same booking simultaneously | Last write wins, refresh shows latest |
-| Mark attended booking with no linked order | Allowed (attendance is independent of payment) |
+| Non-cancelled booking | Both "Attended" and "Unattended" buttons shown inline |
+| Cancelled booking | Buttons hidden, attendance label shown instead |
+| Tap attendance button | Buttons replaced by loading spinner |
+| Network failure on update | Red error text below attendance row, buttons restored |
+| Tap button after error | Error clears, spinner shows, retries |
+| Two people update same booking simultaneously | Last write wins, refresh shows latest |
+| Update attendance on booking with no linked order | Allowed (attendance is independent of payment) |
+| Mark attended → then mark unattended | Both directions work, badge toggles |
 
 ### M2: Cancel Booking
 | Scenario | Expected |

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingAttendanceSectionView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingAttendanceSectionView.swift
@@ -7,7 +7,7 @@ struct POSBookingAttendanceSectionView: View {
 
     @Environment(POSBookingsModel.self) private var bookingsModel
 
-    @State private var isUpdatingAttendance = false
+    @State private var optimisticAttendanceStatus: BookingAttendanceStatus?
     @State private var attendanceUpdateError = false
 
     var body: some View {
@@ -19,6 +19,14 @@ struct POSBookingAttendanceSectionView: View {
         }
     }
 
+    private var isUpdatingAttendance: Bool {
+        optimisticAttendanceStatus != nil
+    }
+
+    private var displayedAttendance: POSBookingAttendanceDisplay {
+        POSBookingAttendanceDisplay(attendanceStatus: optimisticAttendanceStatus ?? booking.attendanceStatus)
+    }
+
     @ViewBuilder
     private var sectionContent: some View {
         HStack(alignment: .top) {
@@ -27,21 +35,18 @@ struct POSBookingAttendanceSectionView: View {
                 .foregroundStyle(Color.posOnSurface)
                 .accessibilityAddTraits(.isHeader)
             Spacer()
-            if isUpdatingAttendance {
-                ProgressView()
-                    .frame(maxHeight: .infinity, alignment: .center)
-            } else {
-                HStack(spacing: POSSpacing.small) {
-                    attendanceButton(Localization.attendedPill,
-                                     isSelected: booking.attendanceDisplay == .attended) {
-                        performAttendanceUpdate(targetStatus: .attended)
-                    }
-                    attendanceButton(Localization.unattendedPill,
-                                     isSelected: booking.attendanceDisplay == .unattended) {
-                        performAttendanceUpdate(targetStatus: .unattended)
-                    }
+            HStack(spacing: POSSpacing.small) {
+                attendanceButton(Localization.attendedPill,
+                                 isSelected: displayedAttendance == .attended) {
+                    performAttendanceUpdate(targetStatus: .attended)
+                }
+                attendanceButton(Localization.unattendedPill,
+                                 isSelected: displayedAttendance == .unattended) {
+                    performAttendanceUpdate(targetStatus: .unattended)
                 }
             }
+            .disabled(isUpdatingAttendance)
+            .shimmering(active: isUpdatingAttendance)
         }
     }
 
@@ -62,8 +67,8 @@ struct POSBookingAttendanceSectionView: View {
 
     private func performAttendanceUpdate(targetStatus: BookingAttendanceStatus) {
         guard targetStatus != booking.attendanceStatus else { return }
+        optimisticAttendanceStatus = targetStatus
         attendanceUpdateError = false
-        isUpdatingAttendance = true
         Task { @MainActor in
             do {
                 try await bookingsModel.bookingsController.updateAttendanceStatus(
@@ -73,7 +78,7 @@ struct POSBookingAttendanceSectionView: View {
             } catch {
                 attendanceUpdateError = true
             }
-            isUpdatingAttendance = false
+            optimisticAttendanceStatus = nil
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingAttendanceSectionView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingAttendanceSectionView.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+import struct Yosemite.POSBooking
+import enum Yosemite.BookingAttendanceStatus
+
+struct POSBookingAttendanceSectionView: View {
+    let booking: POSBooking
+
+    @Environment(POSBookingsModel.self) private var bookingsModel
+
+    @State private var isUpdatingAttendance = false
+    @State private var attendanceUpdateError = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: POSSpacing.small) {
+            sectionContent
+                .sectionCard()
+
+            subtitleText
+        }
+    }
+
+    @ViewBuilder
+    private var sectionContent: some View {
+        HStack(alignment: .top) {
+            Text(Localization.attendanceStatusTitle)
+                .font(.posBodyXLargeRegular)
+                .foregroundStyle(Color.posOnSurface)
+                .accessibilityAddTraits(.isHeader)
+            Spacer()
+            if isUpdatingAttendance {
+                ProgressView()
+                    .frame(maxHeight: .infinity, alignment: .center)
+            } else {
+                HStack(spacing: POSSpacing.small) {
+                    attendanceButton(Localization.attendedPill,
+                                     isSelected: booking.attendanceDisplay == .attended) {
+                        performAttendanceUpdate(targetStatus: .attended)
+                    }
+                    attendanceButton(Localization.unattendedPill,
+                                     isSelected: booking.attendanceDisplay == .unattended) {
+                        performAttendanceUpdate(targetStatus: .unattended)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var subtitleText: some View {
+        if attendanceUpdateError {
+            Text(Localization.attendanceUpdateErrorMessage)
+                .font(.posBodySmallRegular())
+                .foregroundStyle(Color.posError)
+                .padding(.horizontal, POSPadding.xSmall)
+        } else {
+            Text(Localization.attendanceSubtitle)
+                .font(.posBodySmallRegular())
+                .foregroundStyle(Color.posOnSurfaceVariantHighest)
+                .padding(.horizontal, POSPadding.xSmall)
+        }
+    }
+
+    private func performAttendanceUpdate(targetStatus: BookingAttendanceStatus) {
+        guard targetStatus != booking.attendanceStatus else { return }
+        attendanceUpdateError = false
+        isUpdatingAttendance = true
+        Task { @MainActor in
+            do {
+                try await bookingsModel.bookingsController.updateAttendanceStatus(
+                    bookingID: booking.id,
+                    status: targetStatus
+                )
+            } catch {
+                attendanceUpdateError = true
+            }
+            isUpdatingAttendance = false
+        }
+    }
+
+    @ViewBuilder
+    private func attendanceButton(_ title: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        if isSelected {
+            Button(title, action: action)
+                .buttonStyle(POSFilledAttendanceButtonStyle())
+                .accessibilityAddTraits(.isSelected)
+        } else {
+            Button(title, action: action)
+                .buttonStyle(POSOutlinedButtonStyle(size: .compact))
+                .accessibilityRemoveTraits(.isSelected)
+        }
+    }
+}
+
+// MARK: - Attendance Button Style
+
+private struct POSFilledAttendanceButtonStyle: ButtonStyle {
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var fillColor: Color {
+        colorScheme == .dark ? .posSecondary : .posPrimaryContainer
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.posBodySmallBold())
+            .padding(.vertical, POSPadding.small)
+            .padding(.horizontal, POSPadding.medium)
+            .foregroundStyle(Color.posOnInverseSurface)
+            .background(fillColor)
+            .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value))
+            .opacity(configuration.isPressed ? 0.7 : 1.0)
+            .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
+    }
+}
+
+// MARK: - Localization
+
+private enum Localization {
+    static let attendanceStatusTitle = NSLocalizedString(
+        "pos.bookingDetailView.attendanceStatusTitle",
+        value: "Attendance status",
+        comment: "Section title for the attendance status in booking details."
+    )
+
+    static let attendedPill = NSLocalizedString(
+        "pos.bookingDetailView.attendedPill",
+        value: "Attended",
+        comment: "Label for the attended pill button in booking attendance section."
+    )
+
+    static let unattendedPill = NSLocalizedString(
+        "pos.bookingDetailView.unattendedPill",
+        value: "Unattended",
+        comment: "Label for the unattended pill button in booking attendance section."
+    )
+
+    static let attendanceSubtitle = NSLocalizedString(
+        "pos.bookingDetailView.attendanceSubtitle",
+        value: "Mark attendance to keep your reports accurate and spot booking trends.",
+        comment: "Subtitle text below the attendance section explaining why marking attendance matters."
+    )
+
+    static let attendanceUpdateErrorMessage = NSLocalizedString(
+        "pos.bookingDetailView.attendanceUpdateError",
+        value: "Failed to update attendance. Please try again.",
+        comment: "Error message shown below attendance section when updating attendance status fails."
+    )
+}

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -279,6 +279,7 @@ struct POSBookingDetailView: View {
             sectionTitleWithAction(title: Localization.attendanceStatusTitle) {
                 if isUpdatingAttendance {
                     ProgressView()
+                        .frame(maxHeight: .infinity, alignment: .center)
                 } else {
                     HStack(spacing: POSSpacing.small) {
                         attendanceButton(Localization.attendedPill,

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -310,6 +310,7 @@ struct POSBookingDetailView: View {
     }
 
     private func performAttendanceUpdate(targetStatus: BookingAttendanceStatus) {
+        guard targetStatus != booking.attendanceStatus else { return }
         attendanceUpdateError = false
         isUpdatingAttendance = true
         Task { @MainActor in

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -446,13 +446,19 @@ extension View {
 // MARK: - Attendance Button Style
 
 private struct POSFilledAttendanceButtonStyle: ButtonStyle {
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var fillColor: Color {
+        colorScheme == .dark ? .posSecondary : .posPrimaryContainer
+    }
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.posBodySmallBold())
             .padding(.vertical, POSPadding.small)
             .padding(.horizontal, POSPadding.medium)
             .foregroundStyle(Color.posOnInverseSurface)
-            .background(Color.posInverseSurface)
+            .background(fillColor)
             .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value))
             .opacity(configuration.isPressed ? 0.7 : 1.0)
             .animation(.easeOut(duration: 0.15), value: configuration.isPressed)

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import struct Yosemite.POSBooking
-import enum Yosemite.BookingAttendanceStatus
 
 struct POSBookingDetailView: View {
     let booking: POSBooking
@@ -16,9 +15,6 @@ struct POSBookingDetailView: View {
     @State private var cancelModalState: CancelBookingModalState?
     @State private var showPaymentView = false
     @State private var paymentModel: POSPaymentModel?
-    @State private var isUpdatingAttendance = false
-    @State private var attendanceUpdateError = false
-
 
     private var actionTintColor: Color {
         colorScheme == .dark ? .posSecondary : .posPrimaryContainer
@@ -86,7 +82,7 @@ struct POSBookingDetailView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: POSSpacing.large) {
                     bookingDetailsSection
-                    attendanceSection
+                    POSBookingAttendanceSectionView(booking: booking)
                     customerSection
                     paymentBreakdownSection
                     bookingNoteSection
@@ -271,61 +267,6 @@ struct POSBookingDetailView: View {
         }
     }
 
-    // MARK: - Attendance Status
-
-    @ViewBuilder
-    private var attendanceSection: some View {
-        VStack(alignment: .leading, spacing: POSSpacing.small) {
-            sectionTitleWithAction(title: Localization.attendanceStatusTitle) {
-                if isUpdatingAttendance {
-                    ProgressView()
-                        .frame(maxHeight: .infinity, alignment: .center)
-                } else {
-                    HStack(spacing: POSSpacing.small) {
-                        attendanceButton(Localization.attendedPill,
-                                         isSelected: booking.attendanceDisplay == .attended) {
-                            performAttendanceUpdate(targetStatus: .attended)
-                        }
-                        attendanceButton(Localization.unattendedPill,
-                                         isSelected: booking.attendanceDisplay == .unattended) {
-                            performAttendanceUpdate(targetStatus: .unattended)
-                        }
-                    }
-                }
-            }
-            .sectionCard()
-
-            if attendanceUpdateError {
-                Text(Localization.attendanceUpdateErrorMessage)
-                    .font(.posBodySmallRegular())
-                    .foregroundStyle(Color.posError)
-                    .padding(.horizontal, POSPadding.xSmall)
-            } else {
-                Text(Localization.attendanceSubtitle)
-                    .font(.posBodySmallRegular())
-                    .foregroundStyle(Color.posOnSurfaceVariantHighest)
-                    .padding(.horizontal, POSPadding.xSmall)
-            }
-        }
-    }
-
-    private func performAttendanceUpdate(targetStatus: BookingAttendanceStatus) {
-        guard targetStatus != booking.attendanceStatus else { return }
-        attendanceUpdateError = false
-        isUpdatingAttendance = true
-        Task { @MainActor in
-            do {
-                try await bookingsModel.bookingsController.updateAttendanceStatus(
-                    bookingID: booking.id,
-                    status: targetStatus
-                )
-            } catch {
-                attendanceUpdateError = true
-            }
-            isUpdatingAttendance = false
-        }
-    }
-
     // MARK: - Payment Breakdown
 
     private var paymentBreakdownSection: some View {
@@ -398,19 +339,6 @@ struct POSBookingDetailView: View {
     }
 
     @ViewBuilder
-    private func attendanceButton(_ title: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
-        if isSelected {
-            Button(title, action: action)
-                .buttonStyle(POSFilledAttendanceButtonStyle())
-                .accessibilityAddTraits(.isSelected)
-        } else {
-            Button(title, action: action)
-                .buttonStyle(POSOutlinedButtonStyle(size: .compact))
-                .accessibilityRemoveTraits(.isSelected)
-        }
-    }
-
-    @ViewBuilder
     private func detailRow(label: String, value: String) -> some View {
         HStack {
             Text(label)
@@ -442,28 +370,6 @@ struct POSBookingSectionCardModifier: ViewModifier {
 extension View {
     func sectionCard() -> some View {
         modifier(POSBookingSectionCardModifier())
-    }
-}
-
-// MARK: - Attendance Button Style
-
-private struct POSFilledAttendanceButtonStyle: ButtonStyle {
-    @Environment(\.colorScheme) private var colorScheme
-
-    private var fillColor: Color {
-        colorScheme == .dark ? .posSecondary : .posPrimaryContainer
-    }
-
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .font(.posBodySmallBold())
-            .padding(.vertical, POSPadding.small)
-            .padding(.horizontal, POSPadding.medium)
-            .foregroundStyle(Color.posOnInverseSurface)
-            .background(fillColor)
-            .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value))
-            .opacity(configuration.isPressed ? 0.7 : 1.0)
-            .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
     }
 }
 
@@ -537,30 +443,6 @@ private enum Localization {
         comment: "Subtitle text below the booking note section explaining the note is private."
     )
 
-    static let attendanceStatusTitle = NSLocalizedString(
-        "pos.bookingDetailView.attendanceStatusTitle",
-        value: "Attendance status",
-        comment: "Section title for the attendance status in booking details."
-    )
-
-    static let attendedPill = NSLocalizedString(
-        "pos.bookingDetailView.attendedPill",
-        value: "Attended",
-        comment: "Label for the attended pill button in booking attendance section."
-    )
-
-    static let unattendedPill = NSLocalizedString(
-        "pos.bookingDetailView.unattendedPill",
-        value: "Unattended",
-        comment: "Label for the unattended pill button in booking attendance section."
-    )
-
-    static let attendanceSubtitle = NSLocalizedString(
-        "pos.bookingDetailView.attendanceSubtitle",
-        value: "Mark attendance to keep your reports accurate and spot booking trends.",
-        comment: "Subtitle text below the attendance section explaining why marking attendance matters."
-    )
-
     static let paymentTitle = NSLocalizedString(
         "pos.bookingDetailView.paymentTitle",
         value: "Payment",
@@ -629,11 +511,6 @@ private enum Localization {
         comment: "Menu action to cancel a booking from the POS booking detail view."
     )
 
-    static let attendanceUpdateErrorMessage = NSLocalizedString(
-        "pos.bookingDetailView.attendanceUpdateError",
-        value: "Failed to update attendance. Please try again.",
-        comment: "Error message shown below attendance section when updating attendance status fails."
-    )
 }
 
 // MARK: - Previews

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import struct Yosemite.POSBooking
+import enum Yosemite.BookingAttendanceStatus
 
 struct POSBookingDetailView: View {
     let booking: POSBooking
@@ -15,6 +16,8 @@ struct POSBookingDetailView: View {
     @State private var cancelModalState: CancelBookingModalState?
     @State private var showPaymentView = false
     @State private var paymentModel: POSPaymentModel?
+    @State private var isUpdatingAttendance = false
+    @State private var attendanceUpdateError = false
 
 
     private var actionTintColor: Color {
@@ -274,23 +277,50 @@ struct POSBookingDetailView: View {
     private var attendanceSection: some View {
         VStack(alignment: .leading, spacing: POSSpacing.small) {
             sectionTitleWithAction(title: Localization.attendanceStatusTitle) {
-                HStack(spacing: POSSpacing.small) {
-                    attendanceButton(Localization.attendedPill,
-                                     isSelected: booking.attendanceDisplay == .attended) {
-                        // TODO: Implement mark attended action
-                    }
-                    attendanceButton(Localization.unattendedPill,
-                                     isSelected: booking.attendanceDisplay == .unattended) {
-                        // TODO: Implement mark unattended action
+                if isUpdatingAttendance {
+                    ProgressView()
+                } else {
+                    HStack(spacing: POSSpacing.small) {
+                        attendanceButton(Localization.attendedPill,
+                                         isSelected: booking.attendanceDisplay == .attended) {
+                            performAttendanceUpdate(targetStatus: .attended)
+                        }
+                        attendanceButton(Localization.unattendedPill,
+                                         isSelected: booking.attendanceDisplay == .unattended) {
+                            performAttendanceUpdate(targetStatus: .unattended)
+                        }
                     }
                 }
             }
             .sectionCard()
 
-            Text(Localization.attendanceSubtitle)
-                .font(.posBodySmallRegular())
-                .foregroundStyle(Color.posOnSurfaceVariantHighest)
-                .padding(.horizontal, POSPadding.xSmall)
+            if attendanceUpdateError {
+                Text(Localization.attendanceUpdateErrorMessage)
+                    .font(.posBodySmallRegular())
+                    .foregroundStyle(Color.posError)
+                    .padding(.horizontal, POSPadding.xSmall)
+            } else {
+                Text(Localization.attendanceSubtitle)
+                    .font(.posBodySmallRegular())
+                    .foregroundStyle(Color.posOnSurfaceVariantHighest)
+                    .padding(.horizontal, POSPadding.xSmall)
+            }
+        }
+    }
+
+    private func performAttendanceUpdate(targetStatus: BookingAttendanceStatus) {
+        attendanceUpdateError = false
+        isUpdatingAttendance = true
+        Task { @MainActor in
+            do {
+                try await bookingsModel.bookingsController.updateAttendanceStatus(
+                    bookingID: booking.id,
+                    status: targetStatus
+                )
+            } catch {
+                attendanceUpdateError = true
+            }
+            isUpdatingAttendance = false
         }
     }
 
@@ -589,6 +619,12 @@ private enum Localization {
         "pos.bookingDetailView.cancelBookingAction",
         value: "Cancel Booking",
         comment: "Menu action to cancel a booking from the POS booking detail view."
+    )
+
+    static let attendanceUpdateErrorMessage = NSLocalizedString(
+        "pos.bookingDetailView.attendanceUpdateError",
+        value: "Failed to update attendance. Please try again.",
+        comment: "Error message shown below attendance section when updating attendance status fails."
     )
 }
 

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -524,6 +524,8 @@ final class POSBookingServicePreview: POSBookingServiceProtocol {
     }
 
     func cancelBooking(bookingID: Int64) async throws {}
+
+    func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws {}
 }
 
 final class POSBookingListFetchStrategyPreview: POSBookingListFetchStrategy {
@@ -712,6 +714,7 @@ final class POSConfigurablePreviewBookingListController: POSSearchingBookingList
     func loadNextBookings() async {}
     func selectBooking(_ booking: POSBooking?) { }
     func cancelBooking(bookingID: Int64) async throws {}
+    func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws {}
     func searchBookings(searchTerm: String) async {}
     func clearSearchBookings() {}
 }

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingService.swift
@@ -92,6 +92,19 @@ public final class POSBookingService: POSBookingServiceProtocol {
             throw POSBookingServiceError.requestFailed
         }
     }
+
+    public func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws {
+        let result = try await bookingsRemote.updateBooking(
+            from: siteID,
+            bookingID: bookingID,
+            attendanceStatus: status,
+            bookingStatus: nil,
+            note: nil
+        )
+        guard result != nil else {
+            throw POSBookingServiceError.requestFailed
+        }
+    }
 }
 
 private extension POSBookingService {

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingServiceProtocol.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingServiceProtocol.swift
@@ -13,4 +13,6 @@ public protocol POSBookingServiceProtocol: Sendable {
                        searchQuery: String?) async throws -> PagedItems<POSBooking>
 
     func cancelBooking(bookingID: Int64) async throws
+
+    func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws
 }

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
@@ -157,6 +157,41 @@ final class POSBookingListControllerTests {
         #expect(sut.bookingsViewState == .loaded(initialBookings, hasMoreItems: true))
     }
 
+    // MARK: - updateAttendanceStatus
+
+    @Test func test_updateAttendanceStatus_calls_service_and_refreshes_bookings() async throws {
+        // Given
+        let bookings = [makeBooking(id: 1)]
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: bookings, hasMorePages: false, totalItems: nil))
+        await sut.loadBookings()
+
+        let mockService = mockFactory.bookingService as! MockPOSBookingService
+
+        // When
+        try await sut.updateAttendanceStatus(bookingID: 1, status: .attended)
+
+        // Then
+        #expect(mockService.updateAttendanceCallCount == 1)
+        #expect(mockService.lastUpdatedAttendanceBookingID == 1)
+        #expect(mockService.lastUpdatedAttendanceStatus == .attended)
+        // Verify bookings were refreshed (loadBookings was called)
+        #expect(sut.bookingsViewState == .loaded(bookings, hasMoreItems: false))
+    }
+
+    @Test func test_updateAttendanceStatus_when_service_throws_then_throws_error() async {
+        // Given
+        let mockService = mockFactory.bookingService as! MockPOSBookingService
+        mockService.updateAttendanceError = NSError(domain: "test", code: 1)
+
+        // When/Then
+        do {
+            try await sut.updateAttendanceStatus(bookingID: 1, status: .attended)
+            Issue.record("Expected error to be thrown")
+        } catch {
+            #expect(mockService.updateAttendanceCallCount == 1)
+        }
+    }
+
     // MARK: - Caching
 
     @Test func test_loadBookings_uses_cached_data_on_reload() async {

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
@@ -5,6 +5,7 @@ import protocol Yosemite.POSBookingListFetchStrategyFactoryProtocol
 import protocol Yosemite.POSBookingListFetchStrategy
 import protocol Yosemite.POSBookingServiceProtocol
 import struct Yosemite.PagedItems
+import enum Yosemite.BookingAttendanceStatus
 
 final class MockPOSBookingListFetchStrategyFactory: POSBookingListFetchStrategyFactoryProtocol {
     var defaultStrategyResult: POSBookingListFetchStrategy = MockPOSBookingListFetchStrategy()
@@ -25,6 +26,10 @@ final class MockPOSBookingService: POSBookingServiceProtocol {
     var cancelBookingError: Error?
     var cancelBookingCallCount = 0
     var lastCancelledBookingID: Int64?
+    var updateAttendanceError: Error?
+    var updateAttendanceCallCount = 0
+    var lastUpdatedAttendanceBookingID: Int64?
+    var lastUpdatedAttendanceStatus: BookingAttendanceStatus?
 
     func fetchBookings(siteID: Int64, pageNumber: Int, pageSize: Int, searchQuery: String?) async throws -> PagedItems<POSBooking> {
         try fetchBookingsResult.get()
@@ -34,6 +39,15 @@ final class MockPOSBookingService: POSBookingServiceProtocol {
         cancelBookingCallCount += 1
         lastCancelledBookingID = bookingID
         if let error = cancelBookingError {
+            throw error
+        }
+    }
+
+    func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws {
+        updateAttendanceCallCount += 1
+        lastUpdatedAttendanceBookingID = bookingID
+        lastUpdatedAttendanceStatus = status
+        if let error = updateAttendanceError {
             throw error
         }
     }


### PR DESCRIPTION
Closes WOOMOB-2151

## Description
This PR adds handling attendance status by toggling in the POS Booking Detail view. Buttons swap to a loading spinner during the update, and show an inline error message on failure.

The labels updates on the Booking lists to the left are still not implemented.

https://github.com/user-attachments/assets/b4037ff3-c5f6-4d48-83c3-146a438de5d1

We might want to hide the row if a booking is cancelled, or at least disable the buttons. Asked here: node-id=154-3093#1632263849-fi-0fzXPGPRTPyjU3ExPLW6To

## Test Steps
- Happy path: 
  - Toggle between Attended and Attended
  - Observe the loading indicator
  - Observe the button is marked as selected upon completion

<img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - CIAB - 2026-02-13 at 13 46 14" src="https://github.com/user-attachments/assets/3314d266-d708-4399-bd5c-e995f99025fe" />

- Unhappy path: Add `throw NSError(domain: "debug", code: 1)` to `POSBookingDetailView` in `performAttendanceUpdate`:
```diff
    private func performAttendanceUpdate(targetStatus: BookingAttendanceStatus) {
        attendanceUpdateError = false
        isUpdatingAttendance = true
        Task { @MainActor in
            do {
+                throw NSError(domain: "debug", code: 1)
                try await bookingsModel.bookingsController.updateAttendanceStatus(
```

<img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - CIAB - 2026-02-13 at 13 51 26" src="https://github.com/user-attachments/assets/7da77acb-52be-4348-91c3-e7709b99e94d" />

