### PR TITLE
Add ContextA8C MCP agent integration

### DIFF
--- a/.agents/rules
+++ b/.agents/rules
@@ -1,0 +1,1 @@
+../.claude/rules

--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.claude/rules/context-a8c.md
+++ b/.claude/rules/context-a8c.md
@@ -1,0 +1,94 @@
+# ContextA8C (Automattic Internal Resources)
+
+ContextA8C is an Automattic MCP server (`@automattic/mcp-context-a8c`) that gives AI tools access to internal resources. It works with any MCP-compatible client (Claude Code, Cursor, VS Code, etc.). It is configured per-user and requires a one-time browser-based account connection.
+
+## Setup
+
+**Prerequisites**: Node.js v18+ (npx must be available).
+
+### 1. Connect accounts (all clients)
+
+Visit the ContextA8C setup page on MC (Automatticians: search "ContextA8C" on MC) and authorize each provider you want to use (Slack, Linear, GitHub, etc.). Some require OAuth, others are simple toggles. This is a one-time step per provider.
+
+### 2. Configure your MCP client
+
+| Client | Setup |
+|--------|-------|
+| Claude Code | `claude mcp add --transport stdio --scope user context-a8c -- npx -y @automattic/mcp-context-a8c` (or run `/setup-context-a8c` skill) |
+| Cursor | Add JSON config below to `.cursor/mcp.json` |
+| VS Code | Add JSON config below to `.vscode/mcp.json` |
+| Other MCP clients | Use JSON config below in the client's MCP settings |
+
+```json
+{
+  "mcpServers": {
+    "context-a8c": {
+      "command": "npx",
+      "args": ["-y", "@automattic/mcp-context-a8c"]
+    }
+  }
+}
+```
+
+## Providers
+
+| Provider | Use For |
+|----------|---------|
+| `mgs` | Broad search across P2s, Field Guide, internal docs (preferred for search) |
+| `slack` | Messages, channels, threads, DMs |
+| `wpcom` | Specific P2 posts, WordPress.com content, A8C Reader |
+| `fieldguide` | Field Guide articles (policies, processes, how-to guides) |
+| `github` | Public GitHub repos (github.com) |
+| `github-a8c` | Internal GitHub Enterprise |
+| `linear` | Linear issues, projects, team assignments |
+
+Additional providers (matticspace, zendesk, etc.) may be available depending on connected accounts. Use the load-provider tool to discover what's available.
+
+## Usage Pattern
+
+ContextA8C uses a two-step progressive disclosure pattern:
+
+1. **Load a provider** — returns the list of available tools and their parameter schemas
+2. **Execute a tool** — call a specific tool within the loaded provider
+
+Load a provider once per session. The response describes available tools and parameters, so there is no need to hardcode tool names.
+
+### Claude Code tool names
+
+In Claude Code, tools are prefixed with `mcp__context-a8c__`:
+```
+mcp__context-a8c__context-a8c-load-provider(provider: "slack")
+mcp__context-a8c__context-a8c-execute-tool(provider: "slack", tool: "search", params: {"query": "..."})
+```
+
+If these tools are not available in a Claude Code session, ContextA8C is not configured. Suggest running `/setup-context-a8c` once, then continue without it.
+
+## When to Use
+
+Proactively use ContextA8C when it adds context beyond what the local codebase provides:
+
+- **Task research**: When given a `WOOMOB-XXXX` issue ID, fetch the task description via `linear` or search via `mgs`
+- **URL resolution**: When given internal Slack, P2, or Linear URLs, fetch the content via the appropriate provider
+- **Internal docs**: Search Field Guide or P2s for policies, prior discussions, or design decisions via `mgs` or `fieldguide`
+- **Cross-platform parity**: Search `woocommerce/woocommerce-android` PRs via `github`
+
+## When ContextA8C Errors or is Unavailable
+
+When a ContextA8C call fails, do NOT silently give up. Follow this sequence:
+
+1. **Diagnose**: Tell the user what error occurred (permission denied, invalid provider, auth error, tool not found, etc.)
+2. **Suggest a fix**: Give the user concrete human-actionable steps based on the error type. Never tell the user to run agent skills or commands that only the agent can execute — those are for the agent, not the user.
+   - **Permission denied / Access forbidden**: The MCP may be disabled or misconfigured. Ask the user to check that ContextA8C is enabled (not disabled) in their MCP client settings and that accounts are connected on the ContextA8C setup page on MC
+   - **Invalid provider name**: Try `mgs` as a fallback for search tasks. List known valid providers for the user
+   - **Auth errors**: Ask the user to re-visit the ContextA8C setup page on MC and re-authorize the affected provider
+   - **Tool not found / MCP not recognized**: The MCP is not configured. Offer to run the setup (the agent should execute `/setup-context-a8c` itself, not ask the user to type it). For non-Claude Code clients, point the user to the JSON config in the Setup section above
+   - **Other errors**: Show the error details and suggest restarting the AI tool session
+3. **Ask the user**: Offer to help troubleshoot further or to proceed without ContextA8C
+4. **Fall back gracefully**: If the user chooses to skip, continue with codebase, git history, or ask the user to paste the needed information directly
+
+Do NOT:
+- Silently skip ContextA8C without telling the user what went wrong
+- Tell the user to run agent skills or slash commands — those are for the agent to execute, not the user
+- Assume which client the user is running — ask them. The `claude` CLI binary may exist on the system even when the user is running Claude Desktop. Setup steps differ per client (`claude mcp add` only works for Claude Code CLI, not Claude Desktop)
+- Retry the same failing call more than once in a session
+- Block on ContextA8C — always offer to proceed without it

