### PR TITLE
Reintroduce refund CTA in bookings

### DIFF
--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -1093,6 +1093,7 @@ public enum WooAnalyticsStat: String {
     case bookingDetailAttendanceStatusUpdate = "booking_detail_attendance_status_update"
     case bookingDetailAddNoteTap = "booking_detail_add_note_tap"
     case bookingDetailViewLinkedOrderTap = "booking_detail_view_linked_order_tap"
+    case bookingDetailRefundTap = "booking_detail_refund_tap"
     case bookingListTabSelect = "booking_list_tab_select"
     case bookingListView = "booking_list_view"
     case bookingListFailedToFetchBookings = "booking_list_failed_to_fetch_bookings"

--- a/WooCommerce/Classes/Extensions/Booking+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Booking+Helpers.swift
@@ -1,5 +1,6 @@
 import Foundation
 import struct Yosemite.Booking
+import enum Yosemite.BookingPaymentStatus
 
 extension Booking {
     var productName: String? {
@@ -11,6 +12,10 @@ extension Booking {
             return Localization.guest
         }
         return name.isEmpty ? Localization.guest : name
+    }
+
+    var isPaid: Bool {
+        paymentStatusBadge == .paid
     }
 
     var hasAssociatedOrder: Bool {

--- a/WooCommerce/Classes/Extensions/Booking+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Booking+Helpers.swift
@@ -15,7 +15,7 @@ extension Booking {
     }
 
     var isPaid: Bool {
-        paymentStatusBadge == .paid
+        paymentStatusBadge == .paid || paymentStatusBadge == .partiallyRefunded
     }
 
     var hasAssociatedOrder: Bool {

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel+Analytics.swift
@@ -32,6 +32,10 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .bookingDetailViewLinkedOrderTap)
         }
 
+        static func refundTap() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .bookingDetailRefundTap)
+        }
+
         static func failedToUpdateBookingDetails(action: Action, error: Error) -> WooAnalyticsEvent {
             let properties: [String: WooAnalyticsEventPropertyType] = [
                 Properties.action: action.rawValue

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -394,12 +394,7 @@ extension BookingDetailsViewModel {
 private extension BookingDetailsViewModel {
     func presentRefundFlow(order: Order, refunds: [Refund]) {
         let refundController = IssueRefundCoordinatingController(order: order, refunds: refunds)
-        let scenes = UIApplication.shared.connectedScenes
-        guard let presenter = scenes
-            .compactMap({ $0 as? UIWindowScene })
-            .flatMap({ $0.windows })
-            .first?
-            .topmostPresentedViewController else {
+        guard let presenter = UIApplication.wooKeyWindow?.topmostPresentedViewController else {
             return
         }
         refundController.onDismissCallback = { [weak self] in

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -402,6 +402,11 @@ private extension BookingDetailsViewModel {
             .topmostPresentedViewController else {
             return
         }
+        refundController.onDismissCallback = { [weak self] in
+            Task {
+                await self?.syncData()
+            }
+        }
         presenter.present(refundController, animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -383,6 +383,7 @@ extension BookingDetailsViewModel {
 
         guard let order = storage.viewStorage.loadOrder(siteID: booking.siteID, orderID: booking.orderID)?.toReadOnly() else {
             DDLogError("⛔️ Order not found in storage for booking \(booking.bookingID)")
+            assertionFailure("Order should be in storage after syncData()")
             return
         }
 

--- a/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/BookingDetailsViewModel.swift
@@ -6,6 +6,7 @@ import SwiftUI
 
 final class BookingDetailsViewModel: ObservableObject {
     private let stores: StoresManager
+    private let storage: StorageManagerType
 
     private var bookingResource: BookingResource?
     private var booking: Booking {
@@ -56,6 +57,7 @@ final class BookingDetailsViewModel: ObservableObject {
          analytics: Analytics = ServiceLocator.analytics) {
         self.booking = booking
         self.stores = stores
+        self.storage = storage
         self.analytics = analytics
         self.bookingResource = storage.viewStorage.loadBookingResource(
             siteID: booking.siteID,
@@ -374,6 +376,34 @@ extension BookingDetailsViewModel {
         analytics.track(event: .BookingsDetail.viewLinkedOrderTap())
         MainTabBarController.navigateToOrderDetails(with: booking.orderID, siteID: booking.siteID)
     }
+
+    @MainActor
+    func issueRefund() async {
+        analytics.track(event: .BookingsDetail.refundTap())
+
+        guard let order = storage.viewStorage.loadOrder(siteID: booking.siteID, orderID: booking.orderID)?.toReadOnly() else {
+            DDLogError("⛔️ Order not found in storage for booking \(booking.bookingID)")
+            return
+        }
+
+        let refunds = storage.viewStorage.loadRefunds(siteID: booking.siteID, orderID: booking.orderID).map { $0.toReadOnly() }
+        presentRefundFlow(order: order, refunds: refunds)
+    }
+}
+
+private extension BookingDetailsViewModel {
+    func presentRefundFlow(order: Order, refunds: [Refund]) {
+        let refundController = IssueRefundCoordinatingController(order: order, refunds: refunds)
+        let scenes = UIApplication.shared.connectedScenes
+        guard let presenter = scenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap({ $0.windows })
+            .first?
+            .topmostPresentedViewController else {
+            return
+        }
+        presenter.present(refundController, animated: true)
+    }
 }
 
 private extension BookingDetailsViewModel {
@@ -472,5 +502,6 @@ private extension BookingDetailsViewModel {
             value: "Retry",
             comment: "Retry Action"
         )
+
     }
 }

--- a/WooCommerce/Classes/ViewModels/Booking Details/PaymentContent.swift
+++ b/WooCommerce/Classes/ViewModels/Booking Details/PaymentContent.swift
@@ -27,6 +27,7 @@ extension BookingDetailsViewModel {
             ]
 
             actions = [
+                booking.isPaid && booking.hasAssociatedOrder ? .refund : nil,
                 booking.hasAssociatedOrder ? .viewOrder : nil
             ].compactMap { $0 }
         }
@@ -81,6 +82,7 @@ extension BookingDetailsViewModel.PaymentContent.Amount.AmountType {
 
 extension BookingDetailsViewModel.PaymentContent {
     enum Action: String, Identifiable {
+        case refund
         case viewOrder
 
         var id: String {
@@ -92,6 +94,8 @@ extension BookingDetailsViewModel.PaymentContent {
 extension BookingDetailsViewModel.PaymentContent.Action {
     var buttonTitle: String {
         switch self {
+        case .refund:
+            return Localization.paymentRefundButtonTitle
         case .viewOrder:
             return Localization.paymentViewOrderButtonTitle
         }
@@ -121,6 +125,12 @@ private enum Localization {
         "BookingDetailsView.payment.totalRow.title",
         value: "Total",
         comment: "Total row title in payment section in booking details view."
+    )
+
+    static let paymentRefundButtonTitle = NSLocalizedString(
+        "BookingDetailsView.payment.refund.title",
+        value: "Refund",
+        comment: "Title for 'Refund' button in payment section in booking details view."
     )
 
     static let paymentViewOrderButtonTitle = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -213,6 +213,13 @@ private extension BookingDetailsView {
             VStack(alignment: .leading, spacing: Layout.contentVerticalPadding) {
                 ForEach(content.actions) { action in
                     switch action {
+                    case .refund:
+                        Button(action.buttonTitle) {
+                            Task {
+                                await viewModel.issueRefund()
+                            }
+                        }
+                        .buttonStyle(SecondaryButtonStyle())
                     case .viewOrder:
                         Button(action.buttonTitle) {
                             viewModel.navigateToOrderDetails()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundCoordinatingController.swift
@@ -18,6 +18,10 @@ final class IssueRefundCoordinatingController: WooNavigationController {
     ///
     private let systemNoticePresenter: NoticePresenter
 
+    /// Called when the refund flow is dismissed (whether refund was completed or cancelled).
+    ///
+    var onDismissCallback: (() -> Void)?
+
     init(order: Order, refunds: [Refund], systemNoticePresenter: NoticePresenter = ServiceLocator.noticePresenter) {
         self.order = order
         self.refunds = refunds
@@ -151,6 +155,7 @@ private extension IssueRefundCoordinatingController {
             if presentSuccessNotice {
                 self?.systemNoticePresenter.enqueue(notice: .init(title: Localization.refundSuccess))
             }
+            self?.onDismissCallback?()
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
@@ -433,23 +433,6 @@ final class BookingDetailsViewModelTests: XCTestCase {
         XCTAssertFalse(paymentContent.actions.contains(.viewOrder))
     }
 
-    func test_event_fired_when_booking_marked_as_paid() async throws {
-        // Given
-        let viewModel = givenViewModel()
-
-        // When
-        let task = Task { try await viewModel.markBookingAsPaid() }
-        let action = try await waitForFirstBookingAction()
-        guard case let .markBookingAsPaid(_, _, onCompletion) = action else {
-            return XCTFail("Expected markBookingAsPaid action")
-        }
-        onCompletion(nil)
-        try await task.value
-
-        // Then
-        analyticsProvider.assertReceived(event: "booking_detail_mark_as_paid_tapped")
-    }
-
     func test_event_fired_when_booking_cancelled() async throws {
         // Given
         let viewModel = givenViewModel()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
@@ -461,6 +461,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
         analyticsProvider.assertReceived(event: "booking_detail_add_note_tap")
     }
 
+
 }
 
 private extension BookingDetailsViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
@@ -433,6 +433,23 @@ final class BookingDetailsViewModelTests: XCTestCase {
         XCTAssertFalse(paymentContent.actions.contains(.viewOrder))
     }
 
+    func test_event_fired_when_booking_marked_as_paid() async throws {
+        // Given
+        let viewModel = givenViewModel()
+
+        // When
+        let task = Task { try await viewModel.markBookingAsPaid() }
+        let action = try await waitForFirstBookingAction()
+        guard case let .markBookingAsPaid(_, _, onCompletion) = action else {
+            return XCTFail("Expected markBookingAsPaid action")
+        }
+        onCompletion(nil)
+        try await task.value
+
+        // Then
+        analyticsProvider.assertReceived(event: "booking_detail_mark_as_paid_tapped")
+    }
+
     func test_event_fired_when_booking_cancelled() async throws {
         // Given
         let viewModel = givenViewModel()
@@ -461,12 +478,11 @@ final class BookingDetailsViewModelTests: XCTestCase {
         analyticsProvider.assertReceived(event: "booking_detail_add_note_tap")
     }
 
-
 }
 
 private extension BookingDetailsViewModelTests {
     func givenViewModel(booking: Booking = Booking.fake()) -> BookingDetailsViewModel {
-        return BookingDetailsViewModel(booking: booking, stores: storesManager, analytics: analytics)
+        return BookingDetailsViewModel(booking: booking, stores: storesManager, storage: storageManager, analytics: analytics)
     }
 
     func waitForFirstBookingAction(


### PR DESCRIPTION
## Description

Reintroduces the "Refund" button that was removed in commit c9f86d6bc7.

## Test Steps

1. Open a paid booking in the Bookings tab for a CIAB store.
2. Scroll to Payment section
3. Verify "Refund" button appears above "View order"
4. Tap "Refund" to launch the refund flow
5. Wait a couple of seconds when completing the flow.
6. The refund button should disappear.
7. Verify unpaid bookings don't show the refund button

## Screenshots

![Simulator Screen Recording - iPhone 17 Pro - 2026-03-03 at 15 21 44](https://github.com/user-attachments/assets/b39354f3-2cd2-4c69-94f5-97cce17b0777)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.