### PR TITLE
POS Bookings: Optimize booking updates after mutations

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -1,3 +1,4 @@
+import CocoaLumberjackSwift
 import Foundation
 import Observation
 import protocol Yosemite.POSBookingListFetchStrategyFactoryProtocol
@@ -19,6 +20,7 @@ protocol POSBookingListControllerProtocol {
     func cancelBooking(bookingID: Int64) async throws
     func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws
     func updateBooking(bookingID: Int64) async throws
+    func updateBookingOptimistically(bookingID: Int64, optimisticUpdate: (POSBooking) -> POSBooking) async
 }
 
 protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProtocol {
@@ -108,6 +110,23 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     func updateBooking(bookingID: Int64) async throws {
         let updatedBooking = try await bookingService.fetchBooking(bookingID: bookingID)
         updateBooking(updatedBooking)
+    }
+
+    @MainActor
+    func updateBookingOptimistically(bookingID: Int64, optimisticUpdate: (POSBooking) -> POSBooking) async {
+        guard let existing = bookingsViewState.bookings.first(where: { $0.id == bookingID }) else {
+            return
+        }
+
+        let optimisticBooking = optimisticUpdate(existing)
+        updateBooking(optimisticBooking)
+
+        do {
+            let realBooking = try await bookingService.fetchBooking(bookingID: bookingID)
+            updateBooking(realBooking)
+        } catch {
+            DDLogError("⛔️ Failed to fetch booking \(bookingID) after optimistic update: \(error)")
+        }
     }
 
     @MainActor

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -18,6 +18,7 @@ protocol POSBookingListControllerProtocol {
     func selectBooking(_ booking: POSBooking?)
     func cancelBooking(bookingID: Int64) async throws
     func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws
+    func updateBooking(bookingID: Int64) async throws
 }
 
 protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProtocol {
@@ -101,6 +102,12 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         if let existing = bookingsViewState.bookings.first(where: { $0.id == bookingID }) {
             updateBooking(existing.copy(attendanceStatus: updatedStatus))
         }
+    }
+
+    @MainActor
+    func updateBooking(bookingID: Int64) async throws {
+        let updatedBooking = try await bookingService.fetchBooking(bookingID: bookingID)
+        updateBooking(updatedBooking)
     }
 
     @MainActor

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -95,7 +95,9 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     @MainActor
     func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws {
         try await bookingService.updateAttendanceStatus(bookingID: bookingID, status: status)
-        await refreshBookings()
+        if let existing = bookingsViewState.bookings.first(where: { $0.id == bookingID }) {
+            updateBooking(existing.copy(attendanceStatus: status))
+        }
     }
 
     @MainActor
@@ -193,5 +195,19 @@ private extension POSBookingListController {
         }
 
         bookingsViewState = .loading(cachedBookings)
+    }
+
+    @MainActor
+    func updateBooking(_ updatedBooking: POSBooking) {
+        let updatedBookings = bookingsViewState.bookings.map { booking in
+            booking.id == updatedBooking.id ? updatedBooking : booking
+        }
+        bookingsViewState = bookingsViewState.updatingBookings(with: updatedBookings)
+        cachedBookings = cachedBookings.map { booking in
+            booking.id == updatedBooking.id ? updatedBooking : booking
+        }
+        if selectedBooking?.id == updatedBooking.id {
+            selectedBooking = updatedBooking
+        }
     }
 }

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -7,6 +7,7 @@ import class Yosemite.AsyncPaginationTracker
 import enum Yosemite.POSBookingServiceError
 import protocol Yosemite.POSBookingServiceProtocol
 import enum Yosemite.BookingAttendanceStatus
