### PR TITLE
POS Bookings: Fix payment view showing wrong total for multi-booking orders

### DIFF
--- a/Modules/Sources/PointOfSale/Models/POSBookingsModel.swift
+++ b/Modules/Sources/PointOfSale/Models/POSBookingsModel.swift
@@ -46,7 +46,7 @@ import class Yosemite.PaymentCaptureCelebration
                            analytics: POSAnalyticsProviding) -> POSPaymentModel {
         let orderProvider = POSBookingPaymentOrderProvider(
             orderID: booking.orderID ?? 0,
-            formattedTotal: booking.formattedAmount,
+            formattedTotal: booking.order.formattedTotal,
             orderService: orderService)
 
         return POSPaymentModel(

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingPaymentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingPaymentView.swift
@@ -10,9 +10,9 @@ struct POSBookingPaymentView: View {
 
     var body: some View {
         POSPaymentContentView(
-            formattedSubtotal: booking.formattedSubtotal ?? booking.formattedAmount,
-            formattedTax: booking.formattedTax ?? Localization.taxesZero,
-            formattedTotal: booking.formattedAmount,
+            formattedSubtotal: booking.order.formattedSubtotal,
+            formattedTax: booking.order.formattedTotalTax,
+            formattedTotal: booking.order.formattedTotal,
             onDismiss: onDismiss)
             .environment(paymentModel)
             .background(Color.posSurface)
@@ -22,17 +22,5 @@ struct POSBookingPaymentView: View {
             .onDisappear {
                 paymentModel.tearDown()
             }
-    }
-}
-
-// MARK: - Localization
-
-private extension POSBookingPaymentView {
-    enum Localization {
-        static let taxesZero = NSLocalizedString(
-            "pointOfSale.bookingPayment.taxesZero",
-            value: "$0.00",
-            comment: "Placeholder for zero taxes in the booking payment screen"
-        )
     }
 }


### PR DESCRIPTION
## Description
When a POS booking has multiple bookings and products on the same order, the payment view was showing only the individual booking's cost (`booking.formattedAmount`) instead of the full order total.

This fix updates `POSBookingPaymentView` and `POSBookingsModel.makePaymentModel()` to use `booking.order.formattedTotal` (and order-level subtotal/tax), matching how `POSBookingDetailView` already displays these values.

The actual card charge amount was already correct (it uses `order.total` from the loaded order), but the displayed total in the payment UI and payment success/error messages was wrong.

## Test Steps
- Create a booking order with multiple items/bookings
- Open the booking in POS and tap to collect payment
- Verify the payment view shows the full order total, not just the individual booking cost
- Verify the booking detail view still shows correct values (unchanged)
- Verify cash and card payment success/error messages show the correct total

## Video

https://github.com/user-attachments/assets/e5e7ce6a-192f-4edf-aca4-54f41e6b68a1

### Before

<img width="2752" height="2064" alt="image (24)" src="https://github.com/user-attachments/assets/d9a24073-9972-4f5c-b971-7c359f6cfce5" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.