### PR TITLE
Add label and milestone assignment steps to PR creation skill

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -52,6 +52,14 @@ EOF
 )"
 ```
 
-8. Report the PR URL.
+8. **Add labels.** After creating the PR, add labels using `gh pr edit <number> --add-label "<label>"`. Pick labels from these categories:
+   - **Type** (pick one): `type: bug`, `type: crash`, `type: enhancement`, `type: task`, `type: technical debt`, `type: documentation`, `type: question`
+   - **Feature** (pick one if applicable): match the changed area to a `feature: *` label (e.g., `feature: POS`, `feature: order list`, `feature: order details`, `feature: product details`, `feature: login`, `feature: dashboard`, `feature: analytics hub`, `feature: coupons`, `feature: shipping labels`, `feature: order creation`, `feature: notifications`, `feature: Blaze`, `feature: CIAB Mobile Experience`, `feature: subscriptions`, `feature: app settings`, etc.)
+   - **Priority** (pick one if known): `priority: low`, `priority: medium`, `priority: high`, `priority: critical`
+   - **Category** (pick any that apply): `category: accessibility`, `category: design`, `category: performance`, `category: tracks`, `category: unit tests`, `category: ui tests`, `category: tooling`, `category: parity`, `category: i18n`, `category: dark mode`, `category: tablet`, etc.
+   - If the feature is behind a flag, also add `status: feature-flagged`
+   - Infer labels from the diff and branch name. If unsure about the feature label, ask the user.
+
+9. Report the PR URL.
 
 If non-test diff exceeds 300 lines, warn that Danger will flag it and suggest splitting.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -60,6 +60,13 @@ EOF
    - If the feature is behind a flag, also add `status: feature-flagged`
    - Infer labels from the diff and branch name. If unsure about the feature label, ask the user.
 
-9. Report the PR URL.
+9. **Set milestone.** After creating the PR, assign the correct milestone:
+   - List open milestones: `gh api repos/woocommerce/woocommerce-ios/milestones --jq '.[] | "\(.title)\t\(.description)"'`
+   - Each milestone description contains a `Code Freeze:` date.
+   - **If the PR targets `trunk`**: pick the earliest milestone whose code freeze date has **not yet passed** (i.e., the next unfrozen milestone).
+   - **If the PR targets a `release/X.Y` branch**: use milestone `X.Y` (the frozen release milestone).
+   - Apply with: `gh pr edit <number> --milestone "<milestone title>"`
+
+10. Report the PR URL.
 
 If non-test diff exceeds 300 lines, warn that Danger will flag it and suggest splitting.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -52,7 +52,7 @@ EOF
 )"
 ```
 
-8. **Add labels.** After creating the PR, add labels using `gh pr edit <number> --add-label "<label>"`. Pick labels from these categories:
+8. **Add labels.** After creating the PR, add all labels in a single call using multiple `--add-label` flags: `gh pr edit <number> --add-label "<label1>" --add-label "<label2>"`. Pick labels from these categories:
    - **Type** (pick one): `type: bug`, `type: crash`, `type: enhancement`, `type: task`, `type: technical debt`, `type: documentation`, `type: question`
    - **Feature** (pick one if applicable): match the changed area to a `feature: *` label (e.g., `feature: POS`, `feature: order list`, `feature: order details`, `feature: product details`, `feature: login`, `feature: dashboard`, `feature: analytics hub`, `feature: coupons`, `feature: shipping labels`, `feature: order creation`, `feature: notifications`, `feature: Blaze`, `feature: CIAB Mobile Experience`, `feature: subscriptions`, `feature: app settings`, etc.)
    - **Priority** (pick one if known): `priority: low`, `priority: medium`, `priority: high`, `priority: critical`


### PR DESCRIPTION
## Description
The PR skill was missing steps to add GitHub labels and assign milestones after creating PRs. This adds:

**Step 8 - Label assignment** picks and applies labels from these categories:
- **Type**: bug, crash, enhancement, task, technical debt, documentation, question
- **Feature**: matched from the changed area (POS, order list, dashboard, login, etc.)
- **Priority**: low, medium, high, critical
- **Category**: accessibility, design, performance, tracks, tooling, etc.

**Step 9 - Milestone assignment** automatically assigns the correct milestone:
- For PRs targeting `trunk`: picks the earliest milestone whose code freeze date has not yet passed
- For PRs targeting `release/X.Y`: uses the matching `X.Y` milestone (the frozen release)

Labels and milestone are inferred from the diff, branch name, and milestone descriptions. If the feature label is unclear, the skill asks the user.

Mirrors the label assignment change on Android: https://github.com/woocommerce/woocommerce-android/pull/15441

## Test Steps
1. Run `/pr` skill on a branch with changes
2. Verify that after the PR is created, the skill adds appropriate labels and assigns the correct milestone

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.