### PR TITLE
POS Bookings: rely on customer id being zero for guest customers

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -236,7 +236,7 @@ struct POSBookingDetailView: View {
                     .foregroundStyle(Color.posOnSurface)
                     .accessibilityAddTraits(.isHeader)
 
-                if booking.hasNoCustomerDetails {
+                if booking.isGuest {
                     POSBookingBadgeView(
                         title: Localization.guestBadge,
                         textColor: .posOnDefault,
@@ -455,9 +455,8 @@ struct POSBookingDetailView: View {
 // MARK: - POSBooking Presentation Helpers
 
 private extension POSBooking {
-    var hasNoCustomerDetails: Bool {
-        customerName == nil && customerEmail == nil && customerPhone == nil
-            && billingAddress == nil && customerNote == nil
+    var isGuest: Bool {
+        customerID == 0
     }
 }
 
@@ -530,7 +529,7 @@ private enum Localization {
     static let guestBadge = NSLocalizedString(
         "pos.bookingDetailView.guestBadge",
         value: "Guest",
-        comment: "Badge label shown next to the customer section title when there is no customer info for a booking."
+        comment: "Badge label shown next to the customer section title when the booking has no associated customer (guest checkout)."
     )
 
     static let noteLabel = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -562,6 +562,7 @@ extension POSPreviewHelpers {
         [
             POSBooking(
                 id: 1,
+                customerID: 10,
                 customerName: "Margarita Nikolaevna",
                 serviceName: "Women's Haircut",
                 startDate: Date(),
@@ -584,6 +585,7 @@ extension POSPreviewHelpers {
             ),
             POSBooking(
                 id: 2,
+                customerID: 11,
                 customerName: "Jane Doe",
                 serviceName: "Massage",
                 startDate: Date().addingTimeInterval(7200),
@@ -605,6 +607,7 @@ extension POSPreviewHelpers {
             ),
             POSBooking(
                 id: 3,
+                customerID: 12,
                 customerName: "Alex Johnson",
                 serviceName: "Consultation",
                 startDate: Date().addingTimeInterval(-3600),
@@ -642,6 +645,7 @@ extension POSPreviewHelpers {
         )
         return POSBooking(
             id: 333,
+            customerID: 10,
             customerName: "Margarita Nikolaevna",
             serviceName: "Women's Haircut",
             startDate: now,
@@ -686,6 +690,7 @@ extension POSPreviewHelpers {
         )
         return POSBooking(
             id: 334,
+            customerID: 10,
             customerName: "Margarita Nikolaevna",
             serviceName: "Women's Haircut",
             startDate: now,
@@ -770,6 +775,7 @@ extension POSPreviewHelpers {
         )
         return POSBooking(
             id: 336,
+            customerID: 12,
             customerName: "Alex Johnson",
             serviceName: "Consultation",
             startDate: now,

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBooking.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBooking.swift
@@ -13,6 +13,7 @@ public struct POSBooking: Equatable, Hashable, Identifiable, GeneratedCopiable {
     }
 
     public let id: Int64
+    public let customerID: Int64
     public let customerName: String?
     public let serviceName: String
     public let startDate: Date
@@ -35,6 +36,7 @@ public struct POSBooking: Equatable, Hashable, Identifiable, GeneratedCopiable {
     public let order: POSOrder
 
     public init(id: Int64,
+                customerID: Int64 = 0,
                 customerName: String?,
                 serviceName: String,
                 startDate: Date,
@@ -56,6 +58,7 @@ public struct POSBooking: Equatable, Hashable, Identifiable, GeneratedCopiable {
                 formattedTax: String? = nil,
                 order: POSOrder) {
         self.id = id
+        self.customerID = customerID
         self.customerName = customerName
         self.serviceName = serviceName
         self.startDate = startDate

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingMapper.swift
@@ -60,6 +60,7 @@ struct POSBookingMapper {
 
         return POSBooking(
             id: booking.bookingID,
+            customerID: booking.customerID,
             customerName: customerName,
             serviceName: serviceName,
             startDate: booking.startDate,


### PR DESCRIPTION
Closes WOOMOB-2311

 👋 This one can go in 24.2 or we can wait to 24.3, feel free to skip till next week based on priorities.

## Description

Shows the "Guest" badge in POS booking details based on `customerID == 0`, instead of checking if all customer fields are nil. This matches the web's behavior for identifying guest bookings

## Test Steps
1. Open a POS booking made by a guest customer (or create a new booking leaving default "Guest" selected in wp-admin)
2. Verify the "Guest" badge appears next to the Customer section title
3. Open a POS booking made by a logged-in customer
4. Verify the "Guest" badge does not appear

## Screenshots

<img width="2420" height="1668" alt="simulator_screenshot_E131C14F-519D-4A1E-A1A9-5CAF46A70E7F" src="https://github.com/user-attachments/assets/b0cc81c5-02e2-4393-939a-7df992fb4c77" />

