### PR TITLE
POS Bookings: Fix incorrect booking time being displayed due timezone

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -44,7 +44,7 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     private(set) var selectedBooking: POSBooking?
     private let bookingListFetchStrategyFactory: POSBookingListFetchStrategyFactoryProtocol
     private let bookingService: POSBookingServiceProtocol
-    private let siteTimezone: TimeZone
+
     private var loadTask: Task<Void, Never>?
     private var prefetchTasks: [Date: Task<Void, Never>] = [:]
 
@@ -58,11 +58,9 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
     }
 
     init(bookingListFetchStrategyFactory: POSBookingListFetchStrategyFactoryProtocol,
-         siteTimezone: TimeZone,
          initialDate: Date? = nil,
          initialState: POSBookingListState = .loading([])) {
-        self.siteTimezone = siteTimezone
-        self.selectedDate = initialDate ?? Self.todayInSiteTimezone(siteTimezone)
+        self.selectedDate = initialDate ?? Self.todayInUTC()
         self.bookingsViewState = initialState
         self.bookingListFetchStrategyFactory = bookingListFetchStrategyFactory
         self.bookingService = bookingListFetchStrategyFactory.bookingService
@@ -189,17 +187,13 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
 
     @MainActor
     func goToPreviousDay() async {
-        var calendar = Calendar.current
-        calendar.timeZone = siteTimezone
-        guard let previousDay = calendar.date(byAdding: .day, value: -1, to: selectedDate) else { return }
+        guard let previousDay = POSBookingDateFormatter.utcCalendar.date(byAdding: .day, value: -1, to: selectedDate) else { return }
         await selectDate(previousDay)
     }
 
     @MainActor
     func goToNextDay() async {
-        var calendar = Calendar.current
-        calendar.timeZone = siteTimezone
-        guard let nextDay = calendar.date(byAdding: .day, value: 1, to: selectedDate) else { return }
+        guard let nextDay = POSBookingDateFormatter.utcCalendar.date(byAdding: .day, value: 1, to: selectedDate) else { return }
         await selectDate(nextDay)
     }
 
@@ -232,15 +226,13 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
 
 extension POSBookingListController {
     func dateFilters(for date: Date) -> BookingFilters {
-        var calendar = Calendar.current
-        calendar.timeZone = siteTimezone
-        let startOfDay = calendar.startOfDay(for: date)
-        guard let endOfDay = calendar.date(byAdding: DateComponents(day: 1, second: -1), to: startOfDay) else {
+        let startOfDay = POSBookingDateFormatter.utcCalendar.startOfDay(for: date)
+        guard let endOfDay = POSBookingDateFormatter.utcCalendar.date(byAdding: DateComponents(day: 1, second: -1), to: startOfDay) else {
             return BookingFilters()
         }
 
         let formatter = ISO8601DateFormatter()
-        formatter.timeZone = siteTimezone
+        formatter.timeZone = POSBookingDateFormatter.utcTimeZone
 
         return BookingFilters(
             startDateBefore: formatter.string(from: endOfDay),
@@ -253,20 +245,16 @@ extension POSBookingListController {
 
 private extension POSBookingListController {
     func prefetchAdjacentDates(for date: Date) {
-        var calendar = Calendar.current
-        calendar.timeZone = siteTimezone
-        if let yesterday = calendar.date(byAdding: .day, value: -1, to: date) {
+        if let yesterday = POSBookingDateFormatter.utcCalendar.date(byAdding: .day, value: -1, to: date) {
             prefetchDateIfNeeded(yesterday)
         }
-        if let tomorrow = calendar.date(byAdding: .day, value: 1, to: date) {
+        if let tomorrow = POSBookingDateFormatter.utcCalendar.date(byAdding: .day, value: 1, to: date) {
             prefetchDateIfNeeded(tomorrow)
         }
     }
 
     func prefetchDateIfNeeded(_ date: Date) {
-        var calendar = Calendar.current
-        calendar.timeZone = siteTimezone
-        let normalizedDate = calendar.startOfDay(for: date)
+        let normalizedDate = POSBookingDateFormatter.utcCalendar.startOfDay(for: date)
 
         guard prefetchTasks[normalizedDate] == nil else { return }
 
@@ -281,10 +269,8 @@ private extension POSBookingListController {
         }
     }
 
-    static func todayInSiteTimezone(_ timezone: TimeZone) -> Date {
-        var calendar = Calendar.current
-        calendar.timeZone = timezone
-        return calendar.startOfDay(for: Date())
+    static func todayInUTC() -> Date {
+        POSBookingDateFormatter.utcCalendar.startOfDay(for: Date())
     }
 
     @MainActor

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/CancelBooking/POSCancelBookingModalContent.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/CancelBooking/POSCancelBookingModalContent.swift
@@ -7,7 +7,6 @@ struct POSCancelBookingModalContent: View {
     @Binding var cancelModalState: CancelBookingModalState?
 
     @Environment(POSBookingsModel.self) private var bookingsModel
-    @Environment(\.siteTimezone) private var siteTimezone
 
     var body: some View {
         switch state {
@@ -15,7 +14,7 @@ struct POSCancelBookingModalContent: View {
             POSCancelBookingConfirmationView(
                 bookingNumber: booking.id,
                 serviceName: booking.serviceName,
-                formattedDateTime: formattedCancelDateTime,
+                formattedDateTime: POSBookingDateFormatter.formattedDateTime(for: booking.startDate),
                 customerName: booking.customerName,
                 isProcessing: false,
                 onClose: { cancelModalState = nil },
@@ -31,7 +30,7 @@ struct POSCancelBookingModalContent: View {
             POSCancelBookingConfirmationView(
                 bookingNumber: booking.id,
                 serviceName: booking.serviceName,
-                formattedDateTime: formattedCancelDateTime,
+                formattedDateTime: POSBookingDateFormatter.formattedDateTime(for: booking.startDate),
                 customerName: booking.customerName,
                 isProcessing: true,
                 onClose: {},
@@ -57,19 +56,6 @@ struct POSCancelBookingModalContent: View {
                 onClose: { cancelModalState = nil }
             )
         }
-    }
-
-    private static let cancelDateTimeFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .short
-        return formatter
-    }()
-
-    private var formattedCancelDateTime: String {
-        // Use UTC: the API timestamps already represent site-local wall-clock time.
-        Self.cancelDateTimeFormatter.timeZone = TimeZone(identifier: "UTC")
-        return Self.cancelDateTimeFormatter.string(from: booking.startDate)
     }
 
     @MainActor

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/CancelBooking/POSCancelBookingModalContent.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/CancelBooking/POSCancelBookingModalContent.swift
@@ -67,7 +67,8 @@ struct POSCancelBookingModalContent: View {
     }()
 
     private var formattedCancelDateTime: String {
-        Self.cancelDateTimeFormatter.timeZone = siteTimezone
+        // Use UTC: the API timestamps already represent site-local wall-clock time.
+        Self.cancelDateTimeFormatter.timeZone = TimeZone(identifier: "UTC")
         return Self.cancelDateTimeFormatter.string(from: booking.startDate)
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingCalendarView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingCalendarView.swift
@@ -2,14 +2,12 @@ import SwiftUI
 
 struct POSBookingCalendarView: View {
     let selectedDate: Date
-    let siteTimezone: TimeZone
     let onDateSelected: (Date) -> Void
 
     @State private var pickerDate: Date
 
-    init(selectedDate: Date, siteTimezone: TimeZone, onDateSelected: @escaping (Date) -> Void) {
+    init(selectedDate: Date, onDateSelected: @escaping (Date) -> Void) {
         self.selectedDate = selectedDate
-        self.siteTimezone = siteTimezone
         self.onDateSelected = onDateSelected
         self._pickerDate = State(initialValue: selectedDate)
     }
@@ -22,7 +20,7 @@ struct POSBookingCalendarView: View {
         )
         .datePickerStyle(.graphical)
         .tint(.posPrimaryContainer)
-        .environment(\.timeZone, siteTimezone)
+        .environment(\.timeZone, POSBookingDateFormatter.utcTimeZone)
         .onChange(of: pickerDate) { _, newDate in
             onDateSelected(newDate)
         }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDateBarView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDateBarView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct POSBookingDateBarView: View {
     @Environment(POSBookingsModel.self) private var bookingsModel
-    @Environment(\.siteTimezone) private var siteTimezone
     @Environment(\.colorScheme) private var colorScheme
     @State private var showingCalendar = false
 
@@ -11,10 +10,7 @@ struct POSBookingDateBarView: View {
     }
 
     private var formattedDate: String {
-        let formatter = DateFormatter()
-        formatter.setLocalizedDateFormatFromTemplate("dMMMEEE")
-        formatter.timeZone = siteTimezone
-        return formatter.string(from: bookingsModel.bookingsController.selectedDate)
+        POSBookingDateFormatter.formattedShortDate(for: bookingsModel.bookingsController.selectedDate)
     }
 
     var body: some View {
@@ -51,7 +47,6 @@ struct POSBookingDateBarView: View {
                 .popover(isPresented: $showingCalendar) {
                     POSBookingCalendarView(
                         selectedDate: bookingsModel.bookingsController.selectedDate,
-                        siteTimezone: siteTimezone,
                         onDateSelected: { date in
                             showingCalendar = false
                             Task { await bookingsModel.bookingsController.selectDate(date) }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -10,7 +10,6 @@ struct POSBookingDetailView: View {
     @Environment(POSOrderListModel.self) private var orderListModel
     @Environment(POSBookingsModel.self) private var bookingsModel
     @Environment(\.posAnalytics) private var analytics
-    @Environment(\.siteTimezone) private var siteTimezone
 
     @State private var navigationPath: [NavigationDestination] = []
     @State private var cancelModalState: CancelBookingModalState?
@@ -80,7 +79,7 @@ struct POSBookingDetailView: View {
     private var bookingDetailContent: some View {
         VStack(spacing: POSSpacing.none) {
             POSPageHeaderView(
-                title: POSBookingSummaryView.formattedTimeRange(for: booking, siteTimezone: siteTimezone),
+                title: POSBookingDateFormatter.formattedTimeRange(for: booking),
                 isLoading: isDetailsUpdating,
                 backButtonConfiguration: shouldShowBackButton ? .init(state: .enabled, action: onBack) : nil,
                 trailingContent: {

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingRowView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingRowView.swift
@@ -47,7 +47,8 @@ struct POSBookingRowView: View {
 
     private var accessibilityLabel: String {
         let formatter = DateFormatter.posAccessibilityTimeFormatter
-        formatter.timeZone = siteTimezone
+        // Use UTC: the API timestamps already represent site-local wall-clock time.
+        formatter.timeZone = TimeZone(identifier: "UTC")
         let timeRange = Localization.timeRangeAccessibilityLabel(
             start: formatter.string(from: booking.startDate),
             end: formatter.string(from: booking.endDate)

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingRowView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingRowView.swift
@@ -7,7 +7,6 @@ struct POSBookingRowView: View {
 
     @ScaledMetric private var scale: CGFloat = 1.0
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
-    @Environment(\.siteTimezone) private var siteTimezone
 
     var body: some View {
         VStack(alignment: .leading, spacing: POSSpacing.none) {
@@ -34,7 +33,7 @@ struct POSBookingRowView: View {
     @ViewBuilder
     private var bookingHeaderRow: some View {
         HStack(alignment: .center) {
-            Text(POSBookingSummaryView.formattedTimeRange(for: booking, siteTimezone: siteTimezone))
+            Text(POSBookingDateFormatter.formattedTimeRange(for: booking))
                 .font(.posBodySmallBold())
                 .foregroundStyle(Color.posOnSurface)
                 .fixedSize(horizontal: false, vertical: true)
@@ -46,12 +45,9 @@ struct POSBookingRowView: View {
     }
 
     private var accessibilityLabel: String {
-        let formatter = DateFormatter.posAccessibilityTimeFormatter
-        // Use UTC: the API timestamps already represent site-local wall-clock time.
-        formatter.timeZone = TimeZone(identifier: "UTC")
         let timeRange = Localization.timeRangeAccessibilityLabel(
-            start: formatter.string(from: booking.startDate),
-            end: formatter.string(from: booking.endDate)
+            start: POSBookingDateFormatter.accessibilityFormattedTime(for: booking.startDate),
+            end: POSBookingDateFormatter.accessibilityFormattedTime(for: booking.endDate)
         )
 
         let customerDisplayName = booking.customerName ?? booking.customerEmail
@@ -78,13 +74,4 @@ private enum Localization {
         )
         return String(format: format, start, end)
     }
-}
-
-private extension DateFormatter {
-    static let posAccessibilityTimeFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .none
-        formatter.timeStyle = .short
-        return formatter
-    }()
 }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingSummaryView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingSummaryView.swift
@@ -58,26 +58,3 @@ struct POSBookingSummaryView: View {
         return parts.joined(separator: ", ")
     }
 }
-
-// MARK: - Date Formatting
-
-extension POSBookingSummaryView {
-    private static let timeRangeFormatter: DateIntervalFormatter = {
-        let formatter = DateIntervalFormatter()
-        formatter.dateStyle = .none
-        formatter.timeStyle = .short
-        return formatter
-    }()
-
-    /// Formats the booking time range for display.
-    ///
-    /// The Bookings API encodes site-local times as UTC timestamps (the raw
-    /// Unix epoch already represents the wall-clock time at the site). Because
-    /// bookings are in-person services, we always display site-local time
-    /// regardless of the device timezone — so we format using UTC to avoid
-    /// applying any additional offset.
-    static func formattedTimeRange(for booking: POSBooking, siteTimezone: TimeZone) -> String {
-        timeRangeFormatter.timeZone = TimeZone(identifier: "UTC")
-        return timeRangeFormatter.string(from: booking.startDate, to: booking.endDate)
-    }
-}

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingSummaryView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingSummaryView.swift
@@ -69,8 +69,15 @@ extension POSBookingSummaryView {
         return formatter
     }()
 
+    /// Formats the booking time range for display.
+    ///
+    /// The Bookings API encodes site-local times as UTC timestamps (the raw
+    /// Unix epoch already represents the wall-clock time at the site). Because
+    /// bookings are in-person services, we always display site-local time
+    /// regardless of the device timezone — so we format using UTC to avoid
+    /// applying any additional offset.
     static func formattedTimeRange(for booking: POSBooking, siteTimezone: TimeZone) -> String {
-        timeRangeFormatter.timeZone = siteTimezone
+        timeRangeFormatter.timeZone = TimeZone(identifier: "UTC")
         return timeRangeFormatter.string(from: booking.startDate, to: booking.endDate)
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -148,8 +148,7 @@ public struct PointOfSaleEntryPointView: View {
                                                       currencyFormatter: CurrencyFormatter(currencySettings: services.currency.currencySettings))
         self.orderListModel = POSOrderListModel(ordersController: ordersController, receiptSender: receiptSender)
         if isBookingsEligible && services.featureFlags.isFeatureFlagEnabled(.pointOfSaleBookings) {
-            let bookingsController = POSBookingListController(bookingListFetchStrategyFactory: bookingListFetchStrategyFactory,
-                                                               siteTimezone: siteTimezone)
+            let bookingsController = POSBookingListController(bookingListFetchStrategyFactory: bookingListFetchStrategyFactory)
             self.bookingsModel = POSBookingsModel(
                 bookingsController: bookingsController,
                 cardPresentPaymentService: cardPresentPaymentService,

--- a/Modules/Sources/PointOfSale/ViewHelpers/POSBookingDateFormatter.swift
+++ b/Modules/Sources/PointOfSale/ViewHelpers/POSBookingDateFormatter.swift
@@ -8,17 +8,24 @@ import struct Yosemite.POSBooking
 /// Because bookings are in-person services, we display site-local time
 /// regardless of the device timezone by formatting in UTC (applying no offset).
 ///
-/// For date selection, calendar display, and filtering by day, use
-/// `siteTimezone` instead , those operations work with real calendar dates,
-/// not API-encoded booking timestamps.
+/// All booking-related date operations (display, calendar, filtering) use UTC
+/// to match the API's encoding.
 struct POSBookingDateFormatter {
 
-    // Example: Time Range (e.g. "9:00 AM – 10:00 AM")
+    static let utcTimeZone = TimeZone(identifier: "UTC")!
+
+    static let utcCalendar: Calendar = {
+        var calendar = Calendar.current
+        calendar.timeZone = utcTimeZone
+        return calendar
+    }()
+
+    // Example: Time Range (e.g. "9:00 AM - 10:00 AM")
     private static let timeRangeFormatter: DateIntervalFormatter = {
         let formatter = DateIntervalFormatter()
         formatter.dateStyle = .none
         formatter.timeStyle = .short
-        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.timeZone = utcTimeZone
         return formatter
     }()
 
@@ -31,7 +38,7 @@ struct POSBookingDateFormatter {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
-        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.timeZone = utcTimeZone
         return formatter
     }()
 
@@ -44,11 +51,23 @@ struct POSBookingDateFormatter {
         let formatter = DateFormatter()
         formatter.dateStyle = .none
         formatter.timeStyle = .short
-        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.timeZone = utcTimeZone
         return formatter
     }()
 
     static func accessibilityFormattedTime(for date: Date) -> String {
         accessibilityTimeFormatter.string(from: date)
+    }
+
+    // Example: Short Date (e.g. "Mon, Mar 15")
+    private static let shortDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("dMMMEEE")
+        formatter.timeZone = utcTimeZone
+        return formatter
+    }()
+
+    static func formattedShortDate(for date: Date) -> String {
+        shortDateFormatter.string(from: date)
     }
 }

--- a/Modules/Sources/PointOfSale/ViewHelpers/POSBookingDateFormatter.swift
+++ b/Modules/Sources/PointOfSale/ViewHelpers/POSBookingDateFormatter.swift
@@ -1,0 +1,54 @@
+import Foundation
+import struct Yosemite.POSBooking
+
+/// Formats booking dates for display in POS views.
+///
+/// The WooCommerce Bookings API encodes site-local wall-clock times as UTC
+/// Unix timestamps. The raw epoch already represents the time at the store.
+/// Because bookings are in-person services, we display site-local time
+/// regardless of the device timezone by formatting in UTC (applying no offset).
+///
+/// For date selection, calendar display, and filtering by day, use
+/// `siteTimezone` instead , those operations work with real calendar dates,
+/// not API-encoded booking timestamps.
+struct POSBookingDateFormatter {
+
+    // Example: Time Range (e.g. "9:00 AM – 10:00 AM")
+    private static let timeRangeFormatter: DateIntervalFormatter = {
+        let formatter = DateIntervalFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter
+    }()
+
+    static func formattedTimeRange(for booking: POSBooking) -> String {
+        timeRangeFormatter.string(from: booking.startDate, to: booking.endDate)
+    }
+
+    // Example: Date + Time (e.g. "Jan 15, 2025 at 9:00 AM")
+    private static let dateTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter
+    }()
+
+    static func formattedDateTime(for date: Date) -> String {
+        dateTimeFormatter.string(from: date)
+    }
+
+    // Example: Accessibility Time (e.g. "9:00 AM")
+    private static let accessibilityTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter
+    }()
+
+    static func accessibilityFormattedTime(for date: Date) -> String {
+        accessibilityTimeFormatter.string(from: date)
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
@@ -12,15 +12,13 @@ import struct Yosemite.BookingFilters
 @MainActor
 final class POSBookingListControllerTests {
 
-    private let siteTimezone = TimeZone(identifier: "America/New_York")!
     private let mockStrategy = MockPOSBookingListFetchStrategy()
     private lazy var mockFactory: MockPOSBookingListFetchStrategyFactory = {
         let factory = MockPOSBookingListFetchStrategyFactory()
         factory.defaultStrategyResult = mockStrategy
         return factory
     }()
-    private lazy var sut = POSBookingListController(bookingListFetchStrategyFactory: mockFactory,
-                                                     siteTimezone: siteTimezone)
+    private lazy var sut = POSBookingListController(bookingListFetchStrategyFactory: mockFactory)
 
     // MARK: - loadBookings
 
@@ -389,11 +387,9 @@ final class POSBookingListControllerTests {
 
     // MARK: - Date Navigation
 
-    @Test func test_selectedDate_defaults_to_today_in_site_timezone() {
+    @Test func test_selectedDate_defaults_to_today_in_UTC() {
         // Given
-        var calendar = Calendar.current
-        calendar.timeZone = siteTimezone
-        let expectedStartOfDay = calendar.startOfDay(for: Date())
+        let expectedStartOfDay = POSBookingDateFormatter.utcCalendar.startOfDay(for: Date())
 
         // Then
         #expect(sut.selectedDate == expectedStartOfDay)
@@ -419,10 +415,7 @@ final class POSBookingListControllerTests {
         mockStrategy.fetchBookingsResult = .success(PagedItems(items: [], hasMorePages: false, totalItems: nil))
         await sut.loadBookings()
         let initialDate = sut.selectedDate
-
-        var calendar = Calendar.current
-        calendar.timeZone = siteTimezone
-        let expectedNextDay = calendar.date(byAdding: .day, value: 1, to: initialDate)!
+        let expectedNextDay = POSBookingDateFormatter.utcCalendar.date(byAdding: .day, value: 1, to: initialDate)!
 
         // When
         await sut.goToNextDay()
@@ -436,10 +429,7 @@ final class POSBookingListControllerTests {
         mockStrategy.fetchBookingsResult = .success(PagedItems(items: [], hasMorePages: false, totalItems: nil))
         await sut.loadBookings()
         let initialDate = sut.selectedDate
-
-        var calendar = Calendar.current
-        calendar.timeZone = siteTimezone
-        let expectedPreviousDay = calendar.date(byAdding: .day, value: -1, to: initialDate)!
+        let expectedPreviousDay = POSBookingDateFormatter.utcCalendar.date(byAdding: .day, value: -1, to: initialDate)!
 
         // When
         await sut.goToPreviousDay()
@@ -448,40 +438,19 @@ final class POSBookingListControllerTests {
         #expect(sut.selectedDate == expectedPreviousDay)
     }
 
-    @Test func test_dateFilters_generates_correct_day_boundaries() {
+    @Test func test_dateFilters_generates_correct_UTC_day_boundaries() {
         // Given
-        let utcTimezone = TimeZone(identifier: "UTC")!
-        let controller = POSBookingListController(bookingListFetchStrategyFactory: mockFactory,
-                                                   siteTimezone: utcTimezone)
+        let controller = POSBookingListController(bookingListFetchStrategyFactory: mockFactory)
 
-        var calendar = Calendar.current
-        calendar.timeZone = utcTimezone
-        let date = calendar.date(from: DateComponents(year: 2026, month: 3, day: 15))!
+        let date = POSBookingDateFormatter.utcCalendar.date(from: DateComponents(year: 2026, month: 3, day: 15))!
 
         // When
         let filters = controller.dateFilters(for: date)
 
-        // Then
+        // Then - always UTC regardless of device timezone,
+        // because the API stores local times as UTC timestamps
         #expect(filters.startDateAfter == "2026-03-15T00:00:00Z")
         #expect(filters.startDateBefore == "2026-03-15T23:59:59Z")
-    }
-
-    @Test func test_dateFilters_with_positive_offset_timezone() {
-        // Given - Tokyo is UTC+9
-        let tokyoTimezone = TimeZone(identifier: "Asia/Tokyo")!
-        let controller = POSBookingListController(bookingListFetchStrategyFactory: mockFactory,
-                                                   siteTimezone: tokyoTimezone)
-
-        var calendar = Calendar.current
-        calendar.timeZone = tokyoTimezone
-        let date = calendar.date(from: DateComponents(year: 2026, month: 6, day: 20))!
-
-        // When
-        let filters = controller.dateFilters(for: date)
-
-        // Then
-        #expect(filters.startDateAfter == "2026-06-20T00:00:00+09:00")
-        #expect(filters.startDateBefore == "2026-06-20T23:59:59+09:00")
     }
 
     @Test func test_selectDate_when_searching_then_uses_search_strategy_with_new_date() async {

--- a/Modules/Tests/PointOfSaleTests/ViewHelpers/POSBookingDateFormatterTests.swift
+++ b/Modules/Tests/PointOfSaleTests/ViewHelpers/POSBookingDateFormatterTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+import Testing
+@testable import PointOfSale
+import struct Yosemite.POSBooking
+import struct Yosemite.POSOrder
+import enum Networking.BookingStatus
+import enum Networking.BookingAttendanceStatus
+
+struct POSBookingDateFormatterTests {
+
+    // 09:00 UTC on 2025-01-15 (Wednesday)
+    private let referenceStart = Date(timeIntervalSince1970: 1_736_935_200)
+    // 10:00 UTC on 2025-01-15
+    private let referenceEnd = Date(timeIntervalSince1970: 1_736_938_800)
+
+    // MARK: - formattedTimeRange
+
+    @Test func test_formattedTimeRange_when_booking_has_known_UTC_times_then_output_contains_both_hours() {
+        // Given
+        let booking = makeBooking(startDate: referenceStart, endDate: referenceEnd)
+
+        // When
+        let result = POSBookingDateFormatter.formattedTimeRange(for: booking)
+
+        // Then
+        // DateIntervalFormatter may omit the AM/PM on the start time when both
+        // times share the same period (e.g. "9:00 – 10:00 AM"), so we verify
+        // the result against a same-configured DateIntervalFormatter in POSIX locale.
+        let referenceIntervalFormatter = makePOSIXTimeRangeFormatter()
+        let expected = referenceIntervalFormatter.string(from: referenceStart, to: referenceEnd)
+        #expect(result == expected)
+    }
+
+    @Test func test_formattedTimeRange_when_same_input_given_twice_then_output_is_identical() {
+        // Given
+        let booking = makeBooking(startDate: referenceStart, endDate: referenceEnd)
+
+        // When
+        let first = POSBookingDateFormatter.formattedTimeRange(for: booking)
+        let second = POSBookingDateFormatter.formattedTimeRange(for: booking)
+
+        // Then
+        #expect(first == second)
+    }
+
+    @Test func test_formattedTimeRange_when_end_is_after_start_then_output_is_non_empty() {
+        // Given
+        let booking = makeBooking(startDate: referenceStart, endDate: referenceEnd)
+
+        // When
+        let result = POSBookingDateFormatter.formattedTimeRange(for: booking)
+
+        // Then
+        #expect(!result.isEmpty)
+    }
+
+    // MARK: - formattedDateTime
+
+    @Test func test_formattedDateTime_when_given_known_UTC_date_then_output_contains_date_and_time_components() {
+        // Given
+        let referenceFormatter = makePOSIXDateTimeFormatter()
+
+        // When
+        let result = POSBookingDateFormatter.formattedDateTime(for: referenceStart)
+
+        // Then
+        // The production formatter and the reference formatter share the same UTC
+        // timezone, so their outputs must agree on the time portion regardless of
+        // the device locale.
+        let referenceTime = makePOSIXTimeFormatter().string(from: referenceStart)
+        #expect(result.contains(referenceTime))
+        // Date component: Jan 15, 2025 encoded as epoch seconds — verify the year
+        // appears to confirm the date portion is included.
+        #expect(result.contains("2025"))
+        _ = referenceFormatter // suppress unused-variable warning
+    }
+
+    @Test func test_formattedDateTime_when_same_date_given_twice_then_output_is_identical() {
+        // Given / When
+        let first = POSBookingDateFormatter.formattedDateTime(for: referenceStart)
+        let second = POSBookingDateFormatter.formattedDateTime(for: referenceStart)
+
+        // Then
+        #expect(first == second)
+    }
+
+    // MARK: - accessibilityFormattedTime
+
+    @Test func test_accessibilityFormattedTime_when_given_known_UTC_date_then_output_matches_UTC_time_only() {
+        // Given
+        let referenceFormatter = makePOSIXTimeFormatter()
+        let expected = referenceFormatter.string(from: referenceStart)
+
+        // When
+        let result = POSBookingDateFormatter.accessibilityFormattedTime(for: referenceStart)
+
+        // Then
+        #expect(result == expected)
+    }
+
+    @Test func test_accessibilityFormattedTime_when_same_date_given_twice_then_output_is_identical() {
+        // Given / When
+        let first = POSBookingDateFormatter.accessibilityFormattedTime(for: referenceStart)
+        let second = POSBookingDateFormatter.accessibilityFormattedTime(for: referenceStart)
+
+        // Then
+        #expect(first == second)
+    }
+}
+
+// MARK: - Helpers
+
+private extension POSBookingDateFormatterTests {
+
+    func makeBooking(startDate: Date, endDate: Date) -> POSBooking {
+        POSBooking(
+            id: 1,
+            customerName: "Jane Doe",
+            serviceName: "Test Service",
+            startDate: startDate,
+            endDate: endDate,
+            formattedAmount: "$50.00",
+            status: .confirmed,
+            attendanceStatus: .unattended,
+            orderID: 10,
+            resourceName: nil,
+            order: makeOrder()
+        )
+    }
+
+    func makeOrder() -> POSOrder {
+        POSOrder(
+            id: 10,
+            number: "10",
+            dateCreated: Date(),
+            status: .completed,
+            formattedTotal: "$50.00",
+            formattedSubtotal: "$50.00",
+            paymentMethodID: "cod",
+            paymentMethodTitle: "Cash",
+            formattedDiscountTotal: nil,
+            formattedTotalTax: "$0.00",
+            formattedPaymentTotal: "$50.00",
+            datePaid: nil
+        )
+    }
+
+    /// A time range formatter pinned to en_US_POSIX locale and UTC, mirroring
+    /// the production `timeRangeFormatter` configuration.
+    func makePOSIXTimeRangeFormatter() -> DateIntervalFormatter {
+        let formatter = DateIntervalFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter
+    }
+
+    /// A time-only formatter pinned to en_US_POSIX locale and UTC, mirroring
+    /// the production `accessibilityTimeFormatter` configuration.
+    func makePOSIXTimeFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter
+    }
+
+    /// A date+time formatter pinned to en_US_POSIX locale and UTC, mirroring
+    /// the production `dateTimeFormatter` configuration.
+    func makePOSIXDateTimeFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/ViewHelpers/POSBookingDateFormatterTests.swift
+++ b/Modules/Tests/PointOfSaleTests/ViewHelpers/POSBookingDateFormatterTests.swift
@@ -8,103 +8,61 @@ import enum Networking.BookingAttendanceStatus
 
 struct POSBookingDateFormatterTests {
 
-    // 09:00 UTC on 2025-01-15 (Wednesday)
+    // 10:00 UTC on 2025-01-15 (Wednesday)
     private let referenceStart = Date(timeIntervalSince1970: 1_736_935_200)
-    // 10:00 UTC on 2025-01-15
+    // 11:00 UTC on 2025-01-15
     private let referenceEnd = Date(timeIntervalSince1970: 1_736_938_800)
 
     // MARK: - formattedTimeRange
 
-    @Test func test_formattedTimeRange_when_booking_has_known_UTC_times_then_output_contains_both_hours() {
+    @Test func test_formattedTimeRange_formats_using_UTC_hours() {
         // Given
         let booking = makeBooking(startDate: referenceStart, endDate: referenceEnd)
 
         // When
         let result = POSBookingDateFormatter.formattedTimeRange(for: booking)
 
-        // Then
-        // DateIntervalFormatter may omit the AM/PM on the start time when both
-        // times share the same period (e.g. "9:00 – 10:00 AM"), so we verify
-        // the result against a same-configured DateIntervalFormatter in POSIX locale.
-        let referenceIntervalFormatter = makePOSIXTimeRangeFormatter()
-        let expected = referenceIntervalFormatter.string(from: referenceStart, to: referenceEnd)
-        #expect(result == expected)
-    }
-
-    @Test func test_formattedTimeRange_when_same_input_given_twice_then_output_is_identical() {
-        // Given
-        let booking = makeBooking(startDate: referenceStart, endDate: referenceEnd)
-
-        // When
-        let first = POSBookingDateFormatter.formattedTimeRange(for: booking)
-        let second = POSBookingDateFormatter.formattedTimeRange(for: booking)
-
-        // Then
-        #expect(first == second)
-    }
-
-    @Test func test_formattedTimeRange_when_end_is_after_start_then_output_is_non_empty() {
-        // Given
-        let booking = makeBooking(startDate: referenceStart, endDate: referenceEnd)
-
-        // When
-        let result = POSBookingDateFormatter.formattedTimeRange(for: booking)
-
-        // Then
-        #expect(!result.isEmpty)
+        // Then - contains UTC hours 10 and 11, no date components
+        #expect(result.contains("10"))
+        #expect(result.contains("11"))
+        #expect(!result.contains("2025"))
+        #expect(!result.contains("15"))
     }
 
     // MARK: - formattedDateTime
 
-    @Test func test_formattedDateTime_when_given_known_UTC_date_then_output_contains_date_and_time_components() {
-        // Given
-        let referenceFormatter = makePOSIXDateTimeFormatter()
-
+    @Test func test_formattedDateTime_formats_using_UTC_date_and_time() {
         // When
         let result = POSBookingDateFormatter.formattedDateTime(for: referenceStart)
 
-        // Then
-        // The production formatter and the reference formatter share the same UTC
-        // timezone, so their outputs must agree on the time portion regardless of
-        // the device locale.
-        let referenceTime = makePOSIXTimeFormatter().string(from: referenceStart)
-        #expect(result.contains(referenceTime))
-        // Date component: Jan 15, 2025 encoded as epoch seconds — verify the year
-        // appears to confirm the date portion is included.
+        // Then - contains both UTC date and time components
+        #expect(result.contains("10"))
+        #expect(result.contains("15"))
         #expect(result.contains("2025"))
-        _ = referenceFormatter // suppress unused-variable warning
-    }
-
-    @Test func test_formattedDateTime_when_same_date_given_twice_then_output_is_identical() {
-        // Given / When
-        let first = POSBookingDateFormatter.formattedDateTime(for: referenceStart)
-        let second = POSBookingDateFormatter.formattedDateTime(for: referenceStart)
-
-        // Then
-        #expect(first == second)
     }
 
     // MARK: - accessibilityFormattedTime
 
-    @Test func test_accessibilityFormattedTime_when_given_known_UTC_date_then_output_matches_UTC_time_only() {
-        // Given
-        let referenceFormatter = makePOSIXTimeFormatter()
-        let expected = referenceFormatter.string(from: referenceStart)
-
+    @Test func test_accessibilityFormattedTime_formats_using_UTC_hour() {
         // When
         let result = POSBookingDateFormatter.accessibilityFormattedTime(for: referenceStart)
 
-        // Then
-        #expect(result == expected)
+        // Then - contains UTC hour only, no date components
+        #expect(result.contains("10"))
+        #expect(!result.contains("2025"))
+        #expect(!result.contains("15"))
     }
 
-    @Test func test_accessibilityFormattedTime_when_same_date_given_twice_then_output_is_identical() {
-        // Given / When
-        let first = POSBookingDateFormatter.accessibilityFormattedTime(for: referenceStart)
-        let second = POSBookingDateFormatter.accessibilityFormattedTime(for: referenceStart)
+    // MARK: - formattedShortDate
 
-        // Then
-        #expect(first == second)
+    @Test func test_formattedShortDate_formats_using_UTC_date() {
+        // When
+        let result = POSBookingDateFormatter.formattedShortDate(for: referenceStart)
+
+        // Then - contains day in UTC, no year or time
+        #expect(result.contains("15"))
+        #expect(!result.contains("2025"))
+        #expect(!result.contains("10:"))
     }
 }
 
@@ -143,38 +101,5 @@ private extension POSBookingDateFormatterTests {
             formattedPaymentTotal: "$50.00",
             datePaid: nil
         )
-    }
-
-    /// A time range formatter pinned to en_US_POSIX locale and UTC, mirroring
-    /// the production `timeRangeFormatter` configuration.
-    func makePOSIXTimeRangeFormatter() -> DateIntervalFormatter {
-        let formatter = DateIntervalFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateStyle = .none
-        formatter.timeStyle = .short
-        formatter.timeZone = TimeZone(identifier: "UTC")
-        return formatter
-    }
-
-    /// A time-only formatter pinned to en_US_POSIX locale and UTC, mirroring
-    /// the production `accessibilityTimeFormatter` configuration.
-    func makePOSIXTimeFormatter() -> DateFormatter {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateStyle = .none
-        formatter.timeStyle = .short
-        formatter.timeZone = TimeZone(identifier: "UTC")
-        return formatter
-    }
-
-    /// A date+time formatter pinned to en_US_POSIX locale and UTC, mirroring
-    /// the production `dateTimeFormatter` configuration.
-    func makePOSIXDateTimeFormatter() -> DateFormatter {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .short
-        formatter.timeZone = TimeZone(identifier: "UTC")
-        return formatter
     }
 }


### PR DESCRIPTION
Closes WOOMOB-2575

## Description

When making a test booking I've noticed that while it was made for 11AM, it showed 13PM in the app, and my timezone should fit 16PM, so the booking hours were off at some point.

It seems that the API sends local time disguised as UTC. For booking x (the 11AM Vilnius booking):                                                                                  
  - API raw timestamp 1771930800 decodes to 11:00 UTC       
  - But 11AM Vilnius (UTC+2) should be 09:00 UTC
  - The timestamp is off by exactly +2 hours — the Vilnius GMT offset

This means the Bookings API is encoding the site-local time as a UTC timestamp, not converting to true UTC first (e.g., 11:00 AM Vilnius is sent as epoch for 11:00 UTC, not 09:00 UTC). 

More details in p1771921078262749-slack-C070SJRA8DP

## Changes

Created `POSBookingDateFormatter` that centralizes all booking time formatting using UTC, so the site-local time is shown correctly regardless of device timezone.

## Test Steps
- Create a new booking and note down the booking time. I've used https://generously-zealous-triumph.commerce-garden.com/ which is set to Vilnius time (note the store address itself is set to Ventnor City which is 12h behind, but not the booking settings)  
- In the app, switch the device timezone to something else. Then navigate to the booking. Observe that the booking day and time still matches of the original (Vilnius time)

<img width="804" height="630" alt="Screenshot 2026-02-24 at 15 50 36" src="https://github.com/user-attachments/assets/47bd4a4a-a57b-4c38-b23c-7eb1892da455" />

<img width="2420" height="1668" alt="simulator_screenshot_306D9B26-A82F-4308-9D0F-F595B498BB93" src="https://github.com/user-attachments/assets/259d5880-4692-45a6-af38-8993862e19b1" />

- Attempt to cancel booking, note the time is correct:

<img width="2420" height="1668" alt="simulator_screenshot_507E0777-83EF-4A30-B3EC-EF58224204C8" src="https://github.com/user-attachments/assets/99a35f7b-cbef-4685-80b8-1b553252a86e" />

