### PR TITLE
Add AI agent E2E verification capabilities

### DIFF
--- a/.claude/feature-map.json
+++ b/.claude/feature-map.json
@@ -97,6 +97,70 @@
       "interactions": [{"action": "tap", "element": "menu-blaze"}],
       "verifyElements": [],
       "description": "Blaze campaigns screen accessible via Hub Menu"
+    },
+    "settings": {
+      "pathPatterns": [
+        "WooCommerce/Classes/ViewRelated/Dashboard/Settings/"
+      ],
+      "tab": "tab-bar-menu-item",
+      "interactions": [{"action": "tap", "element": "dashboard-settings-button"}],
+      "verifyElements": ["settings-beta-features-button", "settings-log-out-button"],
+      "description": "Settings screen accessible via Hub Menu gear button"
+    },
+    "authentication": {
+      "pathPatterns": [
+        "WooCommerce/Classes/Authentication/",
+        "WooCommerce/Classes/ViewRelated/Authentication/"
+      ],
+      "verifyElements": [],
+      "description": "Authentication and login flows — verify app launches without crashing"
+    },
+    "notifications": {
+      "pathPatterns": [
+        "WooCommerce/Classes/Notifications/"
+      ],
+      "verifyElements": [],
+      "description": "Push notification handling — verify app launches without crashing"
+    },
+    "universal_links": {
+      "pathPatterns": [
+        "WooCommerce/Classes/Universal Links/"
+      ],
+      "verifyElements": [],
+      "description": "Universal link / deep link handling — verify app launches without crashing"
+    },
+    "google_ads": {
+      "pathPatterns": [
+        "WooCommerce/Classes/GoogleAds/"
+      ],
+      "tab": "tab-bar-menu-item",
+      "interactions": [{"action": "tap", "element": "menu-google-ads"}],
+      "verifyElements": [],
+      "description": "Google Ads screen accessible via Hub Menu"
+    },
+    "inbox": {
+      "pathPatterns": [
+        "WooCommerce/Classes/ViewRelated/Inbox/"
+      ],
+      "tab": "tab-bar-menu-item",
+      "interactions": [{"action": "tap", "element": "menu-inbox"}],
+      "verifyElements": [],
+      "description": "Inbox screen accessible via Hub Menu"
+    },
+    "widgets": {
+      "pathPatterns": [
+        "WooCommerce/StoreWidgets/"
+      ],
+      "verifyElements": [],
+      "description": "Home screen widgets — build-only verification, cannot be launched from app"
+    },
+    "watch_app": {
+      "pathPatterns": [
+        "WooCommerce/Woo Watch App/",
+        "WooCommerce/WatchWidgetsExtension/"
+      ],
+      "verifyElements": [],
+      "description": "Watch app and watch widgets — build-only verification, cannot be tested in iPhone simulator"
     }
   }
 }

--- a/.claude/feature-map.json
+++ b/.claude/feature-map.json
@@ -1,0 +1,102 @@
+{
+  "features": {
+    "orders": {
+      "pathPatterns": [
+        "WooCommerce/Classes/ViewRelated/Orders/",
+        "Modules/Sources/Yosemite/Stores/Order",
+        "Modules/Sources/Networking/Remote/Order"
+      ],
+      "tab": "tab-bar-orders-item",
+      "verifyElements": ["order-search-button", "orders-filter-button"],
+      "description": "Orders list loads and displays orders from mock data"
+    },
+    "products": {
+      "pathPatterns": [
+        "WooCommerce/Classes/ViewRelated/Products/",
+        "Modules/Sources/Yosemite/Stores/Product",
+        "Modules/Sources/Networking/Remote/Product"
+      ],
+      "tab": "tab-bar-products-item",
+      "verifyElements": ["product-search-button", "product-add-button"],
+      "description": "Products tab loads and shows product list"
+    },
+    "pos": {
+      "pathPatterns": [
+        "WooCommerce/Classes/POS/",
+        "WooCommerce/Classes/ViewRelated/POS/",
+        "Modules/Sources/PointOfSale/"
+      ],
+      "tab": "tab-bar-pos-item",
+      "launchArgs": [
+        "bypass-pos-eligibility-checks",
+        "load-mocked-pos-products",
+        "bypass-pos-order-syncing"
+      ],
+      "verifyElements": ["pos-cart-view", "pos-checkout-button"],
+      "description": "POS tab loads with mocked products and cart"
+    },
+    "dashboard": {
+      "pathPatterns": [
+        "WooCommerce/Classes/ViewRelated/Dashboard/"
+      ],
+      "tab": "tab-bar-my-store-item",
+      "verifyElements": ["revenue-value", "performance-time-range-menu"],
+      "description": "Dashboard loads with performance stats"
+    },
+    "coupons": {
+      "pathPatterns": [
+        "WooCommerce/Classes/ViewRelated/Coupons/"
+      ],
+      "tab": "tab-bar-menu-item",
+      "interactions": [{"action": "tap", "element": "menu-coupons"}],
+      "verifyElements": [],
+      "description": "Coupons screen accessible via Hub Menu"
+    },
+    "reviews": {
+      "pathPatterns": [
+        "WooCommerce/Classes/ViewRelated/Reviews/"
+      ],
+      "tab": "tab-bar-menu-item",
+      "interactions": [{"action": "tap", "element": "menu-reviews"}],
+      "verifyElements": ["reviews-table"],
+      "description": "Reviews screen accessible via Hub Menu"
+    },
+    "payments": {
+      "pathPatterns": [
+        "WooCommerce/Classes/ViewRelated/CardPresentPayments/",
+        "Modules/Sources/Hardware/"
+      ],
+      "tab": "tab-bar-menu-item",
+      "interactions": [{"action": "tap", "element": "menu-payments"}],
+      "verifyElements": [],
+      "description": "Payments screen accessible via Hub Menu"
+    },
+    "bookings": {
+      "pathPatterns": [
+        "WooCommerce/Classes/ViewRelated/Bookings/"
+      ],
+      "tab": "tab-bar-menu-item",
+      "interactions": [{"action": "tap", "element": "menu-bookings"}],
+      "verifyElements": [],
+      "description": "Bookings screen accessible via Hub Menu"
+    },
+    "customers": {
+      "pathPatterns": [
+        "WooCommerce/Classes/ViewRelated/Customers/"
+      ],
+      "tab": "tab-bar-menu-item",
+      "interactions": [{"action": "tap", "element": "menu-customers"}],
+      "verifyElements": [],
+      "description": "Customers screen accessible via Hub Menu"
+    },
+    "blaze": {
+      "pathPatterns": [
+        "WooCommerce/Classes/ViewRelated/Blaze/"
+      ],
+      "tab": "tab-bar-menu-item",
+      "interactions": [{"action": "tap", "element": "menu-blaze"}],
+      "verifyElements": [],
+      "description": "Blaze campaigns screen accessible via Hub Menu"
+    }
+  }
+}