--- a/.claude/skills/setup-context-a8c/SKILL.md
+++ b/.claude/skills/setup-context-a8c/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: setup-context-a8c
+description: Set up the ContextA8C MCP server for accessing Automattic internal resources (Slack, Linear, P2s, GitHub Enterprise, etc.)
+user-invocable: true
+allowed-tools: "Bash, Read"
+---
+
+Set up the ContextA8C MCP server for the current user.
+
+**IMPORTANT**: The `claude` CLI binary may exist on the system regardless of which client the user is actually running. Do NOT use `which claude` to detect the client. Always ask the user first.
+
+## Step 1: Identify the client
+
+Ask the user which AI client they are currently using. Present these options:
+- **Claude Code** (CLI in terminal)
+- **Claude Desktop** (macOS/Windows app)
+- **Cursor**
+- **VS Code**
+- **Other**
+
+Do NOT proceed until the user confirms their client. The setup steps differ per client and applying the wrong one will silently fail (e.g., `claude mcp add` registers for Claude Code only, not Claude Desktop).
+
+## Step 2: Check prerequisites
+
+```bash
+npx --version
+```
+
+If npx is not found, tell the user to install Node.js (v18+) and stop.
+
+## Step 3: Register MCP (client-specific)
+
+### Claude Code (CLI)
+
+Find and run the `claude` binary:
+```bash
+which claude 2>/dev/null || ls "$HOME/.local/bin/claude" 2>/dev/null
+```
+Then register:
+```bash
+claude mcp list 2>&1
+```
+If `context-a8c` is not listed:
+```bash
+claude mcp add --transport stdio --scope user context-a8c -- npx -y @automattic/mcp-context-a8c
+```
+
+### Claude Desktop
+
+Guide the user through these manual steps (the agent cannot do this for them):
+1. Go to the ContextA8C setup page on MC (search "ContextA8C" in MC)
+2. Select "Claude Desktop"
+3. Download the MCPB bundle file
+4. Double-click it — Claude Desktop will walk through the rest
+5. If it fails with a Node version error: install Node from nodejs.org, quit and restart Claude Desktop, then double-click the MCPB file again
+
+### Cursor / VS Code / Other MCP clients
+
+Tell the user to add this JSON config to their client's MCP settings file:
+- **Cursor**: `.cursor/mcp.json`
+- **VS Code**: `.vscode/mcp.json`
+
+```json
+{
+  "mcpServers": {
+    "context-a8c": {
+      "command": "npx",
+      "args": ["-y", "@automattic/mcp-context-a8c"]
+    }
+  }
+}
+```
+
+## Step 4: Connect accounts
+
+Tell the user to connect their Automattic accounts in a browser:
+
+1. Open the ContextA8C setup page on MC in a browser
+2. Enable and authorize each provider they want (Slack, Linear, WordPress.com, GitHub, etc.)
+3. Some providers require OAuth, others are simple toggles
+4. This is a one-time setup per provider
+
+Wait for the user to confirm they have connected their accounts.
+
+## Step 5: Restart
+
+Tell the user to fully quit and relaunch their AI tool (not just start a new session) for the MCP server to load.

--- a/.claude/skills/setup-context-a8c/SKILL.md
+++ b/.claude/skills/setup-context-a8c/SKILL.md
@@ -32,17 +32,9 @@ If npx is not found, tell the user to install Node.js (v18+) and stop.
 
 ### Claude Code (CLI)
 
-Find and run the `claude` binary:
+Run the setup script:
 ```bash
-which claude 2>/dev/null || ls "$HOME/.local/bin/claude" 2>/dev/null
-```
-Then register:
-```bash
-claude mcp list 2>&1
-```
-If `context-a8c` is not listed:
-```bash
-claude mcp add --transport stdio --scope user context-a8c -- npx -y @automattic/mcp-context-a8c
+bash .claude/skills/setup-context-a8c/setup-for-claude-code.sh
 ```
 
 ### Claude Desktop

