### PR TITLE
Improve AI agent build/test readiness

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,10 +28,12 @@
       "Bash(pushd BuildTools *)",
       "Bash(xcrun *)",
       "Bash(rake lint *)",
+      "Bash(rake mocks *)",
       "Bash(rake test *)",
       "Bash(rake build *)",
       "Bash(rake generate *)",
       "Bash(rake clean *)",
+      "Bash(bundle install *)",
       "Bash(bundle exec rake *)"
     ],
     "deny": [

--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -7,12 +7,19 @@ allowed-tools: "Bash, Read"
 
 Bootstrap the local environment for WooCommerce iOS.
 
-Run the dependency install command:
+First, ensure the correct Ruby version is installed and active:
+```bash
+ruby --version        # should match the version in .ruby-version
+rvm install ruby-$(cat .ruby-version)   # installs if missing, no-op if already present
+rvm use ruby-$(cat .ruby-version)       # activate
+```
+
+Then run the dependency install command:
 ```bash
 bundle install && bundle exec rake dependencies
 ```
 
 If the command fails:
 1. Report the failing step and error output
-2. Check whether Ruby version matches `.ruby-version`
-3. Remind that Xcode 14+ is required
+2. If `Bundler::GemNotFound` or wrong Ruby version errors appear, run `rvm use ruby-$(cat .ruby-version)` and retry
+3. If `configure_apply` (fastlane credentials) fails with exit 128, this is a git-crypt/mobile-secrets issue — it does not block building or testing, only internal credentials are missing

--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -7,12 +7,20 @@ allowed-tools: "Bash, Read"
 
 Bootstrap the local environment for WooCommerce iOS.
 
-First, ensure the correct Ruby version is installed and active:
+First, check the required Xcode version and select it if available:
 ```bash
-ruby --version        # should match the version in .ruby-version
-rvm install ruby-$(cat .ruby-version)   # installs if missing, no-op if already present
-rvm use ruby-$(cat .ruby-version)       # activate
+cat .xcode-version   # check required version
+xcode-select -p      # check currently selected Xcode
 ```
+If the selected Xcode doesn't match, look for the required version under `/Applications/` and switch to it via `xcode-select -s <path>`. If it's not installed, note this to the user and proceed with the currently selected Xcode.
+
+Then, ensure the correct Ruby version is active. The required version is in `.ruby-version`.
+Detect which Ruby version manager is available and use it:
+- `rvm`: `rvm install ruby-$(cat .ruby-version) && rvm use ruby-$(cat .ruby-version)`
+- `rbenv`: `rbenv install $(cat .ruby-version) && rbenv local $(cat .ruby-version)`
+- `chruby` / `mise`: activate the version from `.ruby-version` using the appropriate command
+
+Verify with `ruby --version` before proceeding.
 
 Then run the dependency install command:
 ```bash
@@ -21,5 +29,5 @@ bundle install && bundle exec rake dependencies
 
 If the command fails:
 1. Report the failing step and error output
-2. If `Bundler::GemNotFound` or wrong Ruby version errors appear, run `rvm use ruby-$(cat .ruby-version)` and retry
+2. If `Bundler::GemNotFound` or wrong Ruby version errors appear, ensure the correct Ruby version is active and retry
 3. If `configure_apply` (fastlane credentials) fails with exit 128, this is a git-crypt/mobile-secrets issue — it does not block building or testing, only internal credentials are missing

--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: bootstrap
+description: Install dependencies and build tools for WooCommerce iOS
+user-invocable: true
+allowed-tools: "Bash, Read"
+---
+
+Bootstrap the local environment for WooCommerce iOS.
+
+Run the dependency install command:
+```bash
+bundle install && bundle exec rake dependencies
+```
+
+If the command fails:
+1. Report the failing step and error output
+2. Check whether Ruby version matches `.ruby-version`
+3. Remind that Xcode 14+ is required

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -16,6 +16,7 @@ If the build fails:
 1. Analyze the error output — look for compilation errors, identify file and line
 2. Check if it is a missing import, type mismatch, syntax error, or stale generated code
 3. If stale codegen, run: `bundle exec rake generate`
-4. Suggest or apply the fix
+4. If `Unable to find a device matching` — run `xcrun simctl list devices available | grep -E "iPhone [0-9]" | tail -5` to find an available simulator name, then retry
+5. Suggest or apply the fix
 
 If the build succeeds, report success.

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -34,4 +34,8 @@ After running:
 3. Read the failing test files to understand what went wrong
 4. Suggest fixes for failing tests
 
-If the simulator `iPhone 16` is not available, try `iPhone 15` or `iPhone 16 Pro`.
+If the simulator `iPhone 16` is not available, discover available simulators:
+```bash
+xcrun simctl list devices available | grep -E "iPhone [0-9]" | tail -5
+```
+Then retry with an available iPhone name.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,16 @@ CONTRIBUTING.md                  # PR merge policy
 .swiftlint.yml                   # SwiftLint configuration (opt-in rules only)
 ```
 
+## Bootstrap (Required Once)
+
+Use this to make builds and tests runnable from a clean checkout:
+
+```bash
+# Ensure Xcode 14+ is installed and selected.
+# Ensure Ruby matches .ruby-version.
+bundle install && bundle exec rake dependencies
+```
+
 ## Build Commands
 
 ```bash
@@ -226,6 +236,7 @@ Stars indicate priority. `[Internal]` for changes not visible to users.
 - **Test data**: Use `.fake()` from Fakes module and `.copy()` from Copiable
 - **Test plan**: `WooCommerce/WooCommerceTests/UnitTests.xctestplan`
 - See `Modules/Tests/CLAUDE.md` for detailed async testing patterns
+- UI tests require a local mock server: run `rake mocks` and use the `WooCommerceUITests` scheme
 
 ## Localization
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,13 +52,7 @@ CONTRIBUTING.md                  # PR merge policy
 
 ## Bootstrap (Required Once)
 
-Use this to make builds and tests runnable from a clean checkout:
-
-```bash
-# Ensure Xcode 14+ is installed and selected.
-# Ensure Ruby matches .ruby-version.
-bundle install && bundle exec rake dependencies
-```
+Use the `bootstrap` skill to set up the environment from a clean checkout. It will guide through Xcode version verification, Ruby version setup, and dependency installation.
 
 ## Build Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ pushd BuildTools && export SDKROOT=$(xcrun --sdk macosx --show-sdk-path) && \
   --allow-writing-to-package-directory sourcery-command --disableCache && popd
 ```
 
-If the simulator name `iPhone 16` is not available, try `iPhone 15` or `iPhone 16 Pro`.
+If the simulator `iPhone 16` is not available, discover what's installed: `xcrun simctl list devices available | grep -E "iPhone [0-9]" | tail -5`
 
 ## Architecture
 

--- a/Rakefile
+++ b/Rakefile
@@ -135,7 +135,7 @@ end
 
 def xcodebuild(*build_cmds)
   cmd = 'xcodebuild'
-  cmd += " -destination 'platform=iOS Simulator,name=iPhone 6s'"
+  cmd += " -destination 'platform=iOS Simulator,name=iPhone 16'"
   cmd += ' -sdk iphonesimulator'
   cmd += " -workspace #{XCODE_WORKSPACE}"
   cmd += " -scheme #{XCODE_SCHEME}"


### PR DESCRIPTION
## Description
Improves the AI agent setup so an agent can autonomously build the project and run tests without hand-holding.

Changes:
- Fix Rakefile simulator destination: `iPhone 6s` → `iPhone 16` (6s is absent from modern Xcode)
- Add `rvm install` step to bootstrap skill so the required Ruby version is installed automatically on a clean machine
- Add `configure_apply` failure note to bootstrap skill (git-crypt failure is non-blocking for builds)
- Add `xcrun simctl` discovery hint to build and test skills so an agent can self-recover from a missing simulator name
- Update AGENTS.md simulator fallback hint to use active `simctl` discovery instead of hardcoded guesses

## Test Steps
- Run `/bootstrap` skill on a clean machine — should install Ruby and gems without errors
- Run `/build` skill — should invoke `rake build` cleanly with `iPhone 16` destination
- Run `/test` skill — targeted xcodebuild commands use `iPhone 16` with correct flags

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.