### PR TITLE
Add POS module docs to Claude Code configuration

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -127,7 +127,7 @@ Hardware module (Stripe Terminal SDK integration)
 **Key types:**
 
 - **`CardPresentPaymentFacade`** (`Card Present Payments/CardPresentPaymentFacade.swift`) - protocol defining the payment interface. Exposes three long-lived Combine publishers (`paymentEventPublisher`, `readerConnectionStatusPublisher`, `cardReaderUpdateStatePublisher`) and async methods (`connectReader`, `collectPayment`, `cancelPayment`, `disconnectReader`)
-- **`CardPresentPaymentService`** (`WooCommerce/Classes/POS/Adaptors/Card Present Payments/`) - concrete implementation living in the app target. Dispatches `CardPresentPaymentAction` to Yosemite stores and bridges to the Hardware module's `CollectOrderPaymentUseCase`
+- **`CardPresentPaymentService`** (`WooCommerce/Classes/POS/Adaptors/Card Present Payments/`) - concrete implementation in the app target. Dispatches `CardPresentPaymentAction` to Yosemite stores and bridges to the app target's `CollectOrderPaymentUseCase` via `CardPresentPaymentCollectOrderPaymentUseCaseAdaptor`
 - **`POSPaymentModel`** (`Controllers/POSPaymentModel.swift`) - `@Observable` `@MainActor` controller that owns all payment state. Subscribes to facade publishers and maps `CardPresentPaymentEvent` stream into UI-consumable state
 - **`PointOfSalePaymentState`** (`Models/PointOfSalePaymentState.swift`) - top-level state containing `card` (`PointOfSaleCardPaymentState`) and `cash` (`PointOfSaleCashPaymentState`) sub-states
 
@@ -139,7 +139,7 @@ idle -> validatingOrder -> preparingReader -> acceptingCard -> cardInserted -> p
 
 **Event-driven communication:**
 1. `CardPresentPaymentService` publishes `CardPresentPaymentEvent` values (idle, show(eventDetails), showOnboarding)
-2. `CardPresentPaymentEventDetails` has ~47 cases covering reader scanning, connection, payment processing, results, and firmware updates
+2. `CardPresentPaymentEventDetails` cases cover reader scanning, connection, payment processing, results, and firmware updates
 3. `POSPaymentModel` subscribes with two scopes:
    - **Always-on** (`cancellables`): reader connection status, update state, onboarding, alerts
    - **Session-scoped** (`paymentSessionCancellables`): payment state, inline messages - prevents cross-flow contamination between payments

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -50,3 +50,111 @@ ServiceLocator.stores.dispatch(action)
 - `GeneratedCopiable`: conform your struct/class, then run codegen to get `copy()` methods
 - `GeneratedFakeable`: conform then run codegen to get `.fake()` test factory methods
 - Run codegen: `pushd BuildTools && export SDKROOT=$(xcrun --sdk macosx --show-sdk-path) && swift package plugin --allow-writing-to-directory .. --allow-writing-to-package-directory sourcery-command --disableCache && popd`