--- a/.claude/references/screen-identifiers.md
+++ b/.claude/references/screen-identifiers.md
@@ -1,0 +1,334 @@
+# Screen Identifiers Reference
+
+This document maps every major screen in the WooCommerce iOS app to the accessibility identifiers that AI agents can use with mobile-mcp's `list_elements_on_screen` to detect which screen is displayed and interact with key elements.
+
+## How to Use This Reference
+
+1. **Identify the current screen**: After navigating, call `list_elements_on_screen` and look for the **Primary Identifier** listed for each screen.
+2. **Find interactive elements**: Use the **Key Elements** table to locate buttons, fields, and views you need to interact with.
+3. **Navigate between screens**: Follow the **Navigation Flows** section to reach any screen from the initial launch.
+4. **Handle overlays**: Check **Common Dialogs and Overlays** to dismiss anything blocking interaction.
+
+**Tip**: Always call `list_elements_on_screen` before every interaction. Coordinates shift between screens and after keyboard appearance. Match by `identifier` field, then use the element's coordinates to tap.
+
+---
+
+## Bottom Navigation Tabs
+
+The tab bar is visible on all top-level screens.
+
+| Tab | Identifier | Target Screen |
+|-----|-----------|---------------|
+| My Store | `tab-bar-my-store-item` | Dashboard |
+| Orders | `tab-bar-orders-item` | Orders List |
+| Products | `tab-bar-products-item` | Products List |
+| Bookings | `tab-bar-bookings-item` | Bookings List (only if Bookings extension active) |
+| Point of Sale | `tab-bar-pos-item` | POS (only if POS enabled, requires specific launch args) |
+| Menu | `tab-bar-menu-item` | Hub Menu |
+
+---
+
+## Login / Prologue
+
+The app launches to the prologue screen when started with `logout-at-launch`.
+
+| | |
+|---|---|
+| **Primary Identifier** | `prologue-title-label` |
+
+| Element | Identifier | Notes |
+|---------|-----------|-------|
+| Log In button | `Prologue Self Hosted Button` | Navigates to site address entry |
+| New Store button | `Prologue Site Creation Guide button` | |
+
+### Site Address Screen
+
+| Element | Identifier | Notes |
+|---------|-----------|-------|
+| Site address field | `Site address` | Enter the store URL here |
+| Continue button | `Site Address Next Button` | |
+| Help button | `authenticator-help-button` | |
+
+### 2FA / Authentication Code Screen
+
+The mock server always requires 2FA. Enter any 6-digit code (e.g., `123456`).
+
+| Element | Identifier | Notes |
+|---------|-----------|-------|
+| Code field | `Authentication code` | Enter any OTP code for mock login |
+| Continue button | `Continue Button` | |
+| Help button | `authenticator-help-button` | |
+
+### Login Epilogue (Store Picker)
+
+| Element | Identifier | Notes |
+|---------|-----------|-------|
+| Continue button | `login-epilogue-continue-button` | Proceeds to Dashboard after login |
+| Store name | `name-label` | |
+| Store URL | `url-label` | |
+
+**Mock credentials** for WireMock: site `http://yourwoosite.com`, email `t@wp.com`, password `pw`.
+
+---
+
+## Top-Level Screens
+
+### Dashboard (My Store)
+
+| | |
+|---|---|
+| **Primary Identifier** | `revenue-value` (always visible on Dashboard) |
+| **Nav Path** | Tap `tab-bar-my-store-item` |
+
+| Element | Identifier | Notes |
+|---------|-----------|-------|
+| Revenue value | `revenue-value` | Revenue display |
+| Time range menu | `performance-time-range-menu` | Date range selector |
+| Stats chart | `store-stats-chart` | Statistics chart |
+| Time range: Today | `time-range-today` | |
+| Time range: This Week | `time-range-this-week` | |
+| Time range: This Month | `time-range-this-month` | |
+| Time range: This Year | `time-range-this-year` | |
+
+### Orders List
+
+| | |
+|---|---|
+| **Primary Identifier** | `order-search-button` (always visible on Orders screen) |
+| **Nav Path** | Tap `tab-bar-orders-item` |
+
+| Element | Identifier | Notes |
+|---------|-----------|-------|
+| Search button | `order-search-button` | |
+| New order button | `new-order-type-sheet-button` | Creates a new order |
+| Filter button | `orders-filter-button` | |
+| Scan to create | `create-new-order-by-product-scanning` | |
+
+### Products List
+
+| | |
+|---|---|
+| **Primary Identifier** | `product-search-button` (always visible on Products screen) |
+| **Nav Path** | Tap `tab-bar-products-item` |
+
+| Element | Identifier | Notes |
+|---------|-----------|-------|
+| Add product button | `product-add-button` | |
+| Search button | `product-search-button` | |
+| Filter button | `product-filter-button` | |
+| Scan button | `product-scan-button` | |
+| Product cell | `single-product-cell` | Individual product row |
+
+### Hub Menu
+
+| | |
+|---|---|
+| **Primary Identifier** | `menu-payments` (first menu item, reliably present) |
+| **Nav Path** | Tap `tab-bar-menu-item` |
+
+Menu items (vary by store configuration):
+
+| Menu Item | Identifier | Target Screen |
+|-----------|-----------|---------------|
+| Settings | `dashboard-settings-button` | Settings screen |
+| Payments | `menu-payments` | Payments Hub |
+| Blaze | `menu-blaze` | Blaze Campaigns |
+| Google Ads | `menu-google-ads` | Google Ads |
+| WooCommerce Admin | `menu-woocommerce-admin` | Web admin |
+| View Store | `menu-view-store` | Store website |
+| Inbox | `menu-inbox` | Inbox |
+| Coupons | `menu-coupons` | Coupons List |
+| Reviews | `menu-reviews` | Reviews List |
+| Customers | `menu-customers` | Customers List |
+| Bookings | `menu-bookings` | Bookings List |
+
+---
+
+## Detail Screens
+
+### Order Detail
+
+| | |
+|---|---|
+| **Primary Identifier** | `order-details-table-view` |
+| **Nav Path** | Orders List → tap any order row |
+
+| Element | Identifier | Notes |
+|---------|-----------|-------|
+| Details table | `order-details-table-view` | Main content |
+| Edit button | `order-details-edit-button` | |
+| Trash button | `order-details-trash-order-button` | |
+| Status list | `order-status-list` | Status selector |
+| Summary cell | `summary-table-view-cell` | Order summary |
+| Title label | `summary-table-view-cell-title-label` | |
+| Created label | `summary-table-view-cell-created-label` | |
+| Payment status | `summary-table-view-cell-payment-status-label` | |
+
+### Order Creation
+
+| | |
+|---|---|
+| **Primary Identifier** | `order-form-scroll-view` |
+| **Nav Path** | Orders List → tap `new-order-type-sheet-button` |
+
+| Element | Identifier | Notes |
+|---------|-----------|-------|
+| Create button | `new-order-create-button` | |
+| Cancel button | `new-order-cancel-button` | |
+| Add product | `new-order-add-product-button` | |
+| Add coupon | `add-coupon-button` | |
+| Add shipping | `add-shipping-button` | |
+| Add gift card | `add-gift-card-button` | |
+| Add custom amount | `new-order-add-custom-amount-button` | |
+| Customer details | `add-customer-details-plus-button` | |
+| Collect payment | `order-form-collect-payment` | |
+| Address form | `order-address-form` | |
+| First name field | `order-address-form-first-name-field` | |
+
+### Product Detail
+
+| | |
+|---|---|
+| **Primary Identifier** | `product-form` |
+| **Nav Path** | Products List → tap any product row |
+
+| Element | Identifier | Notes |
+|---------|-----------|-------|
+| Product form | `product-form` | Main content |
+| Title | `product-title` | Product name field |
+| Description | `product-description` | |
+| Publish button | `publish-product-button` | |
+| Save button | `save-product-button` | |
+| More options | `edit-product-more-options-button` | |
+| Add tags | `add-tags` | |
+
+### Reviews List
+
+| | |
+|---|---|
+| **Primary Identifier** | `reviews-table` |
+| **Nav Path** | Hub Menu → tap `menu-reviews` |
+
+| Element | Identifier | Notes |
+|---------|-----------|-------|
+| Reviews table | `reviews-table` | |
+| Menu button | `reviews-open-menu-button` | |
+| Spam button | `single-review-spam-button` | On individual review |
+| Trash button | `single-review-trash-button` | On individual review |
+| Approve button | `single-review-approval-button` | On individual review |
+| Reply button | `single-review-reply-button` | |
+| Comment text | `single-review-comment` | |
+
+---
+
+## Point of Sale (POS)
+
+POS requires additional launch arguments: `bypass-pos-eligibility-checks`, `load-mocked-pos-products`, `bypass-pos-order-syncing`.
+
+| | |
+|---|---|
+| **Primary Identifier** | `pos-cart-view` |
+| **Nav Path** | Tap `tab-bar-pos-item` |
+
+| Element | Identifier | Notes |
+|---------|-----------|-------|
+| Cart view | `pos-cart-view` | Cart container |
+| Checkout button | `pos-checkout-button` | |
+| Product card | `pos-product-card-{productID}` | Dynamic — includes product ID |
+| Variation card | `pos-search-variation-card-{variationID}` | Dynamic — includes variation ID |
+| Total field | `pos-total-field` | |
+| Cash payment | `pos-cash-payment-button` | |
+| Mark complete | `pos-mark-payment-complete-button` | |
+| Connect reader | `pos-connect-reader-button` | |
+| Reader connected | `pos-reader-connected` | Indicator when connected |
+| Card payment msg | `pos-card-payment-message` | Status during card payment |
+| Payment success | `pos-payment-success-view` | |
+| Menu button | `pos-menu-button` | Floating menu |
+| Exit menu item | `pos-exit-menu-item` | |
+| Exit close | `pos-exit-modal-close-button` | Close exit confirmation |
+| Exit confirm | `pos-exit-confirm-button` | Confirm exit |
+
+---
+
+## Settings
+
+| | |
+|---|---|
+| **Nav Path** | Hub Menu → tap `dashboard-settings-button` |
+
+| Element | Identifier | Notes |
+|---------|-----------|-------|
+| Beta features | `settings-beta-features-button` | |
+| Log out | `settings-log-out-button` | |
+| Card reader manuals | `card-reader-manuals` | |
+
+---
+
+## Common UI Components
+
+These may appear on any screen.
+
+| Element | Identifier | Notes |
+|---------|-----------|-------|
+| Top banner dismiss | `top-banner-view-dismiss-button` | Dismiss informational banners |
+| Top banner expand | `top-banner-view-expand-collapse-button` | |
+| Top banner info | `top-banner-view-info-label` | |
+| Feedback close | `feedback-banner-popover-close-button` | |
+
+---
+
+## Navigation Flows
+
+Step-by-step paths for reaching common screens from the Dashboard.
+
+### Login (from prologue)
+```
+Prologue → tap "Prologue Self Hosted Button"
+  → type site URL in "Site address" field → tap "Site Address Next Button"
+  → type email → tap continue
+  → type password → tap continue
+  → type 2FA code (any 6 digits, e.g. "123456") in "Authentication code" → tap "Continue Button"
+  → tap "login-epilogue-continue-button"
+  → Dashboard
+```
+
+### Orders
+```
+Orders List:       Tap tab "tab-bar-orders-item"
+Order Detail:      Orders List → tap any order row → wait for "order-details-table-view"
+Order Creation:    Orders List → tap "new-order-type-sheet-button" → wait for "order-form-scroll-view"
+```
+
+### Products
+```
+Products List:     Tap tab "tab-bar-products-item"
+Product Detail:    Products List → tap any "single-product-cell" → wait for "product-form"
+Product Creation:  Products List → tap "product-add-button"
+Product Search:    Products List → tap "product-search-button"
+```
+
+### Hub Menu Screens
+```
+Hub Menu:          Tap tab "tab-bar-menu-item"
+Coupons:           Hub Menu → tap "menu-coupons"
+Reviews:           Hub Menu → tap "menu-reviews" → wait for "reviews-table"
+Customers:         Hub Menu → tap "menu-customers"
+Payments:          Hub Menu → tap "menu-payments"
+Blaze:             Hub Menu → tap "menu-blaze"
+Bookings:          Hub Menu → tap "menu-bookings"
+```
+
+### Settings
+```
+Settings:          Hub Menu → tap "dashboard-settings-button"
+Beta Features:     Settings → tap "settings-beta-features-button"
+Logout:            Settings → tap "settings-log-out-button"
+```
+
+### POS
+```
+POS:               Tap tab "tab-bar-pos-item" → wait for "pos-cart-view"
+POS Checkout:      POS → add products → tap "pos-checkout-button"
+POS Cash Payment:  Checkout → tap "pos-cash-payment-button" → tap "pos-mark-payment-complete-button"
+POS Exit:          POS → tap "pos-menu-button" → tap "pos-exit-menu-item" → tap "pos-exit-confirm-button"
+```

