### PR TITLE
POS Bookings: Fix broken emails navigation

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -23,6 +23,7 @@ struct POSBookingDetailView: View {
     @State private var scrollViewHeight: CGFloat = 0
     @State private var isDetailsUpdating = false
     @State private var isShowingNoteView = false
+    @State private var isShowingEmailReceiptView = false
 
     private var actionTintColor: Color {
         colorScheme == .dark ? .posSecondary : .posPrimaryContainer
@@ -40,7 +41,7 @@ struct POSBookingDetailView: View {
                     case .orderDetail:
                         POSOrderDetailsView(order: booking.order, onBack: {
                             navigationPath.removeLast()
-                        })
+                        }, isShowingEmailReceiptView: $isShowingEmailReceiptView)
                         // Forces back button to be rendered, otherwise the system assumes that
                         // navigation is handled by the split view's sidebar, not a back button
                         .environment(\.posHeaderBackButtonConfiguration, .init(state: .enabled, action: {
@@ -50,6 +51,7 @@ struct POSBookingDetailView: View {
                         POSOrderDetailsView(
                             order: booking.order,
                             onBack: { navigationPath.removeLast() },
+                            isShowingEmailReceiptView: $isShowingEmailReceiptView,
                             autoStartRefund: true,
                             onRefundSuccess: {
                                 Task {
@@ -72,6 +74,12 @@ struct POSBookingDetailView: View {
             if let paymentModel {
                 POSBookingPaymentView(booking: booking, paymentModel: paymentModel, onDismiss: dismissPayment)
             }
+        }
+        .posFullScreenCover(isPresented: $isShowingEmailReceiptView) {
+            POSSendReceiptView(isShowingSendReceiptView: $isShowingEmailReceiptView) { email in
+                try await orderListModel.sendReceipt(order: booking.order, email: email)
+            }
+            .posHeaderBackButtonIcon(systemName: "xmark")
         }
         .posFullScreenCover(isPresented: $isShowingNoteView) {
             POSBookingNoteView(booking: booking, isShowingNoteView: $isShowingNoteView)

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -8,6 +8,7 @@ import typealias Yosemite.OrderItemAttribute
 struct POSOrderDetailsView: View {
     let order: POSOrder
     let onBack: () -> Void
+    @Binding var isShowingEmailReceiptView: Bool
     var autoStartRefund: Bool = false
     var onRefundSuccess: (() -> Void)? = nil
     var onRefundFailure: ((Error) -> Void)? = nil
@@ -18,7 +19,6 @@ struct POSOrderDetailsView: View {
     @Environment(\.posAnalytics) private var analytics
     @Environment(\.posFeatureFlags) private var featureFlags
     @Environment(\.posCurrencyProvider) private var currencyProvider
-    @State private var isShowingEmailReceiptView: Bool = false
     @State private var refundModalState: RefundModalState?
 
     private var shouldShowBackButton: Bool {
@@ -72,12 +72,6 @@ struct POSOrderDetailsView: View {
         }
         .background(Color.posSurface)
         .navigationBarHidden(true)
-        .posFullScreenCover(isPresented: $isShowingEmailReceiptView) {
-            POSSendReceiptView(isShowingSendReceiptView: $isShowingEmailReceiptView) { email in
-                try await orderListModel.sendReceipt(order: order, email: email)
-            }
-            .posHeaderBackButtonIcon(systemName: "xmark")
-        }
         .posModal(item: $refundModalState, onDismiss: {
             orderListModel.ordersController.clearRefundSelection()
         }) { state in
@@ -558,7 +552,8 @@ private enum Localization {
 #Preview("Order Details - Completed") {
     POSOrderDetailsView(
         order: POSPreviewHelpers.makePreviewOrder(),
-        onBack: {}
+        onBack: {},
+        isShowingEmailReceiptView: .constant(false)
     )
     .environment(POSPreviewHelpers.makePreviewOrdersModel(state: .empty))
 }
@@ -566,7 +561,8 @@ private enum Localization {
 #Preview("Order Details - Refunded") {
     POSOrderDetailsView(
         order: POSPreviewHelpers.makePreviewOrderWithRefund(),
-        onBack: {}
+        onBack: {},
+        isShowingEmailReceiptView: .constant(false)
     )
     .environment(POSPreviewHelpers.makePreviewOrdersModel(state: .empty))
 }
@@ -574,7 +570,8 @@ private enum Localization {
 #Preview("Order Details - Failed") {
     POSOrderDetailsView(
         order: POSPreviewHelpers.makePreviewFailedOrder(),
-        onBack: {}
+        onBack: {},
+        isShowingEmailReceiptView: .constant(false)
     )
     .environment(POSPreviewHelpers.makePreviewOrdersModel(state: .empty))
 }
@@ -582,7 +579,8 @@ private enum Localization {
 #Preview("Order Details - Without Email") {
     POSOrderDetailsView(
         order: POSPreviewHelpers.makePreviewOrderWithoutEmail(),
-        onBack: {}
+        onBack: {},
+        isShowingEmailReceiptView: .constant(false)
     )
     .environment(POSPreviewHelpers.makePreviewOrdersModel(state: .empty))
 }
@@ -590,7 +588,8 @@ private enum Localization {
 #Preview("Order Details - With Net Payment") {
     POSOrderDetailsView(
         order: POSPreviewHelpers.makePreviewOrderWithNetPayment(),
-        onBack: {}
+        onBack: {},
+        isShowingEmailReceiptView: .constant(false)
     )
     .environment(POSPreviewHelpers.makePreviewOrdersModel(state: .empty))
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
@@ -11,11 +11,20 @@ struct POSOrdersView: View {
     @State private var isSearching: Bool = false
     @State private var searchTerm: String = ""
     @State private var showBlog = false
+    @State private var isShowingEmailReceiptView = false
 
     var body: some View {
         contentView
             .task {
                 await orderListModel.ordersController.loadOrders()
+            }
+            .posFullScreenCover(isPresented: $isShowingEmailReceiptView) {
+                if let order = orderListModel.ordersController.selectedOrder {
+                    POSSendReceiptView(isShowingSendReceiptView: $isShowingEmailReceiptView) { email in
+                        try await orderListModel.sendReceipt(order: order, email: email)
+                    }
+                    .posHeaderBackButtonIcon(systemName: "xmark")
+                }
             }
     }
 
@@ -40,7 +49,8 @@ struct POSOrdersView: View {
                     order: selection,
                     onBack: {
                         orderListModel.ordersController.selectOrder(nil)
-                    }
+                    },
+                    isShowingEmailReceiptView: $isShowingEmailReceiptView
                 )
                 .id(selection.id)
                 .environment(orderListModel)

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -83,10 +83,10 @@ struct POSModalViewModifier<Item: Identifiable & Equatable, ModalContent: View>:
     func body(content: Content) -> some View {
         content
             .onChange(of: item) { _, newItem in
-                // Don't show a modal if a full screen overlay is presented on top
-                guard !coverManager.isPresented else { return }
-
                 if let newItem = newItem {
+                    // Don't show a modal if a full screen overlay is presented on top
+                    guard !coverManager.isPresented else { return }
+
                     modalManager.present(onDismiss: {
                         // Internal dismissal, i.e. from tapping the background
                         onDismiss?()
@@ -113,10 +113,10 @@ struct POSModalViewModifierForBool<ModalContent: View>: ViewModifier {
     func body(content: Content) -> some View {
         content
             .onChange(of: isPresented) { _, newValue in
-                // Don't show a modal if a full screen overlay is presented on top
-                guard !coverManager.isPresented else { return }
-
                 if newValue {
+                    // Don't show a modal if a full screen overlay is presented on top
+                    guard !coverManager.isPresented else { return }
+
                     modalManager.present(onDismiss: {
                         // Internal dismissal, i.e. from tapping the background
                         onDismiss?()


### PR DESCRIPTION
## Description

WOOMOB-2330

Emails receipt presentation is broken in two cases when we present order details from the booking details. The issues happen when presenting fullscreen cover within the nested navigation stack:
- Booking details -> Order details -> Email receipt -> X - dismissal appears with a lag, order details are dismissed as well
- Booking Details -> Issue refund -> Email Receipt - email view is non-responsive

We don't have a grand navigation approach with iOS, so for now I'm only fixing the particular issue. Lift the fullscreen cover presentation outside the inner navigation.

The fix lifts the email receipt presentation state (`isShowingEmailReceiptView`) out of `POSOrderDetailsView` and into its parent views (`POSBookingDetailView`, `POSOrdersView`). Each parent now owns the `@State` and places `.posFullScreenCover` at the correct level - outside any NavigationStack destination - matching how `POSBookingDetailView` already handles its payment and note covers.

## Changes

- **`POSOrderDetailsView`**: Changed `@State` to `@Binding` for `isShowingEmailReceiptView`, removed `.posFullScreenCover` from this view
- **`POSBookingDetailView`**: Added `@State isShowingEmailReceiptView`, passes binding to `POSOrderDetailsView` navigation destinations, presents email receipt cover on the `NavigationStack`
- **`POSOrdersView`**: Added `@State isShowingEmailReceiptView`, passes binding to `POSOrderDetailsView`, presents email receipt cover on the body (outside `POSNavigationSplitView`)

## Test Steps

1. POS -> Bookings -> paid booking -> View Order -> Email receipt -> tap X. Should return to Order Details without popping navigation
2. POS -> Bookings -> paid booking -> View Order -> Issue refund -> complete refund -> Email receipt -> tap X. Should return to Order Details
3. POS -> Orders -> order -> Email receipt -> tap X. Should still work correctly (regression check)

## Videos

### Before

Broken refunds + emails flow

https://github.com/user-attachments/assets/64c0a06c-6980-45f5-a849-117d8a7dc08d

### After

Normal email receipt dismiss:

https://github.com/user-attachments/assets/a9a09c23-6670-4210-adc0-312cf46c0522



Email receipt after issue refund:

https://github.com/user-attachments/assets/553e54fd-bf52-4bdf-b412-bd4beffef2a3



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.