### PR TITLE
POS Bookings: Fix customer being marked with guest badge on toggling attendance

### DIFF
--- a/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -4,6 +4,8 @@ import Codegen
 import Foundation
 import Networking
 import WooFoundation
+import enum Networking.BookingAttendanceStatus
+import enum Networking.BookingStatus
 import enum NetworkingCore.OrderStatusEnum
 import struct NetworkingCore.Address
 import struct NetworkingCore.MetaData
@@ -61,6 +63,7 @@ extension Yosemite.JustInTimeMessage {
 extension Yosemite.POSBooking {
     public func copy(
         id: CopiableProp<Int64> = .copy,
+        customerID: CopiableProp<Int64> = .copy,
         customerName: NullableCopiableProp<String> = .copy,
         serviceName: CopiableProp<String> = .copy,
         startDate: CopiableProp<Date> = .copy,
@@ -83,6 +86,7 @@ extension Yosemite.POSBooking {
         order: CopiableProp<POSOrder> = .copy
     ) -> Yosemite.POSBooking {
         let id = id ?? self.id
+        let customerID = customerID ?? self.customerID
         let customerName = customerName ?? self.customerName
         let serviceName = serviceName ?? self.serviceName
         let startDate = startDate ?? self.startDate
@@ -106,6 +110,7 @@ extension Yosemite.POSBooking {
 
         return Yosemite.POSBooking(
             id: id,
+            customerID: customerID,
             customerName: customerName,
             serviceName: serviceName,
             startDate: startDate,

--- a/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -4,8 +4,6 @@ import Codegen
 import Foundation
 import Networking
 import WooFoundation
-import enum Networking.BookingAttendanceStatus
-import enum Networking.BookingStatus
 import enum NetworkingCore.OrderStatusEnum
 import struct NetworkingCore.Address
 import struct NetworkingCore.MetaData

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
@@ -193,6 +193,19 @@ final class POSBookingListControllerTests {
         }
     }
 
+    @Test func test_updateAttendanceStatus_then_preserves_customerID() async throws {
+        // Given
+        let bookings = [makeBooking(id: 1, customerID: 99)]
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: bookings, hasMorePages: false, totalItems: nil))
+        await sut.loadBookings()
+
+        // When
+        try await sut.updateAttendanceStatus(bookingID: 1, status: .attended)
+
+        // Then
+        #expect(sut.bookingsViewState.bookings.first?.customerID == 99)
+    }
+
     // MARK: - cancelBooking
 
     @Test func test_cancelBooking_calls_service_and_updates_booking_in_place() async throws {
@@ -224,6 +237,19 @@ final class POSBookingListControllerTests {
         } catch {
             #expect(mockService.cancelBookingCallCount == 1)
         }
+    }
+
+    @Test func test_cancelBooking_then_preserves_customerID() async throws {
+        // Given
+        let bookings = [makeBooking(id: 1, customerID: 99)]
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: bookings, hasMorePages: false, totalItems: nil))
+        await sut.loadBookings()
+
+        // When
+        try await sut.cancelBooking(bookingID: 1)
+
+        // Then
+        #expect(sut.bookingsViewState.bookings.first?.customerID == 99)
     }
 
     // MARK: - updateBookingNote
@@ -271,6 +297,19 @@ final class POSBookingListControllerTests {
         } catch {
             #expect(mockService.updateBookingNoteCallCount == 1)
         }
+    }
+
+    @Test func test_updateBookingNote_then_preserves_customerID() async throws {
+        // Given
+        let bookings = [makeBooking(id: 1, customerID: 99)]
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: bookings, hasMorePages: false, totalItems: nil))
+        await sut.loadBookings()
+
+        // When
+        try await sut.updateBookingNote(bookingID: 1, note: "Test note")
+
+        // Then
+        #expect(sut.bookingsViewState.bookings.first?.customerID == 99)
     }
 
     // MARK: - updateBooking
@@ -608,10 +647,12 @@ final class POSBookingListControllerTests {
 
 private extension POSBookingListControllerTests {
     func makeBooking(id: Int64,
+                     customerID: Int64 = 42,
                      serviceName: String? = nil,
                      attendanceStatus: BookingAttendanceStatus = .unattended) -> POSBooking {
         POSBooking(
             id: id,
+            customerID: customerID,
             customerName: "Customer \(id)",
             serviceName: serviceName ?? "Service \(id)",
             startDate: Date(),


### PR DESCRIPTION
Closes WOOMOB-2361

## Description
Fixes _"Changing attendance status makes the customer a “guest”"_

`POSBooking` never passed `customerID` on copy, so it always fallback to the default value ( 0 ), since customerID == 0 is a guest, all customers were granted the badge on copy. We fix this by running `rake generate`.

## Test Steps
On a booking with a customer attached to it:
- Toggle attendance
- Observe that the guest badge is not added to the customer section

On a booking without a customer attached to it (guest):
- Observe that the guest badge is attached
- Toggling attendance does nothing to the badge 