+
+---
+
+## Point of Sale (POS) Module
+
+The POS module (`Modules/Sources/PointOfSale/`) uses a **different architecture** from the main app. See `Modules/Sources/PointOfSale/README.md` for full architectural details and `AGENTS.md` for build/test commands and source layout.
+
+**Do not apply main app patterns to POS code or vice versa.** POS uses Aggregate Model (not Flux/Redux), SwiftUI-only (not UIKit), and `@Environment` injection (not ServiceLocator).
+
+### Key Rules
+- **`PointOfSaleAggregateModel`** is the single coordinator of globally shared POS state
+- **Controllers** manage domain-specific shared state using Services - they are NOT ViewModels
+- **Services** are stateless wrappers around Yosemite/external resources
+- **Views** act as their own view models (`@State` for local, `@Environment` for shared state)
+- **ViewHelpers** must be stateless - pass data in, never store it
+- For leaf views, prefer passing required state directly rather than accessing the full aggregate model
+- Expose state as enums covering all valid possibilities rather than raw model objects
+- POS does NOT use `ServiceLocator` - dependencies come through `POSDependencyProviding` + `@Environment`
+- Use POS design tokens for UI: `POSPadding`, `POSSpacing`, `POSFontStyle`, and `Color+POSColorPalette` - no hardcoded values
+
+### POS Design System
+POS has its own design tokens. When building POS UI, use these instead of app-wide or hardcoded values:
+- **`POSPadding`** - padding constants (`.xSmall` through `.xxLarge`)
+- **`POSSpacing`** - spacing constants (`.xSmall` through `.xxLarge`)
+- **`POSFontStyle`** - typography (`.posHeadingBold`, `.posBodyLargeRegular()`, etc.) applied via `.font(.posBodyMediumBold)`
+- **`Color+POSColorPalette`** - semantic colors (`.posPrimary`, `.posSurface`, `.posError`, etc.) defined in `Colors/Color+POSColorPalette.swift`
+
+Do not use hardcoded spacing/padding values or system fonts directly in POS views.
+
+### POS Dependency Injection
+POS does NOT use `ServiceLocator`. Dependencies are injected at module entry via `POSDependencyProviding` and accessed through SwiftUI environment values:
+```swift
+@Environment(\.posAnalytics) private var analytics
+@Environment(\.posExternalNavigation) private var navigation
+```
+
+### SwiftUI Previews
+POS is an **iPad-first** interface using `horizontalSizeClass` for layout adaptation. When creating POS views:
+- Always add `#Preview` blocks to verify iPad layout
+- Use `POSPreviewHelpers.makePreviewAggregateModel(...)` from `Utils/PreviewHelpers.swift` to set up preview state
+- Preview helpers include mock implementations for all controller and service protocols (guarded with `#if DEBUG`)
+
+```swift
+#Preview("Card Reader Connected") {
+    let model = POSPreviewHelpers.makePreviewAggregateModel(
+        cardPresentPaymentService: CardPresentPaymentPreviewService(
+            connectionStatus: .connected(CardPresentPaymentCardReader(name: "Reader", batteryLevel: 0.85))
+        )
+    )
+    TotalsView()
+        .environment(model)
+        .environment(model.paymentModel)
+}
+```
+
+### Card Present Payments Flow
+
+Card payments in POS flow through several layers using a facade pattern and Combine publishers.
+
+**Architecture layers:**
+```
+Views (observe POSPaymentModel state)
+  ↓
+POSPaymentModel (@Observable controller - owns payment state + logic)
+  ↓
+CardPresentPaymentFacade (protocol in PointOfSale module)
+  ↓
+CardPresentPaymentService (concrete impl in WooCommerce/Classes/POS/Adaptors/)
+  ↓
+CardPresentPaymentAction (Yosemite action dispatch)
+  ↓
+Hardware module (Stripe Terminal SDK integration)
+```
+
+**Key types:**
+
+- **`CardPresentPaymentFacade`** (`Card Present Payments/CardPresentPaymentFacade.swift`) - protocol defining the payment interface. Exposes three long-lived Combine publishers (`paymentEventPublisher`, `readerConnectionStatusPublisher`, `cardReaderUpdateStatePublisher`) and async methods (`connectReader`, `collectPayment`, `cancelPayment`, `disconnectReader`)
+- **`CardPresentPaymentService`** (`WooCommerce/Classes/POS/Adaptors/Card Present Payments/`) - concrete implementation living in the app target. Dispatches `CardPresentPaymentAction` to Yosemite stores and bridges to the Hardware module's `CollectOrderPaymentUseCase`
+- **`POSPaymentModel`** (`Controllers/POSPaymentModel.swift`) - `@Observable` `@MainActor` controller that owns all payment state. Subscribes to facade publishers and maps `CardPresentPaymentEvent` stream into UI-consumable state
+- **`PointOfSalePaymentState`** (`Models/PointOfSalePaymentState.swift`) - top-level state containing `card` (`PointOfSaleCardPaymentState`) and `cash` (`PointOfSaleCashPaymentState`) sub-states
+
+**Card payment state flow:**
+```
+idle -> validatingOrder -> preparingReader -> acceptingCard -> cardInserted -> processingPayment -> cardPaymentSuccessful
+                ↘ validatingOrderError     ↘ paymentIntentCreationError      ↘ paymentError
+```
+
+**Event-driven communication:**
+1. `CardPresentPaymentService` publishes `CardPresentPaymentEvent` values (idle, show(eventDetails), showOnboarding)
+2. `CardPresentPaymentEventDetails` has ~47 cases covering reader scanning, connection, payment processing, results, and firmware updates
+3. `POSPaymentModel` subscribes with two scopes:
+   - **Always-on** (`cancellables`): reader connection status, update state, onboarding, alerts
+   - **Session-scoped** (`paymentSessionCancellables`): payment state, inline messages - prevents cross-flow contamination between payments
+
+**Order provision pattern:**
+- `POSPaymentOrderProviding` protocol abstracts where the order comes from
+- `POSCartPaymentOrderProvider` - provides order from cart controller
+- `POSBookingPaymentOrderProvider` - provides order from booking controller
+- This allows the same `POSPaymentModel` to serve both cart and bookings flows via different configurations (`POSPaymentFlowConfiguration`)
+
+**Cash payments** follow a simpler path via `POSCashPaymentHandling` protocol with cart/booking implementations that mark orders as paid without hardware interaction.
+
+### Adding a New POS Feature
+1. If new shared state: add a Controller in `Controllers/`, wire it into `PointOfSaleAggregateModel`
+2. If new Yosemite interaction: add a Service that wraps Yosemite actions in an async interface
+3. If new UI: add SwiftUI views in `Presentation/`, include `#Preview` blocks using `POSPreviewHelpers`
+4. If external dependency needed: extend `POSDependencyProviding` and add adaptor in `WooCommerce/Classes/POS/`
+5. Tests go in `Modules/Tests/PointOfSaleTests/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,8 @@ If the simulator name `iPhone 16` is not available, try `iPhone 15` or `iPhone 1
 ```
 WooCommerce (UI: ViewControllers, SwiftUI Views, ViewModels, Coordinators)
      |
+     +----> PointOfSale (Standalone SwiftUI module, Aggregate Model architecture)
+     |
      v
 Yosemite (Business Logic: Stores, Actions, Dispatcher)
      |
@@ -139,6 +141,55 @@ ServiceLocator.stores.dispatch(action)
 - Expose state via `@Published` properties or Combine publishers
 - Dispatch Yosemite actions and handle results
 - Should be testable without UI dependencies
+
+## Point of Sale (POS) Module
+
+The POS module (`Modules/Sources/PointOfSale/`) is a **self-contained SwiftUI module** with its own architecture, distinct from the main app. It is reachable as a dedicated tab via `POSTabCoordinator`. See `Modules/Sources/PointOfSale/README.md` for full architectural documentation and `.claude/rules/architecture.md` for POS-specific rules.
+
+**Key differences from the main app:**
+
+| Aspect | Main App | PointOfSale Module |
+|--------|----------|-------------------|
+| Presentation | SwiftUI + UIKit | SwiftUI only |
+| State management | Combine + Yosemite Flux/Redux | Aggregate Model + @Observable Controllers |
+| Dependency injection | ServiceLocator + constructor injection | `POSDependencyProviding` protocol + `@Environment` |
+| Navigation | UIKit Coordinators | SwiftUI state-driven navigation |
+| Testing framework | Mixed XCTest / Swift Testing | Primarily Swift Testing |
+
+### POS Build and Test Commands
+When working on POS, you can build and test the module in isolation for faster feedback:
+```bash
+# Build PointOfSale module only
+xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
+  -destination 'platform=iOS Simulator,name=iPhone 16' -sdk iphonesimulator \
+  build-for-testing -only-testing:"PointOfSaleTests"
+
+# Run POS tests only
+xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
+  -destination 'platform=iOS Simulator,name=iPhone 16' -sdk iphonesimulator \
+  test -only-testing:"PointOfSaleTests"
+
+# Run a specific POS test class
+xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
+  -destination 'platform=iOS Simulator,name=iPhone 16' -sdk iphonesimulator \
+  test -only-testing:"PointOfSaleTests/SomeTestClass"
+```
+
+### POS Source Layout
+```
+Modules/Sources/PointOfSale/
+  Controllers/            # Business logic (order, items, coupons, order list)
+  Models/                 # State definitions (aggregate model, payment state, order stage)
+  Presentation/           # SwiftUI views organized by feature
+  ViewHelpers/            # Stateless view logic extracted for testability
+  Protocols/              # Public interfaces (POSDependencyProviding)
+  Card Present Payments/  # Stripe Terminal integration
+  Analytics/              # POS-specific event tracking
+  Utils/                  # Helpers (PreviewHelpers, audio, etc.)
+  Resources/              # Assets (images, colors)
+Modules/Tests/PointOfSaleTests/  # POS unit tests
+WooCommerce/Classes/POS/         # App-target POS integration (POSTabCoordinator, adaptors)
+```
 
 ## Git Conventions
 


### PR DESCRIPTION
## Description
Adds Point of Sale module documentation to the Claude Code configuration files. POS has a distinct architecture (Aggregate Model vs Flux/Redux) and this ensures agents understand POS-specific patterns when working on POS code.

Changes to two files:
- **AGENTS.md** - Compact POS overview: architecture comparison table, build/test commands, source layout
- **.claude/rules/architecture.md** - Expanded POS rules: key architectural rules, design system tokens, dependency injection, SwiftUI previews with examples, card present payments flow, and adding new features checklist

## Test Steps
- Verify the POS sections in AGENTS.md and architecture.md are accurate and comprehensive
- Check that card present payments flow description matches the actual codebase architecture

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.