### PR TITLE
POS Bookings: Address PR review feedback for date picker performance

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -85,7 +85,9 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         } else {
             fetchStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: filters)
         }
-        setLocalDataOrLoadingState()
+
+        // Show cached bookings from local storage immediately (if any), then fetch fresh data from remote.
+        showCachedBookingsOrLoadingIndicator()
         loadTask = Task { await loadFirstPage() }
         await loadTask?.value
         prefetchAdjacentDates(for: selectedDate)
@@ -179,10 +181,13 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
             fetchStrategy = bookingListFetchStrategyFactory.searchStrategy(searchTerm: searchTerm, filters: filters)
             bookingsViewState = .loading([])
         } else {
+            // Show cached bookings for the new date immediately (if previously prefetched).
             fetchStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: filters)
             let localBookings = fetchStrategy.fetchLocalBookings()
             bookingsViewState = .loading(localBookings)
         }
+
+        // Then fetch fresh data from remote.
         loadTask = Task { await loadFirstPage() }
         await loadTask?.value
         prefetchAdjacentDates(for: date)
@@ -307,19 +312,29 @@ private extension POSBookingListController {
         }
     }
 
+    /// Sets the view state before a remote fetch begins.
+    /// - If local storage has bookings for the current filters, show them immediately with a loading indicator.
+    /// - If the strategy doesn't cache data (e.g. search), show an empty loading state.
+    /// - Otherwise, keep displaying whatever bookings are already on screen while loading refreshes.
     @MainActor
-    func setLocalDataOrLoadingState() {
+    func showCachedBookingsOrLoadingIndicator() {
         let localBookings = fetchStrategy.fetchLocalBookings()
         if localBookings.isNotEmpty {
             bookingsViewState = .loading(localBookings)
-        } else if !fetchStrategy.showsLoadingWithItems {
+            return
+        }
+
+        guard fetchStrategy.showsCachedDataWhileLoading else {
             bookingsViewState = .loading([])
-        } else {
-            let bookings = bookingsViewState.bookings
-            let isInitialState = bookingsViewState.isLoading && bookings.isEmpty
-            if !isInitialState {
-                bookingsViewState = .loading(bookings)
-            }
+            return
+        }
+
+        // For the default strategy, preserve existing bookings on screen while loading.
+        // Skip if we're already in the initial empty loading state (nothing to preserve).
+        let existingBookings = bookingsViewState.bookings
+        let isInitialEmptyLoading = bookingsViewState.isLoading && existingBookings.isEmpty
+        if !isInitialEmptyLoading {
+            bookingsViewState = .loading(existingBookings)
         }
     }
 

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -35,6 +35,7 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     func clearSearchBookings()
 }
 
+@MainActor
 @Observable final class POSBookingListController: POSSearchingBookingListControllerProtocol {
     var bookingsViewState: POSBookingListState
     private(set) var selectedDate: Date
@@ -76,7 +77,6 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         prefetchAdjacentDates(for: date)
     }
 
-    @MainActor
     func loadBookings() async {
         loadTask?.cancel()
         let filters = dateFilters(for: selectedDate)
@@ -93,38 +93,42 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         prefetchAdjacentDates(for: selectedDate)
     }
 
-    @MainActor
     func refreshBookings() async {
         loadTask?.cancel()
         loadTask = Task { await loadFirstPage() }
         await loadTask?.value
     }
 
