### PR TITLE
Remove dead availability guards for iOS <= 16

### DIFF
--- a/Modules/Sources/WooFoundation/Colors/Color+RGBStringDecoding.swift
+++ b/Modules/Sources/WooFoundation/Colors/Color+RGBStringDecoding.swift
@@ -6,45 +6,10 @@ extension Color {
     private typealias RGBComponents = (red: Double, green: Double, blue: Double, opacity: Double)
 
     public init(rgbString: String) throws {
-        let components: RGBComponents
-        if #available(iOS 16.0, *) {
-            components = try Color.colorComponents(from: rgbString)
-        } else {
-            components = try Color.legacyColorComponents(from: rgbString)
-        }
+        let components = try Color.colorComponents(from: rgbString)
         self = Color(red: components.red, green: components.green, blue: components.blue, opacity: components.opacity)
     }
 
-    @available(iOS 15.0, *)
-    private static func legacyColorComponents(from rgbString: String) throws -> RGBComponents {
-        let pattern = #"rgba\((\d+),\s*(\d+),\s*(\d+),\s*(\d+(\.\d+)?)\)"#
-        let regex = try NSRegularExpression(pattern: pattern, options: [])
-
-        guard let match = regex.firstMatch(in: rgbString, options: [], range: NSRange(location: 0, length: rgbString.count)) else {
-            throw ColorDecodingError.invalidRGBStringProvided
-        }
-
-        let redRange = match.range(at: 1)
-        let greenRange = match.range(at: 2)
-        let blueRange = match.range(at: 3)
-        let alphaRange = match.range(at: 4)
-
-        let redString = (rgbString as NSString).substring(with: redRange)
-        let greenString = (rgbString as NSString).substring(with: greenRange)
-        let blueString = (rgbString as NSString).substring(with: blueRange)
-        let alphaString = (rgbString as NSString).substring(with: alphaRange)
-
-        guard let red = Double(redString),
-              let green = Double(greenString),
-              let blue = Double(blueString),
-              let alpha = Double(alphaString) else {
-            throw ColorDecodingError.invalidRGBStringProvided
-        }
-
-        return (red/255.0, green/255.0, blue/255.0, alpha)
-    }
-
-    @available(iOS 16.0, *)
     private static func colorComponents(from rgbString: String) throws -> RGBComponents {
         let componentMatcher: Regex<(Substring, Int, Int, Int, Double)> = Regex {
             "rgba("

--- a/WooCommerce/Classes/App Intents/CollectPaymentAppIntent.swift
+++ b/WooCommerce/Classes/App Intents/CollectPaymentAppIntent.swift
@@ -2,7 +2,6 @@ import AppIntents
 import Foundation
 
 
-@available(iOS 16, *)
 struct CollectPaymentAppIntent: AppIntent {
     // looks up in our Localizable.string to localize
     static var title: LocalizedStringResource = "Collect payment"
@@ -17,7 +16,6 @@ struct CollectPaymentAppIntent: AppIntent {
     }
 }
 
-@available(iOS 16, *)
 extension CollectPaymentAppIntent {
     enum Localization {
         // Here to be added to Localizable.strings so it can be looked up by the `LocalizedStringResource` above

--- a/WooCommerce/Classes/App Intents/CreateOrderAppIntent.swift
+++ b/WooCommerce/Classes/App Intents/CreateOrderAppIntent.swift
@@ -2,7 +2,6 @@ import AppIntents
 import Foundation
 
 
-@available(iOS 16, *)
 struct CreateOrderAppIntent: AppIntent {
     // looks up in our Localizable.string to localize
     static var title: LocalizedStringResource = "Create order"
@@ -17,7 +16,6 @@ struct CreateOrderAppIntent: AppIntent {
     }
 }
 
-@available(iOS 16, *)
 extension CreateOrderAppIntent {
     enum Localization {
         // Here to be added to Localizable.strings so it can be looked up by the `LocalizedStringResource` above

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -102,11 +102,7 @@ private extension LoginPrologueView {
 
 private extension View {
     func scrollBounceBasedOnSize() -> some View {
-        if #available(iOS 16.4, *) {
-            return self.scrollBounceBehavior(.basedOnSize)
-        } else {
-            return self
-        }
+        return self.scrollBounceBehavior(.basedOnSize)
     }
 }
 

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPCom2FALoginView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPCom2FALoginView.swift
@@ -96,7 +96,7 @@ struct WPCom2FALoginView: View {
                     }
                 })
 
-                if #available(iOS 16, *), viewModel.shouldEnableSecurityKeyOption {
+                if viewModel.shouldEnableSecurityKeyOption {
                     // Security key button
                     Button {
                         viewModel.loginWithSecurityKey()

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPCom2FALoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPCom2FALoginViewModel.swift
@@ -55,7 +55,6 @@ final class WPCom2FALoginViewModel: NSObject, ObservableObject {
         loginFacade.delegate = self
     }
 
-    @available(iOS 16, *)
     func loginWithSecurityKey() {
         guard let twoStepNonce = loginFields.nonceInfo?.nonceWebauthn else {
             return handleError(.webAuthNonceNotFound)
@@ -129,8 +128,7 @@ extension WPCom2FALoginViewModel: ASAuthorizationControllerDelegate, ASAuthoriza
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
 
         // Validate necessary data
-        guard #available(iOS 16, *),
-              let credential = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion,
+        guard let credential = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion,
               let challengeInfo = loginFields.webauthnChallengeInfo,
               let clientDataJson = extractClientData(from: credential, challengeInfo: challengeInfo) else {
             return handleError(.webAuthChallengeRequestFailed)
@@ -151,7 +149,6 @@ extension WPCom2FALoginViewModel: ASAuthorizationControllerDelegate, ASAuthoriza
     }
 
     // Some password managers(like 1P) don't deliver `rawClientDataJSON`. In those cases we need to assemble it manually.
-    @available(iOS 16, *)
     func extractClientData(from credential: ASAuthorizationPlatformPublicKeyCredentialAssertion, challengeInfo: WebauthnChallengeInfo) -> Data? {
 
         if credential.rawClientDataJSON.count > 0 {
@@ -176,7 +173,6 @@ extension WPCom2FALoginViewModel: ASAuthorizationControllerDelegate, ASAuthoriza
 // MARK: - Helpers
 //
 private extension WPCom2FALoginViewModel {
-    @available(iOS 16, *)
     func signChallenge(_ challengeInfo: WebauthnChallengeInfo) {
 
         loginFields.nonceInfo?.updateNonce(with: challengeInfo.twoStepNonce)

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -438,11 +438,7 @@ extension UIImage {
     /// Subscription Product
     ///
     static var variableSubscriptionProductImage: UIImage {
-        if #available(iOS 16.0, *) {
-            return UIImage(systemName: "square.3.layers.3d")!
-        } else {
-            return UIImage(systemName: "square.stack.3d.up")!
-        }
+        return UIImage(systemName: "square.3.layers.3d")!
     }
 
     /// Fixed cart discount icon

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeIntro/BlazeCreateCampaignIntroView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeIntro/BlazeCreateCampaignIntroView.swift
@@ -103,13 +103,9 @@ struct BlazeCreateCampaignIntroView: View {
                 .background(Color(UIColor.systemBackground))
             }
             .sheet(isPresented: $viewModel.showLearnHowSheet) {
-                if #available(iOS 16, *) {
-                    BlazeLearnHowView(isPresented: $viewModel.showLearnHowSheet)
-                        .presentationDetents([.medium, .large])
-                        .presentationDragIndicator(.hidden)
-                } else {
-                    BlazeLearnHowView(isPresented: $viewModel.showLearnHowSheet)
-                }
+                BlazeLearnHowView(isPresented: $viewModel.showLearnHowSheet)
+                    .presentationDetents([.medium, .large])
+                    .presentationDragIndicator(.hidden)
             }
         }
         .onAppear() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsPayoutsCurrencyOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsPayoutsCurrencyOverviewView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import Yosemite
 
-@available(iOS 16.0, *)
 struct WooPaymentsPayoutsCurrencyOverviewView: View {
     @ObservedObject var viewModel: WooPaymentsPayoutsCurrencyOverviewViewModel
 
@@ -138,7 +137,6 @@ private extension WooPaymentsPayoutsBadge {
     }
 }
 
-@available(iOS 16.0, *)
 private extension WooPaymentsPayoutsCurrencyOverviewView {
     enum Layout {
         static let padding: CGFloat = 8.0
@@ -146,7 +144,6 @@ private extension WooPaymentsPayoutsCurrencyOverviewView {
     }
 }
 
-@available(iOS 16.0, *)
 private extension WooPaymentsPayoutsCurrencyOverviewView {
     enum Localization {
         static let availableFunds = NSLocalizedString(
@@ -178,7 +175,6 @@ private extension WooPaymentsPayoutsCurrencyOverviewView {
     }
 }
 
-@available(iOS 16.0, *)
 struct WooPaymentsPayoutsCurrencyOverviewView_Previews: PreviewProvider {
     static var previews: some View {
         let overviewData = WooPaymentsPayoutsOverviewByCurrency(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsPayoutsOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsPayoutsOverviewView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import Yosemite
 
-@available(iOS 16.0, *)
 struct WooPaymentsPayoutsOverviewView: View {
     @ObservedObject var viewModel: WooPaymentsPayoutsOverviewViewModel
 
@@ -29,7 +28,6 @@ struct WooPaymentsPayoutsOverviewView: View {
     }
 }
 
-@available(iOS 16.0, *)
 struct WooPaymentsPayoutsOverviewView_Previews: PreviewProvider {
     static var previews: some View {
         let overviewData = WooPaymentsPayoutsOverviewByCurrency(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -190,8 +190,7 @@ struct InPersonPaymentsMenu: View {
 
     @ViewBuilder
     var payoutSummary: some View {
-        if #available(iOS 16.0, *),
-           viewModel.shouldShowPayoutSummary {
+        if viewModel.shouldShowPayoutSummary {
             if viewModel.isLoadingPayoutSummary {
                 WooPaymentsPayoutsOverviewView(viewModel: payoutSummaryLoadingViewModel)
                     .redacted(reason: .placeholder)
@@ -201,8 +200,6 @@ struct InPersonPaymentsMenu: View {
             } else if let payoutViewModel = viewModel.payoutViewModel {
                 WooPaymentsPayoutsOverviewView(viewModel: payoutViewModel)
             }
-        } else {
-            EmptyView()
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/AddOrderComponentsSection/AddOrderComponentsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/AddOrderComponentsSection/AddOrderComponentsSection.swift
@@ -84,9 +84,7 @@ private extension AddOrderComponentsSection {
         .accessibilityIdentifier("add-coupon-button")
         .tooltip(isPresented: $shouldShowCouponsInfoTooltip,
                  toolTipTitle: Localization.couponsTooltipTitle,
-                 toolTipDescription: Localization.couponsTooltipDescription,
-                 offset: CGSize(width: 0, height: (Constants.rowMinHeight * scale) + Constants.sectionPadding),
-                 safeAreaInsets: EdgeInsets())
+                 toolTipDescription: Localization.couponsTooltipDescription)
         .sheet(isPresented: $shouldShowAddCouponLineDetails) {
             NavigationView {
                 CouponListView(siteID: viewModel.siteID,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -349,13 +349,9 @@ struct OrderForm: View {
                                                        storeSelectedTaxRate: viewModel.shouldStoreTaxRateInSelectorByDefault)
                             }
                             .sheet(isPresented: $shouldShowStoredTaxRateSheet) {
-                                if #available(iOS 16.0, *) {
-                                    storedTaxRateBottomSheetContent
-                                        .presentationDetents([.medium])
-                                        .presentationDragIndicator(.visible)
-                                } else {
-                                    storedTaxRateBottomSheetContent
-                                }
+                                storedTaxRateBottomSheetContent
+                                    .presentationDetents([.medium])
+                                    .presentationDragIndicator(.visible)
                             }
 
                             Spacer(minLength: Layout.sectionSpacing)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -557,19 +557,8 @@ private extension OrderListViewController {
         }
     }
 
-    /// Focus code crashes on iPadOS 16 and 16.1 versions
-    /// peaMlT-Ng-p2
-    /// https://github.com/woocommerce/woocommerce-ios/issues/13485
     private func supportsFocus() -> Bool {
-        guard UIDevice.current.userInterfaceIdiom == .pad else {
-            return true
-        }
-
-        if #available(iOS 16.2, *) {
-            return true
-        } else {
-            return false
-        }
+        return true
     }
 
     /// Checks to see if there is a selected order ID, and selects its order.

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsHostingController.swift
@@ -49,15 +49,8 @@ struct HostedPaymentMethodsView: View {
     var viewModel: PaymentMethodsViewModel
 
     var body: some View {
-        if #available(iOS 16.0, *) {
-            NavigationStack {
-                paymentMethodsView
-            }
-        } else {
-            NavigationView {
-                paymentMethodsView
-            }
-            .navigationViewStyle(.stack)
+        NavigationStack {
+            paymentMethodsView
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
@@ -171,15 +171,9 @@ struct ProductDescriptionGenerationView: View {
         .notice($copyTextNotice, autoDismiss: true)
     }
 
-    @ViewBuilder
     private var nameTextField: some View {
-        if #available(iOS 16.0, *) {
-            TextField(Localization.productNamePlaceholder, text: $viewModel.name, axis: .vertical)
-                .bodyStyle()
-        } else {
-            TextField(Localization.productNamePlaceholder, text: $viewModel.name)
-                .bodyStyle()
-        }
+        TextField(Localization.productNamePlaceholder, text: $viewModel.name, axis: .vertical)
+            .bodyStyle()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/ImageTextScanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/ImageTextScanner.swift
@@ -32,10 +32,8 @@ final class ImageTextScanner: ImageTextScannerProtocol {
                 continuation.resume(returning: scannedTexts)
             }
 
-            if #available(iOS 16.0, *) {
-                request.revision = VNRecognizeTextRequestRevision3
-                request.automaticallyDetectsLanguage = true
-            }
+            request.revision = VNRecognizeTextRequestRevision3
+            request.automaticallyDetectsLanguage = true
 
             do {
                 // Performs the text-recognition request.

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SelfSizingHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SelfSizingHostingController.swift
@@ -5,9 +5,7 @@ import SwiftUI
 class SelfSizingHostingController<Content: View>: UIHostingController<Content> {
     override init(rootView: Content) {
         super.init(rootView: rootView)
-        if #available(iOS 16.0, *) {
-            sizingOptions =  [.intrinsicContentSize]
-        }
+        sizingOptions = [.intrinsicContentSize]
     }
 
     @available(*, unavailable)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RefreshablePlainList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RefreshablePlainList.swift
@@ -1,9 +1,6 @@
 import SwiftUI
 
-/// This view simulates pull-to-refresh support on ScrollView before iOS 16.
-///
-/// On iOS 16+ it uses ScrollView.
-/// On iOS 15 it falls back to List with modifiers removing all its default rows styling.
+/// A refreshable ScrollView wrapper.
 ///
 struct RefreshablePlainList<Content: View>: View {
     let action: () async -> Void
@@ -15,24 +12,11 @@ struct RefreshablePlainList<Content: View>: View {
     }
 
     var body: some View {
-        if #available(iOS 16, *) {
-            ScrollView {
-                content
-            }
-            .refreshable {
-                await action()
-            }
-        } else {
-            List {
-                content
-                    .listRowSeparatorTint(.clear)
-                    .listRowBackground(Color.clear)
-                    .listRowInsets(EdgeInsets.zero)
-            }
-            .listStyle(.plain)
-            .refreshable {
-                await action()
-            }
+        ScrollView {
+            content
+        }
+        .refreshable {
+            await action()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ShareSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ShareSheet.swift
@@ -36,12 +36,8 @@ private struct ShareSheetView: UIViewControllerRepresentable {
 extension View {
     func shareSheet(isPresented: Binding<Bool>, content: @escaping () -> ShareSheet) -> some View {
         sheet(isPresented: isPresented) {
-            if #available(iOS 16.0, *) {
-                ShareSheetView(shareSheet: content())
-                    .presentationDetents([.medium, .large])
-            } else {
-                ShareSheetView(shareSheet: content())
-            }
+            ShareSheetView(shareSheet: content())
+                .presentationDetents([.medium, .large])
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TooltipView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TooltipView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Modifier to display a tooltip as a popover or overlay, depending on the available support.
+/// Modifier to display a tooltip as a popover.
 ///
 struct TooltipView: ViewModifier {
     /// Indicates if the tooltip should be shown or not.
@@ -9,27 +9,13 @@ struct TooltipView: ViewModifier {
 
     let toolTipTitle: String
     let toolTipDescription: String
-    let offset: CGSize?
-    let safeAreaInsets: EdgeInsets
 
     func body(content: Content) -> some View {
-        if #available(iOS 16.4, *) {
-            content
-                .popover(isPresented: $isPresented, attachmentAnchor: .point(.trailing)) {
-                    TooltipPopover(toolTipTitle: toolTipTitle, toolTipDescription: toolTipDescription)
-                        .padding()
-                }
-        } else {
-            content
-                .overlay {
-                    TooltipOverlay(toolTipTitle: toolTipTitle,
-                                   toolTipDescription: toolTipDescription,
-                                   offset: offset,
-                                   safeAreaInsets: safeAreaInsets)
+        content
+            .popover(isPresented: $isPresented, attachmentAnchor: .point(.trailing)) {
+                TooltipPopover(toolTipTitle: toolTipTitle, toolTipDescription: toolTipDescription)
                     .padding()
-                    .renderedIf(isPresented)
-                }
-        }
+            }
     }
 }
 
@@ -37,19 +23,14 @@ extension View {
     /// Displays a tooltip when `isPresented` is `true`.
     func tooltip(isPresented: Binding<Bool>,
                  toolTipTitle: String,
-                 toolTipDescription: String,
-                 offset: CGSize? = nil,
-                 safeAreaInsets: EdgeInsets = .zero) -> some View {
+                 toolTipDescription: String) -> some View {
         self.modifier(TooltipView(isPresented: isPresented,
                                   toolTipTitle: toolTipTitle,
-                                  toolTipDescription: toolTipDescription,
-                                  offset: offset,
-                                  safeAreaInsets: safeAreaInsets))
+                                  toolTipDescription: toolTipDescription))
     }
 }
 
 /// Tooltip view that can be displayed as a popover
-@available(iOS 16.4, *)
 private struct TooltipPopover: View {
     let toolTipTitle: String
     let toolTipDescription: String
@@ -70,70 +51,5 @@ private struct TooltipPopover: View {
         .padding()
         .presentationBackground(Color(.systemGray5.color(for: UITraitCollection(userInterfaceStyle: .dark))))
         .presentationCompactAdaptation(.popover)
-    }
-}
-
-/// Tooltip view that can be used as an overlay.
-/// Can be used in iOS <16.4 for tooltips.
-private struct TooltipOverlay: View {
-
-    private let toolTipTitle: String
-    private let toolTipDescription: String
-    private var offset: CGSize? = nil
-    private let safeAreaInsets: EdgeInsets
-
-    init(toolTipTitle: String, toolTipDescription: String, offset: CGSize?, safeAreaInsets: EdgeInsets = .zero) {
-        self.toolTipTitle = toolTipTitle
-        self.toolTipDescription = toolTipDescription
-        self.offset = offset
-        self.safeAreaInsets = safeAreaInsets
-    }
-
-    var body: some View {
-        ZStack(alignment: .topTrailing) {
-            RoundedRectangle(cornerRadius: Layout.frameCornerRadius )
-                .fill(Color.black)
-
-            TooltipPointerView()
-                .fill(Color.black)
-                .frame(width: Layout.tooltipPointerSize, height: Layout.tooltipPointerSize)
-                .offset(x: Layout.tooltipPointerOffset, y: Layout.tooltipPointerOffset)
-
-            VStack(alignment: .leading) {
-                Text(toolTipTitle)
-                    .font(.body)
-                    .foregroundColor(.white)
-                    .fontWeight(.bold)
-                Text(toolTipDescription)
-                    .font(.body)
-                    .multilineTextAlignment(.leading)
-                    .lineLimit(nil)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .foregroundColor(.gray)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .padding()
-        }
-        .shadow(color: Color.secondary, radius: Layout.toolTipShadowCornerRadius)
-        .offset(offset ?? CGSize(width: 0, height: 0))
-        .padding(insets: safeAreaInsets)
-    }
-
-    private struct TooltipPointerView: Shape {
-        func path(in rect: CGRect) -> Path {
-            var path = Path()
-            path.move(to: CGPoint(x: rect.midX, y: rect.minY))
-            path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
-            path.addLine(to: CGPoint(x: rect.maxY, y: rect.maxY))
-            path.closeSubpath()
-            return path
-        }
-    }
-
-    private enum Layout {
-        static let frameCornerRadius: CGFloat = 4
-        static let toolTipShadowCornerRadius: CGFloat = 26
-        static let tooltipPointerSize: CGFloat = 20
-        static let tooltipPointerOffset: CGFloat = -10
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemesPreviewView.swift
@@ -146,12 +146,8 @@ struct ThemesPreviewView: View {
         }
         .task { await viewModel.fetchPages() }
         .sheet(isPresented: $showPagesMenu) {
-            if #available(iOS 16, *) {
-                pagesListSheet
-                    .presentationDetents([.medium, .large])
-            } else {
-                pagesListSheet
-            }
+            pagesListSheet
+                .presentationDetents([.medium, .large])
         }
         .notice($viewModel.notice)
         .onAppear {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -243,11 +243,7 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         viewModel.selectedIntervalIndex = 0
 
         // Then
-        if #available(iOS 16.0, *) {
             XCTAssertEqual(timeRangeBarViewModels.map { $0.timeRangeText }, ["Monday, Jan 3", "Monday, Jan 3 at 1:00 AM"])
-        } else {
-            XCTAssertEqual(timeRangeBarViewModels.map { $0.timeRangeText }, ["Monday, Jan 3", "Monday, Jan 3, 1:00 AM"])
-        }
     }
 
     func test_timeRangeBarViewModel_for_thisWeek_is_emitted_twice_after_order_and_visitor_stats_updated_and_selecting_interval() {


### PR DESCRIPTION
## Description

The minimum deployment target is iOS 17.0. All `#available` and `@available` checks for iOS 16.4 and below are always true and constitute dead code.

This removes ~30 such guards:
- Removed `@available(iOS 16, *)` attributes from App Intents, Payouts views, 2FA security key flow
- Simplified `if #available` / `else` blocks by keeping only the modern code path (NavigationStack, presentationDetents, TextField axis, RegexBuilder, etc.)
- Deleted the entire `TooltipOverlay` fallback struct and its unused `offset`/`safeAreaInsets` parameters
- Deleted the legacy `NSRegularExpression`-based color parser in `Color+RGBStringDecoding.swift`
- Deleted the `List`-based fallback in `RefreshablePlainList`

## Test Steps

1. CI builds
3. Verify tooltips still appear on order creation screens (popover style)
    1. Go to Orders tab → tap + to create a new order
    2. Add a product that has a price (e.g. a simple product)
    3. Add a discount to the product
    4. Scroll down to the Coupons section and tap the info icon next to “Add Coupon”
    5.  verify the popover tooltip appears correctly
4. Verify pull-to-refresh works on analytics hub
    1. Go to My Store tab (Dashboard)
    2. Tap the analytics bar/card to open the Analytics Hub screen
    3. Pull down on the list → verify the refresh indicator appears and data reloads
    4. While refreshing, verify the list scrolls smoothly and the spinner dismisses after data loads

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.