### PR TITLE
Push Notifications: Handle plugin check step

### DIFF
--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
@@ -49,10 +49,19 @@ final class WPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol {
         self.credentials = credentials
         self.stores = stores
         self.jetpackConnectionService = jetpackConnectionService
+        let minimumVersion: String = {
+            #if DEBUG
+            if let override: String = UserDefaults.standard[.debugMinWooVersionForSelfDrivenPushNotifications],
+               !override.isEmpty {
+                return override
+            }
+            #endif
+            return Constants.minimumWooVersion
+        }()
         self.pluginVersionChecker = pluginVersionChecker ?? PluginVersionChecker(
             siteID: siteID,
             pluginPath: Constants.wooPluginPath,
-            minimumVersion: Constants.minimumWooVersion
+            minimumVersion: minimumVersion
         )
     }
 
@@ -185,7 +194,7 @@ private extension WPComConnectionSetupHandler {
                 }
             } catch {
                 DDLogError("⛔️ Plugin version check failed: \(error)")
-                delegate?.stepDidUpdate(.checkPlugin, status: .failure(error: .generic(reason: Localization.ConnectionStep.genericError)))
+                delegate?.stepDidUpdate(.checkPlugin, status: .failure(error: .generic(reason: Localization.PluginCheckStep.genericError)))
             }
         }
     }
