### PR TITLE
Enable ciabBookings feature flag

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -95,7 +95,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .pointOfSaleFTSSearch:
             return true
         case .ciabBookings:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .pointOfSaleCatalogAPI:
             return false
         case .pointOfSaleRefundsi1:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] POS: Fix barcode scanning not working after completing a payment [https://github.com/woocommerce/woocommerce-ios/pull/16672]
 - [*] Media library: Fix decoding failure when media details are returned as array [https://github.com/woocommerce/woocommerce-ios/pull/16715]
+- [Internal] Enable Bookings MVP for CIAB sites [https://github.com/woocommerce/woocommerce-ios/pull/16738]
 
 
 24.1


### PR DESCRIPTION
## Description
Enable the `ciabBookings` feature flag for all build types so that the Bookings tab is visible in production for CIAB sites.

This mirrors the Android PR: https://github.com/woocommerce/woocommerce-android/pull/15445

No release notes entry — bookings will be mentioned in release notes once the full Woo launch is confirmed.

## Test Steps
1. Install release app on a simulator connected to a CIAB site
2. Verify the Bookings tab appears in the tab bar
3. Verify bookings list loads and booking details are accessible

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.