### PR TITLE
POS Bookings: Date picker performance - local caching and prefetch

### DIFF
--- a/Modules/Sources/Networking/Model/Bookings/BookingOrderInfo.swift
+++ b/Modules/Sources/Networking/Model/Bookings/BookingOrderInfo.swift
@@ -3,21 +3,41 @@ import Foundation
 
 public struct BookingOrderInfo: Hashable {
     public let statusKey: String
+    public let orderID: Int64
+    public let orderNumber: String?
+    public let dateCreated: Date?
+    public let datePaid: Date?
+    public let discountTotal: String?
     public let paymentInfo: BookingPaymentInfo?
     public let customerInfo: BookingCustomerInfo?
     public let productInfo: BookingProductInfo?
 
     public init(statusKey: String,
+                orderID: Int64 = 0,
+                orderNumber: String? = nil,
+                dateCreated: Date? = nil,
+                datePaid: Date? = nil,
+                discountTotal: String? = nil,
                 paymentInfo: BookingPaymentInfo?,
                 customerInfo: BookingCustomerInfo?,
                 productInfo: BookingProductInfo?) {
         self.statusKey = statusKey
+        self.orderID = orderID
+        self.orderNumber = orderNumber
+        self.dateCreated = dateCreated
+        self.datePaid = datePaid
+        self.discountTotal = discountTotal
         self.paymentInfo = paymentInfo
         self.customerInfo = customerInfo
         self.productInfo = productInfo
     }
 
     public init(booking: Booking, order: Order) {
+        self.orderID = order.orderID
+        self.orderNumber = order.number
+        self.dateCreated = order.dateCreated
+        self.datePaid = order.datePaid
+        self.discountTotal = order.discountTotal
         self.customerInfo = {
             guard let billingAddress = order.billingAddress else {
                 return nil

--- a/Modules/Sources/Networking/Model/Bookings/BookingOrderInfo.swift
+++ b/Modules/Sources/Networking/Model/Bookings/BookingOrderInfo.swift
@@ -4,20 +4,20 @@ import Foundation
 public struct BookingOrderInfo: Hashable {
     public let statusKey: String
     public let orderID: Int64
-    public let orderNumber: String?
-    public let dateCreated: Date?
+    public let orderNumber: String
+    public let dateCreated: Date
     public let datePaid: Date?
-    public let discountTotal: String?
+    public let discountTotal: String
     public let paymentInfo: BookingPaymentInfo?
     public let customerInfo: BookingCustomerInfo?
     public let productInfo: BookingProductInfo?
 
     public init(statusKey: String,
                 orderID: Int64 = 0,
-                orderNumber: String? = nil,
-                dateCreated: Date? = nil,
+                orderNumber: String = "",
+                dateCreated: Date = Date(),
                 datePaid: Date? = nil,
-                discountTotal: String? = nil,
+                discountTotal: String = "",
                 paymentInfo: BookingPaymentInfo?,
                 customerInfo: BookingCustomerInfo?,
                 productInfo: BookingProductInfo?) {

--- a/Modules/Sources/Networking/Remote/BookingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/BookingsRemote.swift
@@ -124,7 +124,8 @@ public final class BookingsRemote: Remote, BookingsRemoteProtocol {
         var parameters: [String: Any] = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),
-            ParameterKey.order: order.rawValue
+            ParameterKey.order: order.rawValue,
+            ParameterKey.orderBy: OrderBy.startDate.rawValue
         ]
 
         // Apply filters if provided
@@ -295,6 +296,11 @@ public extension BookingsRemote {
         case descending = "desc"
     }
 
+    enum OrderBy: String {
+        case date
+        case startDate = "start_date"
+    }
+
     private enum Path {
         static let bookings = "bookings"
         static let resources = "resources/team-members"
@@ -307,6 +313,7 @@ public extension BookingsRemote {
         static let startDateAfter: String  = "start_date_after"
         static let search: String          = "search"
         static let order: String           = "order"
+        static let orderBy: String         = "orderby"
         static let product: String         = "product"
         static let customer: String        = "customer"
         static let resource: String        = "resource"

--- a/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
@@ -136,6 +136,7 @@ public class OrdersRemote: Remote, OrdersRemoteProtocol {
 
         let parameters: [String: Any] = [
             ParameterKeys.include: Set(orderIDs).map(String.init).joined(separator: ","),
+            ParameterKeys.perPage: String(orderIDs.count),
             ParameterKeys.fields: ParameterValues.fieldValues
         ]
 

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -175,6 +175,7 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     @MainActor
     func selectDate(_ date: Date) async {
         loadTask?.cancel()
+        prefetchTask?.cancel()
         isPaginating = false
         selectedDate = date
         let filters = dateFilters(for: date)
@@ -189,6 +190,7 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         let task = Task { await loadFirstPage() }
         loadTask = task
         await task.value
+        prefetchTask = Task { await syncAdjacentDateBookings(for: date) }
     }
 
     @MainActor

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -75,7 +75,11 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         let date = selectedDate
         prefetchTask = Task {
             let todayStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: dateFilters(for: date))
-            _ = try? await todayStrategy.fetchBookings(pageNumber: 1)
+            do {
+                _ = try await todayStrategy.fetchBookings(pageNumber: 1)
+            } catch {
+                DDLogError("⛔️ Failed to prefetch bookings for today: \(error)")
+            }
             await syncAdjacentDateBookings(for: date)
         }
     }
@@ -267,8 +271,20 @@ private extension POSBookingListController {
         let yesterdayStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: dateFilters(for: yesterday))
         let tomorrowStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: dateFilters(for: tomorrow))
 
-        async let yesterdayFetch: Void = { _ = try? await yesterdayStrategy.fetchBookings(pageNumber: 1) }()
-        async let tomorrowFetch: Void = { _ = try? await tomorrowStrategy.fetchBookings(pageNumber: 1) }()
+        async let yesterdayFetch: Void = {
+            do {
+                _ = try await yesterdayStrategy.fetchBookings(pageNumber: 1)
+            } catch {
+                DDLogError("⛔️ Failed to prefetch bookings for yesterday: \(error)")
+            }
+        }()
+        async let tomorrowFetch: Void = {
+            do {
+                _ = try await tomorrowStrategy.fetchBookings(pageNumber: 1)
+            } catch {
+                DDLogError("⛔️ Failed to prefetch bookings for tomorrow: \(error)")
+            }
+        }()
         _ = await (yesterdayFetch, tomorrowFetch)
     }
 

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -92,9 +92,8 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
             fetchStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: filters)
         }
         setLocalDataOrLoadingState()
-        let task = Task { await loadFirstPage() }
-        loadTask = task
-        await task.value
+        loadTask = Task { await loadFirstPage() }
+        await loadTask?.value
         prefetchTask = Task { await syncAdjacentDateBookings(for: selectedDate) }
     }
 
@@ -102,9 +101,8 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     func refreshBookings() async {
         loadTask?.cancel()
         isPaginating = false
-        let task = Task { await loadFirstPage() }
-        loadTask = task
-        await task.value
+        loadTask = Task { await loadFirstPage() }
+        await loadTask?.value
     }
 
     @MainActor
@@ -187,9 +185,8 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
             let localBookings = fetchStrategy.fetchLocalBookings()
             bookingsViewState = .loading(localBookings)
         }
-        let task = Task { await loadFirstPage() }
-        loadTask = task
-        await task.value
+        loadTask = Task { await loadFirstPage() }
+        await loadTask?.value
         prefetchTask = Task { await syncAdjacentDateBookings(for: date) }
     }
 
@@ -216,9 +213,8 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         activeSearchTerm = searchTerm
         fetchStrategy = bookingListFetchStrategyFactory.searchStrategy(searchTerm: searchTerm, filters: dateFilters(for: selectedDate))
         bookingsViewState = .loading([])
-        let task = Task { await loadFirstPage() }
-        loadTask = task
-        await task.value
+        loadTask = Task { await loadFirstPage() }
+        await loadTask?.value
     }
 
     @MainActor
@@ -232,10 +228,7 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
             bookingsViewState = .loaded(localBookings, hasMoreItems: true)
         } else {
             bookingsViewState = .loading([])
-            let task = Task {
-                await loadFirstPage()
-            }
-            loadTask = task
+            loadTask = Task { await loadFirstPage() }
         }
     }
 }
@@ -328,13 +321,7 @@ private extension POSBookingListController {
             let uniqueNewBookings = pagedBookings.items.filter { newBooking in
                 !existingBookings.contains(where: { $0.id == newBooking.id })
             }
-            let mergedBookings = appendToExistingBookings ? existingBookings + uniqueNewBookings : uniqueNewBookings
-            let allBookings = mergedBookings.sorted { lhs, rhs in
-                if lhs.startDate == rhs.startDate {
-                    return lhs.id < rhs.id
-                }
-                return lhs.startDate < rhs.startDate
-            }
+            let allBookings = appendToExistingBookings ? existingBookings + uniqueNewBookings : uniqueNewBookings
 
             bookingsViewState = allBookings.isEmpty ? .empty : .loaded(allBookings, hasMoreItems: pagedBookings.hasMorePages)
 

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -15,6 +15,8 @@ protocol POSBookingListControllerProtocol {
     var bookingsViewState: POSBookingListState { get }
     var selectedBooking: POSBooking? { get }
     var selectedDate: Date { get }
+    var isPaginating: Bool { get }
+    func syncBookings()
     func loadBookings() async
     func refreshBookings() async
     func loadNextBookings() async
@@ -36,6 +38,7 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
 @Observable final class POSBookingListController: POSSearchingBookingListControllerProtocol {
     var bookingsViewState: POSBookingListState
     private(set) var selectedDate: Date
+    private(set) var isPaginating: Bool = false
     private var strategyPaginationTracker: [String: AsyncPaginationTracker] = [:]
     private var fetchStrategy: POSBookingListFetchStrategy
     private var activeSearchTerm: String?
@@ -43,6 +46,8 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     private let bookingListFetchStrategyFactory: POSBookingListFetchStrategyFactoryProtocol
     private let bookingService: POSBookingServiceProtocol
     private let siteTimezone: TimeZone
+    private var loadTask: Task<Void, Never>?
+    private var prefetchTask: Task<Void, Never>?
 
     private var paginationTracker: AsyncPaginationTracker {
         if let existing = strategyPaginationTracker[fetchStrategy.id] {
@@ -65,8 +70,20 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         self.fetchStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: nil)
     }
 
+    func syncBookings() {
+        prefetchTask?.cancel()
+        prefetchTask = Task {
+            let todayStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: dateFilters(for: selectedDate))
+            _ = try? await todayStrategy.fetchBookings(pageNumber: 1)
+            await syncAdjacentDateBookings()
+        }
+    }
+
     @MainActor
     func loadBookings() async {
+        loadTask?.cancel()
+        prefetchTask?.cancel()
+        isPaginating = false
         let filters = dateFilters(for: selectedDate)
         if let searchTerm = activeSearchTerm {
             fetchStrategy = bookingListFetchStrategyFactory.searchStrategy(searchTerm: searchTerm, filters: filters)
@@ -74,12 +91,20 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
             fetchStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: filters)
         }
         setLocalDataOrLoadingState()
-        await loadFirstPage()
+        let task = Task { await loadFirstPage() }
+        loadTask = task
+        await task.value
+        prefetchTask?.cancel()
+        prefetchTask = Task { await syncAdjacentDateBookings() }
     }
 
     @MainActor
     func refreshBookings() async {
-        await loadFirstPage()
+        loadTask?.cancel()
+        isPaginating = false
+        let task = Task { await loadFirstPage() }
+        loadTask = task
+        await task.value
     }
 
     @MainActor
@@ -87,6 +112,7 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         guard paginationTracker.hasNextPage else {
             return
         }
+        isPaginating = true
         let currentBookings = bookingsViewState.bookings
         bookingsViewState = .loading(currentBookings)
         do {
@@ -99,6 +125,7 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
                                              error: .errorOnLoadingBookingsNextPage(error: error),
                                              context: .pagination)
         }
+        isPaginating = false
     }
 
     @MainActor
@@ -147,6 +174,8 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
 
     @MainActor
     func selectDate(_ date: Date) async {
+        loadTask?.cancel()
+        isPaginating = false
         selectedDate = date
         let filters = dateFilters(for: date)
         if let searchTerm = activeSearchTerm {
@@ -157,7 +186,9 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
             let localBookings = fetchStrategy.fetchLocalBookings()
             bookingsViewState = .loading(localBookings)
         }
-        await loadFirstPage()
+        let task = Task { await loadFirstPage() }
+        loadTask = task
+        await task.value
     }
 
     @MainActor
@@ -178,14 +209,20 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
 
     @MainActor
     func searchBookings(searchTerm: String) async {
+        loadTask?.cancel()
+        isPaginating = false
         activeSearchTerm = searchTerm
         fetchStrategy = bookingListFetchStrategyFactory.searchStrategy(searchTerm: searchTerm, filters: dateFilters(for: selectedDate))
         bookingsViewState = .loading([])
-        await loadFirstPage()
+        let task = Task { await loadFirstPage() }
+        loadTask = task
+        await task.value
     }
 
     @MainActor
     func clearSearchBookings() {
+        loadTask?.cancel()
+        isPaginating = false
         activeSearchTerm = nil
         fetchStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: dateFilters(for: selectedDate))
         let localBookings = fetchStrategy.fetchLocalBookings()
@@ -193,9 +230,10 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
             bookingsViewState = .loaded(localBookings, hasMoreItems: true)
         } else {
             bookingsViewState = .loading([])
-            Task {
+            let task = Task {
                 await loadFirstPage()
             }
+            loadTask = task
         }
     }
 }
@@ -224,6 +262,21 @@ extension POSBookingListController {
 // MARK: - Private
 
 private extension POSBookingListController {
+    func syncAdjacentDateBookings() async {
+        var calendar = Calendar.current
+        calendar.timeZone = siteTimezone
+        guard let yesterday = calendar.date(byAdding: .day, value: -1, to: selectedDate),
+              let tomorrow = calendar.date(byAdding: .day, value: 1, to: selectedDate) else {
+            return
+        }
+        let yesterdayStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: dateFilters(for: yesterday))
+        let tomorrowStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: dateFilters(for: tomorrow))
+
+        async let yesterdayFetch: Void = { _ = try? await yesterdayStrategy.fetchBookings(pageNumber: 1) }()
+        async let tomorrowFetch: Void = { _ = try? await tomorrowStrategy.fetchBookings(pageNumber: 1) }()
+        _ = await (yesterdayFetch, tomorrowFetch)
+    }
+
     static func todayInSiteTimezone(_ timezone: TimeZone) -> Date {
         var calendar = Calendar.current
         calendar.timeZone = timezone
@@ -273,7 +326,13 @@ private extension POSBookingListController {
             let uniqueNewBookings = pagedBookings.items.filter { newBooking in
                 !existingBookings.contains(where: { $0.id == newBooking.id })
             }
-            let allBookings = appendToExistingBookings ? existingBookings + uniqueNewBookings : uniqueNewBookings
+            let mergedBookings = appendToExistingBookings ? existingBookings + uniqueNewBookings : uniqueNewBookings
+            let allBookings = mergedBookings.sorted { lhs, rhs in
+                if lhs.startDate == rhs.startDate {
+                    return lhs.id < rhs.id
+                }
+                return lhs.startDate < rhs.startDate
+            }
 
             bookingsViewState = allBookings.isEmpty ? .empty : .loaded(allBookings, hasMoreItems: pagedBookings.hasMorePages)
 

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -94,7 +94,6 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         let task = Task { await loadFirstPage() }
         loadTask = task
         await task.value
-        prefetchTask?.cancel()
         prefetchTask = Task { await syncAdjacentDateBookings() }
     }
 

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -115,6 +115,7 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
             return
         }
         isPaginating = true
+        defer { isPaginating = false }
         let currentBookings = bookingsViewState.bookings
         bookingsViewState = .loading(currentBookings)
         do {
@@ -127,7 +128,6 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
                                              error: .errorOnLoadingBookingsNextPage(error: error),
                                              context: .pagination)
         }
-        isPaginating = false
     }
 
     @MainActor

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -313,6 +313,7 @@ private extension POSBookingListController {
         }
     }
 
+    @MainActor
     func setLocalDataOrLoadingState() {
         let localBookings = fetchStrategy.fetchLocalBookings()
         if localBookings.isNotEmpty {

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -38,7 +38,6 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     private(set) var selectedDate: Date
     private var strategyPaginationTracker: [String: AsyncPaginationTracker] = [:]
     private var fetchStrategy: POSBookingListFetchStrategy
-    private var cachedBookings: [POSBooking] = []
     private var activeSearchTerm: String?
     private(set) var selectedBooking: POSBooking?
     private let bookingListFetchStrategyFactory: POSBookingListFetchStrategyFactoryProtocol
@@ -74,8 +73,7 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         } else {
             fetchStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: filters)
         }
-        setCachedData()
-        setLoadingState()
+        setLocalDataOrLoadingState()
         await loadFirstPage()
     }
 
@@ -150,14 +148,15 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     @MainActor
     func selectDate(_ date: Date) async {
         selectedDate = date
-        cachedBookings = []
         let filters = dateFilters(for: date)
         if let searchTerm = activeSearchTerm {
             fetchStrategy = bookingListFetchStrategyFactory.searchStrategy(searchTerm: searchTerm, filters: filters)
+            bookingsViewState = .loading([])
         } else {
             fetchStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: filters)
+            let localBookings = fetchStrategy.fetchLocalBookings()
+            bookingsViewState = .loading(localBookings)
         }
-        bookingsViewState = .loading([])
         await loadFirstPage()
     }
 
@@ -189,8 +188,9 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     func clearSearchBookings() {
         activeSearchTerm = nil
         fetchStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: dateFilters(for: selectedDate))
-        if cachedBookings.isNotEmpty {
-            bookingsViewState = .loaded(cachedBookings, hasMoreItems: true)
+        let localBookings = fetchStrategy.fetchLocalBookings()
+        if localBookings.isNotEmpty {
+            bookingsViewState = .loaded(localBookings, hasMoreItems: true)
         } else {
             bookingsViewState = .loading([])
             Task {
@@ -249,16 +249,18 @@ private extension POSBookingListController {
         }
     }
 
-    func setLoadingState() {
-        if !fetchStrategy.showsLoadingWithItems {
+    func setLocalDataOrLoadingState() {
+        let localBookings = fetchStrategy.fetchLocalBookings()
+        if localBookings.isNotEmpty {
+            bookingsViewState = .loading(localBookings)
+        } else if !fetchStrategy.showsLoadingWithItems {
             bookingsViewState = .loading([])
-            return
-        }
-
-        let bookings = bookingsViewState.bookings
-        let isInitialState = bookingsViewState.isLoading && bookings.isEmpty
-        if !isInitialState {
-            bookingsViewState = .loading(bookings)
+        } else {
+            let bookings = bookingsViewState.bookings
+            let isInitialState = bookingsViewState.isLoading && bookings.isEmpty
+            if !isInitialState {
+                bookingsViewState = .loading(bookings)
+            }
         }
     }
 
@@ -280,27 +282,10 @@ private extension POSBookingListController {
                 selectedBooking = updatedSelectedBooking
             }
 
-            if fetchStrategy.supportsCaching {
-                cachedBookings = allBookings
-            }
-
             return pagedBookings.hasMorePages
         } catch POSBookingServiceError.requestCancelled {
             return true
         }
-    }
-
-    @MainActor
-    func setCachedData() {
-        guard fetchStrategy.supportsCaching else {
-            return
-        }
-
-        guard !bookingsViewState.bookings.isEmpty || !cachedBookings.isEmpty else {
-            return
-        }
-
-        bookingsViewState = .loading(cachedBookings)
     }
 
     @MainActor
@@ -309,9 +294,6 @@ private extension POSBookingListController {
             booking.id == updatedBooking.id ? updatedBooking : booking
         }
         bookingsViewState = bookingsViewState.updatingBookings(with: updatedBookings)
-        cachedBookings = cachedBookings.map { booking in
-            booking.id == updatedBooking.id ? updatedBooking : booking
-        }
         if selectedBooking?.id == updatedBooking.id {
             selectedBooking = updatedBooking
         }

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -72,10 +72,11 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
 
     func syncBookings() {
         prefetchTask?.cancel()
+        let date = selectedDate
         prefetchTask = Task {
-            let todayStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: dateFilters(for: selectedDate))
+            let todayStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: dateFilters(for: date))
             _ = try? await todayStrategy.fetchBookings(pageNumber: 1)
-            await syncAdjacentDateBookings()
+            await syncAdjacentDateBookings(for: date)
         }
     }
 
@@ -94,7 +95,7 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         let task = Task { await loadFirstPage() }
         loadTask = task
         await task.value
-        prefetchTask = Task { await syncAdjacentDateBookings() }
+        prefetchTask = Task { await syncAdjacentDateBookings(for: selectedDate) }
     }
 
     @MainActor
