### PR TITLE
POS: Bypass coupon settings if CIAB site. Always enabled

### DIFF
--- a/Modules/Sources/Yosemite/PointOfSale/Coupons/PointOfSaleCouponService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Coupons/PointOfSaleCouponService.swift
@@ -19,14 +19,17 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
     private var siteID: Int64
     private let storage: StorageManagerType
     private let settingsStoreMethods: SettingStoreMethodsProtocol
+    private let isSiteCIAB: Bool
 
     init(siteID: Int64,
          currencySettings: CurrencySettings,
          settingStoreMethods: SettingStoreMethodsProtocol,
-         storage: StorageManagerType) {
+         storage: StorageManagerType,
+         isSiteCIAB: Bool = false) {
         self.siteID = siteID
         self.storage = storage
         self.settingsStoreMethods = settingStoreMethods
+        self.isSiteCIAB = isSiteCIAB
     }
 
     public convenience init(siteID: Int64,
@@ -34,14 +37,16 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
                             credentials: Credentials?,
                             selectedSite: AnyPublisher<JetpackSite?, Never>,
                             appPasswordSupportState: AnyPublisher<Bool, Never>,
-                            storage: StorageManagerType) {
+                            storage: StorageManagerType,
+                            isSiteCIAB: Bool = false) {
         let network = AlamofireNetwork(credentials: credentials,
                                        selectedSite: selectedSite,
                                        appPasswordSupportState: appPasswordSupportState)
         self.init(siteID: siteID,
                   currencySettings: currencySettings,
                   settingStoreMethods: SettingStoreMethods(storageManager: storage, network: network),
-                  storage: storage)
+                  storage: storage,
+                  isSiteCIAB: isSiteCIAB)
     }
 
     @MainActor
