### PR TITLE
Remove mark-as-paid button from booking details

### DIFF
--- a/WooCommerce/Classes/Extensions/Booking+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Booking+Helpers.swift
@@ -13,10 +13,6 @@ extension Booking {
         return name.isEmpty ? Localization.guest : name
     }
 
-    var isEligibleForMarkAsPaid: Bool {
-        bookingStatus == .unpaid
-    }
-
     var hasAssociatedOrder: Bool {
         return orderID > 0
     }

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
@@ -11,7 +11,6 @@ extension WooAnalyticsEvent {
         enum Action: String {
             case cancelBooking = "cancel_booking"
             case updateAttendance = "update_attendance"
-            case markAsPaid = "mark_as_paid"
         }
 
         static func bookingCancelled() -> WooAnalyticsEvent {
@@ -27,10 +26,6 @@ extension WooAnalyticsEvent {
 
         static func bookingAddNoteTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .bookingAddNoteTapped)
-        }
-
-        static func bookingMarkAsPaidTapped() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .bookingMarkAsPaidTapped)
         }
 
         static func bookingViewLinkedOrderTapped() -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -306,39 +306,6 @@ extension BookingDetailsViewModel {
     }
 }
 
-/// Mark booking as paid
-extension BookingDetailsViewModel {
-    var shouldShowMarkAsPaid: Bool {
-        booking.isEligibleForMarkAsPaid
-    }
-
-    @MainActor
-    func markBookingAsPaid() async throws {
-        analytics.track(event: .BookingsDetail.bookingMarkAsPaidTapped())
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            stores.dispatch(BookingAction.markBookingAsPaid(siteID: booking.siteID, bookingID: booking.bookingID) { [analytics] error in
-                if let error {
-                    analytics.track(event: .BookingsDetail.failedToUpdateBookingDetails(action: .markAsPaid, error: error))
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume(returning: ())
-                }
-            })
-        }
-    }
-
-    func displayMarkingAsPaidErrorNotice(onRetry: @escaping () -> Void) {
-        let text = String.localizedStringWithFormat(
-            Localization.bookingMarkAsPaidFailedMessage,
-            booking.bookingID
-        )
-        self.notice = Notice(
-            message: text,
-            feedbackType: .error,
-            actionTitle: Localization.retryActionTitle
-        ) { onRetry() }
-    }
-}
 
 private extension BookingDetailsViewModel {
     @MainActor
@@ -497,14 +464,6 @@ private extension BookingDetailsViewModel {
             value: "Unable to cancel Booking #%1$d.",
             comment: "Content of error presented when cancelling a Booking fails. "
             + "It reads: Unable to cancel Booking #{Booking number}. "
-            + "Parameters: %1$d - Booking number"
-        )
-
-        static let bookingMarkAsPaidFailedMessage = NSLocalizedString(
-            "BookingDetailsView.markAsPaid.failureMessage",
-            value: "Unable to mark Booking #%1$d as paid.",
-            comment: "Content of error presented when cancelling a Booking fails. "
-            + "It reads: Unable to mark Booking #{Booking number} as paid. "
             + "Parameters: %1$d - Booking number"
         )
 

--- a/WooCommerce/Classes/ViewModels/Booking Details/PaymentContent.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/PaymentContent.swift
@@ -27,7 +27,6 @@ extension BookingDetailsViewModel {
             ]
 
             actions = [
-                booking.isEligibleForMarkAsPaid ? .markAsPaid : nil,
                 booking.hasAssociatedOrder ? .viewOrder : nil
             ].compactMap { $0 }
         }
