### PR TITLE
POS Bookings: Avatar placeholder for team members

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingAvatarView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingAvatarView.swift
@@ -42,7 +42,7 @@ struct POSBookingAvatarView: View {
 
     @ViewBuilder
     private var initialsPlaceholder: some View {
-        if let initials = Self.initials(from: resourceName) {
+        if let initials = POSAvatarInitialsFormatter.initials(from: resourceName) {
             Circle()
                 .fill(fillColor)
                 .frame(width: Constants.avatarSize, height: Constants.avatarSize)
@@ -52,15 +52,6 @@ struct POSBookingAvatarView: View {
                         .foregroundStyle(textColor)
                 )
         }
-    }
-
-    static func initials(from name: String?) -> String? {
-        guard let name, !name.isEmpty else { return nil }
-        let components = name.split(separator: " ")
-        if components.count >= 2 {
-            return String(components[0].prefix(1) + components[1].prefix(1)).uppercased()
-        }
-        return String(components[0].prefix(1)).uppercased()
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingAvatarView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingAvatarView.swift
@@ -5,6 +5,14 @@ struct POSBookingAvatarView: View {
     let imageURL: String?
     let resourceName: String?
 
+    private var fillColor: Color {
+        Color(light: .posDefault, dark: .posSurfaceDim)
+    }
+
+    private var textColor: Color {
+        Color(light: .posOnSurfaceVariantLowest, dark: .posOnSurfaceVariantHighest)
+    }
+
     var body: some View {
         if let imageURL, let url = URL(string: imageURL) {
             KFImage
@@ -18,7 +26,7 @@ struct POSBookingAvatarView: View {
                 .clipShape(Circle())
                 .overlay(
                     Circle()
-                        .stroke(Color.posOutlineVariant, lineWidth: Constants.borderWidth)
+                        .stroke(fillColor, lineWidth: Constants.borderWidth)
                 )
         } else if resourceName != nil {
             initialsPlaceholder
@@ -36,12 +44,12 @@ struct POSBookingAvatarView: View {
     private var initialsPlaceholder: some View {
         if let initials = Self.initials(from: resourceName) {
             Circle()
-                .fill(Color.posOutline)
+                .fill(fillColor)
                 .frame(width: Constants.avatarSize, height: Constants.avatarSize)
                 .overlay(
                     Text(initials)
                         .font(.system(size: Constants.initialsSize, weight: .medium))
-                        .foregroundStyle(Color.posOnPrimary)
+                        .foregroundStyle(textColor)
                 )
         }
     }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingAvatarView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingAvatarView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct POSBookingAvatarView: View {
     let imageURL: String?
+    let resourceName: String?
 
     var body: some View {
         if let imageURL, let url = URL(string: imageURL) {
@@ -18,14 +19,40 @@ struct POSBookingAvatarView: View {
                                 .stroke(Color.posOutlineVariant, lineWidth: Constants.borderWidth)
                         )
                 default:
-                    EmptyView()
+                    initialsPlaceholder
                 }
             }
+        } else if resourceName != nil {
+            initialsPlaceholder
         }
+    }
+
+    @ViewBuilder
+    private var initialsPlaceholder: some View {
+        if let initials = Self.initials(from: resourceName) {
+            Circle()
+                .fill(Color.posOutline)
+                .frame(width: Constants.avatarSize, height: Constants.avatarSize)
+                .overlay(
+                    Text(initials)
+                        .font(.system(size: Constants.initialsSize, weight: .medium))
+                        .foregroundStyle(Color.posOnPrimary)
+                )
+        }
+    }
+
+    static func initials(from name: String?) -> String? {
+        guard let name, !name.isEmpty else { return nil }
+        let components = name.split(separator: " ")
+        if components.count >= 2 {
+            return String(components[0].prefix(1) + components[1].prefix(1)).uppercased()
+        }
+        return String(components[0].prefix(1)).uppercased()
     }
 }
 
 private enum Constants {
     static let avatarSize: CGFloat = 24
     static let borderWidth: CGFloat = 1
+    static let initialsSize: CGFloat = 10
 }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingAvatarView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingAvatarView.swift
@@ -1,3 +1,4 @@
+import Kingfisher
 import SwiftUI
 
 struct POSBookingAvatarView: View {
@@ -6,25 +7,29 @@ struct POSBookingAvatarView: View {
 
     var body: some View {
         if let imageURL, let url = URL(string: imageURL) {
-            AsyncImage(url: url) { phase in
-                switch phase {
-                case .success(let image):
-                    image
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: Constants.avatarSize, height: Constants.avatarSize)
-                        .clipShape(Circle())
-                        .overlay(
-                            Circle()
-                                .stroke(Color.posOutlineVariant, lineWidth: Constants.borderWidth)
-                        )
-                default:
-                    initialsPlaceholder
+            KFImage
+                .url(url)
+                .placeholder {
+                    ghostAvatar
                 }
-            }
+                .resizable()
+                .scaledToFill()
+                .frame(width: Constants.avatarSize, height: Constants.avatarSize)
+                .clipShape(Circle())
+                .overlay(
+                    Circle()
+                        .stroke(Color.posOutlineVariant, lineWidth: Constants.borderWidth)
+                )
         } else if resourceName != nil {
             initialsPlaceholder
         }
+    }
+
+    private var ghostAvatar: some View {
+        Circle()
+            .fill(Color.posOnSurfaceVariantLowest)
+            .frame(width: Constants.avatarSize, height: Constants.avatarSize)
+            .shimmering()
     }
 
     @ViewBuilder

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingRowView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingRowView.swift
@@ -40,7 +40,7 @@ struct POSBookingRowView: View {
 
             Spacer()
 
-            POSBookingAvatarView(imageURL: booking.resourceImageURL)
+            POSBookingAvatarView(imageURL: booking.resourceImageURL, resourceName: booking.resourceName)
         }
     }
 

--- a/Modules/Sources/PointOfSale/Utils/POSAvatarInitialsFormatter.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSAvatarInitialsFormatter.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct POSAvatarInitialsFormatter {
+    static func initials(from name: String?) -> String? {
+        guard let name, !name.isEmpty else { return nil }
+        let components = name.split(separator: " ")
+        guard let first = components.first else { return nil }
+        if components.count >= 2 {
+            return String(first.prefix(1) + components[1].prefix(1)).uppercased()
+        }
+        return String(first.prefix(1)).uppercased()
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Utils/POSAvatarInitialsFormatterTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Utils/POSAvatarInitialsFormatterTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+@testable import PointOfSale
+
+struct POSAvatarInitialsFormatterTests {
+    @Test func test_initials_when_name_is_nil_then_returns_nil() {
+        // Given
+        let name: String? = nil
+
+        // When
+        let result = POSAvatarInitialsFormatter.initials(from: name)
+
+        // Then
+        #expect(result == nil)
+    }
+
+    @Test func test_initials_when_name_is_empty_then_returns_nil() {
+        // Given
+        let name = ""
+
+        // When
+        let result = POSAvatarInitialsFormatter.initials(from: name)
+
+        // Then
+        #expect(result == nil)
+    }
+
+    @Test func test_initials_when_name_is_whitespace_only_then_returns_nil() {
+        // Given
+        let name = "     "
+
+        // When
+        let result = POSAvatarInitialsFormatter.initials(from: name)
+
+        // Then
+        #expect(result == nil)
+    }
+
+    @Test func test_initials_when_single_word_name_then_returns_first_letter_uppercased() {
+        // Given
+        let name = "John"
+
+        // When
+        let result = POSAvatarInitialsFormatter.initials(from: name)
+
+        // Then
+        #expect(result == "J")
+    }
+
+    @Test func test_initials_when_two_word_name_then_returns_both_initials_uppercased() {
+        // Given
+        let name = "John Doe"
+
+        // When
+        let result = POSAvatarInitialsFormatter.initials(from: name)
+
+        // Then
+        #expect(result == "JD")
+    }
+
+    @Test func test_initials_when_three_word_name_then_returns_first_two_initials() {
+        // Given
+        let name = "John Michael Doe"
+
+        // When
+        let result = POSAvatarInitialsFormatter.initials(from: name)
+
+        // Then
+        #expect(result == "JM")
+    }
+
+    @Test func test_initials_when_lowercase_name_then_returns_uppercased() {
+        // Given
+        let name = "jane smith"
+
+        // When
+        let result = POSAvatarInitialsFormatter.initials(from: name)
+
+        // Then
+        #expect(result == "JS")
+    }
+
+    @Test func test_initials_when_name_has_leading_trailing_spaces_then_returns_correct_initials() {
+        // Given
+        let name = "  Alice  "
+
+        // When
+        let result = POSAvatarInitialsFormatter.initials(from: name)
+
+        // Then
+        #expect(result == "A")
+    }
+
+    @Test func test_initials_when_single_character_name_then_returns_that_character_uppercased() {
+        // Given
+        let name = "j"
+
+        // When
+        let result = POSAvatarInitialsFormatter.initials(from: name)
+
+        // Then
+        #expect(result == "J")
+    }
+
+    @Test func test_initials_when_name_has_multiple_spaces_between_words_then_returns_correct_initials() {
+        // Given
+        let name = "John   Doe"
+
+        // When
+        let result = POSAvatarInitialsFormatter.initials(from: name)
+
+        // Then
+        #expect(result == "JD")
+    }
+}


### PR DESCRIPTION
Closes: WOOMOB-2260

## Description

Add avatar support for team members in booking rows:
- Show team member photo with a border when an image URL is available  (using KFImage caching)
- Show initials placeholder when a team member has no image
- Show nothing when no team member is assigned

## Screenshots

| Light mode | Dark mode |
|---|---|
| <img src="https://generously-zealous-triumph.commerce-garden.com/wp-content/uploads/2026/02/light-mode-scaled.png" width="600"> | <img src="https://generously-zealous-triumph.commerce-garden.com/wp-content/uploads/2026/02/dark-mode-scaled.png" width="600"> |

## Testing instructions

1. Set up team members in the Bookings admin (some with profile images, some without)
2. Assign team members to bookings
3. Open POS and navigate to Bookings
4. Confirm:
   - Team members with images show a circular photo with a border
   - Team members without images show an initials placeholder
   - Bookings without a team member show no avatar
   - Verify in both light and dark mode