### PR TITLE
Hide connection step in push notification setup when site is already connected

### DIFF
--- a/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -222,7 +222,6 @@ private extension DefaultApplicationPasswordUseCase {
     /// - Returns: Generated `ApplicationPassword`
     ///
     func createApplicationPassword() async throws -> ApplicationPassword {
-        await awaitDiscoveryIfNeeded()
         let passwordName = applicationPasswordName
 
         let parameters = [ParameterKey.name: passwordName]
@@ -237,6 +236,8 @@ private extension DefaultApplicationPasswordUseCase {
                 return try await fetchWPOrgUsername(siteID: siteID)
             }
         }()
+
+        await awaitDiscoveryIfNeeded()
         return try await withCheckedThrowingContinuation { continuation in
             network.responseData(for: request) { result in
                 switch result {
@@ -274,8 +275,9 @@ private extension DefaultApplicationPasswordUseCase {
     /// Get the UUID of the application password
     ///
     func fetchUUIDForApplicationPassword(_ passwordName: String) async throws -> String {
-        await awaitDiscoveryIfNeeded()
         let request = constructRequest(method: .get, path: Path.applicationPasswords)
+
+        await awaitDiscoveryIfNeeded()
         return try await withCheckedThrowingContinuation { continuation in
             network.responseData(for: request) { result in
                 switch result {
@@ -301,8 +303,9 @@ private extension DefaultApplicationPasswordUseCase {
     /// Deletes application password using UUID
     ///
     func deleteApplicationPassword(_ uuid: String) async throws {
-        await awaitDiscoveryIfNeeded()
         let request = constructRequest(method: .delete, path: Path.applicationPasswords + "/" + uuid)
+
+        await awaitDiscoveryIfNeeded()
         try await withCheckedThrowingContinuation { continuation in
             network.responseData(for: request) { result in
                 switch result {

--- a/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -222,6 +222,7 @@ private extension DefaultApplicationPasswordUseCase {
     /// - Returns: Generated `ApplicationPassword`
     ///
     func createApplicationPassword() async throws -> ApplicationPassword {
+        await awaitDiscoveryIfNeeded()
         let passwordName = applicationPasswordName
 
         let parameters = [ParameterKey.name: passwordName]
@@ -236,8 +237,6 @@ private extension DefaultApplicationPasswordUseCase {
                 return try await fetchWPOrgUsername(siteID: siteID)
             }
         }()
-
-        await awaitDiscoveryIfNeeded()
         return try await withCheckedThrowingContinuation { continuation in
             network.responseData(for: request) { result in
                 switch result {
@@ -275,9 +274,8 @@ private extension DefaultApplicationPasswordUseCase {
     /// Get the UUID of the application password
     ///
     func fetchUUIDForApplicationPassword(_ passwordName: String) async throws -> String {
-        let request = constructRequest(method: .get, path: Path.applicationPasswords)
-
         await awaitDiscoveryIfNeeded()
+        let request = constructRequest(method: .get, path: Path.applicationPasswords)
         return try await withCheckedThrowingContinuation { continuation in
             network.responseData(for: request) { result in
                 switch result {
@@ -303,9 +301,8 @@ private extension DefaultApplicationPasswordUseCase {
     /// Deletes application password using UUID
     ///
     func deleteApplicationPassword(_ uuid: String) async throws {
-        let request = constructRequest(method: .delete, path: Path.applicationPasswords + "/" + uuid)
-
         await awaitDiscoveryIfNeeded()
+        let request = constructRequest(method: .delete, path: Path.applicationPasswords + "/" + uuid)
         try await withCheckedThrowingContinuation { continuation in
             network.responseData(for: request) { result in
                 switch result {

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerProtocol.swift
@@ -114,7 +114,6 @@ private extension WPComConnectionSetupHandler {
                     if !siteAlreadyConnected {
                         startJetpackConnection()
                     } else {
-                        delegate?.stepDidUpdate(.connect, status: .success)
                         startPushRegistration()
                     }
                 case .incompatible(let currentVersion, _):

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupView.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupView.swift
@@ -41,7 +41,7 @@ struct WPComConnectionSetupView: View {
                 VStack(alignment: .leading, spacing: Constants.contentVerticalSpacing) {
                     ConnectWPComHeaderView()
                     VStack(alignment: .leading, spacing: Constants.headerVerticalSpacing) {
-                        Text(Localization.title)
+                        Text(viewModel.title)
                             .largeTitleStyle()
                             .bold()
                         Text(viewModel.subtitleAttributedString)
@@ -127,11 +127,6 @@ private extension WPComConnectionSetupView {
     }
 
     enum Localization {
-        static let title = NSLocalizedString(
-            "wpComConnectionSetupView.title",
-            value: "Connect to WordPress.com",
-            comment: "Title for the WPCom connection setup screen."
-        )
         static let cancelButton = NSLocalizedString(
             "wpComConnectionSetupView.cancelButton",
             value: "Cancel",

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
@@ -23,6 +23,7 @@ final class WPComConnectionSetupViewModel: ObservableObject {
     }
 
     @Published private(set) var steps: [WPComConnectionSetupStep] = []
+    private var stepIndexMap: [SetupStep: Int] = [:]
     @Published private var setupState: SetupState = .inProgress
     @Published var isShowingGetHelp = false
 
@@ -68,6 +69,7 @@ final class WPComConnectionSetupViewModel: ObservableObject {
     private var shouldAutoOpenUpdatePlugin = false
 
     init(storeName: String,
+         siteAlreadyConnected: Bool = false,
          handler: WPComConnectionSetupHandlerProtocol,
          analytics: Analytics = ServiceLocator.analytics,
          onDismiss: @escaping () -> Void,
@@ -93,7 +95,7 @@ final class WPComConnectionSetupViewModel: ObservableObject {
         }()
 
         self.handler.delegate = self
-        setupInitialSteps()
+        setupInitialSteps(siteAlreadyConnected: siteAlreadyConnected)
     }
 
     func onAppear() {
@@ -159,19 +161,23 @@ final class WPComConnectionSetupViewModel: ObservableObject {
         handler.retry()
     }
 
-    private func setupInitialSteps() {
-        steps = [
-            WPComConnectionSetupStep(title: Localization.checkPluginStep, status: .notStarted),
-            WPComConnectionSetupStep(title: Localization.connectStoreStep, status: .notStarted),
-            WPComConnectionSetupStep(title: Localization.enablePushNotificationsStep, status: .notStarted)
+    private func setupInitialSteps(siteAlreadyConnected: Bool) {
+        var stepsAndTitles: [(SetupStep, String)] = [
+            (.checkPlugin, Localization.checkPluginStep)
         ]
+        if !siteAlreadyConnected {
+            stepsAndTitles.append((.connect, Localization.connectStoreStep))
+        }
+        stepsAndTitles.append((.enablePush, Localization.enablePushNotificationsStep))
+
+        steps = stepsAndTitles.map { WPComConnectionSetupStep(title: $0.1, status: .notStarted) }
+        stepIndexMap = Dictionary(uniqueKeysWithValues: stepsAndTitles.enumerated().map { ($0.element.0, $0.offset) })
     }
 
     private func updateStep(_ step: SetupStep, status: WPComConnectionSetupStep.Status) {
-        assert(step.rawValue < steps.count, "SetupStep out of sync with steps array")
-        guard step.rawValue < steps.count else { return }
-        steps[step.rawValue] = WPComConnectionSetupStep(
-            title: steps[step.rawValue].title,
+        guard let index = stepIndexMap[step] else { return }
+        steps[index] = WPComConnectionSetupStep(
+            title: steps[index].title,
             status: status
         )
     }

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModel.swift
@@ -29,6 +29,7 @@ final class WPComConnectionSetupViewModel: ObservableObject {
 
     static let supportSourceTag = "origin:woo-push-notifications-setup"
 
+    let title: String
     let subtitleAttributedString: AttributedString
 
     var primaryButtonTitle: String {
@@ -81,6 +82,8 @@ final class WPComConnectionSetupViewModel: ObservableObject {
         self.onDismiss = onDismiss
         self.onGoToStore = onGoToStore
         self.onUpdatePlugin = onUpdatePlugin
+
+        self.title = siteAlreadyConnected ? Localization.titleSetUpPushNotifications : Localization.titleConnectToWordPressCom
 
         self.subtitleAttributedString = {
             let content = String.localizedStringWithFormat(Localization.subtitle, storeName)
@@ -215,6 +218,16 @@ extension WPComConnectionSetupViewModel: WPComConnectionSetupHandlerDelegate {
 
 private extension WPComConnectionSetupViewModel {
     enum Localization {
+        static let titleConnectToWordPressCom = NSLocalizedString(
+            "wpComConnectionSetupViewModel.titleConnectToWordPressCom",
+            value: "Connect to WordPress.com",
+            comment: "Title for the WPCom connection setup screen when the site is not yet connected."
+        )
+        static let titleSetUpPushNotifications = NSLocalizedString(
+            "wpComConnectionSetupViewModel.titleSetUpPushNotifications",
+            value: "Set up push notifications",
+            comment: "Title for the WPCom connection setup screen when the site is already connected to WordPress.com."
+        )
         static let subtitle = NSLocalizedString(
             "wpComConnectionSetupViewModel.message",
             value: "Please wait while we finalize connecting your store %1$@ to WordPress.com.",

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -232,9 +232,6 @@ extension PushNotificationsManager {
     /// Unregisters the Application from both Woo and WordPress.com Push Notifications Services.
     ///
     func unregisterForRemoteNotifications(onCompletion: @escaping () -> Void) {
-        guard stores.isAuthenticatedWithoutWPCom == false else {
-            return
-        }
         DDLogInfo("📱 Unregistering For Remote Notifications...")
 
         let group = DispatchGroup()
@@ -253,15 +250,17 @@ extension PushNotificationsManager {
             }
         }
 
-        group.enter()
-        unregisterDotcomDeviceIfPossible() { error in
-            if let error = error {
-                DDLogError("⛔️ Unable to unregister from WordPress.com Push Notifications: \(error)")
-            } else {
-                DDLogInfo("📱 Successfully unregistered from WordPress.com Push Notifications!")
+        if stores.isAuthenticatedWithoutWPCom == false {
+            group.enter()
+            unregisterDotcomDeviceIfPossible() { error in
+                if let error = error {
+                    DDLogError("⛔️ Unable to unregister from WordPress.com Push Notifications: \(error)")
+                } else {
+                    DDLogInfo("📱 Successfully unregistered from WordPress.com Push Notifications!")
+                }
+                self.registrationState.clearWPComRegistration()
+                group.leave()
             }
-            self.registrationState.clearWPComRegistration()
-            group.leave()
         }
 
         group.notify(queue: .main) {

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -30,6 +30,7 @@ final class WooPushNotificationSetupCoordinator {
         )
         let viewModel = WPComConnectionSetupViewModel(
             storeName: site.name,
+            siteAlreadyConnected: siteAlreadyConnected,
             handler: handler,
             onDismiss: { [weak navigationController] in
                 navigationController?.dismiss(animated: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupHandlerTests.swift
@@ -53,11 +53,11 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
         // When
         handler.start()
-        await delegateSpy.waitForStepUpdate(count: 3)
+        await delegateSpy.waitForStepUpdate(count: 2)
 
         // Then
         XCTAssertEqual(mockConnectionService.establishSiteConnectionCallCount, 0)
-        XCTAssertFalse(delegateSpy.stepUpdates.contains { $0.step == .connect && $0.status == .running })
+        XCTAssertFalse(delegateSpy.stepUpdates.contains { $0.step == .connect })
     }
 
     func test_start_with_connection_failure_marks_connect_step_as_failure() async throws {
@@ -194,7 +194,7 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
 
         // When
         handler.start()
-        await delegateSpy.waitForStepUpdate(count: 5)
+        await delegateSpy.waitForStepUpdate(count: 4)
 
         // Then
         XCTAssertTrue(delegateSpy.stepUpdates.contains { $0.step == .enablePush && $0.status == .running })
@@ -211,7 +211,7 @@ final class WPComConnectionSetupHandlerTests: XCTestCase {
         handler.start()
 
         // Wait for all steps including the async push registration failure
-        await delegateSpy.waitForStepUpdate(count: 5, timeout: 5.0)
+        await delegateSpy.waitForStepUpdate(count: 4, timeout: 5.0)
 
         // Then
         XCTAssertTrue(delegateSpy.stepUpdates.contains { $0.step == .enablePush && $0.status == .running })

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModelTests.swift
@@ -51,6 +51,24 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.steps.map(\.title).contains("Connect store to WordPress.com"))
     }
 
+    // MARK: - Title Tests
+
+    func test_title_is_connect_to_wordpresscom_when_site_not_connected() {
+        // Given / When
+        let viewModel = makeViewModel(siteAlreadyConnected: false)
+
+        // Then
+        XCTAssertEqual(viewModel.title, "Connect to WordPress.com")
+    }
+
+    func test_title_is_set_up_push_notifications_when_site_already_connected() {
+        // Given / When
+        let viewModel = makeViewModel(siteAlreadyConnected: true)
+
+        // Then
+        XCTAssertEqual(viewModel.title, "Set up push notifications")
+    }
+
     // MARK: - Delegate Update Tests
 
     func test_stepDidUpdate_updates_step_status() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/WPComConnectionSetupViewModelTests.swift
@@ -42,6 +42,15 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isShowingSecondaryButton)
     }
 
+    func test_initial_state_has_two_steps_when_site_already_connected() {
+        // Given
+        let viewModel = makeViewModel(siteAlreadyConnected: true)
+
+        // Then — connect step is hidden
+        XCTAssertEqual(viewModel.steps.count, 2)
+        XCTAssertFalse(viewModel.steps.map(\.title).contains("Connect store to WordPress.com"))
+    }
+
     // MARK: - Delegate Update Tests
 
     func test_stepDidUpdate_updates_step_status() {
@@ -358,9 +367,11 @@ final class WPComConnectionSetupViewModelTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makeViewModel(analytics: Analytics = ServiceLocator.analytics) -> WPComConnectionSetupViewModel {
+    private func makeViewModel(siteAlreadyConnected: Bool = false,
+                               analytics: Analytics = ServiceLocator.analytics) -> WPComConnectionSetupViewModel {
         WPComConnectionSetupViewModel(
             storeName: "Test Store",
+            siteAlreadyConnected: siteAlreadyConnected,
             handler: mockHandler,
             analytics: analytics,
             onDismiss: { [weak self] in self?.dismissCalled = true },


### PR DESCRIPTION
Closes WOOMOB-2378

## Description
When starting the WPCom push notification setup flow for a site that is already connected to WordPress.com, the "Connect store to WordPress.com" step was shown even though it would always succeed trivially (no actual connection needed). This caused unnecessary UI noise.

The `connect` step is now hidden from the step list when `siteAlreadyConnected` is `true`. The handler also no longer emits a spurious `connect: .success` delegate call in that case.

Internally, a `stepIndexMap` dictionary is used to safely look up step indices regardless of how many steps are visible, replacing fragile raw-value array indexing.

Title of setup view has also been updated to "Set up push notifications" if the site is already connected.

## Test Steps
1. Trigger the push notification setup flow for a site **not** yet connected to WordPress.com — verify all 3 steps appear (Check plugin, Connect, Enable push notifications).
2. Trigger the same flow for a site **already** connected — verify only 2 steps appear (Check plugin, Enable push notifications) and the flow completes without showing the connect step.

## Screenshots

<img width="320" alt="image" src="https://github.com/user-attachments/assets/4e2f687a-29d2-41de-869f-4213d560b73f" />

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.