### PR TITLE
Fix infinite retry loop when booking list filter request fails

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Fix issue displaying onboarding tasks when logging in to sites with pretty permalinks using site credentials [https://github.com/woocommerce/woocommerce-ios/pull/16731]
 - [*] Fix scrolling glitch on Orders and Products lists [https://github.com/woocommerce/woocommerce-ios/pull/16714]
 - [*] Fix "See Receipt" button not appearing for orders with custom statuses [https://github.com/woocommerce/woocommerce-ios/pull/16673]
+- [*] Fix infinite retries in InfiniteScrollIndicator [https://github.com/woocommerce/woocommerce-ios/pull/16778]
 
 
 24.2

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/InfiniteScrollIndicator.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/InfiniteScrollIndicator.swift
@@ -12,14 +12,12 @@ struct InfiniteScrollIndicator: View {
 
     @ViewBuilder func createProgressView() -> some View {
         ProgressView()
+            .opacity(showContent ? 1 : 0)
             .frame(maxWidth: .infinity, alignment: .center)
             .listRowInsets(EdgeInsets())
             .listRowBackground(Color(.listBackground))
             .accessibilityElement()
             .accessibilityLabel(Localization.accessibilityLabel)
-            .if(!showContent) { progressView in
-                progressView.hidden() // Hidden but still in view hierarchy so `onAppear` will trigger the load action when needed
-            }
     }
 }
 


### PR DESCRIPTION
Part of WOOMOB-2399

## Description
When a booking list API request fails (e.g. the `attendance_status` filter causes a 400 error), `InfiniteScrollIndicator` was triggering an infinite retry loop.

**Root cause:** `InfiniteScrollIndicator` used `.if(!showContent) { progressView.hidden() }` to show/hide the spinner. The `.if` extension uses `@ViewBuilder if-else` internally, which returns `_ConditionalContent` with two branches. When `showContent` toggles, SwiftUI destroys the old branch and inserts the new one — firing `.onAppear` each time. Since `.onAppear` calls `ensureNextPageIsSynced()`, every toggle of `shouldShowBottomActivityIndicator` (sync start → sync end) triggered a new page load attempt. On error, this created an infinite loop: sync fails → indicator toggles → `onAppear` fires → retry → fails → repeat.

**Fix:** Replace `.if { .hidden() }` with `.opacity(showContent ? 1 : 0)`. Opacity applies a modifier to the same stable view identity — no branch switching, no view recreation, no spurious `.onAppear`. The indicator still correctly fires `.onAppear` when it scrolls into the viewport, which is the only trigger needed for pagination.

## Test Steps
1. Enable the Bookings tab (requires a site with WooCommerce Bookings plugin)
2. Open the booking list
3. Apply the "Attended" attendance status filter
4. Observe that the failed request is not retried in a loop (previously it would retry continuously)
5. Verify infinite scroll still works on a successful request by scrolling to the bottom of a long list

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.