### PR TITLE
POS Bookings: Update date bar to match design

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDateBarView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDateBarView.swift
@@ -3,12 +3,7 @@ import SwiftUI
 struct POSBookingDateBarView: View {
     @Environment(POSBookingsModel.self) private var bookingsModel
     @Environment(\.siteTimezone) private var siteTimezone
-    @Environment(\.colorScheme) private var colorScheme
     @State private var showingCalendar = false
-
-    private var tintColor: Color {
-        colorScheme == .dark ? .posSecondary : .posPrimaryContainer
-    }
 
     private var formattedDate: String {
         let formatter = DateFormatter()
@@ -19,34 +14,22 @@ struct POSBookingDateBarView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Divider()
-                .overlay(Color.posOutlineVariant)
-
-            HStack(spacing: POSSpacing.medium) {
+            HStack(spacing: POSSpacing.small) {
                 Button {
                     Task { await bookingsModel.bookingsController.goToPreviousDay() }
                 } label: {
-                    Image(systemName: "chevron.left")
-                        .font(.posButtonSymbolXSmall)
-                        .foregroundStyle(tintColor)
+                    Text("\(Image(systemName: "chevron.backward"))")
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(POSSurfaceButtonStyle(size: .extraSmall))
                 .accessibilityLabel(Localization.previousDay)
 
                 Button {
                     showingCalendar = true
                 } label: {
-                    HStack(spacing: POSSpacing.small) {
-                        Image(systemName: "calendar")
-                            .foregroundStyle(tintColor)
-
-                        Text(formattedDate)
-                            .font(.posBodySmallRegular())
-                            .foregroundStyle(tintColor)
-                    }
+                    Label(formattedDate, systemImage: "calendar")
+                        .frame(maxWidth: .infinity)
                 }
-                .buttonStyle(.plain)
-                .frame(minWidth: Constants.dateTextMinWidth, alignment: .center)
+                .buttonStyle(POSSurfaceButtonStyle(size: .extraSmall))
                 .accessibilityLabel(String(format: Localization.selectedDateFormat, formattedDate))
                 .popover(isPresented: $showingCalendar) {
                     POSBookingCalendarView(
@@ -62,27 +45,20 @@ struct POSBookingDateBarView: View {
                 Button {
                     Task { await bookingsModel.bookingsController.goToNextDay() }
                 } label: {
-                    Image(systemName: "chevron.right")
-                        .font(.posButtonSymbolXSmall)
-                        .foregroundStyle(tintColor)
+                    Text("\(Image(systemName: "chevron.forward"))")
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(POSSurfaceButtonStyle(size: .extraSmall))
                 .accessibilityLabel(Localization.nextDay)
-
-                Spacer()
             }
+            .font(.posBodySmallBold())
             .dynamicTypeSize(...DynamicTypeSize.accessibility1)
             .padding(.horizontal, POSPadding.medium)
-            .frame(minHeight: Constants.minBarHeight)
+            .padding(.bottom, POSPadding.medium)
+
             Divider()
                 .overlay(Color.posOutlineVariant)
         }
     }
-}
-
-private enum Constants {
-    static let minBarHeight: CGFloat = 64
-    static let dateTextMinWidth: CGFloat = 120
 }
 
 private enum Localization {
@@ -100,7 +76,7 @@ private enum Localization {
 
     static let selectedDateFormat = NSLocalizedString(
         "pos.bookingDateBar.selectedDate",
-        value: "%@, tap to open calendar",
-        comment: "Accessibility label for the date button in the bookings date bar. %@ is the formatted date."
+        value: "%1$@, tap to open calendar",
+        comment: "Accessibility label for the date button in the bookings date bar. %1$@ is the formatted date."
     )
 }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDateBarView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDateBarView.swift
@@ -20,7 +20,7 @@ struct POSBookingDateBarView: View {
                 } label: {
                     Text("\(Image(systemName: "chevron.backward"))")
                 }
-                .buttonStyle(POSSurfaceButtonStyle(size: .extraSmall))
+                .buttonStyle(POSTonalButtonStyle(size: .extraSmall))
                 .accessibilityLabel(Localization.previousDay)
 
                 Button {
@@ -29,7 +29,7 @@ struct POSBookingDateBarView: View {
                     Label(formattedDate, systemImage: "calendar")
                         .frame(maxWidth: .infinity)
                 }
-                .buttonStyle(POSSurfaceButtonStyle(size: .extraSmall))
+                .buttonStyle(POSTonalButtonStyle(size: .extraSmall))
                 .accessibilityLabel(String(format: Localization.selectedDateFormat, formattedDate))
                 .popover(isPresented: $showingCalendar) {
                     POSBookingCalendarView(
@@ -47,7 +47,7 @@ struct POSBookingDateBarView: View {
                 } label: {
                     Text("\(Image(systemName: "chevron.forward"))")
                 }
-                .buttonStyle(POSSurfaceButtonStyle(size: .extraSmall))
+                .buttonStyle(POSTonalButtonStyle(size: .extraSmall))
                 .accessibilityLabel(Localization.nextDay)
             }
             .font(.posBodySmallBold())

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/Buttons/POSButtonStyle.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/Buttons/POSButtonStyle.swift
@@ -78,8 +78,8 @@ struct POSInfoCardButtonStyle: ButtonStyle {
 }
 
 
-/// Surface button style in POS with a subtle surface background and no border.
-struct POSSurfaceButtonStyle: ButtonStyle {
+/// Tonal button style in POS with a subtle surface background and no border.
+struct POSTonalButtonStyle: ButtonStyle {
     private let size: POSButtonSize
 
     init(size: POSButtonSize) {
@@ -87,7 +87,7 @@ struct POSSurfaceButtonStyle: ButtonStyle {
     }
 
     func makeBody(configuration: Configuration) -> some View {
-        POSButtonStyleInternal(configuration: configuration, variant: .surface, size: size, state: .idle)
+        POSButtonStyleInternal(configuration: configuration, variant: .tonal, size: size, state: .idle)
     }
 }
 
@@ -96,7 +96,7 @@ fileprivate enum POSButtonVariant {
     case filled
     case outlined
     case infoCardOutlined
-    case surface
+    case tonal
 }
 
 private struct POSButtonStyleInternal: View {
@@ -168,9 +168,9 @@ private struct POSButtonStyleInternal: View {
                 .clear
         case (.infoCardOutlined, _):
                 .posSurfaceContainerLowest
-        case (.surface, true):
+        case (.tonal, true):
                 .posSurface
-        case (.surface, false):
+        case (.tonal, false):
                 .posDisabledContainer
         }
     }
@@ -189,9 +189,9 @@ private struct POSButtonStyleInternal: View {
                 .posOnSurface
         case (.infoCardOutlined, false):
                 .posOnDisabledContainer
-        case (.surface, true):
+        case (.tonal, true):
                 .posOnSurface
-        case (.surface, false):
+        case (.tonal, false):
                 .posOnDisabledContainer
         }
     }
@@ -337,12 +337,12 @@ struct POSButtonStyle_Previews: View {
                 Button("Disabled Button") {}
                     .buttonStyle(POSInfoCardButtonStyle(size: size, variant: .default))
                     .disabled(true)
-            case .surface:
+            case .tonal:
                 Button("Enabled Button") {}
-                    .buttonStyle(POSSurfaceButtonStyle(size: size))
+                    .buttonStyle(POSTonalButtonStyle(size: size))
 
                 Button("Disabled Button") {}
-                    .buttonStyle(POSSurfaceButtonStyle(size: size))
+                    .buttonStyle(POSTonalButtonStyle(size: size))
                     .disabled(true)
             }
         }

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/Buttons/POSButtonStyle.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/Buttons/POSButtonStyle.swift
@@ -78,11 +78,25 @@ struct POSInfoCardButtonStyle: ButtonStyle {
 }
 
 
+/// Surface button style in POS with a subtle surface background and no border.
+struct POSSurfaceButtonStyle: ButtonStyle {
+    private let size: POSButtonSize
+
+    init(size: POSButtonSize) {
+        self.size = size
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        POSButtonStyleInternal(configuration: configuration, variant: .surface, size: size, state: .idle)
+    }
+}
+
 /// The visual variant of the POS button.
 fileprivate enum POSButtonVariant {
     case filled
     case outlined
     case infoCardOutlined
+    case surface
 }
 
 private struct POSButtonStyleInternal: View {
@@ -154,6 +168,10 @@ private struct POSButtonStyleInternal: View {
                 .clear
         case (.infoCardOutlined, _):
                 .posSurfaceContainerLowest
+        case (.surface, true):
+                .posSurface
+        case (.surface, false):
+                .posDisabledContainer
         }
     }
 
@@ -170,6 +188,10 @@ private struct POSButtonStyleInternal: View {
         case (.infoCardOutlined, true):
                 .posOnSurface
         case (.infoCardOutlined, false):
+                .posOnDisabledContainer
+        case (.surface, true):
+                .posOnSurface
+        case (.surface, false):
                 .posOnDisabledContainer
         }
     }
@@ -314,6 +336,13 @@ struct POSButtonStyle_Previews: View {
 
                 Button("Disabled Button") {}
                     .buttonStyle(POSInfoCardButtonStyle(size: size, variant: .default))
+                    .disabled(true)
+            case .surface:
+                Button("Enabled Button") {}
+                    .buttonStyle(POSSurfaceButtonStyle(size: size))
+
+                Button("Disabled Button") {}
+                    .buttonStyle(POSSurfaceButtonStyle(size: size))
                     .disabled(true)
             }
         }


### PR DESCRIPTION
Closes: WOOMOB-2299

## Description

Updates the POS bookings date bar to match the latest Figma design. The date navigation buttons now use a new style, and the layout is updated so the date button fills the center with chevron buttons at each edge.

**Changes:**
- Add `POSTonalButtonStyle` to the POS button style system (`posSurface` background, `posOnSurface` foreground, no border)
- Restyle date bar buttons from plain icons to styled tonal buttons with rounded backgrounds
- Center the date button between the chevron navigation buttons

## Test Steps

1. Open POS and navigate to the Bookings tab
2. Verify the date bar shows three rounded buttons: `<`, date with calendar icon, `>`
3. The date button should fill the center space, with chevrons at each edge
4. Tap `<` and `>` to navigate dates
5. Tap the date button to open the calendar popover

## Screenshots


https://github.com/user-attachments/assets/661f2115-21f3-47c5-95db-a887c4865282



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.