### PR TITLE
Media library: Allow failure decoding media details

### DIFF
--- a/Modules/Sources/Networking/Model/Media/WordPressMedia.swift
+++ b/Modules/Sources/Networking/Model/Media/WordPressMedia.swift
@@ -43,7 +43,7 @@ extension WordPressMedia: Decodable {
         let mimeType = try container.decodeIfPresent(String.self, forKey: .mimeType) ?? ""
         let src = try container.decodeIfPresent(String.self, forKey: .src) ?? ""
         let alt = try container.decodeIfPresent(String.self, forKey: .alt)
-        let details = try container.decodeIfPresent(MediaDetails.self, forKey: .details)
+        let details = try? container.decodeIfPresent(MediaDetails.self, forKey: .details)
         let title = try container.decodeIfPresent(MediaTitle.self, forKey: .title)
 
         self.init(mediaID: mediaID,

--- a/Modules/Tests/NetworkingTests/Mapper/WordPressMediaMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/WordPressMediaMapperTests.swift
@@ -25,6 +25,24 @@ final class WordPressMediaMapperTests: XCTestCase {
         XCTAssertEqual(media?.details?.sizes?["large"]?.height, 768)
     }
 
+    /// Tests that WordPressMediaList and consequently WordPressMedia is correctly mapped from a response where media_details is an array.
+    ///
+    /// - Throws: An error if the mapping fails.
+    func test_it_maps_WordPressMediaList_correctly_with_media_details_as_array() throws {
+        // Given
+        let data = try retrieveWordPressMediaResponseWithMediaDetailsAsArray()
+        let mapper = WordPressMediaListMapper()
+
+        // When
+        let mediaList = try mapper.map(response: data)
+
+        // Then
+        XCTAssertEqual(mediaList.count, 1)
+        let media = mediaList.first { $0.mediaID == 7 }
+        XCTAssertNotNil(media)
+        XCTAssertNil(media?.details)
+    }
+
     /// Tests that WordPressMediaList and consequently WordPressMedia is correctly mapped from a response where sizes is an empty array.
     ///
     /// - Throws: An error if the mapping fails.
@@ -49,6 +67,14 @@ final class WordPressMediaMapperTests: XCTestCase {
 private extension WordPressMediaMapperTests {
     func retrieveWordPressMediaResponseWithSizesAsDictionary() throws -> Data {
         guard let response = Loader.contentsOf("media-library") else {
+            throw FileNotFoundError()
+        }
+
+        return response
+    }
+
+    func retrieveWordPressMediaResponseWithMediaDetailsAsArray() throws -> Data {
+        guard let response = Loader.contentsOf("media-library-with-media-details-as-array") else {
             throw FileNotFoundError()
         }
 

--- a/Modules/Tests/NetworkingTests/Responses/media-library-with-media-details-as-array.json
+++ b/Modules/Tests/NetworkingTests/Responses/media-library-with-media-details-as-array.json
@@ -1,0 +1,14 @@
+[
+    {
+        "id": 7,
+        "date_gmt": "2025-03-01T10:00:00",
+        "slug": "malformed-media",
+        "title": {
+            "rendered": "malformed media"
+        },
+        "alt_text": "",
+        "mime_type": "image/jpeg",
+        "media_details": [],
+        "source_url": "https://example.com/wp-content/uploads/malformed-media.jpeg"
+    }
+]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 24.2
 -----
 - [*] POS: Fix barcode scanning not working after completing a payment [https://github.com/woocommerce/woocommerce-ios/pull/16672]
+- [*] Media library: Fix decoding failure when media details are returned as array [https://github.com/woocommerce/woocommerce-ios/pull/16715]
 
 
 24.1


### PR DESCRIPTION
Closes WOOMOB-2001

## Description
Some WordPress sites return `media_details` as an array (e.g. `[]`) instead of a dictionary when the media item has no details. This caused the entire media list request to fail because `WordPressMedia.init(from:)` would throw on that malformed item.

The fix wraps the `media_details` decoding in `try?` so malformed items decode with `details = nil` rather than throwing, keeping the rest of the media list intact.

Tests added:
- New fixture `media-library-with-media-details-as-array.json` with a media item whose `media_details` is an array
- New test `test_it_maps_WordPressMediaList_correctly_with_media_details_as_array` verifying the item is decoded successfully with `details == nil`

## Test Steps
- Run `WordPressMediaMapperTests` — all three tests should pass, including the new `test_it_maps_WordPressMediaList_correctly_with_media_details_as_array`.
- CI should pass.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.