### PR TITLE
POS Bookings: Fix "Edit note" in header appearing just before view dismissal

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Bookings/BookingNote/POSBookingNoteView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/BookingNote/POSBookingNoteView.swift
@@ -21,7 +21,7 @@ struct POSBookingNoteView: View {
     @State private var shouldMinimizePadding: Bool = false
 
     private var originalNote: String
-    private var isEditingExistingNote: Bool
+    @State private var isEditingExistingNote: Bool
 
     init(booking: POSBooking, isShowingNoteView: Binding<Bool>) {
         self.booking = booking


### PR DESCRIPTION
Closes WOOMOB-2364

## Description
From CfT: pdfdoF-8M9#comment-10206-p2

When adding a new note in `POSBookingNoteView`, the title shows "Add note" correctly. However, after saving, the title briefly flashes to "Edit note" before the view dismisses. This happens because the booking model is updated before the dismiss animation completes.

## Test Steps
- In booking, add note, save, observe only "add note" can be read in the header
- Edit note, save, observe only "Edit note" can be read in the header

## Screenshots

https://github.com/user-attachments/assets/6f77bc73-6c43-4953-9030-db7d2ad83aa3