+import enum Yosemite.BookingStatus
 
 protocol POSBookingListControllerProtocol {
     var bookingsViewState: POSBookingListState { get }
@@ -88,15 +89,17 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
 
     @MainActor
     func cancelBooking(bookingID: Int64) async throws {
-        try await bookingService.cancelBooking(bookingID: bookingID)
-        await refreshBookings()
+        let updatedStatus = try await bookingService.cancelBooking(bookingID: bookingID)
+        if let existing = bookingsViewState.bookings.first(where: { $0.id == bookingID }) {
+            updateBooking(existing.copy(status: updatedStatus))
+        }
     }
 
     @MainActor
     func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws {
-        try await bookingService.updateAttendanceStatus(bookingID: bookingID, status: status)
+        let updatedStatus = try await bookingService.updateAttendanceStatus(bookingID: bookingID, status: status)
         if let existing = bookingsViewState.bookings.first(where: { $0.id == bookingID }) {
-            updateBooking(existing.copy(attendanceStatus: status))
+            updateBooking(existing.copy(attendanceStatus: updatedStatus))
         }
     }
 

--- a/Modules/Sources/PointOfSale/Models/POSBookingsModel.swift
+++ b/Modules/Sources/PointOfSale/Models/POSBookingsModel.swift
@@ -1,6 +1,8 @@
 import Foundation
 import Observation
 import struct Yosemite.POSBooking
+import enum Yosemite.BookingStatus
+import enum Yosemite.OrderStatusEnum
 import protocol Yosemite.POSOrderServiceProtocol
 import protocol Yosemite.PaymentCaptureCelebrationProtocol
 import class Yosemite.PaymentCaptureCelebration
@@ -22,6 +24,20 @@ import class Yosemite.PaymentCaptureCelebration
         self.orderService = orderService
         self.receiptSender = receiptSender
         self.collectOrderPaymentAnalyticsTracker = collectOrderPaymentAnalyticsTracker
+    }
+
+    @MainActor
+    func updateAfterPayment(bookingID: Int64) async {
+        await bookingsController.updateBookingOptimistically(bookingID: bookingID) {
+            $0.copy(status: .paid, order: $0.order.copy(datePaid: Date()))
+        }
+    }
+
+    @MainActor
+    func updateAfterRefund(bookingID: Int64) async {
+        await bookingsController.updateBookingOptimistically(bookingID: bookingID) {
+            $0.copy(order: $0.order.copy(status: .refunded))
+        }
     }
 
     @MainActor

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -45,7 +45,7 @@ struct POSBookingDetailView: View {
                             autoStartRefund: true,
                             onRefundSuccess: {
                                 Task {
-                                    await bookingsModel.bookingsController.refreshBookings()
+                                    try? await bookingsModel.bookingsController.updateBooking(bookingID: booking.id)
                                 }
                             }
                         )
