### PR TITLE
POS Bookings: Fix cash button offset and loading state for free orders

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
@@ -65,6 +65,7 @@ struct POSFloatingControlView: View {
         }
         .posFullScreenCover(isPresented: $showBookings) {
             POSBookingsContainerView(isPresented: $showBookings)
+                .environment(\.floatingControlAreaSize, .zero)
         }
         .onChange(of: showBookings) { _, isShowing in
             if isShowing {

--- a/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
@@ -92,7 +92,7 @@ struct POSPaymentContentView: View {
                 paymentState: paymentModel.paymentState,
                 cardPresentPaymentInlineMessage: paymentModel.cardPresentPaymentInlineMessage,
                 connectCardReaderAction: paymentModel.connectCardReader,
-                showLoadingWhenIdle: true)
+                showLoadingWhenIdle: !paymentModel.isZeroTotal)
         }
     }
 


### PR DESCRIPTION
Closes: WOOMOB-2262

## Description

Two fixes for POS bookings payments:

1. **Fix cash payment button offset** — The bookings fullscreen cover inherits `floatingControlAreaSize` from the dashboard, causing the collect cash view to add bottom padding for floating controls that aren't visible in bookings. This overrides the environment value to `.zero` in the bookings cover.

2. **Skip "Loading order" for free bookings** — When a booking has a zero total, the card payment state stays `.idle` and the reader stays `.connected`, causing the "Loading order" spinner to show indefinitely. This skips the loading view when `isZeroTotal` is true.

## Test Steps

**Cash button offset:**
1. Open POS with bookings enabled
2. Open a booking and tap "Collect payment"
3. With a card reader connected, tap "Cash payment"
4. Dismiss the keyboard
5. Verify the "Mark payment as complete" button is not offset from the bottom, as if floating controls were present.

Check the main payment flow as well – there, the button should still be offset from the buttons.

**Free order loading:**
1. Open POS with bookings enabled and a card reader connected
2. Open a free booking (total = $0.00) and tap "Collect payment"
3. Verify the "Loading order" spinner is only shown for a short time, and then hidden.

You can only create a free, but "unpaid" booking in wp-admin – from the frontend, they're marked as paid by the checkout. It requires a free booking product. So... this is quite an edge case!

Note that the keyboard button on iOS 18 sometimes puts a small safearea when it's hidden, and sometimes doesn't. We respect that when the safearea's available.

## Screenshots
https://github.com/user-attachments/assets/edaffa3a-4dbb-4d9c-8230-688a6a775e78

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.