### PR TITLE
Update release notes for 24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 Contains editorialized release notes. Raw release notes should go into `RELEASE-NOTES.txt`.
 -->
 ## 24.2
-This update improves dashboard onboarding when switching between stores, ensures barcode scanning works seamlessly in Point of Sale after payments, and enhances media library reliability. Update now for a smoother store management experience!
+This update shows store setup tasks more reliably, ensures barcode scanning works seamlessly in Point of Sale, and enhances media library reliability. Update now for a smoother store management experience!
 
 ## 24.0
 This update improves sign-in clarity by showing a clear error when site login fails due to authentication issues, adds a helpful “Learn more” flow to better explain POS features, and includes behind-the-scenes connection tracking to help us improve reliability and performance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <!--
 Contains editorialized release notes. Raw release notes should go into `RELEASE-NOTES.txt`.
 -->
+## 24.2
+This update improves dashboard onboarding when switching between stores, ensures barcode scanning works seamlessly in Point of Sale after payments, and enhances media library reliability. Update now for a smoother store management experience!
+
 ## 24.0
 This update improves sign-in clarity by showing a clear error when site login fails due to authentication issues, adds a helpful “Learn more” flow to better explain POS features, and includes behind-the-scenes connection tracking to help us improve reliability and performance.
 

--- a/WooCommerce/Resources/release_notes.txt
+++ b/WooCommerce/Resources/release_notes.txt
@@ -1,4 +1,1 @@
-- [*] Fix onboarding tasks not displayed after switching stores [https://github.com/woocommerce/woocommerce-ios/pull/16740]
-- [*] POS: Fix barcode scanning not working after completing a payment [https://github.com/woocommerce/woocommerce-ios/pull/16672]
-- [*] Media library: Fix decoding failure when media details are returned as array [https://github.com/woocommerce/woocommerce-ios/pull/16715]
-- [Internal] Enable Bookings MVP for CIAB sites [https://github.com/woocommerce/woocommerce-ios/pull/16738]
+This update improves dashboard onboarding when switching between stores, ensures barcode scanning works seamlessly in Point of Sale after payments, and enhances media library reliability. Update now for a smoother store management experience!

--- a/WooCommerce/Resources/release_notes.txt
+++ b/WooCommerce/Resources/release_notes.txt
@@ -1,1 +1,1 @@
-This update improves dashboard onboarding when switching between stores, ensures barcode scanning works seamlessly in Point of Sale after payments, and enhances media library reliability. Update now for a smoother store management experience!
+This update shows store setup tasks more reliably, ensures barcode scanning works seamlessly in Point of Sale, and enhances media library reliability. Update now for a smoother store management experience!


### PR DESCRIPTION
## Description
Updated release notes in `WooCommerce/Resources/release_notes.txt` and `CHANGELOG.md` for 24.2.

## Test Steps
1. Check `WooCommerce/Resources/release_notes.txt` contains the editorialized copy.
2. Check `CHANGELOG.md` has a new `## 24.2` section at the top with the same copy.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.