@@ -82,7 +81,6 @@ extension BookingDetailsViewModel.PaymentContent.Amount.AmountType {
 
 extension BookingDetailsViewModel.PaymentContent {
     enum Action: String, Identifiable {
-        case markAsPaid
         case viewOrder
 
         var id: String {
@@ -94,8 +92,6 @@ extension BookingDetailsViewModel.PaymentContent {
 extension BookingDetailsViewModel.PaymentContent.Action {
     var buttonTitle: String {
         switch self {
-        case .markAsPaid:
-            return Localization.paymentMarkAsPaidButtonTitle
         case .viewOrder:
             return Localization.paymentViewOrderButtonTitle
         }
@@ -125,12 +121,6 @@ private enum Localization {
         "BookingDetailsView.payment.totalRow.title",
         value: "Total",
         comment: "Total row title in payment section in booking details view."
-    )
-
-    static let paymentMarkAsPaidButtonTitle = NSLocalizedString(
-        "BookingDetailsView.payment.markAsPaid.title",
-        value: "Mark as paid",
-        comment: "Title for 'Mark as paid' button in payment section in booking details view."
     )
 
     static let paymentViewOrderButtonTitle = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -8,7 +8,6 @@ struct BookingDetailsView: View {
     @State private var showingCancelAlert = false
     @State private var cancellingBooking = false
     @State private var updatingAttendance = false
-    @State private var markingAsPaid = false
     @State private var notice: Notice?
 
     @ObservedObject private var viewModel: BookingDetailsViewModel
@@ -62,11 +61,6 @@ struct BookingDetailsView: View {
                     Image(systemName: "ellipsis")
                 }
                 .confirmationDialog("", isPresented: $showingOptions, titleVisibility: .hidden) {
-                    Button(Localization.markAsPaid) {
-                        markBookingAsPaid()
-                    }
-                    .renderedIf(viewModel.shouldShowMarkAsPaid)
-
                     Button(Localization.viewOrder) {
                         viewModel.navigateToOrderDetails()
                     }
@@ -223,9 +217,6 @@ private extension BookingDetailsView {
                             viewModel.navigateToOrderDetails()
                         }
                         .buttonStyle(SecondaryButtonStyle())
-                    case .markAsPaid:
-                        Button(action.buttonTitle, action: markBookingAsPaid)
-                            .buttonStyle(PrimaryLoadingButtonStyle(isLoading: markingAsPaid))
                     }
                 }
             }
@@ -254,26 +245,10 @@ extension BookingDetailsView {
         }
     }
 
-    func markBookingAsPaid() {
-        Task { @MainActor in
-            markingAsPaid = true
-            do {
-                try await viewModel.markBookingAsPaid()
-            } catch {
-                viewModel.displayMarkingAsPaidErrorNotice(onRetry: markBookingAsPaid)
-            }
-            markingAsPaid = false
-        }
-    }
 }
 
 extension BookingDetailsView {
     enum Localization {
-        static let markAsPaid = NSLocalizedString(
-            "BookingDetailsView.options.markAsPaid",
-            value: "Mark as paid",
-            comment: "Action sheet option to mark a booking as paid."
-        )
         static let viewOrder = NSLocalizedString(
             "BookingDetailsView.options.viewOrder",
             value: "View order",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
@@ -427,23 +427,6 @@ final class BookingDetailsViewModelTests: XCTestCase {
         XCTAssertFalse(paymentContent.actions.contains(.viewOrder))
     }
 
-    func test_event_fired_when_booking_marked_as_paid() async throws {
-        // Given
-        let viewModel = givenViewModel()
-
-        // When
-        let task = Task { try await viewModel.markBookingAsPaid() }
-        let action = try await waitForFirstBookingAction()
-        guard case let .markBookingAsPaid(_, _, onCompletion) = action else {
-            return XCTFail("Expected markBookingAsPaid action")
-        }
-        onCompletion(nil)
-        try await task.value
-
-        // Then
-        analyticsProvider.assertReceived(event: "booking_detail_mark_as_paid_tapped")
-    }
-
     func test_event_fired_when_booking_cancelled() async throws {
         // Given
         let viewModel = givenViewModel()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingViewTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingViewTests.swift
@@ -48,44 +48,4 @@ final class BookingViewTests: XCTestCase {
         XCTAssertEqual(booking.paymentStatusBadge, .unpaid)
     }
 
-    // MARK: - isEligibleForMarkAsPaid
-
-    func test_isEligibleForMarkAsPaid_when_payment_status_is_unpaid_then_returns_true() {
-        // Given
-        let orderInfo = BookingOrderInfo(statusKey: "pending",
-                                         datePaid: nil,
-                                         paymentInfo: nil,
-                                         customerInfo: nil,
-                                         productInfo: nil)
-        let booking = Booking.fake().copy(orderInfo: orderInfo)
-
-        // When / Then
-        XCTAssertTrue(booking.isEligibleForMarkAsPaid)
-    }
-
-    func test_isEligibleForMarkAsPaid_when_payment_status_is_paid_then_returns_false() {
-        // Given
-        let orderInfo = BookingOrderInfo(statusKey: "processing",
-                                         datePaid: Date(),
-                                         paymentInfo: nil,
-                                         customerInfo: nil,
-                                         productInfo: nil)
-        let booking = Booking.fake().copy(orderInfo: orderInfo)
-
-        // When / Then
-        XCTAssertFalse(booking.isEligibleForMarkAsPaid)
-    }
-
-    func test_isEligibleForMarkAsPaid_when_payment_status_is_refunded_then_returns_false() {
-        // Given
-        let orderInfo = BookingOrderInfo(statusKey: "refunded",
-                                         datePaid: nil,
-                                         paymentInfo: nil,
-                                         customerInfo: nil,
-                                         productInfo: nil)
-        let booking = Booking.fake().copy(orderInfo: orderInfo)
-
-        // When / Then
-        XCTAssertFalse(booking.isEligibleForMarkAsPaid)
-    }
 }


### PR DESCRIPTION
## Description

Removes the "Mark as paid" button from the booking details screen.

The button updated the **booking** status to `paid` via the API, but did not modify the **linked order** status. Since the payment status badge is now derived from the order status (not the booking status), tapping "Mark as paid" had no visible effect — the booking still appeared unpaid. This is the same approach desktop takes: only "View order" is shown.

**Changes:**
- Remove "Mark as paid" button from the toolbar options menu and the payment section
- Remove related view model logic (`shouldShowMarkAsPaid`, `markBookingAsPaid()`, error notice)
- Remove `isEligibleForMarkAsPaid` helper on `Booking`
- Remove `.markAsPaid` action case from `PaymentContent`
- Remove mark-as-paid analytics event factory
- Remove associated unit test

The Yosemite action/store/remote layer (`BookingAction.markBookingAsPaid`) is intentionally kept as-is to avoid a larger scope change.

## Test Steps

1. Create a booking with "Unpaid" status (wp-admin > Bookings > Add Booking, or edit an existing booking and set its status to "Unpaid"). This is the only status that previously showed the "Mark as paid" button.
2. Open that booking in the app
3. Tap the ellipsis (⋯) toolbar button
4. Verify "Mark as paid" is **not** listed — only "View order" and "Cancel booking" appear
5. Scroll to the Payment section
6. Verify only the "View order" button is shown (no "Mark as paid" button)
7. Also check bookings with other statuses (paid, confirmed, etc.) to confirm no regressions in the payment section

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.