### PR TITLE
Add refundTotal and total to BookingOrderInfo for partial-refund detection

### DIFF
--- a/Modules/Sources/Networking/Model/Bookings/BookingOrderInfo.swift
+++ b/Modules/Sources/Networking/Model/Bookings/BookingOrderInfo.swift
@@ -4,17 +4,23 @@ import Foundation
 public struct BookingOrderInfo: Hashable {
     public let statusKey: String
     public let datePaid: Date?
+    public let total: Decimal
+    public let refundTotal: Decimal
     public let paymentInfo: BookingPaymentInfo?
     public let customerInfo: BookingCustomerInfo?
     public let productInfo: BookingProductInfo?
 
     public init(statusKey: String,
                 datePaid: Date?,
+                total: Decimal = 0,
+                refundTotal: Decimal = 0,
                 paymentInfo: BookingPaymentInfo?,
                 customerInfo: BookingCustomerInfo?,
                 productInfo: BookingProductInfo?) {
         self.statusKey = statusKey
         self.datePaid = datePaid
+        self.total = total
+        self.refundTotal = refundTotal
         self.paymentInfo = paymentInfo
         self.customerInfo = customerInfo
         self.productInfo = productInfo
@@ -22,6 +28,11 @@ public struct BookingOrderInfo: Hashable {
 
     public init(booking: Booking, order: Order) {
         self.datePaid = order.datePaid
+        self.total = Decimal(string: order.total) ?? 0
+        self.refundTotal = order.refunds
+            .compactMap { Decimal(string: $0.total) }
+            .map { abs($0) }
+            .reduce(0, +)
         self.customerInfo = {
             guard let billingAddress = order.billingAddress else {
                 return nil

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingStatusPresentation.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingStatusPresentation.swift
@@ -21,6 +21,10 @@ import struct Yosemite.POSBooking
 
 extension BookingPaymentStatus {
     /// Creates a payment status from a POS booking's order data.
+    ///
+    /// `refundTotal`/`total` are not available on `POSOrder` (amounts are pre-formatted),
+    /// so partial-refund detection relies on the `orderStatus == .refunded` fallback.
+    /// POS collapses `.partiallyRefunded` → "Refunded" in `localizedTitle` anyway.
     init(booking: POSBooking) {
         self.init(orderStatusKey: booking.order.status.rawValue,
                   datePaid: booking.order.datePaid)

--- a/Modules/Sources/Storage/Model/Booking/BookingOrderInfo+CoreDataProperties.swift
+++ b/Modules/Sources/Storage/Model/Booking/BookingOrderInfo+CoreDataProperties.swift
@@ -3,7 +3,9 @@ import CoreData
 
 extension BookingOrderInfo {
     @NSManaged public var datePaid: Date?
+    @NSManaged public var refundTotal: NSDecimalNumber?
     @NSManaged public var statusKey: String?
+    @NSManaged public var total: NSDecimalNumber?
     @NSManaged public var paymentInfo: BookingPaymentInfo?
     @NSManaged public var customerInfo: BookingCustomerInfo?
     @NSManaged public var productInfo: BookingProductInfo?

--- a/Modules/Sources/Storage/Model/MIGRATIONS.md
+++ b/Modules/Sources/Storage/Model/MIGRATIONS.md
@@ -5,6 +5,8 @@ This file documents changes in the WCiOS Storage data model. Please explain any 
 ## Model 132
 - @jmucientes 2026-02-26
   - Added `datePaid` attribute to `BookingOrderInfo` entity.
+  - Added `total` attribute to `BookingOrderInfo` entity.
+  - Added `refundTotal` attribute to `BookingOrderInfo` entity.
 
 ## Model 130 (Release 23.7)
 - @adborbas 2025-11-06

--- a/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 132.xcdatamodel/contents
+++ b/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 132.xcdatamodel/contents
@@ -102,7 +102,9 @@
     </entity>
     <entity name="BookingOrderInfo" representedClassName="BookingOrderInfo" syncable="YES">
         <attribute name="datePaid" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="refundTotal" optional="YES" attributeType="Decimal" defaultValueString="0"/>
         <attribute name="statusKey" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="Decimal" defaultValueString="0"/>
         <relationship name="booking" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Booking" inverseName="orderInfo" inverseEntity="Booking"/>
         <relationship name="customerInfo" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BookingCustomerInfo" inverseName="orderInfo" inverseEntity="BookingCustomerInfo"/>
         <relationship name="paymentInfo" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BookingPaymentInfo" inverseName="orderInfo" inverseEntity="BookingPaymentInfo"/>

--- a/Modules/Sources/Yosemite/Model/Booking/BookingOrderInfo+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Booking/BookingOrderInfo+ReadOnlyConvertible.swift
@@ -7,12 +7,16 @@ extension Storage.BookingOrderInfo: ReadOnlyConvertible {
     public func update(with orderInfo: Yosemite.BookingOrderInfo) {
         statusKey = orderInfo.statusKey
         datePaid = orderInfo.datePaid
+        total = orderInfo.total as NSDecimalNumber
+        refundTotal = orderInfo.refundTotal as NSDecimalNumber
         // Relationships are handled in BookingStore
     }
 
     public func toReadOnly() -> Yosemite.BookingOrderInfo {
         return .init(statusKey: statusKey ?? "",
                      datePaid: datePaid,
+                     total: total as Decimal? ?? 0,
+                     refundTotal: refundTotal as Decimal? ?? 0,
                      paymentInfo: paymentInfo?.toReadOnly(),
                      customerInfo: customerInfo?.toReadOnly(),
                      productInfo: productInfo?.toReadOnly())

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -559,6 +559,14 @@ private extension BookingStore {
 
                 orderInfo.statusKey = associatedOrder.status.rawValue
                 orderInfo.datePaid = associatedOrder.datePaid
+                orderInfo.total = NSDecimalNumber(string: associatedOrder.total)
+                orderInfo.refundTotal = {
+                    let sum = associatedOrder.refunds
+                        .compactMap { Decimal(string: $0.total) }
+                        .map { abs($0) }
+                        .reduce(0, +)
+                    return sum as NSDecimalNumber
+                }()
                 storageBooking.orderInfo = orderInfo
             }
 

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -557,16 +557,7 @@ private extension BookingStore {
                 }
                 orderInfo.paymentInfo = paymentInfo
 
-                orderInfo.statusKey = associatedOrder.status.rawValue
-                orderInfo.datePaid = associatedOrder.datePaid
-                orderInfo.total = NSDecimalNumber(string: associatedOrder.total)
-                orderInfo.refundTotal = {
-                    let sum = associatedOrder.refunds
-                        .compactMap { Decimal(string: $0.total) }
-                        .map { abs($0) }
-                        .reduce(0, +)
-                    return sum as NSDecimalNumber
-                }()
+                orderInfo.update(with: readOnlyOrderInfo)
                 storageBooking.orderInfo = orderInfo
             }
 

--- a/Modules/Tests/StorageTests/CoreData/MigrationTests.swift
+++ b/Modules/Tests/StorageTests/CoreData/MigrationTests.swift
@@ -2393,6 +2393,45 @@ final class MigrationTests: XCTestCase {
 
         XCTAssertEqual(migratedOrderInfo.value(forKey: "datePaid") as? Date, updatedDate)
     }
+
+    func test_migrating_from_131_to_132_adds_total_and_refundTotal_attributes_to_bookingOrderInfo() throws {
+        // Given
+        let sourceContainer = try startPersistentContainer("Model 131")
+        let sourceContext = sourceContainer.viewContext
+
+        let orderInfo = insertBookingOrderInfo(to: sourceContext)
+        try sourceContext.save()
+
+        XCTAssertNil(orderInfo.entity.attributesByName["total"], "Precondition. Attribute does not exist.")
+        XCTAssertNil(orderInfo.entity.attributesByName["refundTotal"], "Precondition. Attribute does not exist.")
+
+        // When
+        let targetContainer = try migrate(sourceContainer, to: "Model 132")
+
+        // Then
+        let targetContext = targetContainer.viewContext
+        let migratedOrderInfo = try XCTUnwrap(targetContext.first(entityName: "BookingOrderInfo"))
+
+        XCTAssertNotNil(migratedOrderInfo.entity.attributesByName["total"])
+        XCTAssertNotNil(migratedOrderInfo.entity.attributesByName["refundTotal"])
+
+        // Defaults should be 0
+        let totalValue = migratedOrderInfo.value(forKey: "total") as? NSDecimalNumber
+        XCTAssertEqual(totalValue, NSDecimalNumber(string: "0"))
+
+        let refundTotalValue = migratedOrderInfo.value(forKey: "refundTotal") as? NSDecimalNumber
+        XCTAssertEqual(refundTotalValue, NSDecimalNumber(string: "0"))
+
+        // Verify values can be updated
+        let updatedTotal = NSDecimalNumber(string: "99.99")
+        let updatedRefundTotal = NSDecimalNumber(string: "25.00")
+        migratedOrderInfo.setValue(updatedTotal, forKey: "total")
+        migratedOrderInfo.setValue(updatedRefundTotal, forKey: "refundTotal")
+        try targetContext.save()
+
+        XCTAssertEqual(migratedOrderInfo.value(forKey: "total") as? NSDecimalNumber, updatedTotal)
+        XCTAssertEqual(migratedOrderInfo.value(forKey: "refundTotal") as? NSDecimalNumber, updatedRefundTotal)
+    }
 }
 
 // MARK: - Persistent Store Setup and Migrations

--- a/WooCommerce/Classes/Extensions/Booking+View.swift
+++ b/WooCommerce/Classes/Extensions/Booking+View.swift
@@ -12,6 +12,8 @@ extension Booking {
 
     var paymentStatusBadge: BookingPaymentStatus {
         BookingPaymentStatus(orderStatusKey: orderInfo?.statusKey ?? "",
-                             datePaid: orderInfo?.datePaid)
+                             datePaid: orderInfo?.datePaid,
+                             refundTotal: orderInfo?.refundTotal ?? 0,
+                             total: orderInfo?.total ?? 0)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
@@ -55,6 +55,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
         )
         let orderInfo = BookingOrderInfo(
             statusKey: "confirmed",
+            datePaid: nil,
             paymentInfo: paymentInfo,
             customerInfo: customerInfo,
             productInfo: productInfo
@@ -104,6 +105,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
         // Given
         let orderInfo = BookingOrderInfo(
             statusKey: "confirmed",
+            datePaid: nil,
             paymentInfo: nil,
             customerInfo: nil,
             productInfo: nil
@@ -136,6 +138,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
         let productInfo = BookingProductInfo(name: "Massage Therapy")
         let orderInfo = BookingOrderInfo(
             statusKey: "confirmed",
+            datePaid: nil,
             paymentInfo: nil,
             customerInfo: customerInfo,
             productInfo: productInfo
@@ -180,6 +183,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
         let customerInfo = BookingCustomerInfo(billingAddress: billingAddress)
         let orderInfo = BookingOrderInfo(
             statusKey: "confirmed",
+            datePaid: nil,
             paymentInfo: nil,
             customerInfo: customerInfo,
             productInfo: nil
@@ -226,6 +230,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
         let customerInfo = BookingCustomerInfo(billingAddress: billingAddress, note: note)
         let orderInfo = BookingOrderInfo(
             statusKey: "confirmed",
+            datePaid: nil,
             paymentInfo: nil,
             customerInfo: customerInfo,
             productInfo: nil


### PR DESCRIPTION
Part of: [WOOMOB-2316](https://linear.app/a8c/issue/WOOMOB-2316)

## Description

Addresses PR comments from https://github.com/woocommerce/woocommerce-ios/pull/16725

Extends `BookingOrderInfo` with `total` and `refundTotal` so the shared `BookingPaymentStatus` resolver can distinguish full refunds from partial refunds. Previously, only `orderStatusKey` and `datePaid` were available, making the `.partiallyRefunded` case unreachable.

Values are computed from the associated `Order` at mapping time (total from `order.total`, refundTotal aggregated from `order.refunds`) and persisted in CoreData (Model 132).

Store Management now passes these values through to the resolver. POS continues without them since `POSOrder` only carries pre-formatted amounts — POS already collapses `partiallyRefunded` into "Refunded" in its display layer.

Also fixes 5 pre-existing compilation errors in `BookingDetailsViewModelTests` where the `datePaid` parameter was missing.

## Demo

<img width="569" height="332" alt="Screenshot 2026-02-27 at 00 06 01" src="https://github.com/user-attachments/assets/44c245dd-48b7-4ccc-b086-585c5b9445e0" />

## Test Steps

1. Create a booking with an associated order
2. Process a partial refund on the order (add two appointments to a cart in storefront, then refund one)
3. Verify the booking shows "Partially Refunded" badge in Store Management booking detail
4. Process a full refund → verify "Refunded" badge
5. Verify POS bookings still show correct payment status (no behavior change expected)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.