### PR TITLE
Change attendance status filter to single selection

### DIFF
--- a/Modules/Sources/Networking/Remote/BookingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/BookingsRemote.swift
@@ -39,7 +39,7 @@ public struct BookingFilters {
     public let resourceIDs: [Int64]
     public let startDateBefore: String?
     public let startDateAfter: String?
-    public let attendanceStatuses: [String]
+    public let attendanceStatus: String?
     public let paymentStatuses: [String]
     public let bookingStatusExclude: [String]
 
@@ -49,7 +49,7 @@ public struct BookingFilters {
         resourceIDs: [Int64] = [],
         startDateBefore: String? = nil,
         startDateAfter: String? = nil,
-        attendanceStatuses: [String] = [],
+        attendanceStatus: String? = nil,
         paymentStatuses: [String] = [],
         bookingStatusExclude: [String] = []
     ) {
@@ -58,7 +58,7 @@ public struct BookingFilters {
         self.resourceIDs = resourceIDs
         self.startDateBefore = startDateBefore
         self.startDateAfter = startDateAfter
-        self.attendanceStatuses = attendanceStatuses
+        self.attendanceStatus = attendanceStatus
         self.paymentStatuses = paymentStatuses
         self.bookingStatusExclude = bookingStatusExclude
     }
@@ -77,7 +77,7 @@ public struct BookingFilters {
             startDateAfter: Self.mostRestrictiveDate(date1: startDateAfter,
                                                      date2: userFilters.startDateAfter,
                                                      pickEarlier: false),
-            attendanceStatuses: userFilters.attendanceStatuses,
+            attendanceStatus: userFilters.attendanceStatus,
             bookingStatusExclude: bookingStatusExclude
         )
     }
@@ -156,8 +156,8 @@ public final class BookingsRemote: Remote, BookingsRemoteProtocol {
                 parameters[ParameterKey.startDateAfter] = adjustedDate.ISO8601Format()
             }
 
-            if filters.attendanceStatuses.isNotEmpty {
-                parameters[ParameterKey.attendanceStatus] = filters.attendanceStatuses
+            if let attendanceStatus = filters.attendanceStatus {
+                parameters[ParameterKey.attendanceStatus] = attendanceStatus
             }
 
             if filters.paymentStatuses.isNotEmpty {

--- a/Modules/Sources/Yosemite/Model/Bookings/StoredBookingFilters.swift
+++ b/Modules/Sources/Yosemite/Model/Bookings/StoredBookingFilters.swift
@@ -16,19 +16,19 @@ public struct StoredBookingFilters: Codable, Equatable, GeneratedFakeable {
     public struct Filters: Codable, Equatable {
         public let teamMembers: [BookingTeamMemberFilter]
         public let products: [BookingProductFilter]
-        public let attendanceStatuses: [BookingAttendanceStatus]
+        public let attendanceStatus: BookingAttendanceStatus?
         public let customers: [BookingCustomerFilter]
         public let dateRange: BookingDateRangeFilter?
         public let numberOfActiveFilters: Int
 
         public init(teamMembers: [BookingTeamMemberFilter],
                     products: [BookingProductFilter],
-                    attendanceStatuses: [BookingAttendanceStatus],
+                    attendanceStatus: BookingAttendanceStatus?,
                     customers: [BookingCustomerFilter],
                     dateRange: BookingDateRangeFilter?) {
             self.teamMembers = teamMembers
             self.products = products
-            self.attendanceStatuses = attendanceStatuses
+            self.attendanceStatus = attendanceStatus
             self.customers = customers
             self.dateRange = dateRange
             self.numberOfActiveFilters = {
@@ -39,7 +39,7 @@ public struct StoredBookingFilters: Codable, Equatable, GeneratedFakeable {
                 if products.isNotEmpty {
                     total += 1
                 }
-                if attendanceStatuses.isNotEmpty {
+                if attendanceStatus != nil {
                     total += 1
                 }
                 if customers.isNotEmpty {

--- a/Modules/Sources/Yosemite/Tools/Bookings/ResultsController+FilterBookings.swift
+++ b/Modules/Sources/Yosemite/Tools/Bookings/ResultsController+FilterBookings.swift
@@ -23,8 +23,9 @@ extension NSPredicate {
         // TODO: update `statusKey` to paymentStatusKey once available
         let paymentStatusesPredicate = filters.paymentStatuses.isNotEmpty ? NSPredicate(format: "statusKey IN %@", filters.paymentStatuses) : nil
 
-        let attendanceStatusesPredicate = filters.attendanceStatuses.isNotEmpty ?
-        NSPredicate(format: "attendanceStatusKey IN %@", filters.attendanceStatuses) : nil
+        let attendanceStatusPredicate = filters.attendanceStatus.map {
+            NSPredicate(format: "attendanceStatusKey == %@", $0)
+        }
 
         let bookingStatusExcludePredicate = filters.bookingStatusExclude.isNotEmpty ?
         NSPredicate(format: "NOT (statusKey IN %@)", filters.bookingStatusExclude) : nil
@@ -37,7 +38,7 @@ extension NSPredicate {
             startDateBeforePredicate,
             startDateAfterPredicate,
             paymentStatusesPredicate,
-            attendanceStatusesPredicate,
+            attendanceStatusPredicate,
             bookingStatusExcludePredicate
         ].compactMap({ $0 })
 

--- a/Modules/Tests/YosemiteTests/Stores/AppSettingsStoreTests+BookingFilters.swift
+++ b/Modules/Tests/YosemiteTests/Stores/AppSettingsStoreTests+BookingFilters.swift
@@ -56,7 +56,7 @@ struct AppSettingsStoreTests_BookingFilters {
         let filters = StoredBookingFilters.Filters(
             teamMembers: [BookingTeamMemberFilter(resourceID: 100, name: "Team Member 1")],
             products: [BookingProductFilter(productID: 1, name: "Product 1")],
-            attendanceStatuses: [.attended, .unattended],
+            attendanceStatus: .attended,
             customers: [BookingCustomerFilter(customerID: 10, name: "Customer 1")],
             dateRange: nil
         )
@@ -96,7 +96,7 @@ struct AppSettingsStoreTests_BookingFilters {
         let filters1 = StoredBookingFilters.Filters(
             teamMembers: [BookingTeamMemberFilter(resourceID: 100, name: "Team Member 1")],
             products: [BookingProductFilter(productID: 1, name: "Product 1")],
-            attendanceStatuses: [.attended],
+            attendanceStatus: .attended,
             customers: [BookingCustomerFilter(customerID: 10, name: "Customer 1")],
             dateRange: nil
         )
@@ -104,7 +104,7 @@ struct AppSettingsStoreTests_BookingFilters {
         let filters2 = StoredBookingFilters.Filters(
             teamMembers: [BookingTeamMemberFilter(resourceID: 200, name: "Team Member 2")],
             products: [BookingProductFilter(productID: 2, name: "Product 2")],
-            attendanceStatuses: [.unattended],
+            attendanceStatus: .unattended,
             customers: [],
             dateRange: nil
         )
@@ -159,7 +159,7 @@ struct AppSettingsStoreTests_BookingFilters {
         let initialFilters = StoredBookingFilters.Filters(
             teamMembers: [BookingTeamMemberFilter(resourceID: 100, name: "Team Member 1")],
             products: [BookingProductFilter(productID: 1, name: "Product 1")],
-            attendanceStatuses: [],
+            attendanceStatus: nil,
             customers: [BookingCustomerFilter(customerID: 10, name: "Customer 1")],
             dateRange: nil
         )
@@ -167,7 +167,7 @@ struct AppSettingsStoreTests_BookingFilters {
         let updatedFilters = StoredBookingFilters.Filters(
             teamMembers: [],
             products: [],
-            attendanceStatuses: [.attended],
+            attendanceStatus: .attended,
             customers: [BookingCustomerFilter(customerID: 20, name: "Customer 2")],
             dateRange: nil
         )
@@ -216,7 +216,7 @@ struct AppSettingsStoreTests_BookingFilters {
         let filters = StoredBookingFilters.Filters(
             teamMembers: [BookingTeamMemberFilter(resourceID: 100, name: "Team Member 1")],
             products: [],
-            attendanceStatuses: [.attended],
+            attendanceStatus: .attended,
             customers: [],
             dateRange: nil
         )

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Fix scrolling glitch on Orders and Products lists [https://github.com/woocommerce/woocommerce-ios/pull/16714]
 - [*] Fix "See Receipt" button not appearing for orders with custom statuses [https://github.com/woocommerce/woocommerce-ios/pull/16673]
 - [*] Fix infinite retries in InfiniteScrollIndicator [https://github.com/woocommerce/woocommerce-ios/pull/16778]
+- [*] Fix attendance status filter in Bookings [https://github.com/woocommerce/woocommerce-ios/pull/16779]
 
 
 24.2

--- a/WooCommerce/Classes/Bookings/BookingFilters/BookingFiltersViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/BookingFiltersViewModel.swift
@@ -35,13 +35,13 @@ final class BookingFiltersViewModel: FilterListViewModel {
         let teamMembers = (teamMemberFilterViewModel.selectedValue as? MultipleFilterSelection)?.items as? [BookingTeamMemberFilter] ?? []
         let products = (productFilterViewModel.selectedValue as? MultipleFilterSelection)?.items as? [BookingProductFilter] ?? []
         let customers = (customerFilterViewModel.selectedValue as? MultipleFilterSelection)?.items as? [BookingCustomerFilter] ?? []
-        let attendanceStatuses = (attendanceStatusFilterViewModel.selectedValue as? MultipleFilterSelection)?.items as? [BookingAttendanceStatus] ?? []
+        let attendanceStatus = attendanceStatusFilterViewModel.selectedValue as? BookingAttendanceStatus
         let dateRange = dateTimeFilterViewModel.selectedValue as? BookingDateRangeFilter
         let numberOfActiveFilters = filterTypeViewModels.numberOfActiveFilters
 
         return Filters(teamMembers: teamMembers,
                        products: products,
-                       attendanceStatuses: attendanceStatuses,
+                       attendanceStatus: attendanceStatus,
                        customers: customers,
                        dateRange: dateRange,
                        numberOfActiveFilters: numberOfActiveFilters)
@@ -82,7 +82,7 @@ final class BookingFiltersViewModel: FilterListViewModel {
 
         let teamMembers: [BookingTeamMemberFilter]
         let products: [BookingProductFilter]
-        let attendanceStatuses: [BookingAttendanceStatus]
+        let attendanceStatus: BookingAttendanceStatus?
         let customers: [BookingCustomerFilter]
         let dateRange: BookingDateRangeFilter?
 
@@ -91,7 +91,7 @@ final class BookingFiltersViewModel: FilterListViewModel {
         init() {
             teamMembers = []
             products = []
-            attendanceStatuses = []
+            attendanceStatus = nil
             customers = []
             dateRange = nil
             numberOfActiveFilters = 0
@@ -99,13 +99,13 @@ final class BookingFiltersViewModel: FilterListViewModel {
 
         init(teamMembers: [BookingTeamMemberFilter],
              products: [BookingProductFilter],
-             attendanceStatuses: [BookingAttendanceStatus],
+             attendanceStatus: BookingAttendanceStatus?,
              customers: [BookingCustomerFilter],
              dateRange: BookingDateRangeFilter?,
              numberOfActiveFilters: Int) {
             self.teamMembers = teamMembers
             self.products = products
-            self.attendanceStatuses = attendanceStatuses
+            self.attendanceStatus = attendanceStatus
             self.customers = customers
             self.dateRange = dateRange
             self.numberOfActiveFilters = numberOfActiveFilters
@@ -113,8 +113,10 @@ final class BookingFiltersViewModel: FilterListViewModel {
 
         var readableString: String {
             var readable: [String] = teamMembers.map { $0.name } +
-            products.map { $0.name } +
-            attendanceStatuses.map { $0.localizedTitle }
+            products.map { $0.name }
+            if let attendanceStatus {
+                readable.append(attendanceStatus.localizedTitle)
+            }
 
             readable += customers.map { $0.name }
 
@@ -132,7 +134,7 @@ final class BookingFiltersViewModel: FilterListViewModel {
                 resourceIDs: teamMembers.map { $0.resourceID },
                 startDateBefore: dateRange?.endDate?.ISO8601Format(),
                 startDateAfter: dateRange?.startDate?.ISO8601Format(),
-                attendanceStatuses: attendanceStatuses.map { $0.rawValue },
+                attendanceStatus: attendanceStatus?.rawValue,
             )
         }
     }
@@ -183,10 +185,10 @@ extension BookingFiltersViewModel.BookingListFilter {
                                        listSelectorConfig: .bookingCustomers(siteID: siteID),
                                        selectedValue: MultipleFilterSelection(items: filters.customers))
         case .attendanceStatus:
-            let options: [BookingAttendanceStatus?] = [.attended, .unattended]
+            let options: [BookingAttendanceStatus?] = [nil, .attended, .unattended]
             return FilterTypeViewModel(title: title,
-                                       listSelectorConfig: .multiSelectStaticOptions(options: options),
-                                       selectedValue: MultipleFilterSelection(items: filters.attendanceStatuses))
+                                       listSelectorConfig: .staticOptions(options: options),
+                                       selectedValue: filters.attendanceStatus)
         case .dateTime:
             return FilterTypeViewModel(title: title,
                                        listSelectorConfig: .bookingDateTime,

--- a/WooCommerce/Classes/Bookings/BookingList/BookingList+Analytics.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingList+Analytics.swift
@@ -43,7 +43,7 @@ extension WooAnalyticsEvent {
 
         static func applyFilters(_ filters: BookingFiltersViewModel.Filters) -> WooAnalyticsEvent {
             var appliedFilters = [WooAnalyticsEvent.BookingList.Filter]()
-            if filters.attendanceStatuses.isNotEmpty {
+            if filters.attendanceStatus != nil {
                 appliedFilters.append(.attendanceStatus)
             }
             if filters.bookingFilters.customerIDs.isNotEmpty {

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
@@ -206,7 +206,7 @@ private extension BookingListContainerViewModel {
             let filters = BookingFiltersViewModel.Filters(
                 teamMembers: storedFilters.teamMembers,
                 products: storedFilters.products,
-                attendanceStatuses: storedFilters.attendanceStatuses,
+                attendanceStatus: storedFilters.attendanceStatus,
                 customers: storedFilters.customers,
                 dateRange: storedFilters.dateRange,
                 numberOfActiveFilters: storedFilters.numberOfActiveFilters
@@ -236,7 +236,7 @@ private extension BookingListContainerViewModel {
         let persistedFilters = StoredBookingFilters.Filters(
             teamMembers: filters.teamMembers,
             products: filters.products,
-            attendanceStatuses: filters.attendanceStatuses,
+            attendanceStatus: filters.attendanceStatus,
             customers: filters.customers,
             dateRange: filters.dateRange
         )

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListContainerViewModelTests.swift
@@ -123,7 +123,7 @@ class BookingListContainerViewModelTests {
         let filters = BookingFiltersViewModel.Filters(
             teamMembers: [BookingTeamMemberFilter(resourceID: 0, name: "")],
             products: [BookingProductFilter(productID: 0, name: "")],
-            attendanceStatuses: [BookingAttendanceStatus.attended],
+            attendanceStatus: .attended,
             customers: [BookingCustomerFilter(customerID: 0, name: "")],
             dateRange: BookingDateRangeFilter(startDate: Date(), endDate: Date()),
             numberOfActiveFilters: 5
@@ -168,7 +168,7 @@ class BookingListContainerViewModelTests {
         let filters = BookingFiltersViewModel.Filters(
             teamMembers: [BookingTeamMemberFilter(resourceID: 1, name: "Alice")],
             products: [],
-            attendanceStatuses: [],
+            attendanceStatus: nil,
             customers: [],
             dateRange: nil,
             numberOfActiveFilters: 1
@@ -191,7 +191,7 @@ class BookingListContainerViewModelTests {
         let filters = BookingFiltersViewModel.Filters(
             teamMembers: [BookingTeamMemberFilter(resourceID: 1, name: "Alice")],
             products: [],
-            attendanceStatuses: [],
+            attendanceStatus: nil,
             customers: [],
             dateRange: nil,
             numberOfActiveFilters: 1

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
@@ -650,7 +650,7 @@ class BookingListViewModelTests {
         let userFilters = BookingFiltersViewModel.Filters(
             teamMembers: [BookingTeamMemberFilter(resourceID: 0, name: "Any")],
             products: [],
-            attendanceStatuses: [],
+            attendanceStatus: nil,
             customers: [],
             dateRange: nil,
             numberOfActiveFilters: 1
@@ -684,7 +684,7 @@ class BookingListViewModelTests {
         let userFilters = BookingFiltersViewModel.Filters(
             teamMembers: [],
             products: [],
-            attendanceStatuses: [],
+            attendanceStatus: nil,
             customers: [],
             dateRange: BookingDateRangeFilter(
                 startDate: Date(timeIntervalSince1970: 1609416000), // 2020-12-31T12:00:00Z
@@ -729,7 +729,7 @@ class BookingListViewModelTests {
         let userFilters = BookingFiltersViewModel.Filters(
             teamMembers: [],
             products: [],
-            attendanceStatuses: [],
+            attendanceStatus: nil,
             customers: [],
             dateRange: BookingDateRangeFilter(
                 startDate: Date(timeIntervalSince1970: 1609632000), // 2021-01-03T00:00:00Z
@@ -773,7 +773,7 @@ class BookingListViewModelTests {
         let userFilters = BookingFiltersViewModel.Filters(
             teamMembers: [],
             products: [],
-            attendanceStatuses: [],
+            attendanceStatus: nil,
             customers: [],
             dateRange: BookingDateRangeFilter(startDate: userStartDate, endDate: userEndDate),
             numberOfActiveFilters: 1
@@ -806,7 +806,7 @@ class BookingListViewModelTests {
         let userFilters = BookingFiltersViewModel.Filters(
             teamMembers: [BookingTeamMemberFilter(resourceID: 42, name: "Alice")],
             products: [BookingProductFilter(productID: 100, name: "Massage")],
-            attendanceStatuses: [.attended],
+            attendanceStatus: .attended,
             customers: [BookingCustomerFilter(customerID: 7, name: "Bob")],
             dateRange: nil,
             numberOfActiveFilters: 4
@@ -819,7 +819,7 @@ class BookingListViewModelTests {
         // Then - non-date filters should pass through
         #expect(capturedFilters?.resourceIDs == [42])
         #expect(capturedFilters?.productIDs == [100])
-        #expect(capturedFilters?.attendanceStatuses == [BookingAttendanceStatus.attended.rawValue])
+        #expect(capturedFilters?.attendanceStatus == BookingAttendanceStatus.attended.rawValue)
         #expect(capturedFilters?.customerIDs == [7])
         // Tab date constraints should still be applied
         #expect(capturedFilters?.startDateAfter == "2020-12-31T23:59:59Z")
@@ -847,7 +847,7 @@ class BookingListViewModelTests {
         let userFilters = BookingFiltersViewModel.Filters(
             teamMembers: [BookingTeamMemberFilter(resourceID: 42, name: "Alice")],
             products: [],
-            attendanceStatuses: [],
+            attendanceStatus: nil,
             customers: [],
             dateRange: nil,
             numberOfActiveFilters: 1
@@ -864,7 +864,7 @@ class BookingListViewModelTests {
         #expect(capturedFilters?.startDateBefore == "2021-01-02T00:00:00Z")
         #expect(capturedFilters?.resourceIDs == [])
         #expect(capturedFilters?.productIDs == [])
-        #expect(capturedFilters?.attendanceStatuses == [])
+        #expect(capturedFilters?.attendanceStatus == nil)
         #expect(capturedFilters?.customerIDs == [])
         #expect(capturedFilters?.bookingStatusExclude == [BookingStatus.cancelled.rawValue])
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingSearchViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingSearchViewModelTests.swift
@@ -353,7 +353,7 @@ struct BookingSearchViewModelTests {
         let userFilters = BookingFiltersViewModel.Filters(
             teamMembers: [],
             products: [],
-            attendanceStatuses: [],
+            attendanceStatus: nil,
             customers: [],
             dateRange: BookingDateRangeFilter(
                 startDate: Date(timeIntervalSince1970: 1609416000), // 2020-12-31T12:00:00Z
@@ -400,7 +400,7 @@ struct BookingSearchViewModelTests {
         let userFilters = BookingFiltersViewModel.Filters(
             teamMembers: [],
             products: [],
-            attendanceStatuses: [],
+            attendanceStatus: nil,
             customers: [],
             dateRange: BookingDateRangeFilter(
                 startDate: Date(timeIntervalSince1970: 1609632000), // 2021-01-03T00:00:00Z
@@ -449,7 +449,7 @@ struct BookingSearchViewModelTests {
         let userFilters = BookingFiltersViewModel.Filters(
             teamMembers: [],
             products: [],
-            attendanceStatuses: [],
+            attendanceStatus: nil,
             customers: [],
             dateRange: BookingDateRangeFilter(startDate: userStartDate, endDate: userEndDate),
             numberOfActiveFilters: 1
@@ -491,7 +491,7 @@ struct BookingSearchViewModelTests {
         let userFilters = BookingFiltersViewModel.Filters(
             teamMembers: [BookingTeamMemberFilter(resourceID: 42, name: "Alice")],
             products: [BookingProductFilter(productID: 100, name: "Massage")],
-            attendanceStatuses: [.attended],
+            attendanceStatus: .attended,
             customers: [BookingCustomerFilter(customerID: 7, name: "Bob")],
             dateRange: nil,
             numberOfActiveFilters: 4
@@ -505,7 +505,7 @@ struct BookingSearchViewModelTests {
         // Then
         #expect(capturedFilters?.resourceIDs == [42])
         #expect(capturedFilters?.productIDs == [100])
-        #expect(capturedFilters?.attendanceStatuses == [BookingAttendanceStatus.attended.rawValue])
+        #expect(capturedFilters?.attendanceStatus == BookingAttendanceStatus.attended.rawValue)
         #expect(capturedFilters?.customerIDs == [7])
         #expect(capturedFilters?.startDateAfter == "2020-12-31T23:59:59Z")
         #expect(capturedFilters?.startDateBefore == "2021-01-02T00:00:00Z")


### PR DESCRIPTION
## Description
The `/wc-bookings/v2/bookings` API accepts `attendance_status` as a single string value, not an array. The previous implementation modelled it as a multi-select array (`[BookingAttendanceStatus]`), which caused a 400 error when the filter was applied.

This PR fixes the root cause by converting attendance status filtering to single selection throughout the stack:

- **`BookingFilters`** (`BookingsRemote`): `attendanceStatuses: [String]` → `attendanceStatus: String?`, sent directly as a plain string parameter
- **`StoredBookingFilters`**: `attendanceStatuses: [BookingAttendanceStatus]` → `attendanceStatus: BookingAttendanceStatus?` for persistence
- **`ResultsController+FilterBookings`**: local predicate changed from `IN %@` (array) to `== %@` (single value)
- **`BookingFiltersViewModel`**: `Filters.attendanceStatuses` → `attendanceStatus`; UI selector changed from `.multiSelectStaticOptions` to `.staticOptions` (single-select) with `nil` as the "any" option
- All call sites and tests updated accordingly

## Test Steps
1. Log in to a CIAB site with bookings.
2. Open the booking list
3. Tap the filter button → Attendance Status
4. Verify only one option can be selected at a time (single-select UI)
5. Select "Attended" and apply — verify the API request sends `attendance_status=attended` as a plain string (no 400 error)
6. Clear the filter — verify the parameter is omitted from the request and the request succeeds.

## Screenshots


https://github.com/user-attachments/assets/3639cba6-ab98-4caf-a986-8840e5f188a2



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.