@@ -261,11 +262,11 @@ extension POSBookingListController {
 // MARK: - Private
 
 private extension POSBookingListController {
-    func syncAdjacentDateBookings() async {
+    func syncAdjacentDateBookings(for date: Date) async {
         var calendar = Calendar.current
         calendar.timeZone = siteTimezone
-        guard let yesterday = calendar.date(byAdding: .day, value: -1, to: selectedDate),
-              let tomorrow = calendar.date(byAdding: .day, value: 1, to: selectedDate) else {
+        guard let yesterday = calendar.date(byAdding: .day, value: -1, to: date),
+              let tomorrow = calendar.date(byAdding: .day, value: 1, to: date) else {
             return
         }
         let yesterdayStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: dateFilters(for: yesterday))

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -15,7 +15,6 @@ protocol POSBookingListControllerProtocol {
     var bookingsViewState: POSBookingListState { get }
     var selectedBooking: POSBooking? { get }
     var selectedDate: Date { get }
-    var isPaginating: Bool { get }
     func syncBookings()
     func loadBookings() async
     func refreshBookings() async
@@ -38,7 +37,6 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
 @Observable final class POSBookingListController: POSSearchingBookingListControllerProtocol {
     var bookingsViewState: POSBookingListState
     private(set) var selectedDate: Date
-    private(set) var isPaginating: Bool = false
     private var strategyPaginationTracker: [String: AsyncPaginationTracker] = [:]
     private var fetchStrategy: POSBookingListFetchStrategy
     private var activeSearchTerm: String?
@@ -88,7 +86,6 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     func loadBookings() async {
         loadTask?.cancel()
         prefetchTask?.cancel()
-        isPaginating = false
         let filters = dateFilters(for: selectedDate)
         if let searchTerm = activeSearchTerm {
             fetchStrategy = bookingListFetchStrategyFactory.searchStrategy(searchTerm: searchTerm, filters: filters)
@@ -104,7 +101,6 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     @MainActor
     func refreshBookings() async {
         loadTask?.cancel()
-        isPaginating = false
         loadTask = Task { await loadFirstPage() }
         await loadTask?.value
     }
@@ -114,10 +110,8 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         guard paginationTracker.hasNextPage else {
             return
         }
-        isPaginating = true
-        defer { isPaginating = false }
         let currentBookings = bookingsViewState.bookings
-        bookingsViewState = .loading(currentBookings)
+        bookingsViewState = .loading(currentBookings, context: .nextPage)
         do {
             _ = try await paginationTracker.ensureNextPageIsSynced { [weak self] pageNumber in
                 guard let self else { return true }
@@ -178,7 +172,6 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     func selectDate(_ date: Date) async {
         loadTask?.cancel()
         prefetchTask?.cancel()
-        isPaginating = false
         selectedDate = date
         let filters = dateFilters(for: date)
         if let searchTerm = activeSearchTerm {
@@ -213,7 +206,6 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     @MainActor
     func searchBookings(searchTerm: String) async {
         loadTask?.cancel()
-        isPaginating = false
         activeSearchTerm = searchTerm
         fetchStrategy = bookingListFetchStrategyFactory.searchStrategy(searchTerm: searchTerm, filters: dateFilters(for: selectedDate))
         bookingsViewState = .loading([])
@@ -224,7 +216,6 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     @MainActor
     func clearSearchBookings() {
         loadTask?.cancel()
-        isPaginating = false
         activeSearchTerm = nil
         fetchStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: dateFilters(for: selectedDate))
         let localBookings = fetchStrategy.fetchLocalBookings()

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -45,7 +45,7 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     private let bookingService: POSBookingServiceProtocol
     private let siteTimezone: TimeZone
     private var loadTask: Task<Void, Never>?
-    private var prefetchTask: Task<Void, Never>?
+    private var prefetchTasks: [Date: Task<Void, Never>] = [:]
 
     private var paginationTracker: AsyncPaginationTracker {
         if let existing = strategyPaginationTracker[fetchStrategy.id] {
@@ -69,23 +69,14 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     }
 
     func syncBookings() {
-        prefetchTask?.cancel()
         let date = selectedDate
-        prefetchTask = Task {
-            let todayStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: dateFilters(for: date))
-            do {
-                _ = try await todayStrategy.fetchBookings(pageNumber: 1)
-            } catch {
-                DDLogError("⛔️ Failed to prefetch bookings for today: \(error)")
-            }
-            await syncAdjacentDateBookings(for: date)
-        }
+        prefetchDateIfNeeded(date)
+        prefetchAdjacentDates(for: date)
     }
 
     @MainActor
     func loadBookings() async {
         loadTask?.cancel()
-        prefetchTask?.cancel()
         let filters = dateFilters(for: selectedDate)
         if let searchTerm = activeSearchTerm {
             fetchStrategy = bookingListFetchStrategyFactory.searchStrategy(searchTerm: searchTerm, filters: filters)
@@ -95,7 +86,7 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         setLocalDataOrLoadingState()
         loadTask = Task { await loadFirstPage() }
         await loadTask?.value
-        prefetchTask = Task { await syncAdjacentDateBookings(for: selectedDate) }
+        prefetchAdjacentDates(for: selectedDate)
     }
 
     @MainActor
@@ -171,7 +162,6 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     @MainActor
     func selectDate(_ date: Date) async {
         loadTask?.cancel()
-        prefetchTask?.cancel()
         selectedDate = date
         let filters = dateFilters(for: date)
         if let searchTerm = activeSearchTerm {
@@ -184,7 +174,7 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         }
         loadTask = Task { await loadFirstPage() }
         await loadTask?.value
-        prefetchTask = Task { await syncAdjacentDateBookings(for: date) }
+        prefetchAdjacentDates(for: date)
     }
 
     @MainActor
@@ -252,31 +242,33 @@ extension POSBookingListController {
 // MARK: - Private
 
 private extension POSBookingListController {
-    func syncAdjacentDateBookings(for date: Date) async {
+    func prefetchAdjacentDates(for date: Date) {
         var calendar = Calendar.current
         calendar.timeZone = siteTimezone
-        guard let yesterday = calendar.date(byAdding: .day, value: -1, to: date),
-              let tomorrow = calendar.date(byAdding: .day, value: 1, to: date) else {
-            return
+        if let yesterday = calendar.date(byAdding: .day, value: -1, to: date) {
+            prefetchDateIfNeeded(yesterday)
         }
-        let yesterdayStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: dateFilters(for: yesterday))
-        let tomorrowStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: dateFilters(for: tomorrow))
+        if let tomorrow = calendar.date(byAdding: .day, value: 1, to: date) {
+            prefetchDateIfNeeded(tomorrow)
+        }
+    }
 
-        async let yesterdayFetch: Void = {
+    func prefetchDateIfNeeded(_ date: Date) {
+        var calendar = Calendar.current
+        calendar.timeZone = siteTimezone
+        let normalizedDate = calendar.startOfDay(for: date)
+
+        guard prefetchTasks[normalizedDate] == nil else { return }
+
+        let strategy = bookingListFetchStrategyFactory.defaultStrategy(filters: dateFilters(for: normalizedDate))
+        prefetchTasks[normalizedDate] = Task { [weak self] in
             do {
-                _ = try await yesterdayStrategy.fetchBookings(pageNumber: 1)
+                _ = try await strategy.fetchBookings(pageNumber: 1)
             } catch {
-                DDLogError("⛔️ Failed to prefetch bookings for yesterday: \(error)")
+                DDLogError("⛔️ Failed to prefetch bookings for \(normalizedDate): \(error)")
             }
-        }()
-        async let tomorrowFetch: Void = {
-            do {
-                _ = try await tomorrowStrategy.fetchBookings(pageNumber: 1)
-            } catch {
-                DDLogError("⛔️ Failed to prefetch bookings for tomorrow: \(error)")
-            }
-        }()
-        _ = await (yesterdayFetch, tomorrowFetch)
+            self?.prefetchTasks[normalizedDate] = nil
+        }
     }
 
     static func todayInSiteTimezone(_ timezone: TimeZone) -> Date {

--- a/Modules/Sources/PointOfSale/Models/POSBookingListState.swift
+++ b/Modules/Sources/PointOfSale/Models/POSBookingListState.swift
@@ -2,11 +2,16 @@ import Foundation
 import struct Yosemite.POSBooking
 
 enum POSBookingListState: Equatable {
-    case loading([POSBooking])
+    case loading([POSBooking], context: LoadingContext = .firstPage)
     case loaded([POSBooking], hasMoreItems: Bool)
     case inlineError([POSBooking], error: PointOfSaleErrorState, context: InlineErrorContext)
     case error(PointOfSaleErrorState)
     case empty
+
+    enum LoadingContext {
+        case firstPage
+        case nextPage
+    }
 
     enum InlineErrorContext {
         case refresh
@@ -22,11 +27,18 @@ enum POSBookingListState: Equatable {
         }
     }
 
+    var isPaginating: Bool {
+        if case .loading(_, .nextPage) = self {
+            return true
+        }
+        return false
+    }
+
     var isEmpty: Bool {
         switch self {
         case .loaded:
             return false
-        case .loading(let bookings):
+        case .loading(let bookings, _):
             return bookings.isEmpty
         default:
             return true
@@ -35,7 +47,7 @@ enum POSBookingListState: Equatable {
 
     var bookings: [POSBooking] {
         switch self {
-        case .loading(let bookings),
+        case .loading(let bookings, _),
              .loaded(let bookings, _),
              .inlineError(let bookings, _, _):
             return bookings
@@ -48,8 +60,8 @@ enum POSBookingListState: Equatable {
         switch self {
         case .loaded(_, let hasMoreItems):
             return .loaded(updatedBookings, hasMoreItems: hasMoreItems)
-        case .loading:
-            return .loading(updatedBookings)
+        case .loading(_, let context):
+            return .loading(updatedBookings, context: context)
         case .inlineError(_, let error, let context):
             return .inlineError(updatedBookings, error: error, context: context)
         case .empty, .error:

--- a/Modules/Sources/PointOfSale/Models/POSBookingsModel.swift
+++ b/Modules/Sources/PointOfSale/Models/POSBookingsModel.swift
@@ -24,6 +24,7 @@ import class Yosemite.PaymentCaptureCelebration
         self.orderService = orderService
         self.receiptSender = receiptSender
         self.collectOrderPaymentAnalyticsTracker = collectOrderPaymentAnalyticsTracker
+        bookingsController.syncBookings()
     }
 
     @MainActor

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/CancelBooking/POSCancelBookingModalContent.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/CancelBooking/POSCancelBookingModalContent.swift
@@ -7,6 +7,7 @@ struct POSCancelBookingModalContent: View {
     @Binding var cancelModalState: CancelBookingModalState?
 
     @Environment(POSBookingsModel.self) private var bookingsModel
+    @Environment(\.siteTimezone) private var siteTimezone
 
     var body: some View {
         switch state {
@@ -59,7 +60,11 @@ struct POSCancelBookingModalContent: View {
     }
 
     private var formattedCancelDateTime: String {
-        DateFormatter.dateTimeFormatter.string(from: booking.startDate)
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        formatter.timeZone = siteTimezone
+        return formatter.string(from: booking.startDate)
     }
 
     @MainActor
@@ -71,17 +76,6 @@ struct POSCancelBookingModalContent: View {
             cancelModalState = .error
         }
     }
-}
-
-// MARK: - Date Formatters
-
-private extension DateFormatter {
-    static let dateTimeFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .short
-        return formatter
-    }()
 }
 
 // MARK: - Localization

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/CancelBooking/POSCancelBookingModalContent.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/CancelBooking/POSCancelBookingModalContent.swift
@@ -59,12 +59,16 @@ struct POSCancelBookingModalContent: View {
         }
     }
 
-    private var formattedCancelDateTime: String {
+    private static let cancelDateTimeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
-        formatter.timeZone = siteTimezone
-        return formatter.string(from: booking.startDate)
+        return formatter
+    }()
+
+    private var formattedCancelDateTime: String {
+        Self.cancelDateTimeFormatter.timeZone = siteTimezone
+        return Self.cancelDateTimeFormatter.string(from: booking.startDate)
     }
 
     @MainActor

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -10,6 +10,7 @@ struct POSBookingDetailView: View {
     @Environment(POSOrderListModel.self) private var orderListModel
     @Environment(POSBookingsModel.self) private var bookingsModel
     @Environment(\.posAnalytics) private var analytics
+    @Environment(\.siteTimezone) private var siteTimezone
 
     @State private var navigationPath: [NavigationDestination] = []
     @State private var cancelModalState: CancelBookingModalState?
@@ -74,7 +75,7 @@ struct POSBookingDetailView: View {
     private var bookingDetailContent: some View {
         VStack(spacing: POSSpacing.none) {
             POSPageHeaderView(
-                title: POSBookingSummaryView.formattedTimeRange(for: booking),
+                title: POSBookingSummaryView.formattedTimeRange(for: booking, siteTimezone: siteTimezone),
                 isLoading: isDetailsUpdating,
                 backButtonConfiguration: shouldShowBackButton ? .init(state: .enabled, action: onBack) : nil,
                 trailingContent: {

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingListView.swift
@@ -146,13 +146,9 @@ struct POSBookingListView: View {
                     }
                 }
             )
+            .id(bookingsModel.bookingsController.selectedDate)
             .scrollDismissesKeyboard(.immediately)
             .onChange(of: searchTerm) { _, _ in
-                withAnimation {
-                    proxy.scrollTo(Constants.scrollTopID, anchor: .top)
-                }
-            }
-            .onChange(of: bookingsModel.bookingsController.selectedDate) { _, _ in
                 withAnimation {
                     proxy.scrollTo(Constants.scrollTopID, anchor: .top)
                 }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingListView.swift
@@ -22,7 +22,7 @@ struct POSBookingListView: View {
                     subtitle: nil,
                     isSelected: true,
                     isLoading: isSearching ? false : {
-                        if case .loading(let bookings) = bookingsViewState {
+                        if case .loading(let bookings, _) = bookingsViewState {
                             return !bookings.isEmpty
                         }
                         return false
@@ -159,14 +159,14 @@ struct POSBookingListView: View {
     @ViewBuilder
     private var footerRows: some View {
         switch bookingsViewState {
-        case .loading(let bookings):
+        case .loading(let bookings, _):
             if bookings.isEmpty {
                 ForEach(0..<8, id: \.self) { _ in
                     POSBookingGhostRowView()
                 }
                 .opacity(bookings.isEmpty ? 1 : 0)
                 .animation(.default, value: bookings.isEmpty)
-            } else if bookingsModel.bookingsController.isPaginating {
+            } else if bookingsViewState.isPaginating {
                 POSBookingGhostRowView()
             }
         case .inlineError(_, let errorState, .pagination):

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingListView.swift
@@ -165,7 +165,7 @@ struct POSBookingListView: View {
                 }
                 .opacity(bookings.isEmpty ? 1 : 0)
                 .animation(.default, value: bookings.isEmpty)
-            } else {
+            } else if bookingsModel.bookingsController.isPaginating {
                 POSBookingGhostRowView()
             }
         case .inlineError(_, let errorState, .pagination):

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingListView.swift
@@ -152,6 +152,11 @@ struct POSBookingListView: View {
                     proxy.scrollTo(Constants.scrollTopID, anchor: .top)
                 }
             }
+            .onChange(of: bookingsModel.bookingsController.selectedDate) { _, _ in
+                withAnimation {
+                    proxy.scrollTo(Constants.scrollTopID, anchor: .top)
+                }
+            }
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingRowView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingRowView.swift
@@ -46,7 +46,8 @@ struct POSBookingRowView: View {
     }
 
     private var accessibilityLabel: String {
-        let formatter = DateFormatter.posAccessibilityTimeFormatter(timeZone: siteTimezone)
+        let formatter = DateFormatter.posAccessibilityTimeFormatter
+        formatter.timeZone = siteTimezone
         let timeRange = Localization.timeRangeAccessibilityLabel(
             start: formatter.string(from: booking.startDate),
             end: formatter.string(from: booking.endDate)
@@ -79,11 +80,10 @@ private enum Localization {
 }
 
 private extension DateFormatter {
-    static func posAccessibilityTimeFormatter(timeZone: TimeZone) -> DateFormatter {
+    static let posAccessibilityTimeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .none
         formatter.timeStyle = .short
-        formatter.timeZone = timeZone
         return formatter
-    }
+    }()
 }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingRowView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingRowView.swift
@@ -7,6 +7,7 @@ struct POSBookingRowView: View {
 
     @ScaledMetric private var scale: CGFloat = 1.0
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
+    @Environment(\.siteTimezone) private var siteTimezone
 
     var body: some View {
         VStack(alignment: .leading, spacing: POSSpacing.none) {
@@ -33,7 +34,7 @@ struct POSBookingRowView: View {
     @ViewBuilder
     private var bookingHeaderRow: some View {
         HStack(alignment: .center) {
-            Text(POSBookingSummaryView.formattedTimeRange(for: booking))
+            Text(POSBookingSummaryView.formattedTimeRange(for: booking, siteTimezone: siteTimezone))
                 .font(.posBodySmallBold())
                 .foregroundStyle(Color.posOnSurface)
                 .fixedSize(horizontal: false, vertical: true)
@@ -45,9 +46,10 @@ struct POSBookingRowView: View {
     }
 
     private var accessibilityLabel: String {
+        let formatter = DateFormatter.posAccessibilityTimeFormatter(timeZone: siteTimezone)
         let timeRange = Localization.timeRangeAccessibilityLabel(
-            start: DateFormatter.posAccessibilityTimeFormatter.string(from: booking.startDate),
-            end: DateFormatter.posAccessibilityTimeFormatter.string(from: booking.endDate)
+            start: formatter.string(from: booking.startDate),
+            end: formatter.string(from: booking.endDate)
         )
 
         let customerDisplayName = booking.customerName ?? booking.customerEmail
@@ -77,10 +79,11 @@ private enum Localization {
 }
 
 private extension DateFormatter {
-    static let posAccessibilityTimeFormatter: DateFormatter = {
+    static func posAccessibilityTimeFormatter(timeZone: TimeZone) -> DateFormatter {
         let formatter = DateFormatter()
         formatter.dateStyle = .none
         formatter.timeStyle = .short
+        formatter.timeZone = timeZone
         return formatter
-    }()
+    }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingSummaryView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingSummaryView.swift
@@ -62,11 +62,15 @@ struct POSBookingSummaryView: View {
 // MARK: - Date Formatting
 
 extension POSBookingSummaryView {
-    static func formattedTimeRange(for booking: POSBooking, siteTimezone: TimeZone) -> String {
+    private static let timeRangeFormatter: DateIntervalFormatter = {
         let formatter = DateIntervalFormatter()
         formatter.dateStyle = .none
         formatter.timeStyle = .short
-        formatter.timeZone = siteTimezone
-        return formatter.string(from: booking.startDate, to: booking.endDate)
+        return formatter
+    }()
+
+    static func formattedTimeRange(for booking: POSBooking, siteTimezone: TimeZone) -> String {
+        timeRangeFormatter.timeZone = siteTimezone
+        return timeRangeFormatter.string(from: booking.startDate, to: booking.endDate)
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingSummaryView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingSummaryView.swift
@@ -62,16 +62,11 @@ struct POSBookingSummaryView: View {
 // MARK: - Date Formatting
 
 extension POSBookingSummaryView {
-    static func formattedTimeRange(for booking: POSBooking) -> String {
-        DateIntervalFormatter.posTimeRangeFormatter.string(from: booking.startDate, to: booking.endDate)
-    }
-}
-
-private extension DateIntervalFormatter {
-    static let posTimeRangeFormatter: DateIntervalFormatter = {
+    static func formattedTimeRange(for booking: POSBooking, siteTimezone: TimeZone) -> String {
         let formatter = DateIntervalFormatter()
         formatter.dateStyle = .none
         formatter.timeStyle = .short
-        return formatter
-    }()
+        formatter.timeZone = siteTimezone
+        return formatter.string(from: booking.startDate, to: booking.endDate)
+    }
 }

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -58,7 +58,7 @@ public struct PointOfSaleEntryPointView: View {
          couponProvider: PointOfSaleCouponServiceProtocol,
          couponFetchStrategyFactory: PointOfSaleCouponFetchStrategyFactoryProtocol,
          orderListFetchStrategyFactory: POSOrderListFetchStrategyFactoryProtocol,
-         bookingListFetchStrategyFactory: POSBookingListFetchStrategyFactoryProtocol?,
+         bookingListFetchStrategyFactory: POSBookingListFetchStrategyFactoryProtocol,
          isBookingsEligible: Bool,
          orderService: POSOrderServiceProtocol,
          refundsService: POSRefundsServiceProtocol,
@@ -147,7 +147,7 @@ public struct PointOfSaleEntryPointView: View {
                                                       currencySettingsProvider: services.currency,
                                                       currencyFormatter: CurrencyFormatter(currencySettings: services.currency.currencySettings))
         self.orderListModel = POSOrderListModel(ordersController: ordersController, receiptSender: receiptSender)
-        if let bookingListFetchStrategyFactory {
+        if isBookingsEligible && services.featureFlags.isFeatureFlagEnabled(.pointOfSaleBookings) {
             let bookingsController = POSBookingListController(bookingListFetchStrategyFactory: bookingListFetchStrategyFactory,
                                                                siteTimezone: siteTimezone)
             self.bookingsModel = POSBookingsModel(
@@ -236,7 +236,7 @@ public struct PointOfSaleEntryPointView: View {
         couponProvider: PointOfSaleCouponServicePreview(),
         couponFetchStrategyFactory: PointOfSaleCouponFetchStrategyFactoryPreview(),
         orderListFetchStrategyFactory: POSOrderListFetchStrategyFactoryPreview(),
-        bookingListFetchStrategyFactory: nil,
+        bookingListFetchStrategyFactory: POSBookingListFetchStrategyFactoryPreview(),
         isBookingsEligible: true,
         orderService: POSOrderServicePreview(),
         refundsService: POSRefundsServicePreview(),

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -532,7 +532,6 @@ final class POSBookingServicePreview: POSBookingServiceProtocol {
 }
 
 final class POSBookingListFetchStrategyPreview: POSBookingListFetchStrategy {
-    var supportsCaching: Bool = true
     var showsLoadingWithItems: Bool = false
     var id: String = "BookingPreview"
 

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -786,7 +786,6 @@ final class POSConfigurablePreviewBookingListController: POSSearchingBookingList
     let bookingsViewState: POSBookingListState
     var selectedBooking: POSBooking?
     var selectedDate: Date = Date()
-    var isPaginating: Bool = false
 
     init(state: POSBookingListState) {
         self.bookingsViewState = state

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -786,12 +786,14 @@ final class POSConfigurablePreviewBookingListController: POSSearchingBookingList
     let bookingsViewState: POSBookingListState
     var selectedBooking: POSBooking?
     var selectedDate: Date = Date()
+    var isPaginating: Bool = false
 
     init(state: POSBookingListState) {
         self.bookingsViewState = state
         self.selectedBooking = state.bookings.first
     }
 
+    func syncBookings() {}
     func loadBookings() async {}
     func refreshBookings() async {}
     func loadNextBookings() async {}

--- a/Modules/Sources/Storage/Model/Booking/BookingOrderInfo+CoreDataProperties.swift
+++ b/Modules/Sources/Storage/Model/Booking/BookingOrderInfo+CoreDataProperties.swift
@@ -2,6 +2,11 @@ import Foundation
 import CoreData
 
 extension BookingOrderInfo {
+    @NSManaged public var dateCreated: Date?
+    @NSManaged public var datePaid: Date?
+    @NSManaged public var discountTotal: String?
+    @NSManaged public var orderID: Int64
+    @NSManaged public var orderNumber: String?
     @NSManaged public var statusKey: String?
     @NSManaged public var paymentInfo: BookingPaymentInfo?
     @NSManaged public var customerInfo: BookingCustomerInfo?

--- a/Modules/Sources/Storage/Model/MIGRATIONS.md
+++ b/Modules/Sources/Storage/Model/MIGRATIONS.md
@@ -2,6 +2,9 @@
 
 This file documents changes in the WCiOS Storage data model. Please explain any changes to the data model as well as any custom migrations.
 
+## Model 132
+- Added `orderID`, `orderNumber`, `dateCreated`, `datePaid`, `discountTotal` attributes to `BookingOrderInfo` entity.
+
 ## Model 130 (Release 23.7)
 - @adborbas 2025-11-06
   - Added `note` attribute to `Booking` entity.

--- a/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/.xccurrentversion
+++ b/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Model 131.xcdatamodel</string>
+	<string>Model 132.xcdatamodel</string>
 </dict>
 </plist>

--- a/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 132.xcdatamodel/contents
+++ b/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 132.xcdatamodel/contents
@@ -1,0 +1,1183 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="25A362" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Account" representedClassName="Account" syncable="YES">
+        <attribute name="displayName" optional="YES" attributeType="String"/>
+        <attribute name="email" optional="YES" attributeType="String"/>
+        <attribute name="gravatarUrl" optional="YES" attributeType="String"/>
+        <attribute name="userID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="username" attributeType="String"/>
+    </entity>
+    <entity name="AccountSettings" representedClassName="AccountSettings" syncable="YES">
+        <attribute name="firstName" optional="YES" attributeType="String"/>
+        <attribute name="lastName" optional="YES" attributeType="String"/>
+        <attribute name="tracksOptOut" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="userID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="AddOnGroup" representedClassName="AddOnGroup" syncable="YES">
+        <attribute name="groupID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="priority" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="addOns" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductAddOn" inverseName="group" inverseEntity="ProductAddOn"/>
+    </entity>
+    <entity name="BlazeCampaignListItem" representedClassName="BlazeCampaignListItem" syncable="YES">
+        <attribute name="budgetAmount" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="budgetCurrency" attributeType="String" defaultValueString="USD"/>
+        <attribute name="budgetMode" attributeType="String" defaultValueString="total"/>
+        <attribute name="campaignID" attributeType="String" defaultValueString=""/>
+        <attribute name="clicks" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="durationDays" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="imageURL" optional="YES" attributeType="String"/>
+        <attribute name="impressions" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isEvergreen" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="rawStatus" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="spentBudget" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="startTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="targetUrl" optional="YES" attributeType="String"/>
+        <attribute name="textSnippet" attributeType="String" defaultValueString=""/>
+        <attribute name="totalBudget" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="BlazeCampaignObjective" representedClassName="BlazeCampaignObjective" syncable="YES">
+        <attribute name="generalDescription" attributeType="String" defaultValueString=""/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="locale" attributeType="String" defaultValueString=""/>
+        <attribute name="suitableForDescription" attributeType="String" defaultValueString=""/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+    </entity>
+    <entity name="BlazeTargetDevice" representedClassName="BlazeTargetDevice" syncable="YES">
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="locale" attributeType="String" defaultValueString=""/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+    </entity>
+    <entity name="BlazeTargetLanguage" representedClassName="BlazeTargetLanguage" syncable="YES">
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="locale" attributeType="String" defaultValueString=""/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+    </entity>
+    <entity name="BlazeTargetTopic" representedClassName="BlazeTargetTopic" syncable="YES">
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="locale" attributeType="String" defaultValueString=""/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+    </entity>
+    <entity name="Booking" representedClassName="Booking" syncable="YES">
+        <attribute name="allDay" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="attendanceStatusKey" attributeType="String" defaultValueString=""/>
+        <attribute name="bookingID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="cost" attributeType="String" defaultValueString=""/>
+        <attribute name="currency" optional="YES" attributeType="String"/>
+        <attribute name="customerID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="googleCalendarEventID" optional="YES" attributeType="String"/>
+        <attribute name="localTimezone" attributeType="String" defaultValueString=""/>
+        <attribute name="note" optional="YES" attributeType="String"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="orderItemID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="parentID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="productID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="resourceID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="startDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="statusKey" attributeType="String" defaultValueString=""/>
+        <relationship name="orderInfo" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BookingOrderInfo" inverseName="booking" inverseEntity="BookingOrderInfo"/>
+    </entity>
+    <entity name="BookingCustomerInfo" representedClassName="BookingCustomerInfo" syncable="YES">
+        <attribute name="billingAddress1" optional="YES" attributeType="String"/>
+        <attribute name="billingAddress2" optional="YES" attributeType="String"/>
+        <attribute name="billingCity" optional="YES" attributeType="String"/>
+        <attribute name="billingCompany" optional="YES" attributeType="String"/>
+        <attribute name="billingCountry" optional="YES" attributeType="String"/>
+        <attribute name="billingEmail" optional="YES" attributeType="String"/>
+        <attribute name="billingFirstName" optional="YES" attributeType="String"/>
+        <attribute name="billingLastName" optional="YES" attributeType="String"/>
+        <attribute name="billingPhone" optional="YES" attributeType="String"/>
+        <attribute name="billingPostcode" optional="YES" attributeType="String"/>
+        <attribute name="billingState" optional="YES" attributeType="String"/>
+        <attribute name="note" optional="YES" attributeType="String"/>
+        <relationship name="orderInfo" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BookingOrderInfo" inverseName="customerInfo" inverseEntity="BookingOrderInfo"/>
+    </entity>
+    <entity name="BookingOrderInfo" representedClassName="BookingOrderInfo" syncable="YES">
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="datePaid" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="discountTotal" optional="YES" attributeType="String"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="orderNumber" optional="YES" attributeType="String"/>
+        <attribute name="statusKey" attributeType="String"/>
+        <relationship name="booking" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Booking" inverseName="orderInfo" inverseEntity="Booking"/>
+        <relationship name="customerInfo" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BookingCustomerInfo" inverseName="orderInfo" inverseEntity="BookingCustomerInfo"/>
+        <relationship name="paymentInfo" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BookingPaymentInfo" inverseName="orderInfo" inverseEntity="BookingPaymentInfo"/>
+        <relationship name="productInfo" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BookingProductInfo" inverseName="orderInfo" inverseEntity="BookingProductInfo"/>
+    </entity>
+    <entity name="BookingPaymentInfo" representedClassName="BookingPaymentInfo" syncable="YES">
+        <attribute name="paymentMethodID" optional="YES" attributeType="String"/>
+        <attribute name="paymentMethodTitle" optional="YES" attributeType="String"/>
+        <attribute name="subtotal" optional="YES" attributeType="String"/>
+        <attribute name="subtotalTax" optional="YES" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <attribute name="totalTax" optional="YES" attributeType="String"/>
+        <relationship name="orderInfo" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BookingOrderInfo" inverseName="paymentInfo" inverseEntity="BookingOrderInfo"/>
+    </entity>
+    <entity name="BookingProductInfo" representedClassName="BookingProductInfo" syncable="YES">
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <relationship name="orderInfo" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BookingOrderInfo" inverseName="productInfo" inverseEntity="BookingOrderInfo"/>
+    </entity>
+    <entity name="BookingResource" representedClassName="BookingResource" syncable="YES">
+        <attribute name="descriptionText" optional="YES" attributeType="String"/>
+        <attribute name="email" optional="YES" attributeType="String"/>
+        <attribute name="imageID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="imageURL" optional="YES" attributeType="String"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="phoneNumber" optional="YES" attributeType="String"/>
+        <attribute name="quantity" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="resourceID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="role" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="Country" representedClassName="Country" syncable="YES">
+        <attribute name="code" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <relationship name="states" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="StateOfACountry" inverseName="relationship" inverseEntity="StateOfACountry"/>
+    </entity>
+    <entity name="Coupon" representedClassName="Coupon" syncable="YES">
+        <attribute name="amount" optional="YES" attributeType="String"/>
+        <attribute name="code" optional="YES" attributeType="String"/>
+        <attribute name="couponID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateExpires" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="discountType" optional="YES" attributeType="String"/>
+        <attribute name="emailRestrictions" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="excludedProductCategories" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="excludedProducts" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="excludeSaleItems" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="freeShipping" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="fullDescription" optional="YES" attributeType="String"/>
+        <attribute name="individualUse" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="limitUsageToXItems" optional="YES" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="maximumAmount" optional="YES" attributeType="String"/>
+        <attribute name="minimumAmount" optional="YES" attributeType="String"/>
+        <attribute name="productCategories" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="products" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usageCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usageLimit" optional="YES" attributeType="Integer 64" usesScalarValueType="NO"/>
+        <attribute name="usageLimitPerUser" optional="YES" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="usedBy" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CouponSearchResult" inverseName="coupons" inverseEntity="CouponSearchResult"/>
+    </entity>
+    <entity name="CouponSearchResult" representedClassName="CouponSearchResult" syncable="YES">
+        <attribute name="keyword" optional="YES" attributeType="String"/>
+        <relationship name="coupons" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Coupon" inverseName="searchResults" inverseEntity="Coupon"/>
+    </entity>
+    <entity name="Customer" representedClassName="Customer" syncable="YES">
+        <attribute name="billingAddress1" optional="YES" attributeType="String"/>
+        <attribute name="billingAddress2" optional="YES" attributeType="String"/>
+        <attribute name="billingCity" optional="YES" attributeType="String"/>
+        <attribute name="billingCompany" optional="YES" attributeType="String"/>
+        <attribute name="billingCountry" optional="YES" attributeType="String"/>
+        <attribute name="billingEmail" optional="YES" attributeType="String"/>
+        <attribute name="billingFirstName" optional="YES" attributeType="String"/>
+        <attribute name="billingLastName" optional="YES" attributeType="String"/>
+        <attribute name="billingPhone" optional="YES" attributeType="String"/>
+        <attribute name="billingPostcode" optional="YES" attributeType="String"/>
+        <attribute name="billingState" optional="YES" attributeType="String"/>
+        <attribute name="customerID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="email" optional="YES" attributeType="String"/>
+        <attribute name="firstName" optional="YES" attributeType="String"/>
+        <attribute name="lastName" optional="YES" attributeType="String"/>
+        <attribute name="shippingAddress1" optional="YES" attributeType="String"/>
+        <attribute name="shippingAddress2" optional="YES" attributeType="String"/>
+        <attribute name="shippingCity" optional="YES" attributeType="String"/>
+        <attribute name="shippingCompany" optional="YES" attributeType="String"/>
+        <attribute name="shippingCountry" optional="YES" attributeType="String"/>
+        <attribute name="shippingEmail" optional="YES" attributeType="String"/>
+        <attribute name="shippingFirstName" optional="YES" attributeType="String"/>
+        <attribute name="shippingLastName" optional="YES" attributeType="String"/>
+        <attribute name="shippingPhone" optional="YES" attributeType="String"/>
+        <attribute name="shippingPostcode" optional="YES" attributeType="String"/>
+        <attribute name="shippingState" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="username" optional="YES" attributeType="String"/>
+        <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CustomerSearchResult" inverseName="customers" inverseEntity="CustomerSearchResult"/>
+    </entity>
+    <entity name="CustomerSearchResult" representedClassName="CustomerSearchResult" syncable="YES">
+        <attribute name="keyword" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="customers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Customer" inverseName="searchResults" inverseEntity="Customer"/>
+    </entity>
+    <entity name="GenericAttribute" representedClassName="GenericAttribute" syncable="YES">
+        <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="key" attributeType="String"/>
+        <attribute name="value" attributeType="String"/>
+        <relationship name="productBundleItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductBundleItem" inverseName="defaultVariationAttributes" inverseEntity="ProductBundleItem"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="attributes" inverseEntity="ProductVariation"/>
+    </entity>
+    <entity name="InboxAction" representedClassName="InboxAction" syncable="YES">
+        <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="label" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="status" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <relationship name="inboxNote" maxCount="1" deletionRule="Nullify" destinationEntity="InboxNote" inverseName="actions" inverseEntity="InboxNote"/>
+    </entity>
+    <entity name="InboxNote" representedClassName="InboxNote" syncable="YES">
+        <attribute name="content" optional="YES" attributeType="String"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isRead" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isRemoved" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="status" optional="YES" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+        <relationship name="actions" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="InboxAction" inverseName="inboxNote" inverseEntity="InboxAction"/>
+    </entity>
+    <entity name="MetaData" representedClassName="MetaData" elementID="OrderMetaData" versionHashModifier="1" syncable="YES">
+        <attribute name="key" optional="YES" attributeType="String"/>
+        <attribute name="metadataID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="value" optional="YES" attributeType="String"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="customFields" inverseEntity="Order"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="customFields" inverseEntity="Product"/>
+    </entity>
+    <entity name="Note" representedClassName="Note" syncable="YES">
+        <attribute name="body" optional="YES" attributeType="Binary"/>
+        <attribute name="deleteInProgress" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="header" optional="YES" attributeType="Binary"/>
+        <attribute name="icon" optional="YES" attributeType="String"/>
+        <attribute name="meta" optional="YES" attributeType="Binary"/>
+        <attribute name="noteHash" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="noteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="noticon" optional="YES" attributeType="String"/>
+        <attribute name="read" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="subject" optional="YES" attributeType="Binary"/>
+        <attribute name="subtype" optional="YES" attributeType="String"/>
+        <attribute name="timestamp" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="Order" representedClassName="Order" syncable="YES">
+        <attribute name="billingAddress1" optional="YES" attributeType="String"/>
+        <attribute name="billingAddress2" optional="YES" attributeType="String"/>
+        <attribute name="billingCity" optional="YES" attributeType="String"/>
+        <attribute name="billingCompany" optional="YES" attributeType="String"/>
+        <attribute name="billingCountry" optional="YES" attributeType="String"/>
+        <attribute name="billingEmail" optional="YES" attributeType="String"/>
+        <attribute name="billingFirstName" optional="YES" attributeType="String"/>
+        <attribute name="billingLastName" optional="YES" attributeType="String"/>
+        <attribute name="billingPhone" optional="YES" attributeType="String"/>
+        <attribute name="billingPostcode" optional="YES" attributeType="String"/>
+        <attribute name="billingState" optional="YES" attributeType="String"/>
+        <attribute name="chargeID" optional="YES" attributeType="String"/>
+        <attribute name="createdVia" optional="YES" attributeType="String"/>
+        <attribute name="currency" optional="YES" attributeType="String"/>
+        <attribute name="customerID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="customerNote" optional="YES" attributeType="String"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="datePaid" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="discountTax" optional="YES" attributeType="String"/>
+        <attribute name="discountTotal" optional="YES" attributeType="String"/>
+        <attribute name="exclusiveForSearch" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isEditable" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="needsPayment" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="needsProcessing" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="number" optional="YES" attributeType="String"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="orderKey" attributeType="String" defaultValueString=""/>
+        <attribute name="parentID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="paymentMethodID" optional="YES" attributeType="String"/>
+        <attribute name="paymentMethodTitle" optional="YES" attributeType="String"/>
+        <attribute name="paymentURL" optional="YES" attributeType="URI"/>
+        <attribute name="renewalSubscriptionID" optional="YES" attributeType="String"/>
+        <attribute name="shippingAddress1" optional="YES" attributeType="String"/>
+        <attribute name="shippingAddress2" optional="YES" attributeType="String"/>
+        <attribute name="shippingCity" optional="YES" attributeType="String"/>
+        <attribute name="shippingCompany" optional="YES" attributeType="String"/>
+        <attribute name="shippingCountry" optional="YES" attributeType="String"/>
+        <attribute name="shippingEmail" optional="YES" attributeType="String"/>
+        <attribute name="shippingFirstName" optional="YES" attributeType="String"/>
+        <attribute name="shippingLastName" optional="YES" attributeType="String"/>
+        <attribute name="shippingPhone" optional="YES" attributeType="String"/>
+        <attribute name="shippingPostcode" optional="YES" attributeType="String"/>
+        <attribute name="shippingState" optional="YES" attributeType="String"/>
+        <attribute name="shippingTax" optional="YES" attributeType="String"/>
+        <attribute name="shippingTotal" optional="YES" attributeType="String"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="statusKey" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <attribute name="totalTax" optional="YES" attributeType="String"/>
+        <relationship name="appliedGiftCards" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderGiftCard" inverseName="order" inverseEntity="OrderGiftCard"/>
+        <relationship name="attributionInfo" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrderAttributionInfo" inverseName="order" inverseEntity="OrderAttributionInfo"/>
+        <relationship name="coupons" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderCoupon" inverseName="order" inverseEntity="OrderCoupon"/>
+        <relationship name="customFields" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MetaData" inverseName="order" inverseEntity="MetaData"/>
+        <relationship name="fees" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderFeeLine" inverseName="order" inverseEntity="OrderFeeLine"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="OrderItem" inverseName="order" inverseEntity="OrderItem"/>
+        <relationship name="notes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderNote" inverseName="order" inverseEntity="OrderNote"/>
+        <relationship name="refunds" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderRefundCondensed" inverseName="order" inverseEntity="OrderRefundCondensed"/>
+        <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderSearchResults" inverseName="orders" inverseEntity="OrderSearchResults"/>
+        <relationship name="shipments" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WooShippingShipment" inverseName="order" inverseEntity="WooShippingShipment"/>
+        <relationship name="shippingLabels" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShippingLabel" inverseName="order" inverseEntity="ShippingLabel"/>
+        <relationship name="shippingLabelSettings" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ShippingLabelSettings" inverseName="order" inverseEntity="ShippingLabelSettings"/>
+        <relationship name="shippingLines" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShippingLine" inverseName="order" inverseEntity="ShippingLine"/>
+        <relationship name="taxes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderTaxLine" inverseName="order" inverseEntity="OrderTaxLine"/>
+    </entity>
+    <entity name="OrderAttributionInfo" representedClassName="OrderAttributionInfo" syncable="YES">
+        <attribute name="campaign" optional="YES" attributeType="String"/>
+        <attribute name="deviceType" optional="YES" attributeType="String"/>
+        <attribute name="medium" optional="YES" attributeType="String"/>
+        <attribute name="sessionPageViews" optional="YES" attributeType="String"/>
+        <attribute name="source" optional="YES" attributeType="String"/>
+        <attribute name="sourceType" optional="YES" attributeType="String"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="attributionInfo" inverseEntity="Order"/>
+    </entity>
+    <entity name="OrderCoupon" representedClassName="OrderCoupon" syncable="YES">
+        <attribute name="code" optional="YES" attributeType="String"/>
+        <attribute name="couponID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="discount" optional="YES" attributeType="String"/>
+        <attribute name="discountTax" optional="YES" attributeType="String"/>
+        <relationship name="order" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="coupons" inverseEntity="Order"/>
+    </entity>
+    <entity name="OrderFeeLine" representedClassName="OrderFeeLine" syncable="YES">
+        <attribute name="feeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="taxClass" optional="YES" attributeType="String"/>
+        <attribute name="taxStatusKey" optional="YES" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <attribute name="totalTax" optional="YES" attributeType="String"/>
+        <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="OrderItemAttribute" inverseName="orderFeeLine" inverseEntity="OrderItemAttribute"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="fees" inverseEntity="Order"/>
+        <relationship name="taxes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderItemTax" inverseName="feeLine" inverseEntity="OrderItemTax"/>
+    </entity>
+    <entity name="OrderGiftCard" representedClassName="OrderGiftCard" syncable="YES">
+        <attribute name="amount" attributeType="Double" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="code" attributeType="String" defaultValueString=""/>
+        <attribute name="giftCardID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="appliedGiftCards" inverseEntity="Order"/>
+    </entity>
+    <entity name="OrderItem" representedClassName="OrderItem" syncable="YES">
+        <attribute name="itemID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="parent" optional="YES" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="price" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="Decimal" defaultValueString="0"/>
+        <attribute name="sku" optional="YES" attributeType="String"/>
+        <attribute name="subtotal" optional="YES" attributeType="String"/>
+        <attribute name="subtotalTax" optional="YES" attributeType="String"/>
+        <attribute name="taxClass" optional="YES" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <attribute name="totalTax" optional="YES" attributeType="String"/>
+        <attribute name="variationID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="addOns" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="OrderItemProductAddOn" inverseName="orderItem" inverseEntity="OrderItemProductAddOn"/>
+        <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="OrderItemAttribute" inverseName="orderItem" inverseEntity="OrderItemAttribute"/>
+        <relationship name="order" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="items" inverseEntity="Order"/>
+        <relationship name="taxes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="OrderItemTax" inverseName="item" inverseEntity="OrderItemTax"/>
+    </entity>
+    <entity name="OrderItemAttribute" representedClassName="OrderItemAttribute" syncable="YES">
+        <attribute name="metaID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="value" attributeType="String"/>
+        <relationship name="orderFeeLine" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderFeeLine" inverseName="attributes" inverseEntity="OrderFeeLine"/>
+        <relationship name="orderItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderItem" inverseName="attributes" inverseEntity="OrderItem"/>
+        <relationship name="orderTaxLine" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderTaxLine" inverseName="attributes" inverseEntity="OrderTaxLine"/>
+    </entity>
+    <entity name="OrderItemProductAddOn" representedClassName="OrderItemProductAddOn" syncable="YES">
+        <attribute name="addOnID" optional="YES" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="key" attributeType="String" defaultValueString=""/>
+        <attribute name="value" attributeType="String" defaultValueString=""/>
+        <relationship name="orderItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderItem" inverseName="addOns" inverseEntity="OrderItem"/>
+    </entity>
+    <entity name="OrderItemRefund" representedClassName="OrderItemRefund" syncable="YES">
+        <attribute name="itemID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="price" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="refundedItemID" optional="YES" attributeType="String"/>
+        <attribute name="sku" optional="YES" attributeType="String"/>
+        <attribute name="subtotal" optional="YES" attributeType="String"/>
+        <attribute name="subtotalTax" optional="YES" attributeType="String"/>
+        <attribute name="taxClass" optional="YES" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <attribute name="totalTax" optional="YES" attributeType="String"/>
+        <attribute name="variationID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="refund" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Refund" inverseName="items" inverseEntity="Refund"/>
+        <relationship name="taxes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="OrderItemTaxRefund" inverseName="item" inverseEntity="OrderItemTaxRefund"/>
+    </entity>
+    <entity name="OrderItemTax" representedClassName="OrderItemTax" syncable="YES">
+        <attribute name="subtotal" optional="YES" attributeType="String"/>
+        <attribute name="taxID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <relationship name="feeLine" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderFeeLine" inverseName="taxes" inverseEntity="OrderFeeLine"/>
+        <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderItem" inverseName="taxes" inverseEntity="OrderItem"/>
+    </entity>
+    <entity name="OrderItemTaxRefund" representedClassName="OrderItemTaxRefund" syncable="YES">
+        <attribute name="subtotal" optional="YES" attributeType="String"/>
+        <attribute name="taxID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderItemRefund" inverseName="taxes" inverseEntity="OrderItemRefund"/>
+    </entity>
+    <entity name="OrderNote" representedClassName="OrderNote" syncable="YES">
+        <attribute name="author" optional="YES" attributeType="String"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="isCustomerNote" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="note" optional="YES" attributeType="String"/>
+        <attribute name="noteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="notes" inverseEntity="Order"/>
+    </entity>
+    <entity name="OrderRefundCondensed" representedClassName="OrderRefundCondensed" syncable="YES">
+        <attribute name="reason" optional="YES" attributeType="String"/>
+        <attribute name="refundID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="refunds" inverseEntity="Order"/>
+    </entity>
+    <entity name="OrderSearchResults" representedClassName="OrderSearchResults" syncable="YES">
+        <attribute name="keyword" attributeType="String"/>
+        <relationship name="orders" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Order" inverseName="searchResults" inverseEntity="Order"/>
+    </entity>
+    <entity name="OrderStatsV4" representedClassName="OrderStatsV4" syncable="YES">
+        <attribute name="granularity" optional="YES" attributeType="String"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="timeRange" optional="YES" attributeType="String"/>
+        <relationship name="intervals" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="OrderStatsV4Interval" inverseName="stats" inverseEntity="OrderStatsV4Interval"/>
+        <relationship name="totals" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrderStatsV4Totals" inverseName="stats" inverseEntity="OrderStatsV4Totals"/>
+    </entity>
+    <entity name="OrderStatsV4Interval" representedClassName="OrderStatsV4Interval" syncable="YES">
+        <attribute name="dateEnd" optional="YES" attributeType="String"/>
+        <attribute name="dateStart" optional="YES" attributeType="String"/>
+        <attribute name="interval" optional="YES" attributeType="String"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4" inverseName="intervals" inverseEntity="OrderStatsV4"/>
+        <relationship name="subtotals" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrderStatsV4Totals" inverseName="interval" inverseEntity="OrderStatsV4Totals"/>
+    </entity>
+    <entity name="OrderStatsV4Totals" representedClassName="OrderStatsV4Totals" syncable="YES">
+        <attribute name="averageOrderValue" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="grossRevenue" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="netRevenue" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="totalItemsSold" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="totalOrders" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="interval" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4Interval" inverseName="subtotals" inverseEntity="OrderStatsV4Interval"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4" inverseName="totals" inverseEntity="OrderStatsV4"/>
+    </entity>
+    <entity name="OrderStatus" representedClassName="OrderStatus" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="slug" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="OrderTaxLine" representedClassName="OrderTaxLine" syncable="YES">
+        <attribute name="isCompoundTaxRate" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="label" optional="YES" attributeType="String"/>
+        <attribute name="rateCode" optional="YES" attributeType="String"/>
+        <attribute name="rateID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="ratePercent" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="taxID" attributeType="Integer 64" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="totalShippingTax" optional="YES" attributeType="String"/>
+        <attribute name="totalTax" optional="YES" attributeType="String"/>
+        <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="OrderItemAttribute" inverseName="orderTaxLine" inverseEntity="OrderItemAttribute"/>
+        <relationship name="order" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="taxes" inverseEntity="Order"/>
+    </entity>
+    <entity name="PaymentGateway" representedClassName="PaymentGateway" syncable="YES">
+        <attribute name="enabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="features" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="gatewayDescription" attributeType="String" defaultValueString=""/>
+        <attribute name="gatewayID" attributeType="String" defaultValueString=""/>
+        <attribute name="instructions" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+    </entity>
+    <entity name="PaymentGatewayAccount" representedClassName="PaymentGatewayAccount" syncable="YES">
+        <attribute name="country" optional="YES" attributeType="String"/>
+        <attribute name="currentDeadline" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="defaultCurrency" optional="YES" attributeType="String"/>
+        <attribute name="gatewayID" optional="YES" attributeType="String"/>
+        <attribute name="hasOverdueRequirements" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="hasPendingRequirements" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isCardPresentEligible" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isInTestMode" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isLive" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="statementDescriptor" optional="YES" attributeType="String"/>
+        <attribute name="status" optional="YES" attributeType="String"/>
+        <attribute name="supportedCurrencies" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+    </entity>
+    <entity name="Product" representedClassName="Product" syncable="YES">
+        <attribute name="averageRating" attributeType="String"/>
+        <attribute name="backordered" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="backordersAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="backordersKey" attributeType="String"/>
+        <attribute name="briefDescription" optional="YES" attributeType="String"/>
+        <attribute name="bundleMaxSize" optional="YES" attributeType="Decimal"/>
+        <attribute name="bundleMinSize" optional="YES" attributeType="Decimal"/>
+        <attribute name="bundleStockQuantity" optional="YES" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="bundleStockStatus" optional="YES" attributeType="String"/>
+        <attribute name="buttonText" attributeType="String" defaultValueString=""/>
+        <attribute name="catalogVisibilityKey" attributeType="String"/>
+        <attribute name="combineVariationQuantities" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateOnSaleEnd" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateOnSaleStart" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="downloadable" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="downloadExpiry" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="downloadLimit" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="externalURL" optional="YES" attributeType="String"/>
+        <attribute name="featured" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="fullDescription" optional="YES" attributeType="String"/>
+        <attribute name="globalUniqueID" optional="YES" attributeType="String"/>
+        <attribute name="groupedProducts" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="groupOfQuantity" optional="YES" attributeType="String"/>
+        <attribute name="isSampleItem" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="manageStock" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="maxAllowedQuantity" optional="YES" attributeType="String"/>
+        <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="minAllowedQuantity" optional="YES" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="onSale" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="parentID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="password" optional="YES" attributeType="String"/>
+        <attribute name="permalink" attributeType="String"/>
+        <attribute name="price" attributeType="String"/>
+        <attribute name="productID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="productTypeKey" attributeType="String"/>
+        <attribute name="purchasable" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="purchaseNote" optional="YES" attributeType="String"/>
+        <attribute name="ratingCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="regularPrice" optional="YES" attributeType="String"/>
+        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="reviewsAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="salePrice" optional="YES" attributeType="String"/>
+        <attribute name="shippingClass" optional="YES" attributeType="String"/>
+        <attribute name="shippingClassID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="shippingRequired" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="shippingTaxable" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String"/>
+        <attribute name="slug" attributeType="String"/>
+        <attribute name="soldIndividually" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="statusKey" attributeType="String"/>
+        <attribute name="stockQuantity" optional="YES" attributeType="String"/>
+        <attribute name="stockStatusKey" attributeType="String"/>
+        <attribute name="taxClass" optional="YES" attributeType="String"/>
+        <attribute name="taxStatusKey" attributeType="String"/>
+        <attribute name="totalSales" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="variations" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="virtual" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="weight" optional="YES" attributeType="String"/>
+        <relationship name="addOns" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductAddOn" inverseName="product" inverseEntity="ProductAddOn"/>
+        <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductAttribute" inverseName="product" inverseEntity="ProductAttribute"/>
+        <relationship name="bundledItems" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductBundleItem" inverseName="product" inverseEntity="ProductBundleItem"/>
+        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductCategory" inverseName="products" inverseEntity="ProductCategory"/>
+        <relationship name="compositeComponents" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductCompositeComponent" inverseName="product" inverseEntity="ProductCompositeComponent"/>
+        <relationship name="customFields" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MetaData" inverseName="product" inverseEntity="MetaData"/>
+        <relationship name="defaultAttributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductDefaultAttribute" inverseName="product" inverseEntity="ProductDefaultAttribute"/>
+        <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductDimensions" inverseName="product" inverseEntity="ProductDimensions"/>
+        <relationship name="downloads" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductDownload" inverseName="product" inverseEntity="ProductDownload"/>
+        <relationship name="images" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductImage" inverseName="product" inverseEntity="ProductImage"/>
+        <relationship name="productShippingClass" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductShippingClass" inverseName="products" inverseEntity="ProductShippingClass"/>
+        <relationship name="productVariations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductVariation" inverseName="product" inverseEntity="ProductVariation"/>
+        <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductSearchResults" inverseName="products" inverseEntity="ProductSearchResults"/>
+        <relationship name="subscription" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductSubscription" inverseName="product" inverseEntity="ProductSubscription"/>
+        <relationship name="tags" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="ProductTag" inverseName="products" inverseEntity="ProductTag"/>
+    </entity>
+    <entity name="ProductAddOn" representedClassName="ProductAddOn" syncable="YES">
+        <attribute name="adjustPrice" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="descriptionEnabled" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="descriptions" attributeType="String" defaultValueString=""/>
+        <attribute name="display" attributeType="String" defaultValueString=""/>
+        <attribute name="max" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="min" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="price" attributeType="String" defaultValueString=""/>
+        <attribute name="priceType" attributeType="String" defaultValueString=""/>
+        <attribute name="required" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="restrictions" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="restrictionsType" attributeType="String" defaultValueString=""/>
+        <attribute name="titleFormat" attributeType="String" defaultValueString=""/>
+        <attribute name="type" attributeType="String" defaultValueString=""/>
+        <relationship name="group" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AddOnGroup" inverseName="addOns" inverseEntity="AddOnGroup"/>
+        <relationship name="options" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductAddOnOption" inverseName="addOn" inverseEntity="ProductAddOnOption"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="addOns" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductAddOnOption" representedClassName="ProductAddOnOption" syncable="YES">
+        <attribute name="imageID" optional="YES" attributeType="String"/>
+        <attribute name="label" optional="YES" attributeType="String"/>
+        <attribute name="price" optional="YES" attributeType="String"/>
+        <attribute name="priceType" optional="YES" attributeType="String"/>
+        <relationship name="addOn" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductAddOn" inverseName="options" inverseEntity="ProductAddOn"/>
+    </entity>
+    <entity name="ProductAttribute" representedClassName="ProductAttribute" syncable="YES">
+        <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="options" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="variation" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="visible" attributeType="Boolean" usesScalarValueType="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="attributes" inverseEntity="Product"/>
+        <relationship name="terms" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductAttributeTerm" inverseName="attribute" inverseEntity="ProductAttributeTerm"/>
+    </entity>
+    <entity name="ProductAttributeTerm" representedClassName="ProductAttributeTerm" syncable="YES">
+        <attribute name="count" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="slug" attributeType="String"/>
+        <attribute name="termID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="attribute" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductAttribute" inverseName="terms" inverseEntity="ProductAttribute"/>
+    </entity>
+    <entity name="ProductBundleItem" representedClassName="ProductBundleItem" syncable="YES">
+        <attribute name="allowedVariations" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="bundledItemID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="defaultQuantity" attributeType="Decimal" defaultValueString="0"/>
+        <attribute name="isOptional" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="maxQuantity" optional="YES" attributeType="Decimal" defaultValueString="0"/>
+        <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="minQuantity" attributeType="Decimal" defaultValueString="0"/>
+        <attribute name="overridesDefaultVariationAttributes" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="overridesVariations" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="pricedIndividually" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="productID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="stockStatus" attributeType="String" defaultValueString=""/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+        <relationship name="defaultVariationAttributes" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="GenericAttribute" inverseName="productBundleItem" inverseEntity="GenericAttribute"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="bundledItems" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductCategory" representedClassName="ProductCategory" syncable="YES">
+        <attribute name="categoryID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="parentID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="slug" attributeType="String"/>
+        <relationship name="products" optional="YES" toMany="YES" deletionRule="Deny" destinationEntity="Product" inverseName="categories" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductCompositeComponent" representedClassName="ProductCompositeComponent" syncable="YES">
+        <attribute name="componentDescription" attributeType="String" defaultValueString=""/>
+        <attribute name="componentID" attributeType="String" defaultValueString=""/>
+        <attribute name="defaultOptionID" attributeType="String" defaultValueString=""/>
+        <attribute name="imageURL" attributeType="String" defaultValueString=""/>
+        <attribute name="optionIDs" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="optionType" attributeType="String" defaultValueString=""/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="compositeComponents" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductDefaultAttribute" representedClassName="ProductDefaultAttribute" syncable="YES">
+        <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="option" optional="YES" attributeType="String"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="defaultAttributes" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductDimensions" representedClassName="ProductDimensions" syncable="YES">
+        <attribute name="height" attributeType="String"/>
+        <attribute name="length" attributeType="String"/>
+        <attribute name="width" attributeType="String"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="dimensions" inverseEntity="Product"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="dimensions" inverseEntity="ProductVariation"/>
+    </entity>
+    <entity name="ProductDownload" representedClassName="ProductDownload" syncable="YES">
+        <attribute name="downloadID" attributeType="String"/>
+        <attribute name="fileURL" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="downloads" inverseEntity="Product"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="downloads" inverseEntity="ProductVariation"/>
+    </entity>
+    <entity name="ProductImage" representedClassName="ProductImage" syncable="YES">
+        <attribute name="alt" optional="YES" attributeType="String"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="imageID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="src" attributeType="String"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="images" inverseEntity="Product"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="image" inverseEntity="ProductVariation"/>
+    </entity>
+    <entity name="ProductReview" representedClassName="ProductReview" syncable="YES">
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="rating" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="review" optional="YES" attributeType="String"/>
+        <attribute name="reviewer" optional="YES" attributeType="String"/>
+        <attribute name="reviewerAvatarURL" optional="YES" attributeType="String"/>
+        <attribute name="reviewerEmail" optional="YES" attributeType="String"/>
+        <attribute name="reviewID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="statusKey" optional="YES" attributeType="String"/>
+        <attribute name="verified" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="ProductSearchResults" representedClassName="ProductSearchResults" syncable="YES">
+        <attribute name="filterKey" optional="YES" attributeType="String"/>
+        <attribute name="keyword" optional="YES" attributeType="String"/>
+        <relationship name="products" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Product" inverseName="searchResults" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductShippingClass" representedClassName="ProductShippingClass" syncable="YES">
+        <attribute name="count" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="descriptionHTML" optional="YES" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="shippingClassID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="slug" attributeType="String"/>
+        <relationship name="products" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Product" inverseName="productShippingClass" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductSubscription" representedClassName="ProductSubscription" syncable="YES">
+        <attribute name="length" attributeType="String" defaultValueString=""/>
+        <attribute name="oneTimeShipping" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="paymentSyncDate" attributeType="String" defaultValueString=""/>
+        <attribute name="paymentSyncMonth" attributeType="String" defaultValueString=""/>
+        <attribute name="period" attributeType="String" defaultValueString=""/>
+        <attribute name="periodInterval" attributeType="String" defaultValueString=""/>
+        <attribute name="price" attributeType="String" defaultValueString=""/>
+        <attribute name="signUpFee" attributeType="String" defaultValueString=""/>
+        <attribute name="trialLength" attributeType="String" defaultValueString=""/>
+        <attribute name="trialPeriod" attributeType="String" defaultValueString=""/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="subscription" inverseEntity="Product"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="subscription" inverseEntity="ProductVariation"/>
+    </entity>
+    <entity name="ProductTag" representedClassName="ProductTag" syncable="YES">
+        <attribute name="name" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="slug" attributeType="String"/>
+        <attribute name="tagID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="products" optional="YES" toMany="YES" deletionRule="Deny" ordered="YES" destinationEntity="Product" inverseName="tags" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductVariation" representedClassName="ProductVariation" syncable="YES">
+        <attribute name="backordered" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="backordersAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="backordersKey" attributeType="String"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateOnSaleEnd" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateOnSaleStart" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="downloadable" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="downloadExpiry" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="downloadLimit" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="fullDescription" optional="YES" attributeType="String"/>
+        <attribute name="globalUniqueID" optional="YES" attributeType="String"/>
+        <attribute name="groupOfQuantity" optional="YES" attributeType="String"/>
+        <attribute name="manageStock" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="maxAllowedQuantity" optional="YES" attributeType="String"/>
+        <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="minAllowedQuantity" optional="YES" attributeType="String"/>
+        <attribute name="onSale" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="overrideProductQuantities" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="permalink" attributeType="String"/>
+        <attribute name="price" attributeType="String"/>
+        <attribute name="productID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="productVariationID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="purchasable" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="regularPrice" optional="YES" attributeType="String"/>
+        <attribute name="salePrice" optional="YES" attributeType="String"/>
+        <attribute name="shippingClass" optional="YES" attributeType="String"/>
+        <attribute name="shippingClassID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String"/>
+        <attribute name="statusKey" attributeType="String"/>
+        <attribute name="stockQuantity" optional="YES" attributeType="Decimal" defaultValueString="0"/>
+        <attribute name="stockStatusKey" attributeType="String"/>
+        <attribute name="taxClass" optional="YES" attributeType="String"/>
+        <attribute name="taxStatusKey" attributeType="String"/>
+        <attribute name="virtual" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="weight" optional="YES" attributeType="String"/>
+        <relationship name="attributes" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="GenericAttribute" inverseName="productVariation" inverseEntity="GenericAttribute"/>
+        <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductDimensions" inverseName="productVariation" inverseEntity="ProductDimensions"/>
+        <relationship name="downloads" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductDownload" inverseName="productVariation" inverseEntity="ProductDownload"/>
+        <relationship name="image" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductImage" inverseName="productVariation" inverseEntity="ProductImage"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="productVariations" inverseEntity="Product"/>
+        <relationship name="subscription" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductSubscription" inverseName="productVariation" inverseEntity="ProductSubscription"/>
+    </entity>
+    <entity name="Refund" representedClassName="Refund" syncable="YES">
+        <attribute name="amount" optional="YES" attributeType="String"/>
+        <attribute name="byUserID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="createAutomated" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="isAutomated" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="reason" optional="YES" attributeType="String"/>
+        <attribute name="refundID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="supportShippingRefunds" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="OrderItemRefund" inverseName="refund" inverseEntity="OrderItemRefund"/>
+        <relationship name="shippingLines" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShippingLine" inverseName="refund" inverseEntity="ShippingLine"/>
+    </entity>
+    <entity name="ShipmentTracking" representedClassName="ShipmentTracking" syncable="YES">
+        <attribute name="dateShipped" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="trackingID" attributeType="String"/>
+        <attribute name="trackingNumber" optional="YES" attributeType="String"/>
+        <attribute name="trackingProvider" optional="YES" attributeType="String"/>
+        <attribute name="trackingURL" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="ShipmentTrackingProvider" representedClassName="ShipmentTrackingProvider" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <relationship name="group" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShipmentTrackingProviderGroup" inverseName="providers" inverseEntity="ShipmentTrackingProviderGroup"/>
+    </entity>
+    <entity name="ShipmentTrackingProviderGroup" representedClassName="ShipmentTrackingProviderGroup" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="providers" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShipmentTrackingProvider" inverseName="group" inverseEntity="ShipmentTrackingProvider"/>
+    </entity>
+    <entity name="ShippingLabel" representedClassName="ShippingLabel" syncable="YES">
+        <attribute name="carrierID" attributeType="String" defaultValueString=""/>
+        <attribute name="commercialInvoiceURL" optional="YES" attributeType="String"/>
+        <attribute name="currency" attributeType="String" defaultValueString=""/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="expiryDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="hazmatCategory" optional="YES" attributeType="String"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="packageName" attributeType="String" defaultValueString=""/>
+        <attribute name="productIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="productNames" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="rate" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="refundableAmount" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="serviceName" attributeType="String" defaultValueString=""/>
+        <attribute name="shipmentID" optional="YES" attributeType="String"/>
+        <attribute name="shippingLabelID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="status" attributeType="String" defaultValueString=""/>
+        <attribute name="trackingNumber" attributeType="String" defaultValueString=""/>
+        <attribute name="usedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="destinationAddress" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ShippingLabelAddress" inverseName="destinationShippingLabel" inverseEntity="ShippingLabelAddress"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="shippingLabels" inverseEntity="Order"/>
+        <relationship name="originAddress" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ShippingLabelAddress" inverseName="originShippingLabel" inverseEntity="ShippingLabelAddress"/>
+        <relationship name="refund" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ShippingLabelRefund" inverseName="shippingLabel" inverseEntity="ShippingLabelRefund"/>
+        <relationship name="shipment" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingShipment" inverseName="shippingLabel" inverseEntity="WooShippingShipment"/>
+    </entity>
+    <entity name="ShippingLabelAccountSettings" representedClassName="ShippingLabelAccountSettings" syncable="YES">
+        <attribute name="addPaymentMethodURL" optional="YES" attributeType="String"/>
+        <attribute name="canEditSettings" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="canManagePayments" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isEmailReceiptsEnabled" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="lastOrderCompleted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastSelectedPackageID" attributeType="String" defaultValueString=""/>
+        <attribute name="paperSize" attributeType="String"/>
+        <attribute name="selectedPaymentMethodID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="storeOwnerDisplayName" attributeType="String"/>
+        <attribute name="storeOwnerUsername" attributeType="String"/>
+        <attribute name="storeOwnerWpcomEmail" attributeType="String"/>
+        <attribute name="storeOwnerWpcomUsername" attributeType="String"/>
+        <relationship name="paymentMethods" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShippingLabelPaymentMethod" inverseName="accountSettings" inverseEntity="ShippingLabelPaymentMethod"/>
+    </entity>
+    <entity name="ShippingLabelAddress" representedClassName="ShippingLabelAddress" syncable="YES">
+        <attribute name="address1" attributeType="String" defaultValueString=""/>
+        <attribute name="address2" attributeType="String" defaultValueString=""/>
+        <attribute name="city" attributeType="String" defaultValueString=""/>
+        <attribute name="company" attributeType="String" defaultValueString=""/>
+        <attribute name="country" attributeType="String" defaultValueString=""/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="phone" attributeType="String" defaultValueString=""/>
+        <attribute name="postcode" attributeType="String" defaultValueString=""/>
+        <attribute name="state" attributeType="String" defaultValueString=""/>
+        <relationship name="destinationShippingLabel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShippingLabel" inverseName="destinationAddress" inverseEntity="ShippingLabel"/>
+        <relationship name="originShippingLabel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShippingLabel" inverseName="originAddress" inverseEntity="ShippingLabel"/>
+    </entity>
+    <entity name="ShippingLabelPaymentMethod" representedClassName="ShippingLabelPaymentMethod" syncable="YES">
+        <attribute name="cardDigits" attributeType="String"/>
+        <attribute name="cardType" attributeType="String"/>
+        <attribute name="expiry" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="paymentMethodID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="accountSettings" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShippingLabelAccountSettings" inverseName="paymentMethods" inverseEntity="ShippingLabelAccountSettings"/>
+    </entity>
+    <entity name="ShippingLabelRefund" representedClassName="ShippingLabelRefund" syncable="YES">
+        <attribute name="dateRequested" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="status" attributeType="String" defaultValueString=""/>
+        <relationship name="shippingLabel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShippingLabel" inverseName="refund" inverseEntity="ShippingLabel"/>
+    </entity>
+    <entity name="ShippingLabelSettings" representedClassName="ShippingLabelSettings" syncable="YES">
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="paperSize" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="shippingLabelSettings" inverseEntity="Order"/>
+    </entity>
+    <entity name="ShippingLine" representedClassName="ShippingLine" syncable="YES">
+        <attribute name="methodID" optional="YES" attributeType="String"/>
+        <attribute name="methodTitle" optional="YES" attributeType="String"/>
+        <attribute name="shippingID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <attribute name="totalTax" optional="YES" attributeType="String"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="shippingLines" inverseEntity="Order"/>
+        <relationship name="refund" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Refund" inverseName="shippingLines" inverseEntity="Refund"/>
+        <relationship name="taxes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShippingLineTax" inverseName="shipping" inverseEntity="ShippingLineTax"/>
+    </entity>
+    <entity name="ShippingLineTax" representedClassName="ShippingLineTax" syncable="YES">
+        <attribute name="subtotal" optional="YES" attributeType="String"/>
+        <attribute name="taxID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <relationship name="shipping" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShippingLine" inverseName="taxes" inverseEntity="ShippingLine"/>
+    </entity>
+    <entity name="ShippingMethod" representedClassName="ShippingMethod" syncable="YES">
+        <attribute name="methodID" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+    </entity>
+    <entity name="Site" representedClassName="Site" syncable="YES">
+        <attribute name="adminURL" optional="YES" attributeType="String"/>
+        <attribute name="canBlaze" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="frameNonce" optional="YES" attributeType="String"/>
+        <attribute name="gardenName" optional="YES" attributeType="String"/>
+        <attribute name="gardenPartner" optional="YES" attributeType="String"/>
+        <attribute name="gmtOffset" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="hasSSOEnabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isAdmin" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isAIAssitantFeatureActive" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isGarden" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isJetpackConnected" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isJetpackThePluginInstalled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isSiteOwner" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isWooCommerceActive" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="isWordPressStore" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="jetpackConnectionActivePlugins" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="loginURL" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="plan" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="tagline" optional="YES" attributeType="String"/>
+        <attribute name="timezone" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="visibility" attributeType="Integer 64" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="wasEcommerceTrial" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="SitePlugin" representedClassName="SitePlugin" syncable="YES">
+        <attribute name="author" attributeType="String" defaultValueString=""/>
+        <attribute name="authorUri" attributeType="String" defaultValueString=""/>
+        <attribute name="descriptionRaw" attributeType="String" defaultValueString=""/>
+        <attribute name="descriptionRendered" attributeType="String" defaultValueString=""/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="networkOnly" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="plugin" attributeType="String" defaultValueString=""/>
+        <attribute name="pluginUri" attributeType="String" defaultValueString=""/>
+        <attribute name="requiresPHPVersion" attributeType="String" defaultValueString=""/>
+        <attribute name="requiresWPVersion" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="status" attributeType="String" defaultValueString="unknown"/>
+        <attribute name="textDomain" attributeType="String" defaultValueString=""/>
+        <attribute name="version" attributeType="String" defaultValueString=""/>
+    </entity>
+    <entity name="SiteSetting" representedClassName="SiteSetting" syncable="YES">
+        <attribute name="label" optional="YES" attributeType="String"/>
+        <attribute name="settingDescription" optional="YES" attributeType="String"/>
+        <attribute name="settingGroupKey" optional="YES" attributeType="String"/>
+        <attribute name="settingID" optional="YES" attributeType="String"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="value" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="SiteSummaryStats" representedClassName="SiteSummaryStats" syncable="YES">
+        <attribute name="date" attributeType="String" defaultValueString=""/>
+        <attribute name="period" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="views" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitors" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="SiteVisitStats" representedClassName="SiteVisitStats" syncable="YES">
+        <attribute name="date" attributeType="String"/>
+        <attribute name="granularity" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="timeRange" attributeType="String" defaultValueString=""/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SiteVisitStatsItem" inverseName="stats" inverseEntity="SiteVisitStatsItem"/>
+    </entity>
+    <entity name="SiteVisitStatsItem" representedClassName="SiteVisitStatsItem" syncable="YES">
+        <attribute name="period" optional="YES" attributeType="String"/>
+        <attribute name="views" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="visitors" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SiteVisitStats" inverseName="items" inverseEntity="SiteVisitStats"/>
+    </entity>
+    <entity name="StateOfACountry" representedClassName="StateOfACountry" syncable="YES">
+        <attribute name="code" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <relationship name="relationship" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Country" inverseName="states" inverseEntity="Country"/>
+    </entity>
+    <entity name="SystemPlugin" representedClassName="SystemPlugin" syncable="YES">
+        <attribute name="active" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="authorName" attributeType="String"/>
+        <attribute name="authorUrl" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="networkActivated" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="plugin" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="url" attributeType="String"/>
+        <attribute name="version" attributeType="String"/>
+        <attribute name="versionLatest" attributeType="String"/>
+    </entity>
+    <entity name="TaxClass" representedClassName="TaxClass" syncable="YES">
+        <attribute name="name" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="slug" attributeType="String"/>
+    </entity>
+    <entity name="TaxRate" representedClassName="TaxRate" versionHashModifier="2" syncable="YES">
+        <attribute name="cities" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray" versionHashModifier="2"/>
+        <attribute name="city" optional="YES" attributeType="String"/>
+        <attribute name="compound" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="country" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="order" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="postcode" optional="YES" attributeType="String"/>
+        <attribute name="postcodes" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray" versionHashModifier="2"/>
+        <attribute name="priority" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="rate" optional="YES" attributeType="String"/>
+        <attribute name="shipping" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="state" optional="YES" attributeType="String"/>
+        <attribute name="taxRateClass" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="TopEarnerStats" representedClassName="TopEarnerStats" syncable="YES">
+        <attribute name="date" attributeType="String"/>
+        <attribute name="granularity" attributeType="String"/>
+        <attribute name="limit" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TopEarnerStatsItem" inverseName="stats" inverseEntity="TopEarnerStatsItem"/>
+    </entity>
+    <entity name="TopEarnerStatsItem" representedClassName="TopEarnerStatsItem" syncable="YES">
+        <attribute name="currency" optional="YES" attributeType="String"/>
+        <attribute name="imageUrl" optional="YES" attributeType="String"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="productName" optional="YES" attributeType="String"/>
+        <attribute name="quantity" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="total" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TopEarnerStats" inverseName="items" inverseEntity="TopEarnerStats"/>
+    </entity>
+    <entity name="WCAnalyticsCustomer" representedClassName="WCAnalyticsCustomer" syncable="YES">
+        <attribute name="averageOrderValue" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="city" optional="YES" attributeType="String"/>
+        <attribute name="country" optional="YES" attributeType="String"/>
+        <attribute name="customerID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="dateLastActive" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateRegistered" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="email" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="ordersCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="postcode" optional="YES" attributeType="String"/>
+        <attribute name="region" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="totalSpend" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="userID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="username" optional="YES" attributeType="String"/>
+        <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="WCAnalyticsCustomerSearchResult" inverseName="customers" inverseEntity="WCAnalyticsCustomerSearchResult"/>
+    </entity>
+    <entity name="WCAnalyticsCustomerSearchResult" representedClassName="WCAnalyticsCustomerSearchResult" syncable="YES">
+        <attribute name="keyword" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="customers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="WCAnalyticsCustomer" inverseName="searchResults" inverseEntity="WCAnalyticsCustomer"/>
+    </entity>
+    <entity name="WCPayCardPaymentDetails" representedClassName="WCPayCardPaymentDetails" syncable="YES">
+        <attribute name="brand" attributeType="String"/>
+        <attribute name="funding" attributeType="String"/>
+        <attribute name="last4" attributeType="String"/>
+        <relationship name="charge" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WCPayCharge" inverseName="cardDetails" inverseEntity="WCPayCharge"/>
+    </entity>
+    <entity name="WCPayCardPresentPaymentDetails" representedClassName="WCPayCardPresentPaymentDetails" syncable="YES">
+        <attribute name="brand" attributeType="String"/>
+        <attribute name="funding" attributeType="String"/>
+        <attribute name="last4" attributeType="String"/>
+        <relationship name="charge" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WCPayCharge" inverseName="cardPresentDetails" inverseEntity="WCPayCharge"/>
+        <relationship name="receipt" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="WCPayCardPresentReceiptDetails" inverseName="cardPresentPayment" inverseEntity="WCPayCardPresentReceiptDetails"/>
+    </entity>
+    <entity name="WCPayCardPresentReceiptDetails" representedClassName="WCPayCardPresentReceiptDetails" syncable="YES">
+        <attribute name="accountType" attributeType="String"/>
+        <attribute name="applicationPreferredName" optional="YES" attributeType="String"/>
+        <attribute name="dedicatedFileName" optional="YES" attributeType="String"/>
+        <relationship name="cardPresentPayment" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WCPayCardPresentPaymentDetails" inverseName="receipt" inverseEntity="WCPayCardPresentPaymentDetails"/>
+    </entity>
+    <entity name="WCPayCharge" representedClassName="WCPayCharge" syncable="YES">
+        <attribute name="amount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="amountCaptured" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="amountRefunded" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="authorizationCode" optional="YES" attributeType="String"/>
+        <attribute name="captured" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="chargeID" attributeType="String"/>
+        <attribute name="created" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="currency" attributeType="String"/>
+        <attribute name="paid" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="paymentIntentID" optional="YES" attributeType="String"/>
+        <attribute name="paymentMethodID" attributeType="String"/>
+        <attribute name="paymentMethodType" attributeType="String"/>
+        <attribute name="refunded" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="status" attributeType="String"/>
+        <relationship name="cardDetails" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="WCPayCardPaymentDetails" inverseName="charge" inverseEntity="WCPayCardPaymentDetails"/>
+        <relationship name="cardPresentDetails" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="WCPayCardPresentPaymentDetails" inverseName="charge" inverseEntity="WCPayCardPresentPaymentDetails"/>
+    </entity>
+    <entity name="WooShippingCarrierPredefinedOptions" representedClassName="WooShippingCarrierPredefinedOptions" syncable="YES">
+        <attribute name="carrierID" attributeType="String" defaultValueString=""/>
+        <relationship name="packagesResponse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingPackagesResponse" inverseName="allPredefinedOptions" inverseEntity="WooShippingPackagesResponse"/>
+        <relationship name="predefinedOptions" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="WooShippingPredefinedOption" inverseName="carrier" inverseEntity="WooShippingPredefinedOption"/>
+    </entity>
+    <entity name="WooShippingCustomPackage" representedClassName="WooShippingCustomPackage" syncable="YES">
+        <attribute name="boxWeight" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="dimensions" attributeType="String" defaultValueString=""/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="rawType" attributeType="String" defaultValueString=""/>
+        <relationship name="packagesResponse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingPackagesResponse" inverseName="customPackages" inverseEntity="WooShippingPackagesResponse"/>
+    </entity>
+    <entity name="WooShippingOriginAddress" representedClassName="WooShippingOriginAddress" syncable="YES">
+        <attribute name="address1" attributeType="String" defaultValueString=""/>
+        <attribute name="address2" attributeType="String" defaultValueString=""/>
+        <attribute name="city" attributeType="String" defaultValueString=""/>
+        <attribute name="company" attributeType="String" defaultValueString=""/>
+        <attribute name="country" attributeType="String" defaultValueString=""/>
+        <attribute name="defaultAddress" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="email" attributeType="String" defaultValueString=""/>
+        <attribute name="firstName" attributeType="String" defaultValueString=""/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="isVerified" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastName" attributeType="String" defaultValueString=""/>
+        <attribute name="phone" attributeType="String" defaultValueString=""/>
+        <attribute name="postcode" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="state" attributeType="String" defaultValueString=""/>
+    </entity>
+    <entity name="WooShippingPackagesResponse" representedClassName="WooShippingPackagesResponse" syncable="YES">
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="allPredefinedOptions" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="WooShippingCarrierPredefinedOptions" inverseName="packagesResponse" inverseEntity="WooShippingCarrierPredefinedOptions"/>
+        <relationship name="customPackages" toMany="YES" deletionRule="Cascade" destinationEntity="WooShippingCustomPackage" inverseName="packagesResponse" inverseEntity="WooShippingCustomPackage"/>
+        <relationship name="savedPredefinedPackages" toMany="YES" deletionRule="Cascade" destinationEntity="WooShippingSavedPredefinedPackage" inverseName="packagesResponse" inverseEntity="WooShippingSavedPredefinedPackage"/>
+    </entity>
+    <entity name="WooShippingPredefinedOption" representedClassName="WooShippingPredefinedOption" syncable="YES">
+        <attribute name="providerID" attributeType="String" defaultValueString=""/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+        <relationship name="carrier" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingCarrierPredefinedOptions" inverseName="predefinedOptions" inverseEntity="WooShippingCarrierPredefinedOptions"/>
+        <relationship name="predefinedPackages" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WooShippingPredefinedPackage" inverseName="predefinedOption" inverseEntity="WooShippingPredefinedPackage"/>
+    </entity>
+    <entity name="WooShippingPredefinedPackage" representedClassName="WooShippingPredefinedPackage" syncable="YES">
+        <attribute name="boxWeight" attributeType="String" defaultValueString=""/>
+        <attribute name="dimensions" attributeType="String" defaultValueString=""/>
+        <attribute name="groupID" attributeType="String" defaultValueString=""/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="isLetter" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <relationship name="predefinedOption" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingPredefinedOption" inverseName="predefinedPackages" inverseEntity="WooShippingPredefinedOption"/>
+        <relationship name="savedPredefinedPackage" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingSavedPredefinedPackage" inverseName="package" inverseEntity="WooShippingSavedPredefinedPackage"/>
+    </entity>
+    <entity name="WooShippingSavedPredefinedPackage" representedClassName="WooShippingSavedPredefinedPackage" syncable="YES">
+        <attribute name="groupTitle" attributeType="String" defaultValueString=""/>
+        <attribute name="providerID" attributeType="String" defaultValueString=""/>
+        <relationship name="package" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="WooShippingPredefinedPackage" inverseName="savedPredefinedPackage" inverseEntity="WooShippingPredefinedPackage"/>
+        <relationship name="packagesResponse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingPackagesResponse" inverseName="savedPredefinedPackages" inverseEntity="WooShippingPackagesResponse"/>
+    </entity>
+    <entity name="WooShippingShipment" representedClassName="WooShippingShipment" syncable="YES">
+        <attribute name="index" attributeType="String" defaultValueString="0"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WooShippingShipmentItem" inverseName="shipment" inverseEntity="WooShippingShipmentItem"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="shipments" inverseEntity="Order"/>
+        <relationship name="shippingLabel" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ShippingLabel" inverseName="shipment" inverseEntity="ShippingLabel"/>
+    </entity>
+    <entity name="WooShippingShipmentItem" representedClassName="WooShippingShipmentItem" syncable="YES">
+        <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="subItems" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <relationship name="shipment" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WooShippingShipment" inverseName="items" inverseEntity="WooShippingShipment"/>
+    </entity>
+</model>

--- a/Modules/Sources/Storage/Tools/StorageType+Deletions.swift
+++ b/Modules/Sources/Storage/Tools/StorageType+Deletions.swift
@@ -256,4 +256,14 @@ public extension StorageType {
             deleteObject(booking)
         }
     }
+
+    /// Deletes stored Bookings matching the given predicate.
+    ///
+    func deleteBookings(matching predicate: NSPredicate) {
+        let descriptor = NSSortDescriptor(keyPath: \Booking.bookingID, ascending: false)
+        let bookings = allObjects(ofType: Booking.self, matching: predicate, sortedBy: [descriptor])
+        for booking in bookings {
+            deleteObject(booking)
+        }
+    }
 }

--- a/Modules/Sources/Yosemite/Model/Booking/BookingOrderInfo+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Booking/BookingOrderInfo+ReadOnlyConvertible.swift
@@ -6,11 +6,21 @@ import Storage
 extension Storage.BookingOrderInfo: ReadOnlyConvertible {
     public func update(with orderInfo: Yosemite.BookingOrderInfo) {
         statusKey = orderInfo.statusKey
+        orderID = orderInfo.orderID
+        orderNumber = orderInfo.orderNumber
+        dateCreated = orderInfo.dateCreated
+        datePaid = orderInfo.datePaid
+        discountTotal = orderInfo.discountTotal
         // Relationships are handled in BookingStore
     }
 
     public func toReadOnly() -> Yosemite.BookingOrderInfo {
         return .init(statusKey: statusKey ?? "",
+                     orderID: orderID,
+                     orderNumber: orderNumber,
+                     dateCreated: dateCreated,
+                     datePaid: datePaid,
+                     discountTotal: discountTotal,
                      paymentInfo: paymentInfo?.toReadOnly(),
                      customerInfo: customerInfo?.toReadOnly(),
                      productInfo: productInfo?.toReadOnly())

--- a/Modules/Sources/Yosemite/Model/Booking/BookingOrderInfo+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Booking/BookingOrderInfo+ReadOnlyConvertible.swift
@@ -17,10 +17,10 @@ extension Storage.BookingOrderInfo: ReadOnlyConvertible {
     public func toReadOnly() -> Yosemite.BookingOrderInfo {
         return .init(statusKey: statusKey ?? "",
                      orderID: orderID,
-                     orderNumber: orderNumber,
-                     dateCreated: dateCreated,
+                     orderNumber: orderNumber ?? "",
+                     dateCreated: dateCreated ?? Date(),
                      datePaid: datePaid,
-                     discountTotal: discountTotal,
+                     discountTotal: discountTotal ?? "",
                      paymentInfo: paymentInfo?.toReadOnly(),
                      customerInfo: customerInfo?.toReadOnly(),
                      productInfo: productInfo?.toReadOnly())

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
@@ -81,12 +81,15 @@ private extension POSDefaultBookingListFetchStrategy {
     }
 
     func fetchLocalBookingsSync(filters: BookingFilters) -> [POSBooking] {
-        let predicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: filters)
-        let descriptor = NSSortDescriptor(keyPath: \StorageBooking.startDate, ascending: true)
+        let bookingPredicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: filters)
+        let hasOrderPredicate = NSPredicate(format: "orderInfo != nil")
+        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [bookingPredicate, hasOrderPredicate])
+        let sortByDate = NSSortDescriptor(keyPath: \StorageBooking.startDate, ascending: true)
+        let sortByID = NSSortDescriptor(keyPath: \StorageBooking.bookingID, ascending: true)
         let resultsController = ResultsController<StorageBooking>(
             storageManager: storageManager,
             matching: predicate,
-            sortedBy: [descriptor]
+            sortedBy: [sortByDate, sortByID]
         )
 
         do {

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
@@ -1,9 +1,11 @@
 import Foundation
 import struct NetworkingCore.PagedItems
+import protocol Storage.StorageManagerType
+import class WooFoundationCore.CurrencyFormatter
 
 public protocol POSBookingListFetchStrategy {
     func fetchBookings(pageNumber: Int) async throws -> PagedItems<POSBooking>
-    var supportsCaching: Bool { get }
+    func fetchLocalBookings() -> [POSBooking]
     var showsLoadingWithItems: Bool { get }
     var id: String { get }
 }
@@ -12,35 +14,106 @@ extension POSBookingListFetchStrategy {
     public var id: String {
         String(describing: type(of: self))
     }
+
+    public func fetchLocalBookings() -> [POSBooking] {
+        []
+    }
 }
 
 struct POSDefaultBookingListFetchStrategy: POSBookingListFetchStrategy {
-    private let bookingService: POSBookingServiceProtocol
+    private let bookingStoreMethods: BookingStoreMethodsProtocol
+    private let storageManager: StorageManagerType
+    private let storageBookingMapper: StorageBookingToPOSBookingMapper
     private let siteID: Int64
     private let pageSize: Int
     private let filters: BookingFilters?
-    let supportsCaching: Bool = true
     let showsLoadingWithItems: Bool = true
 
     var id: String {
         "POSDefaultBookingListFetchStrategy-\(filters?.startDateAfter ?? "none")"
     }
 
-    init(bookingService: POSBookingServiceProtocol, siteID: Int64, filters: BookingFilters? = nil, pageSize: Int = 25) {
-        self.bookingService = bookingService
+    init(bookingStoreMethods: BookingStoreMethodsProtocol,
+         storageManager: StorageManagerType,
+         currencyFormatter: CurrencyFormatter,
+         siteSettings: [SiteSetting] = [],
+         siteID: Int64,
+         filters: BookingFilters? = nil,
+         pageSize: Int = 25) {
+        self.bookingStoreMethods = bookingStoreMethods
+        self.storageManager = storageManager
+        self.storageBookingMapper = StorageBookingToPOSBookingMapper(currencyFormatter: currencyFormatter, siteSettings: siteSettings)
         self.siteID = siteID
         self.filters = filters
         self.pageSize = pageSize
     }
 
     func fetchBookings(pageNumber: Int) async throws -> PagedItems<POSBooking> {
-        try await bookingService.fetchBookings(
+        let hasMorePages = try await bookingStoreMethods.synchronizeBookings(
             siteID: siteID,
             pageNumber: pageNumber,
             pageSize: pageSize,
             filters: filters,
             searchQuery: nil
         )
+        let bookings = await fetchLocalBookingsFromStorage()
+        return PagedItems(items: bookings, hasMorePages: hasMorePages, totalItems: nil)
+    }
+
+    func fetchLocalBookings() -> [POSBooking] {
+        guard let filters else { return [] }
+        return fetchLocalBookingsSync(filters: filters)
+    }
+}
+
+private extension POSDefaultBookingListFetchStrategy {
+    @MainActor
+    func fetchLocalBookingsFromStorage() -> [POSBooking] {
+        guard let filters else { return [] }
+        return fetchLocalBookingsSync(filters: filters)
+    }
+
+    func fetchLocalBookingsSync(filters: BookingFilters) -> [POSBooking] {
+        let predicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: filters)
+        let descriptor = NSSortDescriptor(keyPath: \StorageBooking.startDate, ascending: true)
+        let resultsController = ResultsController<StorageBooking>(
+            storageManager: storageManager,
+            matching: predicate,
+            sortedBy: [descriptor]
+        )
+
+        do {
+            try resultsController.performFetch()
+        } catch {
+            return []
+        }
+
+        let readOnlyBookings = resultsController.fetchedObjects
+
+        let resourceIDs = Set(readOnlyBookings.compactMap { $0.resourceID != 0 ? $0.resourceID : nil })
+        let storedResources = loadStoredResources(resourceIDs: resourceIDs)
+
+        return readOnlyBookings.compactMap { booking in
+            let resource = storedResources[booking.resourceID]
+            return storageBookingMapper.map(booking: booking, resource: resource)
+        }
+    }
+
+    func loadStoredResources(resourceIDs: Set<Int64>) -> [Int64: BookingResource] {
+        guard !resourceIDs.isEmpty else { return [:] }
+        let predicate = NSPredicate(format: "siteID == %lld AND resourceID IN %@", siteID, Array(resourceIDs))
+        let descriptor = NSSortDescriptor(keyPath: \StorageBookingResource.resourceID, ascending: true)
+        let resultsController = ResultsController<StorageBookingResource>(
+            storageManager: storageManager,
+            matching: predicate,
+            sortedBy: [descriptor]
+        )
+        do {
+            try resultsController.performFetch()
+        } catch {
+            return [:]
+        }
+        return Dictionary(uniqueKeysWithValues: resultsController.fetchedObjects.map { ($0.resourceID, $0) })
     }
 }
 
@@ -50,7 +123,6 @@ struct POSSearchBookingListFetchStrategy: POSBookingListFetchStrategy {
     private let searchTerm: String
     private let pageSize: Int
     private let filters: BookingFilters?
-    let supportsCaching: Bool = false
     let showsLoadingWithItems: Bool = false
 
     var id: String {

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
@@ -1,4 +1,6 @@
 import Foundation
+import enum Alamofire.AFError
+import class Networking.BookingsRemote
 import struct NetworkingCore.PagedItems
 import protocol Storage.StorageManagerType
 import class WooFoundationCore.CurrencyFormatter
@@ -49,15 +51,20 @@ struct POSDefaultBookingListFetchStrategy: POSBookingListFetchStrategy {
     }
 
     func fetchBookings(pageNumber: Int) async throws -> PagedItems<POSBooking> {
-        let hasMorePages = try await bookingStoreMethods.synchronizeBookings(
-            siteID: siteID,
-            pageNumber: pageNumber,
-            pageSize: pageSize,
-            filters: filters,
-            searchQuery: nil
-        )
-        let bookings = await fetchLocalBookingsFromStorage()
-        return PagedItems(items: bookings, hasMorePages: hasMorePages, totalItems: nil)
+        do {
+            let hasMorePages = try await bookingStoreMethods.synchronizeBookings(
+                siteID: siteID,
+                pageNumber: pageNumber,
+                pageSize: pageSize,
+                filters: filters,
+                searchQuery: nil,
+                order: .ascending
+            )
+            let bookings = await fetchLocalBookingsFromStorage()
+            return PagedItems(items: bookings, hasMorePages: hasMorePages, totalItems: nil)
+        } catch AFError.explicitlyCancelled, is CancellationError {
+            throw POSBookingServiceError.requestCancelled
+        }
     }
 
     func fetchLocalBookings() -> [POSBooking] {

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
@@ -52,13 +52,17 @@ struct POSDefaultBookingListFetchStrategy: POSBookingListFetchStrategy {
 
     func fetchBookings(pageNumber: Int) async throws -> PagedItems<POSBooking> {
         do {
+            let cacheClearStrategy: BookingStoreMethods.CacheClearStrategy = pageNumber == 1
+                ? (filters.map { .filtersOnly($0) } ?? .all)
+                : .none
             let hasMorePages = try await bookingStoreMethods.synchronizeBookings(
                 siteID: siteID,
                 pageNumber: pageNumber,
                 pageSize: pageSize,
                 filters: filters,
                 searchQuery: nil,
-                order: .ascending
+                order: .ascending,
+                cacheClearStrategy: cacheClearStrategy
             )
             let bookings = await fetchLocalBookingsFromStorage()
             return PagedItems(items: bookings, hasMorePages: hasMorePages, totalItems: nil)

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
@@ -7,7 +7,7 @@ import class WooFoundationCore.CurrencyFormatter
 
 public protocol POSBookingListFetchStrategy {
     func fetchBookings(pageNumber: Int) async throws -> PagedItems<POSBooking>
-    func fetchLocalBookings() -> [POSBooking]
+    @MainActor func fetchLocalBookings() -> [POSBooking]
     var showsLoadingWithItems: Bool { get }
     var id: String { get }
 }
@@ -17,7 +17,7 @@ extension POSBookingListFetchStrategy {
         String(describing: type(of: self))
     }
 
-    public func fetchLocalBookings() -> [POSBooking] {
+    @MainActor public func fetchLocalBookings() -> [POSBooking] {
         []
     }
 }
@@ -71,6 +71,7 @@ struct POSDefaultBookingListFetchStrategy: POSBookingListFetchStrategy {
         }
     }
 
+    @MainActor
     func fetchLocalBookings() -> [POSBooking] {
         guard let filters else { return [] }
         return fetchLocalBookingsSync(filters: filters)
@@ -84,6 +85,7 @@ private extension POSDefaultBookingListFetchStrategy {
         return fetchLocalBookingsSync(filters: filters)
     }
 
+    @MainActor
     func fetchLocalBookingsSync(filters: BookingFilters) -> [POSBooking] {
         let bookingPredicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: filters)
         let hasOrderPredicate = NSPredicate(format: "orderInfo != nil")

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategyFactory.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategyFactory.swift
@@ -3,6 +3,7 @@ import class Networking.AlamofireNetwork
 import class Networking.BookingsRemote
 import class Networking.OrdersRemote
 import class WooFoundationCore.CurrencyFormatter
+import protocol Storage.StorageManagerType
 import struct Combine.AnyPublisher
 import struct NetworkingCore.JetpackSite
 
@@ -14,20 +15,31 @@ public protocol POSBookingListFetchStrategyFactoryProtocol {
 
 public final class POSBookingListFetchStrategyFactory: POSBookingListFetchStrategyFactoryProtocol {
     private let siteID: Int64
+    private let storageManager: StorageManagerType
+    private let currencyFormatter: CurrencyFormatter
+    private let siteSettings: [SiteSetting]
+    private let bookingStoreMethods: BookingStoreMethodsProtocol
     public let bookingService: POSBookingServiceProtocol
 
     public init(siteID: Int64,
                 credentials: Credentials?,
                 selectedSite: AnyPublisher<JetpackSite?, Never>,
                 appPasswordSupportState: AnyPublisher<Bool, Never>,
+                storageManager: StorageManagerType,
                 currencyFormatter: CurrencyFormatter,
                 siteSettings: [SiteSetting] = []) {
         self.siteID = siteID
+        self.storageManager = storageManager
+        self.currencyFormatter = currencyFormatter
+        self.siteSettings = siteSettings
         let network = AlamofireNetwork(credentials: credentials,
                                        selectedSite: selectedSite,
                                        appPasswordSupportState: appPasswordSupportState)
         let bookingsRemote = BookingsRemote(network: network)
         let ordersRemote = OrdersRemote(network: network)
+        self.bookingStoreMethods = BookingStoreMethods(storageManager: storageManager,
+                                                       bookingsRemote: bookingsRemote,
+                                                       ordersRemote: ordersRemote)
         self.bookingService = POSBookingService(
             siteID: siteID,
             bookingsRemote: bookingsRemote,
@@ -38,7 +50,12 @@ public final class POSBookingListFetchStrategyFactory: POSBookingListFetchStrate
     }
 
     public func defaultStrategy(filters: BookingFilters? = nil) -> POSBookingListFetchStrategy {
-        POSDefaultBookingListFetchStrategy(bookingService: bookingService, siteID: siteID, filters: filters)
+        POSDefaultBookingListFetchStrategy(bookingStoreMethods: bookingStoreMethods,
+                                           storageManager: storageManager,
+                                           currencyFormatter: currencyFormatter,
+                                           siteSettings: siteSettings,
+                                           siteID: siteID,
+                                           filters: filters)
     }
 
     public func searchStrategy(searchTerm: String, filters: BookingFilters? = nil) -> POSBookingListFetchStrategy {

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategyFactory.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategyFactory.swift
@@ -5,7 +5,6 @@ import class Networking.OrdersRemote
 import class WooFoundationCore.CurrencyFormatter
 import struct Combine.AnyPublisher
 import struct NetworkingCore.JetpackSite
-import protocol Storage.StorageManagerType
 
 public protocol POSBookingListFetchStrategyFactoryProtocol {
     func defaultStrategy(filters: BookingFilters?) -> POSBookingListFetchStrategy
@@ -22,7 +21,6 @@ public final class POSBookingListFetchStrategyFactory: POSBookingListFetchStrate
                 selectedSite: AnyPublisher<JetpackSite?, Never>,
                 appPasswordSupportState: AnyPublisher<Bool, Never>,
                 currencyFormatter: CurrencyFormatter,
-                storageManager: StorageManagerType,
                 siteSettings: [SiteSetting] = []) {
         self.siteID = siteID
         let network = AlamofireNetwork(credentials: credentials,
@@ -35,7 +33,6 @@ public final class POSBookingListFetchStrategyFactory: POSBookingListFetchStrate
             bookingsRemote: bookingsRemote,
             ordersRemote: ordersRemote,
             currencyFormatter: currencyFormatter,
-            storageManager: storageManager,
             siteSettings: siteSettings
         )
     }

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategyFactory.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategyFactory.swift
@@ -5,6 +5,7 @@ import class Networking.OrdersRemote
 import class WooFoundationCore.CurrencyFormatter
 import struct Combine.AnyPublisher
 import struct NetworkingCore.JetpackSite
+import protocol Storage.StorageManagerType
 
 public protocol POSBookingListFetchStrategyFactoryProtocol {
     func defaultStrategy(filters: BookingFilters?) -> POSBookingListFetchStrategy
@@ -21,6 +22,7 @@ public final class POSBookingListFetchStrategyFactory: POSBookingListFetchStrate
                 selectedSite: AnyPublisher<JetpackSite?, Never>,
                 appPasswordSupportState: AnyPublisher<Bool, Never>,
                 currencyFormatter: CurrencyFormatter,
+                storageManager: StorageManagerType,
                 siteSettings: [SiteSetting] = []) {
         self.siteID = siteID
         let network = AlamofireNetwork(credentials: credentials,
@@ -33,6 +35,7 @@ public final class POSBookingListFetchStrategyFactory: POSBookingListFetchStrate
             bookingsRemote: bookingsRemote,
             ordersRemote: ordersRemote,
             currencyFormatter: currencyFormatter,
+            storageManager: storageManager,
             siteSettings: siteSettings
         )
     }

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingService.swift
@@ -8,25 +8,31 @@ import struct Networking.BookingOrderInfo
 import struct Networking.BookingResource
 import protocol NetworkingCore.POSOrdersRemoteProtocol
 import class WooFoundationCore.CurrencyFormatter
+import Storage
 
 public final class POSBookingService: POSBookingServiceProtocol {
     private let siteID: Int64
     private let bookingsRemote: BookingsRemoteProtocol
     private let ordersRemote: POSOrdersRemoteProtocol
     private let mapper: POSBookingMapper
+    private let storageBookingMapper: StorageBookingToPOSBookingMapper
     private let orderMapper: POSOrderMapper
     private let resourceCache = BookingResourceCache()
+    private let storageManager: StorageManagerType?
 
     public init(siteID: Int64,
                 bookingsRemote: BookingsRemoteProtocol,
                 ordersRemote: POSOrdersRemoteProtocol,
                 currencyFormatter: CurrencyFormatter,
+                storageManager: StorageManagerType? = nil,
                 siteSettings: [SiteSetting] = []) {
         self.siteID = siteID
         self.bookingsRemote = bookingsRemote
         self.ordersRemote = ordersRemote
         self.mapper = POSBookingMapper(currencyFormatter: currencyFormatter, siteSettings: siteSettings)
+        self.storageBookingMapper = StorageBookingToPOSBookingMapper(currencyFormatter: currencyFormatter, siteSettings: siteSettings)
         self.orderMapper = POSOrderMapper(currencyFormatter: currencyFormatter)
+        self.storageManager = storageManager
     }
 
     public func fetchBookings(siteID: Int64,
@@ -34,6 +40,34 @@ public final class POSBookingService: POSBookingServiceProtocol {
                               pageSize: Int,
                               filters: BookingFilters?,
                               searchQuery: String?) async throws -> PagedItems<POSBooking> {
+        // Page 1 with date filters and no search: try local cache first
+        if pageNumber == 1, searchQuery == nil, let filters, let storageManager {
+            let cachedBookings = fetchCachedBookings(storageManager: storageManager, siteID: siteID, filters: filters)
+            if cachedBookings.isNotEmpty {
+                triggerBackgroundRefresh(siteID: siteID, pageSize: pageSize, filters: filters)
+                return PagedItems(items: cachedBookings, hasMorePages: true, totalItems: nil)
+            }
+        }
+
+        return try await fetchRemoteBookings(
+            siteID: siteID,
+            pageNumber: pageNumber,
+            pageSize: pageSize,
+            filters: filters,
+            searchQuery: searchQuery
+        )
+    }
+
+}
+
+// MARK: - Remote Fetching
+
+private extension POSBookingService {
+    func fetchRemoteBookings(siteID: Int64,
+                             pageNumber: Int,
+                             pageSize: Int,
+                             filters: BookingFilters?,
+                             searchQuery: String?) async throws -> PagedItems<POSBooking> {
         do {
             let bookings = try await bookingsRemote.loadAllBookings(
                 for: siteID,
@@ -67,6 +101,17 @@ public final class POSBookingService: POSBookingServiceProtocol {
                     return nil
                 }
                 return mapper.map(booking: booking, orderInfo: orderInfo, resource: resource, order: posOrder)
+            }
+
+            // Persist to CoreData for caching
+            if let storageManager, searchQuery == nil {
+                persistBookings(
+                    storageManager: storageManager,
+                    bookings: bookings,
+                    orders: Array(orders.values),
+                    siteID: siteID,
+                    filters: pageNumber == 1 ? filters : nil
+                )
             }
 
             let hasMorePages = bookings.count == pageSize
@@ -185,9 +230,117 @@ private extension POSBookingService {
     }
 }
 
+// MARK: - Local Storage
+
+private extension POSBookingService {
+    func fetchCachedBookings(storageManager: StorageManagerType, siteID: Int64, filters: BookingFilters) -> [POSBooking] {
+        let predicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: filters)
+        let descriptor = NSSortDescriptor(keyPath: \Storage.Booking.startDate, ascending: true)
+        let resultsController = ResultsController<Storage.Booking>(
+            storageManager: storageManager,
+            matching: predicate,
+            sortedBy: [descriptor]
+        )
+
+        do {
+            try resultsController.performFetch()
+        } catch {
+            return []
+        }
+
+        let readOnlyBookings = resultsController.fetchedObjects
+
+        // Load resources from storage
+        let resourceIDs = Set(readOnlyBookings.compactMap { $0.resourceID != 0 ? $0.resourceID : nil })
+        let storedResources: [Int64: BookingResource] = {
+            guard !resourceIDs.isEmpty else { return [:] }
+            let resourcePredicate = NSPredicate(format: "siteID == %lld AND resourceID IN %@", siteID, Array(resourceIDs))
+            let resourceDescriptor = NSSortDescriptor(keyPath: \Storage.BookingResource.resourceID, ascending: true)
+            let resourceRC = ResultsController<Storage.BookingResource>(
+                storageManager: storageManager,
+                matching: resourcePredicate,
+                sortedBy: [resourceDescriptor]
+            )
+            do {
+                try resourceRC.performFetch()
+            } catch {
+                return [:]
+            }
+            return Dictionary(uniqueKeysWithValues: resourceRC.fetchedObjects.map { ($0.resourceID, $0) })
+        }()
+
+        return readOnlyBookings.compactMap { booking in
+            let resource = storedResources[booking.resourceID]
+            return storageBookingMapper.map(booking: booking, resource: resource)
+        }
+    }
+
+    func triggerBackgroundRefresh(siteID: Int64, pageSize: Int, filters: BookingFilters?) {
+        Task { [weak self] in
+            _ = try? await self?.fetchRemoteBookings(
+                siteID: siteID,
+                pageNumber: 1,
+                pageSize: pageSize,
+                filters: filters,
+                searchQuery: nil
+            )
+        }
+    }
+
+    func persistBookings(storageManager: StorageManagerType,
+                         bookings: [Networking.Booking],
+                         orders: [Order],
+                         siteID: Int64,
+                         filters: BookingFilters?) {
+        storageManager.performAndSave({ storage in
+            // Smart deletion: only delete bookings matching the filter scope on page 1
+            if let filters {
+                let predicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: filters)
+                storage.deleteBookings(matching: predicate)
+            }
+
+            // Upsert bookings
+            let bookingIDs = bookings.map { $0.bookingID }
+            let storedBookings = storage.loadBookings(siteID: siteID, bookingIDs: bookingIDs)
+
+            for readOnlyBooking in bookings {
+                let storageBooking = storedBookings.first { $0.bookingID == readOnlyBooking.bookingID } ??
+                    storage.insertNewObject(ofType: Storage.Booking.self)
+
+                if let associatedOrder = orders.first(where: { $0.orderID == readOnlyBooking.orderID }) {
+                    let readOnlyOrderInfo = BookingOrderInfo(booking: readOnlyBooking, order: associatedOrder)
+
+                    let orderInfo = storageBooking.orderInfo ?? storage.insertNewObject(ofType: Storage.BookingOrderInfo.self)
+
+                    let productInfo = orderInfo.productInfo ?? storage.insertNewObject(ofType: Storage.BookingProductInfo.self)
+                    if let readOnlyProductInfo = readOnlyOrderInfo.productInfo {
+                        productInfo.update(with: readOnlyProductInfo)
+                    }
+                    orderInfo.productInfo = productInfo
+
+                    let customerInfo = orderInfo.customerInfo ?? storage.insertNewObject(ofType: Storage.BookingCustomerInfo.self)
+                    if let readOnlyCustomerInfo = readOnlyOrderInfo.customerInfo {
+                        customerInfo.update(with: readOnlyCustomerInfo)
+                    }
+                    orderInfo.customerInfo = customerInfo
+
+                    let paymentInfo = orderInfo.paymentInfo ?? storage.insertNewObject(ofType: Storage.BookingPaymentInfo.self)
+                    if let readOnlyPaymentInfo = readOnlyOrderInfo.paymentInfo {
+                        paymentInfo.update(with: readOnlyPaymentInfo)
+                    }
+                    orderInfo.paymentInfo = paymentInfo
+
+                    orderInfo.update(with: readOnlyOrderInfo)
+                    storageBooking.orderInfo = orderInfo
+                }
+
+                storageBooking.update(with: readOnlyBooking)
+            }
+        }, completion: nil, on: .main)
+    }
+}
+
 // MARK: - BookingResourceCache
-// Caches booking resources across pages to avoid redundant network requests,
-// since multiple bookings often share the same resource. Cleared on page 1 reload.
 
 private actor BookingResourceCache {
     private var cache: [Int64: BookingResource] = [:]

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingService.swift
@@ -8,31 +8,25 @@ import struct Networking.BookingOrderInfo
 import struct Networking.BookingResource
 import protocol NetworkingCore.POSOrdersRemoteProtocol
 import class WooFoundationCore.CurrencyFormatter
-import Storage
 
 public final class POSBookingService: POSBookingServiceProtocol {
     private let siteID: Int64
     private let bookingsRemote: BookingsRemoteProtocol
     private let ordersRemote: POSOrdersRemoteProtocol
     private let mapper: POSBookingMapper
-    private let storageBookingMapper: StorageBookingToPOSBookingMapper
     private let orderMapper: POSOrderMapper
     private let resourceCache = BookingResourceCache()
-    private let storageManager: StorageManagerType?
 
     public init(siteID: Int64,
                 bookingsRemote: BookingsRemoteProtocol,
                 ordersRemote: POSOrdersRemoteProtocol,
                 currencyFormatter: CurrencyFormatter,
-                storageManager: StorageManagerType? = nil,
                 siteSettings: [SiteSetting] = []) {
         self.siteID = siteID
         self.bookingsRemote = bookingsRemote
         self.ordersRemote = ordersRemote
         self.mapper = POSBookingMapper(currencyFormatter: currencyFormatter, siteSettings: siteSettings)
-        self.storageBookingMapper = StorageBookingToPOSBookingMapper(currencyFormatter: currencyFormatter, siteSettings: siteSettings)
         self.orderMapper = POSOrderMapper(currencyFormatter: currencyFormatter)
-        self.storageManager = storageManager
     }
 
     public func fetchBookings(siteID: Int64,
@@ -40,34 +34,6 @@ public final class POSBookingService: POSBookingServiceProtocol {
                               pageSize: Int,
                               filters: BookingFilters?,
                               searchQuery: String?) async throws -> PagedItems<POSBooking> {
-        // Page 1 with date filters and no search: try local cache first
-        if pageNumber == 1, searchQuery == nil, let filters, let storageManager {
-            let cachedBookings = fetchCachedBookings(storageManager: storageManager, siteID: siteID, filters: filters)
-            if cachedBookings.isNotEmpty {
-                triggerBackgroundRefresh(siteID: siteID, pageSize: pageSize, filters: filters)
-                return PagedItems(items: cachedBookings, hasMorePages: true, totalItems: nil)
-            }
-        }
-
-        return try await fetchRemoteBookings(
-            siteID: siteID,
-            pageNumber: pageNumber,
-            pageSize: pageSize,
-            filters: filters,
-            searchQuery: searchQuery
-        )
-    }
-
-}
-
-// MARK: - Remote Fetching
-
-private extension POSBookingService {
-    func fetchRemoteBookings(siteID: Int64,
-                             pageNumber: Int,
-                             pageSize: Int,
-                             filters: BookingFilters?,
-                             searchQuery: String?) async throws -> PagedItems<POSBooking> {
         do {
             let bookings = try await bookingsRemote.loadAllBookings(
                 for: siteID,
@@ -101,17 +67,6 @@ private extension POSBookingService {
                     return nil
                 }
                 return mapper.map(booking: booking, orderInfo: orderInfo, resource: resource, order: posOrder)
-            }
-
-            // Persist to CoreData for caching
-            if let storageManager, searchQuery == nil {
-                persistBookings(
-                    storageManager: storageManager,
-                    bookings: bookings,
-                    orders: Array(orders.values),
-                    siteID: siteID,
-                    filters: pageNumber == 1 ? filters : nil
-                )
             }
 
             let hasMorePages = bookings.count == pageSize
@@ -230,117 +185,9 @@ private extension POSBookingService {
     }
 }
 
-// MARK: - Local Storage
-
-private extension POSBookingService {
-    func fetchCachedBookings(storageManager: StorageManagerType, siteID: Int64, filters: BookingFilters) -> [POSBooking] {
-        let predicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: filters)
-        let descriptor = NSSortDescriptor(keyPath: \Storage.Booking.startDate, ascending: true)
-        let resultsController = ResultsController<Storage.Booking>(
-            storageManager: storageManager,
-            matching: predicate,
-            sortedBy: [descriptor]
-        )
-
-        do {
-            try resultsController.performFetch()
-        } catch {
-            return []
-        }
-
-        let readOnlyBookings = resultsController.fetchedObjects
-
-        // Load resources from storage
-        let resourceIDs = Set(readOnlyBookings.compactMap { $0.resourceID != 0 ? $0.resourceID : nil })
-        let storedResources: [Int64: BookingResource] = {
-            guard !resourceIDs.isEmpty else { return [:] }
-            let resourcePredicate = NSPredicate(format: "siteID == %lld AND resourceID IN %@", siteID, Array(resourceIDs))
-            let resourceDescriptor = NSSortDescriptor(keyPath: \Storage.BookingResource.resourceID, ascending: true)
-            let resourceRC = ResultsController<Storage.BookingResource>(
-                storageManager: storageManager,
-                matching: resourcePredicate,
-                sortedBy: [resourceDescriptor]
-            )
-            do {
-                try resourceRC.performFetch()
-            } catch {
-                return [:]
-            }
-            return Dictionary(uniqueKeysWithValues: resourceRC.fetchedObjects.map { ($0.resourceID, $0) })
-        }()
-
-        return readOnlyBookings.compactMap { booking in
-            let resource = storedResources[booking.resourceID]
-            return storageBookingMapper.map(booking: booking, resource: resource)
-        }
-    }
-
-    func triggerBackgroundRefresh(siteID: Int64, pageSize: Int, filters: BookingFilters?) {
-        Task { [weak self] in
-            _ = try? await self?.fetchRemoteBookings(
-                siteID: siteID,
-                pageNumber: 1,
-                pageSize: pageSize,
-                filters: filters,
-                searchQuery: nil
-            )
-        }
-    }
-
-    func persistBookings(storageManager: StorageManagerType,
-                         bookings: [Networking.Booking],
-                         orders: [Order],
-                         siteID: Int64,
-                         filters: BookingFilters?) {
-        storageManager.performAndSave({ storage in
-            // Smart deletion: only delete bookings matching the filter scope on page 1
-            if let filters {
-                let predicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: filters)
-                storage.deleteBookings(matching: predicate)
-            }
-
-            // Upsert bookings
-            let bookingIDs = bookings.map { $0.bookingID }
-            let storedBookings = storage.loadBookings(siteID: siteID, bookingIDs: bookingIDs)
-
-            for readOnlyBooking in bookings {
-                let storageBooking = storedBookings.first { $0.bookingID == readOnlyBooking.bookingID } ??
-                    storage.insertNewObject(ofType: Storage.Booking.self)
-
-                if let associatedOrder = orders.first(where: { $0.orderID == readOnlyBooking.orderID }) {
-                    let readOnlyOrderInfo = BookingOrderInfo(booking: readOnlyBooking, order: associatedOrder)
-
-                    let orderInfo = storageBooking.orderInfo ?? storage.insertNewObject(ofType: Storage.BookingOrderInfo.self)
-
-                    let productInfo = orderInfo.productInfo ?? storage.insertNewObject(ofType: Storage.BookingProductInfo.self)
-                    if let readOnlyProductInfo = readOnlyOrderInfo.productInfo {
-                        productInfo.update(with: readOnlyProductInfo)
-                    }
-                    orderInfo.productInfo = productInfo
-
-                    let customerInfo = orderInfo.customerInfo ?? storage.insertNewObject(ofType: Storage.BookingCustomerInfo.self)
-                    if let readOnlyCustomerInfo = readOnlyOrderInfo.customerInfo {
-                        customerInfo.update(with: readOnlyCustomerInfo)
-                    }
-                    orderInfo.customerInfo = customerInfo
-
-                    let paymentInfo = orderInfo.paymentInfo ?? storage.insertNewObject(ofType: Storage.BookingPaymentInfo.self)
-                    if let readOnlyPaymentInfo = readOnlyOrderInfo.paymentInfo {
-                        paymentInfo.update(with: readOnlyPaymentInfo)
-                    }
-                    orderInfo.paymentInfo = paymentInfo
-
-                    orderInfo.update(with: readOnlyOrderInfo)
-                    storageBooking.orderInfo = orderInfo
-                }
-
-                storageBooking.update(with: readOnlyBooking)
-            }
-        }, completion: nil, on: .main)
-    }
-}
-
 // MARK: - BookingResourceCache
+// Caches booking resources across pages to avoid redundant network requests,
+// since multiple bookings often share the same resource. Cleared on page 1 reload.
 
 private actor BookingResourceCache {
     private var cache: [Int64: BookingResource] = [:]

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingService.swift
@@ -72,7 +72,7 @@ public final class POSBookingService: POSBookingServiceProtocol {
             let hasMorePages = bookings.count == pageSize
 
             return PagedItems(items: posBookings, hasMorePages: hasMorePages, totalItems: nil)
-        } catch AFError.explicitlyCancelled {
+        } catch AFError.explicitlyCancelled, is CancellationError {
             throw POSBookingServiceError.requestCancelled
         } catch is POSBookingServiceError {
             throw POSBookingServiceError.requestCancelled

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/StorageBookingToPOSBookingMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/StorageBookingToPOSBookingMapper.swift
@@ -97,15 +97,15 @@ private extension StorageBookingToPOSBookingMapper {
             currencyFormatter.formatAmount($0.totalTax, with: booking.currency)
         } ?? ""
 
-        let formattedDiscountTotal: String? = orderInfo.discountTotal.flatMap { discount in
-            guard let value = Double(discount), value > 0 else { return nil }
-            return currencyFormatter.formatAmount(discount, with: booking.currency, isNegative: true)
-        }
+        let formattedDiscountTotal: String? = {
+            guard let value = Double(orderInfo.discountTotal), value > 0 else { return nil }
+            return currencyFormatter.formatAmount(orderInfo.discountTotal, with: booking.currency, isNegative: true)
+        }()
 
         return POSOrder(
             id: orderInfo.orderID,
-            number: orderInfo.orderNumber ?? "",
-            dateCreated: orderInfo.dateCreated ?? Date(),
+            number: orderInfo.orderNumber,
+            dateCreated: orderInfo.dateCreated,
             status: .init(rawValue: orderInfo.statusKey),
             formattedTotal: formattedTotal,
             formattedSubtotal: formattedSubtotal,

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/StorageBookingToPOSBookingMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/StorageBookingToPOSBookingMapper.swift
@@ -1,0 +1,120 @@
+import Foundation
+import class WooFoundationCore.CurrencyFormatter
+import Storage
+
+struct StorageBookingToPOSBookingMapper {
+    private let currencyFormatter: CurrencyFormatter
+    private let siteSettings: [SiteSetting]
+
+    init(currencyFormatter: CurrencyFormatter, siteSettings: [SiteSetting] = []) {
+        self.currencyFormatter = currencyFormatter
+        self.siteSettings = siteSettings
+    }
+
+    func map(booking: Yosemite.Booking, resource: BookingResource?) -> POSBooking? {
+        guard let orderInfo = booking.orderInfo else {
+            return nil
+        }
+
+        let posOrder = buildPOSOrder(from: orderInfo, booking: booking)
+
+        let billingAddress = orderInfo.customerInfo?.billingAddress
+
+        let customerName: String? = {
+            guard let billingAddress else { return nil }
+            let fullName = [billingAddress.firstName, billingAddress.lastName]
+                .filter { !$0.isEmpty }
+                .joined(separator: " ")
+            return fullName.isEmpty ? nil : fullName
+        }()
+
+        let serviceName = orderInfo.productInfo?.name ?? ""
+
+        let formattedAmount = currencyFormatter.formatAmount(booking.cost, with: booking.currency) ?? booking.cost
+
+        let orderID: Int64? = booking.orderID != 0 ? booking.orderID : nil
+
+        let formattedBillingAddress: String? = {
+            guard let billingAddress else { return nil }
+            let parts = [billingAddress.address1, billingAddress.city, billingAddress.state, billingAddress.postcode]
+                .filter { !$0.isEmpty }
+            return parts.isEmpty ? nil : parts.joined(separator: ", ")
+        }()
+
+        let location: String? = {
+            let siteAddress = SiteAddress(siteSettings: siteSettings)
+            let parts = [siteAddress.address, siteAddress.city, siteAddress.state, siteAddress.postalCode]
+                .filter { !$0.isEmpty }
+            return parts.isEmpty ? nil : parts.joined(separator: ", ")
+        }()
+
+        let duration = POSBookingMapper.formatDuration(from: booking.startDate, to: booking.endDate)
+
+        let formattedSubtotal = orderInfo.paymentInfo.flatMap {
+            currencyFormatter.formatAmount($0.subtotal, with: booking.currency)
+        }
+        let formattedTax = orderInfo.paymentInfo.flatMap {
+            currencyFormatter.formatAmount($0.totalTax, with: booking.currency)
+        }
+
+        return POSBooking(
+            id: booking.bookingID,
+            customerName: customerName,
+            serviceName: serviceName,
+            startDate: booking.startDate,
+            endDate: booking.endDate,
+            formattedAmount: formattedAmount,
+            status: booking.bookingStatus,
+            attendanceStatus: booking.attendanceStatus,
+            orderID: orderID,
+            resourceName: resource?.name,
+            resourceImageURL: resource?.imageURL,
+            customerEmail: billingAddress?.email.flatMap { $0.isEmpty ? nil : $0 },
+            customerPhone: billingAddress?.phone.flatMap { $0.isEmpty ? nil : $0 },
+            billingAddress: formattedBillingAddress,
+            customerNote: orderInfo.customerInfo?.note.flatMap { $0.isEmpty ? nil : $0 },
+            bookingNote: booking.note.isEmpty ? nil : booking.note,
+            location: location,
+            duration: duration,
+            formattedSubtotal: formattedSubtotal,
+            formattedTax: formattedTax,
+            order: posOrder
+        )
+    }
+}
+
+private extension StorageBookingToPOSBookingMapper {
+    func buildPOSOrder(from orderInfo: BookingOrderInfo, booking: Booking) -> POSOrder {
+        let formattedTotal = orderInfo.paymentInfo.flatMap {
+            currencyFormatter.formatAmount($0.total, with: booking.currency)
+        } ?? ""
+
+        let formattedSubtotal = orderInfo.paymentInfo.flatMap {
+            currencyFormatter.formatAmount($0.subtotal, with: booking.currency)
+        } ?? ""
+
+        let formattedTotalTax = orderInfo.paymentInfo.flatMap {
+            currencyFormatter.formatAmount($0.totalTax, with: booking.currency)
+        } ?? ""
+
+        let formattedDiscountTotal: String? = orderInfo.discountTotal.flatMap { discount in
+            guard let value = Double(discount), value > 0 else { return nil }
+            return currencyFormatter.formatAmount(discount, with: booking.currency, isNegative: true)
+        }
+
+        return POSOrder(
+            id: orderInfo.orderID,
+            number: orderInfo.orderNumber ?? "",
+            dateCreated: orderInfo.dateCreated ?? Date(),
+            status: .init(rawValue: orderInfo.statusKey),
+            formattedTotal: formattedTotal,
+            formattedSubtotal: formattedSubtotal,
+            paymentMethodID: orderInfo.paymentInfo?.paymentMethodID ?? "",
+            paymentMethodTitle: orderInfo.paymentInfo?.paymentMethodTitle ?? "",
+            formattedDiscountTotal: formattedDiscountTotal,
+            formattedTotalTax: formattedTotalTax,
+            formattedPaymentTotal: formattedTotal,
+            datePaid: orderInfo.datePaid
+        )
+    }
+}

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -557,7 +557,7 @@ private extension BookingStore {
                 }
                 orderInfo.paymentInfo = paymentInfo
 
-                orderInfo.statusKey = associatedOrder.status.rawValue
+                orderInfo.update(with: readOnlyOrderInfo)
                 storageBooking.orderInfo = orderInfo
             }
 

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -126,7 +126,8 @@ private extension BookingStore {
                     readOnlyBookings: bookings,
                     readOnlyOrders: orders,
                     siteID: siteID,
-                    shouldDeleteExistingBookings: shouldClearCache
+                    shouldDeleteExistingBookings: shouldClearCache,
+                    deleteFilters: shouldClearCache ? nil : filters
                 )
                 let hasNextPage = bookings.count == pageSize
                 onCompletion(.success(hasNextPage))
@@ -478,10 +479,12 @@ private extension BookingStore {
 
     /// Updates (OR Inserts) the specified ReadOnly Booking Entities *in a background thread* async.
     /// Also deletes existing bookings if requested.
+    /// When `deleteFilters` is provided, only bookings matching that filter scope are deleted (smart invalidation).
     func upsertStoredBookingsInBackground(readOnlyBookings: [Yosemite.Booking],
                                           readOnlyOrders: [Yosemite.Order],
                                           siteID: Int64,
-                                          shouldDeleteExistingBookings: Bool = false) async {
+                                          shouldDeleteExistingBookings: Bool = false,
+                                          deleteFilters: BookingFilters? = nil) async {
         await withCheckedContinuation { [weak self] continuation in
             guard let self else {
                 return continuation.resume()
@@ -490,7 +493,8 @@ private extension BookingStore {
             upsertStoredBookingsInBackground(readOnlyBookings: readOnlyBookings,
                                              readOnlyOrders: readOnlyOrders,
                                              siteID: siteID,
-                                             shouldDeleteExistingBookings: shouldDeleteExistingBookings) {
+                                             shouldDeleteExistingBookings: shouldDeleteExistingBookings,
+                                             deleteFilters: deleteFilters) {
                 continuation.resume()
             }
         }
@@ -498,12 +502,14 @@ private extension BookingStore {
 
     /// Updates (OR Inserts) the specified ReadOnly Booking Entities *in a background thread*.
     /// Also deletes existing bookings if requested.
+    /// When `deleteFilters` is provided, only bookings matching that filter scope are deleted (smart invalidation).
     /// `onCompletion` will be called on the main thread!
     ///
     func upsertStoredBookingsInBackground(readOnlyBookings: [Yosemite.Booking],
                                           readOnlyOrders: [Yosemite.Order],
                                           siteID: Int64,
                                           shouldDeleteExistingBookings: Bool = false,
+                                          deleteFilters: BookingFilters? = nil,
                                           onCompletion: @escaping () -> Void) {
         storageManager.performAndSave({ [weak self] storage in
             guard let self else {
@@ -511,6 +517,9 @@ private extension BookingStore {
             }
             if shouldDeleteExistingBookings {
                 storage.deleteBookings(siteID: siteID)
+            } else if let deleteFilters {
+                let predicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: deleteFilters)
+                storage.deleteBookings(matching: predicate)
             }
             upsertStoredBookings(readOnlyBookings: readOnlyBookings, readOnlyOrders: readOnlyOrders, in: storage)
         }, completion: onCompletion, on: .main)

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -116,9 +116,10 @@ private extension BookingStore {
                     siteID: siteID,
                     pageNumber: pageNumber,
                     pageSize: pageSize,
-                    filters: shouldClearCache ? nil : filters,
+                    filters: filters,
                     searchQuery: nil,
-                    order: order
+                    order: order,
+                    cacheClearStrategy: shouldClearCache ? .all : .none
                 )
                 onCompletion(.success(hasNextPage))
             } catch {

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -7,6 +7,7 @@ import Storage
 public class BookingStore: Store {
     private let remote: BookingsRemoteProtocol
     private let ordersRemote: OrdersRemoteProtocol
+    private let methods: BookingStoreMethods
 
     public override convenience init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
         let remote = BookingsRemote(network: network)
@@ -21,6 +22,7 @@ public class BookingStore: Store {
                 ordersRemote: OrdersRemoteProtocol) {
         self.remote = remote
         self.ordersRemote = ordersRemote
+        self.methods = BookingStoreMethods(storageManager: storageManager, bookingsRemote: remote, ordersRemote: ordersRemote)
         super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
     }
 
@@ -110,26 +112,13 @@ private extension BookingStore {
                              onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         Task { @MainActor in
             do {
-                let bookings = try await remote.loadAllBookings(for: siteID,
-                                                                pageNumber: pageNumber,
-                                                                pageSize: pageSize,
-                                                                filters: filters,
-                                                                searchQuery: nil,
-                                                                order: order)
-
-                let orders = try await ordersRemote.loadOrders(
-                    for: siteID,
-                    orderIDs: bookings.map { $0.orderID }
-                )
-
-                await upsertStoredBookingsInBackground(
-                    readOnlyBookings: bookings,
-                    readOnlyOrders: orders,
+                let hasNextPage = try await methods.synchronizeBookings(
                     siteID: siteID,
-                    shouldDeleteExistingBookings: shouldClearCache,
-                    deleteFilters: shouldClearCache ? nil : filters
+                    pageNumber: pageNumber,
+                    pageSize: pageSize,
+                    filters: shouldClearCache ? nil : filters,
+                    searchQuery: nil
                 )
-                let hasNextPage = bookings.count == pageSize
                 onCompletion(.success(hasNextPage))
             } catch {
                 onCompletion(.failure(error))

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -117,7 +117,8 @@ private extension BookingStore {
                     pageNumber: pageNumber,
                     pageSize: pageSize,
                     filters: shouldClearCache ? nil : filters,
-                    searchQuery: nil
+                    searchQuery: nil,
+                    order: order
                 )
                 onCompletion(.success(hasNextPage))
             } catch {

--- a/Modules/Sources/Yosemite/Stores/Helpers/BookingStoreMethods.swift
+++ b/Modules/Sources/Yosemite/Stores/Helpers/BookingStoreMethods.swift
@@ -7,9 +7,6 @@ import Storage
 ///
 internal protocol BookingStoreMethodsProtocol {
     /// Syncs bookings from remote and persists to local storage.
-    /// On page 1 with filters, performs smart deletion (only deletes bookings matching the filter scope).
-    /// On page 1 without filters, deletes all bookings for the site.
-    /// On subsequent pages, appends (upsert only, no deletion).
     ///
     /// - Returns: `true` if there are more pages to fetch.
     func synchronizeBookings(siteID: Int64,
@@ -17,10 +14,18 @@ internal protocol BookingStoreMethodsProtocol {
                              pageSize: Int,
                              filters: BookingFilters?,
                              searchQuery: String?,
-                             order: BookingsRemote.Order) async throws -> Bool
+                             order: BookingsRemote.Order,
+                             cacheClearStrategy: BookingStoreMethods.CacheClearStrategy) async throws -> Bool
 }
 
 internal class BookingStoreMethods: BookingStoreMethodsProtocol {
+
+    enum CacheClearStrategy {
+        case none
+        case all
+        case filtersOnly(BookingFilters)
+    }
+
     private let bookingsRemote: BookingsRemoteProtocol
     private let ordersRemote: OrdersRemoteProtocol
     private let storageManager: StorageManagerType
@@ -38,7 +43,8 @@ internal class BookingStoreMethods: BookingStoreMethodsProtocol {
                              pageSize: Int,
                              filters: BookingFilters?,
                              searchQuery: String?,
-                             order: BookingsRemote.Order = .ascending) async throws -> Bool {
+                             order: BookingsRemote.Order = .ascending,
+                             cacheClearStrategy: CacheClearStrategy = .none) async throws -> Bool {
         let bookings = try await bookingsRemote.loadAllBookings(
             for: siteID,
             pageNumber: pageNumber,
@@ -53,13 +59,11 @@ internal class BookingStoreMethods: BookingStoreMethodsProtocol {
             orderIDs: bookings.map { $0.orderID }
         )
 
-        let isFirstPage = pageNumber == 1
         await upsertStoredBookingsInBackground(
             readOnlyBookings: bookings,
             readOnlyOrders: orders,
             siteID: siteID,
-            shouldDeleteAllBookings: isFirstPage && filters == nil,
-            deleteFilters: isFirstPage ? filters : nil
+            cacheClearStrategy: cacheClearStrategy
         )
 
         return bookings.count == pageSize
@@ -72,14 +76,16 @@ private extension BookingStoreMethods {
     func upsertStoredBookingsInBackground(readOnlyBookings: [Networking.Booking],
                                           readOnlyOrders: [Networking.Order],
                                           siteID: Int64,
-                                          shouldDeleteAllBookings: Bool = false,
-                                          deleteFilters: BookingFilters? = nil) async {
+                                          cacheClearStrategy: CacheClearStrategy = .none) async {
         await withCheckedContinuation { continuation in
             storageManager.performAndSave({ storage in
-                if shouldDeleteAllBookings {
+                switch cacheClearStrategy {
+                case .none:
+                    break
+                case .all:
                     storage.deleteBookings(siteID: siteID)
-                } else if let deleteFilters {
-                    let predicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: deleteFilters)
+                case .filtersOnly(let filters):
+                    let predicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: filters)
                     storage.deleteBookings(matching: predicate)
                 }
                 Self.upsertStoredBookings(readOnlyBookings: readOnlyBookings, readOnlyOrders: readOnlyOrders, in: storage)

--- a/Modules/Sources/Yosemite/Stores/Helpers/BookingStoreMethods.swift
+++ b/Modules/Sources/Yosemite/Stores/Helpers/BookingStoreMethods.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Networking
+import Storage
+
+/// BookingStoreMethods extracts persistence functionality from BookingStore for reuse within Yosemite.
+/// Intentionally internal - not exposed outside the module.
+///
+internal protocol BookingStoreMethodsProtocol {
+    /// Syncs bookings from remote and persists to local storage.
+    /// On page 1 with filters, performs smart deletion (only deletes bookings matching the filter scope).
+    /// On page 1 without filters, deletes all bookings for the site.
+    /// On subsequent pages, appends (upsert only, no deletion).
+    ///
+    /// - Returns: `true` if there are more pages to fetch.
+    func synchronizeBookings(siteID: Int64,
+                             pageNumber: Int,
+                             pageSize: Int,
+                             filters: BookingFilters?,
+                             searchQuery: String?) async throws -> Bool
+}
+
+internal class BookingStoreMethods: BookingStoreMethodsProtocol {
+    private let bookingsRemote: BookingsRemoteProtocol
+    private let ordersRemote: OrdersRemoteProtocol
+    private let storageManager: StorageManagerType
+
+    init(storageManager: StorageManagerType,
+         bookingsRemote: BookingsRemoteProtocol,
+         ordersRemote: OrdersRemoteProtocol) {
+        self.storageManager = storageManager
+        self.bookingsRemote = bookingsRemote
+        self.ordersRemote = ordersRemote
+    }
+
+    func synchronizeBookings(siteID: Int64,
+                             pageNumber: Int,
+                             pageSize: Int,
+                             filters: BookingFilters?,
+                             searchQuery: String?) async throws -> Bool {
+        let bookings = try await bookingsRemote.loadAllBookings(
+            for: siteID,
+            pageNumber: pageNumber,
+            pageSize: pageSize,
+            filters: filters,
+            searchQuery: searchQuery,
+            order: .ascending
+        )
+
+        let orders = try await ordersRemote.loadOrders(
+            for: siteID,
+            orderIDs: bookings.map { $0.orderID }
+        )
+
+        let isFirstPage = pageNumber == 1
+        await upsertStoredBookingsInBackground(
+            readOnlyBookings: bookings,
+            readOnlyOrders: orders,
+            siteID: siteID,
+            shouldDeleteAllBookings: isFirstPage && filters == nil,
+            deleteFilters: isFirstPage ? filters : nil
+        )
+
+        return bookings.count == pageSize
+    }
+}
+
+// MARK: - Persistence
+
+private extension BookingStoreMethods {
+    func upsertStoredBookingsInBackground(readOnlyBookings: [Networking.Booking],
+                                          readOnlyOrders: [Networking.Order],
+                                          siteID: Int64,
+                                          shouldDeleteAllBookings: Bool = false,
+                                          deleteFilters: BookingFilters? = nil) async {
+        await withCheckedContinuation { continuation in
+            storageManager.performAndSave({ storage in
+                if shouldDeleteAllBookings {
+                    storage.deleteBookings(siteID: siteID)
+                } else if let deleteFilters {
+                    let predicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: deleteFilters)
+                    storage.deleteBookings(matching: predicate)
+                }
+                Self.upsertStoredBookings(readOnlyBookings: readOnlyBookings, readOnlyOrders: readOnlyOrders, in: storage)
+            }, completion: {
+                continuation.resume()
+            }, on: .main)
+        }
+    }
+
+    static func upsertStoredBookings(readOnlyBookings: [Networking.Booking],
+                                     readOnlyOrders: [Networking.Order],
+                                     in storage: StorageType) {
+        let bookingIDs = readOnlyBookings.map { $0.bookingID }
+        let siteID = readOnlyBookings.first?.siteID ?? 0
+        let storedBookings = storage.loadBookings(siteID: siteID, bookingIDs: bookingIDs)
+
+        for readOnlyBooking in readOnlyBookings {
+            let storageBooking = storedBookings.first { $0.bookingID == readOnlyBooking.bookingID } ??
+                storage.insertNewObject(ofType: Storage.Booking.self)
+
+            if let associatedOrder = readOnlyOrders.first(where: { $0.orderID == readOnlyBooking.orderID }) {
+                let readOnlyOrderInfo = Networking.BookingOrderInfo(booking: readOnlyBooking, order: associatedOrder)
+
+                let orderInfo = storageBooking.orderInfo ?? storage.insertNewObject(ofType: Storage.BookingOrderInfo.self)
+
+                let productInfo = orderInfo.productInfo ?? storage.insertNewObject(ofType: Storage.BookingProductInfo.self)
+                if let readOnlyProductInfo = readOnlyOrderInfo.productInfo {
+                    productInfo.update(with: readOnlyProductInfo)
+                }
+                orderInfo.productInfo = productInfo
+
+                let customerInfo = orderInfo.customerInfo ?? storage.insertNewObject(ofType: Storage.BookingCustomerInfo.self)
+                if let readOnlyCustomerInfo = readOnlyOrderInfo.customerInfo {
+                    customerInfo.update(with: readOnlyCustomerInfo)
+                }
+                orderInfo.customerInfo = customerInfo
+
+                let paymentInfo = orderInfo.paymentInfo ?? storage.insertNewObject(ofType: Storage.BookingPaymentInfo.self)
+                if let readOnlyPaymentInfo = readOnlyOrderInfo.paymentInfo {
+                    paymentInfo.update(with: readOnlyPaymentInfo)
+                }
+                orderInfo.paymentInfo = paymentInfo
+
+                orderInfo.update(with: readOnlyOrderInfo)
+                storageBooking.orderInfo = orderInfo
+            }
+
+            storageBooking.update(with: readOnlyBooking)
+        }
+    }
+}

--- a/Modules/Sources/Yosemite/Stores/Helpers/BookingStoreMethods.swift
+++ b/Modules/Sources/Yosemite/Stores/Helpers/BookingStoreMethods.swift
@@ -16,7 +16,8 @@ internal protocol BookingStoreMethodsProtocol {
                              pageNumber: Int,
                              pageSize: Int,
                              filters: BookingFilters?,
-                             searchQuery: String?) async throws -> Bool
+                             searchQuery: String?,
+                             order: BookingsRemote.Order) async throws -> Bool
 }
 
 internal class BookingStoreMethods: BookingStoreMethodsProtocol {
@@ -36,14 +37,15 @@ internal class BookingStoreMethods: BookingStoreMethodsProtocol {
                              pageNumber: Int,
                              pageSize: Int,
                              filters: BookingFilters?,
-                             searchQuery: String?) async throws -> Bool {
+                             searchQuery: String?,
+                             order: BookingsRemote.Order = .ascending) async throws -> Bool {
         let bookings = try await bookingsRemote.loadAllBookings(
             for: siteID,
             pageNumber: pageNumber,
             pageSize: pageSize,
             filters: filters,
             searchQuery: searchQuery,
-            order: .ascending
+            order: order
         )
 
         let orders = try await ordersRemote.loadOrders(

--- a/Modules/Sources/Yosemite/Stores/Helpers/BookingStoreMethods.swift
+++ b/Modules/Sources/Yosemite/Stores/Helpers/BookingStoreMethods.swift
@@ -18,7 +18,7 @@ internal protocol BookingStoreMethodsProtocol {
                              cacheClearStrategy: BookingStoreMethods.CacheClearStrategy) async throws -> Bool
 }
 
-internal class BookingStoreMethods: BookingStoreMethodsProtocol {
+internal final class BookingStoreMethods: BookingStoreMethodsProtocol {
 
     enum CacheClearStrategy {
         case none

--- a/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
@@ -71,6 +71,7 @@ struct BookingsRemoteTests {
         #expect((parameters["start_date_after"] as? String) == "2023-12-31T23:59:59Z")
         #expect((parameters["search"] as? String) == searchQuery)
         #expect((parameters["order"] as? String) == "asc")
+        #expect((parameters["orderby"] as? String) == "start_date")
     }
 
     @Test func test_loadAllBookings_omits_nil_parameters() async throws {

--- a/Modules/Tests/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -180,7 +180,7 @@ final class OrdersRemoteTests: XCTestCase {
         XCTAssertEqual(Set(includedIDs ?? []), Set(["1", "2", "3"])) // check for unique ids
 
         XCTAssertNotNil(parameters["_fields"])
-        XCTAssertNil(parameters["per_page"]) // verify per_page is not sent
+        XCTAssertEqual(parameters["per_page"] as? String, "4") // per_page matches order ID count
     }
 
     func test_loadOrders_by_ids_with_empty_ids_returns_empty_array_and_makes_no_request() async throws {

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
@@ -126,7 +126,7 @@ final class POSBookingListControllerTests {
         let searchBookings = [makeBooking(id: 10)]
         let searchStrategy = MockPOSBookingListFetchStrategy()
         searchStrategy.fetchBookingsResult = .success(PagedItems(items: searchBookings, hasMorePages: false, totalItems: nil))
-        searchStrategy.supportsCaching = false
+
         searchStrategy.id = "SearchStrategy"
         mockFactory.searchStrategyResult = searchStrategy
 
@@ -139,16 +139,17 @@ final class POSBookingListControllerTests {
 
     // MARK: - clearSearchBookings
 
-    @Test func test_clearSearchBookings_restores_cached_bookings() async {
-        // Given - load initial bookings (cached)
+    @Test func test_clearSearchBookings_restores_local_bookings() async {
+        // Given - load initial bookings
         let initialBookings = [makeBooking(id: 1), makeBooking(id: 2)]
         mockStrategy.fetchBookingsResult = .success(PagedItems(items: initialBookings, hasMorePages: false, totalItems: nil))
+        mockStrategy.localBookings = initialBookings
         await sut.loadBookings()
 
         // Switch to search
         let searchStrategy = MockPOSBookingListFetchStrategy()
         searchStrategy.fetchBookingsResult = .success(PagedItems(items: [makeBooking(id: 10)], hasMorePages: false, totalItems: nil))
-        searchStrategy.supportsCaching = false
+
         searchStrategy.id = "SearchStrategy"
         mockFactory.searchStrategyResult = searchStrategy
         await sut.searchBookings(searchTerm: "test")
@@ -156,7 +157,7 @@ final class POSBookingListControllerTests {
         // When
         sut.clearSearchBookings()
 
-        // Then - should restore cached bookings
+        // Then - should restore local bookings from CoreData
         #expect(sut.bookingsViewState == .loaded(initialBookings, hasMoreItems: true))
     }
 
@@ -440,7 +441,7 @@ final class POSBookingListControllerTests {
         // Given - start a search
         let searchStrategy = MockPOSBookingListFetchStrategy()
         searchStrategy.fetchBookingsResult = .success(PagedItems(items: [makeBooking(id: 10)], hasMorePages: false, totalItems: nil))
-        searchStrategy.supportsCaching = false
+
         searchStrategy.id = "SearchStrategy"
         mockFactory.searchStrategyResult = searchStrategy
         await sut.searchBookings(searchTerm: "test")

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
@@ -461,7 +461,6 @@ final class POSBookingListControllerTests {
         // Given - start a search
         let searchStrategy = MockPOSBookingListFetchStrategy()
         searchStrategy.fetchBookingsResult = .success(PagedItems(items: [makeBooking(id: 10)], hasMorePages: false, totalItems: nil))
-        searchStrategy.supportsCaching = false
         searchStrategy.id = "SearchStrategy"
         mockFactory.searchStrategyResult = searchStrategy
         await sut.searchBookings(searchTerm: "test")

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
@@ -472,8 +472,6 @@ final class POSBookingListControllerTests {
         // 2 search strategy calls: initial searchBookings + loadBookings reload
         #expect(mockFactory.searchStrategyCallCount == 2)
         #expect(mockFactory.lastSearchTerm == "test")
-        // 1 default strategy call from init only
-        #expect(mockFactory.defaultStrategyCallCount == 1)
     }
 
     // MARK: - Prefetch

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
@@ -478,6 +478,57 @@ final class POSBookingListControllerTests {
         #expect(mockFactory.defaultStrategyCallCount == defaultCallCountBeforeReload)
     }
 
+    // MARK: - Prefetch
+
+    @Test func test_syncBookings_syncs_today_and_adjacent_dates() async throws {
+        // Given
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: [makeBooking(id: 1)], hasMorePages: false, totalItems: nil))
+
+        _ = sut.selectedDate
+        let callCountBeforeSync = mockFactory.defaultStrategyCallCount
+
+        // When
+        sut.syncBookings()
+
+        // Wait for the sync task to complete
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        // Then - 3 calls: today + yesterday + tomorrow
+        let newCalls = mockFactory.defaultStrategyCallCount - callCountBeforeSync
+        #expect(newCalls == 3)
+    }
+
+    // MARK: - isPaginating
+
+    @Test func test_isPaginating_is_false_initially() {
+        #expect(sut.isPaginating == false)
+    }
+
+    @Test func test_isPaginating_is_false_after_loadBookings() async {
+        // Given
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: [makeBooking(id: 1)], hasMorePages: false, totalItems: nil))
+
+        // When
+        await sut.loadBookings()
+
+        // Then
+        #expect(sut.isPaginating == false)
+    }
+
+    @Test func test_isPaginating_is_false_after_selectDate() async {
+        // Given
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: [makeBooking(id: 1)], hasMorePages: false, totalItems: nil))
+        await sut.loadBookings()
+
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: Date())!
+
+        // When
+        await sut.selectDate(tomorrow)
+
+        // Then
+        #expect(sut.isPaginating == false)
+    }
+
     @Test func test_selectDate_clears_cache_and_shows_loading() async {
         // Given - load bookings for initial date
         let bookings = [makeBooking(id: 1)]

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
@@ -465,36 +465,35 @@ final class POSBookingListControllerTests {
         mockFactory.searchStrategyResult = searchStrategy
         await sut.searchBookings(searchTerm: "test")
 
-        let searchCallCountBeforeReload = mockFactory.searchStrategyCallCount
-        let defaultCallCountBeforeReload = mockFactory.defaultStrategyCallCount
-
         // When - loadBookings is called (e.g. from a retry path)
         await sut.loadBookings()
 
         // Then - should use search strategy, not default
-        #expect(mockFactory.searchStrategyCallCount == searchCallCountBeforeReload + 1)
+        // 2 search strategy calls: initial searchBookings + loadBookings reload
+        #expect(mockFactory.searchStrategyCallCount == 2)
         #expect(mockFactory.lastSearchTerm == "test")
-        #expect(mockFactory.defaultStrategyCallCount == defaultCallCountBeforeReload)
+        // 1 default strategy call from init only
+        #expect(mockFactory.defaultStrategyCallCount == 1)
     }
 
     // MARK: - Prefetch
 
-    @Test func test_syncBookings_syncs_today_and_adjacent_dates() async throws {
+    @Test func test_syncBookings_syncs_today_and_adjacent_dates() async {
         // Given
         mockStrategy.fetchBookingsResult = .success(PagedItems(items: [makeBooking(id: 1)], hasMorePages: false, totalItems: nil))
 
-        _ = sut.selectedDate
-        let callCountBeforeSync = mockFactory.defaultStrategyCallCount
+        // When - 3 calls expected: today + yesterday + tomorrow (+ 1 from init = 4 total)
+        await withCheckedContinuation { continuation in
+            mockFactory.onDefaultStrategyCalled = {
+                if self.mockFactory.defaultStrategyCallCount == 4 {
+                    continuation.resume()
+                }
+            }
+            sut.syncBookings()
+        }
 
-        // When
-        sut.syncBookings()
-
-        // Wait for the sync task to complete
-        try await Task.sleep(nanoseconds: 200_000_000)
-
-        // Then - 3 calls: today + yesterday + tomorrow
-        let newCalls = mockFactory.defaultStrategyCallCount - callCountBeforeSync
-        #expect(newCalls == 3)
+        // Then
+        #expect(mockFactory.defaultStrategyCallCount == 4)
     }
 
     // MARK: - isPaginating

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
@@ -499,7 +499,7 @@ final class POSBookingListControllerTests {
     // MARK: - isPaginating
 
     @Test func test_isPaginating_is_false_initially() {
-        #expect(sut.isPaginating == false)
+        #expect(sut.bookingsViewState.isPaginating == false)
     }
 
     @Test func test_isPaginating_is_false_after_loadBookings() async {
@@ -510,7 +510,7 @@ final class POSBookingListControllerTests {
         await sut.loadBookings()
 
         // Then
-        #expect(sut.isPaginating == false)
+        #expect(sut.bookingsViewState.isPaginating == false)
     }
 
     @Test func test_isPaginating_is_false_after_selectDate() async {
@@ -524,7 +524,7 @@ final class POSBookingListControllerTests {
         await sut.selectDate(tomorrow)
 
         // Then
-        #expect(sut.isPaginating == false)
+        #expect(sut.bookingsViewState.isPaginating == false)
     }
 
     @Test func test_selectDate_clears_cache_and_shows_loading() async {

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
@@ -83,11 +83,15 @@ final class MockPOSBookingService: POSBookingServiceProtocol {
 
 final class MockPOSBookingListFetchStrategy: POSBookingListFetchStrategy {
     var fetchBookingsResult: Result<PagedItems<POSBooking>, Error> = .success(PagedItems(items: [], hasMorePages: false, totalItems: nil))
-    var supportsCaching: Bool = true
+    var localBookings: [POSBooking] = []
     var showsLoadingWithItems: Bool = true
     var id: String = "MockPOSBookingListFetchStrategy"
 
     func fetchBookings(pageNumber: Int) async throws -> PagedItems<POSBooking> {
         try fetchBookingsResult.get()
+    }
+
+    func fetchLocalBookings() -> [POSBooking] {
+        localBookings
     }
 }

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
@@ -18,10 +18,12 @@ final class MockPOSBookingListFetchStrategyFactory: POSBookingListFetchStrategyF
     var searchStrategyCallCount = 0
     var defaultStrategyCallCount = 0
     var lastDefaultStrategyFilters: BookingFilters?
+    var onDefaultStrategyCalled: (() -> Void)?
 
     func defaultStrategy(filters: BookingFilters? = nil) -> POSBookingListFetchStrategy {
         defaultStrategyCallCount += 1
         lastDefaultStrategyFilters = filters
+        onDefaultStrategyCalled?()
         return defaultStrategyResult
     }
 

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
@@ -17,9 +17,11 @@ final class MockPOSBookingListFetchStrategyFactory: POSBookingListFetchStrategyF
     var lastSearchTerm: String?
     var searchStrategyCallCount = 0
     var defaultStrategyCallCount = 0
+    var lastDefaultStrategyFilters: BookingFilters?
 
     func defaultStrategy(filters: BookingFilters? = nil) -> POSBookingListFetchStrategy {
         defaultStrategyCallCount += 1
+        lastDefaultStrategyFilters = filters
         return defaultStrategyResult
     }
 

--- a/Modules/Tests/StorageTests/CoreData/MigrationTests.swift
+++ b/Modules/Tests/StorageTests/CoreData/MigrationTests.swift
@@ -2363,6 +2363,40 @@ final class MigrationTests: XCTestCase {
 
         XCTAssertEqual(migratedCustomerInfo.value(forKey: "note") as? String, updatedNote)
     }
+
+    func test_migrating_from_131_to_132_adds_new_attributes_to_bookingOrderInfo() throws {
+        // Given
+        let sourceContainer = try startPersistentContainer("Model 131")
+        let sourceContext = sourceContainer.viewContext
+
+        let orderInfo = insertBookingOrderInfo(to: sourceContext)
+        try sourceContext.save()
+
+        XCTAssertNil(orderInfo.entity.attributesByName["orderID"], "Precondition. Attribute does not exist.")
+        XCTAssertNil(orderInfo.entity.attributesByName["orderNumber"], "Precondition. Attribute does not exist.")
+        XCTAssertNil(orderInfo.entity.attributesByName["dateCreated"], "Precondition. Attribute does not exist.")
+        XCTAssertNil(orderInfo.entity.attributesByName["datePaid"], "Precondition. Attribute does not exist.")
+        XCTAssertNil(orderInfo.entity.attributesByName["discountTotal"], "Precondition. Attribute does not exist.")
+
+        // When
+        let targetContainer = try migrate(sourceContainer, to: "Model 132")
+
+        // Then
+        let targetContext = targetContainer.viewContext
+        let migratedOrderInfo = try XCTUnwrap(targetContext.first(entityName: "BookingOrderInfo"))
+
+        XCTAssertNotNil(migratedOrderInfo.entity.attributesByName["orderID"])
+        XCTAssertNotNil(migratedOrderInfo.entity.attributesByName["orderNumber"])
+        XCTAssertNotNil(migratedOrderInfo.entity.attributesByName["dateCreated"])
+        XCTAssertNotNil(migratedOrderInfo.entity.attributesByName["datePaid"])
+        XCTAssertNotNil(migratedOrderInfo.entity.attributesByName["discountTotal"])
+
+        XCTAssertEqual(migratedOrderInfo.value(forKey: "orderID") as? Int64, 0)
+        XCTAssertNil(migratedOrderInfo.value(forKey: "orderNumber") as? String)
+        XCTAssertNil(migratedOrderInfo.value(forKey: "dateCreated") as? Date)
+        XCTAssertNil(migratedOrderInfo.value(forKey: "datePaid") as? Date)
+        XCTAssertNil(migratedOrderInfo.value(forKey: "discountTotal") as? String)
+    }
 }
 
 // MARK: - Persistent Store Setup and Migrations

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -87,6 +87,18 @@ final class POSTabCoordinator {
                                         storage: storageManager)
     }()
 
+    private lazy var posBookingListFetchStrategyFactory: POSBookingListFetchStrategyFactory = {
+        POSBookingListFetchStrategyFactory(
+            siteID: siteID,
+            credentials: credentials,
+            selectedSite: defaultSitePublisher,
+            appPasswordSupportState: isAppPasswordSupported,
+            storageManager: storageManager,
+            currencyFormatter: CurrencyFormatter(currencySettings: currencySettings),
+            siteSettings: ServiceLocator.selectedSiteSettings.siteSettings
+        )
+    }()
+
     /// Creates the appropriate barcode scan service based on local catalog availability
     private func createBarcodeScanService(isLocalCatalogEligible: Bool,
                                           grdbManager: GRDBManagerProtocol?) -> any PointOfSaleBarcodeScanServiceProtocol {
@@ -269,18 +281,6 @@ private extension POSTabCoordinator {
                 let isBookingsEligible = storesManager.sessionManager.defaultSite
                     .map { CIABEligibilityChecker().isSiteCIAB($0) } ?? false
 
-                let bookingListFetchStrategyFactory: POSBookingListFetchStrategyFactory? =
-                    ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleBookings)
-                    ? POSBookingListFetchStrategyFactory(
-                        siteID: siteID,
-                        credentials: credentials,
-                        selectedSite: defaultSitePublisher,
-                        appPasswordSupportState: isAppPasswordSupported,
-                        storageManager: storageManager,
-                        currencyFormatter: CurrencyFormatter(currencySettings: currencySettings),
-                        siteSettings: ServiceLocator.selectedSiteSettings.siteSettings
-                    ) : nil
-
                 let posView = PointOfSaleEntryPointView(
                     siteID: siteID,
                     itemFetchStrategyFactory: createItemFetchStrategyFactory(isLocalCatalogEnabled: isLocalCatalogEligible),
@@ -295,7 +295,7 @@ private extension POSTabCoordinator {
                         currencyFormatter: CurrencyFormatter(currencySettings: currencySettings),
                         analytics: POSOrderListFetchAnalytics(analytics: serviceAdaptor.analytics)
                     ),
-                    bookingListFetchStrategyFactory: bookingListFetchStrategyFactory,
+                    bookingListFetchStrategyFactory: posBookingListFetchStrategyFactory,
                     isBookingsEligible: isBookingsEligible,
                     orderService: orderService,
                     refundsService: refundsService,

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -276,6 +276,7 @@ private extension POSTabCoordinator {
                         credentials: credentials,
                         selectedSite: defaultSitePublisher,
                         appPasswordSupportState: isAppPasswordSupported,
+                        storageManager: storageManager,
                         currencyFormatter: CurrencyFormatter(currencySettings: currencySettings),
                         siteSettings: ServiceLocator.selectedSiteSettings.siteSettings
                     ) : nil

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -277,7 +277,6 @@ private extension POSTabCoordinator {
                         selectedSite: defaultSitePublisher,
                         appPasswordSupportState: isAppPasswordSupported,
                         currencyFormatter: CurrencyFormatter(currencySettings: currencySettings),
-                        storageManager: ServiceLocator.storageManager,
                         siteSettings: ServiceLocator.selectedSiteSettings.siteSettings
                     ) : nil
 

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -277,6 +277,7 @@ private extension POSTabCoordinator {
                         selectedSite: defaultSitePublisher,
                         appPasswordSupportState: isAppPasswordSupported,
                         currencyFormatter: CurrencyFormatter(currencySettings: currencySettings),
+                        storageManager: ServiceLocator.storageManager,
                         siteSettings: ServiceLocator.selectedSiteSettings.siteSettings
                     ) : nil
 


### PR DESCRIPTION
WOOMOB-2267

## Description

Adds local-first data loading for POS bookings via CoreData caching and date-based filtering. Switching dates now shows cached data instantly while syncing fresh data in the background.

I ended up reusing what is already built for the store management part of the app. Sorry about the lots of changes, there's a lot of plumbing code to hook in already existing Core Data code.

### Key changes

- **CoreData caching** - Bookings are stored locally with order/customer/product info. On date switch, cached data is shown immediately with a header spinner while remote sync happens.
- **Adjacent date prefetch** - After loading today's bookings, yesterday and tomorrow are prefetched in the background so date navigation is instant.
- **Task cancellation** - Switching dates or starting a search cancels any in-flight fetch, preventing stale data from overwriting the current view.
- **Smart cache invalidation** - Page 1 fetches with date filters delete only bookings matching that date scope before upserting. Page 2+ upserts only.
- **Ghost row during pagination only** - Bottom ghost row only appears when loading the next page, not during first-page refresh with cached data.
- **per_page fix for order fetches** - `loadOrders(for:orderIDs:)` now sets `per_page` to match the number of requested IDs, fixing a bug where the API returned only 10 orders by default.
- **Scroll to top on date change** - List scrolls to the top when navigating between dates.
- **Site timezone** - Date bar, booking times, and date filters all use the site's configured timezone.

## Test plan

1. Open POS Bookings - verify today's bookings load
2. Switch to yesterday/tomorrow - cached data appears instantly without a full loading state
3. Rapidly tap next/prev day - no stale data from a previous date appears (cancellation)
4. Scroll down with many bookings, switch date - list scrolls back to top
5. Scroll to bottom with many bookings - single ghost row appears for pagination
6. First load with cached data - no bottom ghost row, header spinner only
7. Kill and reopen the app, open bookings - cached data shows while syncing
8. Search bookings, change date while searching - search results update for new date
9. Clear search - returns to cached default bookings for the selected date

Additionally:
- Confirm Bookings store management continues to work

## Video

https://github.com/user-attachments/assets/19c57213-f793-4381-b434-bf63fe1c776c

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.