### PR TITLE
POS Bookings: Sorting ascending/descending

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -10,11 +10,13 @@ import protocol Yosemite.POSBookingServiceProtocol
 protocol POSBookingListControllerProtocol {
     var bookingsViewState: POSBookingListState { get }
     var selectedBooking: POSBooking? { get }
+    var currentSortOption: POSBookingSortOption { get }
     func loadBookings() async
     func refreshBookings() async
     func loadNextBookings() async
     func selectBooking(_ booking: POSBooking?)
     func cancelBooking(bookingID: Int64) async throws
+    func updateSortOption(_ option: POSBookingSortOption) async
 }
 
 protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProtocol {
@@ -24,6 +26,7 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
 
 @Observable final class POSBookingListController: POSSearchingBookingListControllerProtocol {
     var bookingsViewState: POSBookingListState
+    private(set) var currentSortOption: POSBookingSortOption = .ascending
     private var strategyPaginationTracker: [String: AsyncPaginationTracker] = [:]
     private var fetchStrategy: POSBookingListFetchStrategy
     private var cachedBookings: [POSBooking] = []
@@ -45,7 +48,7 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         self.bookingsViewState = initialState
         self.bookingListFetchStrategyFactory = bookingListFetchStrategyFactory
         self.bookingService = bookingListFetchStrategyFactory.bookingService
-        self.fetchStrategy = bookingListFetchStrategyFactory.defaultStrategy()
+        self.fetchStrategy = bookingListFetchStrategyFactory.defaultStrategy(order: POSBookingSortOption.ascending.order)
     }
 
     @MainActor
@@ -91,15 +94,24 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     }
 
     @MainActor
