### PR TITLE
Store completed onboarding state per site ID

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 24.2
 -----
+- [*] Fix onboarding tasks not displayed after switching stores [https://github.com/woocommerce/woocommerce-ios/pull/16740]
 - [*] POS: Fix barcode scanning not working after completing a payment [https://github.com/woocommerce/woocommerce-ios/pull/16672]
 - [*] Media library: Fix decoding failure when media details are returned as array [https://github.com/woocommerce/woocommerce-ios/pull/16715]
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -115,7 +115,7 @@ class StoreOnboardingViewModel: ObservableObject {
     }
 
     func reloadTasks() async {
-        guard !(defaults.completedAllStoreOnboardingTasks[String(siteID)] == true) else {
+        guard defaults.completedAllStoreOnboardingTasks[String(siteID)] != true else {
             waitingTimeTracker.end(action: .loadOnboardingTasks)
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -108,7 +108,6 @@ class StoreOnboardingViewModel: ObservableObject {
                 }
                 return true
             }
-            .print("💀 Can show in dashboard: ")
             .map { [siteID] (noTasksAvailable, completedDict) in
                 !(noTasksAvailable || (completedDict[String(siteID)] == true))
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -108,12 +108,15 @@ class StoreOnboardingViewModel: ObservableObject {
                 }
                 return true
             }
-            .map { !($0 || $1) }
+            .print("💀 Can show in dashboard: ")
+            .map { [siteID] (noTasksAvailable, completedDict) in
+                !(noTasksAvailable || (completedDict[String(siteID)] == true))
+            }
             .assign(to: &$canShowInDashboard)
     }
 
     func reloadTasks() async {
-        guard !defaults.completedAllStoreOnboardingTasks else {
+        guard !(defaults.completedAllStoreOnboardingTasks[String(siteID)] == true) else {
             waitingTimeTracker.end(action: .loadOnboardingTasks)
             return
         }
@@ -209,7 +212,9 @@ private extension StoreOnboardingViewModel {
         }
 
         // This will be reset to `nil` when session resets
-        defaults[.completedAllStoreOnboardingTasks] = true
+        var completedTasks: [String: Bool] = defaults[.completedAllStoreOnboardingTasks] ?? [:]
+        completedTasks[String(siteID)] = true
+        defaults[.completedAllStoreOnboardingTasks] = completedTasks
     }
 
     @MainActor
@@ -269,7 +274,7 @@ private extension StoreOnboardingTaskViewModel {
 }
 
 extension UserDefaults {
-    @objc dynamic var completedAllStoreOnboardingTasks: Bool {
-        bool(forKey: Key.completedAllStoreOnboardingTasks.rawValue)
+    @objc dynamic var completedAllStoreOnboardingTasks: [String: Bool] {
+        dictionary(forKey: Key.completedAllStoreOnboardingTasks.rawValue) as? [String: Bool] ?? [:]
     }
 }

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -114,10 +114,10 @@ final class SessionManagerTests: XCTestCase {
         let sut = SessionManager(defaults: defaults, keychainServiceName: Settings.keychainServiceName)
 
         // When
-        defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] = true
+        defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] = ["123": true]
 
         // Then
-        XCTAssertTrue(try XCTUnwrap(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] as? Bool))
+        XCTAssertNotNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] as? [String: Bool])
 
         // When
         sut.reset()

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -117,7 +117,7 @@ final class SessionManagerTests: XCTestCase {
         defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] = ["123": true]
 
         // Then
-        XCTAssertNotNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] as? [String: Bool])
+        XCTAssertEqual((defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] as? [String: Bool])?["123"], true)
 
         // When
         sut.reset()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -379,7 +379,7 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         let uuid = UUID().uuidString
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
-        defaults[.completedAllStoreOnboardingTasks] = true
+        defaults[.completedAllStoreOnboardingTasks] = ["0": true]
         let viewModel = DashboardViewModel(siteID: 0,
                                            stores: stores,
                                            userDefaults: defaults,
@@ -563,7 +563,7 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_dashboard_cards_has_disabled_onboarding_card_if_all_tasks_are_completed() async throws {
         // Given
-        userDefaults[.completedAllStoreOnboardingTasks] = true
+        userDefaults[.completedAllStoreOnboardingTasks] = [String(sampleSiteID): true]
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
                                            stores: stores,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -479,7 +479,7 @@ final class StoreOnboardingViewModelTests: XCTestCase {
     @MainActor
     func test_it_does_not_send_network_request_when_completedAllStoreOnboardingTasks_is_true() async {
         // Given
-        defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] = true
+        defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] = ["0": true]
         let tasks: [StoreOnboardingTask] = [
             .init(isComplete: false, type: .addFirstProduct),
             .init(isComplete: false, type: .launchStore),
@@ -542,7 +542,7 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         await sut.reloadTasks()
 
         // Then
-        XCTAssertNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks])
+        XCTAssertNil((defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] as? [String: Bool])?["0"])
     }
 
     @MainActor
@@ -562,7 +562,7 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         await sut.reloadTasks()
 
         // Then
-        XCTAssertTrue(try XCTUnwrap(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] as? Bool))
+        XCTAssertTrue(try XCTUnwrap((defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] as? [String: Bool])?["0"]))
     }
 
     @MainActor
@@ -574,13 +574,13 @@ final class StoreOnboardingViewModelTests: XCTestCase {
                                            stores: stores,
                                            defaults: defaults)
         // Then
-        XCTAssertNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks])
+        XCTAssertNil((defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] as? [String: Bool])?["0"])
 
         // When
         await sut.reloadTasks()
 
         // Then
-        XCTAssertNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks])
+        XCTAssertNil((defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] as? [String: Bool])?["0"])
     }
 
     @MainActor
@@ -592,13 +592,13 @@ final class StoreOnboardingViewModelTests: XCTestCase {
                                            stores: stores,
                                            defaults: defaults)
         // Then
-        XCTAssertNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks])
+        XCTAssertNil((defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] as? [String: Bool])?["0"])
 
         // When
         await sut.reloadTasks()
 
         // Then
-        XCTAssertNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks])
+        XCTAssertNil((defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] as? [String: Bool])?["0"])
     }
 
     // MARK: - canShowInDashboard
@@ -677,7 +677,7 @@ final class StoreOnboardingViewModelTests: XCTestCase {
     @MainActor
     func test_reloadTasks_notifies_waitingTimeTracker_when_completedAllStoreOnboardingTasks_is_true() async {
         // Given
-        defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] = true
+        defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] = ["0": true]
         let tracker = AppStartupWaitingTimeTracker(analyticsService: analytics)
         XCTAssert(tracker.startupActionsPending.contains(.loadOnboardingTasks))
         let sut = StoreOnboardingViewModel(siteID: 0,


### PR DESCRIPTION
## Description
Previously, `completedAllStoreOnboardingTasks` was stored in `UserDefaults` as a single `Bool`, meaning all sites shared the same "completed" flag. This caused onboarding tasks to be hidden after switching to a different store that hadn't completed onboarding yet.

This change stores the completed state as a `[String: Bool]` dictionary keyed by site ID, so each site tracks its own completion state independently.

## Test Steps
1. Complete all onboarding tasks on Site A — the onboarding card should be hidden.
2. Switch to Site B (which hasn't completed onboarding) — the onboarding card should appear.
3. Switch back to Site A — the onboarding card should remain hidden.

## Screenshots

https://github.com/user-attachments/assets/3d7e672d-6e32-4fca-b167-6623584b8323



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.