### PR TITLE
Move plugin version check to be the first setup step

### DIFF
--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
@@ -2,8 +2,8 @@ import Foundation
 import Yosemite
 
 enum SetupStep: Int, CaseIterable {
-    case connect = 0
-    case checkPlugin = 1
+    case checkPlugin = 0
+    case connect = 1
     case enablePush = 2
 }
 
@@ -65,15 +65,7 @@ final class WPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol {
     }
 
     func start() {
-        /// Step 1 (optional): check Jetpack connection
-        if !siteAlreadyConnected {
-            currentStep = .connect
-            startJetpackConnection()
-        } else {
-            /// Step 2: Check plugin version
-            delegate?.stepDidUpdate(.connect, status: .success)
-            startPluginVersionCheck()
-        }
+        startPluginVersionCheck()
     }
 
     func retry() {
@@ -96,12 +88,13 @@ final class WPComConnectionSetupHandler: WPComConnectionSetupHandlerProtocol {
 
 private extension WPComConnectionSetupHandler {
     func startJetpackConnection() {
+        currentStep = .connect
         Task { @MainActor in
             do {
                 delegate?.stepDidUpdate(.connect, status: .running)
                 try await jetpackConnectionService.establishSiteConnection(siteURL: siteURL)
                 delegate?.stepDidUpdate(.connect, status: .success)
-                startPluginVersionCheck()
+                startPushRegistration()
             } catch {
                 didFailConnection(with: error)
             }
@@ -123,7 +116,12 @@ private extension WPComConnectionSetupHandler {
                 switch result {
                 case .compatible:
                     delegate?.stepDidUpdate(.checkPlugin, status: .success)
-                    startPushRegistration()
+                    if !siteAlreadyConnected {
+                        startJetpackConnection()
+                    } else {
+                        delegate?.stepDidUpdate(.connect, status: .success)
+                        startPushRegistration()
+                    }
                 case .incompatible(let currentVersion, _):
                     delegate?.stepDidUpdate(.checkPlugin, status: .failure(error: .outdatedPlugin(version: currentVersion)))
                 }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
@@ -104,7 +104,6 @@ final class WPComConnectionSetupViewModel: ObservableObject {
     }
 
     func setPluginOutdatedState(version: String) {
-        stepDidUpdate(.connect, status: .success)
         stepDidUpdate(.checkPlugin, status: .failure(error: .outdatedPlugin(version: version)))
         shouldAutoOpenUpdatePlugin = true
     }
@@ -150,8 +149,8 @@ final class WPComConnectionSetupViewModel: ObservableObject {
 
     private func setupInitialSteps() {
         steps = [
-            WPComConnectionSetupStep(title: Localization.connectStoreStep, status: .notStarted),
             WPComConnectionSetupStep(title: Localization.checkPluginStep, status: .notStarted),
+            WPComConnectionSetupStep(title: Localization.connectStoreStep, status: .notStarted),
             WPComConnectionSetupStep(title: Localization.enablePushNotificationsStep, status: .notStarted)
         ]
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerTests.swift
@@ -16,6 +16,7 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
         super.setUp()
         mockConnectionService = MockJetpackConnectionService()
         mockPluginVersionChecker = MockPluginVersionChecker()
+        mockPluginVersionChecker.result = .success(.compatible)
         mockPushNotesManager = MockPushNotificationsManager()
         delegateSpy = MockWPComConnectionSetupHandlerDelegate()
     }
@@ -39,11 +40,11 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
         await delegateSpy.waitForStepUpdate(count: 4)
 
         // Then
-        XCTAssertGreaterThanOrEqual(delegateSpy.stepUpdates.count, 2)
-        XCTAssertEqual(delegateSpy.stepUpdates[0].step, .connect)
-        XCTAssertEqual(delegateSpy.stepUpdates[0].status, .running)
-        XCTAssertEqual(delegateSpy.stepUpdates[1].step, .connect)
-        XCTAssertEqual(delegateSpy.stepUpdates[1].status, .success)
+        XCTAssertGreaterThanOrEqual(delegateSpy.stepUpdates.count, 4)
+        XCTAssertEqual(delegateSpy.stepUpdates[2].step, .connect)
+        XCTAssertEqual(delegateSpy.stepUpdates[2].status, .running)
+        XCTAssertEqual(delegateSpy.stepUpdates[3].step, .connect)
+        XCTAssertEqual(delegateSpy.stepUpdates[3].status, .success)
     }
 
     func test_start_with_siteAlreadyConnected_skips_connect_step() async throws {
@@ -66,12 +67,12 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
         // When
         handler.start()
-        await delegateSpy.waitForStepUpdate(count: 2)
+        await delegateSpy.waitForStepUpdate(count: 4)
 
         // Then
-        XCTAssertGreaterThanOrEqual(delegateSpy.stepUpdates.count, 2)
-        XCTAssertEqual(delegateSpy.stepUpdates[0].status, .running)
-        assertFailureStatus(delegateSpy.stepUpdates[1].status)
+        XCTAssertGreaterThanOrEqual(delegateSpy.stepUpdates.count, 4)
+        XCTAssertEqual(delegateSpy.stepUpdates[2].status, .running)
+        assertFailureStatus(delegateSpy.stepUpdates[3].status)
     }
 
     // MARK: - retry() Tests
@@ -81,7 +82,7 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
         mockConnectionService.establishSiteConnectionResult = .failure(NSError(domain: "Test", code: -1))
         let handler = makeHandler(siteAlreadyConnected: false)
         handler.start()
-        await delegateSpy.waitForStepUpdate(count: 2)
+        await delegateSpy.waitForStepUpdate(count: 4)
 
         // Reset for retry
         mockConnectionService.establishSiteConnectionResult = .success(())
@@ -100,25 +101,27 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
     // MARK: - Plugin Version Check Tests
 
-    func test_start_with_connection_success_chains_to_plugin_check_success() async throws {
+    func test_start_with_plugin_check_success_chains_to_connection_step() async throws {
         // Given
-        mockPluginVersionChecker.result = .success(.compatible)
-        let handler = makeHandler()
+        let handler = makeHandler(siteAlreadyConnected: false)
 
         // When
         handler.start()
         await delegateSpy.waitForStepUpdate(count: 4)
 
         // Then
-        XCTAssertEqual(delegateSpy.stepUpdates[2].step, .checkPlugin)
+        XCTAssertEqual(delegateSpy.stepUpdates[0].step, .checkPlugin)
+        XCTAssertEqual(delegateSpy.stepUpdates[0].status, .running)
+        XCTAssertEqual(delegateSpy.stepUpdates[1].step, .checkPlugin)
+        XCTAssertEqual(delegateSpy.stepUpdates[1].status, .success)
+        XCTAssertEqual(delegateSpy.stepUpdates[2].step, .connect)
         XCTAssertEqual(delegateSpy.stepUpdates[2].status, .running)
-        XCTAssertEqual(delegateSpy.stepUpdates[3].step, .checkPlugin)
+        XCTAssertEqual(delegateSpy.stepUpdates[3].step, .connect)
         XCTAssertEqual(delegateSpy.stepUpdates[3].status, .success)
     }
 
     func test_start_with_siteAlreadyConnected_starts_plugin_check() async throws {
         // Given
-        mockPluginVersionChecker.result = .success(.compatible)
         let handler = makeHandler(siteAlreadyConnected: true)
 
         // When
@@ -126,10 +129,10 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
         await delegateSpy.waitForStepUpdate(count: 3)
 
         // Then
+        XCTAssertEqual(delegateSpy.stepUpdates[0].step, .checkPlugin)
+        XCTAssertEqual(delegateSpy.stepUpdates[0].status, .running)
         XCTAssertEqual(delegateSpy.stepUpdates[1].step, .checkPlugin)
-        XCTAssertEqual(delegateSpy.stepUpdates[1].status, .running)
-        XCTAssertEqual(delegateSpy.stepUpdates[2].step, .checkPlugin)
-        XCTAssertEqual(delegateSpy.stepUpdates[2].status, .success)
+        XCTAssertEqual(delegateSpy.stepUpdates[1].status, .success)
     }
 
     func test_plugin_check_incompatible_marks_step_as_failure_with_outdated_message() async throws {
@@ -139,11 +142,11 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
         // When
         handler.start()
-        await delegateSpy.waitForStepUpdate(count: 3)
+        await delegateSpy.waitForStepUpdate(count: 2)
 
         // Then
-        XCTAssertEqual(delegateSpy.stepUpdates[2].step, .checkPlugin)
-        XCTAssertEqual(delegateSpy.stepUpdates[2].status, .failure(error: .outdatedPlugin(version: "10.3.4")))
+        XCTAssertEqual(delegateSpy.stepUpdates[1].step, .checkPlugin)
+        XCTAssertEqual(delegateSpy.stepUpdates[1].status, .failure(error: .outdatedPlugin(version: "10.3.4")))
     }
 
     func test_plugin_check_error_marks_step_as_failure_with_generic_error() async throws {
@@ -153,11 +156,11 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
         // When
         handler.start()
-        await delegateSpy.waitForStepUpdate(count: 3)
+        await delegateSpy.waitForStepUpdate(count: 2)
 
         // Then
-        XCTAssertEqual(delegateSpy.stepUpdates[2].step, .checkPlugin)
-        assertFailureStatus(delegateSpy.stepUpdates[2].status)
+        XCTAssertEqual(delegateSpy.stepUpdates[1].step, .checkPlugin)
+        assertFailureStatus(delegateSpy.stepUpdates[1].status)
     }
 
     func test_retry_after_plugin_check_failure_restarts_plugin_check() async throws {
@@ -186,7 +189,6 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
     func test_start_with_compatible_plugin_triggers_push_registration_and_completes_on_success() async throws {
         // Given
-        mockPluginVersionChecker.result = .success(.compatible)
         mockPushNotesManager.registerDeviceAndWaitForTokenAcceptanceResult = .success(1)
         let handler = makeHandler(siteAlreadyConnected: true)
 
@@ -202,7 +204,6 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
     func test_start_with_compatible_plugin_marks_push_step_as_failure_on_registration_error() async throws {
         // Given
-        mockPluginVersionChecker.result = .success(.compatible)
         mockPushNotesManager.registerDeviceAndWaitForTokenAcceptanceResult = .failure(NSError(domain: "Test", code: -1))
         let handler = makeHandler(siteAlreadyConnected: true)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModelTests.swift
@@ -46,7 +46,7 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
         let viewModel = makeViewModel()
 
         // When
-        mockHandler.simulateStepUpdate(.connect, status: .running)
+        mockHandler.simulateStepUpdate(.checkPlugin, status: .running)
 
         // Then
         XCTAssertEqual(viewModel.steps[0].status, .running)
@@ -170,7 +170,7 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
 
     // MARK: - setPluginOutdatedState Tests
 
-    func test_setPluginOutdatedState_sets_connect_to_success_and_checkPlugin_to_failure() {
+    func test_setPluginOutdatedState_sets_checkPlugin_to_failure() {
         // Given
         let viewModel = makeViewModel()
 
@@ -178,8 +178,8 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
         viewModel.setPluginOutdatedState(version: "10.4.0")
 
         // Then
-        XCTAssertEqual(viewModel.steps[0].status, .success)
-        XCTAssertEqual(viewModel.steps[1].status, .failure(error: .outdatedPlugin(version: "10.4.0")))
+        XCTAssertEqual(viewModel.steps[0].status, .failure(error: .outdatedPlugin(version: "10.4.0")))
+        XCTAssertEqual(viewModel.steps[1].status, .notStarted)
         XCTAssertEqual(viewModel.steps[2].status, .notStarted)
     }
 


### PR DESCRIPTION
Closes: WOOMOB-2269

## Description
Reorders the WPCom connection setup flow so the plugin version check runs **first**, before attempting Jetpack connection. This ensures the WooCommerce plugin version is validated before proceeding with the rest of the setup. The flow changes from **Connect → Check Plugin → Push** to **Check Plugin → Connect → Push**.

## Test Steps
1. Set up a JurassicNinja site without Jetpack but with Woo added.
2. Update the WooCommerce plugin from p91TBi-dyW-p2#comment-14607.
3. Log in to the store with site credentials. Enable PN feature flags if needed.
4. Start the setup flow from the dashboard card or Settings > Enable push notifications.
5. Connect to WP.com.
6. Confirm that on the setup steps screen the **plugin version check is the first step**, followed by Connect Store and Enable Push.

## Screenshots
| Before | After |
| --- | --- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-20 at 11 57 55" src="https://github.com/user-attachments/assets/48c4c166-1dab-45cc-abe5-e5a54273252a" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-20 at 10 44 16" src="https://github.com/user-attachments/assets/b5a4283a-0208-4efc-9c57-273cea6efe82" /> |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.