@@ -290,7 +290,7 @@ struct POSBookingDetailView: View {
         showPaymentView = false
         paymentModel = nil
         Task { @MainActor in
-            await bookingsModel.bookingsController.refreshBookings()
+            try? await bookingsModel.bookingsController.updateBooking(bookingID: booking.id)
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -15,6 +15,7 @@ struct POSBookingDetailView: View {
     @State private var cancelModalState: CancelBookingModalState?
     @State private var showPaymentView = false
     @State private var paymentModel: POSPaymentModel?
+    @State private var isDetailsUpdating = false
 
     private var actionTintColor: Color {
         colorScheme == .dark ? .posSecondary : .posPrimaryContainer
@@ -45,7 +46,9 @@ struct POSBookingDetailView: View {
                             autoStartRefund: true,
                             onRefundSuccess: {
                                 Task {
-                                    try? await bookingsModel.bookingsController.updateBooking(bookingID: booking.id)
+                                    isDetailsUpdating = true
+                                    await bookingsModel.updateAfterRefund(bookingID: booking.id)
+                                    isDetailsUpdating = false
                                 }
                             }
                         )
@@ -67,6 +70,7 @@ struct POSBookingDetailView: View {
         VStack(spacing: POSSpacing.none) {
             POSPageHeaderView(
                 title: POSBookingSummaryView.formattedTimeRange(for: booking),
+                isLoading: isDetailsUpdating,
                 backButtonConfiguration: shouldShowBackButton ? .init(state: .enabled, action: onBack) : nil,
                 trailingContent: {
                     viewOrderMenu
@@ -290,7 +294,9 @@ struct POSBookingDetailView: View {
         showPaymentView = false
         paymentModel = nil
         Task { @MainActor in
-            try? await bookingsModel.bookingsController.updateBooking(bookingID: booking.id)
+            isDetailsUpdating = true
+            await bookingsModel.updateAfterPayment(bookingID: booking.id)
+            isDetailsUpdating = false
         }
     }
 

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -523,7 +523,7 @@ final class POSBookingServicePreview: POSBookingServiceProtocol {
         PagedItems(items: [], hasMorePages: false, totalItems: nil)
     }
 
-    func fetchBooking(bookingID: Int64) async throws -> POSBooking { throw POSBookingServiceError.requestFailed }
+    func fetchBooking(bookingID: Int64) async throws -> POSBooking { throw NSError(domain: "Preview", code: 0) }
 
     func cancelBooking(bookingID: Int64) async throws -> BookingStatus { .cancelled }
 

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -523,6 +523,8 @@ final class POSBookingServicePreview: POSBookingServiceProtocol {
         PagedItems(items: [], hasMorePages: false, totalItems: nil)
     }
 
+    func fetchBooking(bookingID: Int64) async throws -> POSBooking { throw POSBookingServiceError.requestFailed }
+
     func cancelBooking(bookingID: Int64) async throws -> BookingStatus { .cancelled }
 
     func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws -> BookingAttendanceStatus { status }
@@ -715,6 +717,7 @@ final class POSConfigurablePreviewBookingListController: POSSearchingBookingList
     func selectBooking(_ booking: POSBooking?) { }
     func cancelBooking(bookingID: Int64) async throws {}
     func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws {}
+    func updateBooking(bookingID: Int64) async throws {}
     func searchBookings(searchTerm: String) async {}
     func clearSearchBookings() {}
 }

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -718,6 +718,7 @@ final class POSConfigurablePreviewBookingListController: POSSearchingBookingList
     func cancelBooking(bookingID: Int64) async throws {}
     func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws {}
     func updateBooking(bookingID: Int64) async throws {}
+    func updateBookingOptimistically(bookingID: Int64, optimisticUpdate: (POSBooking) -> POSBooking) async {}
     func searchBookings(searchTerm: String) async {}
     func clearSearchBookings() {}
 }

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -523,9 +523,9 @@ final class POSBookingServicePreview: POSBookingServiceProtocol {
         PagedItems(items: [], hasMorePages: false, totalItems: nil)
     }
 
-    func cancelBooking(bookingID: Int64) async throws {}
+    func cancelBooking(bookingID: Int64) async throws -> BookingStatus { .cancelled }
 
-    func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws {}
+    func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws -> BookingAttendanceStatus { status }
 }
 
 final class POSBookingListFetchStrategyPreview: POSBookingListFetchStrategy {

--- a/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -4,6 +4,8 @@ import Codegen
 import Foundation
 import Networking
 import WooFoundation
+import enum Networking.BookingAttendanceStatus
+import enum Networking.BookingStatus
 import enum NetworkingCore.OrderStatusEnum
 import struct NetworkingCore.Address
 import struct NetworkingCore.MetaData
@@ -54,6 +56,78 @@ extension Yosemite.JustInTimeMessage {
             badgeImageUrl: badgeImageUrl,
             badgeImageDarkUrl: badgeImageDarkUrl,
             template: template
+        )
+    }
+}
+
+extension Yosemite.POSBooking {
+    public func copy(
+        id: CopiableProp<Int64> = .copy,
+        customerName: NullableCopiableProp<String> = .copy,
+        serviceName: CopiableProp<String> = .copy,
+        startDate: CopiableProp<Date> = .copy,
+        endDate: CopiableProp<Date> = .copy,
+        formattedAmount: CopiableProp<String> = .copy,
+        status: CopiableProp<BookingStatus> = .copy,
+        attendanceStatus: CopiableProp<BookingAttendanceStatus> = .copy,
+        orderID: NullableCopiableProp<Int64> = .copy,
+        resourceName: NullableCopiableProp<String> = .copy,
+        resourceImageURL: NullableCopiableProp<String> = .copy,
+        customerEmail: NullableCopiableProp<String> = .copy,
+        customerPhone: NullableCopiableProp<String> = .copy,
+        billingAddress: NullableCopiableProp<String> = .copy,
+        customerNote: NullableCopiableProp<String> = .copy,
+        bookingNote: NullableCopiableProp<String> = .copy,
+        location: NullableCopiableProp<String> = .copy,
+        duration: CopiableProp<String> = .copy,
+        formattedSubtotal: NullableCopiableProp<String> = .copy,
+        formattedTax: NullableCopiableProp<String> = .copy,
+        order: CopiableProp<POSOrder> = .copy
+    ) -> Yosemite.POSBooking {
+        let id = id ?? self.id
+        let customerName = customerName ?? self.customerName
+        let serviceName = serviceName ?? self.serviceName
+        let startDate = startDate ?? self.startDate
+        let endDate = endDate ?? self.endDate
+        let formattedAmount = formattedAmount ?? self.formattedAmount
+        let status = status ?? self.status
+        let attendanceStatus = attendanceStatus ?? self.attendanceStatus
+        let orderID = orderID ?? self.orderID
+        let resourceName = resourceName ?? self.resourceName
+        let resourceImageURL = resourceImageURL ?? self.resourceImageURL
+        let customerEmail = customerEmail ?? self.customerEmail
+        let customerPhone = customerPhone ?? self.customerPhone
+        let billingAddress = billingAddress ?? self.billingAddress
+        let customerNote = customerNote ?? self.customerNote
+        let bookingNote = bookingNote ?? self.bookingNote
+        let location = location ?? self.location
+        let duration = duration ?? self.duration
+        let formattedSubtotal = formattedSubtotal ?? self.formattedSubtotal
+        let formattedTax = formattedTax ?? self.formattedTax
+        let order = order ?? self.order
+
+        return Yosemite.POSBooking(
+            id: id,
+            customerName: customerName,
+            serviceName: serviceName,
+            startDate: startDate,
+            endDate: endDate,
+            formattedAmount: formattedAmount,
+            status: status,
+            attendanceStatus: attendanceStatus,
+            orderID: orderID,
+            resourceName: resourceName,
+            resourceImageURL: resourceImageURL,
+            customerEmail: customerEmail,
+            customerPhone: customerPhone,
+            billingAddress: billingAddress,
+            customerNote: customerNote,
+            bookingNote: bookingNote,
+            location: location,
+            duration: duration,
+            formattedSubtotal: formattedSubtotal,
+            formattedTax: formattedTax,
+            order: order
         )
     }
 }

--- a/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -4,8 +4,6 @@ import Codegen
 import Foundation
 import Networking
 import WooFoundation
-import enum Networking.BookingAttendanceStatus
-import enum Networking.BookingStatus
 import enum NetworkingCore.OrderStatusEnum
 import struct NetworkingCore.Address
 import struct NetworkingCore.MetaData

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBooking.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBooking.swift
@@ -2,7 +2,7 @@ import Foundation
 import enum Networking.BookingStatus
 import enum Networking.BookingAttendanceStatus
 
-public struct POSBooking: Equatable, Hashable, Identifiable {
+public struct POSBooking: Equatable, Hashable, Identifiable, GeneratedCopiable {
     /// Whether the linked order indicates payment was collected.
     /// Uses `datePaid` rather than order status because the Bookings API
     /// may change the order status when a booking is cancelled,

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBooking.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBooking.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Codegen
 import enum Networking.BookingStatus
 import enum Networking.BookingAttendanceStatus
 

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingService.swift
@@ -80,6 +80,29 @@ public final class POSBookingService: POSBookingServiceProtocol {
         }
     }
 
+    public func fetchBooking(bookingID: Int64) async throws -> POSBooking {
+        guard let booking = try await bookingsRemote.loadBooking(bookingID: bookingID, siteID: siteID) else {
+            throw POSBookingServiceError.requestFailed
+        }
+
+        let orderID = booking.orderID != 0 ? booking.orderID : nil
+        let resourceID = booking.resourceID != 0 ? booking.resourceID : nil
+
+        async let orderTask = orderID.map { fetchOrders(orderIDs: [$0]) } ?? [:]
+        async let resourceTask = resourceID.map { fetchResources(resourceIDs: [$0]) } ?? [:]
+        let (orders, resources) = await (orderTask, resourceTask)
+
+        let order = orders[booking.orderID]
+        let orderInfo: BookingOrderInfo? = order.map { BookingOrderInfo(booking: booking, order: $0) }
+        let resource = resources[booking.resourceID]
+
+        guard let posOrder = order.flatMap({ try? orderMapper.map(order: $0) }) else {
+            throw POSBookingServiceError.requestFailed
+        }
+
+        return mapper.map(booking: booking, orderInfo: orderInfo, resource: resource, order: posOrder)
+    }
+
     @discardableResult
     public func cancelBooking(bookingID: Int64) async throws -> BookingStatus {
         guard let booking = try await bookingsRemote.updateBooking(

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingService.swift
@@ -80,30 +80,32 @@ public final class POSBookingService: POSBookingServiceProtocol {
         }
     }
 
-    public func cancelBooking(bookingID: Int64) async throws {
-        let result = try await bookingsRemote.updateBooking(
+    @discardableResult
+    public func cancelBooking(bookingID: Int64) async throws -> BookingStatus {
+        guard let booking = try await bookingsRemote.updateBooking(
             from: siteID,
             bookingID: bookingID,
             attendanceStatus: nil,
             bookingStatus: .cancelled,
             note: nil
-        )
-        guard result != nil else {
+        ) else {
             throw POSBookingServiceError.requestFailed
         }
+        return booking.bookingStatus
     }
 
-    public func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws {
-        let result = try await bookingsRemote.updateBooking(
+    @discardableResult
+    public func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws -> BookingAttendanceStatus {
+        guard let booking = try await bookingsRemote.updateBooking(
             from: siteID,
             bookingID: bookingID,
             attendanceStatus: status,
             bookingStatus: nil,
             note: nil
-        )
-        guard result != nil else {
+        ) else {
             throw POSBookingServiceError.requestFailed
         }
+        return booking.attendanceStatus
     }
 }
 

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingService.swift
@@ -85,11 +85,11 @@ public final class POSBookingService: POSBookingServiceProtocol {
             throw POSBookingServiceError.requestFailed
         }
 
-        let orderID = booking.orderID != 0 ? booking.orderID : nil
-        let resourceID = booking.resourceID != 0 ? booking.resourceID : nil
+        let orderIDs = booking.orderID != 0 ? [booking.orderID] : []
+        let resourceIDs = booking.resourceID != 0 ? [booking.resourceID] : []
 
-        async let orderTask = orderID.map { fetchOrders(orderIDs: [$0]) } ?? [:]
-        async let resourceTask = resourceID.map { fetchResources(resourceIDs: [$0]) } ?? [:]
+        async let orderTask = fetchOrders(orderIDs: orderIDs)
+        async let resourceTask = fetchResources(resourceIDs: resourceIDs)
         let (orders, resources) = await (orderTask, resourceTask)
 
         let order = orders[booking.orderID]

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingServiceProtocol.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingServiceProtocol.swift
@@ -12,6 +12,8 @@ public protocol POSBookingServiceProtocol: Sendable {
                        pageSize: Int,
                        searchQuery: String?) async throws -> PagedItems<POSBooking>
 
+    func fetchBooking(bookingID: Int64) async throws -> POSBooking
+
     func cancelBooking(bookingID: Int64) async throws -> BookingStatus
 
     func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws -> BookingAttendanceStatus

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingServiceProtocol.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingServiceProtocol.swift
@@ -12,7 +12,7 @@ public protocol POSBookingServiceProtocol: Sendable {
                        pageSize: Int,
                        searchQuery: String?) async throws -> PagedItems<POSBooking>
 
-    func cancelBooking(bookingID: Int64) async throws
+    func cancelBooking(bookingID: Int64) async throws -> BookingStatus
 
-    func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws
+    func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws -> BookingAttendanceStatus
 }

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
@@ -191,6 +191,75 @@ final class POSBookingListControllerTests {
         }
     }
 
+    // MARK: - cancelBooking
+
+    @Test func test_cancelBooking_calls_service_and_updates_booking_in_place() async throws {
+        // Given
+        let bookings = [makeBooking(id: 1)]
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: bookings, hasMorePages: false, totalItems: nil))
+        await sut.loadBookings()
+
+        let mockService = mockFactory.bookingService as! MockPOSBookingService
+
+        // When
+        try await sut.cancelBooking(bookingID: 1)
+
+        // Then
+        #expect(mockService.cancelBookingCallCount == 1)
+        #expect(mockService.lastCancelledBookingID == 1)
+        #expect(sut.bookingsViewState.bookings.first?.status == .cancelled)
+    }
+
+    @Test func test_cancelBooking_when_service_throws_then_throws_error() async {
+        // Given
+        let mockService = mockFactory.bookingService as! MockPOSBookingService
+        mockService.cancelBookingError = NSError(domain: "test", code: 1)
+
+        // When/Then
+        do {
+            try await sut.cancelBooking(bookingID: 1)
+            Issue.record("Expected error to be thrown")
+        } catch {
+            #expect(mockService.cancelBookingCallCount == 1)
+        }
+    }
+
+    // MARK: - updateBooking
+
+    @Test func test_updateBooking_fetches_and_updates_booking_in_place() async throws {
+        // Given
+        let bookings = [makeBooking(id: 1)]
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: bookings, hasMorePages: false, totalItems: nil))
+        await sut.loadBookings()
+        sut.selectBooking(bookings[0])
+
+        let mockService = mockFactory.bookingService as! MockPOSBookingService
+        let updatedBooking = makeBooking(id: 1, serviceName: "Updated Service", attendanceStatus: .attended)
+        mockService.fetchBookingResult = .success(updatedBooking)
+
+        // When
+        try await sut.updateBooking(bookingID: 1)
+
+        // Then
+        #expect(sut.bookingsViewState.bookings.first?.serviceName == "Updated Service")
+        #expect(sut.bookingsViewState.bookings.first?.attendanceStatus == .attended)
+        #expect(sut.selectedBooking?.serviceName == "Updated Service")
+    }
+
+    @Test func test_updateBooking_when_service_throws_then_throws_error() async {
+        // Given
+        let mockService = mockFactory.bookingService as! MockPOSBookingService
+        mockService.fetchBookingResult = nil
+
+        // When/Then
+        do {
+            try await sut.updateBooking(bookingID: 1)
+            Issue.record("Expected error to be thrown")
+        } catch {
+            // Expected
+        }
+    }
+
     // MARK: - Caching
 
     @Test func test_loadBookings_uses_cached_data_on_reload() async {
@@ -211,16 +280,18 @@ final class POSBookingListControllerTests {
 // MARK: - Helpers
 
 private extension POSBookingListControllerTests {
-    func makeBooking(id: Int64) -> POSBooking {
+    func makeBooking(id: Int64,
+                     serviceName: String? = nil,
+                     attendanceStatus: BookingAttendanceStatus = .unattended) -> POSBooking {
         POSBooking(
             id: id,
             customerName: "Customer \(id)",
-            serviceName: "Service \(id)",
+            serviceName: serviceName ?? "Service \(id)",
             startDate: Date(),
             endDate: Date().addingTimeInterval(3600),
             formattedAmount: "$50.00",
             status: .confirmed,
-            attendanceStatus: .unattended,
+            attendanceStatus: attendanceStatus,
             orderID: id * 10,
             resourceName: nil,
             order: makeOrder(id: id * 10)

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
@@ -159,7 +159,7 @@ final class POSBookingListControllerTests {
 
     // MARK: - updateAttendanceStatus
 
-    @Test func test_updateAttendanceStatus_calls_service_and_refreshes_bookings() async throws {
+    @Test func test_updateAttendanceStatus_calls_service_and_updates_booking_in_place() async throws {
         // Given
         let bookings = [makeBooking(id: 1)]
         mockStrategy.fetchBookingsResult = .success(PagedItems(items: bookings, hasMorePages: false, totalItems: nil))
@@ -174,8 +174,7 @@ final class POSBookingListControllerTests {
         #expect(mockService.updateAttendanceCallCount == 1)
         #expect(mockService.lastUpdatedAttendanceBookingID == 1)
         #expect(mockService.lastUpdatedAttendanceStatus == .attended)
-        // Verify bookings were refreshed (loadBookings was called)
-        #expect(sut.bookingsViewState == .loaded(bookings, hasMoreItems: false))
+        #expect(sut.bookingsViewState.bookings.first?.attendanceStatus == .attended)
     }
 
     @Test func test_updateAttendanceStatus_when_service_throws_then_throws_error() async {

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
@@ -260,6 +260,66 @@ final class POSBookingListControllerTests {
         }
     }
 
+    // MARK: - updateBookingOptimistically
+
+    @Test func test_updateBookingOptimistically_applies_optimistic_state_then_fetches_real_booking() async {
+        // Given
+        let bookings = [makeBooking(id: 1)]
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: bookings, hasMorePages: false, totalItems: nil))
+        await sut.loadBookings()
+        sut.selectBooking(bookings[0])
+
+        let mockService = mockFactory.bookingService as! MockPOSBookingService
+        let realBooking = makeBooking(id: 1, serviceName: "Updated Service", attendanceStatus: .attended)
+        mockService.fetchBookingResult = .success(realBooking)
+
+        // When
+        await sut.updateBookingOptimistically(bookingID: 1) {
+            $0.copy(status: .paid, order: $0.order.copy(datePaid: Date()))
+        }
+
+        // Then - real booking replaces optimistic
+        #expect(sut.bookingsViewState.bookings.first?.serviceName == "Updated Service")
+        #expect(sut.bookingsViewState.bookings.first?.attendanceStatus == .attended)
+        #expect(sut.selectedBooking?.serviceName == "Updated Service")
+        #expect(mockService.fetchBookingCallCount == 1)
+        #expect(mockService.lastFetchedBookingID == 1)
+    }
+
+    @Test func test_updateBookingOptimistically_when_fetch_fails_then_keeps_optimistic_state() async {
+        // Given
+        let bookings = [makeBooking(id: 1)]
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: bookings, hasMorePages: false, totalItems: nil))
+        await sut.loadBookings()
+        sut.selectBooking(bookings[0])
+
+        let mockService = mockFactory.bookingService as! MockPOSBookingService
+        mockService.fetchBookingResult = nil
+
+        // When
+        await sut.updateBookingOptimistically(bookingID: 1) {
+            $0.copy(status: .paid, order: $0.order.copy(datePaid: Date()))
+        }
+
+        // Then - optimistic state persists
+        #expect(sut.bookingsViewState.bookings.first?.status == .paid)
+        #expect(sut.bookingsViewState.bookings.first?.order.datePaid != nil)
+        #expect(sut.selectedBooking?.status == .paid)
+    }
+
+    @Test func test_updateBookingOptimistically_when_booking_not_found_then_does_nothing() async {
+        // Given - no bookings loaded
+        let mockService = mockFactory.bookingService as! MockPOSBookingService
+
+        // When
+        await sut.updateBookingOptimistically(bookingID: 999) {
+            $0.copy(status: .paid)
+        }
+
+        // Then - no fetch attempted
+        #expect(mockService.fetchBookingCallCount == 0)
+    }
+
     // MARK: - Caching
 
     @Test func test_loadBookings_uses_cached_data_on_reload() async {

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
@@ -32,8 +32,17 @@ final class MockPOSBookingService: POSBookingServiceProtocol {
     var lastUpdatedAttendanceBookingID: Int64?
     var lastUpdatedAttendanceStatus: BookingAttendanceStatus?
 
+    var fetchBookingResult: Result<POSBooking, Error>?
+
     func fetchBookings(siteID: Int64, pageNumber: Int, pageSize: Int, searchQuery: String?) async throws -> PagedItems<POSBooking> {
         try fetchBookingsResult.get()
+    }
+
+    func fetchBooking(bookingID: Int64) async throws -> POSBooking {
+        guard let result = fetchBookingResult else {
+            throw NSError(domain: "MockPOSBookingService", code: 0)
+        }
+        return try result.get()
     }
 
     var cancelBookingStatusResult: BookingStatus = .cancelled

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
@@ -33,12 +33,16 @@ final class MockPOSBookingService: POSBookingServiceProtocol {
     var lastUpdatedAttendanceStatus: BookingAttendanceStatus?
 
     var fetchBookingResult: Result<POSBooking, Error>?
+    var fetchBookingCallCount = 0
+    var lastFetchedBookingID: Int64?
 
     func fetchBookings(siteID: Int64, pageNumber: Int, pageSize: Int, searchQuery: String?) async throws -> PagedItems<POSBooking> {
         try fetchBookingsResult.get()
     }
 
     func fetchBooking(bookingID: Int64) async throws -> POSBooking {
+        fetchBookingCallCount += 1
+        lastFetchedBookingID = bookingID
         guard let result = fetchBookingResult else {
             throw NSError(domain: "MockPOSBookingService", code: 0)
         }

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
@@ -6,6 +6,7 @@ import protocol Yosemite.POSBookingListFetchStrategy
 import protocol Yosemite.POSBookingServiceProtocol
 import struct Yosemite.PagedItems
 import enum Yosemite.BookingAttendanceStatus
+import enum Yosemite.BookingStatus
 
 final class MockPOSBookingListFetchStrategyFactory: POSBookingListFetchStrategyFactoryProtocol {
     var defaultStrategyResult: POSBookingListFetchStrategy = MockPOSBookingListFetchStrategy()
@@ -35,21 +36,27 @@ final class MockPOSBookingService: POSBookingServiceProtocol {
         try fetchBookingsResult.get()
     }
 
-    func cancelBooking(bookingID: Int64) async throws {
+    var cancelBookingStatusResult: BookingStatus = .cancelled
+
+    func cancelBooking(bookingID: Int64) async throws -> BookingStatus {
         cancelBookingCallCount += 1
         lastCancelledBookingID = bookingID
         if let error = cancelBookingError {
             throw error
         }
+        return cancelBookingStatusResult
     }
 
-    func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws {
+    var updateAttendanceStatusResult: BookingAttendanceStatus?
+
+    func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws -> BookingAttendanceStatus {
         updateAttendanceCallCount += 1
         lastUpdatedAttendanceBookingID = bookingID
         lastUpdatedAttendanceStatus = status
         if let error = updateAttendanceError {
             throw error
         }
+        return updateAttendanceStatusResult ?? status
     }
 }
 

--- a/WooCommerce/Classes/Copiable/Models+Copiable.generated.swift
+++ b/WooCommerce/Classes/Copiable/Models+Copiable.generated.swift
@@ -6,6 +6,51 @@ import Yosemite
 
 // swiftlint:disable line_length
 
+extension WooCommerce.AggregateOrderItem {
+    func copy(
+        itemID: CopiableProp<String> = .copy,
+        productID: CopiableProp<Int64> = .copy,
+        variationID: CopiableProp<Int64> = .copy,
+        name: CopiableProp<String> = .copy,
+        price: NullableCopiableProp<NSDecimalNumber> = .copy,
+        quantity: CopiableProp<Decimal> = .copy,
+        sku: NullableCopiableProp<String> = .copy,
+        total: NullableCopiableProp<NSDecimalNumber> = .copy,
+        imageURL: NullableCopiableProp<URL> = .copy,
+        attributes: CopiableProp<[OrderItemAttribute]> = .copy,
+        addOns: CopiableProp<[OrderItemProductAddOn]> = .copy,
+        parent: NullableCopiableProp<Int64> = .copy
+    ) -> WooCommerce.AggregateOrderItem {
+        let itemID = itemID ?? self.itemID
+        let productID = productID ?? self.productID
+        let variationID = variationID ?? self.variationID
+        let name = name ?? self.name
+        let price = price ?? self.price
+        let quantity = quantity ?? self.quantity
+        let sku = sku ?? self.sku
+        let total = total ?? self.total
+        let imageURL = imageURL ?? self.imageURL
+        let attributes = attributes ?? self.attributes
+        let addOns = addOns ?? self.addOns
+        let parent = parent ?? self.parent
+
+        return WooCommerce.AggregateOrderItem(
+            itemID: itemID,
+            productID: productID,
+            variationID: variationID,
+            name: name,
+            price: price,
+            quantity: quantity,
+            sku: sku,
+            total: total,
+            imageURL: imageURL,
+            attributes: attributes,
+            addOns: addOns,
+            parent: parent
+        )
+    }
+}
+
 extension WooCommerce.ProductListItem {
     func copy(
         siteID: CopiableProp<Int64> = .copy,
@@ -50,6 +95,27 @@ extension WooCommerce.ProductListItem {
             variations: variations,
             bundleStockStatus: bundleStockStatus,
             bundleStockQuantity: bundleStockQuantity
+        )
+    }
+}
+
+extension WooCommerce.ShippingLabelSelectedRate {
+    func copy(
+        packageID: CopiableProp<String> = .copy,
+        rate: CopiableProp<ShippingLabelCarrierRate> = .copy,
+        signatureRate: NullableCopiableProp<ShippingLabelCarrierRate> = .copy,
+        adultSignatureRate: NullableCopiableProp<ShippingLabelCarrierRate> = .copy
+    ) -> WooCommerce.ShippingLabelSelectedRate {
+        let packageID = packageID ?? self.packageID
+        let rate = rate ?? self.rate
+        let signatureRate = signatureRate ?? self.signatureRate
+        let adultSignatureRate = adultSignatureRate ?? self.adultSignatureRate
+
+        return WooCommerce.ShippingLabelSelectedRate(
+            packageID: packageID,
+            rate: rate,
+            signatureRate: signatureRate,
+            adultSignatureRate: adultSignatureRate
         )
     }
 }

--- a/WooCommerce/Classes/Copiable/Models+Copiable.generated.swift
+++ b/WooCommerce/Classes/Copiable/Models+Copiable.generated.swift
@@ -6,51 +6,6 @@ import Yosemite
 
 // swiftlint:disable line_length
 
-extension WooCommerce.AggregateOrderItem {
-    func copy(
-        itemID: CopiableProp<String> = .copy,
-        productID: CopiableProp<Int64> = .copy,
-        variationID: CopiableProp<Int64> = .copy,
-        name: CopiableProp<String> = .copy,
-        price: NullableCopiableProp<NSDecimalNumber> = .copy,
-        quantity: CopiableProp<Decimal> = .copy,
-        sku: NullableCopiableProp<String> = .copy,
-        total: NullableCopiableProp<NSDecimalNumber> = .copy,
-        imageURL: NullableCopiableProp<URL> = .copy,
-        attributes: CopiableProp<[OrderItemAttribute]> = .copy,
-        addOns: CopiableProp<[OrderItemProductAddOn]> = .copy,
-        parent: NullableCopiableProp<Int64> = .copy
-    ) -> WooCommerce.AggregateOrderItem {
-        let itemID = itemID ?? self.itemID
-        let productID = productID ?? self.productID
-        let variationID = variationID ?? self.variationID
-        let name = name ?? self.name
-        let price = price ?? self.price
-        let quantity = quantity ?? self.quantity
-        let sku = sku ?? self.sku
-        let total = total ?? self.total
-        let imageURL = imageURL ?? self.imageURL
-        let attributes = attributes ?? self.attributes
-        let addOns = addOns ?? self.addOns
-        let parent = parent ?? self.parent
-
-        return WooCommerce.AggregateOrderItem(
-            itemID: itemID,
-            productID: productID,
-            variationID: variationID,
-            name: name,
-            price: price,
-            quantity: quantity,
-            sku: sku,
-            total: total,
-            imageURL: imageURL,
-            attributes: attributes,
-            addOns: addOns,
-            parent: parent
-        )
-    }
-}
-
 extension WooCommerce.ProductListItem {
     func copy(
         siteID: CopiableProp<Int64> = .copy,
@@ -95,27 +50,6 @@ extension WooCommerce.ProductListItem {
             variations: variations,
             bundleStockStatus: bundleStockStatus,
             bundleStockQuantity: bundleStockQuantity
-        )
-    }
-}
-
-extension WooCommerce.ShippingLabelSelectedRate {
-    func copy(
-        packageID: CopiableProp<String> = .copy,
-        rate: CopiableProp<ShippingLabelCarrierRate> = .copy,
-        signatureRate: NullableCopiableProp<ShippingLabelCarrierRate> = .copy,
-        adultSignatureRate: NullableCopiableProp<ShippingLabelCarrierRate> = .copy
-    ) -> WooCommerce.ShippingLabelSelectedRate {
-        let packageID = packageID ?? self.packageID
-        let rate = rate ?? self.rate
-        let signatureRate = signatureRate ?? self.signatureRate
-        let adultSignatureRate = adultSignatureRate ?? self.adultSignatureRate
-
-        return WooCommerce.ShippingLabelSelectedRate(
-            packageID: packageID,
-            rate: rate,
-            signatureRate: signatureRate,
-            adultSignatureRate: adultSignatureRate
         )
     }
 }


### PR DESCRIPTION
## Summary

WOOMOB-2226

At the moment, we refresh all the bookings after any action on the booking is made. We should only update that particular booking.

- Replace full list refresh (`refreshBookings()`) with in-place single-booking updates after attendance changes, cancellations, payments, and refunds
- Use actual API response data (status, attendance status) instead of assuming expected values
- Add `fetchBooking(bookingID:)` to fetch and update a single booking after payment/refund, matching the pattern used by `POSOrderListController`

The result is much faster and pleasant experience, especially visible for attendance change.

## Videos

### Attendance

https://github.com/user-attachments/assets/8cbbc047-7d0d-42cc-83c1-a4838ae7c7bd

### Issue Refund

https://github.com/user-attachments/assets/31122cb5-1754-40e1-adcf-4279e42ac735

### Payment

https://github.com/user-attachments/assets/eeee5788-64ed-44e8-a17c-78dbd43f029f

### Cancel

https://github.com/user-attachments/assets/9b93ad68-2ad2-43cf-8f5e-bd372f346f7e

## Test plan
- [x] Change attendance status on a booking - verify the booking row and detail view update immediately without a full list reload
- [x] Cancel a booking - verify the status updates in-place in the list and detail view
- [x] Complete a payment for a booking - verify the booking updates in the list and detail view
- [x] Process a refund for a booking - verify the booking updates in the list and detail view
- [x] Pull to refresh the bookings list - verify it still performs a full reload
- [x] Search for bookings and clear search - verify cached bookings restore correctly