### PR TITLE
POS Bookings: Booking Note

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -26,6 +26,7 @@ protocol POSBookingListControllerProtocol {
     func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws
     func updateBooking(bookingID: Int64) async throws
     func updateBookingOptimistically(bookingID: Int64, optimisticUpdate: (POSBooking) -> POSBooking) async
+    func updateBookingNote(bookingID: Int64, note: String) async throws
 }
 
 protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProtocol {
@@ -121,6 +122,14 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         let updatedStatus = try await bookingService.updateAttendanceStatus(bookingID: bookingID, status: status)
         if let existing = bookingsViewState.bookings.first(where: { $0.id == bookingID }) {
             updateBooking(existing.copy(attendanceStatus: updatedStatus))
+        }
+    }
+
+    @MainActor
+    func updateBookingNote(bookingID: Int64, note: String) async throws {
+        let updatedNote = try await bookingService.updateBookingNote(bookingID: bookingID, note: note)
+        if let existing = bookingsViewState.bookings.first(where: { $0.id == bookingID }) {
+            updateBooking(existing.copy(bookingNote: updatedNote.isEmpty ? nil : updatedNote))
         }
     }
 

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -128,8 +128,9 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     @MainActor
     func updateBookingNote(bookingID: Int64, note: String) async throws {
         let updatedNote = try await bookingService.updateBookingNote(bookingID: bookingID, note: note)
-        if let existing = bookingsViewState.bookings.first(where: { $0.id == bookingID }) {
-            updateBooking(existing.copy(bookingNote: updatedNote.isEmpty ? nil : updatedNote))
+        if let existingNote = bookingsViewState.bookings.first(where: { $0.id == bookingID }) {
+            let updatedNote = existingNote.copy(bookingNote: updatedNote.isEmpty ? nil : updatedNote)
+            updateBooking(updatedNote)
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/BookingNote/POSBookingNoteView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/BookingNote/POSBookingNoteView.swift
@@ -1,0 +1,199 @@
+import SwiftUI
+import Combine
+import WooFoundation
+import struct Yosemite.POSBooking
+
+struct POSBookingNoteView: View {
+    let booking: POSBooking
+
+    @State private var noteText: String
+    @State private var buttonState: POSButtonState = .idle
+    @State private var errorMessage: String?
+    @FocusState private var isTextFieldFocused: Bool
+
+    @Environment(POSBookingsModel.self) private var bookingsModel
+
+    @Binding private(set) var isShowingNoteView: Bool
+
+    @State private var buttonFrame: CGRect = .zero
+    @State private var keyboardFrame: CGRect = .zero
+    @State private var shouldMinimizePadding: Bool = false
+
+    private var originalNote: String
+
+    init(booking: POSBooking, isShowingNoteView: Binding<Bool>) {
+        self.booking = booking
+        self._isShowingNoteView = isShowingNoteView
+        let existingNote = booking.bookingNote ?? ""
+        self._noteText = State(initialValue: existingNote)
+        self.originalNote = existingNote
+    }
+
+    private var hasChanges: Bool {
+        noteText.trimmingCharacters(in: .whitespacesAndNewlines) != originalNote
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .center, spacing: conditionalPadding(POSSpacing.medium)) {
+                POSPageHeaderView(
+                    title: Localization.title,
+                    backButtonConfiguration: .init(
+                        state: buttonState != .idle ? .disabled : .enabled,
+                        action: {
+                            withAnimation {
+                                isShowingNoteView = false
+                                isTextFieldFocused = false
+                            }
+                        }
+                    )
+                )
+
+                VStack(alignment: .center, spacing: conditionalPadding(POSSpacing.medium)) {
+                    Spacer()
+
+                    VStack(alignment: .center, spacing: POSSpacing.xSmall) {
+                        TextField("",
+                                  text: $noteText,
+                                  prompt: Text(Localization.placeholder).foregroundColor(.posOnDisabledContainer),
+                                  axis: .vertical)
+                        .foregroundStyle(Color.posOnSurface)
+                        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+                        .textInputAutocapitalization(.sentences)
+                        .multilineTextAlignment(.center)
+                        .lineLimit(3...10)
+                        .font(POSFontStyle.posHeadingRegular)
+                        .focused()
+                        .focused($isTextFieldFocused)
+
+                        if let errorMessage {
+                            Text(errorMessage)
+                                .font(POSFontStyle.posBodySmallRegular())
+                                .foregroundColor(.posError)
+                        }
+                    }
+
+                    Spacer()
+
+                    Button(action: {
+                        saveNote()
+                    }, label: {
+                        Text(hasChanges ? Localization.saveButton : Localization.addButton)
+                    })
+                    .measureFrame {
+                        buttonFrame = $0
+                    }
+                    .buttonStyle(POSFilledButtonStyle(size: .normal, state: buttonState))
+                    .dynamicTypeSize(...DynamicTypeSize.accessibility3)
+                    .frame(maxWidth: .infinity)
+                    .disabled(buttonState != .idle || !hasChanges)
+                }
+                .padding([.horizontal])
+                .padding(.bottom, keyboardFrame.height)
+            }
+            .animation(.easeInOut, value: errorMessage)
+            .onChange(of: noteText) {
+                errorMessage = nil
+            }
+            .onReceive(Publishers.keyboardFrame) {
+                keyboardFrame = $0
+                shouldMinimizePadding = $0.intersects(buttonFrame)
+            }
+            .animation(.default, value: shouldMinimizePadding)
+        }
+        .background(Color.posSurfaceBright)
+    }
+
+    private func saveNote() {
+        Task { @MainActor in
+            buttonState = .loading
+            do {
+                errorMessage = nil
+                let trimmedNote = noteText.trimmingCharacters(in: .whitespacesAndNewlines)
+                try await bookingsModel.bookingsController.updateBookingNote(
+                    bookingID: booking.id,
+                    note: trimmedNote
+                )
+
+                withAnimation {
+                    buttonState = .success
+                } completion: {
+                    isShowingNoteView = false
+                    isTextFieldFocused = false
+                }
+            } catch {
+                errorMessage = Localization.saveError
+                buttonState = .idle
+            }
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private extension POSBookingNoteView {
+    enum Constants {
+        static let minimumPadding: CGFloat = POSSpacing.xSmall
+    }
+
+    func conditionalPadding(_ padding: CGFloat) -> CGFloat {
+        if shouldMinimizePadding {
+            return Constants.minimumPadding
+        }
+        return padding
+    }
+}
+
+// MARK: - Localization
+
+private extension POSBookingNoteView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pos.bookingNoteView.title",
+            value: "Add note",
+            comment: "Title shown at the top of the booking note editor screen in POS."
+        )
+
+        static let placeholder = NSLocalizedString(
+            "pos.bookingNoteView.placeholder",
+            value: "Type note",
+            comment: "Placeholder text shown in the booking note text field when empty."
+        )
+
+        static let addButton = NSLocalizedString(
+            "pos.bookingNoteView.addButton",
+            value: "Add",
+            comment: "Button label shown when no changes have been made to the booking note yet."
+        )
+
+        static let saveButton = NSLocalizedString(
+            "pos.bookingNoteView.saveButton",
+            value: "Save",
+            comment: "Button to save the booking note."
+        )
+
+        static let saveError = NSLocalizedString(
+            "pos.bookingNoteView.saveError",
+            value: "Failed to save note. Try again.",
+            comment: "Error message shown when saving a booking note fails."
+        )
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+#Preview("New Note") {
+    POSBookingNoteView(
+        booking: POSPreviewHelpers.makePreviewUnpaidBooking(),
+        isShowingNoteView: .constant(true)
+    )
+}
+
+#Preview("Edit Existing Note") {
+    POSBookingNoteView(
+        booking: POSPreviewHelpers.makePreviewPaidBooking(),
+        isShowingNoteView: .constant(true)
+    )
+}
+#endif

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/BookingNote/POSBookingNoteView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/BookingNote/POSBookingNoteView.swift
@@ -55,13 +55,11 @@ struct POSBookingNoteView: View {
                     VStack(alignment: .center, spacing: POSSpacing.xSmall) {
                         TextField("",
                                   text: $noteText,
-                                  prompt: Text(Localization.placeholder).foregroundColor(.posOnDisabledContainer),
-                                  axis: .vertical)
+                                  prompt: Text(Localization.placeholder).foregroundColor(.posOnDisabledContainer))
                         .foregroundStyle(Color.posOnSurface)
                         .dynamicTypeSize(...DynamicTypeSize.accessibility1)
                         .textInputAutocapitalization(.sentences)
                         .multilineTextAlignment(.center)
-                        .lineLimit(3...10)
                         .font(POSFontStyle.posHeadingRegular)
                         .focused()
                         .focused($isTextFieldFocused)

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/BookingNote/POSBookingNoteView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/BookingNote/POSBookingNoteView.swift
@@ -20,6 +20,7 @@ struct POSBookingNoteView: View {
     @State private var shouldMinimizePadding: Bool = false
 
     private var originalNote: String
+    private var isEditingExistingNote: Bool
 
     init(booking: POSBooking, isShowingNoteView: Binding<Bool>) {
         self.booking = booking
@@ -27,6 +28,7 @@ struct POSBookingNoteView: View {
         let existingNote = booking.bookingNote ?? ""
         self._noteText = State(initialValue: existingNote)
         self.originalNote = existingNote
+        self.isEditingExistingNote = booking.bookingNote != nil
     }
 
     private var hasChanges: Bool {
@@ -37,7 +39,7 @@ struct POSBookingNoteView: View {
         ScrollView {
             VStack(alignment: .center, spacing: conditionalPadding(POSSpacing.medium)) {
                 POSPageHeaderView(
-                    title: Localization.title,
+                    title: isEditingExistingNote ? Localization.editTitle : Localization.addTitle,
                     backButtonConfiguration: .init(
                         state: buttonState != .idle ? .disabled : .enabled,
                         action: {
@@ -146,10 +148,16 @@ private extension POSBookingNoteView {
 
 private extension POSBookingNoteView {
     enum Localization {
-        static let title = NSLocalizedString(
-            "pos.bookingNoteView.title",
+        static let addTitle = NSLocalizedString(
+            "pos.bookingNoteView.addTitle",
             value: "Add note",
-            comment: "Title shown at the top of the booking note editor screen in POS."
+            comment: "Title shown at the top of the booking note editor screen when adding a new note."
+        )
+
+        static let editTitle = NSLocalizedString(
+            "pos.bookingNoteView.editTitle",
+            value: "Edit note",
+            comment: "Title shown at the top of the booking note editor screen when editing an existing note."
         )
 
         static let placeholder = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -21,6 +21,7 @@ struct POSBookingDetailView: View {
     @State private var stickyButtonHeight: CGFloat = 0
     @State private var scrollViewHeight: CGFloat = 0
     @State private var isDetailsUpdating = false
+    @State private var isShowingNoteView = false
 
     private var actionTintColor: Color {
         colorScheme == .dark ? .posSecondary : .posPrimaryContainer
@@ -67,6 +68,10 @@ struct POSBookingDetailView: View {
             if let paymentModel {
                 POSBookingPaymentView(booking: booking, paymentModel: paymentModel, onDismiss: dismissPayment)
             }
+        }
+        .posFullScreenCover(isPresented: $isShowingNoteView) {
+            POSBookingNoteView(booking: booking, isShowingNoteView: $isShowingNoteView)
+                .posHeaderBackButtonIcon(systemName: "chevron.left")
         }
     }
 
@@ -290,8 +295,8 @@ struct POSBookingDetailView: View {
         VStack(alignment: .leading, spacing: POSSpacing.small) {
             VStack(alignment: .leading, spacing: POSSpacing.medium) {
                 sectionTitleWithAction(title: Localization.bookingNoteLabel) {
-                    Button(Localization.addNoteButton) {
-                        // TODO: Implement add note action
+                    Button(booking.bookingNote != nil ? Localization.editNoteButton : Localization.addNoteButton) {
+                        isShowingNoteView = true
                     }
                     .buttonStyle(POSOutlinedButtonStyle(size: .compact))
                 }
@@ -520,6 +525,12 @@ private enum Localization {
         "pos.bookingDetailView.addNoteButton",
         value: "Add note",
         comment: "Button to add a private note to a booking."
+    )
+
+    static let editNoteButton = NSLocalizedString(
+        "pos.bookingDetailView.editNoteButton",
+        value: "Edit note",
+        comment: "Button to edit an existing private note on a booking."
     )
 
     static let bookingNoteSubtitle = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -295,7 +295,7 @@ struct POSBookingDetailView: View {
         VStack(alignment: .leading, spacing: POSSpacing.small) {
             VStack(alignment: .leading, spacing: POSSpacing.medium) {
                 sectionTitleWithAction(title: Localization.bookingNoteLabel) {
-                    Button(booking.bookingNote != nil ? Localization.editNoteButton : Localization.addNoteButton) {
+                    Button(noteButtonTitle) {
                         isShowingNoteView = true
                     }
                     .buttonStyle(POSOutlinedButtonStyle(size: .compact))
@@ -351,6 +351,14 @@ struct POSBookingDetailView: View {
         paymentModel = bookingsModel.makePaymentModel(
             for: booking, onDismiss: dismissPayment, analytics: analytics)
         showPaymentView = true
+    }
+
+    private var noteButtonTitle: String {
+        if booking.bookingNote != nil {
+            Localization.editNoteButton
+        } else {
+            Localization.addNoteButton
+        }
     }
 
     private var shouldShowCollectPayment: Bool {

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -71,7 +71,7 @@ struct POSBookingDetailView: View {
         }
         .posFullScreenCover(isPresented: $isShowingNoteView) {
             POSBookingNoteView(booking: booking, isShowingNoteView: $isShowingNoteView)
-                .posHeaderBackButtonIcon(systemName: "chevron.left")
+                .posHeaderBackButtonIcon(systemName: "xmark")
         }
     }
 

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -529,6 +529,8 @@ final class POSBookingServicePreview: POSBookingServiceProtocol {
     func cancelBooking(bookingID: Int64) async throws -> BookingStatus { .cancelled }
 
     func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws -> BookingAttendanceStatus { status }
+
+    func updateBookingNote(bookingID: Int64, note: String) async throws -> String { note }
 }
 
 final class POSBookingListFetchStrategyPreview: POSBookingListFetchStrategy {
@@ -806,6 +808,7 @@ final class POSConfigurablePreviewBookingListController: POSSearchingBookingList
     func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws {}
     func updateBooking(bookingID: Int64) async throws {}
     func updateBookingOptimistically(bookingID: Int64, optimisticUpdate: (POSBooking) -> POSBooking) async {}
+    func updateBookingNote(bookingID: Int64, note: String) async throws {}
     func searchBookings(searchTerm: String) async {}
     func clearSearchBookings() {}
 }

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingService.swift
@@ -131,6 +131,20 @@ public final class POSBookingService: POSBookingServiceProtocol {
         }
         return booking.attendanceStatus
     }
+
+    @discardableResult
+    public func updateBookingNote(bookingID: Int64, note: String) async throws -> String {
+        guard let booking = try await bookingsRemote.updateBooking(
+            from: siteID,
+            bookingID: bookingID,
+            attendanceStatus: nil,
+            bookingStatus: nil,
+            note: note
+        ) else {
+            throw POSBookingServiceError.requestFailed
+        }
+        return booking.note
+    }
 }
 
 private extension POSBookingService {

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingServiceProtocol.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingServiceProtocol.swift
@@ -18,4 +18,6 @@ public protocol POSBookingServiceProtocol: Sendable {
     func cancelBooking(bookingID: Int64) async throws -> BookingStatus
 
     func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws -> BookingAttendanceStatus
+
+    func updateBookingNote(bookingID: Int64, note: String) async throws -> String
 }

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
@@ -227,6 +227,53 @@ final class POSBookingListControllerTests {
         }
     }
 
+    // MARK: - updateBookingNote
+
+    @Test func test_updateBookingNote_calls_service_and_updates_booking_in_place() async throws {
+        // Given
+        let bookings = [makeBooking(id: 1)]
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: bookings, hasMorePages: false, totalItems: nil))
+        await sut.loadBookings()
+
+        let mockService = mockFactory.bookingService as! MockPOSBookingService
+
+        // When
+        try await sut.updateBookingNote(bookingID: 1, note: "Test note")
+
+        // Then
+        #expect(mockService.updateBookingNoteCallCount == 1)
+        #expect(mockService.lastUpdatedNoteBookingID == 1)
+        #expect(mockService.lastUpdatedNote == "Test note")
+        #expect(sut.bookingsViewState.bookings.first?.bookingNote == "Test note")
+    }
+
+    @Test func test_updateBookingNote_when_empty_note_then_sets_bookingNote_to_nil() async throws {
+        // Given
+        let bookings = [makeBooking(id: 1)]
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: bookings, hasMorePages: false, totalItems: nil))
+        await sut.loadBookings()
+
+        // When
+        try await sut.updateBookingNote(bookingID: 1, note: "")
+
+        // Then
+        #expect(sut.bookingsViewState.bookings.first?.bookingNote == nil)
+    }
+
+    @Test func test_updateBookingNote_when_service_throws_then_throws_error() async {
+        // Given
+        let mockService = mockFactory.bookingService as! MockPOSBookingService
+        mockService.updateBookingNoteError = NSError(domain: "test", code: 1)
+
+        // When/Then
+        do {
+            try await sut.updateBookingNote(bookingID: 1, note: "Test note")
+            Issue.record("Expected error to be thrown")
+        } catch {
+            #expect(mockService.updateBookingNoteCallCount == 1)
+        }
+    }
+
     // MARK: - updateBooking
 
     @Test func test_updateBooking_fetches_and_updates_booking_in_place() async throws {

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
@@ -79,6 +79,21 @@ final class MockPOSBookingService: POSBookingServiceProtocol {
         }
         return updateAttendanceStatusResult ?? status
     }
+
+    var updateBookingNoteError: Error?
+    var updateBookingNoteCallCount = 0
+    var lastUpdatedNoteBookingID: Int64?
+    var lastUpdatedNote: String?
+
+    func updateBookingNote(bookingID: Int64, note: String) async throws -> String {
+        updateBookingNoteCallCount += 1
+        lastUpdatedNoteBookingID = bookingID
+        lastUpdatedNote = note
+        if let error = updateBookingNoteError {
+            throw error
+        }
+        return note
+    }
 }
 
 final class MockPOSBookingListFetchStrategy: POSBookingListFetchStrategy {


### PR DESCRIPTION
Closes WOOMOB-2190

## Description
This PR adds the Booking Note feature, where a merchant can add or update private notes for the booking (different from customer notes or order notes)

## Test Steps

### 1. Add a booking note:

In the Booking details, scroll to the section, tap on the add note button and observe it opens full screen. Test for:
- Save a new note
- Edit an existing note

https://github.com/user-attachments/assets/c089fe6f-16cd-42ed-b1d0-7270f7819031

### Confirm in next admin

This does not seem to be fully cooked yet in the backend, as the notes do not appear in wp-admin, only in next admin. Be sure to get the booking ID of the booking you edit in the app,  then navigate to Bookings > [Booking List](https://generously-zealous-triumph.commerce-garden.com/wp-admin/admin.php?page=next-admin&p=%2Fwoocommerce%2Fbookings%2Flist%2Ftoday) > View Booking, then scroll to the bottom and expand the chevron to see the booking notes.

<img width="600" height="264" alt="Screenshot 2026-02-23 at 15 04 45" src="https://github.com/user-attachments/assets/36e15467-a2a4-42d3-8e02-04bd082d2eeb" />


<img width="600" height="698" alt="Screenshot 2026-02-23 at 14 56 30" src="https://github.com/user-attachments/assets/ec8a4761-5109-4f3a-88a7-3b61ad00f2fc" />

### Test for errors:

Throw on `updateBookingNote`, then try to save a note, see the inline error.
```diff

public func updateBookingNote(bookingID: Int64, note: String) async throws -> String {                           
+ throw POSBookingServiceError.requestFailed 

```

<img width="600" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - CIAB - 2026-02-23 at 14 50 17" src="https://github.com/user-attachments/assets/ff43b1a8-c7e2-48ec-8140-03d30f1b57e0" />

