### PR TITLE
Remove duplicate en-US promotional_text.txt

### DIFF
--- a/fastlane/metadata/en-US/promotional_text.txt
+++ b/fastlane/metadata/en-US/promotional_text.txt
@@ -1,1 +1,0 @@
-Run your store from anywhere


### PR DESCRIPTION
## Summary
- Removes `fastlane/metadata/en-US/promotional_text.txt` which duplicated the content in `default/promotional_text.txt`
- `default/` is the source of truth; having identical content in `en-US/` caused `download_release_translations` to fail

## Test plan
- [ ] Re-run `bundle exec fastlane download_release_translations` and verify it succeeds