### PR TITLE
POS Bookings: Switch `pointOfSaleBookings` feature flag

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -95,9 +95,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .pointOfSaleFTSSearch:
             return true
         case .ciabBookings:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .ciab:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .pointOfSaleCatalogAPI:
             return false
         case .pointOfSaleRefundsi1:

--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -95,13 +95,13 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .pointOfSaleFTSSearch:
             return true
         case .ciabBookings:
-            return true
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .pointOfSaleCatalogAPI:
             return false
         case .pointOfSaleRefundsi1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .pointOfSaleBookings:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .selfDrivenPushTokenWPCom:
             return false
         case .selfDrivenPushTokenAppPasswords:

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -201,11 +201,6 @@ public enum FeatureFlag: Int, CaseIterable {
     ///
     case ciabBookings
 
-    /// Represents CIAB environment availability overall
-    /// Has same underlying logic as `ciabBookings` flag.
-    ///
-    case ciab
-
     /// Enables using the catalog API endpoint for Point of Sale catalog full sync
     ///
     case pointOfSaleCatalogAPI

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockFeatureFlagService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockFeatureFlagService.swift
@@ -24,7 +24,6 @@ final class MockFeatureFlagService: POSFeatureFlagProviding {
     var isFeatureFlagEnabledReturnValue: [FeatureFlag: Bool] = [:]
     var isCIABBookingsEnabled: Bool
     var isPointOfSaleRefundsi1Enabled: Bool
-    var isCIABEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isShowInboxCTAEnabled: Bool = false,
@@ -46,8 +45,7 @@ final class MockFeatureFlagService: POSFeatureFlagProviding {
          backgroundProductImageUpload: Bool = false,
          isProductImageOptimizedHandlingEnabled: Bool = false,
          isCIABBookingsEnabled: Bool = false,
-         isPointOfSaleRefundsi1Enabled: Bool = false,
-         isCIABEnabled: Bool = false) {
+         isPointOfSaleRefundsi1Enabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isShowInboxCTAEnabled = isShowInboxCTAEnabled
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -69,7 +67,6 @@ final class MockFeatureFlagService: POSFeatureFlagProviding {
         self.isProductImageOptimizedHandlingEnabled = isProductImageOptimizedHandlingEnabled
         self.isCIABBookingsEnabled = isCIABBookingsEnabled
         self.isPointOfSaleRefundsi1Enabled = isPointOfSaleRefundsi1Enabled
-        self.isCIABEnabled = isCIABEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -122,8 +119,6 @@ final class MockFeatureFlagService: POSFeatureFlagProviding {
             return isCIABBookingsEnabled
         case .pointOfSaleRefundsi1:
             return isPointOfSaleRefundsi1Enabled
-        case .ciab:
-            return isCIABEnabled
         default:
             return false
         }


### PR DESCRIPTION
Closes WOOMOB-2309

Enables POS bookings for release.

## Changes
- Removed unused `.ciab` flag
- Set `. pointOfSaleBookings` flag to `true`

## Test Steps
- Switch scheme to `release` config, run the app, confirm that:
  - Bookings menu item shows up, and works as expected

<img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - CIAB - 2026-02-26 at 09 25 48" src="https://github.com/user-attachments/assets/42939d74-e3dc-42bc-b2a0-382bcd2e2660" />


  - Refund button is available for paid bookings

<img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - CIAB - 2026-02-26 at 09 26 05" src="https://github.com/user-attachments/assets/b223c490-d0d1-425b-8f4d-5a3d496f53c6" />

- Refund button is not available for paid orders

<img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - CIAB - 2026-02-26 at 09 26 17" src="https://github.com/user-attachments/assets/69c17d93-eb1b-4d7e-b953-fd9308fead8d" />