--- a/.claude/skills/setup-context-a8c/setup-for-claude-code.sh
+++ b/.claude/skills/setup-context-a8c/setup-for-claude-code.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Sets up the ContextA8C MCP server for Claude Code (CLI).
+# Called by the setup-context-a8c skill when the user selects Claude Code.
+
+set -euo pipefail
+
+# Find claude binary
+CLAUDE_BIN=""
+if command -v claude &>/dev/null; then
+    CLAUDE_BIN="claude"
+elif [[ -x "$HOME/.local/bin/claude" ]]; then
+    CLAUDE_BIN="$HOME/.local/bin/claude"
+else
+    echo "ERROR: Could not find the 'claude' binary. Is Claude Code installed?"
+    exit 1
+fi
+
+# Check if context-a8c is already registered
+if "$CLAUDE_BIN" mcp list 2>&1 | grep -q "context-a8c"; then
+    echo "context-a8c is already registered in Claude Code."
+    exit 0
+fi
+
+# Register the MCP server
+echo "Registering context-a8c MCP server..."
+"$CLAUDE_BIN" mcp add --transport stdio --scope user context-a8c -- npx -y @automattic/mcp-context-a8c
+
+echo "Done. context-a8c has been registered for Claude Code."

--- a/.claude/skills/setup-context-a8c/setup-for-claude-code.sh
+++ b/.claude/skills/setup-context-a8c/setup-for-claude-code.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 # Sets up the ContextA8C MCP server for Claude Code (CLI).
 # Called by the setup-context-a8c skill when the user selects Claude Code.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,13 @@ CONTRIBUTING.md                  # PR merge policy
 
 Use the `bootstrap` skill to set up the environment from a clean checkout. It will guide through Xcode version verification, Ruby version setup, and dependency installation.
 
+## Internal Resources (ContextA8C)
+
+ContextA8C is an Automattic MCP server that gives AI tools access to Slack, P2s, Linear, Field Guide, GitHub Enterprise, and other internal resources. It is optional — the agent works without it but provides richer context when available.
+
+- **Setup and usage**: See `.agents/rules/context-a8c.md`
+- **Claude Code setup skill**: `/setup-context-a8c`
+
 ## Build Commands
 
 ```bash


### PR DESCRIPTION
## Description

Adds agent instructions and setup automation for the ContextA8C MCP server, which gives AI tools access to Automattic internal resources (Slack, Linear, P2s, Field Guide, GitHub Enterprise, etc.).

This enables AI agents to proactively fetch task descriptions, read Slack discussions, and search internal documentation during development work. The setup is agent-agnostic — works with Claude Code, Claude Desktop, Cursor, VS Code, and other MCP clients.

**New files:**
- `.claude/rules/context-a8c.md` — agent rules: providers, usage pattern, error handling with troubleshooting guidance
- `.claude/skills/setup-context-a8c/SKILL.md` — setup skill that detects the user's client and guides through client-specific setup
- `.claude/skills/setup-context-a8c/setup-for-claude-code.sh` — shell script for Claude Code MCP registration (extracted from SKILL.md for token efficiency and robustness)
- `.agents/rules` + `.agents/skills` — symlinks to `.claude/` for non-Claude tool discoverability

**Modified:**
- `AGENTS.md` — brief "Internal Resources (ContextA8C)" section with references to the rule file

## Some agent interaction examples during `ContextA8C` initial discovery / setup

<img width="720" height="165" alt="Screenshot 2026-03-02 at 20 01 04" src="https://github.com/user-attachments/assets/c78fe8c6-8388-4d7b-8059-9fa09256203f" />

<img width="762" height="453" alt="Screenshot 2026-03-02 at 20 13 15" src="https://github.com/user-attachments/assets/3c1898db-79fc-4b3c-a5eb-613ef2f4c969" />

<img width="718" height="446" alt="Screenshot 2026-03-02 at 20 13 55" src="https://github.com/user-attachments/assets/fdddd37e-370a-456f-84ac-ceb70749d39e" />

## Test Steps

1. In Claude Code, run `/setup-context-a8c` — verify it asks which client you're using before proceeding
2. For Claude Code path: verify the setup script (`setup-for-claude-code.sh`) finds the `claude` binary, checks existing registration, and registers the MCP if needed
3. Run `bash .claude/skills/setup-context-a8c/setup-for-claude-code.sh` directly — verify it prints clear status messages and is idempotent (re-running when already registered prints "already registered")
4. Start a new session and give the agent a `WOOMOB-XXXX` issue ID — verify it attempts to use ContextA8C providers
5. In an environment without ContextA8C configured, verify the agent diagnoses the error and offers actionable troubleshooting (not "run /setup-context-a8c" to the user)
6. Verify `.agents/rules/context-a8c.md` resolves via symlink to the same file as `.claude/rules/context-a8c.md`

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.