### PR TITLE
Add Get help button to push notification setup flow

### DIFF
--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupView.swift
@@ -66,6 +66,11 @@ struct WPComConnectionSetupView: View {
                         viewModel.cancelTapped()
                     }
                 }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(Localization.getHelpButton) {
+                        viewModel.getHelpTapped()
+                    }
+                }
             }
             .toolbarBackground(.hidden, for: .navigationBar)
             .safeAreaInset(edge: .bottom) {
@@ -75,9 +80,25 @@ struct WPComConnectionSetupView: View {
                     .renderedIf(!dynamicTypeSize.isAccessibilitySize)
             }
         }
+        .sheet(isPresented: $viewModel.isShowingGetHelp) {
+            helpAndSupportView
+        }
         .onAppear {
             viewModel.onAppear()
         }
+    }
+
+    var helpAndSupportView: some View {
+        ViewControllerContainer(Self.makeHelpAndSupportController())
+    }
+
+    private static func makeHelpAndSupportController() -> UIViewController {
+        let identifier = HelpAndSupportViewController.classNameWithoutNamespaces
+        let helpVC = UIStoryboard.settings.instantiateViewController(identifier: identifier) { coder in
+            HelpAndSupportViewController(sourceTag: WPComConnectionSetupViewModel.supportSourceTag, coder: coder)
+        }
+        helpVC.displaysDismissAction = true
+        return WooNavigationController(rootViewController: helpVC)
     }
 
     @ViewBuilder var footer: some View {
@@ -115,6 +136,11 @@ private extension WPComConnectionSetupView {
             "wpComConnectionSetupView.cancelButton",
             value: "Cancel",
             comment: "Cancel button title in the WPCom connection setup screen toolbar."
+        )
+        static let getHelpButton = NSLocalizedString(
+            "wpComConnectionSetupView.getHelpButton",
+            value: "Get help",
+            comment: "Get help button title in the WPCom connection setup screen toolbar."
         )
     }
 }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
@@ -23,6 +23,9 @@ final class WPComConnectionSetupViewModel: ObservableObject {
 
     @Published private(set) var steps: [WPComConnectionSetupStep] = []
     @Published private var setupState: SetupState = .inProgress
+    @Published var isShowingGetHelp = false
+
+    static let supportSourceTag = "origin:woo-push-notifications-setup"
 
     let subtitleAttributedString: AttributedString
 
@@ -135,6 +138,10 @@ final class WPComConnectionSetupViewModel: ObservableObject {
     func cancelTapped() {
         handler.cancel()
         onDismiss()
+    }
+
+    func getHelpTapped() {
+        isShowingGetHelp = true
     }
 
     func doneTapped() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -85,6 +85,12 @@ final class HelpAndSupportViewController: UIViewController {
         super.init(coder: coder)
     }
 
+    init?(sourceTag: String, coder: NSCoder) {
+        self.customHelpCenterContent = nil
+        self.sourceTag = sourceTag
+        super.init(coder: coder)
+    }
+
     required init?(coder: NSCoder) {
         self.customHelpCenterContent = nil
         self.sourceTag = nil


### PR DESCRIPTION
Closes: WOOMOB-2258

## Description
Adds a "Get help" button to the top-right toolbar of the WPCom connection setup screen. Tapping it presents the Help & Support screen modally, with the `origin:woo-push-notifications-setup` source tag so that Contact Support requests are properly routed.

## Test Steps
1. Open the debug menu and tap "Present WPComConnectionSetupView".
2. Verify the "Get help" button appears in the top-right corner.
3. Tap "Get help" and confirm the Help & Support screen opens.

## Screenshots
![Simulator Screen Recording - iPhone 17 Pro - 2026-02-20 at 13 55 42](https://github.com/user-attachments/assets/71c8e643-1ca7-443b-8454-0c75e8c51970)


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.