### PR TITLE
Add `device_locale` and `metadata` for `/push-tokens` requests

### DIFF
--- a/Modules/Sources/Networking/Remote/DevicesRemote.swift
+++ b/Modules/Sources/Networking/Remote/DevicesRemote.swift
@@ -125,7 +125,7 @@ public class DevicesRemote: Remote {
 //
 private extension DevicesRemote {
     enum Values {
-        static let platform = "ios"
+        static let platform = "apple"
     }
 
     enum Paths {

--- a/Modules/Sources/Networking/Remote/DevicesRemote.swift
+++ b/Modules/Sources/Networking/Remote/DevicesRemote.swift
@@ -66,16 +66,26 @@ public class DevicesRemote: Remote {
     /// - Parameters:
     ///     - siteID: ID of the site
     ///     - device: APNS Device to be registered.
-    ///     - applicationId: App ID.
+    ///     - applicationID: App ID.
+    ///     - deviceLocale: Device locale in `xx_XX` format (e.g. `en_US`).
+    ///     - appVersion: App version string (e.g. `1.0.0`).
     /// - Returns: The unique ID of the push token record
     ///
     public func registerForSelfDrivenPushNotifications(siteID: Int64,
                                                        device: APNSDevice,
-                                                       applicationID: String) async throws -> Int64 {
-        var parameters = [
+                                                       applicationID: String,
+                                                       deviceLocale: String,
+                                                       appVersion: String) async throws -> Int64 {
+        var parameters: [String: Any] = [
             ParameterKeys.origin: applicationID,
             ParameterKeys.token: device.token,
-            ParameterKeys.platform: Values.platform
+            ParameterKeys.platform: Values.platform,
+            ParameterKeys.deviceLocale: deviceLocale,
+            ParameterKeys.metadata: [
+                ParameterKeys.applicationVersion: appVersion,
+                ParameterKeys.deviceModel: device.model,
+                ParameterKeys.deviceOSVersion: device.iOSVersion
+            ]
         ]
 
         if let deviceUUID = device.identifierForVendor {
@@ -136,5 +146,7 @@ private extension DevicesRemote {
         static let token = "token"
         static let platform = "platform"
         static let origin = "origin"
+        static let deviceLocale = "device_locale"
+        static let metadata = "metadata"
     }
 }

--- a/Modules/Sources/WooFoundation/Extensions/Locale+Woo.swift
+++ b/Modules/Sources/WooFoundation/Extensions/Locale+Woo.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Locale: Woo Methods
+///
+public extension Locale {
+
+    /// Returns the locale identifier in `xx_XX` format (e.g. `en_US`),
+    /// constructed from the language code and region code.
+    ///
+    /// Falls back to just the language code if the region is unavailable,
+    /// or `nil` if even the language code cannot be determined.
+    ///
+    var languageRegionIdentifier: String? {
+        guard let languageCode = language.languageCode?.identifier else {
+            return nil
+        }
+        guard let regionCode = region?.identifier else {
+            return languageCode
+        }
+        return "\(languageCode)_\(regionCode)"
+    }
+}

--- a/Modules/Sources/Yosemite/Actions/NotificationAction.swift
+++ b/Modules/Sources/Yosemite/Actions/NotificationAction.swift
@@ -44,6 +44,8 @@ public enum NotificationAction: Action {
     case registerDeviceForSelfDrivenPushNotifications(siteID: Int64,
                                                       device: APNSDevice,
                                                       applicationID: String,
+                                                      deviceLocale: String,
+                                                      appVersion: String,
                                                       onCompletion: (Result<Int64, Error>) -> Void)
 
     /// Removes a given tokenID from the the self-driven push notification system.

--- a/Modules/Sources/Yosemite/Stores/JustInTimeMessageStore.swift
+++ b/Modules/Sources/Yosemite/Stores/JustInTimeMessageStore.swift
@@ -104,13 +104,7 @@ private extension JustInTimeMessageStore {
     }
 
     func localeLanguageRegionIdentifier() -> String? {
-        guard let languageCode = Locale.current.language.languageCode?.identifier else {
-            return nil
-        }
-        guard let regionCode = Locale.current.region?.identifier else {
-            return languageCode
-        }
-        return "\(languageCode)_\(regionCode)"
+        Locale.current.languageRegionIdentifier
     }
 
     func displayMessages(_ messages: [Networking.JustInTimeMessage]) -> [JustInTimeMessage] {

--- a/Modules/Sources/Yosemite/Stores/NotificationStore.swift
+++ b/Modules/Sources/Yosemite/Stores/NotificationStore.swift
@@ -56,11 +56,13 @@ public class NotificationStore: Store {
             updateReadStatus(for: noteIDs, read: read, onCompletion: onCompletion)
         case .updateLocalDeletedStatus(let noteID, let deleteInProgress, let onCompletion):
             updateDeletedStatus(noteID: noteID, deleteInProgress: deleteInProgress, onCompletion: onCompletion)
-        case let .registerDeviceForSelfDrivenPushNotifications(siteID, device, applicationID, onCompletion):
+        case let .registerDeviceForSelfDrivenPushNotifications(siteID, device, applicationID, deviceLocale, appVersion, onCompletion):
             registerDeviceForSelfDrivenPushNotifications(
                 siteID: siteID,
                 device: device,
                 applicationID: applicationID,
+                deviceLocale: deviceLocale,
+                appVersion: appVersion,
                 onCompletion: onCompletion
             )
         case let .unregisterFromSelfDrivenPushNotifications(siteID, tokenID, onCompletion):
@@ -97,13 +99,17 @@ private extension NotificationStore {
     func registerDeviceForSelfDrivenPushNotifications(siteID: Int64,
                                                       device: APNSDevice,
                                                       applicationID: String,
+                                                      deviceLocale: String,
+                                                      appVersion: String,
                                                       onCompletion: @escaping (Result<Int64, Error>) -> Void) {
         Task { @MainActor in
             do {
                 let tokenID = try await devicesRemote.registerForSelfDrivenPushNotifications(
                     siteID: siteID,
                     device: device,
-                    applicationID: applicationID
+                    applicationID: applicationID,
+                    deviceLocale: deviceLocale,
+                    appVersion: appVersion
                 )
                 onCompletion(.success(tokenID))
             } catch {

--- a/Modules/Tests/NetworkingTests/Remote/DevicesRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/DevicesRemoteTests.swift
@@ -102,7 +102,9 @@ final class DevicesRemoteTests: XCTestCase {
         let tokenID = try await remote.registerForSelfDrivenPushNotifications(
             siteID: Parameters.siteID,
             device: Parameters.appleDevice,
-            applicationID: Parameters.applicationId
+            applicationID: Parameters.applicationId,
+            deviceLocale: Parameters.deviceLocale,
+            appVersion: Parameters.applicationVersion
         )
 
         XCTAssertEqual(tokenID, 123)
@@ -119,7 +121,9 @@ final class DevicesRemoteTests: XCTestCase {
             _ = try await remote.registerForSelfDrivenPushNotifications(
                 siteID: Parameters.siteID,
                 device: Parameters.appleDevice,
-                applicationID: Parameters.applicationId
+                applicationID: Parameters.applicationId,
+                deviceLocale: Parameters.deviceLocale,
+                appVersion: Parameters.applicationVersion
             )
             XCTFail("Expected error to be thrown")
         } catch {
@@ -174,4 +178,5 @@ private enum Parameters {
     static let dotcomDeviceID = "1234"
     static let siteID: Int64 = 123456
     static let tokenID: Int64 = 123
+    static let deviceLocale = "en_US"
 }

--- a/Modules/Tests/YosemiteTests/Stores/NotificationStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/NotificationStoreTests.swift
@@ -454,7 +454,9 @@ final class NotificationStoreTests: XCTestCase {
             let action = NotificationAction.registerDeviceForSelfDrivenPushNotifications(
                 siteID: self.sampleSiteID,
                 device: self.sampleAPNSDevice(),
-                applicationID: self.sampleApplicationID
+                applicationID: self.sampleApplicationID,
+                deviceLocale: "en_US",
+                appVersion: "1.0.0"
             ) { result in
                 promise(result)
             }
@@ -483,7 +485,9 @@ final class NotificationStoreTests: XCTestCase {
             let action = NotificationAction.registerDeviceForSelfDrivenPushNotifications(
                 siteID: self.sampleSiteID,
                 device: self.sampleAPNSDevice(),
-                applicationID: self.sampleApplicationID
+                applicationID: self.sampleApplicationID,
+                deviceLocale: "en_US",
+                appVersion: "1.0.0"
             ) { result in
                 promise(result)
             }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -710,7 +710,9 @@ private extension PushNotificationsManager {
         let action = NotificationAction.registerDeviceForSelfDrivenPushNotifications(
             siteID: siteID,
             device: device,
-            applicationID: WooConstants.pushApplicationID
+            applicationID: WooConstants.pushApplicationID,
+            deviceLocale: Self.formattedDeviceLocale(),
+            appVersion: Bundle.main.version
         ) { [weak self] result in
             guard let self = self else { return }
 
@@ -780,6 +782,18 @@ private extension PushNotificationsManager {
                 analytics.track(.wpcomDeviceDisablePushNotificationsError, withError: error)
             }
         }))
+    }
+
+    /// Returns the device locale in `xx_XX` format (e.g. `en_US`).
+    /// Falls back to `Locale.current.identifier` if language or region components are unavailable.
+    ///
+    static func formattedDeviceLocale() -> String {
+        let locale = Locale.current
+        guard let languageCode = locale.language.languageCode?.identifier,
+              let regionCode = locale.region?.identifier else {
+            return locale.identifier
+        }
+        return "\(languageCode)_\(regionCode)"
     }
 
     func unregisterFromWooPushNotificationsIfPossible(completion: @escaping (Result<Void, Error>) -> Void) {

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -4,7 +4,7 @@ import Foundation
 import UserNotifications
 import AutomatticTracks
 import Yosemite
-import protocol WooFoundation.Analytics
+import WooFoundation
 
 
 /// PushNotificationsManager: Encapsulates all the tasks related to Push Notifications Auth + Registration + Handling.
@@ -711,7 +711,7 @@ private extension PushNotificationsManager {
             siteID: siteID,
             device: device,
             applicationID: WooConstants.pushApplicationID,
-            deviceLocale: Self.formattedDeviceLocale(),
+            deviceLocale: Locale.current.languageRegionIdentifier ?? Locale.current.identifier,
             appVersion: Bundle.main.version
         ) { [weak self] result in
             guard let self = self else { return }
@@ -782,18 +782,6 @@ private extension PushNotificationsManager {
                 analytics.track(.wpcomDeviceDisablePushNotificationsError, withError: error)
             }
         }))
-    }
-
-    /// Returns the device locale in `xx_XX` format (e.g. `en_US`).
-    /// Falls back to `Locale.current.identifier` if language or region components are unavailable.
-    ///
-    static func formattedDeviceLocale() -> String {
-        let locale = Locale.current
-        guard let languageCode = locale.language.languageCode?.identifier,
-              let regionCode = locale.region?.identifier else {
-            return locale.identifier
-        }
-        return "\(languageCode)_\(regionCode)"
     }
 
     func unregisterFromWooPushNotificationsIfPossible(completion: @escaping (Result<Void, Error>) -> Void) {

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -771,7 +771,7 @@ final class PushNotificationsManagerTests: XCTestCase {
 
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
             switch action {
-            case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, onCompletion):
+            case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, onCompletion):
                 onCompletion(.failure(NSError(domain: "Failure", code: 404)))
             default:
                 break
@@ -845,7 +845,7 @@ private extension PushNotificationsManagerTests {
     func mockSelfDrivenRegistrationActions(token: Int64 = 42, error: Error? = nil) {
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
             switch action {
-            case .registerDeviceForSelfDrivenPushNotifications(_, _, _, let completion):
+            case .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, let completion):
                 if let error {
                     completion(.failure(error))
                 } else {


### PR DESCRIPTION
WOOMOB-2230

## Description

The WooCommerce self-serve push notification token registration endpoint (`POST /wc-push-notifications/push-tokens`) now accepts device locale and metadata. This PR updates the iOS app to send `device_locale` (in `xx_XX` format) and a `metadata` object containing `app_version`, `device_model`, and `os_version` when registering a push token. Additionally, the `platform` value was updated from `"ios"` to `"apple"` to match the latest backend API contract.

- **`DevicesRemote.swift`** — Added `deviceLocale` and `appVersion` parameters to `registerForSelfDrivenPushNotifications`. The request now includes `device_locale` as a top-level param and `metadata` as a nested dictionary (`app_version`, `device_model`, `os_version`). Added `deviceLocale` and `metadata` to `ParameterKeys`. Changed `Values.platform` from `"ios"` to `"apple"`.
- **`NotificationAction.swift`** — Added `deviceLocale: String` and `appVersion: String` to the `.registerDeviceForSelfDrivenPushNotifications` action case.
- **`NotificationStore.swift`** — Forwarded the new parameters through to the remote call.
- **`PushNotificationsManager.swift`** — Added `formattedDeviceLocale()` helper that constructs `xx_XX` format from `Locale.current` language code and region (with fallback to `Locale.current.identifier`). Passes locale and `Bundle.main.version` at the call site.
- **`DevicesRemoteTests.swift`**, **`NotificationStoreTests.swift`**, **`PushNotificationsManagerTests.swift`** — Updated test calls and pattern matches to include the new parameters.

## Test Steps

- Use the app on a device (not sure about simulator. Simulator token format may not fit for the endpoint) with Jetpack-connected site that has self-driven push notifications enabled. Consider running `update_option( 'woocommerce_feature_push_notifications_enabled', 'yes' );` to enable the feature on Woo plugin with PN feature support.
- Enable self-driven-PS related FFs and restart if needed.
- Run the app.
- Observe the console logs — you should see `📱 Self Registering Push Notifications success:`. Make sure the successful token submission event `woo_push_token_register_success` is tracked:
- Verify via network proxy (like Proxyman) that the request to `wc-push-notifications/push-tokens` includes:
   - `"platform": "apple"`
   - `"device_locale"` in `xx_XX` format (e.g. `"en_US"`)
   - `"metadata"` object with `app_version`, `device_model`, `os_version`
- Change the device language/region in Settings and re-trigger token registration — confirm `device_locale` reflects the updated locale.

## Screenshots

N/A — no UI changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
