### PR TITLE
Update push notification card subtitle text

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/ConnectWPComCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/ConnectWPComCard.swift
@@ -58,17 +58,17 @@ private extension ConnectWPComCard {
 
     enum Localization {
         static let title = NSLocalizedString(
-            "dashboardView.connectWPComCard.title",
+            "connectWPComCard.title",
             value: "Never miss a new order",
             comment: "Title of the Connect WPCom card on My Store screen"
         )
         static let subtitle = NSLocalizedString(
-            "dashboardView.connectWPComCard.subtitle",
+            "connectWPComCard.subtitle",
             value: "Enable push notifications to stay on top of new orders and reviews.",
             comment: "Subtitle of the Connect WPCom card on My Store screen"
         )
         static let hideButton = NSLocalizedString(
-            "dashboardView.connectWPComCard.hideButton",
+            "connectWPComCard.hideButton",
             value: "Hide this content",
             comment: "Button to hide the Connect WPCom card from the My Store screen"
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/ConnectWPComCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/ConnectWPComCard.swift
@@ -64,7 +64,7 @@ private extension ConnectWPComCard {
         )
         static let subtitle = NSLocalizedString(
             "dashboardView.connectWPComCard.subtitle",
-            value: "Connect your store to a WordPress.com account to get alerts for new orders and reviews.",
+            value: "Enable push notifications to stay on top of new orders and reviews.",
             comment: "Subtitle of the Connect WPCom card on My Store screen"
         )
         static let hideButton = NSLocalizedString(


### PR DESCRIPTION
Originates from p1772708421676309-slack-C03L1NF1EA3

## Description

Update the WPCOM pn card's text on the dashboard

## Test Steps
1. Fire up/Reuse as a site that has WPCom notifications setup but not registered
2. Check the text on the dashboard card.
3. Validate text matches `Enable push notifications to stay on top of new orders and reviews.`

## Screenshots
| Before | After |
| --- | --- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-05 at 13 29 19" src="https://github.com/user-attachments/assets/7487b3db-78c4-4287-bf97-778cb8bc84e9" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-05 at 13 31 41" src="https://github.com/user-attachments/assets/31c3f82b-9355-43f8-9a8a-a28ec92b21bd" /> |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.