### PR TITLE
Improve WordPressAPIDiscovery: case-insensitive cache keys and deduplicate concurrent requests

### DIFF
--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetwork.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetwork.swift
@@ -116,7 +116,8 @@ public class AlamofireNetwork: Network {
                 switch credentials {
                 case let .wporg(_, _, siteAddress): return siteAddress
                 case let .applicationPassword(_, _, siteAddress): return siteAddress
-                default: return nil
+                case let .wpcom(_, _, siteAddress): return siteAddress
+                case .none: return nil
                 }
             }()
             guard let siteURL else { return nil }

--- a/Modules/Sources/NetworkingCore/Network/AlamofireNetwork.swift
+++ b/Modules/Sources/NetworkingCore/Network/AlamofireNetwork.swift
@@ -72,11 +72,15 @@ public class AlamofireNetwork: Network {
     ///   - selectedSite: Publisher for site selection changes.
     ///   This is necessary if you wish to enable network switching to direct requests while authenticated with WPCOM for better performance.
     ///   - sessionManager: Optional pre-configured session manager.
+    ///   - discoveryHandler: Optional override for REST API discovery. When provided, it is always
+    ///   called instead of the default `WordPressAPIDiscovery` (useful for testing). When `nil`,
+    ///   discovery runs only when no `sessionManager` is injected (production mode).
     public required init(credentials: Credentials?,
                          selectedSite: AnyPublisher<JetpackSite?, Never>?,
                          appPasswordSupportState: AnyPublisher<Bool, Never>?,
                          userDefaults: UserDefaults = .standard,
-                         sessionManager: Alamofire.Session? = nil) {
+                         sessionManager: Alamofire.Session? = nil,
+                         discoveryHandler: ((String) async -> Void)? = nil) {
         self.credentials = credentials
         self.selectedSite = selectedSite
         self.userDefaults = userDefaults
@@ -108,10 +112,12 @@ public class AlamofireNetwork: Network {
             )
         }
 
-        // Eagerly discover the REST API root URL for wporg/applicationPassword sites so that
-        // REST requests made immediately after a relaunch use the correct base path.
-        // Skip when a sessionManager is injected (test mode heuristic).
-        self.discoveryTask = sessionManager == nil ? {
+        // Eagerly discover the REST API root URL so that REST requests made immediately after
+        // a relaunch use the correct base path.
+        // When a discoveryHandler is injected (test mode), always run it so tests can observe
+        // which siteURL was extracted. Otherwise, skip when a sessionManager is injected
+        // (production heuristic — sessionManager injection implies test mode).
+        self.discoveryTask = {
             let siteURL: String? = {
                 switch credentials {
                 case let .wporg(_, _, siteAddress): return siteAddress
@@ -121,11 +127,15 @@ public class AlamofireNetwork: Network {
                 }
             }()
             guard let siteURL else { return nil }
+            if let discoveryHandler {
+                return Task { await discoveryHandler(siteURL) }
+            }
+            guard sessionManager == nil else { return nil }
             return Task {
                 guard WordPressRESTAPIRootCache.shared.root(for: siteURL) == nil else { return }
                 _ = await WordPressAPIDiscovery().discoverRESTAPIRootURL(for: siteURL)
             }
-        }() : nil
+        }()
 
         let authenticationMode: RequestAuthenticationMode? = {
             switch credentials {

--- a/Modules/Sources/NetworkingCore/WordPressAPIDiscovery.swift
+++ b/Modules/Sources/NetworkingCore/WordPressAPIDiscovery.swift
@@ -3,13 +3,22 @@ import Foundation
 /// Discovers the WordPress REST API root URL for a given site by performing a HEAD request
 /// and parsing the `Link` response header per the WordPress REST API discovery specification.
 ///
+/// Concurrent requests for the same site URL are deduplicated — only one HEAD request is
+/// made in-flight at a time per site, and subsequent callers share the result.
+///
 /// See: https://developer.wordpress.org/rest-api/using-the-rest-api/discovery/
 ///
 public struct WordPressAPIDiscovery {
     private let session: URLSessionProtocol
+    private let cache: WordPressRESTAPIRootCache
 
-    public init(session: URLSessionProtocol = URLSession.shared) {
+    /// Shared coordinator that deduplicates in-flight discovery requests.
+    private static let coordinator = DiscoveryCoordinator()
+
+    public init(session: URLSessionProtocol = URLSession.shared,
+                cache: WordPressRESTAPIRootCache = .shared) {
         self.session = session
+        self.cache = cache
     }
 
     /// Discovers the REST API root URL by sending a HEAD request to the given site URL.
@@ -18,23 +27,48 @@ public struct WordPressAPIDiscovery {
     /// - Returns: The discovered REST API root URL string, or `nil` if discovery fails.
     ///
     public func discoverRESTAPIRootURL(for siteURL: String) async -> String? {
-        guard let url = URL(string: siteURL) else { return nil }
-        var request = URLRequest(url: url)
-        request.httpMethod = "HEAD"
-        do {
-            let (_, response) = try await session.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse else { return nil }
-            guard let root = parseRESTAPIRootURL(from: httpResponse) else { return nil }
-            WordPressRESTAPIRootCache.shared.setRoot(root, for: siteURL)
-            return root
-        } catch {
-            DDLogDebug("⚠️ REST API discovery failed for \(siteURL): \(error)")
-            return nil
-        }
+        await Self.coordinator.discover(siteURL: siteURL, session: session, cache: cache)
     }
 }
 
-private extension WordPressAPIDiscovery {
+/// Actor that deduplicates in-flight REST API discovery requests.
+///
+/// When multiple callers request discovery for the same site URL concurrently,
+/// only one HEAD request is performed and all callers receive the same result.
+///
+private actor DiscoveryCoordinator {
+    private var inFlight: [String: Task<String?, Never>] = [:]
+
+    func discover(siteURL: String, session: URLSessionProtocol, cache: WordPressRESTAPIRootCache) async -> String? {
+        let key = siteURL.trimSlashes().lowercased()
+
+        // Return existing in-flight task if one exists
+        if let existing = inFlight[key] {
+            return await existing.value
+        }
+
+        let task = Task<String?, Never> {
+            guard let url = URL(string: siteURL) else { return nil }
+            var request = URLRequest(url: url)
+            request.httpMethod = "HEAD"
+            do {
+                let (_, response) = try await session.data(for: request)
+                guard let httpResponse = response as? HTTPURLResponse else { return nil }
+                guard let root = DiscoveryCoordinator.parseRESTAPIRootURL(from: httpResponse) else { return nil }
+                cache.setRoot(root, for: siteURL)
+                return root
+            } catch {
+                DDLogDebug("⚠️ REST API discovery failed for \(siteURL): \(error)")
+                return nil
+            }
+        }
+
+        inFlight[key] = task
+        let result = await task.value
+        inFlight[key] = nil
+        return result
+    }
+
     /// Parses the REST API root URL from the `Link` header of an HTTP response.
     ///
     /// The expected header format is:
@@ -42,7 +76,7 @@ private extension WordPressAPIDiscovery {
     /// Link: <https://example.com/wp-json/>; rel="https://api.w.org/"
     /// ```
     ///
-    func parseRESTAPIRootURL(from response: HTTPURLResponse) -> String? {
+    static func parseRESTAPIRootURL(from response: HTTPURLResponse) -> String? {
         guard let linkHeader = response.value(forHTTPHeaderField: "Link") else { return nil }
 
         // The Link header may contain multiple link relations separated by commas.

--- a/Modules/Sources/NetworkingCore/WordPressRESTAPIRootCache.swift
+++ b/Modules/Sources/NetworkingCore/WordPressRESTAPIRootCache.swift
@@ -18,11 +18,11 @@ public final class WordPressRESTAPIRootCache: RESTAPIRootCaching {
     init() {}
 
     public func root(for siteURL: String) -> String? {
-        queue.sync { cache[siteURL.trimSlashes()] }
+        queue.sync { cache[siteURL.trimSlashes().lowercased()] }
     }
 
     public func setRoot(_ root: String, for siteURL: String) {
-        queue.async(flags: .barrier) { self.cache[siteURL.trimSlashes()] = root }
+        queue.async(flags: .barrier) { self.cache[siteURL.trimSlashes().lowercased()] = root }
     }
 
     public func reset() {

--- a/Modules/Tests/NetworkingTests/Network/AlamofireNetworkTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/AlamofireNetworkTests.swift
@@ -652,6 +652,92 @@ final class AlamofireNetworkTests: XCTestCase {
         XCTAssertEqual(networkError?.errorCode, "failed")
     }
 
+    // MARK: - Discovery Logic Tests
+
+    func test_discovery_is_triggered_with_siteAddress_for_wporg_credentials() async {
+        // Given
+        let siteAddress = "https://wporg-site.example.com"
+        let credentials = Credentials.wporg(username: "user", password: "pass", siteAddress: siteAddress)
+        let expectation = expectation(description: "Discovery called")
+        var discoveredURL: String?
+
+        // When
+        let network = AlamofireNetwork(credentials: credentials,
+                                       selectedSite: nil,
+                                       appPasswordSupportState: nil,
+                                       sessionManager: createSessionWithMockURLProtocol(),
+                                       discoveryHandler: { siteURL in
+                                           discoveredURL = siteURL
+                                           expectation.fulfill()
+                                       })
+        await fulfillment(of: [expectation], timeout: 1.0)
+
+        // Then
+        XCTAssertEqual(discoveredURL, siteAddress)
+        _ = network
+    }
+
+    func test_discovery_is_triggered_with_siteAddress_for_applicationPassword_credentials() async {
+        // Given
+        let siteAddress = "https://apppw-site.example.com"
+        let credentials = Credentials.applicationPassword(username: "user", password: "pass", siteAddress: siteAddress)
+        let expectation = expectation(description: "Discovery called")
+        var discoveredURL: String?
+
+        // When
+        let network = AlamofireNetwork(credentials: credentials,
+                                       selectedSite: nil,
+                                       appPasswordSupportState: nil,
+                                       sessionManager: createSessionWithMockURLProtocol(),
+                                       discoveryHandler: { siteURL in
+                                           discoveredURL = siteURL
+                                           expectation.fulfill()
+                                       })
+        await fulfillment(of: [expectation], timeout: 1.0)
+
+        // Then
+        XCTAssertEqual(discoveredURL, siteAddress)
+    }
+
+    func test_discovery_is_triggered_with_siteAddress_for_wpcom_credentials() async {
+        // Given
+        let siteAddress = "https://wpcom-site.example.com"
+        let credentials = Credentials.wpcom(username: "user", authToken: "token", siteAddress: siteAddress)
+        let expectation = expectation(description: "Discovery called")
+        var discoveredURL: String?
+
+        // When
+        let network = AlamofireNetwork(credentials: credentials,
+                                       selectedSite: nil,
+                                       appPasswordSupportState: nil,
+                                       sessionManager: createSessionWithMockURLProtocol(),
+                                       discoveryHandler: { siteURL in
+                                           discoveredURL = siteURL
+                                           expectation.fulfill()
+                                       })
+        await fulfillment(of: [expectation], timeout: 1.0)
+
+        // Then
+        XCTAssertEqual(discoveredURL, siteAddress)
+    }
+
+    func test_discovery_is_not_triggered_when_credentials_are_nil() async {
+        // Given
+        let expectation = expectation(description: "Discovery should not be called")
+        expectation.isInverted = true
+
+        // When
+        let network = AlamofireNetwork(credentials: nil,
+                                       selectedSite: nil,
+                                       appPasswordSupportState: nil,
+                                       sessionManager: createSessionWithMockURLProtocol(),
+                                       discoveryHandler: { _ in expectation.fulfill() })
+        await fulfillment(of: [expectation], timeout: 0.1)
+
+        // Then — expectation is inverted; reaching here means the handler was never called
+        _ = network
+    }
+
     // MARK: - Authentication Mode Tests
 
     func test_authenticationMode_is_appPasswords_for_wporg_credentials() {

--- a/Modules/Tests/NetworkingTests/WordPressAPIDiscoveryTests.swift
+++ b/Modules/Tests/NetworkingTests/WordPressAPIDiscoveryTests.swift
@@ -5,17 +5,19 @@ import XCTest
 final class WordPressAPIDiscoveryTests: XCTestCase {
     let sampleSiteURL = "https://example.com"
     var session: MockURLSession!
+    var cache: WordPressRESTAPIRootCache!
     var sut: WordPressAPIDiscovery!
 
     override func setUp() {
         session = MockURLSession()
-        sut = WordPressAPIDiscovery(session: session)
+        cache = WordPressRESTAPIRootCache()
+        sut = WordPressAPIDiscovery(session: session, cache: cache)
     }
 
     override func tearDown() {
         sut = nil
+        cache = nil
         session = nil
-        WordPressRESTAPIRootCache.shared.reset()
         super.tearDown()
     }
 
@@ -121,7 +123,7 @@ final class WordPressAPIDiscoveryTests: XCTestCase {
         _ = await sut.discoverRESTAPIRootURL(for: sampleSiteURL)
 
         // Then
-        XCTAssertEqual(WordPressRESTAPIRootCache.shared.root(for: sampleSiteURL), "https://example.com/wp-json/")
+        XCTAssertEqual(cache.root(for: sampleSiteURL), "https://example.com/wp-json/")
     }
 
     func test_discoverRESTAPIRootURL_when_discovery_fails_then_does_not_populate_cache() async {
@@ -132,7 +134,7 @@ final class WordPressAPIDiscoveryTests: XCTestCase {
         _ = await sut.discoverRESTAPIRootURL(for: sampleSiteURL)
 
         // Then
-        XCTAssertNil(WordPressRESTAPIRootCache.shared.root(for: sampleSiteURL))
+        XCTAssertNil(cache.root(for: sampleSiteURL))
     }
 
     func test_discoverRESTAPIRootURL_sends_head_request() async {
@@ -147,5 +149,63 @@ final class WordPressAPIDiscoveryTests: XCTestCase {
 
         // Then
         XCTAssertEqual(session.lastRequest?.httpMethod, "HEAD")
+    }
+
+    // MARK: - Deduplication Tests
+
+    func test_discoverRESTAPIRootURL_when_concurrent_calls_for_same_url_then_makes_single_request() async {
+        // Given
+        session.simulateResponse(
+            for: sampleSiteURL,
+            headerFields: ["Link": "<https://example.com/wp-json/>; rel=\"https://api.w.org/\""]
+        )
+
+        // When — two concurrent discoveries for the same URL
+        async let result1 = sut.discoverRESTAPIRootURL(for: sampleSiteURL)
+        async let result2 = sut.discoverRESTAPIRootURL(for: sampleSiteURL)
+        let results = await [result1, result2]
+
+        // Then — both get the same result, but only one HEAD request was made
+        XCTAssertEqual(results[0], "https://example.com/wp-json/")
+        XCTAssertEqual(results[1], "https://example.com/wp-json/")
+        XCTAssertEqual(session.requestCount, 1)
+    }
+
+    func test_discoverRESTAPIRootURL_when_concurrent_calls_with_different_casing_then_makes_single_request() async {
+        // Given — simulate responses for both URL casings
+        session.simulateResponse(
+            for: "https://example.com",
+            headerFields: ["Link": "<https://example.com/wp-json/>; rel=\"https://api.w.org/\""]
+        )
+        session.simulateResponse(
+            for: "https://Example.COM",
+            headerFields: ["Link": "<https://example.com/wp-json/>; rel=\"https://api.w.org/\""]
+        )
+
+        // When — two concurrent discoveries with different casing
+        async let result1 = sut.discoverRESTAPIRootURL(for: "https://example.com")
+        async let result2 = sut.discoverRESTAPIRootURL(for: "https://Example.COM")
+        let results = await [result1, result2]
+
+        // Then — both succeed and only one request was made
+        XCTAssertEqual(results[0], "https://example.com/wp-json/")
+        XCTAssertEqual(results[1], "https://example.com/wp-json/")
+        XCTAssertEqual(session.requestCount, 1)
+    }
+
+    func test_discoverRESTAPIRootURL_when_previous_request_completed_then_allows_new_request() async {
+        // Given
+        session.simulateResponse(
+            for: sampleSiteURL,
+            headerFields: ["Link": "<https://example.com/wp-json/>; rel=\"https://api.w.org/\""]
+        )
+
+        // When — sequential discoveries (first completes before second starts)
+        _ = await sut.discoverRESTAPIRootURL(for: sampleSiteURL)
+        cache.reset()
+        _ = await sut.discoverRESTAPIRootURL(for: sampleSiteURL)
+
+        // Then — two separate requests were made
+        XCTAssertEqual(session.requestCount, 2)
     }
 }

--- a/Modules/Tests/NetworkingTests/WordPressRESTAPIRootCacheTests.swift
+++ b/Modules/Tests/NetworkingTests/WordPressRESTAPIRootCacheTests.swift
@@ -48,6 +48,15 @@ struct WordPressRESTAPIRootCacheTests {
         #expect(sut.root(for: "https://example.com/") == "https://example.com/wp-json/")
     }
 
+    @Test func test_root_is_case_insensitive_for_site_url() {
+        // Given
+        sut.setRoot("https://example.com/wp-json/", for: "https://Example.COM")
+
+        // When / Then — different casing should resolve to the same entry
+        #expect(sut.root(for: "https://example.com") == "https://example.com/wp-json/")
+        #expect(sut.root(for: "https://EXAMPLE.COM") == "https://example.com/wp-json/")
+    }
+
     @Test func test_root_treats_different_site_urls_independently() {
         // Given
         let rootA = "https://site-a.com/wp-json/"


### PR DESCRIPTION
Part of WOOMOB-2191

## Description

Fixes two issues in the WordPress REST API discovery layer:

**1. Case-insensitive cache keys in `WordPressRESTAPIRootCache`**

Site URLs are used as cache keys after trimming slashes, but domain names are case-insensitive per RFC. If the same site URL arrived with different casing (e.g. `https://Example.COM` vs `https://example.com`), the cache lookup would miss and fall back to the `?rest_route=` path. Fixed by normalising keys with `.lowercased()` in both `root(for:)` and `setRoot(_:for:)`.

**2. Deduplicate concurrent discovery requests in `WordPressAPIDiscovery`**

Multiple call sites (`AlamofireNetwork.init`, `ApplicationPasswordUseCase.init`) each create a new `WordPressAPIDiscovery()` instance. If the guard check (`root(for:) == nil`) passed concurrently on more than one, multiple HEAD requests could fire for the same site. Fixed by introducing a `DiscoveryCoordinator` actor with an in-flight task map: concurrent callers for the same URL share the result of a single in-flight `Task` rather than each launching their own.

The cache is now injected into `WordPressAPIDiscovery` (defaulting to `.shared`) rather than referenced directly, improving testability.

**3. Root discovery update in `AlamofireNetwork`**

Enable root discovery when authenticated with WPCom as proxied requests can be converted to RESTRequest for sites supporting application passwords.

## Test Steps

These are internal networking changes with no UI impact. Log in to test sites with site credentials and WPCom credentials and smoke test features to confirm that everything still works properly.

## Screenshots

N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.