### PR TITLE
Align POS 'cancelled' spelling to US English 'canceled'

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Bookings/CancelBooking/POSCancelBookingConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/CancelBooking/POSCancelBookingConfirmationView.swift
@@ -115,8 +115,8 @@ private extension POSCancelBookingConfirmationView {
         )
 
         static let processingTitle = NSLocalizedString(
-            "pos.cancelBookingConfirmation.processingTitle",
-            value: "Cancelling booking...",
+            "pos.cancelBookingConfirmation.canceling.processingTitle",
+            value: "Canceling booking...",
             comment: "Title shown while a booking cancellation is being processed in POS."
         )
 
@@ -127,16 +127,16 @@ private extension POSCancelBookingConfirmationView {
         )
 
         static let confirmationMessageWithCustomer = NSLocalizedString(
-            "pos.cancelBookingConfirmation.confirmationMessageWithCustomer",
-            value: "Booking #%1$@ for %2$@ on %3$@ for %4$@ will be cancelled.",
-            comment: "Confirmation message with customer name shown before cancelling a booking in POS. "
+            "pos.cancelBookingConfirmation.canceled.confirmationMessageWithCustomer",
+            value: "Booking #%1$@ for %2$@ on %3$@ for %4$@ will be canceled.",
+            comment: "Confirmation message with customer name shown before canceling a booking in POS. "
             + "%1$@ is the booking number, %2$@ is the service name, %3$@ is the date/time, %4$@ is the customer name."
         )
 
         static let confirmationMessage = NSLocalizedString(
-            "pos.cancelBookingConfirmation.confirmationMessage",
-            value: "Booking #%1$@ for %2$@ on %3$@ will be cancelled.",
-            comment: "Confirmation message shown before cancelling a booking in POS. "
+            "pos.cancelBookingConfirmation.canceled.confirmationMessage",
+            value: "Booking #%1$@ for %2$@ on %3$@ will be canceled.",
+            comment: "Confirmation message shown before canceling a booking in POS. "
             + "%1$@ is the booking number, %2$@ is the service name, %3$@ is the date/time."
         )
 

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/CancelBooking/POSCancelBookingSuccessView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/CancelBooking/POSCancelBookingSuccessView.swift
@@ -90,15 +90,15 @@ private extension POSCancelBookingSuccessView {
 private extension POSCancelBookingSuccessView {
     enum Localization {
         static let title = NSLocalizedString(
-            "pos.cancelBookingSuccess.title",
-            value: "Booking cancelled",
-            comment: "Title shown when a booking has been successfully cancelled in POS."
+            "pos.cancelBookingSuccess.canceled.title",
+            value: "Booking canceled",
+            comment: "Title shown when a booking has been successfully canceled in POS."
         )
 
         static let message = NSLocalizedString(
-            "pos.cancelBookingSuccess.message",
-            value: "The booking has been successfully cancelled.",
-            comment: "Message shown after a booking is successfully cancelled in POS."
+            "pos.cancelBookingSuccess.canceled.message",
+            value: "The booking has been successfully canceled.",
+            comment: "Message shown after a booking is successfully canceled in POS."
         )
 
         static let closeButtonAccessibilityLabel = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingStatusPresentation.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingStatusPresentation.swift
@@ -211,8 +211,8 @@ private enum Localization {
     )
 
     static let cancelled = NSLocalizedString(
-        "pos.bookingLifecycleStatus.cancelled",
-        value: "Cancelled",
-        comment: "POS booking lifecycle status label for cancelled bookings."
+        "pos.bookingLifecycleStatus.canceled",
+        value: "Canceled",
+        comment: "POS booking lifecycle status label for canceled bookings."
     )
 }

--- a/Modules/Sources/PointOfSale/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift
@@ -13,16 +13,16 @@ struct PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel: Equatable
 private extension PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel {
     enum Localization {
         static let cancelledOnReader = NSLocalizedString(
-            "pointOfSale.cardPresent.cancelledOnReader.title",
-            value: "Payment cancelled on reader",
+            "pointOfSale.cardPresent.canceledOnReader.title",
+            value: "Payment canceled on reader",
             comment: "Indicates the status of a card reader. Presented to users when payment collection starts"
         )
 
         static let tryPaymentAgain =  NSLocalizedString(
-            "pointOfSale.cardPresent.cancelledOnReader.tryPaymentAgain.button.title",
+            "pointOfSale.cardPresent.canceledOnReader.tryPaymentAgain.button.title",
             value: "Try payment again",
             comment: "Button to try to collect a payment again. Presented to users after " +
-            "card reader cancelled on the Point of Sale Checkout"
+            "card reader canceled on the Point of Sale Checkout"
         )
     }
 }


### PR DESCRIPTION
## Description

Aligns all user-visible "cancelled"/"cancelling" strings in POS to US English spelling
("canceled"/"canceling") per WOOMOB-2337.

7 NSLocalizedString values updated across 4 files:
- `POSBookingStatusPresentation.swift` — lifecycle badge label
- `PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift` — card reader message
- `POSCancelBookingSuccessView.swift` — success title + message
- `POSCancelBookingConfirmationView.swift` — processing title + 2 confirmation messages

Keys and comments updated alongside values per project localization rules. No logic changes.

## Test Steps

1. Open POS and navigate to Bookings
2. Cancel a booking — verify confirmation says "will be canceled" and processing says "Canceling booking..."
3. After cancellation, verify success screen says "Booking canceled"
4. Verify the booking list shows "Canceled" badge
5. During card payment, cancel on reader — verify message says "Payment canceled on reader"

## Screenshots
https://github.com/user-attachments/assets/81f438a5-ff45-4037-b5f9-e12b224a0ba8


---
- [x] I have considered if this change warrants user-facing release notes and have added them to
`RELEASE-NOTES.txt` if necessary.