### PR TITLE
Track state property for push notifications introduction view event

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WPComPushNotificationsSetup.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WPComPushNotificationsSetup.swift
@@ -4,6 +4,7 @@ extension WooAnalyticsEvent {
     enum WPComPushNotificationsSetup {
         private enum Keys: String {
             case buttonLabel = "button_label"
+            case state = "state"
         }
 
         enum BenefitsButton: String {
@@ -16,6 +17,16 @@ extension WooAnalyticsEvent {
             case goToMyStore = "go_to_my_store"
             case tryAgain = "try_again"
             case updatePlugin = "update_plugin"
+        }
+
+        enum IntroductionViewState: String {
+            case notConnected = "not_connected"
+            case updateRequired = "update_required"
+        }
+
+        static func introductionView(state: IntroductionViewState) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .pushNotificationsSetupIntroductionView,
+                              properties: [Keys.state.rawValue: state.rawValue])
         }
 
         static func introductionButtonTap(_ button: BenefitsButton) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -85,9 +85,6 @@ struct WPComPushNotificationsBenefitsView: View {
                     .renderedIf(!dynamicTypeSize.isAccessibilitySize && !viewModel.isCheckingPlugin)
             }
         }
-        .onAppear {
-            viewModel.onAppear()
-        }
         .task {
             await viewModel.determineSetupVariant()
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -141,6 +141,7 @@ private extension WPComPushNotificationsBenefitsViewModel {
                 analytics.track(event: .WPComPushNotificationsSetup.introductionView(state: .updateRequired))
             } else {
                 error = .noMissingRequirements
+                analytics.track(.pushNotificationsSetupIntroductionError, properties: ["error_type": "generic"], error: error)
             }
         } catch {
             DDLogError("⛔️ Plugin version check failed: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -70,10 +70,6 @@ final class WPComPushNotificationsBenefitsViewModel {
         self.pushNotificationSetupCoordinator = coordinator
     }
 
-    func onAppear() {
-        analytics.track(.pushNotificationsSetupIntroductionView)
-    }
-
     /// Fetches Jetpack connection data to determine whether the site is connected,
     /// then checks the WooCommerce plugin version if Jetpack is connected.
     func determineSetupVariant() async {
@@ -86,6 +82,7 @@ final class WPComPushNotificationsBenefitsViewModel {
                 await checkWooPluginVersion()
             } else {
                 variant = .connect
+                analytics.track(event: .WPComPushNotificationsSetup.introductionView(state: .notConnected))
             }
         } catch {
             DDLogError("⛔️ Failed to fetch Jetpack connection data: \(error)")
@@ -141,6 +138,7 @@ private extension WPComPushNotificationsBenefitsViewModel {
             let result = try await pluginVersionChecker.checkCompatibility()
             if case .incompatible(let currentVersion, _) = result {
                 variant = .pluginUpdate(currentVersion: currentVersion)
+                analytics.track(event: .WPComPushNotificationsSetup.introductionView(state: .updateRequired))
             } else {
                 error = .noMissingRequirements
             }

--- a/WooCommerce/WooCommerceTests/Analytics/WooAnalyticsEvent+WPComPushNotificationsSetupTests.swift
+++ b/WooCommerce/WooCommerceTests/Analytics/WooAnalyticsEvent+WPComPushNotificationsSetupTests.swift
@@ -4,6 +4,25 @@ import Testing
 
 struct WooAnalyticsEvent_PushNotificationsSetupTests {
 
+    // MARK: - introductionView
+
+    @Test func test_introductionView_when_given_each_state_then_produces_correct_event() {
+        // Given
+        let cases: [(WooAnalyticsEvent.WPComPushNotificationsSetup.IntroductionViewState, String)] = [
+            (.notConnected, "not_connected"),
+            (.updateRequired, "update_required")
+        ]
+
+        for (state, expected) in cases {
+            // When
+            let event = WooAnalyticsEvent.WPComPushNotificationsSetup.introductionView(state: state)
+
+            // Then
+            #expect(event.statName == .pushNotificationsSetupIntroductionView)
+            #expect(event.properties["state"] as? String == expected)
+        }
+    }
+
     // MARK: - introductionButtonTap
 
     @Test func test_introductionButtonTap_when_given_each_label_then_produces_correct_event() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/WPComPushNotificationsBenefitsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/WPComPushNotificationsBenefitsViewModelTests.swift
@@ -154,14 +154,82 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
         let viewModel = makeViewModel(analytics: analytics)
 
         // When
-        viewModel.onAppear()
         viewModel.continueTapped()
         viewModel.notNowTapped()
 
         // Then
-        XCTAssertTrue(provider.receivedEvents.contains("push_notifications_setup_introduction_view"))
         provider.assertReceived(event: "push_notifications_setup_introduction_button_tap", with: ["button_label": "continue"])
         XCTAssertEqual(provider.receivedEvents.filter { $0 == "push_notifications_setup_introduction_button_tap" }.count, 2)
+    }
+
+    func test_determineSetupVariant_when_jetpack_not_connected_then_tracks_introduction_view_with_not_connected_state() async {
+        // Given
+        let provider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: provider)
+        let connectionService = MockJetpackConnectionService()
+        connectionService.fetchConnectionDataResult = .success(
+            JetpackConnectionData.fake().copy(isRegistered: false)
+        )
+        let viewModel = makeViewModel(jetpackConnectionService: connectionService, analytics: analytics)
+
+        // When
+        await viewModel.determineSetupVariant()
+
+        // Then
+        provider.assertReceived(event: "push_notifications_setup_introduction_view", with: ["state": "not_connected"])
+    }
+
+    func test_determineSetupVariant_when_jetpack_connected_and_plugin_update_needed_then_tracks_introduction_view_with_update_required_state() async {
+        // Given
+        let provider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: provider)
+        let connectionService = MockJetpackConnectionService()
+        connectionService.fetchConnectionDataResult = .success(
+            JetpackConnectionData.fake().copy(isRegistered: true)
+        )
+        let checker = MockPluginVersionChecker()
+        checker.result = .success(.incompatible(currentVersion: "10.0.0", requiredVersion: "10.5.3"))
+        let viewModel = makeViewModel(jetpackConnectionService: connectionService, pluginVersionChecker: checker, analytics: analytics)
+
+        // When
+        await viewModel.determineSetupVariant()
+
+        // Then
+        provider.assertReceived(event: "push_notifications_setup_introduction_view", with: ["state": "update_required"])
+    }
+
+    func test_determineSetupVariant_when_connection_fails_then_does_not_track_introduction_view() async {
+        // Given
+        let provider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: provider)
+        let connectionService = MockJetpackConnectionService()
+        connectionService.fetchConnectionDataResult = .failure(NSError(domain: "test", code: 1))
+        let viewModel = makeViewModel(jetpackConnectionService: connectionService, analytics: analytics)
+
+        // When
+        await viewModel.determineSetupVariant()
+
+        // Then
+        XCTAssertFalse(provider.receivedEvents.contains("push_notifications_setup_introduction_view"))
+    }
+
+    func test_determineSetupVariant_when_plugin_check_fails_then_does_not_track_introduction_view() async {
+        // Given
+        let provider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: provider)
+        let connectionService = MockJetpackConnectionService()
+        connectionService.fetchConnectionDataResult = .success(
+            JetpackConnectionData.fake().copy(isRegistered: true)
+        )
+        let checker = MockPluginVersionChecker()
+        checker.result = .failure(NSError(domain: "test", code: 1))
+        let viewModel = makeViewModel(jetpackConnectionService: connectionService, pluginVersionChecker: checker, analytics: analytics)
+
+        // When
+        await viewModel.determineSetupVariant()
+
+        // Then
+        XCTAssertFalse(provider.receivedEvents.contains("push_notifications_setup_introduction_view"))
     }
 
     func test_continueTapped_when_pluginUpdate_variant_then_tracks_update_plugin_button_label() async {


### PR DESCRIPTION
Closes WOOMOB-2377

## Description

Tracks a new `state` property on the `push_notifications_setup_introduction_view` analytics event with values:
- `not_connected` — when the view is shown to connect Jetpack
- `update_required` — when the view is shown to update the WooCommerce plugin

The event is now logged **after** the Jetpack connection status check completes (inside `determineSetupVariant()`), rather than on `onAppear`. This ensures the correct state value is available when the event fires.

Also added `push_notifications_setup_introduction_error` tracking when no missing requirement is found.

## Test Steps

1. Open the push notifications benefits/introduction modal from the dashboard card or settings.
2. Verify `push_notifications_setup_introduction_view` is tracked with `state: not_connected` when Jetpack is not connected.
3. Verify the same event is tracked with `state: update_required` when Jetpack is connected but the WooCommerce plugin is outdated.
4. Verify the event is **not** tracked when an error occurs during the connection check. 
5. Verify that if the site is connected and plugin is up-to-date, `push_notifications_setup_introduction_error` is tracked with `noMissingRequirements` error.

## Screenshots

N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.