### PR TITLE
Implement plugin update webview in push notification setup

### DIFF
--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
@@ -65,6 +65,7 @@ final class WPComConnectionSetupViewModel: ObservableObject {
     private let onDismiss: () -> Void
     private let onGoToStore: () -> Void
     private let onUpdatePlugin: () -> Void
+    private var shouldAutoOpenUpdatePlugin = false
 
     init(storeName: String,
          handler: WPComConnectionSetupHandlerProtocol,
@@ -94,6 +95,11 @@ final class WPComConnectionSetupViewModel: ObservableObject {
     }
 
     func onAppear() {
+        if shouldAutoOpenUpdatePlugin {
+            shouldAutoOpenUpdatePlugin = false
+            onUpdatePlugin()
+            return
+        }
         guard setupState == .inProgress else { return }
         handler.start()
     }
@@ -101,6 +107,7 @@ final class WPComConnectionSetupViewModel: ObservableObject {
     func setPluginOutdatedState(version: String) {
         stepDidUpdate(.connect, status: .success)
         stepDidUpdate(.checkPlugin, status: .failure(error: .outdatedPlugin(version: version)))
+        shouldAutoOpenUpdatePlugin = true
     }
 
     func primaryButtonTapped() {

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -87,6 +87,7 @@ final class WooPushNotificationSetupCoordinator {
 private extension WooPushNotificationSetupCoordinator {
     enum Constants {
         static let magicLinkUrlHostname = "magic-login"
+        static let wooCommercePluginUpdatePath = "plugin-install.php?tab=plugin-information&plugin=woocommerce"
     }
 
     /// Creates the connection setup navigation stack with a handler, view model, and hosting controller.
@@ -114,7 +115,7 @@ private extension WooPushNotificationSetupCoordinator {
             onUpdatePlugin: { [weak navigationController, stores] in
                 guard let navigationController,
                       let site = stores.sessionManager.defaultSite,
-                      let url = URL(string: site.adminURL + "plugin-install.php?tab=plugin-information&plugin=woocommerce") else { return }
+                      let url = URL(string: site.adminURL + Constants.wooCommercePluginUpdatePath) else { return }
                 let webView = AuthenticatableWebView(url: url, title: Localization.updateWooCommerce)
                 let vc = UIHostingController(rootView: webView)
                 vc.modalPresentationStyle = .formSheet

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -110,8 +110,20 @@ private extension WooPushNotificationSetupCoordinator {
                 navigationController?.dismiss(animated: true)
                 onSetupCompleted?()
             },
-            onUpdatePlugin: {
-                // TODO: Implement plugin update flow in follow-up PR
+            onUpdatePlugin: { [weak navigationController, stores] in
+                guard let navigationController,
+                      let site = stores.sessionManager.defaultSite,
+                      let url = URL(string: site.adminURL + "plugin-install.php?tab=plugin-information&plugin=woocommerce") else { return }
+                let viewModel = DefaultAuthenticatedWebViewModel(title: Localization.updateWooCommerce, initialURL: url)
+                let webViewController = AuthenticatedWebViewController(viewModel: viewModel)
+                let webNavController = WooNavigationController(rootViewController: webViewController)
+                webViewController.navigationItem.leftBarButtonItem = UIBarButtonItem(
+                    systemItem: .done,
+                    primaryAction: UIAction { [weak webNavController] _ in
+                        webNavController?.dismiss(animated: true)
+                    }
+                )
+                navigationController.present(webNavController, animated: true)
             }
         )
         if let pluginOutdatedVersion {
@@ -155,6 +167,11 @@ private extension WooPushNotificationSetupCoordinator {
             "wooPushNotificationSetupCoordinator.flowTitle",
             value: "Connect to WordPress.com",
             comment: "Title of the self-driven push notification setup flow"
+        )
+        static let updateWooCommerce = NSLocalizedString(
+            "wooPushNotificationSetupCoordinator.updateWooCommerce",
+            value: "Update WooCommerce",
+            comment: "Title of the web view to update WooCommerce plugin during push notification setup"
         )
     }
 }

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -1,4 +1,5 @@
 import UIKit
+import SwiftUI
 import Yosemite
 
 /// Coordinator for the setup of self-driven push notifications for ineligible sites
@@ -114,16 +115,10 @@ private extension WooPushNotificationSetupCoordinator {
                 guard let navigationController,
                       let site = stores.sessionManager.defaultSite,
                       let url = URL(string: site.adminURL + "plugin-install.php?tab=plugin-information&plugin=woocommerce") else { return }
-                let viewModel = DefaultAuthenticatedWebViewModel(title: Localization.updateWooCommerce, initialURL: url)
-                let webViewController = AuthenticatedWebViewController(viewModel: viewModel)
-                let webNavController = WooNavigationController(rootViewController: webViewController)
-                webViewController.navigationItem.leftBarButtonItem = UIBarButtonItem(
-                    systemItem: .done,
-                    primaryAction: UIAction { [weak webNavController] _ in
-                        webNavController?.dismiss(animated: true)
-                    }
-                )
-                navigationController.present(webNavController, animated: true)
+                let webView = AuthenticatableWebView(url: url, title: Localization.updateWooCommerce)
+                let vc = UIHostingController(rootView: webView)
+                vc.modalPresentationStyle = .formSheet
+                navigationController.present(vc, animated: true)
             }
         )
         if let pluginOutdatedVersion {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -210,10 +210,19 @@ final class DashboardViewModel: ObservableObject {
             guard let site = stores.sessionManager.defaultSite, site.isJetpackConnected else {
                 return nil
             }
+            let minimumVersion: String = {
+#if DEBUG
+                if let override: String = UserDefaults.standard[.debugMinWooVersionForSelfDrivenPushNotifications],
+                   !override.isEmpty {
+                    return override
+                }
+#endif
+                return WooPluginRequirements.minimumVersion
+            }()
             return PluginVersionChecker(
                 siteID: site.siteID,
                 pluginPath: WooPluginRequirements.pluginPath,
-                minimumVersion: WooPluginRequirements.minimumVersion
+                minimumVersion: minimumVersion
             )
         }()
 


### PR DESCRIPTION
Closes [WOOMOB-1995](https://linear.app/a8c/issue/WOOMOB-1995)

## Description
Implements the missing plugin update flow when tapping the "Update plugin" button during WPCom connection setup.

Changes:
- Implements `onUpdatePlugin` callback in `WooPushNotificationSetupCoordinator` to open `AuthenticatableWebView` for the WooCommerce plugin update page
- Auto-triggers the update webview when the setup screen appears if opened from the dashboard outdated banner via `shouldAutoOpenUpdatePlugin` flag
- Adds debug override for minimum plugin version in `DashboardViewModel` to test the outdated flow without an actual outdated plugin

## Test Steps
1. Setup a JurassicNinja site with both Jetpack and Woo.
2. Update the Woo plugin from p91TBi-dyW-p2#comment-14563.
3. Enable FFs and complete PN registration
4. Set the minimum required version of the Woo plugin in debug settings to higher than installed version like `1111.1.1`
5. Restart the app
6. Note the DashboardCard for the enabling PNs.
7. Tap it.
8. Tap "Update plugin"
9. Note that the steps steup view is opened briefly to show the webview.

## Screenshots
![ScreenRecording_02-19-2026 14-02-21_1](https://github.com/user-attachments/assets/758c88f6-38a4-4886-b1da-4175788b16d4)


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.