### PR TITLE
WOOMOB-1993: Check Woo plugin version and display outdated banner

### DIFF
--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
@@ -58,11 +58,11 @@ final class WPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol {
                 return override
             }
             #endif
-            return Constants.minimumWooVersion
+            return WooPluginRequirements.minimumVersion
         }()
         self.pluginVersionChecker = pluginVersionChecker ?? PluginVersionChecker(
             siteID: siteID,
-            pluginPath: Constants.wooPluginPath,
+            pluginPath: WooPluginRequirements.pluginPath,
             minimumVersion: minimumVersion
         )
         self.pushNotesManager = pushNotesManager
@@ -228,8 +228,6 @@ private extension WPComConnectionSetupHandler {
 
 private extension WPComConnectionSetupHandler {
     enum Constants {
-        static let wooPluginPath = "woocommerce/woocommerce.php"
-        static let minimumWooVersion = "10.5.3" // This is for testing
         static let accountConnectionURL = "https://jetpack.wordpress.com/jetpack.authorize"
         static let siteConnectionURLFormat = "%@/wp-admin/admin.php?page=jetpack"
     }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
@@ -98,9 +98,9 @@ final class WPComConnectionSetupViewModel: ObservableObject {
         handler.start()
     }
 
-    func setPluginOutdatedState() {
+    func setPluginOutdatedState(version: String) {
         stepDidUpdate(.connect, status: .success)
-        stepDidUpdate(.checkPlugin, status: .failure(error: .outdatedPlugin(version: "")))
+        stepDidUpdate(.checkPlugin, status: .failure(error: .outdatedPlugin(version: version)))
     }
 
     func primaryButtonTapped() {

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
@@ -94,7 +94,13 @@ final class WPComConnectionSetupViewModel: ObservableObject {
     }
 
     func onAppear() {
+        guard setupState == .inProgress else { return }
         handler.start()
+    }
+
+    func setPluginOutdatedState() {
+        stepDidUpdate(.connect, status: .success)
+        stepDidUpdate(.checkPlugin, status: .failure(error: .outdatedPlugin(version: "")))
     }
 
     func primaryButtonTapped() {

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -49,8 +49,8 @@ final class WooPushNotificationSetupCoordinator {
         }
     }
 
-    func showPluginUpdateSetup() {
-        let navigationController = makeConnectionSetupStack(credentials: nil, pluginOutdated: true)
+    func showPluginUpdateSetup(pluginVersion: String = "") {
+        let navigationController = makeConnectionSetupStack(credentials: nil, pluginOutdatedVersion: pluginVersion)
 
         if let presenter = rootViewController.presentingViewController {
             rootViewController.dismiss(animated: true) {
@@ -90,7 +90,7 @@ private extension WooPushNotificationSetupCoordinator {
 
     /// Creates the connection setup navigation stack with a handler, view model, and hosting controller.
     func makeConnectionSetupStack(credentials: Credentials? = nil,
-                                  pluginOutdated: Bool = false) -> WooNavigationController {
+                                  pluginOutdatedVersion: String? = nil) -> WooNavigationController {
         guard let site = stores.sessionManager.defaultSite else {
             fatalError("❌ No default site found for Woo push notification setup!")
         }
@@ -114,8 +114,8 @@ private extension WooPushNotificationSetupCoordinator {
                 // TODO: Implement plugin update flow in follow-up PR
             }
         )
-        if pluginOutdated {
-            viewModel.setPluginOutdatedState()
+        if let pluginOutdatedVersion {
+            viewModel.setPluginOutdatedState(version: pluginOutdatedVersion)
         }
         let connectionSetupController = WPComConnectionSetupHostingController(viewModel: viewModel, credentials: credentials)
         navigationController.viewControllers = [connectionSetupController]

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -50,7 +50,7 @@ final class WooPushNotificationSetupCoordinator {
     }
 
     func showPluginUpdateSetup() {
-        let (navigationController, _) = makeConnectionSetupStack(credentials: nil, pluginOutdated: true)
+        let navigationController = makeConnectionSetupStack(credentials: nil, pluginOutdated: true)
 
         if let presenter = rootViewController.presentingViewController {
             rootViewController.dismiss(animated: true) {
@@ -89,9 +89,8 @@ private extension WooPushNotificationSetupCoordinator {
     }
 
     /// Creates the connection setup navigation stack with a handler, view model, and hosting controller.
-    /// Returns the navigation controller and the view model for further configuration.
     func makeConnectionSetupStack(credentials: Credentials? = nil,
-                                  pluginOutdated: Bool = false) -> (WooNavigationController, WPComConnectionSetupViewModel) {
+                                  pluginOutdated: Bool = false) -> WooNavigationController {
         guard let site = stores.sessionManager.defaultSite else {
             fatalError("❌ No default site found for Woo push notification setup!")
         }
@@ -120,11 +119,11 @@ private extension WooPushNotificationSetupCoordinator {
         }
         let connectionSetupController = WPComConnectionSetupHostingController(viewModel: viewModel, credentials: credentials)
         navigationController.viewControllers = [connectionSetupController]
-        return (navigationController, viewModel)
+        return navigationController
     }
 
     func showConnectionSetup(with credentials: Credentials? = nil) {
-        let (navigationController, _) = makeConnectionSetupStack(credentials: credentials)
+        let navigationController = makeConnectionSetupStack(credentials: credentials)
 
         // Dismiss current modal (login or benefits) and present connection setup
         if let loginNav = loginCoordinator?.navigationController,

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -112,7 +112,7 @@ private extension WooPushNotificationSetupCoordinator {
                 onSetupCompleted?()
             },
             onUpdatePlugin: {
-                // TODO: Open wp-admin plugins page
+                // TODO: Implement plugin update flow in follow-up PR
             }
         )
         if pluginOutdated {

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -1,4 +1,3 @@
-import SwiftUI
 import UIKit
 import Yosemite
 
@@ -53,24 +52,12 @@ final class WooPushNotificationSetupCoordinator {
     func showPluginUpdateSetup() {
         let (navigationController, _) = makeConnectionSetupStack(credentials: nil, pluginOutdated: true)
 
-        // Dismiss benefits modal, then present setup view, then auto-open web view
-        let presentAndAutoOpen: (UIViewController) -> Void = { [stores] presenter in
-            presenter.present(navigationController, animated: true) {
-                guard let site = stores.sessionManager.defaultSite,
-                      let url = URL(string: site.pluginsURL) else { return }
-                let webView = AuthenticatableWebView(url: url, title: Localization.updateWooCommerce)
-                let webViewController = UIHostingController(rootView: webView)
-                webViewController.modalPresentationStyle = .formSheet
-                navigationController.present(webViewController, animated: true)
-            }
-        }
-
         if let presenter = rootViewController.presentingViewController {
             rootViewController.dismiss(animated: true) {
-                presentAndAutoOpen(presenter)
+                presenter.present(navigationController, animated: true)
             }
         } else {
-            presentAndAutoOpen(rootViewController)
+            rootViewController.present(navigationController, animated: true)
         }
     }
 
@@ -124,12 +111,8 @@ private extension WooPushNotificationSetupCoordinator {
                 navigationController?.dismiss(animated: true)
                 onSetupCompleted?()
             },
-            onUpdatePlugin: { [weak navigationController] in
-                guard let url = URL(string: site.pluginsURL) else { return }
-                let webView = AuthenticatableWebView(url: url, title: Localization.updateWooCommerce)
-                let webViewController = UIHostingController(rootView: webView)
-                webViewController.modalPresentationStyle = .formSheet
-                navigationController?.present(webViewController, animated: true)
+            onUpdatePlugin: {
+                // TODO: Open wp-admin plugins page
             }
         )
         if pluginOutdated {
@@ -173,11 +156,6 @@ private extension WooPushNotificationSetupCoordinator {
             "wooPushNotificationSetupCoordinator.flowTitle",
             value: "Connect to WordPress.com",
             comment: "Title of the self-driven push notification setup flow"
-        )
-        static let updateWooCommerce = NSLocalizedString(
-            "wooPushNotificationSetupCoordinator.updateWooCommerce",
-            value: "Update WooCommerce",
-            comment: "Title of the web view shown when the user taps 'Update plugin' to update WooCommerce"
         )
     }
 }

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import UIKit
 import Yosemite
 
@@ -49,6 +50,30 @@ final class WooPushNotificationSetupCoordinator {
         }
     }
 
+    func showPluginUpdateSetup() {
+        let (navigationController, _) = makeConnectionSetupStack(credentials: nil, pluginOutdated: true)
+
+        // Dismiss benefits modal, then present setup view, then auto-open web view
+        let presentAndAutoOpen: (UIViewController) -> Void = { [stores] presenter in
+            presenter.present(navigationController, animated: true) {
+                guard let site = stores.sessionManager.defaultSite,
+                      let url = URL(string: site.pluginsURL) else { return }
+                let webView = AuthenticatableWebView(url: url, title: Localization.updateWooCommerce)
+                let webViewController = UIHostingController(rootView: webView)
+                webViewController.modalPresentationStyle = .formSheet
+                navigationController.present(webViewController, animated: true)
+            }
+        }
+
+        if let presenter = rootViewController.presentingViewController {
+            rootViewController.dismiss(animated: true) {
+                presentAndAutoOpen(presenter)
+            }
+        } else {
+            presentAndAutoOpen(rootViewController)
+        }
+    }
+
     func handleAuthenticationUrl(_ url: URL, dotcomAuthScheme: String = ApiCredentials.dotcomAuthScheme) -> Bool {
         let expectedPrefix = dotcomAuthScheme + "://" + Constants.magicLinkUrlHostname
         guard url.absoluteString.hasPrefix(expectedPrefix) else {
@@ -76,11 +101,13 @@ private extension WooPushNotificationSetupCoordinator {
         static let magicLinkUrlHostname = "magic-login"
     }
 
-    func showConnectionSetup(with credentials: Credentials? = nil) {
+    /// Creates the connection setup navigation stack with a handler, view model, and hosting controller.
+    /// Returns the navigation controller and the view model for further configuration.
+    func makeConnectionSetupStack(credentials: Credentials? = nil,
+                                  pluginOutdated: Bool = false) -> (WooNavigationController, WPComConnectionSetupViewModel) {
         guard let site = stores.sessionManager.defaultSite else {
             fatalError("❌ No default site found for Woo push notification setup!")
         }
-        let storeName = site.name
         let navigationController = WooNavigationController()
         let handler = WPComConnectionSetupHandler(
             siteID: site.siteID,
@@ -88,7 +115,7 @@ private extension WooPushNotificationSetupCoordinator {
             credentials: credentials
         )
         let viewModel = WPComConnectionSetupViewModel(
-            storeName: storeName,
+            storeName: site.name,
             handler: handler,
             onDismiss: { [weak navigationController] in
                 navigationController?.dismiss(animated: true)
@@ -97,12 +124,24 @@ private extension WooPushNotificationSetupCoordinator {
                 navigationController?.dismiss(animated: true)
                 onSetupCompleted?()
             },
-            onUpdatePlugin: {
-                // TODO: Implement plugin update flow in follow-up PR
+            onUpdatePlugin: { [weak navigationController] in
+                guard let url = URL(string: site.pluginsURL) else { return }
+                let webView = AuthenticatableWebView(url: url, title: Localization.updateWooCommerce)
+                let webViewController = UIHostingController(rootView: webView)
+                webViewController.modalPresentationStyle = .formSheet
+                navigationController?.present(webViewController, animated: true)
             }
         )
+        if pluginOutdated {
+            viewModel.setPluginOutdatedState()
+        }
         let connectionSetupController = WPComConnectionSetupHostingController(viewModel: viewModel, credentials: credentials)
         navigationController.viewControllers = [connectionSetupController]
+        return (navigationController, viewModel)
+    }
+
+    func showConnectionSetup(with credentials: Credentials? = nil) {
+        let (navigationController, _) = makeConnectionSetupStack(credentials: credentials)
 
         // Dismiss current modal (login or benefits) and present connection setup
         if let loginNav = loginCoordinator?.navigationController,
@@ -123,12 +162,22 @@ private extension WooPushNotificationSetupCoordinator {
 
 }
 
+enum WooPluginRequirements {
+    static let pluginPath = "woocommerce/woocommerce.php"
+    static let minimumVersion = "10.5.3" // This is for testing
+}
+
 private extension WooPushNotificationSetupCoordinator {
     enum Localization {
         static let flowTitle = NSLocalizedString(
             "wooPushNotificationSetupCoordinator.flowTitle",
             value: "Connect to WordPress.com",
             comment: "Title of the self-driven push notification setup flow"
+        )
+        static let updateWooCommerce = NSLocalizedString(
+            "wooPushNotificationSetupCoordinator.updateWooCommerce",
+            value: "Update WooCommerce",
+            comment: "Title of the web view shown when the user taps 'Update plugin' to update WooCommerce"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -373,6 +373,7 @@ private extension DashboardViewHostingController {
             guard let self else { return }
             let benefitsViewModel = WPComPushNotificationsBenefitsViewModel(
                 variant: self.viewModel.isWooPluginOutdated ? .pluginUpdate : .connect,
+                pluginVersion: self.viewModel.outdatedPluginVersion,
                 onDismiss: {
                     self.dismiss(animated: true)
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -371,9 +371,12 @@ private extension DashboardViewHostingController {
     func configureConnectWPComCard() {
         rootView.onConnectWPComSetup = { [weak self] in
             guard let self else { return }
-            let benefitsViewModel = WPComPushNotificationsBenefitsViewModel(onDismiss: {
-                self.dismiss(animated: true)
-            })
+            let benefitsViewModel = WPComPushNotificationsBenefitsViewModel(
+                variant: self.viewModel.isWooPluginOutdated ? .pluginUpdate : .connect,
+                onDismiss: {
+                    self.dismiss(animated: true)
+                }
+            )
             let navigationController = WooNavigationController()
             let hostingController = WPComPushNotificationsBenefitsHostingController(
                 viewModel: benefitsViewModel,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -949,6 +949,7 @@ private extension DashboardViewModel {
 
     @MainActor
     func checkWooPluginVersion() async {
+        isWooPluginOutdated = false
         let checker: PluginVersionCheckerProtocol? = pluginVersionChecker ?? {
             guard let site = stores.sessionManager.defaultSite, site.isJetpackConnected else {
                 return nil

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -78,6 +78,7 @@ final class DashboardViewModel: ObservableObject {
     @Published private(set) var shouldSuggestWPComConnection = false
 
     @Published private(set) var isWooPluginOutdated = false
+    private(set) var outdatedPluginVersion: String = ""
 
     @Published private(set) var dismissedWPComConnectionSuggestion = false
 
@@ -950,6 +951,7 @@ private extension DashboardViewModel {
     @MainActor
     func checkWooPluginVersion() async {
         isWooPluginOutdated = false
+        outdatedPluginVersion = ""
         let checker: PluginVersionCheckerProtocol? = pluginVersionChecker ?? {
             guard let site = stores.sessionManager.defaultSite, site.isJetpackConnected else {
                 return nil
@@ -963,8 +965,9 @@ private extension DashboardViewModel {
         guard let checker else { return }
         do {
             let result = try await checker.checkCompatibility()
-            if case .incompatible = result {
+            if case .incompatible(let currentVersion, _) = result {
                 isWooPluginOutdated = true
+                outdatedPluginVersion = currentVersion
             }
         } catch {
             DDLogError("⛔️ Plugin version check failed: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -77,6 +77,8 @@ final class DashboardViewModel: ObservableObject {
 
     @Published private(set) var shouldSuggestWPComConnection = false
 
+    @Published private(set) var isWooPluginOutdated = false
+
     @Published private(set) var dismissedWPComConnectionSuggestion = false
 
     @Published private var hasOrders = false
@@ -104,6 +106,7 @@ final class DashboardViewModel: ObservableObject {
     private let usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter
     private let blazeLocalNotificationScheduler: BlazeLocalNotificationScheduler
     private let tapToPayAwarenessMomentDeterminer: TapToPayAwarenessMomentDetermining
+    private let pluginVersionChecker: PluginVersionCheckerProtocol?
     private let clientSideBannerProvider: ClientSideBannerProvider
 
     private var subscriptions: Set<AnyCancellable> = []
@@ -158,6 +161,7 @@ final class DashboardViewModel: ObservableObject {
          siteIsCIABEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker(),
          localNotificationScheduler: BlazeLocalNotificationScheduler? = nil,
          tapToPayAwarenessMomentDeterminer: TapToPayAwarenessMomentDetermining = TapToPayAwarenessMomentDeterminer(),
+         pluginVersionChecker: PluginVersionCheckerProtocol? = nil,
          clientSideBannerProvider: ClientSideBannerProvider? = nil) {
         self.siteID = siteID
         self.stores = stores
@@ -201,6 +205,7 @@ final class DashboardViewModel: ObservableObject {
         self.blazeLocalNotificationScheduler.observeNotificationUserResponse()
 
         self.tapToPayAwarenessMomentDeterminer = tapToPayAwarenessMomentDeterminer
+        self.pluginVersionChecker = pluginVersionChecker
 
         self.clientSideBannerProvider = clientSideBannerProvider ?? ClientSideBannerProvider(
             stores: stores,
@@ -410,6 +415,7 @@ private extension DashboardViewModel {
             }
             group.addTask { [weak self] in
                 await self?.updateSelfDrivenPushRegistrationStatus()
+                await self?.checkWooPluginVersion()
             }
         }
     }
@@ -518,11 +524,11 @@ private extension DashboardViewModel {
             })
             .store(in: &subscriptions)
 
-        $dashboardCards.combineLatest($isInAppFeedbackCardVisible, $shouldSuggestWPComConnection)
+        $dashboardCards.combineLatest($isInAppFeedbackCardVisible, $shouldSuggestWPComConnection, $isWooPluginOutdated)
             .combineLatest($showNewCardsNotice, $hasOrders, $isReloadingAllData)
             .sink { [weak self] combinedResult in
                 guard let self else { return }
-                let ((cards, showFeedbackCard, suggestWPComConnection), showNewCardsNotice, hasOrders, isReloading) = combinedResult
+                let ((cards, showFeedbackCard, suggestWPComConnection, isWooPluginOutdated), showNewCardsNotice, hasOrders, isReloading) = combinedResult
                 let cardsToShow: [DashboardCard] = {
                     var allCards = cards.filter { $0.availability == .show && $0.enabled }
 
@@ -542,8 +548,8 @@ private extension DashboardViewModel {
                         allCards.append(DashboardCard.shareStoreCard)
                     }
 
-                    /// Insert card for connecting WPCom at the top if needed
-                    if suggestWPComConnection {
+                    /// Insert card for connecting WPCom or updating plugin at the top if needed
+                    if suggestWPComConnection || isWooPluginOutdated {
                         allCards.insert(DashboardCard.connectWPCom, at: 0)
                     }
                     return allCards
@@ -939,6 +945,29 @@ private extension DashboardViewModel {
             stores.isAuthenticatedWithoutWPCom &&
             !dismissedWPComConnectionSuggestion &&
             featureFlagService.isFeatureFlagEnabled(.selfDrivenPushTokenAppPasswords)
+    }
+
+    @MainActor
+    func checkWooPluginVersion() async {
+        let checker: PluginVersionCheckerProtocol? = pluginVersionChecker ?? {
+            guard let site = stores.sessionManager.defaultSite, site.isJetpackConnected else {
+                return nil
+            }
+            return PluginVersionChecker(
+                siteID: site.siteID,
+                pluginPath: WooPluginRequirements.pluginPath,
+                minimumVersion: WooPluginRequirements.minimumVersion
+            )
+        }()
+        guard let checker else { return }
+        do {
+            let result = try await checker.checkCompatibility()
+            if case .incompatible = result {
+                isWooPluginOutdated = true
+            }
+        } catch {
+            DDLogError("⛔️ Plugin version check failed: \(error)")
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -206,7 +206,16 @@ final class DashboardViewModel: ObservableObject {
         self.blazeLocalNotificationScheduler.observeNotificationUserResponse()
 
         self.tapToPayAwarenessMomentDeterminer = tapToPayAwarenessMomentDeterminer
-        self.pluginVersionChecker = pluginVersionChecker
+        self.pluginVersionChecker = pluginVersionChecker ?? {
+            guard let site = stores.sessionManager.defaultSite, site.isJetpackConnected else {
+                return nil
+            }
+            return PluginVersionChecker(
+                siteID: site.siteID,
+                pluginPath: WooPluginRequirements.pluginPath,
+                minimumVersion: WooPluginRequirements.minimumVersion
+            )
+        }()
 
         self.clientSideBannerProvider = clientSideBannerProvider ?? ClientSideBannerProvider(
             stores: stores,
@@ -952,19 +961,9 @@ private extension DashboardViewModel {
     func checkWooPluginVersion() async {
         isWooPluginOutdated = false
         outdatedPluginVersion = ""
-        let checker: PluginVersionCheckerProtocol? = pluginVersionChecker ?? {
-            guard let site = stores.sessionManager.defaultSite, site.isJetpackConnected else {
-                return nil
-            }
-            return PluginVersionChecker(
-                siteID: site.siteID,
-                pluginPath: WooPluginRequirements.pluginPath,
-                minimumVersion: WooPluginRequirements.minimumVersion
-            )
-        }()
-        guard let checker else { return }
+        guard let pluginVersionChecker else { return }
         do {
-            let result = try await checker.checkCompatibility()
+            let result = try await pluginVersionChecker.checkCompatibility()
             if case .incompatible(let currentVersion, _) = result {
                 isWooPluginOutdated = true
                 outdatedPluginVersion = currentVersion

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -96,7 +96,7 @@ struct WPComPushNotificationsBenefitsView: View {
 
     private var footer: some View {
         VStack {
-            Button(Localization.continueButton) {
+            Button(primaryButtonText) {
                 viewModel.continueTapped()
             }
             .buttonStyle(PrimaryButtonStyle())
@@ -105,6 +105,15 @@ struct WPComPushNotificationsBenefitsView: View {
                 viewModel.notNowTapped()
             }
             .buttonStyle(SecondaryButtonStyle())
+        }
+    }
+
+    private var primaryButtonText: String {
+        switch viewModel.variant {
+        case .connect:
+            return Localization.continueButton
+        case .pluginUpdate:
+            return Localization.updatePluginButton
         }
     }
 }
@@ -155,6 +164,12 @@ fileprivate extension WPComPushNotificationsBenefitsView {
             "wpcomPushNotificationsBenefitsView.cancelButton",
             value: "Cancel",
             comment: "Cancel button title in the WordPress.com Push Notifications Benefits View toolbar"
+        )
+
+        static let updatePluginButton = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsView.updatePluginButton",
+            value: "Update plugin",
+            comment: "Button title to update the WooCommerce plugin in the Push Notifications Benefits View"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -10,6 +10,7 @@ final class WPComPushNotificationsBenefitsViewModel {
     }
 
     let variant: Variant
+    let pluginVersion: String
 
     private let analytics: Analytics
     private let onDismiss: () -> Void
@@ -17,9 +18,11 @@ final class WPComPushNotificationsBenefitsViewModel {
     private var pushNotificationSetupCoordinator: WooPushNotificationSetupCoordinator?
 
     init(variant: Variant = .connect,
+         pluginVersion: String = "",
          analytics: Analytics = ServiceLocator.analytics,
          onDismiss: @escaping () -> Void) {
         self.variant = variant
+        self.pluginVersion = pluginVersion
         self.analytics = analytics
         self.onDismiss = onDismiss
     }
@@ -38,7 +41,7 @@ final class WPComPushNotificationsBenefitsViewModel {
         case .connect:
             pushNotificationSetupCoordinator?.start()
         case .pluginUpdate:
-            pushNotificationSetupCoordinator?.showPluginUpdateSetup()
+            pushNotificationSetupCoordinator?.showPluginUpdateSetup(pluginVersion: pluginVersion)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -4,13 +4,22 @@ import protocol WooFoundation.Analytics
 @MainActor
 final class WPComPushNotificationsBenefitsViewModel {
 
+    enum Variant {
+        case connect
+        case pluginUpdate
+    }
+
+    let variant: Variant
+
     private let analytics: Analytics
     private let onDismiss: () -> Void
 
     private var pushNotificationSetupCoordinator: WooPushNotificationSetupCoordinator?
 
-    init(analytics: Analytics = ServiceLocator.analytics,
+    init(variant: Variant = .connect,
+         analytics: Analytics = ServiceLocator.analytics,
          onDismiss: @escaping () -> Void) {
+        self.variant = variant
         self.analytics = analytics
         self.onDismiss = onDismiss
     }
@@ -25,7 +34,12 @@ final class WPComPushNotificationsBenefitsViewModel {
 
     func continueTapped() {
         // TODO: Track continue tapped event
-        pushNotificationSetupCoordinator?.start()
+        switch variant {
+        case .connect:
+            pushNotificationSetupCoordinator?.start()
+        case .pluginUpdate:
+            pushNotificationSetupCoordinator?.showPluginUpdateSetup()
+        }
     }
 
     func notNowTapped() {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -411,6 +411,8 @@
 		31FE28C225E6D338003519F2 /* LearnMoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FE28C125E6D338003519F2 /* LearnMoreTableViewCell.swift */; };
 		31FE28C825E6D384003519F2 /* LearnMoreTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 31FE28C725E6D384003519F2 /* LearnMoreTableViewCell.xib */; };
 		3D94B7D5A94E3515D4B9BB4D /* MockWPComConnectionSetupHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FEE9D30367FFF0ADEE1F5B /* MockWPComConnectionSetupHandler.swift */; };
+		376096A213F453CB50D5C49A /* MockPluginVersionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76FD5EECBE550023F426C08 /* MockPluginVersionChecker.swift */; };
+		1BB4EEB656DB82FA344A8517 /* WPComPushNotificationsBenefitsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C0D9EEE446DD689E751F38 /* WPComPushNotificationsBenefitsViewModelTests.swift */; };
 		3F0904092D26A40800D8ACCE /* WordPressAuthenticator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F0904012D26A40700D8ACCE /* WordPressAuthenticator.framework */; };
 		3F0904142D26A40800D8ACCE /* WordPressAuthenticator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F0904012D26A40700D8ACCE /* WordPressAuthenticator.framework */; };
 		3F0904152D26A40800D8ACCE /* WordPressAuthenticator.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3F0904012D26A40700D8ACCE /* WordPressAuthenticator.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -2312,6 +2314,8 @@
 		EEEA41F12869A5F400AEFC4B /* MockProductImagesProductIDUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductImagesProductIDUpdater.swift; sourceTree = "<group>"; };
 		EEF5C14F2BBAFA5900535C86 /* StoreOnboardingTaskViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreOnboardingTaskViewModelTests.swift; sourceTree = "<group>"; };
 		F1FEE9D30367FFF0ADEE1F5B /* MockWPComConnectionSetupHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MockWPComConnectionSetupHandler.swift; sourceTree = "<group>"; };
+		D76FD5EECBE550023F426C08 /* MockPluginVersionChecker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MockPluginVersionChecker.swift; sourceTree = "<group>"; };
+		02C0D9EEE446DD689E751F38 /* WPComPushNotificationsBenefitsViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WPComPushNotificationsBenefitsViewModelTests.swift; sourceTree = "<group>"; };
 		F997170223DBB97500592D8E /* WooCommerceScreenshots.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WooCommerceScreenshots.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE28F6F3268477C1004465C7 /* RoleEligibilityUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoleEligibilityUseCase.swift; sourceTree = "<group>"; };
 		FE3E427626A8545B00C596CE /* MockRoleEligibilityUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRoleEligibilityUseCase.swift; sourceTree = "<group>"; };
@@ -3143,6 +3147,7 @@
 				028E1F712833E954001F8829 /* DashboardViewModelTests.swift */,
 				027F83EE29B048E2002688C6 /* TopPerformersPeriodViewModelTests.swift */,
 				DEC75CC72BC518D900763801 /* DashboardCustomizationViewModelTests.swift */,
+				02C0D9EEE446DD689E751F38 /* WPComPushNotificationsBenefitsViewModelTests.swift */,
 				DE2004522BF4A37B00660A72 /* InboxDashboardCardViewModelTests.swift */,
 				DE2004632BF744F200660A72 /* ProductStockDashboardCardViewModelTests.swift */,
 				DE74A4552BCFB5890009C415 /* TopPerformers */,
@@ -3995,6 +4000,7 @@
 				EE4C75DE2C86D2F500F9D860 /* BlazeLocalNotificationSchedulerSpy.swift */,
 				CEC3CC792C93537B00B93FBE /* MockShippingSettingsService.swift */,
 				F1FEE9D30367FFF0ADEE1F5B /* MockWPComConnectionSetupHandler.swift */,
+				D76FD5EECBE550023F426C08 /* MockPluginVersionChecker.swift */,
 				5E1A903713867FCD550D32AD /* MockJetpackConnectionService.swift */,
 			);
 			path = Mocks;
@@ -7139,6 +7145,8 @@
 				57F42E40253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift in Sources */,
 				DE0BE0C12F333BC0009CE891 /* NotificationServiceSuppressionTests.swift in Sources */,
 				3D94B7D5A94E3515D4B9BB4D /* MockWPComConnectionSetupHandler.swift in Sources */,
+				376096A213F453CB50D5C49A /* MockPluginVersionChecker.swift in Sources */,
+				1BB4EEB656DB82FA344A8517 /* WPComPushNotificationsBenefitsViewModelTests.swift in Sources */,
 				71E7782632CC7D5213733333 /* MockJetpackConnectionService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WooCommerce/WooCommerceTests/Mocks/MockPluginVersionChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPluginVersionChecker.swift
@@ -1,0 +1,10 @@
+import Foundation
+@testable import WooCommerce
+
+final class MockPluginVersionChecker: PluginVersionCheckerProtocol {
+    var result: Result<PluginVersionResult, Error> = .success(.compatible)
+
+    func checkCompatibility() async throws -> PluginVersionResult {
+        try result.get()
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -1098,6 +1098,93 @@ final class DashboardViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldSuggestWPComConnection)
         XCTAssertTrue(viewModel.dismissedWPComConnectionSuggestion)
     }
+
+    // MARK: - Plugin Version Check Tests
+
+    @MainActor
+    func test_isWooPluginOutdated_is_true_when_checker_returns_incompatible() async {
+        // Given
+        mockReloadingData()
+        let checker = MockPluginVersionChecker()
+        checker.result = .success(.incompatible(currentVersion: "10.0.0", requiredVersion: "10.5.3"))
+
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           userDefaults: userDefaults,
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker,
+                                           pluginVersionChecker: checker)
+
+        // When
+        await viewModel.reloadAllData()
+
+        // Then
+        XCTAssertTrue(viewModel.isWooPluginOutdated)
+    }
+
+    @MainActor
+    func test_isWooPluginOutdated_stays_false_when_checker_returns_compatible() async {
+        // Given
+        mockReloadingData()
+        let checker = MockPluginVersionChecker()
+        checker.result = .success(.compatible)
+
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           userDefaults: userDefaults,
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker,
+                                           pluginVersionChecker: checker)
+
+        // When
+        await viewModel.reloadAllData()
+
+        // Then
+        XCTAssertFalse(viewModel.isWooPluginOutdated)
+    }
+
+    @MainActor
+    func test_isWooPluginOutdated_stays_false_when_checker_throws_error() async {
+        // Given
+        mockReloadingData()
+        let checker = MockPluginVersionChecker()
+        checker.result = .failure(NSError(domain: "test", code: 1))
+
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           userDefaults: userDefaults,
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker,
+                                           pluginVersionChecker: checker)
+
+        // When
+        await viewModel.reloadAllData()
+
+        // Then
+        XCTAssertFalse(viewModel.isWooPluginOutdated)
+    }
+
+    @MainActor
+    func test_isWooPluginOutdated_stays_false_when_no_checker_provided() async {
+        // Given
+        mockReloadingData()
+
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           userDefaults: userDefaults,
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
+
+        // When
+        await viewModel.reloadAllData()
+
+        // Then
+        XCTAssertFalse(viewModel.isWooPluginOutdated)
+    }
 }
 
 private extension DashboardViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/WPComPushNotificationsBenefitsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/WPComPushNotificationsBenefitsViewModelTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import WooCommerce
+
+@MainActor
+final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
+
+    // MARK: - Variant
+
+    func test_default_variant_is_connect() {
+        // Given
+        let viewModel = makeViewModel()
+
+        // Then
+        XCTAssertEqual(viewModel.variant, .connect)
+    }
+
+    func test_variant_is_pluginUpdate_when_passed_in_init() {
+        // Given
+        let viewModel = makeViewModel(variant: .pluginUpdate)
+
+        // Then
+        XCTAssertEqual(viewModel.variant, .pluginUpdate)
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel(variant: WPComPushNotificationsBenefitsViewModel.Variant = .connect) -> WPComPushNotificationsBenefitsViewModel {
+        WPComPushNotificationsBenefitsViewModel(
+            variant: variant,
+            onDismiss: {}
+        )
+    }
+}
+
+// MARK: - WPComPushNotificationsBenefitsViewModel.Variant Equatable
+
+extension WPComPushNotificationsBenefitsViewModel.Variant: Equatable {}

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerTests.swift
@@ -473,13 +473,3 @@ private final class MockWPComConnectionSetupHandlerDelegate: WPComConnectionSetu
         }
     }
 }
-
-// MARK: - Mock Plugin Version Checker
-
-private final class MockPluginVersionChecker: PluginVersionCheckerProtocol {
-    var result: Result<PluginVersionResult, Error> = .success(.compatible)
-
-    func checkCompatibility() async throws -> PluginVersionResult {
-        try result.get()
-    }
-}

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModelTests.swift
@@ -232,11 +232,11 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
         let viewModel = makeViewModel()
 
         // When
-        viewModel.setPluginOutdatedState()
+        viewModel.setPluginOutdatedState(version: "10.4.0")
 
         // Then
         XCTAssertEqual(viewModel.steps[0].status, .success)
-        XCTAssertEqual(viewModel.steps[1].status, .failure(error: .outdatedPlugin(version: "")))
+        XCTAssertEqual(viewModel.steps[1].status, .failure(error: .outdatedPlugin(version: "10.4.0")))
         XCTAssertEqual(viewModel.steps[2].status, .notStarted)
     }
 
@@ -245,7 +245,7 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
         let viewModel = makeViewModel()
 
         // When
-        viewModel.setPluginOutdatedState()
+        viewModel.setPluginOutdatedState(version: "10.4.0")
 
         // Then
         XCTAssertEqual(viewModel.primaryButtonTitle, "Update plugin")
@@ -257,7 +257,7 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
     func test_onAppear_does_not_call_handler_start_after_setPluginOutdatedState() {
         // Given
         let viewModel = makeViewModel()
-        viewModel.setPluginOutdatedState()
+        viewModel.setPluginOutdatedState(version: "10.4.0")
 
         // When
         viewModel.onAppear()

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModelTests.swift
@@ -225,6 +225,58 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
         XCTAssertEqual(mockHandler.didCancelWebViewCallCount, 1)
     }
 
+    // MARK: - setPluginOutdatedState Tests
+
+    func test_setPluginOutdatedState_sets_connect_to_success_and_checkPlugin_to_failure() {
+        // Given
+        let viewModel = makeViewModel()
+
+        // When
+        viewModel.setPluginOutdatedState()
+
+        // Then
+        XCTAssertEqual(viewModel.steps[0].status, .success)
+        XCTAssertEqual(viewModel.steps[1].status, .failure(error: .outdatedPlugin(version: "")))
+        XCTAssertEqual(viewModel.steps[2].status, .notStarted)
+    }
+
+    func test_setPluginOutdatedState_shows_updatePlugin_primary_and_tryAgain_secondary() {
+        // Given
+        let viewModel = makeViewModel()
+
+        // When
+        viewModel.setPluginOutdatedState()
+
+        // Then
+        XCTAssertEqual(viewModel.primaryButtonTitle, "Update plugin")
+        XCTAssertTrue(viewModel.isPrimaryButtonEnabled)
+        XCTAssertTrue(viewModel.isShowingSecondaryButton)
+        XCTAssertEqual(viewModel.secondaryButtonTitle, "Try again")
+    }
+
+    func test_onAppear_does_not_call_handler_start_after_setPluginOutdatedState() {
+        // Given
+        let viewModel = makeViewModel()
+        viewModel.setPluginOutdatedState()
+
+        // When
+        viewModel.onAppear()
+
+        // Then
+        XCTAssertEqual(mockHandler.startCallCount, 0)
+    }
+
+    func test_onAppear_calls_handler_start_when_in_initial_state() {
+        // Given
+        let viewModel = makeViewModel()
+
+        // When
+        viewModel.onAppear()
+
+        // Then
+        XCTAssertEqual(mockHandler.startCallCount, 1)
+    }
+
     // MARK: - Helpers
 
     private func makeViewModel() -> WPComConnectionSetupViewModel {


### PR DESCRIPTION
Closes [WOOMOB-1993](https://linear.app/a8c/issue/WOOMOB-1993)

## Description

Implements plugin version checking at the dashboard level to determine card presentation. When the WooCommerce plugin version is below the minimum required (10.5.3), the dashboard displays the WPCom connection card in "Update plugin" variant. Tapping the card launches the benefits screen with an "Update plugin" button (instead of "Continue") that navigates to the connection setup view with the plugin outdated state pre-set.

## Test Steps

1. Setup a site in JurassicNinja with WooCommerce added but NOT Jetpack.
2. Update WooCommerce plugin with the one p91TBi-dyW-p2#comment-14563
3. Logic with site credentails
4. Complete the PN setup flow, which should be failing due to old plugin version.
5. Restart the app.
6. PN should be registered at launch.
8. Restart the app to trigger the plugin version check from Dashboard again.
9. Dashboard card should appear.
10. Tap on card
11. Note that the sheet has "Update plugin" CTA
12. Tap "Update plugin"
13. Note that the setup flow should appear with the failing version step again. Opening the authenticated webview will be implemented in the next PR.
14. Navigate to settings to force the plugin version to 1.1.1
15. Restart the app
16. Note that there is no dashboard card now as the version is above the expected.

## Screenshots

![ScreenRecording_02-16-2026 10-28-23_1](https://github.com/user-attachments/assets/8d3e6f3b-a893-4dbc-8a0a-517d9a60ffe6)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.