-    @MainActor
     func loadNextBookings() async {
-        guard paginationTracker.hasNextPage else {
-            return
+        // Wait for the initial page sync to finish before beginning pagination
+        if case let .loading(bookings, .firstPage) = bookingsViewState, bookings.isNotEmpty, let loadTask {
+            await loadTask.value
         }
-        let currentBookings = bookingsViewState.bookings
-        bookingsViewState = .loading(currentBookings, context: .nextPage)
-        do {
-            _ = try await paginationTracker.ensureNextPageIsSynced { [weak self] pageNumber in
-                guard let self else { return true }
-                return try await fetchBookings(pageNumber: pageNumber)
+
+        guard paginationTracker.hasNextPage,
+              case .loaded(_, let hasMoreItems) = bookingsViewState, hasMoreItems else { return }
+
+        loadTask = Task {
+            let currentBookings = bookingsViewState.bookings
+            bookingsViewState = .loading(currentBookings, context: .nextPage)
+            do {
+                _ = try await paginationTracker.ensureNextPageIsSynced { [weak self] pageNumber in
+                    guard let self else { return true }
+                    return try await fetchBookings(pageNumber: pageNumber)
+                }
+            } catch {
+                bookingsViewState = .inlineError(currentBookings,
+                                                 error: .errorOnLoadingBookingsNextPage(error: error),
+                                                 context: .pagination)
             }
-        } catch {
-            bookingsViewState = .inlineError(currentBookings,
-                                             error: .errorOnLoadingBookingsNextPage(error: error),
-                                             context: .pagination)
         }
+        await loadTask?.value
     }
 
-    @MainActor
     func selectBooking(_ booking: POSBooking?) {
         selectedBooking = booking
     }
 
-    @MainActor
     func cancelBooking(bookingID: Int64) async throws {
         let updatedStatus = try await bookingService.cancelBooking(bookingID: bookingID)
         if let existing = bookingsViewState.bookings.first(where: { $0.id == bookingID }) {
@@ -132,7 +136,6 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         }
     }
 
-    @MainActor
     func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws {
         let updatedStatus = try await bookingService.updateAttendanceStatus(bookingID: bookingID, status: status)
         if let existing = bookingsViewState.bookings.first(where: { $0.id == bookingID }) {
@@ -140,7 +143,6 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         }
     }
 
-    @MainActor
     func updateBookingNote(bookingID: Int64, note: String) async throws {
         let updatedNote = try await bookingService.updateBookingNote(bookingID: bookingID, note: note)
         if let existingNote = bookingsViewState.bookings.first(where: { $0.id == bookingID }) {
@@ -149,13 +151,11 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         }
     }
 
-    @MainActor
     func updateBooking(bookingID: Int64) async throws {
         let updatedBooking = try await bookingService.fetchBooking(bookingID: bookingID)
         updateBooking(updatedBooking)
     }
 
-    @MainActor
     func updateBookingOptimistically(bookingID: Int64, optimisticUpdate: (POSBooking) -> POSBooking) async {
         guard let existing = bookingsViewState.bookings.first(where: { $0.id == bookingID }) else {
             return
@@ -172,7 +172,6 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         }
     }
 
-    @MainActor
     func selectDate(_ date: Date) async {
         loadTask?.cancel()
         selectedDate = date
@@ -193,7 +192,6 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         prefetchAdjacentDates(for: date)
     }
 
-    @MainActor
     func goToPreviousDay() async {
         var calendar = Calendar.current
         calendar.timeZone = siteTimezone
@@ -201,7 +199,6 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         await selectDate(previousDay)
     }
 
-    @MainActor
     func goToNextDay() async {
         var calendar = Calendar.current
         calendar.timeZone = siteTimezone
@@ -209,7 +206,6 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         await selectDate(nextDay)
     }
 
-    @MainActor
     func searchBookings(searchTerm: String) async {
         loadTask?.cancel()
         activeSearchTerm = searchTerm
@@ -219,7 +215,6 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         await loadTask?.value
     }
 
-    @MainActor
     func clearSearchBookings() {
         loadTask?.cancel()
         activeSearchTerm = nil
@@ -293,7 +288,6 @@ private extension POSBookingListController {
         return calendar.startOfDay(for: Date())
     }
 
-    @MainActor
     func loadFirstPage() async {
         do {
             try await paginationTracker.resync { [weak self] pageNumber in
@@ -316,7 +310,6 @@ private extension POSBookingListController {
     /// - If local storage has bookings for the current filters, show them immediately with a loading indicator.
     /// - If the strategy doesn't cache data (e.g. search), show an empty loading state.
     /// - Otherwise, keep displaying whatever bookings are already on screen while loading refreshes.
-    @MainActor
     func showCachedBookingsOrLoadingIndicator() {
         let localBookings = fetchStrategy.fetchLocalBookings()
         if localBookings.isNotEmpty {
@@ -338,10 +331,13 @@ private extension POSBookingListController {
         }
     }
 
-    @MainActor
     func fetchBookings(pageNumber: Int, appendToExistingBookings: Bool = true) async throws -> Bool {
+        let strategyID = fetchStrategy.id
         do {
             let pagedBookings = try await fetchStrategy.fetchBookings(pageNumber: pageNumber)
+
+            // Discard results if context changed (e.g. date switched, search started)
+            guard fetchStrategy.id == strategyID else { return true }
 
             let existingBookings = appendToExistingBookings ? bookingsViewState.bookings : []
             let uniqueNewBookings = pagedBookings.items.filter { newBooking in
@@ -362,7 +358,6 @@ private extension POSBookingListController {
         }
     }
 
-    @MainActor
     func updateBooking(_ updatedBooking: POSBooking) {
         let updatedBookings = bookingsViewState.bookings.map { booking in
             booking.id == updatedBooking.id ? updatedBooking : booking

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -67,6 +67,7 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
         self.bookingListFetchStrategyFactory = bookingListFetchStrategyFactory
         self.bookingService = bookingListFetchStrategyFactory.bookingService
         self.fetchStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: nil)
+        syncBookings()
     }
 
     func syncBookings() {

--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -71,7 +71,7 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
 
     func syncBookings() {
         let date = selectedDate
-        prefetchDateIfNeeded(date)
+        prefetchDate(date)
         prefetchAdjacentDates(for: date)
     }
 
@@ -256,14 +256,14 @@ private extension POSBookingListController {
         var calendar = Calendar.current
         calendar.timeZone = siteTimezone
         if let yesterday = calendar.date(byAdding: .day, value: -1, to: date) {
-            prefetchDateIfNeeded(yesterday)
+            prefetchDate(yesterday)
         }
         if let tomorrow = calendar.date(byAdding: .day, value: 1, to: date) {
-            prefetchDateIfNeeded(tomorrow)
+            prefetchDate(tomorrow)
         }
     }
 
-    func prefetchDateIfNeeded(_ date: Date) {
+    func prefetchDate(_ date: Date) {
         var calendar = Calendar.current
         calendar.timeZone = siteTimezone
         let normalizedDate = calendar.startOfDay(for: date)

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -156,7 +156,7 @@ enum RefundActionAvailability {
     }
 
     private func setLoadingState() {
-        if !fetchStrategy.showsLoadingWithItems {
+        if !fetchStrategy.showsCachedDataWhileLoading {
             ordersViewState = .loading([])
             return
         }

--- a/Modules/Sources/PointOfSale/Models/POSBookingsModel.swift
+++ b/Modules/Sources/PointOfSale/Models/POSBookingsModel.swift
@@ -24,7 +24,6 @@ import class Yosemite.PaymentCaptureCelebration
         self.orderService = orderService
         self.receiptSender = receiptSender
         self.collectOrderPaymentAnalyticsTracker = collectOrderPaymentAnalyticsTracker
-        bookingsController.syncBookings()
     }
 
     @MainActor

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/BookingsSpec.md
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/BookingsSpec.md
@@ -334,7 +334,7 @@ All customer-related fields come from the order enrichment that already happens 
 protocol POSBookingListFetchStrategy {
     func fetchBookings(pageNumber: Int) async throws -> POSBookingPageResult
     var supportsCaching: Bool { get }
-    var showsLoadingWithItems: Bool { get }
+    var showsCachedDataWhileLoading: Bool { get }
 }
 ```
 

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingListView.swift
@@ -116,7 +116,6 @@ struct POSBookingListView: View {
             InfiniteScrollView(
                 triggerDeterminer: infiniteScrollTriggerDeterminer,
                 loadMore: {
-                    guard case .loaded(_, let hasMoreItems) = bookingsViewState, hasMoreItems else { return }
                     await bookingsModel.bookingsController.loadNextBookings()
                 },
                 content: {

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingRowView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingRowView.swift
@@ -27,7 +27,6 @@ struct POSBookingRowView: View {
             }
         }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityLabel)
         .accessibilityAddTraits(isSelected ? [.isSelected] : [])
     }
 
@@ -45,45 +44,4 @@ struct POSBookingRowView: View {
         }
     }
 
-    private var accessibilityLabel: String {
-        let formatter = DateFormatter.posAccessibilityTimeFormatter
-        formatter.timeZone = siteTimezone
-        let timeRange = Localization.timeRangeAccessibilityLabel(
-            start: formatter.string(from: booking.startDate),
-            end: formatter.string(from: booking.endDate)
-        )
-
-        let customerDisplayName = booking.customerName ?? booking.customerEmail
-
-        var parts = [timeRange, booking.serviceName, customerDisplayName].compactMap { $0 }.filter { !$0.isEmpty }
-
-        if booking.lifecycleStatus == .cancelled {
-            parts.append(booking.lifecycleStatus.localizedTitle)
-        } else {
-            parts.append(booking.attendanceDisplay.localizedTitle)
-        }
-        parts.append(booking.paymentStatus.localizedTitle)
-
-        return parts.joined(separator: ", ")
-    }
-}
-
-private enum Localization {
-    static func timeRangeAccessibilityLabel(start: String, end: String) -> String {
-        let format = NSLocalizedString(
-            "pos.bookingListView.bookingRow.accessibilityLabel.timeRange",
-            value: "%1$@ to %2$@",
-            comment: "Time range for booking row accessibility. %1$@ is start time, %2$@ is end time."
-        )
-        return String(format: format, start, end)
-    }
-}
-
-private extension DateFormatter {
-    static let posAccessibilityTimeFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .none
-        formatter.timeStyle = .short
-        return formatter
-    }()
 }

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -540,6 +540,11 @@ final class POSBookingListFetchStrategyPreview: POSBookingListFetchStrategy {
     func fetchBookings(pageNumber: Int) async throws -> PagedItems<POSBooking> {
         PagedItems(items: [], hasMorePages: false, totalItems: nil)
     }
+
+    @MainActor
+    func fetchLocalBookings() -> [POSBooking] {
+        []
+    }
 }
 
 extension POSPreviewHelpers {

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -534,7 +534,7 @@ final class POSBookingServicePreview: POSBookingServiceProtocol {
 }
 
 final class POSBookingListFetchStrategyPreview: POSBookingListFetchStrategy {
-    var showsLoadingWithItems: Bool = false
+    var showsCachedDataWhileLoading: Bool = false
     var id: String = "BookingPreview"
 
     func fetchBookings(pageNumber: Int) async throws -> PagedItems<POSBooking> {
@@ -960,7 +960,7 @@ final class POSOrderListFetchStrategyPreview: POSOrderListFetchStrategy {
 
     var supportsCaching: Bool = true
 
-    var showsLoadingWithItems: Bool = false
+    var showsCachedDataWhileLoading: Bool = false
 
     var id: String = ""
 

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
@@ -59,7 +59,9 @@ struct POSDefaultBookingListFetchStrategy: POSBookingListFetchStrategy {
                 order: .ascending,
                 cacheClearStrategy: cacheClearStrategy
             )
-            guard let filters else { return PagedItems(items: [], hasMorePages: hasMorePages, totalItems: nil) }
+            guard let filters else {
+                return PagedItems(items: [], hasMorePages: hasMorePages, totalItems: nil) 
+            }
             let bookings = await fetchLocalBookingsSync(filters: filters, limit: nil)
             return PagedItems(items: bookings, hasMorePages: hasMorePages, totalItems: nil)
         } catch AFError.explicitlyCancelled, is CancellationError {

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
@@ -16,10 +16,6 @@ extension POSBookingListFetchStrategy {
     public var id: String {
         String(describing: type(of: self))
     }
-
-    @MainActor public func fetchLocalBookings() -> [POSBooking] {
-        []
-    }
 }
 
 struct POSDefaultBookingListFetchStrategy: POSBookingListFetchStrategy {
@@ -165,5 +161,10 @@ struct POSSearchBookingListFetchStrategy: POSBookingListFetchStrategy {
             filters: filters,
             searchQuery: searchTerm
         )
+    }
+
+    @MainActor
+    func fetchLocalBookings() -> [POSBooking] {
+        []
     }
 }

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
@@ -52,9 +52,7 @@ struct POSDefaultBookingListFetchStrategy: POSBookingListFetchStrategy {
 
     func fetchBookings(pageNumber: Int) async throws -> PagedItems<POSBooking> {
         do {
-            let cacheClearStrategy: BookingStoreMethods.CacheClearStrategy = pageNumber == 1
-                ? (filters.map { .filtersOnly($0) } ?? .all)
-                : .none
+            let cacheClearStrategy = cacheClearStrategy(for: pageNumber)
             let hasMorePages = try await bookingStoreMethods.synchronizeBookings(
                 siteID: siteID,
                 pageNumber: pageNumber,
@@ -79,6 +77,18 @@ struct POSDefaultBookingListFetchStrategy: POSBookingListFetchStrategy {
 }
 
 private extension POSDefaultBookingListFetchStrategy {
+    /// On the first page, clear cached bookings matching the current filters (or all if no filters).
+    /// On subsequent pages, keep the cache intact to allow appending.
+    func cacheClearStrategy(for pageNumber: Int) -> BookingStoreMethods.CacheClearStrategy {
+        guard pageNumber == 1 else {
+            return .none
+        }
+        if let filters {
+            return .filtersOnly(filters)
+        }
+        return .all
+    }
+
     @MainActor
     func fetchLocalBookingsSync(filters: BookingFilters) -> [POSBooking] {
         let bookingPredicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: filters)

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
@@ -60,7 +60,7 @@ struct POSDefaultBookingListFetchStrategy: POSBookingListFetchStrategy {
                 cacheClearStrategy: cacheClearStrategy
             )
             guard let filters else {
-                return PagedItems(items: [], hasMorePages: hasMorePages, totalItems: nil) 
+                return PagedItems(items: [], hasMorePages: hasMorePages, totalItems: nil)
             }
             let bookings = await fetchLocalBookingsSync(filters: filters, limit: nil)
             return PagedItems(items: bookings, hasMorePages: hasMorePages, totalItems: nil)

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
@@ -64,7 +64,7 @@ struct POSDefaultBookingListFetchStrategy: POSBookingListFetchStrategy {
                 order: .ascending,
                 cacheClearStrategy: cacheClearStrategy
             )
-            let bookings = await fetchLocalBookingsFromStorage()
+            let bookings = await fetchLocalBookings()
             return PagedItems(items: bookings, hasMorePages: hasMorePages, totalItems: nil)
         } catch AFError.explicitlyCancelled, is CancellationError {
             throw POSBookingServiceError.requestCancelled
@@ -79,12 +79,6 @@ struct POSDefaultBookingListFetchStrategy: POSBookingListFetchStrategy {
 }
 
 private extension POSDefaultBookingListFetchStrategy {
-    @MainActor
-    func fetchLocalBookingsFromStorage() -> [POSBooking] {
-        guard let filters else { return [] }
-        return fetchLocalBookingsSync(filters: filters)
-    }
-
     @MainActor
     func fetchLocalBookingsSync(filters: BookingFilters) -> [POSBooking] {
         let bookingPredicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: filters)

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
@@ -59,7 +59,8 @@ struct POSDefaultBookingListFetchStrategy: POSBookingListFetchStrategy {
                 order: .ascending,
                 cacheClearStrategy: cacheClearStrategy
             )
-            let bookings = await fetchLocalBookings()
+            guard let filters else { return PagedItems(items: [], hasMorePages: hasMorePages, totalItems: nil) }
+            let bookings = await fetchLocalBookingsSync(filters: filters, limit: nil)
             return PagedItems(items: bookings, hasMorePages: hasMorePages, totalItems: nil)
         } catch AFError.explicitlyCancelled, is CancellationError {
             throw POSBookingServiceError.requestCancelled
@@ -69,7 +70,7 @@ struct POSDefaultBookingListFetchStrategy: POSBookingListFetchStrategy {
     @MainActor
     func fetchLocalBookings() -> [POSBooking] {
         guard let filters else { return [] }
-        return fetchLocalBookingsSync(filters: filters)
+        return fetchLocalBookingsSync(filters: filters, limit: pageSize)
     }
 }
 
@@ -87,7 +88,7 @@ private extension POSDefaultBookingListFetchStrategy {
     }
 
     @MainActor
-    func fetchLocalBookingsSync(filters: BookingFilters) -> [POSBooking] {
+    func fetchLocalBookingsSync(filters: BookingFilters, limit: Int?) -> [POSBooking] {
         let bookingPredicate = NSPredicate.createBookingPredicate(siteID: siteID, filters: filters)
         let hasOrderPredicate = NSPredicate(format: "orderInfo != nil")
         let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [bookingPredicate, hasOrderPredicate])
@@ -96,6 +97,7 @@ private extension POSDefaultBookingListFetchStrategy {
         let resultsController = ResultsController<StorageBooking>(
             storageManager: storageManager,
             matching: predicate,
+            fetchLimit: limit,
             sortedBy: [sortByDate, sortByID]
         )
 

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingListFetchStrategy.swift
@@ -8,7 +8,7 @@ import class WooFoundationCore.CurrencyFormatter
 public protocol POSBookingListFetchStrategy {
     func fetchBookings(pageNumber: Int) async throws -> PagedItems<POSBooking>
     @MainActor func fetchLocalBookings() -> [POSBooking]
-    var showsLoadingWithItems: Bool { get }
+    var showsCachedDataWhileLoading: Bool { get }
     var id: String { get }
 }
 
@@ -25,7 +25,7 @@ struct POSDefaultBookingListFetchStrategy: POSBookingListFetchStrategy {
     private let siteID: Int64
     private let pageSize: Int
     private let filters: BookingFilters?
-    let showsLoadingWithItems: Bool = true
+    let showsCachedDataWhileLoading: Bool = true
 
     var id: String {
         "POSDefaultBookingListFetchStrategy-\(filters?.startDateAfter ?? "none")"
@@ -48,6 +48,7 @@ struct POSDefaultBookingListFetchStrategy: POSBookingListFetchStrategy {
 
     func fetchBookings(pageNumber: Int) async throws -> PagedItems<POSBooking> {
         do {
+            // Sync remote bookings into CoreData, then read them back as mapped POSBooking models.
             let cacheClearStrategy = cacheClearStrategy(for: pageNumber)
             let hasMorePages = try await bookingStoreMethods.synchronizeBookings(
                 siteID: siteID,
@@ -139,7 +140,7 @@ struct POSSearchBookingListFetchStrategy: POSBookingListFetchStrategy {
     private let searchTerm: String
     private let pageSize: Int
     private let filters: BookingFilters?
-    let showsLoadingWithItems: Bool = false
+    let showsCachedDataWhileLoading: Bool = false
 
     var id: String {
         "POSSearchBookingListFetchStrategy-\(searchTerm)-\(filters?.startDateAfter ?? "none")"

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderListFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderListFetchStrategy.swift
@@ -7,7 +7,7 @@ public protocol POSOrderListFetchStrategy {
     func trackFetched(millisecondsSinceRequestSent: Int)
     func trackNextPageLoaded(pageNumber: Int)
     var supportsCaching: Bool { get }
-    var showsLoadingWithItems: Bool { get }
+    var showsCachedDataWhileLoading: Bool { get }
     var id: String { get }
 }
 
@@ -21,7 +21,7 @@ struct POSDefaultOrderListFetchStrategy: POSOrderListFetchStrategy {
     private let orderListService: POSOrderListServiceProtocol
     private let analytics: POSOrderListFetchAnalyticsTracking
     let supportsCaching: Bool = true
-    var showsLoadingWithItems: Bool = true
+    var showsCachedDataWhileLoading: Bool = true
 
     init(orderListService: POSOrderListServiceProtocol, analytics: POSOrderListFetchAnalyticsTracking) {
         self.orderListService = orderListService
@@ -51,7 +51,7 @@ struct POSSearchOrderListFetchStrategy: POSOrderListFetchStrategy {
     private let analytics: POSOrderListFetchAnalyticsTracking
 
     var supportsCaching: Bool = false
-    var showsLoadingWithItems = false
+    var showsCachedDataWhileLoading = false
 
     init(orderListService: POSOrderListServiceProtocol, searchTerm: String, analytics: POSOrderListFetchAnalyticsTracking) {
         self.orderListService = orderListService

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
@@ -523,18 +523,18 @@ final class POSBookingListControllerTests {
 
     // MARK: - Prefetch
 
-    @Test func test_syncBookings_syncs_today_and_adjacent_dates() async {
+    @Test func test_init_syncs_today_and_adjacent_dates() async {
         // Given
         mockStrategy.fetchBookingsResult = .success(PagedItems(items: [makeBooking(id: 1)], hasMorePages: false, totalItems: nil))
 
-        // When - 3 calls expected: today + yesterday + tomorrow (+ 1 from init = 4 total)
+        // When - init triggers syncBookings: 1 defaultStrategy from init + 3 from syncBookings (today + yesterday + tomorrow)
         await withCheckedContinuation { continuation in
             mockFactory.onDefaultStrategyCalled = {
                 if self.mockFactory.defaultStrategyCallCount == 4 {
                     continuation.resume()
                 }
             }
-            sut.syncBookings()
+            _ = sut
         }
 
         // Then

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
@@ -587,6 +587,52 @@ final class POSBookingListControllerTests {
         // Then - cache was cleared, new date shows empty
         #expect(sut.bookingsViewState == .empty)
     }
+
+    // MARK: - Stale fetch guard (strategy change mid-flight)
+
+    @Test func test_loadNextBookings_when_strategy_changes_during_pagination_then_discards_stale_results() async {
+        // Given - load first page with more pages available
+        let firstPageBookings = [makeBooking(id: 1)]
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: firstPageBookings, hasMorePages: true, totalItems: nil))
+        await sut.loadBookings()
+
+        // Configure: when page 2 is fetched, simulate a date switch by changing the strategy ID.
+        // This mirrors what selectDate does (replacing fetchStrategy with a new one that has a different id).
+        let originalID = mockStrategy.id
+        mockStrategy.onFetchBookingsCalled = { pageNumber in
+            if pageNumber == 2 {
+                self.mockStrategy.id = "switched-date-strategy"
+            }
+        }
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: [self.makeBooking(id: 99)], hasMorePages: false, totalItems: nil))
+
+        // When
+        await sut.loadNextBookings()
+
+        // Then - stale page 2 results should be discarded
+        let bookingIDs = sut.bookingsViewState.bookings.map(\.id)
+        #expect(!bookingIDs.contains(99), "Stale pagination results from old date should be discarded")
+        #expect(bookingIDs.contains(1), "First page bookings should still be present")
+    }
+
+    @Test func test_loadNextBookings_when_strategy_unchanged_during_pagination_then_results_are_applied() async {
+        // Given - load first page
+        let firstPageBookings = [makeBooking(id: 1)]
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: firstPageBookings, hasMorePages: true, totalItems: nil))
+        await sut.loadBookings()
+
+        // Configure page 2 - strategy ID does NOT change (no callback set)
+        let secondPageBookings = [makeBooking(id: 2)]
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: secondPageBookings, hasMorePages: false, totalItems: nil))
+
+        // When
+        await sut.loadNextBookings()
+
+        // Then - page 2 results should be applied normally
+        let bookingIDs = sut.bookingsViewState.bookings.map(\.id)
+        #expect(bookingIDs.contains(1))
+        #expect(bookingIDs.contains(2), "Page 2 results should be appended when strategy hasn't changed")
+    }
 }
 
 // MARK: - Helpers

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
@@ -105,9 +105,11 @@ final class MockPOSBookingListFetchStrategy: POSBookingListFetchStrategy {
     var localBookings: [POSBooking] = []
     var showsCachedDataWhileLoading: Bool = true
     var id: String = "MockPOSBookingListFetchStrategy"
+    var onFetchBookingsCalled: ((Int) -> Void)?
 
     func fetchBookings(pageNumber: Int) async throws -> PagedItems<POSBooking> {
-        try fetchBookingsResult.get()
+        onFetchBookingsCalled?(pageNumber)
+        return try fetchBookingsResult.get()
     }
 
     func fetchLocalBookings() -> [POSBooking] {

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
@@ -103,7 +103,7 @@ final class MockPOSBookingService: POSBookingServiceProtocol {
 final class MockPOSBookingListFetchStrategy: POSBookingListFetchStrategy {
     var fetchBookingsResult: Result<PagedItems<POSBooking>, Error> = .success(PagedItems(items: [], hasMorePages: false, totalItems: nil))
     var localBookings: [POSBooking] = []
-    var showsLoadingWithItems: Bool = true
+    var showsCachedDataWhileLoading: Bool = true
     var id: String = "MockPOSBookingListFetchStrategy"
 
     func fetchBookings(pageNumber: Int) async throws -> PagedItems<POSBooking> {

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListFetchStrategyFactory.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListFetchStrategyFactory.swift
@@ -26,7 +26,7 @@ private struct MockPOSOrderListFetchStrategy: POSOrderListFetchStrategy {
     let orderService: POSOrderListServiceProtocol
 
     var supportsCaching: Bool { true }
-    var showsLoadingWithItems: Bool { true }
+    var showsCachedDataWhileLoading: Bool { true }
     var id: String = "default"
 
     func fetchOrders(pageNumber: Int) async throws -> PagedItems<POSOrder> {
@@ -47,7 +47,7 @@ private struct MockPOSOrderListSearchFetchStrategy: POSOrderListFetchStrategy {
     let searchTerm: String
 
     var supportsCaching: Bool { false }
-    var showsLoadingWithItems: Bool { false }
+    var showsCachedDataWhileLoading: Bool { false }
     var id: String = "search"
 
     func fetchOrders(pageNumber: Int) async throws -> PagedItems<POSOrder> {


### PR DESCRIPTION
## Description
Addresses code review feedback from #16701.

Changes:
- Remove duplicated `fetchLocalBookingsFromStorage` function
- Extract complex cache clear strategy ternary to a named function
- Rename `prefetchDateIfNeeded` to `prefetchDate` (always re-fetches, only guards against duplicate in-flight requests)
- Remove custom accessibility label from `POSBookingRowView` (combined children default is sufficient)
- Move `fetchLocalBookings()` default from protocol extension to search strategy explicitly
- Move `syncBookings()` call from `POSBookingsModel` init to `POSBookingListController` init
- Improve readability: rename `showsLoadingWithItems` to `showsCachedDataWhileLoading`, restructure `setLocalDataOrLoadingState()` to `showCachedBookingsOrLoadingIndicator()`, add comments clarifying the sync-then-read and two-phase loading patterns
- Pagination fixes:
  - Gate `loadNextBookings()` until first-page loading has finished and `hasMoreItems` is true. We need to wait since we need to know if there's actually anything to paginate.
  - Discard stale paginated results when strategy context changes mid-fetch.

## Test Steps
- Verify bookings list loads, date navigation works, prefetching works as before
- Try paginate quickly after opening the view, switch dates while paginating
- Verify search bookings flow still works

## Pagination

### Quick paginate while the first page is still loading

https://github.com/user-attachments/assets/ac8f3dc9-81ba-4999-8bb9-a2a49937b130

### Pagination only after the first page has loaded

https://github.com/user-attachments/assets/0e1dae5e-03c4-4caa-8cea-aece78b4de50

### Pagination + Date switches

https://github.com/user-attachments/assets/bc10866d-6b90-4742-911e-4416689586b7

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.