### PR TITLE
Disable simulated Stripe card reader in scheme

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
@@ -152,7 +152,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-simulate-stripe-card-reader"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-force-crash-logging 1"


### PR DESCRIPTION
## Description

Disables the `-simulate-stripe-card-reader` launch argument in the WooCommerce debug scheme. It was accidentally committed as enabled.

## Testing

Not applicable — scheme-only change.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.