### PR TITLE
POS: Fix `unable to load coupons` error when shouldn't be an error

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleCouponsController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleCouponsController.swift
@@ -120,11 +120,14 @@ private extension PointOfSaleCouponsController {
             if !storedCoupons.isEmpty {
                 setCouponsLoadedViewState(storedCoupons, hasMoreItems: true)
             }
-
-            await loadFirstPageRemotely()
         } catch {
-            setCouponsErrorViewState(error)
+            if let couponError = error as? PointOfSaleCouponServiceError,
+               couponError == .couponsDisabled {
+                setCouponsErrorViewState(error)
+                return
+            }
         }
+        await loadFirstPageRemotely()
     }
 
     func loadFirstPageRemotely() async {

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleCouponsControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleCouponsControllerTests.swift
@@ -311,6 +311,43 @@ struct PointOfSaleCouponsControllerTests {
         #expect(sut.itemsViewState == expectedViewState)
     }
 
+    @Test func loadItems_when_local_fetch_fails_with_loading_error_then_still_loads_remotely() async throws {
+        // Given
+        let couponProvider = MockPointOfSaleCouponService()
+        couponProvider.localErrorToThrow = .couponsLoadingError(underlyingError: NSError(domain: "test", code: 0))
+        couponProvider.shouldReturnZeroItems = true
+        let sut = PointOfSaleCouponsController(itemProvider: couponProvider,
+                                               fetchStrategyFactory: fetchStrategyFactory,
+                                               analyticsProvider: MockPOSAnalytics())
+
+        let expectedItemStackState = ItemsStackState(root: .empty, itemStates: [:])
+        let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
+
+        // When
+        await sut.loadItems(base: .root)
+
+        // Then
+        #expect(sut.itemsViewState == expectedViewState)
+    }
+
+    @Test func loadItems_when_local_fetch_fails_with_couponsDisabled_then_shows_disabled_error() async throws {
+        // Given
+        let couponProvider = MockPointOfSaleCouponService()
+        couponProvider.localErrorToThrow = .couponsDisabled
+        let sut = PointOfSaleCouponsController(itemProvider: couponProvider,
+                                               fetchStrategyFactory: fetchStrategyFactory,
+                                               analyticsProvider: MockPOSAnalytics())
+
+        let expectedItemStackState = ItemsStackState(root: .error(.errorCouponsDisabled), itemStates: [:])
+        let expectedViewState = ItemsViewState(containerState: .content, itemsStack: expectedItemStackState)
+
+        // When
+        await sut.loadItems(base: .root)
+
+        // Then
+        #expect(sut.itemsViewState == expectedViewState)
+    }
+
     @Test func searchItems_when_requestCancelled_then_state_unchanged() async throws {
         // Given
         let couponProvider = MockPointOfSaleCouponService()

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleCouponService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleCouponService.swift
@@ -12,11 +12,15 @@ import protocol Yosemite.PointOfSaleCouponFetchStrategy
 final class MockPointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
     var shouldReturnZeroItems = false
     var errorToThrow: PointOfSaleCouponServiceError?
+    var localErrorToThrow: PointOfSaleCouponServiceError?
     var shouldSimulateTwoPages = false
     var shouldSimulateMorePages = false
 
     func provideLocalPointOfSaleCoupons(fetchStrategy: PointOfSaleCouponFetchStrategy) async throws -> [Yosemite.POSItem] {
-        []
+        if let error = localErrorToThrow {
+            throw error
+        }
+        return []
     }
 
     func providePointOfSaleCoupons(pageNumber: Int, fetchStrategy: PointOfSaleCouponFetchStrategy) async throws -> PagedItems<POSItem> {


### PR DESCRIPTION
Closes WOOMOB-2382

## Description
When watching the walkthrough pgzWbf-4N6-p2 we can see POS coupons erroring out, when they should present the empty screen. It was a new store and no coupons were created. Despite that it failed to fetch both on empty and when created coupons later on. 

## Changes

Change `loadFirstPage()` in `PointOfSaleCouponsController` so that only `couponsDisabled` errors stop the flow. Any other error from the local fetch (like a network failure during settings check) now falls through to `loadFirstPageRemotely()`, which handles the error as needed.

I didn't see any recent changes to the involved files, neither any report of this failing, Mr. Claude points to likely be due to 1635ad05e6, where every REST request now waits for a `discoveryTask` to complete before executing. This `performAfterDiscovery` wrapper adds a new async step that introduces a new point of failure that wasn't handled:

>  Why this surfaces the bug now: The coupon settings check in provideLocalPointOfSaleCoupons calls checkRemoteStoreCouponSettings() which makes a network request via SettingStoreMethods. With the new API         discovery step, that request now has an additional point of failure — if the discovery task encounters issues (timing, connectivity, or the self being nil in the weak capture during the async gap), the settings
   check network call fails, throwing couponsLoadingError. That error gets caught in loadFirstPage() and the remote coupon fetch is never attempted.

> In short: The coupons controller code was always fragile (local errors would block the remote fetch), but it wasn't triggered before because the settings check network call was more reliable. The Feb 26
  AlamofireNetwork change added a new performAfterDiscovery await that introduced a new failure path, making the settings check more likely to fail — especially on first launch when the REST API root isn't cached
   yet.

I'm not fully convinced, but I cannot see neither what has changed that started to cause this 🤔 

## Test Steps
- On a CIAB store, load POS > Coupons

1. See empty screen if no coupons
2. See coupons if any.
3. Throw on `PointOfSaleCouponService.provideLocalPointOfSaleCoupons` for coupons disabled:

```diff
@MainActor
public func provideLocalPointOfSaleCoupons(fetchStrategy: PointOfSaleCouponFetchStrategy) async throws -> [POSItem] {
+ throw PointOfSaleCouponServiceError.couponsDisabled
...
}
```
- Observe "Start accepting coupons error message"

4. Throw on `PointOfSaleCouponService.provideLocalPointOfSaleCoupons`:
```diff
@MainActor
public func provideLocalPointOfSaleCoupons(fetchStrategy: PointOfSaleCouponFetchStrategy) async throws -> [POSItem] {
+ throw PointOfSaleCouponServiceError.couponsLoadingError(underlyingError: NSError(domain: "debug", code: -1))
...
}
```
- Observe it shows the store's coupons (remote fetch fallback)

5. Throw on `PointOfSaleCouponsController.fetchCoupons`:

```diff
@MainActor
func fetchCoupons(pageNumber: Int) async throws -> Bool {
+  throw PointOfSaleCouponServiceError.couponsLoadingError(underlyingError: NSError(domain: "debug", code: -1))
...
}
```
- Observe the "Unable to load coupons" error screen

## Screenshots
| Before | After - empty | After - some |
|--------|--------|--------|
| <img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - CIAB - 2026-03-03 at 14 54 12" src="https://github.com/user-attachments/assets/2f3aea78-3541-4674-8ff6-f921ff6e6e00" /> | <img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - CIAB - 2026-03-03 at 15 05 20" src="https://github.com/user-attachments/assets/8e4b31ec-40b6-49ab-aedf-102498379913" /> | <img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - CIAB - 2026-03-03 at 15 14 24" src="https://github.com/user-attachments/assets/d9da6f31-7510-4f0c-a835-ee6aa4c79a51" /> | 