--- a/.claude/references/screen-identifiers.md
+++ b/.claude/references/screen-identifiers.md
@@ -67,7 +67,7 @@ The mock server always requires 2FA. Enter any 6-digit code (e.g., `123456`).
 | Store name | `name-label` | |
 | Store URL | `url-label` | |
 
-**Mock credentials** for WireMock: site `http://yourwoosite.com`, email `t@wp.com`, password `pw`.
+**Mock credentials** (only work with the WireMock mock server, not real accounts): site `http://yourwoosite.com`, email `t@wp.com`, password `pw`.
 
 ---
 

--- a/.claude/rules/verification.md
+++ b/.claude/rules/verification.md
@@ -10,13 +10,13 @@ Agents can verify their changes work from a user's perspective using two complem
 
 ## `/verify` — E2E Simulator Verification
 
-Builds the app, launches it on the simulator with mocked data (WireMock), and uses mobile-mcp to navigate the UI and verify features work. Auto-detects which features changed via `git diff` and the feature map.
+Builds the app, launches on the simulator, and uses mobile-mcp to navigate the UI and verify features work. Auto-detects which features changed via `git diff` and the feature map.
 
 ```bash
 /verify              # auto-detect scope from git diff
 ```
 
-**How it works**: Build app -> start WireMock -> launch on simulator with mock args -> navigate to feature tabs -> screenshot and verify accessibility elements -> cleanup.
+**Environment-aware**: The agent first assesses the current state — if the simulator already has a built app with an active session (the common case during development), it just builds, re-launches, and verifies. It only sets up WireMock mocked environment when there's no existing session, deterministic mock data is needed, or the user explicitly requests it.
 
 **Feature map**: `.claude/feature-map.json` maps file path patterns to feature areas (orders, products, POS, dashboard, etc.) with navigation instructions and expected elements. To add a new feature, add an entry with `pathPatterns`, `tab`, and `verifyElements`.
 

