### PR TITLE
Trigger PN registering after plugin check

### DIFF
--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
@@ -38,13 +38,15 @@ final class WPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol {
     private let stores: StoresManager
     private let jetpackConnectionService: JetpackConnectionServiceProtocol
     private let pluginVersionChecker: PluginVersionCheckerProtocol
+    private let pushNotesManager: PushNotesManager
 
     init(siteID: Int64,
          siteURL: String,
          credentials: Credentials?,
          stores: StoresManager = ServiceLocator.stores,
          jetpackConnectionService: JetpackConnectionServiceProtocol = JetpackConnectionService(),
-         pluginVersionChecker: PluginVersionCheckerProtocol? = nil) {
+         pluginVersionChecker: PluginVersionCheckerProtocol? = nil,
+         pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
         self.siteURL = siteURL
         self.credentials = credentials
         self.stores = stores
@@ -63,6 +65,7 @@ final class WPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol {
             pluginPath: Constants.wooPluginPath,
             minimumVersion: minimumVersion
         )
+        self.pushNotesManager = pushNotesManager
     }
 
     func start() {
@@ -75,9 +78,6 @@ final class WPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol {
             delegate?.stepDidUpdate(.connect, status: .success)
             startPluginVersionCheck()
         }
-
-        /// Step 3: Enable push notification
-        /// TODO: Inject PushNotificationManager to trigger Woo PN registration
     }
 
     func retry() {
@@ -86,9 +86,10 @@ final class WPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol {
             startJetpackConnection()
         case .checkPlugin:
             startPluginVersionCheck()
-        case .enablePush, .none:
-            // TODO
-            break
+        case .enablePush:
+            startPushRegistration()
+        case .none:
+            start()
         }
     }
 
@@ -188,7 +189,7 @@ private extension WPComConnectionSetupHandler {
                 switch result {
                 case .compatible:
                     delegate?.stepDidUpdate(.checkPlugin, status: .success)
-                    // TODO: continue to step 3
+                    startPushRegistration()
                 case .incompatible(let currentVersion, _):
                     delegate?.stepDidUpdate(.checkPlugin, status: .failure(error: .outdatedPlugin(version: currentVersion)))
                 }
@@ -197,6 +198,27 @@ private extension WPComConnectionSetupHandler {
                 delegate?.stepDidUpdate(.checkPlugin, status: .failure(error: .generic(reason: Localization.PluginCheckStep.genericError)))
             }
         }
+    }
+}
+
+private extension WPComConnectionSetupHandler {
+    func startPushRegistration() {
+        currentStep = .enablePush
+        delegate?.stepDidUpdate(.enablePush, status: .running)
+        #if targetEnvironment(simulator)
+        DDLogVerbose("👀 Push Notifications are not supported in the Simulator!")
+        delegate?.stepDidUpdate(.enablePush, status: .success)
+        delegate?.setupDidComplete()
+        #else
+        pushNotesManager.registerForRemoteNotifications()
+        pushNotesManager.ensureAuthorizationIsRequested(includesProvisionalAuth: false) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor in
+                self.delegate?.stepDidUpdate(.enablePush, status: .success)
+                self.delegate?.setupDidComplete()
+            }
+        }
+        #endif
     }
 }
 
@@ -229,5 +251,6 @@ private extension WPComConnectionSetupHandler {
                 comment: "Error message when the connection step is canceled during push notification setup"
             )
         }
+
     }
 }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
@@ -206,19 +206,23 @@ private extension WPComConnectionSetupHandler {
         currentStep = .enablePush
         delegate?.stepDidUpdate(.enablePush, status: .running)
         #if targetEnvironment(simulator)
+        if !isRunningTests {
         DDLogVerbose("👀 Push Notifications are not supported in the Simulator!")
         delegate?.stepDidUpdate(.enablePush, status: .success)
         delegate?.setupDidComplete()
-        #else
-        pushNotesManager.registerForRemoteNotifications()
-        pushNotesManager.ensureAuthorizationIsRequested(includesProvisionalAuth: false) { [weak self] _ in
-            guard let self else { return }
-            Task { @MainActor in
-                self.delegate?.stepDidUpdate(.enablePush, status: .success)
-                self.delegate?.setupDidComplete()
-            }
+        return
         }
         #endif
+        Task { @MainActor in
+            do {
+                let _ = try await pushNotesManager.registerDeviceAndWaitForTokenAcceptance()
+                delegate?.stepDidUpdate(.enablePush, status: .success)
+                delegate?.setupDidComplete()
+            } catch {
+                DDLogError("⛔️ Push notification registration failed: \(error)")
+                delegate?.stepDidUpdate(.enablePush, status: .failure(error: .generic(reason: Localization.PushStep.genericError)))
+            }
+        }
     }
 }
 
