### PR TITLE
Fix POS bookings dismissed when returning from background on iOS 18

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -4,6 +4,7 @@ import struct Yosemite.POSBooking
 
 struct POSBookingDetailView: View {
     let booking: POSBooking
+    @Binding var detailNavigationPath: NavigationPath
     let onBack: () -> Void
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -11,8 +12,6 @@ struct POSBookingDetailView: View {
     @Environment(POSOrderListModel.self) private var orderListModel
     @Environment(POSBookingsModel.self) private var bookingsModel
     @Environment(\.posAnalytics) private var analytics
-
-    @State private var navigationPath: [NavigationDestination] = []
     @State private var cancelModalState: CancelBookingModalState?
     @State private var showPaymentView = false
     @State private var paymentModel: POSPaymentModel?
@@ -33,41 +32,39 @@ struct POSBookingDetailView: View {
     }
 
     var body: some View {
-        NavigationStack(path: $navigationPath) {
-            bookingDetailContent
-                .navigationDestination(for: NavigationDestination.self) { destination in
-                    switch destination {
-                    case .orderDetail:
-                        POSOrderDetailsView(order: booking.order, onBack: {
-                            navigationPath.removeLast()
-                        })
-                        // Forces back button to be rendered, otherwise the system assumes that
-                        // navigation is handled by the split view's sidebar, not a back button
-                        .environment(\.posHeaderBackButtonConfiguration, .init(state: .enabled, action: {
-                            navigationPath.removeLast()
-                        }))
-                    case .orderDetailRefund:
-                        POSOrderDetailsView(
-                            order: booking.order,
-                            onBack: { navigationPath.removeLast() },
-                            autoStartRefund: true,
-                            onRefundSuccess: {
-                                Task {
-                                    isDetailsUpdating = true
-                                    await bookingsModel.updateAfterRefund(bookingID: booking.id)
-                                    isDetailsUpdating = false
-                                }
-                            },
-                            onRefundFailure: { error in
-                                analytics.track(event: WooAnalyticsEvent.PointOfSale.bookingRefundFailed(error: error))
+        bookingDetailContent
+            .navigationDestination(for: NavigationDestination.self) { destination in
+                switch destination {
+                case .orderDetail:
+                    POSOrderDetailsView(order: booking.order, onBack: {
+                        detailNavigationPath.removeLast()
+                    })
+                    // Forces back button to be rendered, otherwise the system assumes that
+                    // navigation is handled by the split view's sidebar, not a back button
+                    .environment(\.posHeaderBackButtonConfiguration, .init(state: .enabled, action: {
+                        detailNavigationPath.removeLast()
+                    }))
+                case .orderDetailRefund:
+                    POSOrderDetailsView(
+                        order: booking.order,
+                        onBack: { detailNavigationPath.removeLast() },
+                        autoStartRefund: true,
+                        onRefundSuccess: {
+                            Task {
+                                isDetailsUpdating = true
+                                await bookingsModel.updateAfterRefund(bookingID: booking.id)
+                                isDetailsUpdating = false
                             }
-                        )
-                        .environment(\.posHeaderBackButtonConfiguration, .init(state: .enabled, action: {
-                            navigationPath.removeLast()
-                        }))
-                    }
+                        },
+                        onRefundFailure: { error in
+                            analytics.track(event: WooAnalyticsEvent.PointOfSale.bookingRefundFailed(error: error))
+                        }
+                    )
+                    .environment(\.posHeaderBackButtonConfiguration, .init(state: .enabled, action: {
+                        detailNavigationPath.removeLast()
+                    }))
                 }
-        }
+            }
         .posFullScreenCover(isPresented: $showPaymentView) {
             if let paymentModel {
                 POSBookingPaymentView(booking: booking, paymentModel: paymentModel, onDismiss: dismissPayment)
@@ -151,7 +148,7 @@ struct POSBookingDetailView: View {
         HStack(spacing: POSSpacing.small) {
             Button(Localization.viewOrderAction) {
                 analytics.track(event: WooAnalyticsEvent.PointOfSale.bookingViewOrderTapped())
-                navigationPath.append(.orderDetail)
+                detailNavigationPath.append(NavigationDestination.orderDetail)
             }
             .buttonStyle(POSFilledButtonStyle(size: .extraSmall))
 
@@ -172,7 +169,7 @@ struct POSBookingDetailView: View {
                 Button(Localization.issueRefundAction) {
                     analytics.track(event: WooAnalyticsEvent.PointOfSale.bookingIssueRefundTapped())
                     orderListModel.ordersController.selectOrder(booking.order)
-                    navigationPath.append(.orderDetailRefund)
+                    detailNavigationPath.append(NavigationDestination.orderDetailRefund)
                 }
             }
             if booking.isCancellable {
@@ -639,6 +636,7 @@ private enum Localization {
 #Preview("Paid Booking") {
     POSBookingDetailView(
         booking: POSPreviewHelpers.makePreviewPaidBooking(),
+        detailNavigationPath: .constant(NavigationPath()),
         onBack: {}
     )
 }
@@ -646,6 +644,7 @@ private enum Localization {
 #Preview("Unpaid Booking") {
     POSBookingDetailView(
         booking: POSPreviewHelpers.makePreviewUnpaidBooking(),
+        detailNavigationPath: .constant(NavigationPath()),
         onBack: {}
     )
 }
@@ -653,6 +652,7 @@ private enum Localization {
 #Preview("Guest Booking") {
     POSBookingDetailView(
         booking: POSPreviewHelpers.makePreviewGuestBooking(),
+        detailNavigationPath: .constant(NavigationPath()),
         onBack: {}
     )
 }
@@ -660,6 +660,7 @@ private enum Localization {
 #Preview("Cancelled Booking") {
     POSBookingDetailView(
         booking: POSPreviewHelpers.makePreviewCancelledBooking(),
+        detailNavigationPath: .constant(NavigationPath()),
         onBack: {}
     )
 }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -4,7 +4,7 @@ import struct Yosemite.POSBooking
 
 struct POSBookingDetailView: View {
     let booking: POSBooking
-    @Binding var detailNavigationPath: NavigationPath
+    @Binding var navigationPath: NavigationPath
     let onBack: () -> Void
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -37,17 +37,17 @@ struct POSBookingDetailView: View {
                 switch destination {
                 case .orderDetail:
                     POSOrderDetailsView(order: booking.order, onBack: {
-                        detailNavigationPath.removeLast()
+                        navigationPath.removeLast()
                     })
                     // Forces back button to be rendered, otherwise the system assumes that
                     // navigation is handled by the split view's sidebar, not a back button
                     .environment(\.posHeaderBackButtonConfiguration, .init(state: .enabled, action: {
-                        detailNavigationPath.removeLast()
+                        navigationPath.removeLast()
                     }))
                 case .orderDetailRefund:
                     POSOrderDetailsView(
                         order: booking.order,
-                        onBack: { detailNavigationPath.removeLast() },
+                        onBack: { navigationPath.removeLast() },
                         autoStartRefund: true,
                         onRefundSuccess: {
                             Task {
@@ -61,7 +61,7 @@ struct POSBookingDetailView: View {
                         }
                     )
                     .environment(\.posHeaderBackButtonConfiguration, .init(state: .enabled, action: {
-                        detailNavigationPath.removeLast()
+                        navigationPath.removeLast()
                     }))
                 }
             }
@@ -148,7 +148,7 @@ struct POSBookingDetailView: View {
         HStack(spacing: POSSpacing.small) {
             Button(Localization.viewOrderAction) {
                 analytics.track(event: WooAnalyticsEvent.PointOfSale.bookingViewOrderTapped())
-                detailNavigationPath.append(NavigationDestination.orderDetail)
+                navigationPath.append(NavigationDestination.orderDetail)
             }
             .buttonStyle(POSFilledButtonStyle(size: .extraSmall))
 
@@ -169,7 +169,7 @@ struct POSBookingDetailView: View {
                 Button(Localization.issueRefundAction) {
                     analytics.track(event: WooAnalyticsEvent.PointOfSale.bookingIssueRefundTapped())
                     orderListModel.ordersController.selectOrder(booking.order)
-                    detailNavigationPath.append(NavigationDestination.orderDetailRefund)
+                    navigationPath.append(NavigationDestination.orderDetailRefund)
                 }
             }
             if booking.isCancellable {
@@ -636,7 +636,7 @@ private enum Localization {
 #Preview("Paid Booking") {
     POSBookingDetailView(
         booking: POSPreviewHelpers.makePreviewPaidBooking(),
-        detailNavigationPath: .constant(NavigationPath()),
+        navigationPath: .constant(NavigationPath()),
         onBack: {}
     )
 }
@@ -644,7 +644,7 @@ private enum Localization {
 #Preview("Unpaid Booking") {
     POSBookingDetailView(
         booking: POSPreviewHelpers.makePreviewUnpaidBooking(),
-        detailNavigationPath: .constant(NavigationPath()),
+        navigationPath: .constant(NavigationPath()),
         onBack: {}
     )
 }
@@ -652,7 +652,7 @@ private enum Localization {
 #Preview("Guest Booking") {
     POSBookingDetailView(
         booking: POSPreviewHelpers.makePreviewGuestBooking(),
-        detailNavigationPath: .constant(NavigationPath()),
+        navigationPath: .constant(NavigationPath()),
         onBack: {}
     )
 }
@@ -660,7 +660,7 @@ private enum Localization {
 #Preview("Cancelled Booking") {
     POSBookingDetailView(
         booking: POSPreviewHelpers.makePreviewCancelledBooking(),
-        detailNavigationPath: .constant(NavigationPath()),
+        navigationPath: .constant(NavigationPath()),
         onBack: {}
     )
 }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingsContainerView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingsContainerView.swift
@@ -26,9 +26,10 @@ struct POSBookingsContainerView: View {
                 isPresented = false
             }
             .environment(bookingsModel)
-        } detail: { selection in
+        } detail: { selection, detailNavigationPath in
             POSBookingDetailView(
                 booking: selection,
+                detailNavigationPath: detailNavigationPath,
                 onBack: {
                     bookingsModel.bookingsController.selectBooking(nil)
                 }

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingsContainerView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingsContainerView.swift
@@ -26,10 +26,10 @@ struct POSBookingsContainerView: View {
                 isPresented = false
             }
             .environment(bookingsModel)
-        } detail: { selection, detailNavigationPath in
+        } detail: { selection, navigationPath in
             POSBookingDetailView(
                 booking: selection,
-                detailNavigationPath: detailNavigationPath,
+                navigationPath: navigationPath,
                 onBack: {
                     bookingsModel.bookingsController.selectBooking(nil)
                 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
@@ -35,7 +35,7 @@ struct POSOrdersView: View {
                     isPresented = false
                 }
                 .environment(orderListModel)
-            } detail: { selection in
+            } detail: { selection, _ in
                 POSOrderDetailsView(
                     order: selection,
                     onBack: {

--- a/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
@@ -76,12 +76,6 @@ struct POSFloatingControlView: View {
                 }
             }
         }
-        .onChange(of: horizontalSizeClass) { _, newSizeClass in
-            guard newSizeClass != .regular else { return }
-            showOrders = false
-            showBookings = false
-            showSettings = false
-        }
         .frame(height: Constants.size)
         .background(Color.clear)
         .animation(.default, value: backgroundAppearance)

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
@@ -58,21 +58,26 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
                 }
             default:
                 NavigationStack(path: $detailNavigationPath) {
-                    sidebar($selection)
-                        .navigationDestination(for: SelectionValue.self) { selectedValue in
-                            detail(selectedValue, $detailNavigationPath)
+                    ZStack {
+                        if let selection {
+                            detail(selection, $detailNavigationPath)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .transition(.move(edge: .trailing))
+                        } else {
+                            sidebar($selection)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .transition(.move(edge: .leading))
                         }
+                    }
+                    .animation(.default, value: selection != nil)
+                    .navigationBarHidden(true)
                 }
             }
         }
         .onAppear {
             stableHorizontalSizeClass = horizontalSizeClass
-            if horizontalSizeClass == .regular {
-                if selection == nil {
-                    setDefaultValue?()
-                }
-            } else if detailNavigationPath.isEmpty, let selection {
-                detailNavigationPath.append(selection)
+            if horizontalSizeClass == .regular, selection == nil {
+                setDefaultValue?()
             }
         }
         .task(id: horizontalSizeClass) {
@@ -86,25 +91,13 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
             let previous = stableHorizontalSizeClass
             stableHorizontalSizeClass = horizontalSizeClass
 
-            // On genuine size class change, adapt the navigation path for
-            // the new layout's path semantics (compact prepends SelectionValue;
-            // regular does not).
-            if let previous, previous != horizontalSizeClass {
-                detailNavigationPath = NavigationPath()
-                if horizontalSizeClass != .regular, let selection {
-                    detailNavigationPath.append(selection)
-                }
-                if horizontalSizeClass == .regular, selection == nil {
-                    setDefaultValue?()
-                }
+            if let previous, previous != horizontalSizeClass,
+               horizontalSizeClass == .regular, selection == nil {
+                setDefaultValue?()
             }
         }
-        .onChange(of: selection) { _, newSelection in
+        .onChange(of: selection) { _, _ in
             detailNavigationPath = NavigationPath()
-            let isCompact = (stableHorizontalSizeClass ?? horizontalSizeClass) != .regular
-            if isCompact, let newSelection {
-                detailNavigationPath.append(newSelection)
-            }
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
@@ -6,16 +6,17 @@ import SwiftUI
 struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: View, SelectionValue: Hashable>: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Binding private var selection: SelectionValue?
+    @State private var detailNavigationPath = NavigationPath()
 
     private let sidebar: (Binding<SelectionValue?>) -> Sidebar
-    private let detail: (SelectionValue) -> Detail
+    private let detail: (SelectionValue, Binding<NavigationPath>) -> Detail
     private let detailPlaceholderView: () -> DetailPlaceholder
     private let setDefaultValue: (() -> Void)?
 
     init(
         selection: Binding<SelectionValue?> = .constant(nil),
         @ViewBuilder sidebar: @escaping (Binding<SelectionValue?>) -> Sidebar,
-        @ViewBuilder detail: @escaping (SelectionValue) -> Detail,
+        @ViewBuilder detail: @escaping (SelectionValue, Binding<NavigationPath>) -> Detail,
         @ViewBuilder detailPlaceholderView: @escaping () -> DetailPlaceholder,
         setDefaultValue: (() -> Void)? = nil
     ) {
@@ -34,18 +35,21 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
                     sidebar($selection)
                         .frame(width: geometry.size.width * Constants.sidebarWidthFraction)
 
-                    VStack {
-                        if let selection = selection {
-                            detail(selection)
-                                .frame(maxWidth: .infinity)
-                                .transition(.opacity)
-                        } else {
-                            detailPlaceholderView()
-                                .frame(maxWidth: .infinity)
-                                .transition(.opacity)
+                    NavigationStack(path: $detailNavigationPath) {
+                        VStack {
+                            if let selection = selection {
+                                detail(selection, $detailNavigationPath)
+                                    .frame(maxWidth: .infinity)
+                                    .transition(.opacity)
+                            } else {
+                                detailPlaceholderView()
+                                    .frame(maxWidth: .infinity)
+                                    .transition(.opacity)
+                            }
                         }
+                        .animation(.default, value: selection != nil)
+                        .navigationBarHidden(true)
                     }
-                    .animation(.default, value: selection != nil)
                 }
             }
             .onAppear {
@@ -53,17 +57,19 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
                     setDefaultValue?()
                 }
             }
+            .onChange(of: selection) { _, _ in
+                detailNavigationPath = NavigationPath()
+            }
         default:
-            NavigationStack {
-                sidebar($selection)
-                    .navigationDestination(isPresented: Binding(
-                        get: { selection != nil },
-                        set: { if !$0 { selection = nil } }
-                    )) {
-                        if let selection = selection {
-                            detail(selection)
-                        }
-                    }
+            NavigationStack(path: $detailNavigationPath) {
+                if let selection = selection {
+                    detail(selection, $detailNavigationPath)
+                } else {
+                    sidebar($selection)
+                }
+            }
+            .onChange(of: selection) { _, _ in
+                detailNavigationPath = NavigationPath()
             }
         }
     }

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
@@ -62,14 +62,16 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
             }
         default:
             NavigationStack(path: $detailNavigationPath) {
-                if let selection = selection {
-                    detail(selection, $detailNavigationPath)
-                } else {
-                    sidebar($selection)
-                }
+                sidebar($selection)
+                    .navigationDestination(for: SelectionValue.self) { selectedValue in
+                        detail(selectedValue, $detailNavigationPath)
+                    }
             }
-            .onChange(of: selection) { _, _ in
+            .onChange(of: selection) { _, newSelection in
                 detailNavigationPath = NavigationPath()
+                if let newSelection {
+                    detailNavigationPath.append(newSelection)
+                }
             }
         }
     }

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
@@ -53,6 +53,9 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
                 }
             }
             .onAppear {
+                // Clear any compact-mode path entries (SelectionValue) that don't
+                // apply in regular mode where the detail is root content.
+                detailNavigationPath = NavigationPath()
                 if selection == nil {
                     setDefaultValue?()
                 }
@@ -66,6 +69,15 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
                     .navigationDestination(for: SelectionValue.self) { selectedValue in
                         detail(selectedValue, $detailNavigationPath)
                     }
+            }
+            .onAppear {
+                // Sync the path with the current selection on appear. This handles
+                // both initial appearance and transitions from regular mode where
+                // the path doesn't include the SelectionValue.
+                detailNavigationPath = NavigationPath()
+                if let selection {
+                    detailNavigationPath.append(selection)
+                }
             }
             .onChange(of: selection) { _, newSelection in
                 detailNavigationPath = NavigationPath()

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
@@ -53,9 +53,6 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
                 }
             }
             .onAppear {
-                // Clear any compact-mode path entries (SelectionValue) that don't
-                // apply in regular mode where the detail is root content.
-                detailNavigationPath = NavigationPath()
                 if selection == nil {
                     setDefaultValue?()
                 }
@@ -71,11 +68,11 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
                     }
             }
             .onAppear {
-                // Sync the path with the current selection on appear. This handles
-                // both initial appearance and transitions from regular mode where
-                // the path doesn't include the SelectionValue.
-                detailNavigationPath = NavigationPath()
-                if let selection {
+                // Sync the path with the current selection on initial appear or
+                // when transitioning from regular mode (where the path doesn't
+                // include SelectionValue). Only populate when empty to preserve
+                // sub-detail navigation during transient size class changes.
+                if detailNavigationPath.isEmpty, let selection {
                     detailNavigationPath.append(selection)
                 }
             }

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
@@ -7,9 +7,6 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Binding private var selection: SelectionValue?
     @State private var detailNavigationPath = NavigationPath()
-    /// Debounced size class that filters out transient changes iOS 18 fires
-    /// during background/foreground transitions.
-    @State private var stableHorizontalSizeClass: UserInterfaceSizeClass?
 
     private let sidebar: (Binding<SelectionValue?>) -> Sidebar
     private let detail: (SelectionValue, Binding<NavigationPath>) -> Detail
@@ -32,7 +29,7 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
 
     var body: some View {
         Group {
-            switch stableHorizontalSizeClass ?? horizontalSizeClass {
+            switch horizontalSizeClass {
             case .regular:
                 GeometryReader { geometry in
                     HStack(spacing: 0) {
@@ -75,24 +72,12 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
             }
         }
         .onAppear {
-            stableHorizontalSizeClass = horizontalSizeClass
             if horizontalSizeClass == .regular, selection == nil {
                 setDefaultValue?()
             }
         }
-        .task(id: horizontalSizeClass) {
-            // Debounce: iOS 18 devices fire transient horizontalSizeClass
-            // changes during background/foreground transitions. By waiting
-            // briefly, we let the transient change revert (cancelling this
-            // task) so the layout never swaps and the path is untouched.
-            try? await Task.sleep(for: .milliseconds(200))
-            guard !Task.isCancelled else { return }
-
-            let previous = stableHorizontalSizeClass
-            stableHorizontalSizeClass = horizontalSizeClass
-
-            if let previous, previous != horizontalSizeClass,
-               horizontalSizeClass == .regular, selection == nil {
+        .onChange(of: horizontalSizeClass) { _, newValue in
+            if newValue == .regular, selection == nil {
                 setDefaultValue?()
             }
         }

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
@@ -7,6 +7,9 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Binding private var selection: SelectionValue?
     @State private var detailNavigationPath = NavigationPath()
+    /// Debounced size class that filters out transient changes iOS 18 fires
+    /// during background/foreground transitions.
+    @State private var stableHorizontalSizeClass: UserInterfaceSizeClass?
 
     private let sidebar: (Binding<SelectionValue?>) -> Sidebar
     private let detail: (SelectionValue, Binding<NavigationPath>) -> Detail
@@ -28,59 +31,79 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
     }
 
     var body: some View {
-        switch horizontalSizeClass {
-        case .regular:
-            GeometryReader { geometry in
-                HStack(spacing: 0) {
-                    sidebar($selection)
-                        .frame(width: geometry.size.width * Constants.sidebarWidthFraction)
+        Group {
+            switch stableHorizontalSizeClass ?? horizontalSizeClass {
+            case .regular:
+                GeometryReader { geometry in
+                    HStack(spacing: 0) {
+                        sidebar($selection)
+                            .frame(width: geometry.size.width * Constants.sidebarWidthFraction)
 
-                    NavigationStack(path: $detailNavigationPath) {
-                        VStack {
-                            if let selection = selection {
-                                detail(selection, $detailNavigationPath)
-                                    .frame(maxWidth: .infinity)
-                                    .transition(.opacity)
-                            } else {
-                                detailPlaceholderView()
-                                    .frame(maxWidth: .infinity)
-                                    .transition(.opacity)
+                        NavigationStack(path: $detailNavigationPath) {
+                            VStack {
+                                if let selection = selection {
+                                    detail(selection, $detailNavigationPath)
+                                        .frame(maxWidth: .infinity)
+                                        .transition(.opacity)
+                                } else {
+                                    detailPlaceholderView()
+                                        .frame(maxWidth: .infinity)
+                                        .transition(.opacity)
+                                }
                             }
+                            .animation(.default, value: selection != nil)
+                            .navigationBarHidden(true)
                         }
-                        .animation(.default, value: selection != nil)
-                        .navigationBarHidden(true)
                     }
                 }
+            default:
+                NavigationStack(path: $detailNavigationPath) {
+                    sidebar($selection)
+                        .navigationDestination(for: SelectionValue.self) { selectedValue in
+                            detail(selectedValue, $detailNavigationPath)
+                        }
+                }
             }
-            .onAppear {
+        }
+        .onAppear {
+            stableHorizontalSizeClass = horizontalSizeClass
+            if horizontalSizeClass == .regular {
                 if selection == nil {
                     setDefaultValue?()
                 }
+            } else if detailNavigationPath.isEmpty, let selection {
+                detailNavigationPath.append(selection)
             }
-            .onChange(of: selection) { _, _ in
+        }
+        .task(id: horizontalSizeClass) {
+            // Debounce: iOS 18 devices fire transient horizontalSizeClass
+            // changes during background/foreground transitions. By waiting
+            // briefly, we let the transient change revert (cancelling this
+            // task) so the layout never swaps and the path is untouched.
+            try? await Task.sleep(for: .milliseconds(200))
+            guard !Task.isCancelled else { return }
+
+            let previous = stableHorizontalSizeClass
+            stableHorizontalSizeClass = horizontalSizeClass
+
+            // On genuine size class change, adapt the navigation path for
+            // the new layout's path semantics (compact prepends SelectionValue;
+            // regular does not).
+            if let previous, previous != horizontalSizeClass {
                 detailNavigationPath = NavigationPath()
-            }
-        default:
-            NavigationStack(path: $detailNavigationPath) {
-                sidebar($selection)
-                    .navigationDestination(for: SelectionValue.self) { selectedValue in
-                        detail(selectedValue, $detailNavigationPath)
-                    }
-            }
-            .onAppear {
-                // Sync the path with the current selection on initial appear or
-                // when transitioning from regular mode (where the path doesn't
-                // include SelectionValue). Only populate when empty to preserve
-                // sub-detail navigation during transient size class changes.
-                if detailNavigationPath.isEmpty, let selection {
+                if horizontalSizeClass != .regular, let selection {
                     detailNavigationPath.append(selection)
                 }
-            }
-            .onChange(of: selection) { _, newSelection in
-                detailNavigationPath = NavigationPath()
-                if let newSelection {
-                    detailNavigationPath.append(newSelection)
+                if horizontalSizeClass == .regular, selection == nil {
+                    setDefaultValue?()
                 }
+            }
+        }
+        .onChange(of: selection) { _, newSelection in
+            detailNavigationPath = NavigationPath()
+            let isCompact = (stableHorizontalSizeClass ?? horizontalSizeClass) != .regular
+            if isCompact, let newSelection {
+                detailNavigationPath.append(newSelection)
             }
         }
     }


### PR DESCRIPTION
## Description

On iOS 18, switching apps triggers a transient `horizontalSizeClass` change (regular → compact → regular). This caused two problems:

1. `POSFloatingControlView` had an `onChange(of: horizontalSizeClass)` handler that dismissed bookings/orders/settings whenever the size class became compact — so the transient change would close the view.
2. Each detail view (e.g. `POSBookingDetailView`) owned its own `NavigationStack`, which was destroyed and recreated during the size class transition, losing any navigation state (e.g. viewing an order from a booking).

### Fix

- **Hoist `NavigationStack` ownership to `POSNavigationSplitView`**: The split view now owns a single `@State NavigationPath` and passes it as a binding to detail views. This means the path survives the view hierarchy rebuild during size class transitions.
- **Unify navigation across size classes**: Both regular and compact layouts use `NavigationStack(path:)` bound to the same state. Regular wraps the detail panel; compact wraps a `ZStack` that swaps between sidebar and detail with slide transitions. (Note – sidebar/detail are not real navigation transitions now... but everything pushed and popped in the detail view is.)
- **Remove the dismiss-on-compact handler**: The `onChange(of: horizontalSizeClass)` in `POSFloatingControlView` that dismissed views on compact transitions has been removed — it was the direct cause of the bug and is no longer needed since the navigation state now persists.
- **Reset sub-detail path on selection change**: When the user selects a different item, `detailNavigationPath` is reset so stale sub-detail views don't linger.

## Test Steps

1. Open POS on an iPad running iOS 18 (note, a simulator would not show the bug, this needs a real device.)
2. Open Bookings
3. Select a booking and tap "View Order"
4. Go to another app using the app switcher, or by swiping the app right at the bottom, wait a moment, then return
5. Verify the bookings view is still open with the order detail visible — it should not be dismissed
6. Go back to the booking detail, select a different booking — verify the order detail is cleared
7. Repeat steps 3-5 with the Orders view to confirm it also survives backgrounding

Also check this on an iPad running iOS 26

### No crash regression (#16730)

1. Go to the booking list
2. Put the app into slide over mode, ie 1/3rd, which forces .compact horizontal size class
3. Select a booking from the list
4. Tap "View Order"
5. Tap the back button to return to booking detail
6. Observe that does not crash

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.