--- a/.claude/rules/verification.md
+++ b/.claude/rules/verification.md
@@ -1,0 +1,51 @@
+# Agent Verification Rules
+
+Agents can verify their changes work from a user's perspective using two complementary loops: **snapshot-driven iteration** (fast inner loop) and **simulator-based E2E verification** (slower outer loop).
+
+## Prerequisites
+- **Node.js v22+** — required by mobile-mcp for simulator interaction
+- **Java** — required by WireMock mock server (`brew install openjdk` if missing)
+- **Booted iOS simulator** — `xcrun simctl boot <UDID>`
+- **mobile-mcp** — auto-configured via `.mcp.json` (project-scoped, no manual setup needed)
+
+## `/verify` — E2E Simulator Verification
+
+Builds the app, launches it on the simulator with mocked data (WireMock), and uses mobile-mcp to navigate the UI and verify features work. Auto-detects which features changed via `git diff` and the feature map.
+
+```bash
+/verify              # auto-detect scope from git diff
+```
+
+**How it works**: Build app -> start WireMock -> launch on simulator with mock args -> navigate to feature tabs -> screenshot and verify accessibility elements -> cleanup.
+
+**Feature map**: `.claude/feature-map.json` maps file path patterns to feature areas (orders, products, POS, dashboard, etc.) with navigation instructions and expected elements. To add a new feature, add an entry with `pathPatterns`, `tab`, and `verifyElements`.
+
+## `/snapshot` — Snapshot-Driven UI Iteration
+
+Uses `swift-snapshot-testing` to render SwiftUI views to PNG images. The agent reads the PNG, compares against design goals, makes changes, and repeats. ~25s per iteration cycle when scoped to a module.
+
+```bash
+/snapshot            # start snapshot iteration for current view work
+```
+
+**How it works**: Temporarily add `swift-snapshot-testing` to `Modules/Package.swift` -> create a snapshot test -> iterate (edit code -> run test -> read PNG -> compare -> fix) -> revert all temporary artifacts.
+
+**Important**: The snapshot dependency, test files, and `__Snapshots__/` directories are always temporary and must never be committed.
+
+## mobile-mcp Tools
+
+Configured via `.mcp.json` at the project root. Provides:
+- `screenshot` — capture current simulator screen
+- `list_ui_elements` — get accessibility tree with element positions
+- `tap` / `swipe` / `type_text` — interact with UI elements
+- `launch_app` / `terminate_app` — manage app lifecycle
+- `list_devices` — discover available simulators
+
+## Key References
+
+- **Screen identifiers and navigation flows**: `.claude/references/screen-identifiers.md`
+- **Feature-to-path scope mapping**: `.claude/feature-map.json`
+- **Mock server management**: `/mocks` skill
+- **Simulator discovery**: `/simulator` skill
+- **Launch arguments**: `WooCommerce/Classes/System/ProcessConfiguration.swift`
+- **Mock API mappings**: `Modules/Sources/APIMocks/Resources/`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,7 +33,7 @@
       "Bash(bundle exec rake mocks *)",
       "Bash(bundle exec fastlane *)",
       "Bash(./API-Mocks/scripts/start.sh *)",
-      "Bash(kill $(lsof -ti:8282) *)",
+      "Bash(./API-Mocks/scripts/stop.sh *)",
       "mcp__mobile-mcp__*"
     ],
     "deny": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,8 +30,11 @@
       "Bash(bundle exec rake dependencies *)",
       "Bash(bundle exec rake generate *)",
       "Bash(bundle exec rake lint *)",      