@@ -237,6 +241,13 @@ private extension WPComConnectionSetupHandler {
                 value: "There was an error checking the version of WooCommerce plugin on your store. " +
                 "Please try again or contact support if this error continues.",
                 comment: "Generic error message when the plugin check step fails during push notification setup"
+            )
+        }
+        enum PushStep {
+            static let genericError = NSLocalizedString(
+                "wpcomConnectionSetupHandler.PushStep.genericError",
+                value: "There was an error enabling push notifications. Please try again or contact support if this error continues.",
+                comment: "Error message when push notification registration fails during setup"
             )
         }
         enum ConnectionStep {

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupStep.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupStep.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct WPComConnectionSetupStep: Identifiable {
-    enum Status {
+    enum Status: Equatable {
         case notStarted
         case running
         case success

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
@@ -147,6 +147,7 @@ final class WPComConnectionSetupViewModel: ObservableObject {
 
     private func retrySetup() {
         setupState = .inProgress
+        updateStep(.enablePush, status: .notStarted)
         handler.retry()
     }
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -117,6 +117,10 @@ final class PushNotificationsManager: PushNotesManager {
     private var selfDrivenPushNotificationEnabled: Bool?
     private var pendingTokenData: Data?
 
+    /// Continuation used by `registerDeviceAndWaitForTokenAcceptance()` to wait for the device token
+    /// delivered asynchronously via `registerDeviceToken(with:)`.
+    private var deviceTokenContinuation: CheckedContinuation<String, Error>?
+
     /// Initializes the PushNotificationsManager.
     ///
     /// - Parameter configuration: PushNotificationsConfiguration Instance that should be used.
@@ -172,6 +176,44 @@ extension PushNotificationsManager {
     func registerForRemoteNotifications() {
         DDLogInfo("📱 Registering for Remote Notifications...")
         configuration.application.registerForRemoteNotifications()
+    }
+
+    /// Registers for remote notifications, requests authorization, waits for the device token,
+    /// and sends it to the push-tokens endpoint.
+    /// - Returns: The token ID on success.
+    /// - Throws: If any step in the registration pipeline fails.
+    @MainActor
+    func registerDeviceAndWaitForTokenAcceptance() async throws -> Int64 {
+        // 1. Register with iOS for remote notifications
+        registerForRemoteNotifications()
+
+        // 2. Request authorization
+        let _ = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            ensureAuthorizationIsRequested(includesProvisionalAuth: false) { granted in
+                continuation.resume(returning: granted)
+            }
+        }
+
+        // 3. Wait for device token from iOS
+        let deviceToken = try await waitForDeviceToken()
+
+        // 4. Send token to endpoint and wait for acceptance
+        return try await withCheckedThrowingContinuation { continuation in
+            registerSelfDrivenPushNotificationFlow(with: deviceToken) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
+    /// Waits for the device token to arrive via `registerDeviceToken(with:)`.
+    /// Returns immediately if a token is already available.
+    private func waitForDeviceToken() async throws -> String {
+        if let existingToken = registrationState.deviceToken {
+            return existingToken
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            deviceTokenContinuation = continuation
+        }
     }
 
 
@@ -260,6 +302,15 @@ extension PushNotificationsManager {
 
         registrationState.applyNewDeviceToken(newToken)
 
+        // Resume any pending continuation waiting for the device token
+        // (from registerDeviceAndWaitForTokenAcceptance). The caller handles
+        // the self-driven registration flow, so we skip the existing path.
+        if let continuation = deviceTokenContinuation {
+            deviceTokenContinuation = nil
+            continuation.resume(returning: newToken)
+            return
+        }
+
         func registerForWPComPushNotifications() {
             // Register in the Dotcom's Infrastructure
             registerDotcomDevice(with: newToken) { (device, error) in
@@ -308,6 +359,14 @@ extension PushNotificationsManager {
     ///
     func registrationDidFail(with error: Error) {
         DDLogError("⛔️ Push Notifications Registration Failure: \(error)")
+
+        // Resume any pending continuation so the awaiting caller gets the error
+        if let continuation = deviceTokenContinuation {
+            deviceTokenContinuation = nil
+            continuation.resume(throwing: error)
+            return
+        }
+
         unregisterForRemoteNotifications {}
     }
 

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -8,12 +8,15 @@ final class WooPushNotificationSetupCoordinator {
     let rootViewController: UIViewController
 
     private let stores: StoresManager
+    private let onSetupCompleted: (() -> Void)?
     private var loginCoordinator: WPComLoginCoordinator?
 
     init(rootViewController: UIViewController,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         onSetupCompleted: (() -> Void)? = nil) {
         self.rootViewController = rootViewController
         self.stores = stores
+        self.onSetupCompleted = onSetupCompleted
         self.loginCoordinator = {
             if stores.sessionManager.defaultSite?.isJetpackConnected == true {
                 return nil // no need to connect WPCom
@@ -90,8 +93,9 @@ private extension WooPushNotificationSetupCoordinator {
             onDismiss: { [weak navigationController] in
                 navigationController?.dismiss(animated: true)
             },
-            onGoToStore: { [weak navigationController] in
+            onGoToStore: { [weak navigationController, onSetupCompleted] in
                 navigationController?.dismiss(animated: true)
+                onSetupCompleted?()
             },
             onUpdatePlugin: {
                 // TODO: Implement plugin update flow in follow-up PR

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -57,6 +57,14 @@ protocol PushNotesManager {
     ///
     func reloadBadgeCount()
 
+    /// Registers for remote notifications, requests authorization, waits for the device token,
+    /// and sends it to the push-tokens endpoint.
+    /// - Note: This must run on the main actor since the registration flow dispatches actions
+    ///   that assert main-thread execution.
+    /// - Returns: The token ID on success.
+    /// - Throws: If any step in the registration pipeline fails.
+    @MainActor func registerDeviceAndWaitForTokenAcceptance() async throws -> Int64
+
     /// Registers the Application for Remote Notifications.
     ///
     func registerForRemoteNotifications()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -371,13 +371,16 @@ private extension DashboardViewHostingController {
     func configureConnectWPComCard() {
         rootView.onConnectWPComSetup = { [weak self] in
             guard let self else { return }
-            let viewModel = WPComPushNotificationsBenefitsViewModel(onDismiss: {
+            let benefitsViewModel = WPComPushNotificationsBenefitsViewModel(onDismiss: {
                 self.dismiss(animated: true)
             })
             let navigationController = WooNavigationController()
             let hostingController = WPComPushNotificationsBenefitsHostingController(
-                viewModel: viewModel,
-                rootViewController: navigationController
+                viewModel: benefitsViewModel,
+                rootViewController: navigationController,
+                onSetupCompleted: {
+                    self.viewModel.hideWPComConnectionSuggestion()
+                }
             )
             navigationController.viewControllers = [hostingController]
             navigationController.modalPresentationStyle = .formSheet

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -7,9 +7,11 @@ import WooFoundation
 final class WPComPushNotificationsBenefitsHostingController: UIHostingController<WPComPushNotificationsBenefitsView> {
 
     init(viewModel: WPComPushNotificationsBenefitsViewModel,
-         rootViewController: UIViewController) {
+         rootViewController: UIViewController,
+         onSetupCompleted: (() -> Void)? = nil) {
         super.init(rootView: WPComPushNotificationsBenefitsView(viewModel: viewModel))
-        let coordinator = WooPushNotificationSetupCoordinator(rootViewController: rootViewController)
+        let coordinator = WooPushNotificationSetupCoordinator(rootViewController: rootViewController,
+                                                              onSetupCompleted: onSetupCompleted)
         viewModel.updateCoordinator(coordinator)
     }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -67,6 +67,7 @@ final class MockPushNotificationsManager: PushNotesManager {
     private(set) var lastIncludesProvisionalAuth: Bool?
     private var authorizationCompletion: ((Bool) -> Void)?
     var onRequestLocalNotificationCalled: (() -> Void)?
+    var registerDeviceAndWaitForTokenAcceptanceResult: Result<Int64, Error> = .success(1)
 
     init(mockedDeviceID: String? = nil,
          siteIDsRegisteredForWooPNs: [Int64] = [],
@@ -87,6 +88,13 @@ final class MockPushNotificationsManager: PushNotesManager {
 
     func reloadBadgeCount() {
 
+    }
+
+    @MainActor
+    func registerDeviceAndWaitForTokenAcceptance() async throws -> Int64 {
+        // Yield to allow MainActor scheduling to settle
+        await Task.yield()
+        return try registerDeviceAndWaitForTokenAcceptanceResult.get()
     }
 
     func registerForRemoteNotifications() {

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -62,6 +62,10 @@ final class MockPushNotificationsManager: PushNotesManager {
     private(set) var triggersForRequestedLocalNotificationsIfNeeded: [UNNotificationTrigger] = []
     private(set) var canceledLocalNotificationScenarios: [[LocalNotification.Scenario]] = []
     private(set) var resetBadgeCountKinds: [Note.Kind] = []
+    private(set) var registerForRemoteNotificationsCallCount = 0
+    private(set) var ensureAuthorizationCallCount = 0
+    private(set) var lastIncludesProvisionalAuth: Bool?
+    private var authorizationCompletion: ((Bool) -> Void)?
     var onRequestLocalNotificationCalled: (() -> Void)?
 
     init(mockedDeviceID: String? = nil,
@@ -86,7 +90,7 @@ final class MockPushNotificationsManager: PushNotesManager {
     }
 
     func registerForRemoteNotifications() {
-
+        registerForRemoteNotificationsCallCount += 1
     }
 
     func unregisterForRemoteNotifications(onCompletion: @escaping () -> Void) {
@@ -94,7 +98,9 @@ final class MockPushNotificationsManager: PushNotesManager {
     }
 
     func ensureAuthorizationIsRequested(includesProvisionalAuth: Bool, onCompletion: ((Bool) -> ())?) {
-
+        ensureAuthorizationCallCount += 1
+        lastIncludesProvisionalAuth = includesProvisionalAuth
+        authorizationCompletion = onCompletion
     }
 
     func registrationDidFail(with error: Error) {
@@ -153,6 +159,12 @@ final class MockPushNotificationsManager: PushNotesManager {
             triggersForRequestedLocalNotifications.removeAll()
             triggersForRequestedLocalNotificationsIfNeeded.removeAll()
         }
+    }
+}
+
+extension MockPushNotificationsManager {
+    func completeAuthorizationRequest(isAllowed: Bool) {
+        authorizationCompletion?(isAllowed)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerTests.swift
@@ -326,26 +326,40 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
     // MARK: - Plugin + Push Registration Tests
 
-    func test_start_with_compatible_plugin_triggers_push_registration() async throws {
+    func test_start_with_compatible_plugin_triggers_push_registration_and_completes_on_success() async throws {
         // Given
         mockPluginVersionChecker.result = .success(.compatible)
+        mockPushNotesManager.registerDeviceAndWaitForTokenAcceptanceResult = .success(1)
         let handler = makeHandler(credentials: .none)
 
         // When
         handler.start()
-        await delegateSpy.waitForStepUpdate(count: 3)
+        await delegateSpy.waitForStepUpdate(count: 5)
 
         // Then
-        XCTAssertTrue(delegateSpy.stepUpdates.contains { $0.step == .checkPlugin })
         XCTAssertTrue(delegateSpy.stepUpdates.contains { $0.step == .enablePush && $0.status == .running })
-
-        // When
-        mockPushNotesManager.completeAuthorizationRequest(isAllowed: true)
-        await delegateSpy.waitForStepUpdate(count: 4)
-
-        // Then
         XCTAssertTrue(delegateSpy.stepUpdates.contains { $0.step == .enablePush && $0.status == .success })
         XCTAssertTrue(delegateSpy.setupCompleteCalled)
+    }
+
+    func test_start_with_compatible_plugin_marks_push_step_as_failure_on_registration_error() async throws {
+        // Given
+        mockPluginVersionChecker.result = .success(.compatible)
+        mockPushNotesManager.registerDeviceAndWaitForTokenAcceptanceResult = .failure(NSError(domain: "Test", code: -1))
+        let handler = makeHandler(credentials: .none)
+
+        // When
+        handler.start()
+
+        // Wait for all steps including the async push registration failure
+        await delegateSpy.waitForStepUpdate(count: 5, timeout: 5.0)
+
+        // Then
+        XCTAssertTrue(delegateSpy.stepUpdates.contains { $0.step == .enablePush && $0.status == .running })
+        let pushUpdates = delegateSpy.stepUpdates.filter { $0.step == .enablePush }
+        XCTAssertEqual(pushUpdates.count, 2, "Expected enablePush.running and enablePush.failure, got: \(pushUpdates.map { $0.status })")
+        assertFailureStatus(pushUpdates.last?.status)
+        XCTAssertFalse(delegateSpy.setupCompleteCalled)
     }
 
     func test_start_with_incompatible_plugin_marks_check_plugin_failure() async throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerTests.swift
@@ -9,18 +9,21 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
     private var mockConnectionService: MockJetpackConnectionService!
     private var mockPluginVersionChecker: MockPluginVersionChecker!
+    private var mockPushNotesManager: MockPushNotificationsManager!
     private var delegateSpy: MockWPComConnectionSetupHandlerDelegate!
 
     override func setUp() {
         super.setUp()
         mockConnectionService = MockJetpackConnectionService()
         mockPluginVersionChecker = MockPluginVersionChecker()
+        mockPushNotesManager = MockPushNotificationsManager()
         delegateSpy = MockWPComConnectionSetupHandlerDelegate()
     }
 
     override func tearDown() {
         mockConnectionService = nil
         mockPluginVersionChecker = nil
+        mockPushNotesManager = nil
         delegateSpy = nil
         super.tearDown()
     }
@@ -37,6 +40,7 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
         await delegateSpy.waitForStepUpdate(count: 4)
 
         // Then
+        XCTAssertGreaterThanOrEqual(delegateSpy.stepUpdates.count, 2)
         XCTAssertEqual(delegateSpy.stepUpdates[0].step, .connect)
         XCTAssertEqual(delegateSpy.stepUpdates[0].status, .running)
         XCTAssertEqual(delegateSpy.stepUpdates[1].step, .connect)
@@ -53,7 +57,7 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
         await delegateSpy.waitForStepUpdate(count: 4)
 
         // Then
-        XCTAssertEqual(delegateSpy.stepUpdates[1].step, .connect)
+        XCTAssertGreaterThanOrEqual(delegateSpy.stepUpdates.count, 2)
         XCTAssertEqual(delegateSpy.stepUpdates[1].status, .success)
     }
 
@@ -113,7 +117,7 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
         await delegateSpy.waitForStepUpdate(count: 2)
 
         // Then
-        XCTAssertEqual(delegateSpy.stepUpdates.count, 2)
+        XCTAssertGreaterThanOrEqual(delegateSpy.stepUpdates.count, 2)
         XCTAssertEqual(delegateSpy.stepUpdates[0].status, .running)
         assertFailureStatus(delegateSpy.stepUpdates[1].status)
     }
@@ -129,7 +133,7 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
         await delegateSpy.waitForStepUpdate(count: 2)
 
         // Then
-        XCTAssertEqual(delegateSpy.stepUpdates.count, 2)
+        XCTAssertGreaterThanOrEqual(delegateSpy.stepUpdates.count, 2)
         assertFailureStatus(delegateSpy.stepUpdates[1].status)
     }
 
@@ -174,7 +178,7 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
         handler.didEncounterWebViewError(code: 404)
 
         // Then
-        XCTAssertEqual(delegateSpy.stepUpdates.count, 1)
+        XCTAssertGreaterThanOrEqual(delegateSpy.stepUpdates.count, 1)
         XCTAssertEqual(delegateSpy.stepUpdates.first?.step, .connect)
         assertFailureStatus(delegateSpy.stepUpdates.first?.status)
     }
@@ -189,7 +193,7 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
         handler.didCancelWebView()
 
         // Then
-        XCTAssertEqual(delegateSpy.stepUpdates.count, 1)
+        XCTAssertGreaterThanOrEqual(delegateSpy.stepUpdates.count, 1)
         XCTAssertEqual(delegateSpy.stepUpdates.first?.step, .connect)
         assertFailureStatus(delegateSpy.stepUpdates.first?.status)
     }
@@ -297,7 +301,7 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
         await delegateSpy.waitForStepUpdate(count: 2)
 
         // Then
-        XCTAssertEqual(delegateSpy.stepUpdates[0].step, .checkPlugin)
+        XCTAssertGreaterThanOrEqual(delegateSpy.stepUpdates.count, 2)
         XCTAssertEqual(delegateSpy.stepUpdates[0].status, .running)
         XCTAssertEqual(delegateSpy.stepUpdates[1].step, .checkPlugin)
         XCTAssertEqual(delegateSpy.stepUpdates[1].status, .success)
@@ -318,6 +322,49 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
         XCTAssertEqual(delegateSpy.stepUpdates[1].status, .running)
         XCTAssertEqual(delegateSpy.stepUpdates[2].step, .checkPlugin)
         XCTAssertEqual(delegateSpy.stepUpdates[2].status, .success)
+    }
+
+    // MARK: - Plugin + Push Registration Tests
+
+    func test_start_with_compatible_plugin_triggers_push_registration() async throws {
+        // Given
+        mockPluginVersionChecker.result = .success(.compatible)
+        let handler = makeHandler(credentials: .none)
+
+        // When
+        handler.start()
+        await delegateSpy.waitForStepUpdate(count: 3)
+
+        // Then
+        XCTAssertTrue(delegateSpy.stepUpdates.contains { $0.step == .checkPlugin })
+        XCTAssertTrue(delegateSpy.stepUpdates.contains { $0.step == .enablePush && $0.status == .running })
+
+        // When
+        mockPushNotesManager.completeAuthorizationRequest(isAllowed: true)
+        await delegateSpy.waitForStepUpdate(count: 4)
+
+        // Then
+        XCTAssertTrue(delegateSpy.stepUpdates.contains { $0.step == .enablePush && $0.status == .success })
+        XCTAssertTrue(delegateSpy.setupCompleteCalled)
+    }
+
+    func test_start_with_incompatible_plugin_marks_check_plugin_failure() async throws {
+        // Given
+        mockPluginVersionChecker.result = .success(.incompatible(currentVersion: "10.5.0", requiredVersion: "10.5.3"))
+        let handler = makeHandler(credentials: .none)
+
+        // When
+        handler.start()
+        await delegateSpy.waitForStepUpdate(count: 2)
+
+        // Then
+        let failureUpdate = delegateSpy.stepUpdates.first { update in
+            if case .failure = update.status {
+                return update.step == .checkPlugin
+            }
+            return false
+        }
+        XCTAssertNotNil(failureUpdate)
     }
 
     // MARK: - Helpers
@@ -346,7 +393,8 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
             credentials: credentials.value,
             stores: MockStoresManager(sessionManager: .makeForTesting()),
             jetpackConnectionService: mockConnectionService,
-            pluginVersionChecker: mockPluginVersionChecker
+            pluginVersionChecker: mockPluginVersionChecker,
+            pushNotesManager: mockPushNotesManager
         )
         handler.delegate = delegateSpy
         return handler


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->
WOOMOB-1932

## Description
The “Enable push notifications” step now only completes when the device token has been accepted by `wc-push-notifications/push-tokens`. This fixes the previous behavior where the step could succeed after OS permission alone, even if token registration failed. The flow now waits for the full APNs → permission → token → backend acceptance pipeline and reports a failure if any part fails.

Changes included:
- Added an async `registerDeviceAndWaitForTokenAcceptance()` entry point to wrap registration + token acceptance.
- Wired `WPComConnectionSetupHandler` to await registration success before marking the step complete.
- Replaced UserDefaults-based banner hiding with a closure-based completion signal.
- Enforced main‑actor execution for the registration flow to avoid dispatcher thread assertions.
- Updated mocks and tests to cover success and failure paths.

## Test Steps (Happy scenario)
- Use a new JN site with Woo but without jetpack.
- Manually install a version of Woo that supports self driven PNs: p91TBi-dyW-p2#comment-14563
- Login to the store with store credentials.
- Enable self-driven push notifications feature flags in the app and restart if needed.
- In the mobile debug panel set the "Minimum woo version for self-driven push notifications lower to the one that's used on site"
- Tap on "Never miss a new order" banner in dashboard
- Proceed with connection flow
- Make sure all steps pass including the "Enable push notifications"
- Make sure the "Go to My Store" button becomes enabled. Tap on it
- Make sure the modal is closed and app dashboard is shown
- Make sure the "Never miss a new order" banner disappeared from dashboard
- Make sure the `Tracked woo_push_token_register_success` analytics event is tracked in console. 

## Test Steps (Error scenario)
- Use a site that doesn't support self-driven PNs. The most recent Woo plugin version should work. Or mock `404` failure for `wc-push-notifications/push-tokens` in Proxyman
- Login to the store with store credentials
- Enable self-driven push notifications feature flags in the app and restart if needed.
- Tap on "Never miss a new order" banner in dashboard
- Proceed with connection flow
- Make sure all steps pass except the "Enable push notifications" and a corresponding error is shown below step item.
- Make sure the "Go to My Store" button is not shown. Make sure "Retry" option is available.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Failure | Success
--- | ---
![IMG_3666](https://github.com/user-attachments/assets/1f7a0a84-53a9-470d-8867-a70120a68900) | ![IMG_3662](https://github.com/user-attachments/assets/b053372d-fb19-4b61-9e92-98798f59fbc5)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.