### PR TITLE
Fix POS booking detail optimistic updates

### DIFF
--- a/Modules/Sources/PointOfSale/Models/POSBookingsModel.swift
+++ b/Modules/Sources/PointOfSale/Models/POSBookingsModel.swift
@@ -27,7 +27,7 @@ import class Yosemite.PaymentCaptureCelebration
     }
 
     @MainActor
-    func updateAfterPayment(bookingID: Int64) async {
+    func updateAfterSuccessfulPayment(bookingID: Int64) async {
         await bookingsController.updateBookingOptimistically(bookingID: bookingID) {
             $0.copy(status: .paid, order: $0.order.copy(datePaid: Date()))
         }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -3,7 +3,7 @@ import struct WooFoundation.WooAnalyticsEvent
 import struct Yosemite.POSBooking
 
 struct POSBookingDetailView: View {
-    let booking: POSBooking
+    @Binding var booking: POSBooking
     let onBack: () -> Void
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -648,28 +648,28 @@ private enum Localization {
 #if DEBUG
 #Preview("Paid Booking") {
     POSBookingDetailView(
-        booking: POSPreviewHelpers.makePreviewPaidBooking(),
+        booking: .constant(POSPreviewHelpers.makePreviewPaidBooking()),
         onBack: {}
     )
 }
 
 #Preview("Unpaid Booking") {
     POSBookingDetailView(
-        booking: POSPreviewHelpers.makePreviewUnpaidBooking(),
+        booking: .constant(POSPreviewHelpers.makePreviewUnpaidBooking()),
         onBack: {}
     )
 }
 
 #Preview("Guest Booking") {
     POSBookingDetailView(
-        booking: POSPreviewHelpers.makePreviewGuestBooking(),
+        booking: .constant(POSPreviewHelpers.makePreviewGuestBooking()),
         onBack: {}
     )
 }
 
 #Preview("Cancelled Booking") {
     POSBookingDetailView(
-        booking: POSPreviewHelpers.makePreviewCancelledBooking(),
+        booking: .constant(POSPreviewHelpers.makePreviewCancelledBooking()),
         onBack: {}
     )
 }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -362,11 +362,13 @@ struct POSBookingDetailView: View {
     // MARK: - Payment Action
 
     private func dismissPayment() {
+        let paymentSucceeded = paymentModel?.paymentState.isSuccess == true
         showPaymentView = false
         paymentModel = nil
+        guard paymentSucceeded else { return }
         Task { @MainActor in
             isDetailsUpdating = true
-            await bookingsModel.updateAfterPayment(bookingID: booking.id)
+            await bookingsModel.updateAfterSuccessfulPayment(bookingID: booking.id)
             isDetailsUpdating = false
         }
     }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingsContainerView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingsContainerView.swift
@@ -28,7 +28,10 @@ struct POSBookingsContainerView: View {
             .environment(bookingsModel)
         } detail: { selection in
             POSBookingDetailView(
-                booking: selection,
+                booking: Binding(
+                    get: { bookingsModel.bookingsController.selectedBooking ?? selection },
+                    set: { bookingsModel.bookingsController.selectBooking($0) }
+                ),
                 onBack: {
                     bookingsModel.bookingsController.selectBooking(nil)
                 }

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListController.swift
@@ -1,0 +1,99 @@
+import Foundation
+@testable import PointOfSale
+import struct Yosemite.POSBooking
+import struct Yosemite.BookingFilters
+import enum Yosemite.BookingStatus
+import enum Yosemite.BookingAttendanceStatus
+
+@MainActor
+final class MockPOSBookingListController: POSSearchingBookingListControllerProtocol {
+    var bookingsViewState: POSBookingListState = .loading([])
+    var selectedBooking: POSBooking?
+    var selectedDate: Date = Date()
+
+    // MARK: - Spy properties
+
+    var syncBookingsCalled = false
+    var loadBookingsCalled = false
+    var refreshBookingsCalled = false
+    var loadNextBookingsCalled = false
+    var selectBookingCalledWith: POSBooking??
+    var selectDateCalledWith: Date?
+    var cancelBookingCalledWith: Int64?
+    var updateAttendanceStatusCalledWith: (bookingID: Int64, status: BookingAttendanceStatus)?
+    var updateBookingCalledWith: Int64?
+    var updateBookingNoteCalledWith: (bookingID: Int64, note: String)?
+    var searchBookingsCalledWith: String?
+    var clearSearchBookingsCalled = false
+
+    // MARK: - Optimistic update tracking
+
+    var updateBookingOptimisticallyCalledWith: Int64?
+    /// Set this before calling the method under test to capture the optimistic update result.
+    var bookingForOptimisticUpdate: POSBooking?
+    private(set) var optimisticUpdateResult: POSBooking?
+
+    // MARK: - POSBookingListControllerProtocol
+
+    func syncBookings() {
+        syncBookingsCalled = true
+    }
+
+    func loadBookings() async {
+        loadBookingsCalled = true
+    }
+
+    func refreshBookings() async {
+        refreshBookingsCalled = true
+    }
+
+    func loadNextBookings() async {
+        loadNextBookingsCalled = true
+    }
+
+    func selectBooking(_ booking: POSBooking?) {
+        selectBookingCalledWith = booking
+        selectedBooking = booking
+    }
+
+    func selectDate(_ date: Date) async {
+        selectDateCalledWith = date
+    }
+
+    func goToPreviousDay() async {}
+
+    func goToNextDay() async {}
+
+    func cancelBooking(bookingID: Int64) async throws {
+        cancelBookingCalledWith = bookingID
+    }
+
+    func updateAttendanceStatus(bookingID: Int64, status: BookingAttendanceStatus) async throws {
+        updateAttendanceStatusCalledWith = (bookingID, status)
+    }
+
+    func updateBooking(bookingID: Int64) async throws {
+        updateBookingCalledWith = bookingID
+    }
+
+    func updateBookingOptimistically(bookingID: Int64, optimisticUpdate: (POSBooking) -> POSBooking) async {
+        updateBookingOptimisticallyCalledWith = bookingID
+        if let booking = bookingForOptimisticUpdate {
+            optimisticUpdateResult = optimisticUpdate(booking)
+        }
+    }
+
+    func updateBookingNote(bookingID: Int64, note: String) async throws {
+        updateBookingNoteCalledWith = (bookingID, note)
+    }
+
+    // MARK: - POSSearchingBookingListControllerProtocol
+
+    func searchBookings(searchTerm: String) async {
+        searchBookingsCalledWith = searchTerm
+    }
+
+    func clearSearchBookings() {
+        clearSearchBookingsCalled = true
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListController.swift
@@ -25,6 +25,7 @@ final class MockPOSBookingListController: POSSearchingBookingListControllerProto
     var updateBookingNoteCalledWith: (bookingID: Int64, note: String)?
     var searchBookingsCalledWith: String?
     var clearSearchBookingsCalled = false
+    var resetCalled = false
 
     // MARK: - Optimistic update tracking
 
@@ -49,6 +50,10 @@ final class MockPOSBookingListController: POSSearchingBookingListControllerProto
 
     func loadNextBookings() async {
         loadNextBookingsCalled = true
+    }
+
+    func reset() {
+        resetCalled = true
     }
 
     func selectBooking(_ booking: POSBooking?) {

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSBookingListFetchStrategyFactory.swift
@@ -34,7 +34,7 @@ final class MockPOSBookingListFetchStrategyFactory: POSBookingListFetchStrategyF
     }
 }
 
-final class MockPOSBookingService: POSBookingServiceProtocol {
+final class MockPOSBookingService: POSBookingServiceProtocol, @unchecked Sendable {
     var fetchBookingsResult: Result<PagedItems<POSBooking>, Error> = .success(PagedItems(items: [], hasMorePages: false, totalItems: nil))
     var cancelBookingError: Error?
     var cancelBookingCallCount = 0

--- a/Modules/Tests/PointOfSaleTests/Models/POSBookingsModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/POSBookingsModelTests.swift
@@ -1,0 +1,166 @@
+import Testing
+import Foundation
+@testable import PointOfSale
+import struct Yosemite.POSBooking
+import struct Yosemite.POSOrder
+import enum Yosemite.BookingStatus
+import enum Yosemite.BookingAttendanceStatus
+import enum Yosemite.OrderStatusEnum
+
+@MainActor
+struct POSBookingsModelTests {
+
+    // MARK: - updateAfterSuccessfulPayment
+
+    @Test func test_updateAfterSuccessfulPayment_then_calls_updateBookingOptimistically_with_bookingID() async {
+        // Given
+        let (sut, bookingsController, _) = makeSUT()
+
+        // When
+        await sut.updateAfterSuccessfulPayment(bookingID: 42)
+
+        // Then
+        #expect(bookingsController.updateBookingOptimisticallyCalledWith == 42)
+    }
+
+    @Test func test_updateAfterSuccessfulPayment_then_sets_status_to_paid() async {
+        // Given
+        let (sut, bookingsController, _) = makeSUT()
+        let booking = makeBooking(id: 1, status: .confirmed)
+        bookingsController.bookingForOptimisticUpdate = booking
+
+        // When
+        await sut.updateAfterSuccessfulPayment(bookingID: 1)
+
+        // Then
+        #expect(bookingsController.optimisticUpdateResult?.status == .paid)
+    }
+
+    @Test func test_updateAfterSuccessfulPayment_then_sets_datePaid() async {
+        // Given
+        let (sut, bookingsController, _) = makeSUT()
+        let booking = makeBooking(id: 1, order: makeOrder(id: 10, datePaid: nil))
+        bookingsController.bookingForOptimisticUpdate = booking
+
+        // When
+        await sut.updateAfterSuccessfulPayment(bookingID: 1)
+
+        // Then
+        #expect(bookingsController.optimisticUpdateResult?.order.datePaid != nil)
+    }
+
+    @Test func test_updateAfterSuccessfulPayment_then_preserves_other_booking_fields() async {
+        // Given
+        let (sut, bookingsController, _) = makeSUT()
+        let booking = makeBooking(id: 5, status: .confirmed)
+        bookingsController.bookingForOptimisticUpdate = booking
+
+        // When
+        await sut.updateAfterSuccessfulPayment(bookingID: 5)
+
+        // Then
+        let result = bookingsController.optimisticUpdateResult
+        #expect(result?.id == 5)
+        #expect(result?.serviceName == booking.serviceName)
+    }
+
+    // MARK: - updateAfterRefund
+
+    @Test func test_updateAfterRefund_then_calls_updateBookingOptimistically_with_bookingID() async {
+        // Given
+        let (sut, bookingsController, _) = makeSUT()
+
+        // When
+        await sut.updateAfterRefund(bookingID: 77)
+
+        // Then
+        #expect(bookingsController.updateBookingOptimisticallyCalledWith == 77)
+    }
+
+    @Test func test_updateAfterRefund_then_sets_order_status_to_refunded() async {
+        // Given
+        let (sut, bookingsController, _) = makeSUT()
+        let booking = makeBooking(id: 1, order: makeOrder(id: 10, status: .completed))
+        bookingsController.bookingForOptimisticUpdate = booking
+
+        // When
+        await sut.updateAfterRefund(bookingID: 1)
+
+        // Then
+        #expect(bookingsController.optimisticUpdateResult?.order.status == .refunded)
+    }
+
+    @Test func test_updateAfterRefund_then_preserves_booking_status() async {
+        // Given
+        let (sut, bookingsController, _) = makeSUT()
+        let booking = makeBooking(id: 1, status: .paid)
+        bookingsController.bookingForOptimisticUpdate = booking
+
+        // When
+        await sut.updateAfterRefund(bookingID: 1)
+
+        // Then
+        #expect(bookingsController.optimisticUpdateResult?.status == .paid)
+    }
+}
+
+// MARK: - Helpers
+
+private extension POSBookingsModelTests {
+    func makeSUT() -> (POSBookingsModel, MockPOSBookingListController, MockCardPresentPaymentService) {
+        let bookingsController = MockPOSBookingListController()
+        let cardPresentPaymentService = MockCardPresentPaymentService()
+        let orderService = MockPOSOrderService()
+        let receiptSender = MockPOSReceiptSender()
+        let analyticsTracker = MockPOSCollectOrderPaymentAnalyticsTracker()
+
+        let sut = POSBookingsModel(
+            bookingsController: bookingsController,
+            cardPresentPaymentService: cardPresentPaymentService,
+            orderService: orderService,
+            receiptSender: receiptSender,
+            collectOrderPaymentAnalyticsTracker: analyticsTracker
+        )
+        return (sut, bookingsController, cardPresentPaymentService)
+    }
+
+    func makeBooking(id: Int64,
+                     customerID: Int64 = 0,
+                     status: BookingStatus = .confirmed,
+                     orderID: Int64? = 10,
+                     order: POSOrder? = nil) -> POSBooking {
+        POSBooking(
+            id: id,
+            customerID: customerID,
+            customerName: "Customer \(id)",
+            serviceName: "Service \(id)",
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(3600),
+            formattedAmount: "$50.00",
+            status: status,
+            attendanceStatus: .unattended,
+            orderID: orderID,
+            resourceName: nil,
+            order: order ?? makeOrder(id: orderID ?? 0)
+        )
+    }
+
+    func makeOrder(id: Int64,
+                   status: OrderStatusEnum = .completed,
+                   datePaid: Date? = Date()) -> POSOrder {
+        POSOrder(
+            id: id,
+            number: "\(id)",
+            dateCreated: Date(),
+            status: status,
+            formattedTotal: "$50.00",
+            formattedSubtotal: "$50.00",
+            paymentMethodID: "cod",
+            paymentMethodTitle: "Cash",
+            formattedDiscountTotal: nil,
+            formattedTotalTax: "$0.00",
+            formattedPaymentTotal: "$50.00",
+            datePaid: datePaid
+        )
+    }
+}


### PR DESCRIPTION
## Description

WOOMOB-2354
WOOMOB-2358

Fixes two issues in POS booking detail view:

1. **Closing payment window optimistically marks booking as paid** - Tapping "Collect payment" then closing the window without paying would optimistically mark the booking as paid. Now checks `paymentState.isSuccess` before performing the optimistic update. Renamed the method to `updateAfterSuccessfulPayment` to clarify intent.

2. **Cancelled badge doesn't show immediately after refund** - The detail view received booking as a `let` value, so it never reflected controller state updates. Changed to `@Binding` that reads from the controller's `selectedBooking`, so refund status and lifecycle changes appear immediately without navigating away and back.

## Test Steps

- Open a booking in POS, tap "Collect payment", then close the payment window without paying - verify the booking is NOT marked as paid
- Open a paid booking, issue a refund - verify the cancelled/refunded badge updates immediately on the detail view

## Video

### Paid no longer changed after closing the window

https://github.com/user-attachments/assets/b3fec2dc-2813-40dc-b3ca-4daa5b65d12b

### Cancelation

https://github.com/user-attachments/assets/9699efbe-15fa-4b36-b470-58bc5eef8547

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.