### PR TITLE
Fix POS receipt success message showing stale billing email

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -256,6 +256,7 @@ extension POSPaymentModel {
             throw POSPaymentError.noOrder
         }
         try await receiptSender.sendReceipt(orderID: order.orderID, recipientEmail: emailAddress)
+        currentOrder = order.copy(billingAddress: order.billingAddress?.copy(email: emailAddress))
     }
 }
 

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 import Combine
 import struct Yosemite.Order
+import struct Yosemite.Address
 import protocol Yosemite.PaymentCaptureCelebrationProtocol
 @testable import PointOfSale
 
@@ -154,6 +155,37 @@ struct POSPaymentModelTests {
         #expect(receiptSender.sendReceiptWasCalled == true)
         #expect(receiptSender.sendReceiptCalledWithOrderID == 123)
         #expect(receiptSender.sendReceiptCalledWithEmail == "test@example.com")
+    }
+
+    @Test("sendReceipt updates customerBillingEmail to sent email")
+    @MainActor
+    func sendReceipt_when_successful_then_updates_customerBillingEmail() async throws {
+        // Given
+        let receiptSender = MockPOSReceiptSender()
+        let orderProvider = MockPOSPaymentOrderProvider()
+        let initialAddress = Address(firstName: "", lastName: "", company: nil, address1: "",
+                                     address2: nil, city: "", state: "", postcode: "",
+                                     country: "", phone: nil, email: "old@example.com")
+        let order = Order.fake().copy(orderID: 123, total: "10.00", billingAddress: initialAddress)
+        orderProvider.orderToReturn = order
+        orderProvider.totalDecimalToReturn = 10
+
+        let service = MockCardPresentPaymentService()
+        service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
+
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            orderProvider: orderProvider,
+            receiptSender: receiptSender)
+
+        await sut.startPayment()
+        #expect(sut.customerBillingEmail == "old@example.com")
+
+        // When
+        try await sut.sendReceipt(to: "new@example.com")
+
+        // Then
+        #expect(sut.customerBillingEmail == "new@example.com")
     }
 
     @Test("sendReceipt throws when no current order")


### PR DESCRIPTION
## Description
After sending a receipt in POS, the server updates the order's billing email. However, the local `currentOrder` in `POSPaymentModel` was never refreshed, so the success screen message "A receipt has been sent to {email}" could show a stale email address.

This fix updates `currentOrder`'s billing email locally after a successful `sendReceipt`, so `customerBillingEmail` returns the correct value and the UI reflects the email the receipt was actually sent to.

## Test Steps
1. In POS -> Bookings complete a card payment for an order that has a billing email
2. Confirm the success view shows a correct email
3. On the success screen, tap "Email receipt"
4. Enter a different email address and send
5. Verify the success screen now shows "A receipt has been sent to {new email}"


### Video


https://github.com/user-attachments/assets/76d76727-f541-4361-83cc-b79f20f77c37


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.