### PR TITLE
Rename booking service label and hide Store Setup card for CIAB sites

### DIFF
--- a/Modules/Sources/Yosemite/Tools/CIAB/CIABAffectedFeature.swift
+++ b/Modules/Sources/Yosemite/Tools/CIAB/CIABAffectedFeature.swift
@@ -13,6 +13,7 @@ public enum CIABAffectedFeature: CaseIterable {
     case productsStockDashboardCard
     case pointOfSale
     case cardReader
+    case storeSetupDashboardCard
 }
 
 extension CIABAffectedFeature {

--- a/WooCommerce/Classes/Bookings/BookingFilters/BookableProductListSyncable.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/BookableProductListSyncable.swift
@@ -92,19 +92,19 @@ struct BookableProductListSyncable: ListSyncable {
 private extension BookableProductListSyncable {
     enum Localization {
         static let title = NSLocalizedString(
-            "bookingServiceEventSelectorView.title",
-            value: "Service / Event",
-            comment: "Title of the booking service/event selector view"
+            "bookingServiceSelectorView.title",
+            value: "Service",
+            comment: "Title of the booking service selector view"
         )
         static let noServiceFound = NSLocalizedString(
-            "bookingServiceEventSelectorView.noMembersFound",
-            value: "No service or event found",
-            comment: "Text on the empty view of the booking service/event selector view"
+            "bookingServiceSelectorView.noMembersFound",
+            value: "No service found",
+            comment: "Text on the empty view of the booking service selector view"
         )
         static let searchPrompt = NSLocalizedString(
-            "bookingServiceEventSelectorView.searchPrompt",
-            value: "Search service / event",
-            comment: "Prompt in the search bar of the booking service/event selector view"
+            "bookingServiceSelectorView.searchPrompt",
+            value: "Search service",
+            comment: "Prompt in the search bar of the booking service selector view"
         )
         static let emptySearchDescription = NSLocalizedString(
             "bookingServiceEventSelectorView.emptySearchDescription",

--- a/WooCommerce/Classes/Bookings/BookingFilters/BookingFiltersViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/BookingFiltersViewModel.swift
@@ -295,8 +295,8 @@ private extension BookingFiltersViewModel.BookingListFilter {
             comment: "Row title for filtering bookings by team member.")
 
         static let rowTitleProduct = NSLocalizedString(
-            "bookingFilters.rowTitleProduct",
-            value: "Service / Event",
+            "bookingFilters.rowTitleService",
+            value: "Service",
             comment: "Row title for filtering bookings by product.")
 
         static let rowTitleCustomer = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -85,6 +85,8 @@ final class DashboardViewModel: ObservableObject {
 
     @Published private(set) var isEligibleForStock = false
 
+    @Published private(set) var isEligibleForStoreSetup = false
+
     @Published var showingCustomization = false
 
     @Published private(set) var showNewCardsNotice = false
@@ -217,6 +219,7 @@ final class DashboardViewModel: ObservableObject {
         }
 
         observeStockEligibility()
+        observeStoreSetupEligibility()
         configureOrdersResultController()
         setupDashboardCards()
         observeWPCOMSiteSuspendedState()
@@ -238,7 +241,7 @@ final class DashboardViewModel: ObservableObject {
         /// we add the Blaze card back in `BlazeCampaignCreationCoordinator`.
         /// Here we need to get the updated cards from storage and update the dashboard accordingly.
         await loadDashboardCardsFromStorage()
-        updateDashboardCards(canShowOnboarding: storeOnboardingViewModel.canShowInDashboard,
+        updateDashboardCards(canShowOnboarding: storeOnboardingViewModel.canShowInDashboard && isEligibleForStoreSetup,
                              canShowBlaze: blazeCampaignDashboardViewModel.canShowInDashboard,
                              canShowGoogle: googleAdsDashboardCardViewModel.canShowOnDashboard,
                              canShowInbox: isEligibleForInbox,
@@ -641,7 +644,11 @@ private extension DashboardViewModel {
 // MARK: Private helpers
 private extension DashboardViewModel {
     func observeValuesForDashboardCards() {
-        storeOnboardingViewModel.$canShowInDashboard
+        let canShowOnboarding = storeOnboardingViewModel.$canShowInDashboard
+            .combineLatest($isEligibleForStoreSetup)
+            .map { $0 && $1 }
+
+        canShowOnboarding
             .combineLatest(blazeCampaignDashboardViewModel.$canShowInDashboard,
                            $isEligibleForStock)
             .combineLatest(googleAdsDashboardCardViewModel.$canShowOnDashboard,
@@ -717,6 +724,26 @@ private extension DashboardViewModel {
                     )
             }
             .assign(to: &$isEligibleForStock)
+    }
+
+    func observeStoreSetupEligibility() {
+        stores.site
+            .removeDuplicates()
+            .map { [weak self] in
+                guard
+                    let self,
+                    let site = $0
+                else {
+                    return false
+                }
+
+                return siteIsCIABEligibilityChecker
+                    .isFeatureSupported(
+                        .storeSetupDashboardCard,
+                        for: site
+                    )
+            }
+            .assign(to: &$isEligibleForStoreSetup)
     }
 
     func configureOrdersResultController() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -706,6 +706,57 @@ final class DashboardViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.dashboardCards.contains(expectedStockCard))
     }
 
+    @MainActor
+    func test_dashboard_cards_contain_onboarding_card_when_store_is_non_ciab() async throws {
+        // Given
+        let siteCIABChecker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: false)
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: UUID().uuidString))
+
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           userDefaults: userDefaults,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker,
+                                           siteIsCIABEligibilityChecker: siteCIABChecker)
+
+        mockReloadingData(storeHasOrders: false)
+
+        let expectedOnboardingCard = DashboardCard(type: .onboarding, availability: .show, enabled: true)
+
+        // When
+        await viewModel.reloadAllData()
+
+        // Then
+        XCTAssertTrue(viewModel.dashboardCards.contains(expectedOnboardingCard))
+    }
+
+    @MainActor
+    func test_dashboard_cards_does_not_contain_onboarding_card_when_store_is_ciab() async throws {
+        // Given
+        let siteCIABChecker = MockCIABEligibilityChecker(
+            mockedIsCurrentSiteCIAB: true,
+            mockedCIABSites: [site]
+        )
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: UUID().uuidString))
+
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           userDefaults: userDefaults,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker,
+                                           siteIsCIABEligibilityChecker: siteCIABChecker)
+
+        mockReloadingData(storeHasOrders: false)
+
+        let expectedOnboardingCard = DashboardCard(type: .onboarding, availability: .show, enabled: true)
+
+        // When
+        await viewModel.reloadAllData()
+
+        // Then
+        XCTAssertFalse(viewModel.dashboardCards.contains(expectedOnboardingCard))
+    }
+
     // MARK: Show New Cards Notice
 
     @MainActor


### PR DESCRIPTION
Closes: WOOMOB-2338, WOOMOB-2324

## Description

This PR addresses two small changes:

1. **Rename "Service / Event" to "Service"** in booking filter UI — updates the selector title, empty state, and search prompt in `BookableProductListSyncable` and the filter row title in `BookingFiltersViewModel`.

2. **Hide the Store Setup dashboard card for CIAB sites** — CIAB sites don't support the store onboarding flow, so the Store Setup (onboarding) card should be hidden on the dashboard. This follows the same pattern already used for the Stock dashboard card:
   - Adds `storeSetupDashboardCard` to `CIABAffectedFeature` enum (automatically included in `unsupportedFeatures`)
   - Adds `isEligibleForStoreSetup` property to `DashboardViewModel` with a site observer that checks CIAB eligibility
   - Gates `canShowOnboarding` on both `storeOnboardingViewModel.canShowInDashboard` and the new CIAB eligibility check

## Test Steps
1. Use a CIAB store that has onboarding tasks returned for dashboard. 
2. Switch to `trunk` and run the app.
3. Make sure "Store Setup" card is displayed in dashbard.
4. Switch to this feature branch.
5. Run the app and make sure the "Store Setup" card is no longer displayed in dasboard.
6. Connect to a **non-CIAB** store → verify the Store Setup card appears on the dashboard as usual
7. Verify booking filter screen shows "Service" (not "Service / Event") as the product filter label

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.