### PR TITLE
Push notifications: Re-check plugin compatibility after update WebView closes

### DIFF
--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupStepView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupStepView.swift
@@ -14,6 +14,7 @@ struct WPComConnectionSetupStepView: View {
 
                 detail
                     .font(.subheadline)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
     }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupView.swift
@@ -155,7 +155,7 @@ private extension WPComConnectionSetupView {
         ),
         onDismiss: {},
         onGoToStore: {},
-        onUpdatePlugin: {}
+        onUpdatePlugin: { _ in }
     )
     WPComConnectionSetupView(viewModel: viewModel)
 }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
@@ -66,14 +66,14 @@ final class WPComConnectionSetupViewModel: ObservableObject {
     private let handler: WPComConnectionSetupHandlerProtocol
     private let onDismiss: () -> Void
     private let onGoToStore: () -> Void
-    private let onUpdatePlugin: () -> Void
+    private let onUpdatePlugin: (@escaping () -> Void) -> Void
     private var shouldAutoOpenUpdatePlugin = false
 
     init(storeName: String,
          handler: WPComConnectionSetupHandlerProtocol,
          onDismiss: @escaping () -> Void,
          onGoToStore: @escaping () -> Void,
-         onUpdatePlugin: @escaping () -> Void) {
+         onUpdatePlugin: @escaping (@escaping () -> Void) -> Void) {
         self.storeName = storeName
         self.handler = handler
         self.onDismiss = onDismiss
@@ -99,7 +99,9 @@ final class WPComConnectionSetupViewModel: ObservableObject {
     func onAppear() {
         if shouldAutoOpenUpdatePlugin {
             shouldAutoOpenUpdatePlugin = false
-            onUpdatePlugin()
+            onUpdatePlugin { [weak self] in
+                self?.retrySetup()
+            }
             return
         }
         guard setupState == .inProgress else { return }
@@ -121,7 +123,9 @@ final class WPComConnectionSetupViewModel: ObservableObject {
                 retrySetup()
             case .checkPlugin:
                 if checkPluginError == .outdated {
-                    onUpdatePlugin()
+                    onUpdatePlugin { [weak self] in
+                        self?.retrySetup()
+                    }
                 } else {
                     retrySetup()
                 }

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -41,11 +41,11 @@ final class WooPushNotificationSetupCoordinator {
                 navigationController?.dismiss(animated: true)
                 onSetupCompleted?()
             },
-            onUpdatePlugin: { [weak navigationController, stores] in
+            onUpdatePlugin: { [weak navigationController, stores] onDismissed in
                 guard let navigationController,
                       let site = stores.sessionManager.defaultSite,
                       let url = URL(string: site.adminURL + Constants.wooCommercePluginUpdatePath) else { return }
-                let webView = AuthenticatableWebView(url: url, title: Localization.updateWooCommerce)
+                let webView = AuthenticatableWebView(url: url, title: Localization.updateWooCommerce, onDismiss: onDismissed)
                 let vc = UIHostingController(rootView: webView)
                 vc.modalPresentationStyle = .formSheet
                 navigationController.present(vc, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/DebugPanelView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/DebugPanelView.swift
@@ -46,7 +46,7 @@ struct DebugPanelView: View {
                         ),
                         onDismiss: dismiss,
                         onGoToStore: dismiss,
-                        onUpdatePlugin: {}
+                        onUpdatePlugin: { _ in }
                     )
                     WPComConnectionSetupView(viewModel: viewModel)
                 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
@@ -120,6 +120,7 @@ struct AuthenticatedWebView_Previews: PreviewProvider {
 struct AuthenticatableWebView: View {
     let url: URL
     var title: String = ""
+    var onDismiss: (() -> Void)? = nil
 
     @Environment(\.dismiss) var dismiss
 
@@ -139,6 +140,9 @@ struct AuthenticatableWebView: View {
             } else {
                 SafariSheetView(url: url)
             }
+        }
+        .onDisappear {
+            onDismiss?()
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModelTests.swift
@@ -8,6 +8,7 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
     private var dismissCalled: Bool!
     private var goToStoreCalled: Bool!
     private var updatePluginCalled: Bool!
+    private var capturedUpdatePluginDismissed: (() -> Void)?
 
     override func setUp() {
         super.setUp()
@@ -15,6 +16,7 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
         dismissCalled = false
         goToStoreCalled = false
         updatePluginCalled = false
+        capturedUpdatePluginDismissed = nil
     }
 
     override func tearDown() {
@@ -22,6 +24,7 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
         dismissCalled = nil
         goToStoreCalled = nil
         updatePluginCalled = nil
+        capturedUpdatePluginDismissed = nil
         super.tearDown()
     }
 
@@ -220,6 +223,47 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
         XCTAssertEqual(mockHandler.startCallCount, 1)
     }
 
+    // MARK: - Plugin WebView Dismissal Tests
+
+    func test_primaryButtonTapped_on_plugin_failure_outdated_retries_when_webview_dismissed() {
+        // Given
+        let viewModel = makeViewModel()
+        mockHandler.simulateStepUpdate(.checkPlugin, status: .failure(error: .outdatedPlugin(version: "10.3.4")))
+        viewModel.primaryButtonTapped()
+
+        // When (simulate web view dismissed)
+        capturedUpdatePluginDismissed?()
+
+        // Then
+        XCTAssertEqual(mockHandler.retryCallCount, 1)
+    }
+
+    func test_onAppear_autoOpen_retries_when_webview_dismissed() {
+        // Given
+        let viewModel = makeViewModel()
+        viewModel.setPluginOutdatedState(version: "10.4.0")
+        viewModel.onAppear() // triggers auto-open of web view
+
+        // When (simulate web view dismissed)
+        capturedUpdatePluginDismissed?()
+
+        // Then
+        XCTAssertEqual(mockHandler.retryCallCount, 1)
+    }
+
+    func test_primaryButtonTapped_on_plugin_failure_outdated_resets_state_when_webview_dismissed() {
+        // Given
+        let viewModel = makeViewModel()
+        mockHandler.simulateStepUpdate(.checkPlugin, status: .failure(error: .outdatedPlugin(version: "10.3.4")))
+        viewModel.primaryButtonTapped()
+
+        // When (simulate web view dismissed)
+        capturedUpdatePluginDismissed?()
+
+        // Then: primary button should be disabled (setup is in progress)
+        XCTAssertFalse(viewModel.isPrimaryButtonEnabled)
+    }
+
     // MARK: - Helpers
 
     private func makeViewModel() -> WPComConnectionSetupViewModel {
@@ -228,7 +272,10 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
             handler: mockHandler,
             onDismiss: { [weak self] in self?.dismissCalled = true },
             onGoToStore: { [weak self] in self?.goToStoreCalled = true },
-            onUpdatePlugin: { [weak self] in self?.updatePluginCalled = true }
+            onUpdatePlugin: { [weak self] onDismissed in
+                self?.updatePluginCalled = true
+                self?.capturedUpdatePluginDismissed = onDismissed
+            }
         )
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModelTests.swift
@@ -279,20 +279,3 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
         )
     }
 }
-
-// MARK: - WPComConnectionSetupStep.Status Equatable
-
-extension WPComConnectionSetupStep.Status: Equatable {
-    public static func == (lhs: WPComConnectionSetupStep.Status, rhs: WPComConnectionSetupStep.Status) -> Bool {
-        switch (lhs, rhs) {
-        case (.notStarted, .notStarted),
-             (.running, .running),
-             (.success, .success):
-            return true
-        case let (.failure(lhsError), .failure(rhsError)):
-            return lhsError == rhsError
-        default:
-            return false
-        }
-    }
-}


### PR DESCRIPTION
Closes WOOMOB-2308

## Description

When the plugin update WebView is dismissed (via Done button or swipe), automatically re-run the WooCommerce plugin compatibility check instead of requiring the user to manually tap "Try Again".

- If the plugin is now compatible, the PN setup flow continues (Jetpack connection → push registration)
- If still incompatible, the existing outdated-plugin error screen is shown with the Update plugin button

**Changes:**
- `AuthenticatableWebView`: added optional `onDismiss` callback, fired via `onDisappear` — handles both Done button and swipe-to-dismiss
- `WPComConnectionSetupViewModel`: changed `onUpdatePlugin` signature to `(@escaping () -> Void) -> Void` so callers can pass a "dismissed" callback; on dismissal, `retrySetup()` is called automatically
- `WooPushNotificationSetupCoordinator`: forwards the dismissed callback to the WebView

## Test Steps

1. Have a site where the WooCommerce plugin version is below the minimum required (use the debug override in Settings → Debug Panel if needed)
2. From Dashboard or Settings, tap Enable Push Notifications
3. The setup screen appears with the Check plugin compatibility step failing and the Update plugin WebView opening automatically
4. In the WebView, do **not** update the plugin — tap Done
5. **Expected:** the compatibility check runs again automatically and the outdated-plugin error screen reappears (no manual "Try Again" needed)
6. Repeat steps 3–4 but this time update the plugin in the WebView (or mock the plugin check response to lower than current version), then dismiss
7. **Expected:** the compatibility check passes and the flow continues to the next step

## Screenshots

When updating fails/cancelled:

https://github.com/user-attachments/assets/3617c3a1-9227-4ccd-b006-10ae6a72e830


When updating completes:


https://github.com/user-attachments/assets/835ebd8d-f9e0-47e5-8265-1acee6544b75



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.