@@ -200,6 +209,14 @@ private extension WPComConnectionSetupHandler {
     }
 
     enum Localization {
+        enum PluginCheckStep {
+            static let genericError = NSLocalizedString(
+                "wpcomConnectionSetupHandler.PluginCheckStep.genericError",
+                value: "There was an error checking the version of WooCommerce plugin on your store. " +
+                "Please try again or contact support if this error continues.",
+                comment: "Generic error message when the plugin check step fails during push notification setup"
+            )
+        }
         enum ConnectionStep {
             static let genericError = NSLocalizedString(
                 "wpcomConnectionSetupHandler.ConnectionStep.genericError",

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
@@ -61,9 +61,11 @@ final class WPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol {
         if credentials != nil {
             currentStep = .connect
             startJetpackConnection()
+        } else {
+            /// Step 2: Check plugin version
+            delegate?.stepDidUpdate(.connect, status: .success)
+            startPluginVersionCheck()
         }
-
-        /// Step 2: TODO: Check plugin version
 
         /// Step 3: Enable push notification
         /// TODO: Inject PushNotificationManager to trigger Woo PN registration
@@ -73,7 +75,9 @@ final class WPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol {
         switch currentStep {
         case .connect:
             startJetpackConnection()
-        case .checkPlugin, .enablePush, .none:
+        case .checkPlugin:
+            startPluginVersionCheck()
+        case .enablePush, .none:
             // TODO
             break
         }
@@ -88,7 +92,7 @@ final class WPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol {
             do {
                 let _ = try await jetpackConnectionService.verifyConnection()
                 delegate?.stepDidUpdate(.connect, status: .success)
-                // TODO: continue to next steps
+                startPluginVersionCheck()
             } catch {
                 didFailConnection(with: error)
             }
@@ -97,11 +101,11 @@ final class WPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol {
 
     func didEncounterWebViewError(code: Int?) {
         DDLogError("⛔️ Web view error (code: \(String(describing: code)))")
-        delegate?.stepDidUpdate(.connect, status: .failure(reason: Localization.ConnectionStep.genericError))
+        delegate?.stepDidUpdate(.connect, status: .failure(error: .generic(reason: Localization.ConnectionStep.genericError)))
     }
 
     func didCancelWebView() {
-        delegate?.stepDidUpdate(.connect, status: .failure(reason: Localization.ConnectionStep.canceled))
+        delegate?.stepDidUpdate(.connect, status: .failure(error: .generic(reason: Localization.ConnectionStep.canceled)))
     }
 }
 
@@ -114,6 +118,7 @@ private extension WPComConnectionSetupHandler {
                 let completed = try await checkJetpackConnection(with: credentials)
                 if completed {
                     delegate?.stepDidUpdate(.connect, status: .success)
+                    startPluginVersionCheck()
                 }
                 // When `completed` is false, the web view flow has been triggered
                 // and the flow will resume via didAuthorizeWebViewConnection().
@@ -162,7 +167,27 @@ private extension WPComConnectionSetupHandler {
 
     func didFailConnection(with error: Error) {
         DDLogError("⛔️ WPCom connection fails: \(error)")
-        delegate?.stepDidUpdate(.connect, status: .failure(reason: Localization.ConnectionStep.genericError))
+        delegate?.stepDidUpdate(.connect, status: .failure(error: .generic(reason: Localization.ConnectionStep.genericError)))
+    }
+
+    func startPluginVersionCheck() {
+        currentStep = .checkPlugin
+        Task { @MainActor in
+            do {
+                delegate?.stepDidUpdate(.checkPlugin, status: .running)
+                let result = try await pluginVersionChecker.checkCompatibility()
+                switch result {
+                case .compatible:
+                    delegate?.stepDidUpdate(.checkPlugin, status: .success)
+                    // TODO: continue to step 3
+                case .incompatible(let currentVersion, _):
+                    delegate?.stepDidUpdate(.checkPlugin, status: .failure(error: .outdatedPlugin(version: currentVersion)))
+                }
+            } catch {
+                DDLogError("⛔️ Plugin version check failed: \(error)")
+                delegate?.stepDidUpdate(.checkPlugin, status: .failure(error: .generic(reason: Localization.ConnectionStep.genericError)))
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
@@ -155,7 +155,7 @@ private extension WPComConnectionSetupHandler {
     @MainActor
     func startConnectionWithWebView() {
         let authenticatedWithWPCom = !stores.isAuthenticatedWithoutWPCom
-        Task { @MainActor [weak self] in
+        Task { [weak self] in
             guard let self else { return }
             do {
                 let url = try await jetpackConnectionService.fetchJetpackConnectionURL(authenticatedWithWPCom: authenticatedWithWPCom)
@@ -181,7 +181,7 @@ private extension WPComConnectionSetupHandler {
 
     func startPluginVersionCheck() {
         currentStep = .checkPlugin
-        Task { @MainActor in
+        Task {
             do {
                 delegate?.stepDidUpdate(.checkPlugin, status: .running)
                 let result = try await pluginVersionChecker.checkCompatibility()

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupStep.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupStep.swift
@@ -5,7 +5,12 @@ struct WPComConnectionSetupStep: Identifiable {
         case notStarted
         case running
         case success
-        case failure(reason: String)
+        case failure(error: ErrorType)
+    }
+
+    enum ErrorType: Equatable {
+        case outdatedPlugin(version: String)
+        case generic(reason: String)
     }
 
     let title: String

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupStepView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupStepView.swift
@@ -30,9 +30,18 @@ struct WPComConnectionSetupStepView: View {
         case .success:
             Text(Localization.complete)
                 .foregroundColor(Color(uiColor: .success))
-        case .failure(reason: let reason):
-            Text(reason)
+        case .failure(error: let error):
+            Text(errorMessage(for: error))
                 .foregroundColor(Color(uiColor: .error))
+        }
+    }
+
+    private func errorMessage(for error: WPComConnectionSetupStep.ErrorType) -> String {
+        switch error {
+        case .outdatedPlugin(let version):
+            return String(format: Localization.outdatedPlugin, version)
+        case .generic(let reason):
+            return reason
         }
     }
 }
@@ -71,6 +80,11 @@ private extension WPComConnectionSetupStepView {
             value: "Complete",
             comment: "Status label shown when a setup step has completed successfully."
         )
+        static let outdatedPlugin = NSLocalizedString(
+            "wpComConnectionSetupStepView.outdatedPlugin",
+            value: "Your current WooCommerce plugin version %1$@ needs updating to fully connect your store to WordPress.com.",
+            comment: "Error message when the WooCommerce plugin version is outdated. %@ is the current plugin version."
+        )
     }
 }
 
@@ -81,6 +95,6 @@ private extension WPComConnectionSetupStepView {
         WPComConnectionSetupStepView(step: WPComConnectionSetupStep(title: title, status: .running))
         WPComConnectionSetupStepView(step: WPComConnectionSetupStep(title: title, status: .success))
         WPComConnectionSetupStepView(step: WPComConnectionSetupStep(title: title,
-                                                                          status: .failure(reason: "Plugin version 10.3.4 needs updating")))
+                                                                          status: .failure(error: .outdatedPlugin(version: "10.3.4"))))
     }
 }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
@@ -172,15 +172,19 @@ extension WPComConnectionSetupViewModel: WPComConnectionSetupHandlerDelegate {
     func stepDidUpdate(_ step: SetupStep, status: WPComConnectionSetupStep.Status) {
         updateStep(step, status: status)
 
-        if case .failure(let reason) = status {
-            let checkPluginError: CheckPluginError? = step == .checkPlugin ? checkPluginError(from: reason) : nil
+        if case .failure(let error) = status {
+            let checkPluginError: CheckPluginError? = step == .checkPlugin ? checkPluginError(from: error) : nil
             setupState = .failed(step: step, checkPluginError: checkPluginError)
         }
     }
 
-    private func checkPluginError(from reason: String) -> CheckPluginError {
-        // TODO: Update condition based on actual error identifier from handler
-        reason.contains("outdated") ? .outdated : .other
+    private func checkPluginError(from error: WPComConnectionSetupStep.ErrorType) -> CheckPluginError {
+        switch error {
+        case .outdatedPlugin:
+            return .outdated
+        case .generic:
+            return .other
+        }
     }
 
     func setupDidComplete() {

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -80,6 +80,9 @@ extension UserDefaults {
 
         /// Pending flow for magic link: notification setup or Jetpack setup
         case pendingMagicLinkFlow
+
+        /// Debug override for the minimum WooCommerce plugin version required for WPCom connection setup
+        case debugMinWooVersionForSelfDrivenPushNotifications
     }
 }
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -249,6 +249,7 @@ final class SessionManager: SessionManagerProtocol {
         defaults[.applicationPasswordsExperimentRemoteFFValue] = nil
         defaults[.ciabBookingsTabAvailable] = nil
         defaults[.hideWPComConnectionOnDashboard] = nil
+        defaults[.debugMinWooVersionForSelfDrivenPushNotifications] = nil
         PendingAuthFlowStorage(userDefaults: defaults).clear()
         resetTimestampsValues()
         imageCache.clearCache()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/DebugPanelView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/DebugPanelView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct DebugPanelView: View {
 
+    @State private var minimumWooVersionOverride: String = UserDefaults.standard[.debugMinWooVersionForSelfDrivenPushNotifications] ?? ""
+
     var body: some View {
         List {
             Button {
@@ -18,6 +20,19 @@ struct DebugPanelView: View {
 
             NavigationLink(destination: OverrideFeatureFlagsView()) {
                 Text("Override Feature Flags")
+            }
+
+            VStack(alignment: .leading) {
+                Text("Minimum Woo Version for self-driven push notifications")
+                    .frame(maxWidth: .infinity)
+                TextField("e.g. 10.5.3", text: $minimumWooVersionOverride)
+                    .textFieldStyle(.roundedBorder)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .onChange(of: minimumWooVersionOverride) { _, newValue in
+                        let trimmed = newValue.trimmingCharacters(in: .whitespaces)
+                        UserDefaults.standard[.debugMinWooVersionForSelfDrivenPushNotifications] = trimmed.isEmpty ? nil : trimmed
+                    }
             }
 
             if let site = ServiceLocator.stores.sessionManager.defaultSite {

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerTests.swift
@@ -34,10 +34,9 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
         // When
         handler.start()
-        await delegateSpy.waitForStepUpdate(count: 2)
+        await delegateSpy.waitForStepUpdate(count: 4)
 
         // Then
-        XCTAssertEqual(delegateSpy.stepUpdates.count, 2)
         XCTAssertEqual(delegateSpy.stepUpdates[0].step, .connect)
         XCTAssertEqual(delegateSpy.stepUpdates[0].status, .running)
         XCTAssertEqual(delegateSpy.stepUpdates[1].step, .connect)
@@ -51,10 +50,10 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
         // When
         handler.start()
-        await delegateSpy.waitForStepUpdate(count: 2)
+        await delegateSpy.waitForStepUpdate(count: 4)
 
         // Then
-        XCTAssertEqual(delegateSpy.stepUpdates.count, 2)
+        XCTAssertEqual(delegateSpy.stepUpdates[1].step, .connect)
         XCTAssertEqual(delegateSpy.stepUpdates[1].status, .success)
     }
 
@@ -97,12 +96,11 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
         // When
         handler.start()
-        // Give a moment for any async work to run
-        try await Task.sleep(nanoseconds: 100_000_000)
+        await delegateSpy.waitForStepUpdate(count: 2)
 
         // Then
-        XCTAssertTrue(delegateSpy.stepUpdates.isEmpty)
         XCTAssertEqual(mockConnectionService.evaluateAndConnectCallCount, 0)
+        XCTAssertTrue(delegateSpy.stepUpdates.allSatisfy { $0.step != .connect })
     }
 
     func test_start_with_evaluateAndConnect_failure_marks_connect_step_as_failure() async throws {
@@ -144,11 +142,12 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
         // When
         handler.didAuthorizeWebViewConnection()
-        await delegateSpy.waitForStepUpdate(count: 1)
+        await delegateSpy.waitForStepUpdate(count: 3)
 
         // Then
         XCTAssertEqual(mockConnectionService.verifyConnectionCallCount, 1)
-        XCTAssertEqual(delegateSpy.stepUpdates.first?.status, .success)
+        XCTAssertEqual(delegateSpy.stepUpdates[0].step, .connect)
+        XCTAssertEqual(delegateSpy.stepUpdates[0].status, .success)
     }
 
     func test_didAuthorizeWebViewConnection_on_verification_failure_marks_failure() async throws {
@@ -210,12 +209,115 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
         // When
         handler.retry()
+        await delegateSpy.waitForStepUpdate(count: 4)
+
+        // Then
+        XCTAssertEqual(delegateSpy.stepUpdates[0].step, .connect)
+        XCTAssertEqual(delegateSpy.stepUpdates[0].status, .running)
+        XCTAssertEqual(delegateSpy.stepUpdates[1].step, .connect)
+        XCTAssertEqual(delegateSpy.stepUpdates[1].status, .success)
+    }
+
+    // MARK: - Plugin Version Check Tests
+
+    func test_start_with_connection_success_chains_to_plugin_check_success() async throws {
+        // Given
+        mockConnectionService.evaluateAndConnectResult = .success(.alreadyConnected(email: "test@example.com"))
+        mockPluginVersionChecker.result = .success(.compatible)
+        let handler = makeHandler()
+
+        // When
+        handler.start()
+        await delegateSpy.waitForStepUpdate(count: 4)
+
+        // Then
+        XCTAssertEqual(delegateSpy.stepUpdates[2].step, .checkPlugin)
+        XCTAssertEqual(delegateSpy.stepUpdates[2].status, .running)
+        XCTAssertEqual(delegateSpy.stepUpdates[3].step, .checkPlugin)
+        XCTAssertEqual(delegateSpy.stepUpdates[3].status, .success)
+    }
+
+    func test_start_without_credentials_starts_plugin_check() async throws {
+        // Given
+        mockPluginVersionChecker.result = .success(.compatible)
+        let handler = makeHandler(credentials: .none)
+
+        // When
+        handler.start()
         await delegateSpy.waitForStepUpdate(count: 2)
 
         // Then
-        XCTAssertEqual(delegateSpy.stepUpdates.count, 2)
+        XCTAssertEqual(delegateSpy.stepUpdates[0].step, .checkPlugin)
         XCTAssertEqual(delegateSpy.stepUpdates[0].status, .running)
+        XCTAssertEqual(delegateSpy.stepUpdates[1].step, .checkPlugin)
         XCTAssertEqual(delegateSpy.stepUpdates[1].status, .success)
+    }
+
+    func test_plugin_check_incompatible_marks_step_as_failure_with_outdated_message() async throws {
+        // Given
+        mockPluginVersionChecker.result = .success(.incompatible(currentVersion: "10.3.4", requiredVersion: "10.5.3"))
+        let handler = makeHandler(credentials: .none)
+
+        // When
+        handler.start()
+        await delegateSpy.waitForStepUpdate(count: 2)
+
+        // Then
+        XCTAssertEqual(delegateSpy.stepUpdates[1].step, .checkPlugin)
+        XCTAssertEqual(delegateSpy.stepUpdates[1].status, .failure(error: .outdatedPlugin(version: "10.3.4")))
+    }
+
+    func test_plugin_check_error_marks_step_as_failure_with_generic_error() async throws {
+        // Given
+        mockPluginVersionChecker.result = .failure(NSError(domain: "Test", code: -1))
+        let handler = makeHandler(credentials: .none)
+
+        // When
+        handler.start()
+        await delegateSpy.waitForStepUpdate(count: 2)
+
+        // Then
+        XCTAssertEqual(delegateSpy.stepUpdates[1].step, .checkPlugin)
+        assertFailureStatus(delegateSpy.stepUpdates[1].status)
+    }
+
+    func test_retry_after_plugin_check_failure_restarts_plugin_check() async throws {
+        // Given
+        mockPluginVersionChecker.result = .failure(NSError(domain: "Test", code: -1))
+        let handler = makeHandler(credentials: .none)
+        handler.start()
+        await delegateSpy.waitForStepUpdate(count: 2)
+
+        // Reset for retry
+        mockPluginVersionChecker.result = .success(.compatible)
+        delegateSpy.stepUpdates.removeAll()
+
+        // When
+        handler.retry()
+        await delegateSpy.waitForStepUpdate(count: 2)
+
+        // Then
+        XCTAssertEqual(delegateSpy.stepUpdates[0].step, .checkPlugin)
+        XCTAssertEqual(delegateSpy.stepUpdates[0].status, .running)
+        XCTAssertEqual(delegateSpy.stepUpdates[1].step, .checkPlugin)
+        XCTAssertEqual(delegateSpy.stepUpdates[1].status, .success)
+    }
+
+    func test_didAuthorizeWebViewConnection_success_chains_to_plugin_check() async throws {
+        // Given
+        mockConnectionService.verifyConnectionResult = .success("test@example.com")
+        mockPluginVersionChecker.result = .success(.compatible)
+        let handler = makeHandler()
+
+        // When
+        handler.didAuthorizeWebViewConnection()
+        await delegateSpy.waitForStepUpdate(count: 3)
+
+        // Then
+        XCTAssertEqual(delegateSpy.stepUpdates[1].step, .checkPlugin)
+        XCTAssertEqual(delegateSpy.stepUpdates[1].status, .running)
+        XCTAssertEqual(delegateSpy.stepUpdates[2].step, .checkPlugin)
+        XCTAssertEqual(delegateSpy.stepUpdates[2].status, .success)
     }
 
     // MARK: - Helpers

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerTests.swift
@@ -96,11 +96,11 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
         // When
         handler.start()
-        await delegateSpy.waitForStepUpdate(count: 2)
+        await delegateSpy.waitForStepUpdate(count: 3)
 
         // Then
         XCTAssertEqual(mockConnectionService.evaluateAndConnectCallCount, 0)
-        XCTAssertTrue(delegateSpy.stepUpdates.allSatisfy { $0.step != .connect })
+        XCTAssertFalse(delegateSpy.stepUpdates.contains { $0.step == .connect && $0.status == .running })
     }
 
     func test_start_with_evaluateAndConnect_failure_marks_connect_step_as_failure() async throws {
@@ -244,13 +244,13 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
         // When
         handler.start()
-        await delegateSpy.waitForStepUpdate(count: 2)
+        await delegateSpy.waitForStepUpdate(count: 3)
 
         // Then
-        XCTAssertEqual(delegateSpy.stepUpdates[0].step, .checkPlugin)
-        XCTAssertEqual(delegateSpy.stepUpdates[0].status, .running)
         XCTAssertEqual(delegateSpy.stepUpdates[1].step, .checkPlugin)
-        XCTAssertEqual(delegateSpy.stepUpdates[1].status, .success)
+        XCTAssertEqual(delegateSpy.stepUpdates[1].status, .running)
+        XCTAssertEqual(delegateSpy.stepUpdates[2].step, .checkPlugin)
+        XCTAssertEqual(delegateSpy.stepUpdates[2].status, .success)
     }
 
     func test_plugin_check_incompatible_marks_step_as_failure_with_outdated_message() async throws {
@@ -260,11 +260,11 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
         // When
         handler.start()
-        await delegateSpy.waitForStepUpdate(count: 2)
+        await delegateSpy.waitForStepUpdate(count: 3)
 
         // Then
-        XCTAssertEqual(delegateSpy.stepUpdates[1].step, .checkPlugin)
-        XCTAssertEqual(delegateSpy.stepUpdates[1].status, .failure(error: .outdatedPlugin(version: "10.3.4")))
+        XCTAssertEqual(delegateSpy.stepUpdates[2].step, .checkPlugin)
+        XCTAssertEqual(delegateSpy.stepUpdates[2].status, .failure(error: .outdatedPlugin(version: "10.3.4")))
     }
 
     func test_plugin_check_error_marks_step_as_failure_with_generic_error() async throws {
@@ -274,11 +274,11 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
         // When
         handler.start()
-        await delegateSpy.waitForStepUpdate(count: 2)
+        await delegateSpy.waitForStepUpdate(count: 3)
 
         // Then
-        XCTAssertEqual(delegateSpy.stepUpdates[1].step, .checkPlugin)
-        assertFailureStatus(delegateSpy.stepUpdates[1].status)
+        XCTAssertEqual(delegateSpy.stepUpdates[2].step, .checkPlugin)
+        assertFailureStatus(delegateSpy.stepUpdates[2].status)
     }
 
     func test_retry_after_plugin_check_failure_restarts_plugin_check() async throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModelTests.swift
@@ -57,7 +57,7 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
         let viewModel = makeViewModel()
 
         // When
-        mockHandler.simulateStepUpdate(.connect, status: .failure(reason: "Connection failed"))
+        mockHandler.simulateStepUpdate(.connect, status: .failure(error: .generic(reason: "Connection failed")))
 
         // Then
         XCTAssertEqual(viewModel.primaryButtonTitle, "Try again")
@@ -70,7 +70,7 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
         let viewModel = makeViewModel()
 
         // When
-        mockHandler.simulateStepUpdate(.checkPlugin, status: .failure(reason: "Plugin outdated"))
+        mockHandler.simulateStepUpdate(.checkPlugin, status: .failure(error: .outdatedPlugin(version: "10.3.4")))
 
         // Then
         XCTAssertEqual(viewModel.primaryButtonTitle, "Update plugin")
@@ -84,7 +84,7 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
         let viewModel = makeViewModel()
 
         // When
-        mockHandler.simulateStepUpdate(.checkPlugin, status: .failure(reason: "Network error"))
+        mockHandler.simulateStepUpdate(.checkPlugin, status: .failure(error: .generic(reason: "Network error")))
 
         // Then
         XCTAssertEqual(viewModel.primaryButtonTitle, "Try again")
@@ -122,7 +122,7 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
     func test_primaryButtonTapped_on_plugin_failure_outdated_calls_updatePlugin() {
         // Given
         let viewModel = makeViewModel()
-        mockHandler.simulateStepUpdate(.checkPlugin, status: .failure(reason: "Plugin outdated"))
+        mockHandler.simulateStepUpdate(.checkPlugin, status: .failure(error: .outdatedPlugin(version: "10.3.4")))
 
         // When
         viewModel.primaryButtonTapped()
@@ -134,7 +134,7 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
     func test_primaryButtonTapped_on_plugin_failure_other_retries() {
         // Given
         let viewModel = makeViewModel()
-        mockHandler.simulateStepUpdate(.checkPlugin, status: .failure(reason: "Network error"))
+        mockHandler.simulateStepUpdate(.checkPlugin, status: .failure(error: .generic(reason: "Network error")))
 
         // When
         viewModel.primaryButtonTapped()
@@ -247,8 +247,8 @@ extension WPComConnectionSetupStep.Status: Equatable {
              (.running, .running),
              (.success, .success):
             return true
-        case let (.failure(lhsReason), .failure(rhsReason)):
-            return lhsReason == rhsReason
+        case let (.failure(lhsError), .failure(rhsError)):
+            return lhsError == rhsError
         default:
             return false
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Part of WOOMOB-1928

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the second step for push notification setup: plugin check. A new item in debug panel was also added for easier testing plugin versions. The implementation for updating plugin should be handled separately in WOOMOB-1995.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Ensure that feature flags M1 & M2 for self-driven push notifications are enabled.
2. Log in to a JN site with no support for Woo PN using site credentials.
3. On My Store select the WPCom connection entry point.
4. After the connection step completes, confirm that the plugin check step is started. If your store is already connected to Jetpack, the connection step should be marked as completed.
5. Currently I'm using 10.5.3 for the expected plugin version, but feel free to use the debug panel to set a different version for testing.
6. If the current version of Woo on your store is up-to-date, the plugin check step should complete. Otherwise, verify that you see an error message about outdated version.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/7fe45a74-921c-4f3a-ae0e-5a5b7bb223f7


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
