### PR TITLE
POS Bookings: Reset state when dismissing bookings view

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSBookingListController.swift
@@ -21,6 +21,7 @@ protocol POSBookingListControllerProtocol {
     func loadNextBookings() async
     func selectBooking(_ booking: POSBooking?)
     func selectDate(_ date: Date) async
+    func reset()
     func goToPreviousDay() async
     func goToNextDay() async
     func cancelBooking(bookingID: Int64) async throws
@@ -125,6 +126,19 @@ protocol POSSearchingBookingListControllerProtocol: POSBookingListControllerProt
 
     func selectBooking(_ booking: POSBooking?) {
         selectedBooking = booking
+    }
+
+    func reset() {
+        loadTask?.cancel()
+        loadTask = nil
+        prefetchTasks.values.forEach { $0.cancel() }
+        prefetchTasks.removeAll()
+        selectedDate = Self.todayInUTC()
+        selectedBooking = nil
+        activeSearchTerm = nil
+        bookingsViewState = .loading([])
+        fetchStrategy = bookingListFetchStrategyFactory.defaultStrategy(filters: nil)
+        strategyPaginationTracker.removeAll()
     }
 
     func cancelBooking(bookingID: Int64) async throws {

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingsContainerView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingsContainerView.swift
@@ -65,7 +65,7 @@ struct POSBookingsContainerView: View {
         }
         .animation(.default, value: bookingsModel.bookingsController.bookingsViewState.bookings.isEmpty)
         .onDisappear {
-            bookingsModel.bookingsController.selectBooking(nil)
+            bookingsModel.bookingsController.reset()
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -820,6 +820,7 @@ final class POSConfigurablePreviewBookingListController: POSSearchingBookingList
     func updateBooking(bookingID: Int64) async throws {}
     func updateBookingOptimistically(bookingID: Int64, optimisticUpdate: (POSBooking) -> POSBooking) async {}
     func updateBookingNote(bookingID: Int64, note: String) async throws {}
+    func reset() { selectedDate = Date(); selectedBooking = nil }
     func searchBookings(searchTerm: String) async {}
     func clearSearchBookings() {}
 }

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSBookingListControllerTests.swift
@@ -529,6 +529,27 @@ final class POSBookingListControllerTests {
         #expect(mockFactory.lastSearchTerm == "test")
     }
 
+    // MARK: - reset
+
+    @Test func test_reset_then_restores_initial_state() async {
+        // Given - modify all user-facing state
+        let bookings = [makeBooking(id: 1)]
+        mockStrategy.fetchBookingsResult = .success(PagedItems(items: bookings, hasMorePages: false, totalItems: nil))
+        await sut.loadBookings()
+        sut.selectBooking(bookings[0])
+        let tomorrow = POSBookingDateFormatter.utcCalendar.date(byAdding: .day, value: 1, to: sut.selectedDate)!
+        await sut.selectDate(tomorrow)
+
+        // When
+        sut.reset()
+
+        // Then
+        let expectedToday = POSBookingDateFormatter.utcCalendar.startOfDay(for: Date())
+        #expect(sut.selectedDate == expectedToday)
+        #expect(sut.selectedBooking == nil)
+        #expect(sut.bookingsViewState == .loading([]))
+    }
+
     // MARK: - Prefetch
 
     @Test func test_init_syncs_today_and_adjacent_dates() async {


### PR DESCRIPTION
## Description

Closes: https://linear.app/a8c/issue/WOOMOB-2357

When closing and reopening the Bookings view, it previously maintained the date and state from the last session. This meant users had to manually navigate back to today's date each time they reopened bookings.

This PR adds a `reset()` method to `POSBookingListController` that restores all state to initial values when the bookings view disappears. On the next open, `loadBookings()` starts fresh with today's date.

## Test Steps
1. Open POS > Menu > Bookings
2. Navigate to a different date (e.g. tomorrow)
3. Close bookings
4. Reopen bookings from the menu
5. Verify bookings shows today's date, not the previously selected date

## Video


https://github.com/user-attachments/assets/0c57f6c3-23e5-41a5-ab91-c6ea919e2f50



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.