### PR TITLE
Fire view event when filters applied in bookings

### DIFF
--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
@@ -49,7 +49,9 @@ struct BookingListContainerView: View {
             sortingOptions
                 .presentationDetents([.fraction(0.25), .medium, .large])
         }
-        .sheet(isPresented: $showingFilters) {
+        .sheet(isPresented: $showingFilters, onDismiss: {
+            viewModel.onAppear()
+        }) {
             FilterListView(viewModel: viewModel.filterViewModel) { filters in
                 viewModel.applyFiltersTapped()
                 viewModel.updateFilters(filters)

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
@@ -57,7 +57,7 @@ struct BookingListContainerView: View {
             } onClearAction: {
                 // no-op
             } onDismissAction: {
-                // no-op
+                viewModel.onAppear()
             }
         }
         .onAppear {

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
@@ -51,8 +51,8 @@ struct BookingListContainerView: View {
         }
         .sheet(isPresented: $showingFilters) {
             FilterListView(viewModel: viewModel.filterViewModel) { filters in
-                viewModel.applyFiltersTapped()
                 viewModel.updateFilters(filters)
+                viewModel.applyFiltersTapped()
                 viewModel.onAppear()
             } onClearAction: {
                 // no-op

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerView.swift
@@ -49,12 +49,11 @@ struct BookingListContainerView: View {
             sortingOptions
                 .presentationDetents([.fraction(0.25), .medium, .large])
         }
-        .sheet(isPresented: $showingFilters, onDismiss: {
-            viewModel.onAppear()
-        }) {
+        .sheet(isPresented: $showingFilters) {
             FilterListView(viewModel: viewModel.filterViewModel) { filters in
                 viewModel.applyFiltersTapped()
                 viewModel.updateFilters(filters)
+                viewModel.onAppear()
             } onClearAction: {
                 // no-op
             } onDismissAction: {

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
@@ -21,6 +21,7 @@ final class BookingListContainerViewModel: ObservableObject {
     @Published var searchQuery: String = ""
     @Published var sortBy: BookingListViewModel.SortBy = .newestToOldest
     @Published var numberOfActiveFilters: Int = 0
+    private var hasUserSwitchedTab = false
 
     private let searchQuerySubject = PassthroughSubject<String, Never>()
     private var searchQuerySubscription: AnyCancellable?
@@ -148,6 +149,7 @@ final class BookingListContainerViewModel: ObservableObject {
     }
 
     func setSelectedTab(to newTab: BookingListTab) {
+        hasUserSwitchedTab = true
         selectedTab = newTab
         analytics.track(event: .BookingList.tabSelect(newTab))
         // Manually trigger onAppear as we are programaticcaly
@@ -160,7 +162,7 @@ final class BookingListContainerViewModel: ObservableObject {
         let tabViewModel = listViewModel(for: selectedTab)
         analytics.track(event: .BookingList.bookingListView(
             tab: selectedTab,
-            isDefaultTab: selectedTab == BookingListContainerViewModel.defaultTab,
+            isDefaultTab: !hasUserSwitchedTab && selectedTab == Self.defaultTab,
             isListEmpty: tabViewModel.bookings.isEmpty,
             isFiltered: tabViewModel.hasFilters
         ))

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
@@ -22,6 +22,7 @@ final class BookingListContainerViewModel: ObservableObject {
     @Published var sortBy: BookingListViewModel.SortBy = .newestToOldest
     @Published var numberOfActiveFilters: Int = 0
     private var hasUserSwitchedTab = false
+    var hasRestoredFilters = false
 
     private let searchQuerySubject = PassthroughSubject<String, Never>()
     private var searchQuerySubscription: AnyCancellable?
@@ -159,6 +160,7 @@ final class BookingListContainerViewModel: ObservableObject {
     }
 
     func onAppear() {
+        guard hasRestoredFilters else { return }
         let tabViewModel = listViewModel(for: selectedTab)
         analytics.track(event: .BookingList.bookingListView(
             tab: selectedTab,
@@ -203,6 +205,8 @@ private extension BookingListContainerViewModel {
     func restorePersistedFilters() {
         Task { @MainActor in
             guard let storedFilters = await loadPersistedFilters() else {
+                hasRestoredFilters = true
+                onAppear()
                 return
             }
             let filters = BookingFiltersViewModel.Filters(
@@ -214,6 +218,8 @@ private extension BookingListContainerViewModel {
                 numberOfActiveFilters: storedFilters.numberOfActiveFilters
             )
             updateFilters(filters, shouldPersist: false)
+            hasRestoredFilters = true
+            onAppear()
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListContainerViewModelTests.swift
@@ -32,7 +32,7 @@ class BookingListContainerViewModelTests {
         #expect(analyticsProvider.received(event: "booking_list_view",
                                            with: [
                                             "selected_tab": "today",
-                                            "is_default_tab": true,
+                                            "is_default_tab": false,
                                             "is_list_empty": true,
                                             "is_filtered": false
                                            ]))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListContainerViewModelTests.swift
@@ -22,6 +22,7 @@ class BookingListContainerViewModelTests {
     @Test func event_fire_when_default_tab_selected() {
         // Given
         let viewModel = givenViewModel()
+        viewModel.hasRestoredFilters = true
 
         // When
         viewModel.setSelectedTab(to: .today)
@@ -41,6 +42,7 @@ class BookingListContainerViewModelTests {
     @Test func event_fire_when_nonDefault_tab_selected() {
         // Given
         let viewModel = givenViewModel()
+        viewModel.hasRestoredFilters = true
 
         // When
         viewModel.setSelectedTab(to: .all)
@@ -60,6 +62,7 @@ class BookingListContainerViewModelTests {
     @Test func event_fire_when_onAppear() {
         // Given
         let viewModel = givenViewModel()
+        viewModel.hasRestoredFilters = true
 
         // When
         viewModel.onAppear()


### PR DESCRIPTION
Follow up on pe5sF9-4Mi-p2#comment-5275

## Description
Adds firing the `booking_list_view` event when the filter sheet disappears.

## Test Steps
1. Open bookings list
2. Tap the Filter button and apply filters
3. Dismiss the filter sheet/Apply any filters
4. Verify `booking_list_view` event fire.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (Internal analytics fix, no user-facing change.)