@@ -91,6 +96,9 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
 private extension PointOfSaleCouponService {
     @MainActor
     private func checkStoreCouponSettings() async throws -> Bool {
+        if isSiteCIAB {
+            return true
+        }
         let settingID = Constants.enableCouponsSettingID
         let storageSetting = storage.viewStorage.loadSiteSetting(siteID: siteID, settingID: settingID)
 
@@ -103,7 +111,10 @@ private extension PointOfSaleCouponService {
     }
 
     private func checkRemoteStoreCouponSettings() async throws -> Bool {
-        try await withCheckedThrowingContinuation { continuation in
+        if isSiteCIAB {
+            return true
+        }
+        return try await withCheckedThrowingContinuation { continuation in
             settingsStoreMethods.retrieveCouponSetting(siteID: siteID) { result in
                 switch result {
                 case let .success(isEnabled):

--- a/Modules/Tests/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/PointOfSaleCouponServiceTests.swift
@@ -99,6 +99,57 @@ struct PointOfSaleCouponServiceTests {
         }
     }
 
+    // MARK: - CIAB site tests
+
+    @Test func provideLocalPointOfSaleCoupons_when_CIAB_site_then_skips_settings_check_and_returns_coupons() async throws {
+        // Given
+        let ciabSettingStoreMethods = MockSettingStoreMethods()
+        ciabSettingStoreMethods.couponsEnabled = false
+        let ciabStorage = MockStorageManager()
+        let ciabMockStrategy = MockPointOfSaleCouponFetchStrategy()
+        let expectedCoupons = [POSItem.coupon(
+            POSCoupon(id: POSItemIdentifier(underlyingType: .product, itemID: 1), code: "test", summary: "test", dateExpires: nil)
+        )]
+        ciabMockStrategy.fetchLocalCouponsResult = expectedCoupons
+        let ciabSut = PointOfSaleCouponService(siteID: 123,
+                                               currencySettings: CurrencySettings(),
+                                               settingStoreMethods: ciabSettingStoreMethods,
+                                               storage: ciabStorage,
+                                               isSiteCIAB: true)
+
+        // When
+        let coupons = try await ciabSut.provideLocalPointOfSaleCoupons(fetchStrategy: ciabMockStrategy)
+
+        // Then
+        #expect(coupons == expectedCoupons)
+        #expect(ciabSettingStoreMethods.retrieveCouponSettingCalled == false)
+    }
+
+    @Test func providePointOfSaleCoupons_when_CIAB_site_and_fetch_fails_then_throws_loading_error_not_disabled() async throws {
+        // Given
+        let ciabSettingStoreMethods = MockSettingStoreMethods()
+        ciabSettingStoreMethods.couponsEnabled = false
+        let ciabStorage = MockStorageManager()
+        let ciabMockStrategy = MockPointOfSaleCouponFetchStrategy()
+        let underlyingError = NSError(domain: "test", code: 0)
+        ciabMockStrategy.fetchCouponsError = PointOfSaleCouponServiceError.couponsLoadingError(underlyingError: underlyingError)
+        let ciabSut = PointOfSaleCouponService(siteID: 123,
+                                               currencySettings: CurrencySettings(),
+                                               settingStoreMethods: ciabSettingStoreMethods,
+                                               storage: ciabStorage,
+                                               isSiteCIAB: true)
+
+        // When
+        do {
+            _ = try await ciabSut.providePointOfSaleCoupons(pageNumber: 1, fetchStrategy: ciabMockStrategy)
+        } catch {
+            // Then — should be loading error, NOT couponsDisabled
+            let expectedError = error as? PointOfSaleCouponServiceError
+            #expect(expectedError == .couponsLoadingError(underlyingError: underlyingError))
+            #expect(ciabSettingStoreMethods.retrieveCouponSettingCalled == false)
+        }
+    }
+
     @Test func providePointOfSaleCoupons_when_strategy_throws_and_coupons_disabled_then_throws_couponsDisabled() async throws {
         // Given
         settingStoreMethods.couponsEnabled = false

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -79,12 +79,15 @@ final class POSTabCoordinator {
     }()
 
     private lazy var posCouponProvider: PointOfSaleCouponServiceProtocol = {
+        let isSiteCIAB = storesManager.sessionManager.defaultSite
+            .map { CIABEligibilityChecker().isSiteCIAB($0) } ?? false
         return PointOfSaleCouponService(siteID: siteID,
                                         currencySettings: currencySettings,
                                         credentials: credentials,
                                         selectedSite: defaultSitePublisher,
                                         appPasswordSupportState: isAppPasswordSupported,
-                                        storage: storageManager)
+                                        storage: storageManager,
+                                        isSiteCIAB: isSiteCIAB)
     }()
 
     private lazy var posBookingListFetchStrategyFactory: POSBookingListFetchStrategyFactory = {


### PR DESCRIPTION
Closes WOOMOB-2400

## Description
Continuation from https://github.com/woocommerce/woocommerce-ios/pull/16763, where we handled catching the error when reaching to site settings fail.

After the fix, [we discovered ](https://github.com/woocommerce/woocommerce-ios/pull/16763#issuecomment-3996169349)that CIAB sites don't even have an endpoint for GET `/wc/v3/settings/general/woocommerce_enable_coupons`, so we can bypass this and enable coupons for CIAB sites regardless of site settings, which mimics Android implementation: https://github.com/woocommerce/woocommerce-android/pull/15479

## Test Steps
- On a CIAB site, Coupons should be enabled by default
- On a non-CIAB site test for no regression: Toggle the checkbox to disable coupons in WooCommerce > Settings > General > Coupons, confirm in POS that coupons are disabled -> Tap enable -> Confirm that are enabled.

<img width="672" height="164" alt="Screenshot 2026-03-05 at 12 23 56" src="https://github.com/user-attachments/assets/5e77c574-c026-4e9e-a862-a1fb8b107e5f" />

| Disabled | Enabled |
|--------|--------|
| <img width="1488" height="2266" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2026-03-05 at 12 25 57" src="https://github.com/user-attachments/assets/117e4d0e-441a-4f16-9a7d-9ba0394e2919" /> | <img width="1488" height="2266" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2026-03-05 at 12 26 02" src="https://github.com/user-attachments/assets/bcde5819-d9b2-4bb9-bda1-dd5d4ed8a138" /> |