-      "Bash(bundle exec rake mocks *)",      
-      "Bash(bundle exec fastlane *)"
+      "Bash(bundle exec rake mocks *)",
+      "Bash(bundle exec fastlane *)",
+      "Bash(./API-Mocks/scripts/start.sh *)",
+      "Bash(kill *)",
+      "mcp__mobile-mcp__*"
     ],
     "deny": [
       "Bash(git push --force *)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,7 +33,7 @@
       "Bash(bundle exec rake mocks *)",
       "Bash(bundle exec fastlane *)",
       "Bash(./API-Mocks/scripts/start.sh *)",
-      "Bash(kill *)",
+      "Bash(kill $(lsof -ti:8282) *)",
       "mcp__mobile-mcp__*"
     ],
     "deny": [

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -16,7 +16,7 @@ If the build fails:
 1. Analyze the error output — look for compilation errors, identify file and line
 2. Check if it is a missing import, type mismatch, syntax error, or stale generated code
 3. If stale codegen, run: `bundle exec rake generate`
-4. If `Unable to find a device matching` — run `xcrun simctl list devices available | grep -E "iPhone [0-9]" | tail -5` to find an available simulator name, then retry
+4. If `Unable to find a device matching` — use the `/simulator` skill to discover an available simulator, then retry
 5. Suggest or apply the fix
 
 If the build succeeds, report success.

--- a/.claude/skills/mocks/SKILL.md
+++ b/.claude/skills/mocks/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: mocks
+description: Start or stop the WireMock API mock server for UI testing and E2E verification.
+user-invocable: true
+allowed-tools: "Bash"
+argument-hint: "[start|stop]"
+---
+
+# WireMock Mock Server
+
+Manage the WireMock mock server that serves API responses for UI tests and E2E verification.
+
+Requires **Java** (`brew install openjdk` if missing).
+
+## Start
+
+```bash
+./API-Mocks/scripts/start.sh 8282 &
+sleep 3
+```
+
+Verify it's running:
+```bash
+curl -s http://localhost:8282/__admin/ > /dev/null && echo "WireMock running on port 8282" || echo "WireMock failed to start"
+```
+
+If Java is not installed, report the prerequisite and stop.
+
+## Stop
+
+Kill by port — more reliable than tracking PIDs across shell sessions:
+
+```bash
+kill $(lsof -ti:8282) 2>/dev/null && echo "WireMock stopped" || echo "Nothing running on 8282"
+```
+
+## Details
+
+- **Port**: 8282 (default)
+- **Mappings**: `Modules/Sources/APIMocks/Resources/mappings/`
+- **Response files**: `Modules/Sources/APIMocks/Resources/__files/`
+- **Start script**: `API-Mocks/scripts/start.sh`
+- **WireMock version**: 2.35.2 (auto-downloaded on first run)

--- a/.claude/skills/mocks/SKILL.md
+++ b/.claude/skills/mocks/SKILL.md
@@ -40,4 +40,4 @@ kill $(lsof -ti:8282) 2>/dev/null && echo "WireMock stopped" || echo "Nothing ru
 - **Mappings**: `Modules/Sources/APIMocks/Resources/mappings/`
 - **Response files**: `Modules/Sources/APIMocks/Resources/__files/`
 - **Start script**: `API-Mocks/scripts/start.sh`
-- **WireMock version**: 2.35.2 (auto-downloaded on first run)
+- **WireMock**: auto-downloaded on first run (version configured in `start.sh`)

--- a/.claude/skills/mocks/SKILL.md
+++ b/.claude/skills/mocks/SKILL.md
@@ -28,10 +28,13 @@ If Java is not installed, report the prerequisite and stop.
 
 ## Stop
 
-Kill by port — more reliable than tracking PIDs across shell sessions:
-
 ```bash
-kill $(lsof -ti:8282) 2>/dev/null && echo "WireMock stopped" || echo "Nothing running on 8282"
+./API-Mocks/scripts/stop.sh 8282
+```
+
+Uses WireMock's graceful shutdown endpoint. Falls back to kill-by-port if the shutdown endpoint is unreachable:
+```bash
+kill $(lsof -ti:8282) 2>/dev/null
 ```
 
 ## Details

--- a/.claude/skills/simulator/SKILL.md
+++ b/.claude/skills/simulator/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: simulator
+description: Discover and boot an iOS simulator. Use before any command that needs a simulator UDID.
+user-invocable: true
+allowed-tools: "Bash"
+---
+
+# Discover and Boot iOS Simulator
+
+Find a booted iPhone simulator or boot one. Returns the UDID for use in subsequent commands.
+
+**Never hardcode a simulator name** (e.g., `iPhone 16`). Available simulators change across Xcode versions — always discover dynamically.
+
+## Step 1: Check for a Booted iPhone
+
+```bash
+xcrun simctl list devices booted | grep -E "iPhone"
+```
+
+If a booted iPhone is found, extract its UDID (the UUID in parentheses) and report it. Done.
+
+## Step 2: Find and Boot an Available iPhone
+
+If no iPhone is booted:
+
+```bash
+xcrun simctl list devices available | grep -E "iPhone [0-9]" | tail -5
+```
+
+Pick the first available device. Extract its UDID. Boot it:
+
+```bash
+xcrun simctl boot <UDID>
+```
+
+Wait a few seconds for the simulator to finish booting, then report the UDID.
+
+## Output
+
+Report the simulator name and UDID so the caller can use it:
+```
+Simulator ready: iPhone 17 (93E9F784-2B91-4D83-BFA5-F1682C28180B)
+```

--- a/.claude/skills/snapshot/SKILL.md
+++ b/.claude/skills/snapshot/SKILL.md
@@ -28,12 +28,11 @@ Use swift-snapshot-testing to create a visual feedback loop when implementing UI
 3. SCAFFOLD   Create snapshot test rendering the target view
 4. LOOP       For each implementation step:
                 a. Edit code
-                b. Commit
-                c. Run snapshot test (record mode)
-                d. Read generated PNG
-                e. Compare against design
-                f. If mismatch -> fix, amend commit, re-snapshot
-                g. If match -> next step
+                b. Run snapshot test (record mode)
+                c. Read generated PNG
+                d. Compare against design
+                e. If mismatch -> fix and re-snapshot
+                f. If match -> commit the verified change, move to next step
 5. CLEANUP    Revert dependency + delete test file
 ```
 
@@ -148,7 +147,7 @@ Common issues caught by snapshots:
 - **Spacing mismatches** — check `POSPadding`/`POSSpacing` values against design
 - **Wrong section order** — compare VStack children order with design
 
-When fixing: amend the current step's commit, then re-run snapshots to verify.
+When fixing: edit the code and re-run snapshots to verify. Only commit once the snapshot matches the design goal — don't commit untested changes.
 
 ## Cleanup: Remove ALL Temporary Artifacts
 
@@ -185,5 +184,5 @@ git status
 | Find PNGs | `Modules/Tests/<Target>/__Snapshots__/<Class>/test_name.1.png` |
 | View snapshot | Read tool on the PNG path |
 | Compare | Read both snapshot PNG and design reference |
-| Fix + re-run | Edit code, `git commit --amend`, re-run xcodebuild |
+| Fix + re-run | Edit code, re-run xcodebuild, commit once verified |
 | Clean up | `git checkout -- Modules/Package.swift`, `rm` test file + snapshots |

--- a/.claude/skills/snapshot/SKILL.md
+++ b/.claude/skills/snapshot/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: snapshot
+description: Use swift-snapshot-testing to visually verify SwiftUI views during implementation. Renders views to PNG for comparison against design references. Fast feedback loop (~25s/cycle).
+user-invocable: true
+allowed-tools: "Bash, Read, Write, Edit, Grep, Glob"
+argument-hint: "[view-name or test-target]"
+---
+
+# Snapshot-Driven UI Iteration
+
+Use swift-snapshot-testing to create a visual feedback loop when implementing UI changes. Render SwiftUI views to PNG after each code change, compare against design goals, fix mismatches, and repeat.
+
+## When to Use
+- Implementing UI from Figma designs or reference screenshots
+- Multi-step view redesigns where each step should match a target
+- Any SwiftUI work where you need to visually verify output
+- When design reference images are available for comparison
+
+## When NOT to Use
+- Simple single-property changes (color, font)
+- Logic-only changes with no visual impact
+- When the project already has snapshot tests covering the view
+
+## Core Flow
+```
+1. SETUP      Add swift-snapshot-testing dependency (temporary)
+2. GOAL       Collect design reference images
+3. SCAFFOLD   Create snapshot test rendering the target view
+4. LOOP       For each implementation step:
+                a. Edit code
+                b. Commit
+                c. Run snapshot test (record mode)
+                d. Read generated PNG
+                e. Compare against design
+                f. If mismatch -> fix, amend commit, re-snapshot
+                g. If match -> next step
+5. CLEANUP    Revert dependency + delete test file
+```
+
+## Setup: Add Dependency
+
+Check if `swift-snapshot-testing` already exists in `Modules/Package.swift`. If not, add it temporarily.
+
+**In the `dependencies` array of `Modules/Package.swift`:**
+```swift
+.package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.0"),
+```
+
+**In the relevant test target's `dependencies` array:**
+```swift
+.product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
+```
+
+Common test targets in this project:
+- `PointOfSaleTests` — for POS views
+- `WooFoundationTests` — for shared UI components
+- `YosemiteTests` — for business logic views
+
+**Remember the original state** of `Modules/Package.swift` so you can revert exactly after cleanup.
+
+## Goal: Collect References
+
+If the user provides design reference images (Figma exports, screenshots):
+```bash
+mkdir -p ~/Downloads/snapshot_experiment
+cp ~/path/to/design.png ~/Downloads/snapshot_experiment/design.png
+```
+Read each reference image to understand the target state before writing code.
+
+If no reference image, the goal is inferred from the user's description of desired UI behavior.
+
+## Scaffold: Create Snapshot Test
+
+Create a test file in the appropriate `Modules/Tests/*Tests/` directory:
+
+```swift
+import XCTest
+import SnapshotTesting
+import SwiftUI
+@testable import TargetModule
+
+final class ViewNameSnapshotTests: XCTestCase {
+    override func invokeTest() {
+        withSnapshotTesting(record: .all) {
+            super.invokeTest()
+        }
+    }
+
+    func test_defaultState_snapshot() {
+        let view = YourView(/* props for default state */)
+            .frame(width: 375, height: 900)
+        assertSnapshot(of: view, as: .image(layout: .sizeThatFits))
+    }
+
+    func test_alternateState_snapshot() {
+        let view = YourView(/* props for alternate state */)
+            .frame(width: 375, height: 900)
+        assertSnapshot(of: view, as: .image(layout: .sizeThatFits))
+    }
+}
+```
+
+**Important details for this project:**
+- `record: .all` in `invokeTest()` forces PNG generation every run
+- For POS views, set `.environment(\.horizontalSizeClass, .regular)` — POS is iPad-first
+- Use `.frame(width:height:)` to control render size. Start with `height: 900`, increase to `1200+` if content is clipped
+- Tests will always "fail" in record mode — this is expected, they report recording, not comparison
+- Use POS design tokens (`POSPadding`, `POSSpacing`, `POSFontStyle`, `Color+POSColorPalette`) when comparing POS designs
+
+## Run: Execute Snapshot Tests
+
+Use the `/simulator` skill approach to discover a booted simulator UDID.
+
+Run only the snapshot tests for fast feedback:
+```bash
+xcodebuild test \
+  -workspace WooCommerce.xcworkspace \
+  -scheme WooCommerce \
+  -destination 'platform=iOS Simulator,id=<SIMULATOR_UDID>' \
+  -only-testing:<TestTarget>/<SnapshotTestClass> \
+  CODE_SIGNING_ALLOWED=NO 2>&1 | tail -30
+```
+
+**Prefer module-level test targets** over the full app for faster feedback (~25s vs minutes).
+
+**Generated PNGs appear at:**
+```
+Modules/Tests/<TestTarget>/__Snapshots__/<TestClass>/test_name.1.png
+```
+
+## Compare: Read and Assess
+
+After each run:
+1. Read the generated PNG using the Read tool
+2. If a design reference exists, read it side by side
+3. Identify specific mismatches: layout, spacing, missing elements, text wrapping, colors
+4. Copy PNGs to working directory with step labels for history:
+```bash
+cp Modules/Tests/<Target>/__Snapshots__/<Class>/test_name.1.png ~/Downloads/snapshot_experiment/step1.png
+```
+
+## Fix: Iterate on Mismatches
+
+Common issues caught by snapshots:
+- **Text wrapping** in pills/badges at narrow widths — add `.lineLimit(1).fixedSize(horizontal: true, vertical: false)`, reduce padding
+- **Back button showing** in non-compact context — set `.environment(\.horizontalSizeClass, .regular)`
+- **Content clipped** at bottom — increase frame height in test
+- **Spacing mismatches** — check `POSPadding`/`POSSpacing` values against design
+- **Wrong section order** — compare VStack children order with design
+
+When fixing: amend the current step's commit, then re-run snapshots to verify.
+
+## Cleanup: Remove ALL Temporary Artifacts
+
+After implementation is complete, revert ALL temporary changes:
+
+```bash
+# Revert Package.swift (removes snapshot dependency)
+git checkout -- Modules/Package.swift
+
+# Revert Package.resolved if it changed
+git checkout -- Modules/Package.resolved
+
+# Also revert workspace Package.resolved if changed
+git checkout -- WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+
+# Delete the snapshot test file
+rm Modules/Tests/<TestTarget>/<SnapshotTestClass>.swift
+
+# Delete generated snapshot directory
+rm -rf Modules/Tests/<TestTarget>/__Snapshots__
+
+# Verify clean state
+git status
+```
+
+**Critical**: Never commit snapshot test files, `__Snapshots__/` directories, or the `swift-snapshot-testing` dependency. These are temporary iteration tools only.
+
+## Quick Reference
+
+| Action | Command/Tool |
+|--------|-------------|
+| Add dependency | Edit `Modules/Package.swift` |
+| Run snapshots | `xcodebuild test -only-testing:<Target>/<Class>` |
+| Find PNGs | `Modules/Tests/<Target>/__Snapshots__/<Class>/test_name.1.png` |
+| View snapshot | Read tool on the PNG path |
+| Compare | Read both snapshot PNG and design reference |
+| Fix + re-run | Edit code, `git commit --amend`, re-run xcodebuild |
+| Clean up | `git checkout -- Modules/Package.swift`, `rm` test file + snapshots |

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -39,8 +39,4 @@ bundle exec fastlane test only_testing:WooCommerceTests/MyClass clean:true 2>&1 
 3. Read the failing test files to understand what went wrong
 4. Suggest fixes for failing tests
 
-If the simulator `iPhone 16` is not available, discover available simulators:
-```bash
-xcrun simctl list devices available | grep -E "iPhone [0-9]" | tail -5
-```
-Then retry with an available iPhone name.
+If the simulator is not available, use the `/simulator` skill to discover an available one, then retry.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,17 +1,34 @@
 ---
 name: verify
-description: Build the app with mock data, launch on simulator, and verify feature behavior via mobile-mcp interaction. Use after making changes to visually confirm they work from a user's perspective.
+description: Build the app, launch on simulator, and verify feature behavior via mobile-mcp interaction. Use after making changes to visually confirm they work from a user's perspective.
 user-invocable: true
 allowed-tools: "Bash, Read, Grep, Glob, mcp__mobile-mcp__*"
 ---
 
 # E2E Simulator Verification
 
-Build the app, launch it on the iOS simulator with mocked data, and verify the affected feature areas work correctly by navigating the UI and checking for expected elements.
+Build the app, launch it on the iOS simulator, and verify the affected feature areas work correctly by navigating the UI and checking for expected elements.
 
 Read `.claude/references/screen-identifiers.md` to understand how to identify screens and navigate between them.
 
-## Step 1: Detect Feature Scope
+## Step 1: Assess the Environment
+
+Before setting up anything, determine what's already available:
+
+1. **Simulator**: is an iPhone simulator already booted? (`xcrun simctl list devices booted | grep iPhone`)
+2. **App state**: is the app already installed? (`xcrun simctl listapps <UDID> 2>/dev/null | grep com.automattic.woocommerce`)
+3. **Session state**: launch the app and check the current screen — is the user already logged in (tab bar visible) or on the login screen?
+
+**Most verification happens during development** where the simulator has a current build and an active session. In this case, you only need to build your changes and re-launch — no mock server or login flow needed.
+
+**Use the mocked environment** (WireMock + `logout-at-launch`) only when:
+- There is no existing session / data on the simulator
+- You need deterministic mock data (e.g., verifying specific order states)
+- The user explicitly requests mocked verification
+
+If a mocked environment is not needed, skip Steps 3 and the mock-specific launch args in Step 5.
+
+## Step 2: Detect Feature Scope
 
 Determine which features were changed:
 
@@ -23,15 +40,13 @@ If no diff against trunk, fall back to `git diff --name-only HEAD~1`.
 
 Read `.claude/feature-map.json` and match changed file paths against `pathPatterns` for each feature. Collect all matched features. If no features match, default to `"dashboard"`.
 
-## Step 2: Discover Simulator
-
-Use the `/simulator` skill approach: find a booted iPhone first, otherwise find an available one and boot it. Store the UDID for all subsequent commands.
-
-## Step 3: Start Mock Server
+## Step 3: Start Mock Server (only if needed)
 
 Use the `/mocks` skill approach: start WireMock on port 8282 in the background. Verify it's running before proceeding.
 
 ## Step 4: Build the App
+
+Use the `/simulator` skill approach to discover a booted simulator UDID.
 
 ```bash
 xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
