### PR TITLE
POS Bookings: Set View Order as primary action button

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -84,7 +84,7 @@ struct POSBookingDetailView: View {
                 isLoading: isDetailsUpdating,
                 backButtonConfiguration: shouldShowBackButton ? .init(state: .enabled, action: onBack) : nil,
                 trailingContent: {
-                    viewOrderMenu
+                    headerTrailingContent
                 },
                 bottomContent: {
                     POSBookingSummaryView(booking: booking)
@@ -144,11 +144,26 @@ struct POSBookingDetailView: View {
     }
 
     @ViewBuilder
-    private var viewOrderMenu: some View {
-        Menu {
+    private var headerTrailingContent: some View {
+        HStack(spacing: POSSpacing.small) {
             Button(Localization.viewOrderAction) {
                 navigationPath.append(.orderDetail)
             }
+            .buttonStyle(POSFilledButtonStyle(size: .extraSmall))
+
+            if hasOverflowMenuActions {
+                overflowMenu
+            }
+        }
+    }
+
+    private var hasOverflowMenuActions: Bool {
+        booking.isPaid || booking.isCancellable
+    }
+
+    @ViewBuilder
+    private var overflowMenu: some View {
+        Menu {
             if booking.isPaid {
                 Button(Localization.issueRefundAction) {
                     orderListModel.ordersController.selectOrder(booking.order)
@@ -569,7 +584,7 @@ private enum Localization {
     static let viewOrderAction = NSLocalizedString(
         "pos.bookingDetailView.viewOrderAction",
         value: "View Order",
-        comment: "Menu action to view the linked order from a booking detail."
+        comment: "Button to view the linked order from the booking detail header."
     )
 
     // MARK: - Accessibility


### PR DESCRIPTION
Closes: WOOMOB-2293

## Description

Extracts "View Order" from the booking detail overflow (`...`) menu into a standalone filled button in the header, making it the primary action. This reduces the risk of accidental destructive actions (Refund, Cancel) by giving the only non-destructive action visual prominence.

- "View Order" is now a filled button to the left of the `...` menu, always visible
- The overflow menu retains only the destructive actions (Issue Refund, Cancel Booking)
- The `...` menu hides entirely when there are no remaining actions (e.g. cancelled, unpaid bookings)

## Test Steps

1. Open POS Bookings and select a **paid** booking → verify "View order" button appears next to `...` menu, and the menu contains only "Issue Refund" and "Cancel Booking"
2. Select an **unpaid** booking → verify "View order" button appears next to `...` menu, and the menu contains only "Cancel Booking"
3. Select a **cancelled** booking → verify "View order" button appears alone with no `...` menu
4. Tap the "View order" button → verify it navigates to the order detail view

## Screenshots


https://github.com/user-attachments/assets/e13aca50-f13d-46f2-b25c-e9d2727b7520


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.