### PR TITLE
Handle email_login_not_allowed error fallback for /token endpoint

### DIFF
--- a/WooCommerce/WordPressAuthenticator/Signin/LoginWPComViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginWPComViewController.swift
@@ -205,6 +205,12 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
     override func displayRemoteError(_ error: Error) {
         configureViewLoading(false)
 
+        if (error as? WordPressComOAuthError)?.authenticationFailureKind == .emailLoginNotAllowed {
+            tracker.track(failure: error.localizedDescription)
+            showMagicLinkRequestScreen()
+            return
+        }
+
         if (error as? WordPressComOAuthError)?.authenticationFailureKind == .invalidRequest {
             let message = NSLocalizedString("It seems like you've entered an incorrect password. Want to give it another try?", comment: "An error message shown when a wpcom user provides the wrong password.")
             displayError(message: message)
@@ -235,6 +241,13 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
     @objc func signinFormVerticalOffset() -> CGFloat {
         // the stackview-based layout shifts fine with this adjustment
         return 0
+    }
+
+    private func showMagicLinkRequestScreen() {
+        let vc = MagicLinkRequestViewController(fallbackAction: .wpcomUsernamePassword)
+        vc.loginFields = loginFields
+        vc.dismissBlock = dismissBlock
+        navigationController?.pushViewController(vc, animated: true)
     }
 }
 

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -124,6 +124,12 @@ class PasswordViewController: LoginViewController {
     override func displayRemoteError(_ error: Error) {
         configureViewLoading(false)
 
+        if (error as? WordPressComOAuthError)?.authenticationFailureKind == .emailLoginNotAllowed {
+            tracker.track(failure: error.localizedDescription)
+            showMagicLinkRequestScreen()
+            return
+        }
+
         if let source = source, loginFields.meta.userIsDotCom {
             let passwordError = SignInError.invalidWPComPassword(source: source)
             if authenticationDelegate.shouldHandleError(passwordError) {
@@ -544,6 +550,13 @@ private extension PasswordViewController {
 
         vc.loginFields = self.loginFields
         vc.loginFields.restrictToWPCom = true
+        navigationController?.pushViewController(vc, animated: true)
+    }
+
+    func showMagicLinkRequestScreen() {
+        let vc = MagicLinkRequestViewController(fallbackAction: .wpcomUsernamePassword)
+        vc.loginFields = loginFields
+        vc.dismissBlock = dismissBlock
         navigationController?.pushViewController(vc, animated: true)
     }
 

--- a/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/WordPressComOAuthClient.swift
+++ b/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/WordPressComOAuthClient.swift
@@ -20,7 +20,8 @@ public struct AuthenticationFailure: LocalizedError {
         "invalid_otp": .invalidOneTimePassword,
         "user_exists": .socialLoginExistingUserUnconnected,
         "invalid_two_step_code": .invalidTwoStepCode,
-        "unknown_user": .unknownUser
+        "unknown_user": .unknownUser,
+        "email_login_not_allowed": .emailLoginNotAllowed
     ]
 
     public enum Kind {
@@ -39,6 +40,7 @@ public struct AuthenticationFailure: LocalizedError {
         /// Supplied MFA code is incorrect
         case invalidTwoStepCode
         case unknownUser
+        case emailLoginNotAllowed
         case unknown
     }
 

--- a/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/Stubs/JSON/WordPressComOAuthEmailLoginNotAllowedFail.json
+++ b/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/Stubs/JSON/WordPressComOAuthEmailLoginNotAllowedFail.json
@@ -1,0 +1,4 @@
+{
+    "error_description": "Please log in using your WordPress.com username instead of your email address.",
+    "error": "email_login_not_allowed"
+}

--- a/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressComOAuthClientTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressComOAuthClientTests.swift
@@ -138,6 +138,37 @@ class WordPressComOAuthClientTests: XCTestCase {
         waitForExpectations(timeout: 2, handler: nil)
     }
 
+    func testAuthenticateUsernameEmailLoginNotAllowedCase() throws {
+        // Given
+        let stubPath = try XCTUnwrap(
+            OHPathForFileInBundle("WordPressComOAuthEmailLoginNotAllowedFail.json", Bundle.coreAPITestsBundle)
+        )
+        stub(condition: isOauthTokenRequest(url: .oAuthTokenUrl)) { _ in
+            return fixture(filePath: stubPath, status: 403, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
+        }
+
+        let expect = expectation(description: "One callback should be invoked")
+        let client = WordPressComOAuthClient(clientID: "Fake", secret: "Fake")
+
+        // When
+        client.authenticate(
+            username: "email@example.com",
+            password: "fakePass",
+            multifactorCode: nil,
+            needsMultifactor: { _, _ in XCTFail("This closure should not be called") },
+            success: { (_) in
+                expect.fulfill()
+                XCTFail("This call should fail")
+            },
+            failure: { (error) in
+                // Then
+                expect.fulfill()
+                XCTAssertEqual(error.authenticationFailureKind, .emailLoginNotAllowed, "The error kind should be emailLoginNotAllowed")
+            }
+        )
+        waitForExpectations(timeout: 2, handler: nil)
+    }
+
     func testAuthenticateUsername2FAWrong2FACase() throws {
         let stubPath = try XCTUnwrap(
             OHPathForFileInBundle("WordPressComOAuthNeeds2FAFail.json", Bundle.coreAPITestsBundle)


### PR DESCRIPTION
WOOMOB-2173

## Description

The `/oauth2/token` endpoint now also returns the `email_login_not_allowed` error when a user's email is flagged as suspicious. Previously this was only handled at the email entry step. This PR adds handling at the password step for both login flows (legacy and unified auth), redirecting the user to the magic link request screen with a "use username and password" fallback.

**Changes:**
- Map `email_login_not_allowed` error code to `AuthenticationFailure.Kind.emailLoginNotAllowed` in the OAuth client
- Handle the error in `LoginWPComViewController.displayRemoteError` (legacy flow) and `PasswordViewController.displayRemoteError` (unified auth flow)
- Use `.wpcomUsernamePassword` fallback action so the user can alternatively log in with their WP.com username instead of email — matching the Android implementation and the existing email-step handling in `GetStartedViewController`

Android counterpart: https://github.com/woocommerce/woocommerce-android/pull/15384

## Test Steps

1. Use an account with a "suspicious" email flagged by WordPress.com (or simulate the `email_login_not_allowed` 400 error from the `/oauth2/token` endpoint):
```
{
  "error": "email_login_not_allowed",
  "error_description": "Please log in using your WordPress.com username instead of your email address."
}
```
2. Attempt to log in with that email + password
3. Verify you are redirected to the magic link request screen
4. Just in case - smoke the invited magic link authorization.

## Demo

https://github.com/user-attachments/assets/857ebaa8-87e5-4079-9e4f-abc7141102ba

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.