### PR TITLE
Add error handling for WPCom push notifications intro modal

### DIFF
--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
@@ -199,8 +199,8 @@ extension WPComConnectionSetupViewModel: WPComConnectionSetupHandlerDelegate {
 private extension WPComConnectionSetupViewModel {
     enum Localization {
         static let subtitle = NSLocalizedString(
-            "wpComConnectionSetupViewModel.subtitle",
-            value: "Please wait while we finalize connecting your store %@ to your WordPress.com account.",
+            "wpComConnectionSetupViewModel.message",
+            value: "Please wait while we finalize connecting your store %@ to WordPress.com.",
             comment: "Subtitle for the WPCom connection setup screen. %@ is the store name."
         )
         static let goToMyStore = NSLocalizedString(

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
@@ -200,8 +200,8 @@ private extension WPComConnectionSetupViewModel {
     enum Localization {
         static let subtitle = NSLocalizedString(
             "wpComConnectionSetupViewModel.message",
-            value: "Please wait while we finalize connecting your store %@ to WordPress.com.",
-            comment: "Subtitle for the WPCom connection setup screen. %@ is the store name."
+            value: "Please wait while we finalize connecting your store %1$@ to WordPress.com.",
+            comment: "Subtitle for the WPCom connection setup screen. %1$@ is the store name."
         )
         static let goToMyStore = NSLocalizedString(
             "wpComConnectionSetupViewModel.goToMyStore",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -372,7 +372,8 @@ private extension DashboardViewHostingController {
         rootView.onConnectWPComSetup = { [weak self] in
             guard let self else { return }
             let benefitsViewModel = WPComPushNotificationsBenefitsViewModel(
-                siteID: self.viewModel.siteID,
+                siteID: viewModel.siteID,
+                siteURL: viewModel.stores.sessionManager.defaultSite?.url ?? "",
                 onDismiss: {
                     self.dismiss(animated: true)
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -432,10 +432,10 @@ private extension SettingsViewController {
 
     func enablePushNotificationsWasPressed() {
         DDLogInfo("🔔 Settings: Enable Push Notifications tapped")
-        guard let siteID = stores.sessionManager.defaultStoreID else {
+        guard let site = stores.sessionManager.defaultSite else {
             return DDLogError("⛔️ Cannot find ID for current site to enable push notifications!")
         }
-        let viewModel = WPComPushNotificationsBenefitsViewModel(siteID: siteID, onDismiss: { [weak self] in
+        let viewModel = WPComPushNotificationsBenefitsViewModel(siteID: site.siteID, siteURL: site.url, onDismiss: { [weak self] in
             self?.dismiss(animated: true)
         })
         let navigationController = WooNavigationController()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/ConnectWPComCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/ConnectWPComCard.swift
@@ -23,6 +23,7 @@ struct ConnectWPComCard: View {
                     .fontWeight(.semibold)
                 Text(Localization.subtitle)
                     .font(.callout)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
             VStack {
                 Menu {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -136,8 +136,8 @@ fileprivate extension WPComPushNotificationsBenefitsView {
                                              comment: "Title of the WordPress.com Push Notifications Benefits View")
 
         static let description = NSLocalizedString(
-            "wpcomPushNotificationsBenefitsView.description",
-            value: "Connect your store to a WordPress.com account to get access to push notifications for new orders, reviews and more.",
+            "wpcomPushNotificationsBenefitsView.mainDescription",
+            value: "Connect your store to WordPress.com to get access to push notifications for new orders, reviews and more.",
             comment: "Main description text of the WordPress.com Push Notifications Benefits View"
         )
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -39,24 +39,25 @@ struct WPComPushNotificationsBenefitsView: View {
     var body: some View {
         NavigationStack {
             ScrollView {
-                VStack(alignment: .leading, spacing: Layout.contentSpacing) {
-                    Spacer()
-                    VStack(alignment: .leading, spacing: Layout.contentSpacing) {
-                        stackedImages
-                        title
-                        detail
-                    }
-                    Spacer()
-                }
-                .redacted(reason: viewModel.isCheckingPlugin ? .placeholder : [])
-                .shimmering(active: viewModel.isCheckingPlugin)
-                .renderedIf(viewModel.error == nil)
-
                 if let error = viewModel.error {
-                    errorView(with: error)
+                    VStack(spacing: Layout.contentSpacing) {
+                        errorView(with: error)
+                    }
+                } else {
+                    VStack(alignment: .leading, spacing: Layout.contentSpacing) {
+                        Spacer()
+                        VStack(alignment: .leading, spacing: Layout.contentSpacing) {
+                            stackedImages
+                            title
+                            detail
+                        }
+                        Spacer()
+                    }
+                    .redacted(reason: viewModel.isCheckingPlugin ? .placeholder : [])
+                    .shimmering(active: viewModel.isCheckingPlugin)
                 }
 
-                if dynamicTypeSize.isAccessibilitySize {
+                if dynamicTypeSize.isAccessibilitySize && !viewModel.isCheckingPlugin {
                     footer
                 }
             }
@@ -73,7 +74,7 @@ struct WPComPushNotificationsBenefitsView: View {
                 footer
                     .padding(Layout.contentPadding)
                     .background(Color(uiColor: .systemBackground))
-                    .renderedIf(!dynamicTypeSize.isAccessibilitySize)
+                    .renderedIf(!dynamicTypeSize.isAccessibilitySize && !viewModel.isCheckingPlugin)
             }
         }
         .onAppear {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -29,6 +29,8 @@ struct WPComPushNotificationsBenefitsView: View {
     private var viewModel: WPComPushNotificationsBenefitsViewModel
 
     @State private var safariURL: URL?
+    @State private var showSupport = false
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     init(viewModel: WPComPushNotificationsBenefitsViewModel) {
         self.viewModel = viewModel
@@ -45,19 +47,33 @@ struct WPComPushNotificationsBenefitsView: View {
                         detail
                     }
                     Spacer()
-                    footer
                 }
                 .redacted(reason: viewModel.isCheckingPlugin ? .placeholder : [])
                 .shimmering(active: viewModel.isCheckingPlugin)
-                .padding([.leading, .bottom, .trailing], Layout.contentPadding)
-                .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button(Localization.cancelButton) {
-                            viewModel.notNowTapped()
-                        }
+                .renderedIf(viewModel.error == nil)
+
+                if let error = viewModel.error {
+                    errorView(with: error)
+                }
+
+                if dynamicTypeSize.isAccessibilitySize {
+                    footer
+                }
+            }
+            .padding([.leading, .bottom, .trailing], Layout.contentPadding)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.cancelButton) {
+                        viewModel.notNowTapped()
                     }
                 }
-                .toolbarBackground(.hidden, for: .navigationBar)
+            }
+            .toolbarBackground(.hidden, for: .navigationBar)
+            .safeAreaInset(edge: .bottom) {
+                footer
+                    .padding(Layout.contentPadding)
+                    .background(Color(uiColor: .systemBackground))
+                    .renderedIf(!dynamicTypeSize.isAccessibilitySize)
             }
         }
         .onAppear {
@@ -72,6 +88,7 @@ struct WPComPushNotificationsBenefitsView: View {
             return .handled
         })
         .safariSheet(url: $safariURL)
+        .sheet(isPresented: $showSupport, content: { supportForm })
     }
 
     private var stackedImages: some View {
@@ -101,10 +118,17 @@ struct WPComPushNotificationsBenefitsView: View {
 
     private var footer: some View {
         VStack {
-            Button(primaryButtonText) {
-                viewModel.continueTapped()
+            if viewModel.error != nil {
+                Button(Localization.contactSupport) {
+                    showSupport = true
+                }
+                .buttonStyle(PrimaryButtonStyle())
+            } else {
+                Button(primaryButtonText) {
+                    viewModel.continueTapped()
+                }
+                .buttonStyle(PrimaryButtonStyle())
             }
-            .buttonStyle(PrimaryButtonStyle())
 
             Button(Localization.notNowButton) {
                 viewModel.notNowTapped()
@@ -119,6 +143,37 @@ struct WPComPushNotificationsBenefitsView: View {
             return Localization.continueButton
         case .pluginUpdate:
             return Localization.updatePluginButton
+        }
+    }
+
+    private func errorView(with error: WPComPushNotificationsBenefitsViewModel.VariantCheckError) -> some View {
+        VStack(spacing: Layout.contentPadding) {
+            Spacer()
+            Image(systemName: "exclamationmark.circle.fill")
+                .font(.largeTitle)
+                .foregroundStyle(Color(.error))
+            Text(Localization.errorTitle)
+                .font(.title)
+            Text(error.message)
+                .font(.body)
+                .multilineTextAlignment(.center)
+            Spacer()
+        }
+    }
+
+    private var supportForm: some View {
+        NavigationStack {
+            SupportForm(
+                isPresented: $showSupport,
+                viewModel: SupportFormViewModel(sourceTag: "origin:woo-push-notifications-setup")
+            )
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.cancelButton) {
+                        showSupport = false
+                    }
+                }
+            }
         }
     }
 }
@@ -175,6 +230,18 @@ fileprivate extension WPComPushNotificationsBenefitsView {
             "wpcomPushNotificationsBenefitsView.updatePluginButton",
             value: "Update plugin",
             comment: "Button title to update the WooCommerce plugin in the Push Notifications Benefits View"
+        )
+
+        static let errorTitle = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsView.errorTitle",
+            value: "Something went wrong",
+            comment: "Title of the error state in the Push Notifications Benefits View"
+        )
+
+        static let contactSupport = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsView.contactSupport",
+            value: "Contact support",
+            comment: "Button title to contact support in the Push Notifications Benefits View"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -137,7 +137,7 @@ struct WPComPushNotificationsBenefitsView: View {
             }
             .buttonStyle(SecondaryButtonStyle())
 
-            if case .connect = viewModel.variant {
+            if case .connect = viewModel.variant, viewModel.error == nil {
                 Text(viewModel.termsAttributedString)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -165,7 +165,7 @@ struct WPComPushNotificationsBenefitsView: View {
         NavigationStack {
             SupportForm(
                 isPresented: $showSupport,
-                viewModel: SupportFormViewModel(sourceTag: "origin:woo-push-notifications-setup")
+                viewModel: SupportFormViewModel(sourceTag: WPComConnectionSetupViewModel.supportSourceTag)
             )
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -109,6 +109,7 @@ struct WPComPushNotificationsBenefitsView: View {
         VStack(alignment: .leading, spacing: Layout.contentSpacing) {
             Text(Localization.description)
                 .font(.body)
+                .frame(maxWidth: .infinity, alignment: .leading)
             Text(Localization.subdescription)
                 .font(.body)
             Link(Localization.whatIsWPCom, destination: WooConstants.URLs.whatIsWPCom.asURL())
@@ -135,6 +136,10 @@ struct WPComPushNotificationsBenefitsView: View {
                 viewModel.notNowTapped()
             }
             .buttonStyle(SecondaryButtonStyle())
+
+            if case .connect = viewModel.variant {
+                Text(viewModel.termsAttributedString)
+            }
         }
     }
 
@@ -158,6 +163,7 @@ struct WPComPushNotificationsBenefitsView: View {
             Text(error.message)
                 .font(.body)
                 .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity, alignment: .center)
             Spacer()
         }
     }
@@ -249,6 +255,6 @@ fileprivate extension WPComPushNotificationsBenefitsView {
 
 #Preview {
     WPComPushNotificationsBenefitsView(
-        viewModel: WPComPushNotificationsBenefitsViewModel(siteID: 0, onDismiss: {})
+        viewModel: WPComPushNotificationsBenefitsViewModel(siteID: 0, siteURL: "https://example.com", onDismiss: {})
     )
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -165,7 +165,7 @@ extension WPComPushNotificationsBenefitsViewModel {
                 "wpcomPushNotificationsBenefitsViewModel.variantCheckError.generic",
                 value: "We could not complete the push notifications setup. " +
                 "Please contact support for assistance.",
-                comment: "Generic rror message in the Push Notifications Benefits View"
+                comment: "Generic error message in the Push Notifications Benefits View"
             )
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -13,6 +13,8 @@ final class WPComPushNotificationsBenefitsViewModel {
         case pluginUpdate(currentVersion: String)
     }
 
+    let termsAttributedString: AttributedString
+
     private(set) var variant: Variant = .connect
     private(set) var isCheckingPlugin: Bool = false
     private(set) var error: VariantCheckError?
@@ -25,6 +27,7 @@ final class WPComPushNotificationsBenefitsViewModel {
     private var pushNotificationSetupCoordinator: WooPushNotificationSetupCoordinator?
 
     init(siteID: Int64,
+         siteURL: String,
          jetpackConnectionService: JetpackConnectionServiceProtocol = JetpackConnectionService(),
          pluginVersionChecker: PluginVersionCheckerProtocol? = nil,
          analytics: Analytics = ServiceLocator.analytics,
@@ -46,6 +49,21 @@ final class WPComPushNotificationsBenefitsViewModel {
             pluginPath: WooPluginRequirements.pluginPath,
             minimumVersion: minimumVersion
         )
+
+        self.termsAttributedString = {
+            let content = String.localizedStringWithFormat(Localization.termsContent, Localization.termsOfService, Localization.shareDetails)
+
+            let attributedText = AttributedString.withEmbeddedLinks(
+                content: content,
+                links: [
+                    Localization.termsOfService: Constants.jetpackTermsURL + siteURL,
+                    Localization.shareDetails: Constants.jetpackShareDetailsURL + siteURL
+                ],
+                font: .footnote,
+                foregroundColor: .secondary
+            )
+            return attributedText
+        }()
     }
 
     func updateCoordinator(_ coordinator: WooPushNotificationSetupCoordinator) {
@@ -150,5 +168,29 @@ extension WPComPushNotificationsBenefitsViewModel {
                 comment: "Generic rror message in the Push Notifications Benefits View"
             )
         }
+    }
+
+    private enum Constants {
+        static let jetpackTermsURL = "https://jetpack.com/redirect/?source=wpcom-tos&site="
+        static let jetpackShareDetailsURL = "https://jetpack.com/redirect/?source=jetpack-support-what-data-does-jetpack-sync&site="
+    }
+
+    enum Localization {
+        static let termsContent = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsViewModel.termsContent",
+            value: "By continuing, you agree to our %1$@ and to %2$@ with WordPress.com.",
+            comment: "Content of the label at the end of the Wrong Account screen. " +
+            "Reads like: By continuing, you agree to our Terms of Service and to share details with WordPress.com."
+        )
+        static let termsOfService = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsViewModel.termsOfService",
+            value: "Terms of Service",
+            comment: "The terms to be agreed upon when tapping the Continue button on the Push Notifications Benefits View."
+        )
+        static let shareDetails = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsViewModel.shareDetails",
+            value: "share details",
+            comment: "The action to be agreed upon when tapping the Continue button on the Push Notifications Benefits View."
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 import Observation
 import Yosemite
 import protocol WooFoundation.Analytics
+import enum NetworkingCore.NetworkError
 
 @MainActor
 @Observable
@@ -14,6 +15,7 @@ final class WPComPushNotificationsBenefitsViewModel {
 
     private(set) var variant: Variant = .connect
     private(set) var isCheckingPlugin: Bool = false
+    private(set) var error: VariantCheckError?
 
     private let analytics: Analytics
     private let onDismiss: () -> Void
@@ -69,7 +71,11 @@ final class WPComPushNotificationsBenefitsViewModel {
             }
         } catch {
             DDLogError("⛔️ Failed to fetch Jetpack connection data: \(error)")
-            variant = .connect
+            if case NetworkError.unacceptableStatusCode(403, _) = error {
+                self.error = .noPermission
+            } else {
+                self.error = .generic(underlyingError: error)
+            }
         }
         isCheckingPlugin = false
     }
@@ -106,13 +112,43 @@ private extension WPComPushNotificationsBenefitsViewModel {
             if case .incompatible(let currentVersion, _) = result {
                 variant = .pluginUpdate(currentVersion: currentVersion)
             } else {
-                // TODO: add error handling for unexpected case
-                variant = .connect
+                error = .noMissingRequirements
             }
         } catch {
             DDLogError("⛔️ Plugin version check failed: \(error)")
-            // TODO: add error handling for unexpected case
-            variant = .connect
+            self.error = .generic(underlyingError: error)
+        }
+    }
+}
+
+extension WPComPushNotificationsBenefitsViewModel {
+    enum VariantCheckError: Error {
+        case noPermission
+        case noMissingRequirements
+        case generic(underlyingError: Error)
+
+        var message: String {
+            switch self {
+            case .noPermission:
+                Localization.noPermission
+            case .noMissingRequirements, .generic:
+                Localization.generic
+            }
+        }
+
+        enum Localization {
+            static let noPermission = NSLocalizedString(
+                "wpcomPushNotificationsBenefitsViewModel.variantCheckError.noPermission",
+                value: "Your account does not have permission to complete push notifications setup. " +
+                "Please ask your store administrator to handle this.",
+                comment: "Error message in the Push Notifications Benefits View for users without admin role"
+            )
+            static let generic = NSLocalizedString(
+                "wpcomPushNotificationsBenefitsViewModel.variantCheckError.generic",
+                value: "We could not complete the push notifications setup. " +
+                "Please contact support for assistance.",
+                comment: "Generic rror message in the Push Notifications Benefits View"
+            )
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/WPComPushNotificationsBenefitsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/WPComPushNotificationsBenefitsViewModelTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Yosemite
+import enum Networking.NetworkError
 @testable import WooCommerce
 
 @MainActor
@@ -25,6 +26,46 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
 
     // MARK: - determineSetupVariant with Jetpack connected
 
+    func test_error_is_nil_initially() {
+        // Given / When
+        let viewModel = makeViewModel()
+
+        // Then
+        XCTAssertNil(viewModel.error)
+    }
+
+    func test_error_is_nil_when_jetpack_connected_and_plugin_update_needed() async {
+        // Given
+        let connectionService = MockJetpackConnectionService()
+        connectionService.fetchConnectionDataResult = .success(
+            JetpackConnectionData.fake().copy(isRegistered: true)
+        )
+        let checker = MockPluginVersionChecker()
+        checker.result = .success(.incompatible(currentVersion: "10.0.0", requiredVersion: "10.5.3"))
+        let viewModel = makeViewModel(jetpackConnectionService: connectionService, pluginVersionChecker: checker)
+
+        // When
+        await viewModel.determineSetupVariant()
+
+        // Then
+        XCTAssertNil(viewModel.error)
+    }
+
+    func test_error_is_nil_when_jetpack_not_connected() async {
+        // Given
+        let connectionService = MockJetpackConnectionService()
+        connectionService.fetchConnectionDataResult = .success(
+            JetpackConnectionData.fake().copy(isRegistered: false)
+        )
+        let viewModel = makeViewModel(jetpackConnectionService: connectionService)
+
+        // When
+        await viewModel.determineSetupVariant()
+
+        // Then
+        XCTAssertNil(viewModel.error)
+    }
+
     func test_variant_is_pluginUpdate_when_jetpack_connected_and_plugin_incompatible() async {
         // Given
         let connectionService = MockJetpackConnectionService()
@@ -43,7 +84,7 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isCheckingPlugin)
     }
 
-    func test_variant_is_connect_when_jetpack_connected_and_plugin_compatible() async {
+    func test_error_is_noMissingRequirements_when_jetpack_connected_and_plugin_compatible() async {
         // Given
         let connectionService = MockJetpackConnectionService()
         connectionService.fetchConnectionDataResult = .success(
@@ -57,11 +98,13 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
         await viewModel.determineSetupVariant()
 
         // Then
-        XCTAssertEqual(viewModel.variant, .connect)
+        guard case .noMissingRequirements = viewModel.error else {
+            return XCTFail("Expected noMissingRequirements error, got \(String(describing: viewModel.error))")
+        }
         XCTAssertFalse(viewModel.isCheckingPlugin)
     }
 
-    func test_variant_is_connect_when_jetpack_connected_and_plugin_check_throws() async {
+    func test_error_is_generic_when_jetpack_connected_and_plugin_check_throws() async {
         // Given
         let connectionService = MockJetpackConnectionService()
         connectionService.fetchConnectionDataResult = .success(
@@ -75,7 +118,9 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
         await viewModel.determineSetupVariant()
 
         // Then
-        XCTAssertEqual(viewModel.variant, .connect)
+        guard case .generic = viewModel.error else {
+            return XCTFail("Expected generic error, got \(String(describing: viewModel.error))")
+        }
         XCTAssertFalse(viewModel.isCheckingPlugin)
     }
 
@@ -101,7 +146,23 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
 
     // MARK: - determineSetupVariant when fetch fails
 
-    func test_variant_is_connect_when_fetching_connection_data_throws() async {
+    func test_error_is_noPermission_when_fetching_connection_data_throws_403() async {
+        // Given
+        let connectionService = MockJetpackConnectionService()
+        connectionService.fetchConnectionDataResult = .failure(NetworkError.unacceptableStatusCode(statusCode: 403, response: nil))
+        let viewModel = makeViewModel(jetpackConnectionService: connectionService)
+
+        // When
+        await viewModel.determineSetupVariant()
+
+        // Then
+        guard case .noPermission = viewModel.error else {
+            return XCTFail("Expected noPermission error, got \(String(describing: viewModel.error))")
+        }
+        XCTAssertFalse(viewModel.isCheckingPlugin)
+    }
+
+    func test_error_is_generic_when_fetching_connection_data_throws_non_403_error() async {
         // Given
         let connectionService = MockJetpackConnectionService()
         connectionService.fetchConnectionDataResult = .failure(NSError(domain: "test", code: 1))
@@ -111,7 +172,9 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
         await viewModel.determineSetupVariant()
 
         // Then
-        XCTAssertEqual(viewModel.variant, .connect)
+        guard case .generic = viewModel.error else {
+            return XCTFail("Expected generic error, got \(String(describing: viewModel.error))")
+        }
         XCTAssertFalse(viewModel.isCheckingPlugin)
     }
 
@@ -125,6 +188,7 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
     ) -> WPComPushNotificationsBenefitsViewModel {
         WPComPushNotificationsBenefitsViewModel(
             siteID: sampleSiteID,
+            siteURL: "https://example.com",
             jetpackConnectionService: jetpackConnectionService,
             pluginVersionChecker: pluginVersionChecker,
             onDismiss: {}


### PR DESCRIPTION
## Description
Adds proper error handling to the WPCom push notifications intro modal, replacing silent fallbacks with user-facing error states and actionable recovery options.

- Introduces a `VariantCheckError` enum to replace the fallback to the `.connect` variant for error cases.
- Renders an error state view (icon + title + message) when an error is present, and swaps the footer action button for a "Contact support" button that opens the support form sheet.
- Updates the subtitle localized string key and value to say "WordPress.com" instead of "your WordPress.com account" to imply that only site connection is required.
- Adds TOS text in the footer when user needs to connect site to WP.Com

## Test Steps
1. Trigger the push notifications intro modal on a store where your account does not have admin permissions → verify the permission error state appears with the appropriate message and a "Contact support" button.
2. Simulate a generic network error during plugin check → verify the generic error message and "Contact support" button appear.
3. Tap "Contact support" → verify the support form sheet opens and can be dismissed.
4. Happy path: verify the normal connect / update-plugin flow still works correctly.

## Screenshots
Missing permission | Generic error | No error | Setup steps
--- | --- | --- | ---
<img alt="Simulator Screenshot - iPhone 17 - 2026-02-23 at 18 27 57" src="https://github.com/user-attachments/assets/18c2b4ce-e5f0-4a15-965e-b954d335d908" /> | <img alt="Simulator Screenshot - iPhone 17 - 2026-02-23 at 18 28 21" src="https://github.com/user-attachments/assets/fff4bcb5-3ed3-4e18-848d-0f3ba3db3f44" /> | <img alt="Simulator Screenshot - iPhone 17 - 2026-02-23 at 18 50 49" src="https://github.com/user-attachments/assets/c55425ee-e718-456e-904a-70392cfed0b8" /> | <img  alt="Simulator Screenshot - iPhone 17 - 2026-02-23 at 18 50 56" src="https://github.com/user-attachments/assets/d9221c74-faed-4787-b2ca-166539e92abe" />



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.