### PR TITLE
POS Bookings: Remove payment section from booking detail

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -110,7 +110,6 @@ struct POSBookingDetailView: View {
                         POSBookingAttendanceSectionView(booking: booking)
                     }
                     customerSection
-                    paymentBreakdownSection
 
                     if shouldShowCollectPayment {
                         collectPaymentButton
@@ -322,23 +321,6 @@ struct POSBookingDetailView: View {
         }
     }
 
-    // MARK: - Payment Breakdown
-
-    private var paymentBreakdownSection: some View {
-        POSTotalsSectionView(
-            sectionTitle: Localization.paymentTitle,
-            subtotalLabel: Localization.serviceLabel,
-            subtotalAmount: booking.formattedSubtotal ?? booking.order.formattedSubtotal,
-            discountAmount: booking.order.formattedDiscountTotal ?? Localization.noDiscountPlaceholder,
-            taxAmount: booking.order.formattedTotalTax,
-            totalAmount: booking.order.formattedTotal,
-            paidAmount: nil,
-            paymentMethodTitle: "",
-            refunds: [],
-            netAmount: nil
-        )
-    }
-
     // MARK: - Payment Action
 
     private func dismissPayment() {
@@ -547,18 +529,6 @@ private enum Localization {
         comment: "Subtitle text below the booking note section explaining the note is private."
     )
 
-    static let paymentTitle = NSLocalizedString(
-        "pos.bookingDetailView.paymentTitle",
-        value: "Payment",
-        comment: "Section title for the payment breakdown in booking details."
-    )
-
-    static let serviceLabel = NSLocalizedString(
-        "pos.bookingDetailView.serviceLabel",
-        value: "Service",
-        comment: "Label for the service cost in booking payment breakdown."
-    )
-
     static let collectPaymentButton = NSLocalizedString(
         "pos.bookingDetailView.collectPaymentButton",
         value: "Collect payment",
@@ -620,13 +590,6 @@ private enum Localization {
         value: "Cancel Booking",
         comment: "Menu action to cancel a booking from the POS booking detail view."
     )
-
-    static let noDiscountPlaceholder = NSLocalizedString(
-        "pos.bookingDetailView.noDiscountPlaceholder",
-        value: "-",
-        comment: "Placeholder shown in the payment breakdown when there is no discount on the booking."
-    )
-
 }
 
 // MARK: - CopyableRow


### PR DESCRIPTION
Closes WOOMOB-2374

## Description

Discussed on call, removes payment section from booking detail. Follows Android: https://github.com/woocommerce/woocommerce-android/pull/15454

> _Temporarily hides Payment section on Booking detail to avoid confusing UX until we discuss a proper UX._

## Test Steps
- Note that paid booking has no payment section

## Screenshots

| Booking details | Order details |
|--------|--------|
| <img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - CIAB - 2026-03-05 at 09 07 29" src="https://github.com/user-attachments/assets/fb6b2fbe-3a3b-4488-8397-702fa4cbd29a" /> | <img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - CIAB - 2026-03-05 at 09 07 38" src="https://github.com/user-attachments/assets/a183bd49-1f38-4073-ac19-762c0744ede7" /> | 