+    func updateSortOption(_ option: POSBookingSortOption) async {
+        currentSortOption = option
+        cachedBookings = []
+        fetchStrategy = bookingListFetchStrategyFactory.defaultStrategy(order: option.order)
+        bookingsViewState = .loading([])
+        await loadFirstPage()
+    }
+
+    @MainActor
     func searchBookings(searchTerm: String) async {
-        fetchStrategy = bookingListFetchStrategyFactory.searchStrategy(searchTerm: searchTerm)
+        fetchStrategy = bookingListFetchStrategyFactory.searchStrategy(searchTerm: searchTerm, order: currentSortOption.order)
         bookingsViewState = .loading([])
         await loadFirstPage()
     }
 
     @MainActor
     func clearSearchBookings() {
-        fetchStrategy = bookingListFetchStrategyFactory.defaultStrategy()
+        fetchStrategy = bookingListFetchStrategyFactory.defaultStrategy(order: currentSortOption.order)
         if cachedBookings.isNotEmpty {
             bookingsViewState = .loaded(cachedBookings, hasMoreItems: true)
         } else {

--- a/Modules/Sources/PointOfSale/Models/POSBookingSortOption.swift
+++ b/Modules/Sources/PointOfSale/Models/POSBookingSortOption.swift
@@ -1,0 +1,38 @@
+import Foundation
+import class Networking.BookingsRemote
+
+enum POSBookingSortOption: CaseIterable, Equatable {
+    case ascending
+    case descending
+
+    var order: BookingsRemote.Order {
+        switch self {
+        case .ascending:
+            .ascending
+        case .descending:
+            .descending
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .ascending:
+            Localization.upcomingToOldest
+        case .descending:
+            Localization.oldestToUpcoming
+        }
+    }
+}
+
+private enum Localization {
+    static let upcomingToOldest = NSLocalizedString(
+        "pos.bookingSortOption.upcomingToOldest",
+        value: "Upcoming to oldest",
+        comment: "Sort option for bookings list — shows soonest upcoming bookings first"
+    )
+    static let oldestToUpcoming = NSLocalizedString(
+        "pos.bookingSortOption.oldestToUpcoming",
+        value: "Oldest to upcoming",
+        comment: "Sort option for bookings list — shows oldest bookings first"
+    )
+}

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDateBarView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDateBarView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 struct POSBookingDateBarView: View {
+    let currentSortOption: POSBookingSortOption
+    let onSortOptionSelected: (POSBookingSortOption) -> Void
+
     @ScaledMetric private var chevronSize: CGFloat = Constants.chevronSize
     @Environment(\.colorScheme) private var colorScheme
 
@@ -32,6 +35,26 @@ struct POSBookingDateBarView: View {
             .buttonStyle(.plain)
 
             Spacer()
+
+            Menu {
+                ForEach(POSBookingSortOption.allCases, id: \.self) { option in
+                    Button {
+                        onSortOptionSelected(option)
+                    } label: {
+                        if option == currentSortOption {
+                            Label(option.title, systemImage: "checkmark")
+                        } else {
+                            Text(option.title)
+                        }
+                    }
+                }
+            } label: {
+                Text(Localization.sortBy)
+                    .font(.posBodyMediumRegular())
+                    .foregroundStyle(tintColor)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(Localization.sortButtonAccessibilityLabel)
         }
         .padding(.horizontal, POSPadding.large)
         .padding(.bottom, POSPadding.large)
@@ -40,4 +63,17 @@ struct POSBookingDateBarView: View {
 
 private enum Constants {
     static let chevronSize: CGFloat = 12
+}
+
+private enum Localization {
+    static let sortBy = NSLocalizedString(
+        "pos.bookingDateBar.sortBy",
+        value: "Sort by",
+        comment: "Label for the sort menu button in the bookings date bar"
+    )
+    static let sortButtonAccessibilityLabel = NSLocalizedString(
+        "pos.bookingDateBar.sortButton.accessibilityLabel",
+        value: "Sort bookings",
+        comment: "Accessibility label for the sort button in the bookings date bar"
+    )
 }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingListView.swift
@@ -72,7 +72,14 @@ struct POSBookingListView: View {
             .animation(.easeInOut(duration: Constants.animationDuration), value: isSearching)
 
             if !isSearching {
-                POSBookingDateBarView()
+                POSBookingDateBarView(
+                    currentSortOption: bookingsModel.bookingsController.currentSortOption,
+                    onSortOptionSelected: { option in
+                        Task { @MainActor in
+                            await bookingsModel.bookingsController.updateSortOption(option)
+                        }
+                    }
+                )
             }
 
             switch (bookingsViewState, isSearching) {

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -38,6 +38,7 @@ import protocol Yosemite.POSBookingServiceProtocol
 import protocol Yosemite.POSBookingListFetchStrategy
 import enum Yosemite.BookingStatus
 import enum Yosemite.BookingAttendanceStatus
+import class Networking.BookingsRemote
 import enum Yosemite.POSCatalogSyncState
 import class Yosemite.POSCatalogSyncStateModel
 import protocol Yosemite.POSCatalogSettingsServiceProtocol
@@ -509,17 +510,17 @@ struct POSPreviewHelpers {
 final class POSBookingListFetchStrategyFactoryPreview: POSBookingListFetchStrategyFactoryProtocol {
     let bookingService: POSBookingServiceProtocol = POSBookingServicePreview()
 
-    func defaultStrategy() -> POSBookingListFetchStrategy {
+    func defaultStrategy(order: BookingsRemote.Order) -> POSBookingListFetchStrategy {
         POSBookingListFetchStrategyPreview()
     }
 
-    func searchStrategy(searchTerm: String) -> POSBookingListFetchStrategy {
+    func searchStrategy(searchTerm: String, order: BookingsRemote.Order) -> POSBookingListFetchStrategy {
         POSBookingListFetchStrategyPreview()
     }
 }
 
 final class POSBookingServicePreview: POSBookingServiceProtocol {
-    func fetchBookings(siteID: Int64, pageNumber: Int, pageSize: Int, searchQuery: String?) async throws -> PagedItems<POSBooking> {
+    func fetchBookings(siteID: Int64, pageNumber: Int, pageSize: Int, searchQuery: String?, order: BookingsRemote.Order) async throws -> PagedItems<POSBooking> {
         PagedItems(items: [], hasMorePages: false, totalItems: nil)
     }
 
@@ -701,6 +702,7 @@ extension POSPreviewHelpers {
 final class POSConfigurablePreviewBookingListController: POSSearchingBookingListControllerProtocol {
     let bookingsViewState: POSBookingListState
     var selectedBooking: POSBooking?
+    var currentSortOption: POSBookingSortOption = .ascending
 
     init(state: POSBookingListState) {
         self.bookingsViewState = state
@@ -712,6 +714,7 @@ final class POSConfigurablePreviewBookingListController: POSSearchingBookingList
     func loadNextBookings() async {}
     func selectBooking(_ booking: POSBooking?) { }
     func cancelBooking(bookingID: Int64) async throws {}
+    func updateSortOption(_ option: POSBookingSortOption) async {}
     func searchBookings(searchTerm: String) async {}
     func clearSearchBookings() {}
 }

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
@@ -1,5 +1,6 @@
 import Foundation
 import struct NetworkingCore.PagedItems
+import class Networking.BookingsRemote
 
 public protocol POSBookingListFetchStrategy {
     func fetchBookings(pageNumber: Int) async throws -> PagedItems<POSBooking>
@@ -18,12 +19,18 @@ struct POSDefaultBookingListFetchStrategy: POSBookingListFetchStrategy {
     private let bookingService: POSBookingServiceProtocol
     private let siteID: Int64
     private let pageSize: Int
+    private let order: BookingsRemote.Order
     let supportsCaching: Bool = true
     let showsLoadingWithItems: Bool = true
 
-    init(bookingService: POSBookingServiceProtocol, siteID: Int64, pageSize: Int = 25) {
+    var id: String {
+        "POSDefaultBookingListFetchStrategy-\(order.rawValue)"
+    }
+
+    init(bookingService: POSBookingServiceProtocol, siteID: Int64, order: BookingsRemote.Order = .ascending, pageSize: Int = 25) {
         self.bookingService = bookingService
         self.siteID = siteID
+        self.order = order
         self.pageSize = pageSize
     }
 
@@ -32,7 +39,8 @@ struct POSDefaultBookingListFetchStrategy: POSBookingListFetchStrategy {
             siteID: siteID,
             pageNumber: pageNumber,
             pageSize: pageSize,
-            searchQuery: nil
+            searchQuery: nil,
+            order: order
         )
     }
 }
@@ -42,13 +50,19 @@ struct POSSearchBookingListFetchStrategy: POSBookingListFetchStrategy {
     private let siteID: Int64
     private let searchTerm: String
     private let pageSize: Int
+    private let order: BookingsRemote.Order
     let supportsCaching: Bool = false
     let showsLoadingWithItems: Bool = false
 
-    init(bookingService: POSBookingServiceProtocol, siteID: Int64, searchTerm: String, pageSize: Int = 25) {
+    var id: String {
+        "POSSearchBookingListFetchStrategy-\(order.rawValue)"
+    }
+
+    init(bookingService: POSBookingServiceProtocol, siteID: Int64, searchTerm: String, order: BookingsRemote.Order = .ascending, pageSize: Int = 25) {
         self.bookingService = bookingService
         self.siteID = siteID
         self.searchTerm = searchTerm
+        self.order = order
         self.pageSize = pageSize
     }
 
@@ -57,7 +71,8 @@ struct POSSearchBookingListFetchStrategy: POSBookingListFetchStrategy {
             siteID: siteID,
             pageNumber: pageNumber,
             pageSize: pageSize,
-            searchQuery: searchTerm
+            searchQuery: searchTerm,
+            order: order
         )
     }
 }

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
@@ -23,10 +23,6 @@ struct POSDefaultBookingListFetchStrategy: POSBookingListFetchStrategy {
     let supportsCaching: Bool = true
     let showsLoadingWithItems: Bool = true
 
-    var id: String {
-        "POSDefaultBookingListFetchStrategy-\(order.rawValue)"
-    }
-
     init(bookingService: POSBookingServiceProtocol, siteID: Int64, order: BookingsRemote.Order = .ascending, pageSize: Int = 25) {
         self.bookingService = bookingService
         self.siteID = siteID
@@ -53,10 +49,6 @@ struct POSSearchBookingListFetchStrategy: POSBookingListFetchStrategy {
     private let order: BookingsRemote.Order
     let supportsCaching: Bool = false
     let showsLoadingWithItems: Bool = false
-
-    var id: String {
-        "POSSearchBookingListFetchStrategy-\(order.rawValue)"
-    }
 
     init(bookingService: POSBookingServiceProtocol, siteID: Int64, searchTerm: String, order: BookingsRemote.Order = .ascending, pageSize: Int = 25) {
         self.bookingService = bookingService

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategyFactory.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategyFactory.swift
@@ -7,8 +7,8 @@ import struct Combine.AnyPublisher
 import struct NetworkingCore.JetpackSite
 
 public protocol POSBookingListFetchStrategyFactoryProtocol {
-    func defaultStrategy() -> POSBookingListFetchStrategy
-    func searchStrategy(searchTerm: String) -> POSBookingListFetchStrategy
+    func defaultStrategy(order: BookingsRemote.Order) -> POSBookingListFetchStrategy
+    func searchStrategy(searchTerm: String, order: BookingsRemote.Order) -> POSBookingListFetchStrategy
     var bookingService: POSBookingServiceProtocol { get }
 }
 
@@ -37,11 +37,11 @@ public final class POSBookingListFetchStrategyFactory: POSBookingListFetchStrate
         )
     }
 
-    public func defaultStrategy() -> POSBookingListFetchStrategy {
-        POSDefaultBookingListFetchStrategy(bookingService: bookingService, siteID: siteID)
+    public func defaultStrategy(order: BookingsRemote.Order) -> POSBookingListFetchStrategy {
+        POSDefaultBookingListFetchStrategy(bookingService: bookingService, siteID: siteID, order: order)
     }
 
-    public func searchStrategy(searchTerm: String) -> POSBookingListFetchStrategy {
-        POSSearchBookingListFetchStrategy(bookingService: bookingService, siteID: siteID, searchTerm: searchTerm)
+    public func searchStrategy(searchTerm: String, order: BookingsRemote.Order) -> POSBookingListFetchStrategy {
+        POSSearchBookingListFetchStrategy(bookingService: bookingService, siteID: siteID, searchTerm: searchTerm, order: order)
     }
 }

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingService.swift
@@ -2,6 +2,7 @@ import Foundation
 import enum Alamofire.AFError
 import struct NetworkingCore.PagedItems
 import struct NetworkingCore.Order
+import class Networking.BookingsRemote
 import protocol Networking.BookingsRemoteProtocol
 import struct Networking.Booking
 import struct Networking.BookingOrderInfo
@@ -32,7 +33,8 @@ public final class POSBookingService: POSBookingServiceProtocol {
     public func fetchBookings(siteID: Int64,
                               pageNumber: Int,
                               pageSize: Int,
-                              searchQuery: String?) async throws -> PagedItems<POSBooking> {
+                              searchQuery: String?,
+                              order: BookingsRemote.Order) async throws -> PagedItems<POSBooking> {
         do {
             let bookings = try await bookingsRemote.loadAllBookings(
                 for: siteID,
@@ -40,7 +42,7 @@ public final class POSBookingService: POSBookingServiceProtocol {
                 pageSize: pageSize,
                 filters: nil,
                 searchQuery: searchQuery,
-                order: .ascending
+                order: order
             )
 
             if pageNumber == 1 {

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingServiceProtocol.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingServiceProtocol.swift
@@ -1,5 +1,6 @@
 import Foundation
 import struct NetworkingCore.PagedItems
+import class Networking.BookingsRemote
 
 public enum POSBookingServiceError: Error, Equatable {
     case requestFailed
@@ -10,7 +11,8 @@ public protocol POSBookingServiceProtocol: Sendable {
     func fetchBookings(siteID: Int64,
                        pageNumber: Int,
                        pageSize: Int,
-                       searchQuery: String?) async throws -> PagedItems<POSBooking>
+                       searchQuery: String?,
+                       order: BookingsRemote.Order) async throws -> PagedItems<POSBooking>
 
     func cancelBooking(bookingID: Int64) async throws
 }

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
@@ -7,6 +7,7 @@ import enum NetworkingCore.OrderStatusEnum
 import struct Yosemite.PagedItems
 import enum Yosemite.BookingStatus
 import enum Yosemite.BookingAttendanceStatus
+import class Networking.BookingsRemote
 
 @MainActor
 final class POSBookingListControllerTests {
@@ -155,6 +156,68 @@ final class POSBookingListControllerTests {
 
         // Then - should restore cached bookings
         #expect(sut.bookingsViewState == .loaded(initialBookings, hasMoreItems: true))
+    }
+
+    // MARK: - Sort
+
+    @Test func test_default_sort_option_is_upcomingToOldest() {
+        // Then
+        #expect(sut.currentSortOption == .ascending)
+    }
+
+    @Test func test_updateSortOption_changes_current_sort_option() async {
+        // When
+        await sut.updateSortOption(.descending)
+
+        // Then
+        #expect(sut.currentSortOption == .descending)
+    }
+
+    @Test func test_updateSortOption_passes_order_to_factory() async {
+        // When
+        await sut.updateSortOption(.descending)
+
+        // Then
+        #expect(mockFactory.lastDefaultStrategyOrder == .descending)
+    }
+
+    @Test func test_updateSortOption_reloads_bookings() async {
+        // Given
+        let bookings = [makeBooking(id: 1)]
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: bookings, hasMorePages: false, totalItems: nil))
+
+        // When
+        await sut.updateSortOption(.descending)
+
+        // Then
+        #expect(sut.bookingsViewState == .loaded(bookings, hasMoreItems: false))
+    }
+
+    @Test func test_searchBookings_passes_current_sort_order_to_factory() async {
+        // Given
+        await sut.updateSortOption(.descending)
+        let searchStrategy = MockPOSBookingListFetchStrategy()
+        searchStrategy.fetchBookingsResult = .success(PagedItems(items: [], hasMorePages: false, totalItems: nil))
+        searchStrategy.supportsCaching = false
+        searchStrategy.id = "SearchStrategy"
+        mockFactory.searchStrategyResult = searchStrategy
+
+        // When
+        await sut.searchBookings(searchTerm: "test")
+
+        // Then
+        #expect(mockFactory.lastSearchStrategyOrder == .descending)
+    }
+
+    @Test func test_clearSearchBookings_passes_current_sort_order_to_factory() async {
+        // Given
+        await sut.updateSortOption(.descending)
+
+        // When
+        sut.clearSearchBookings()
+
+        // Then
+        #expect(mockFactory.lastDefaultStrategyOrder == .descending)
     }
 
     // MARK: - Caching

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
@@ -199,8 +199,6 @@ final class POSBookingListControllerTests {
         let searchStrategy = MockPOSBookingListFetchStrategy()
         searchStrategy.fetchBookingsResult = .success(PagedItems(items: [], hasMorePages: false, totalItems: nil))
         searchStrategy.supportsCaching = false
-        searchStrategy.id = "SearchStrategy"
-        mockFactory.searchStrategyResult = searchStrategy
 
         // When
         await sut.searchBookings(searchTerm: "test")

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
@@ -5,18 +5,24 @@ import protocol Yosemite.POSBookingListFetchStrategyFactoryProtocol
 import protocol Yosemite.POSBookingListFetchStrategy
 import protocol Yosemite.POSBookingServiceProtocol
 import struct Yosemite.PagedItems
+import class Networking.BookingsRemote
 
 final class MockPOSBookingListFetchStrategyFactory: POSBookingListFetchStrategyFactoryProtocol {
     var defaultStrategyResult: POSBookingListFetchStrategy = MockPOSBookingListFetchStrategy()
     var searchStrategyResult: POSBookingListFetchStrategy = MockPOSBookingListFetchStrategy()
     var bookingService: POSBookingServiceProtocol = MockPOSBookingService()
 
-    func defaultStrategy() -> POSBookingListFetchStrategy {
-        defaultStrategyResult
+    var lastDefaultStrategyOrder: BookingsRemote.Order?
+    var lastSearchStrategyOrder: BookingsRemote.Order?
+
+    func defaultStrategy(order: BookingsRemote.Order) -> POSBookingListFetchStrategy {
+        lastDefaultStrategyOrder = order
+        return defaultStrategyResult
     }
 
-    func searchStrategy(searchTerm: String) -> POSBookingListFetchStrategy {
-        searchStrategyResult
+    func searchStrategy(searchTerm: String, order: BookingsRemote.Order) -> POSBookingListFetchStrategy {
+        lastSearchStrategyOrder = order
+        return searchStrategyResult
     }
 }
 
@@ -26,8 +32,11 @@ final class MockPOSBookingService: POSBookingServiceProtocol {
     var cancelBookingCallCount = 0
     var lastCancelledBookingID: Int64?
 
-    func fetchBookings(siteID: Int64, pageNumber: Int, pageSize: Int, searchQuery: String?) async throws -> PagedItems<POSBooking> {
-        try fetchBookingsResult.get()
+    var lastFetchOrder: BookingsRemote.Order?
+
+    func fetchBookings(siteID: Int64, pageNumber: Int, pageSize: Int, searchQuery: String?, order: BookingsRemote.Order) async throws -> PagedItems<POSBooking> {
+        lastFetchOrder = order
+        return try fetchBookingsResult.get()
     }
 
     func cancelBooking(bookingID: Int64) async throws {


### PR DESCRIPTION
Closes WOOMOB-2188

## Description

This PR adds sorting options to the Booking list, specifically `.ascending` and `.descending`. 

There is a 3rd option in the designs as `Recently Added`, but the API does not return the booking creation date or `orderby: date`. The `class-wc-bookings-rest-booking-v2-controller.php` explicitly adds only two custom `orderby` values in `get_collection_params()`:
```
| `start_date` | `_booking_start` meta | Yes — in `prepare_objects_query()` |
| `cost` | `_booking_cost` meta | Yes — in `prepare_objects_query()` |
```

So we can wait for confirmation regarding this item to see if we have to fetch it somehow else (associated order creation date?), or remove it for MLP. Ref: p1770972682638299-slack-C070SJRA8DP

## Test Steps
- Try both ordering options, observe the screen loading and presenting the bookings accordingly.
- I though some of the ordering felt odd, but this seems to be due to the testing data as some might not contain time just date, but we can add a quick debug printing to `POSBookingListController` for confirmation:

```diff
bookingsViewState = allBookings.isEmpty ? .empty : .loaded(allBookings, hasMoreItems: pagedBookings.hasMorePages)

+print("📋 [Sort Debug] option=\(currentSortOption) count=\(allBookings.count)")
+for (index, booking) in allBookings.enumerated() {
+. print("  [\(index)] id=\(booking.id) start=\(booking.startDate) customer=\(booking.customerName) service=\(booking.serviceName)")
+}
```

```
📋 [Sort Debug] option=ascending count=18
  [0] id=73 start=2026-02-06 13:00:00 +0000 customer=nil service=Priority Code Review and Instant Feedback
  [1] id=75 start=2026-02-13 13:00:00 +0000 customer=nil service=Vibe Code Quality Audit Premium
  [2] id=77 start=2026-02-27 09:00:00 +0000 customer=nil service=Priority Code Review and Instant Feedback
  [3] id=79 start=2026-02-06 16:00:00 +0000 customer=nil service=Priority Code Review and Instant Feedback

[...]

 📋 [Sort Debug] option=descending count=18
  [0] id=183 start=2026-02-13 12:00:00 +0000 customer=Optional("Emily Nakamura") service=Vibe Code Quality Audit Premium
  [1] id=176 start=2026-02-13 09:00:00 +0000 customer=Optional("Sarah Mitchell") service=Priority Code Review and Instant Feedback
  [2] id=174 start=2026-02-13 09:00:00 +0000 customer=Optional("Sarah Mitchell") service=Priority Code Review and Instant Feedback
  [3] id=159 start=2026-02-12 14:00:00 +0000 customer=Optional("Emily Nakamura") service=Priority Code Review and Instant Feedback

[...]
```

## Screenshots

<img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - CIAB - 2026-02-13 at 16 04 24" src="https://github.com/user-attachments/assets/e1cfeb8b-d4da-4db8-9b1c-e2a90991ee08" />
