### PR TITLE
Fix Custom Fields dismissing when opened from Orders tab

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [*] Fix "See Receipt" button not appearing for orders with custom statuses [https://github.com/woocommerce/woocommerce-ios/pull/16673]
 - [*] Fix infinite retries in InfiniteScrollIndicator [https://github.com/woocommerce/woocommerce-ios/pull/16778]
 - [*] Fix attendance status filter in Bookings [https://github.com/woocommerce/woocommerce-ios/pull/16779]
+- [*] Fix Custom Fields closing immediately when opened from a product in the Orders tab [https://github.com/woocommerce/woocommerce-ios/pull/16782]
 
 
 24.2

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -6,7 +6,6 @@ final class CustomFieldsListHostingController: UIHostingController<CustomFieldsL
     private let viewModel: CustomFieldsListViewModel
     private let analytics: Analytics
     private var subscriptions: Set<AnyCancellable> = []
-    private var inProgressController: UIViewController?
 
     init(viewModel: CustomFieldsListViewModel, analytics: Analytics = ServiceLocator.analytics) {
         self.viewModel = viewModel
@@ -111,20 +110,18 @@ private extension CustomFieldsListHostingController {
     }
 
     func displayInProgressController() {
-        let controller = InProgressViewController(
+        let inProgressController = InProgressViewController(
             viewProperties: InProgressViewProperties(
                 title: Localization.inProgressTitle,
                 message: Localization.inProgressMessage
             )
         )
-        controller.modalPresentationStyle = .overFullScreen
-        inProgressController = controller
-        present(controller, animated: true)
+        inProgressController.modalPresentationStyle = .overFullScreen
+        present(inProgressController, animated: true)
     }
 
     func dismissInProgressController() {
-        inProgressController?.dismiss(animated: true)
-        inProgressController = nil
+        presentedViewController?.dismiss(animated: true)
     }
 
     func presentBackNavigationActionSheet() {

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -6,6 +6,7 @@ final class CustomFieldsListHostingController: UIHostingController<CustomFieldsL
     private let viewModel: CustomFieldsListViewModel
     private let analytics: Analytics
     private var subscriptions: Set<AnyCancellable> = []
+    private var inProgressController: UIViewController?
 
     init(viewModel: CustomFieldsListViewModel, analytics: Analytics = ServiceLocator.analytics) {
         self.viewModel = viewModel
@@ -110,18 +111,20 @@ private extension CustomFieldsListHostingController {
     }
 
     func displayInProgressController() {
-        let inProgressController = InProgressViewController(
+        let controller = InProgressViewController(
             viewProperties: InProgressViewProperties(
                 title: Localization.inProgressTitle,
                 message: Localization.inProgressMessage
             )
         )
-        inProgressController.modalPresentationStyle = .overFullScreen
-        present(inProgressController, animated: true)
+        controller.modalPresentationStyle = .overFullScreen
+        inProgressController = controller
+        present(controller, animated: true)
     }
 
     func dismissInProgressController() {
-        dismiss(animated: true)
+        inProgressController?.dismiss(animated: true)
+        inProgressController = nil
     }
 
     func presentBackNavigationActionSheet() {


### PR DESCRIPTION
Closes [WOOMOB-2343](https://linear.app/a8c/issue/WOOMOB-2343)

## Description
 
### Issue
Custom fields view closes right after opening it when viewing a product's  detail in an order.

### Root
The `$isSavingChanges` Combine subscription in `CustomFieldsListHostingController` immediately fired `dismiss(animated: true)` on the initial `false` value. When the controller was inside a modally-presented navigation controller (Orders flow), this propagated up the UIKit chain and dismissed the entire product modal.

### Solution
Fix by tracking the in-progress controller explicitly and dismissing it by reference instead of calling `self.dismiss()`.

## Test Steps
You'll need a store with a product that has custom fields and an order for it. 

1. Open the app
2. Navigate to the order with the product having the custom field.
3. Tap the product in the PRODUCTS section
4. Scroll to the "Custom Fields" row and tap it.
5. Note that the custom fields are presented.
6. Validate that custom fields can still be opened as expected view the Products tab.

## Screenshots
| Before | After |
| --- | --- |
| ![Simulator Screen Recording - iPhone 17 Pro - 2026-03-05 at 14 30 05](https://github.com/user-attachments/assets/77419fc1-97fc-4313-bf43-447b5dec1bf6) | ![Simulator Screen Recording - iPhone 17 Pro - 2026-03-05 at 14 24 24](https://github.com/user-attachments/assets/6cbb41d5-303c-4d89-8e12-695bac399d7c) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