@@ -43,19 +58,18 @@ If the build fails, analyze errors and report. The build must succeed — verifi
 
 ## Step 5: Launch App
 
-Collect launch arguments. Start with the base set:
-- `logout-at-launch`
-- `disable-animations`
-- `mocked-wpcom-api`
-- `-ui_testing`
-- `-mocks-port`
-- `8282`
+**If using mocked environment**, collect launch arguments:
+- `logout-at-launch`, `disable-animations`, `mocked-wpcom-api`, `-ui_testing`, `-mocks-port`, `8282`
+- Append any feature-specific `launchArgs` from `feature-map.json`
 
-For each matched feature, check if `feature-map.json` defines additional `launchArgs` and append them.
-
-Launch using `xcrun simctl launch` to pass arguments (mobile-mcp's `launch_app` does not support launch arguments):
+Launch using `xcrun simctl launch` (supports launch arguments, unlike mobile-mcp's `launch_app`):
 ```bash
 xcrun simctl launch <UDID> com.automattic.woocommerce <all-args-space-separated>
+```
+
+**If using existing environment**, launch without mock args:
+```bash
+xcrun simctl launch <UDID> com.automattic.woocommerce
 ```
 
 Wait 5 seconds for the app to settle.
@@ -64,10 +78,7 @@ Wait 5 seconds for the app to settle.
 
 Use mobile-mcp tools (`list_elements_on_screen`, `click_on_screen_at_coordinates`, `take_screenshot`) to interact with the app.
 
-Consult `.claude/references/screen-identifiers.md` for:
-- How to identify which screen you're on (primary identifiers)
-- Which elements to look for on each screen
-- Step-by-step navigation flows to reach any screen
+Consult `.claude/references/screen-identifiers.md` for screen identification, element lookup, and navigation flows (including login flow when using mocked environment).
 
 For each matched feature from the feature map:
 
@@ -97,4 +108,4 @@ Summarize:
 xcrun simctl terminate <UDID> com.automattic.woocommerce
 ```
 
-Stop the mock server using the `/mocks` skill approach (kill by port).
+If mock server was started, stop it using the `/mocks` skill approach (kill by port).

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -38,7 +38,7 @@ git diff --name-only trunk...HEAD
 
 If no diff against trunk, fall back to `git diff --name-only HEAD~1`.
 
-Read `.claude/feature-map.json` and match changed file paths against `pathPatterns` for each feature. Collect all matched features. If no features match, default to `"dashboard"`.
+Read `.claude/feature-map.json` and match changed file paths against `pathPatterns` for each feature. Collect all matched features. If no features match, **skip verification entirely** — report which files changed, note that none matched any feature path pattern, and stop (do not proceed to Steps 3-8).
 
 ## Step 3: Start Mock Server (only if needed)
 

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: verify
+description: Build the app with mock data, launch on simulator, and verify feature behavior via mobile-mcp interaction. Use after making changes to visually confirm they work from a user's perspective.
+user-invocable: true
+allowed-tools: "Bash, Read, Grep, Glob, mcp__mobile-mcp__*"
+---
+
+# E2E Simulator Verification
+
+Build the app, launch it on the iOS simulator with mocked data, and verify the affected feature areas work correctly by navigating the UI and checking for expected elements.
+
+Read `.claude/references/screen-identifiers.md` to understand how to identify screens and navigate between them.
+
+## Step 1: Detect Feature Scope
+
+Determine which features were changed:
+
+```bash
+git diff --name-only trunk...HEAD
+```
+
+If no diff against trunk, fall back to `git diff --name-only HEAD~1`.
+
+Read `.claude/feature-map.json` and match changed file paths against `pathPatterns` for each feature. Collect all matched features. If no features match, default to `"dashboard"`.
+
+## Step 2: Discover Simulator
+
+Use the `/simulator` skill approach: find a booted iPhone first, otherwise find an available one and boot it. Store the UDID for all subsequent commands.
+
+## Step 3: Start Mock Server
+
+Use the `/mocks` skill approach: start WireMock on port 8282 in the background. Verify it's running before proceeding.
+
+## Step 4: Build the App
+
+```bash
+xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
+  -destination "platform=iOS Simulator,id=<UDID>" -sdk iphonesimulator \
+  build 2>&1 | tail -30
+```
+
+If the build fails, analyze errors and report. The build must succeed — verification requires the current code.
+
+## Step 5: Launch App
+
+Collect launch arguments. Start with the base set:
+- `logout-at-launch`
+- `disable-animations`
+- `mocked-wpcom-api`
+- `-ui_testing`
+- `-mocks-port`
+- `8282`
+
+For each matched feature, check if `feature-map.json` defines additional `launchArgs` and append them.
+
+Launch using `xcrun simctl launch` to pass arguments (mobile-mcp's `launch_app` does not support launch arguments):
+```bash
+xcrun simctl launch <UDID> com.automattic.woocommerce <all-args-space-separated>
+```
+
+Wait 5 seconds for the app to settle.
+
+## Step 6: Navigate and Verify
+
+Use mobile-mcp tools (`list_elements_on_screen`, `click_on_screen_at_coordinates`, `take_screenshot`) to interact with the app.
+
+Consult `.claude/references/screen-identifiers.md` for:
+- How to identify which screen you're on (primary identifiers)
+- Which elements to look for on each screen
+- Step-by-step navigation flows to reach any screen
+
+For each matched feature from the feature map:
+
+1. **Navigate** to the feature's screen following the navigation flows in screen-identifiers.md
+2. **List elements** to confirm you arrived at the right screen (match primary identifier)
+3. **Screenshot** and visually assess the screen
+4. **Verify** the feature's `verifyElements` from feature-map.json are present
+5. **Interact** if the feature defines `interactions` — execute each action
+
+### Verification Criteria
+- The screen loaded (not blank/empty/error)
+- Expected accessibility elements are present
+- No crash or unexpected error state visible
+
+## Step 7: Report Results
+
+Summarize:
+- **Features verified**: list each feature and pass/fail
+- **Screenshots taken**: file paths
+- **Missing elements**: any expected elements not found
+- **Visual assessment**: brief description of what the UI looks like
+- **Issues found**: crashes, error states, unexpected behavior
+
+## Step 8: Cleanup
+
+```bash
+xcrun simctl terminate <UDID> com.automattic.woocommerce
+```
+
+Stop the mock server using the `/mocks` skill approach (kill by port).

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "mobile-mcp": {
+      "command": "npx",
+      "args": ["-y", "@mobilenext/mobile-mcp@latest"]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,3 +262,14 @@ Opt-in only rules configured in `.swiftlint.yml`:
 See `Modules/Package.swift` for the definitive list of supported platforms, internal module targets, and external dependencies. Key architectural constraints:
 - WooCommerce app must only import Yosemite for business logic (never Networking or Storage directly)
 - Yosemite bridges Networking and Storage
+
+## Agent Verification
+
+Agents can verify their changes work from a user's perspective using two complementary loops:
+
+- **`/verify`** — E2E simulator verification: builds the app, launches on simulator with WireMock mocked data, navigates UI via mobile-mcp, screenshots and checks elements. Auto-detects scope from `git diff` using `.claude/feature-map.json`.
+- **`/snapshot`** — Fast UI iteration: uses `swift-snapshot-testing` to render SwiftUI views to PNG (~25s/cycle). Agent reads images, compares against design goals, iterates. Temporary — artifacts are never committed.
+
+**Prerequisites**: Node.js v22+, Java (for WireMock), booted iOS simulator. mobile-mcp is auto-configured via `.mcp.json`.
+
+See `.claude/rules/verification.md` for full details on tools, mock server setup, and launch arguments.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,7 +267,7 @@ See `Modules/Package.swift` for the definitive list of supported platforms, inte
 
 Agents can verify their changes work from a user's perspective using two complementary loops:
 
-- **`/verify`** — E2E simulator verification: builds the app, launches on simulator with WireMock mocked data, navigates UI via mobile-mcp, screenshots and checks elements. Auto-detects scope from `git diff` using `.claude/feature-map.json`.
+- **`/verify`** — E2E simulator verification: builds the app, launches on simulator, navigates UI via mobile-mcp, screenshots and checks elements. Auto-detects scope from `git diff` using `.claude/feature-map.json`. Environment-aware — uses existing session during development, sets up WireMock mocked environment only when needed.
 - **`/snapshot`** — Fast UI iteration: uses `swift-snapshot-testing` to render SwiftUI views to PNG (~25s/cycle). Agent reads images, compares against design goals, iterates. Temporary — artifacts are never committed.
 
 **Prerequisites**: Node.js v22+, Java (for WireMock), booted iOS simulator. mobile-mcp is auto-configured via `.mcp.json`.


### PR DESCRIPTION
## Description

Enables AI agents (Claude Code) to verify their changes work from a user's perspective — not just that tests pass, but that features behave correctly in the simulator. Adds two complementary verification loops:

- **`/verify`** — E2E simulator verification: builds the app, launches on simulator with WireMock mocked data, navigates UI via mobile-mcp, screenshots and checks accessibility elements. Auto-detects scope from `git diff`.
- **`/snapshot`** — Fast UI iteration: uses `swift-snapshot-testing` to render SwiftUI views to PNG (~25s/cycle). Agent reads images, compares against design goals, iterates. Temporary — artifacts are never committed.

Supporting infrastructure:
- **`.mcp.json`** — Project-level mobile-mcp config so all teammates get simulator tools automatically
- **`/simulator`** and **`/mocks`** — Reusable skills for simulator discovery and WireMock management
- **`feature-map.json`** — Maps file paths to feature areas for automatic scope detection
- **`screen-identifiers.md`** — Comprehensive reference mapping screens to accessibility identifiers and navigation flows (inspired by the [Android equivalent](https://github.com/woocommerce/woocommerce-android/pull/15418))

No app source code changes. All files are agent configuration (`.claude/`, `.mcp.json`, `AGENTS.md`).

## Test Steps

1. With Claude Code in the repo, verify `/verify` skill is available and mobile-mcp tools are accessible
2. Boot a simulator, invoke `/verify` — confirm it starts WireMock, builds, launches, navigates login, and verifies the Dashboard
3. Invoke `/snapshot` on a SwiftUI view — confirm it adds the dependency temporarily, runs snapshot tests, reads PNGs, and cleans up

Tested E2E: login flow (including 2FA), Dashboard, Orders, Products, and Hub Menu tabs all verified successfully with mock data.

## Screenshots

N/A — no UI changes. All files are agent/tooling configuration.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.