### PR TITLE
Add Figma MCP integration for design-driven development

### DIFF
--- a/.claude/rules/agent-environment-awareness.md
+++ b/.claude/rules/agent-environment-awareness.md
@@ -1,0 +1,40 @@
+# Agent Environment Awareness
+
+**Never assume which environment you are in.** When MCP tools are missing or MCP setup is needed, ask the user which environment they're running (Claude Code CLI, Claude Desktop, Cursor, VS Code, etc.) before giving any setup guidance. The presence of `.mcp.json` in the project does NOT mean you are in Claude Code CLI — the file is checked into the repo and visible to all environments. Claude Code CLI and Claude Desktop have nearly identical capabilities, so you cannot distinguish them from tool availability alone.
+
+These instructions are shared across multiple environments. Most instructions (build commands, git, testing, code conventions, skills, rules) work identically everywhere. The differences are narrow but matter when they come up.
+
+## MCP Configuration
+
+`.mcp.json` in the project root is the **single source of truth** for MCP servers (Figma, mobile-mcp, etc.).
+
+- **Claude Code (CLI)** auto-loads `.mcp.json` — no action needed.
+- **Other environments** (Claude Desktop, Cursor, VS Code, etc.) may not read `.mcp.json`. If expected MCP tools are missing, the agent should:
+  1. Read `.mcp.json` to identify the needed servers
+  2. Ask the user which environment they're in (don't guess)
+  3. Guide the user to add the MCP server through their environment's settings
+
+Known MCP config locations:
+| Environment | Config location |
+|-------------|----------------|
+| Claude Code (CLI) | `.mcp.json` (auto-loaded) |
+| Claude Desktop | Add manually through Desktop settings (not via config file editing — see below) |
+
+For other environments, ask the user where their MCP config lives.
+
+**Claude Desktop**: Do NOT try to programmatically edit config files — this is unreliable and may not be picked up by the app. Instead, provide the user with the server details (name, command, args) and guide them to add the MCP server manually through Claude Desktop's Settings UI. For HTTP MCP servers (like Figma), the user needs the `mcp-remote` bridge: command `npx`, args `mcp-remote <url>`.
+
+## `claude` CLI Commands
+
+Commands like `claude mcp add` require the `claude` CLI binary, which is **only available in Claude Code CLI**. In other environments (including Claude Desktop), guide the user to add the MCP server through their environment's settings.
+
+## When Environment Matters
+
+- **MCP server setup** — config location differs
+- **`claude` CLI commands** — only work in Claude Code CLI
+
+For everything else — build commands, git, testing, code conventions, skills, rules, settings — the environment doesn't matter.
+
+## How to Determine Your Environment
+
+**Ask the user.** Don't infer from tool availability or from the presence of `.mcp.json` — these are not reliable signals.

--- a/.claude/rules/agent-environment-awareness.md
+++ b/.claude/rules/agent-environment-awareness.md
@@ -8,7 +8,7 @@ These instructions are shared across multiple environments. Most instructions (b
 
 `.mcp.json` in the project root is the **single source of truth** for MCP servers (Figma, mobile-mcp, etc.).
 
-- **Claude Code (CLI)** auto-loads `.mcp.json` — no action needed.
+- **Claude Code (CLI)** auto-loads `.mcp.json`. If authentication is required, ask the user to type `/mcp`, select their MCP of choice and proceed with authentication manually.
 - **Other environments** (Claude Desktop, Cursor, VS Code, etc.) may not read `.mcp.json`. If expected MCP tools are missing, the agent should:
   1. Read `.mcp.json` to identify the needed servers
   2. Ask the user which environment they're in (don't guess)

--- a/.claude/rules/context-a8c.md
+++ b/.claude/rules/context-a8c.md
@@ -14,7 +14,8 @@ Visit the ContextA8C setup page on MC (Automatticians: search "ContextA8C" on MC
 
 | Client | Setup |
 |--------|-------|
-| Claude Code | `claude mcp add --transport stdio --scope user context-a8c -- npx -y @automattic/mcp-context-a8c` (or run `/setup-context-a8c` skill) |
+| Claude Code (requires `claude` CLI binary) | `claude mcp add --transport stdio --scope user context-a8c -- npx -y @automattic/mcp-context-a8c` (or run `/setup-context-a8c` skill). For environments without the `claude` binary, add the JSON config below manually — see `agent-environment-awareness.md`. |
+| Claude Desktop | Add manually through Desktop settings: command `npx`, args `-y @automattic/mcp-context-a8c`. Do not edit config files — see `agent-environment-awareness.md`. |
 | Cursor | Add JSON config below to `.cursor/mcp.json` |
 | VS Code | Add JSON config below to `.vscode/mcp.json` |
 | Other MCP clients | Use JSON config below in the client's MCP settings |
@@ -89,6 +90,6 @@ When a ContextA8C call fails, do NOT silently give up. Follow this sequence:
 Do NOT:
 - Silently skip ContextA8C without telling the user what went wrong
 - Tell the user to run agent skills or slash commands — those are for the agent to execute, not the user
-- Assume which client the user is running — ask them. The `claude` CLI binary may exist on the system even when the user is running Claude Desktop. Setup steps differ per client (`claude mcp add` only works for Claude Code CLI, not Claude Desktop)
+- Assume which environment the user is running — ask them (see `agent-environment-awareness.md`). The `claude` CLI binary may exist on the system even when the user is running Claude Desktop. MCP setup steps differ per environment
 - Retry the same failing call more than once in a session
 - Block on ContextA8C — always offer to proceed without it

--- a/.claude/rules/figma-design.md
+++ b/.claude/rules/figma-design.md
@@ -1,0 +1,118 @@
+# Figma Design Integration
+
+## Proactive Design Awareness
+
+When working on any UI-related task:
+1. **Check for Figma links first** — if a Linear issue is available, inspect its description for Figma URLs before starting UI work
+2. **Ask the user for designs** — if no Figma link is found but the task involves visible UI changes, ask the user whether design references are available. Designs help ensure pixel-accurate implementation
+3. **Always fetch design context before writing UI code** when a Figma link is available
+
+## Setup
+
+The Figma MCP is a remote HTTP server at `https://mcp.figma.com/mcp`. It requires a **one-time OAuth flow** — the first connection opens a browser window for Figma login.
+
+**Prerequisites**: A Figma account with access to the relevant design files.
+
+### Configure Your MCP Client
+
+| Client | Setup |
+|--------|-------|
+| Claude Code (CLI) | Already configured via `.mcp.json` — no action needed |
+| Claude Desktop | Add manually through Desktop settings (see Desktop note below) |
+| Cursor | Add to `.cursor/mcp.json` |
+| VS Code | Add to `.vscode/mcp.json` |
+| Other MCP clients | Use the JSON config below in the client's MCP settings |
+
+JSON config for Cursor, VS Code, and other clients that support a JSON MCP config file:
+```json
+{
+  "mcpServers": {
+    "figma": {
+      "url": "https://mcp.figma.com/mcp",
+      "type": "http"
+    }
+  }
+}
+```
+
+**Claude Desktop** (two options):
+1. **Browse built-in connectors** (preferred): Open Claude Desktop's settings or integrations area, browse available connectors/integrations, find the Figma connector, and enable it. The exact menu labels may vary across Desktop versions — look for sections like "Integrations", "Connectors", "MCP Servers", or similar. Follow the on-screen prompts to authorize with Figma.
+2. **Manual MCP config**: If the built-in connector is not available, add the Figma MCP manually through Desktop settings using the `mcp-remote` bridge: command `npx`, args `mcp-remote https://mcp.figma.com/mcp`. Do not edit config files directly — see `agent-environment-awareness.md`.
+
+After adding the config or enabling the connector, **restart the client** if needed to trigger the OAuth flow in the browser.
+
+## When Figma MCP is Unavailable
+
+When a Figma link is available but `mcp__figma__*` tools are not present in the session, the agent must NOT silently skip — follow this sequence:
+
+1. **Tell the user**: "Figma MCP is not connected — I can't fetch design context from this link."
+2. **Ask which environment** the user is running (see `agent-environment-awareness.md`). Do NOT assume Claude Code CLI — the presence of `.mcp.json` in the repo is not evidence of your runtime environment. Then provide the environment-specific setup steps from the **Setup** section above.
+   - For **Claude Desktop**: follow the two-option procedure in the **Setup** section above (built-in connector preferred, manual MCP config as fallback). Do NOT try to edit config files — this is unreliable for Desktop. Never suggest `claude mcp add` — that's CLI-only.
+   - For **Claude Code**: check if `.mcp.json` already has the Figma entry. If it does, the issue is likely OAuth — suggest restarting the session.
+3. **Fall back gracefully**: If the user can't set up Figma MCP right now, offer alternatives:
+   - Ask the user to paste a screenshot or describe the design
+   - Use the Figma link in a browser manually and relay details via chat
+   - Proceed with best-effort implementation based on existing code patterns
+4. **Do NOT** retry a failing Figma MCP call more than once in a session
+
+## Figma MCP
+
+Authentication is via OAuth (one-time browser flow on first use — see Setup above).
+
+### Key Tools
+- **`get_design_context`** — Layout structure, styles, and code suggestions for a Figma frame/node. Pass the full Figma URL
+- **`get_screenshot`** — Visual screenshot of a Figma frame for comparison
+- **`get_variable_defs`** — Design tokens (colors, spacing, typography) used in a selection
+- **`get_metadata`** — Sparse XML with layer IDs, names, types, positions, and sizes
+- **`get_code_connect_map`** — Mappings between Figma nodes and codebase components
+
+### When to Use
+- When a Figma URL is available (from a Linear issue, user message, or PR description)
+- When implementing UI and design references would improve accuracy
+- When visually verifying implementation against designs (use `get_screenshot` alongside `/snapshot` if available)
+
+### When NOT to Use
+- For non-UI changes (business logic, networking, storage)
+- Do not proactively search for Figma files — only use links that are provided or found in Linear issues
+
+## Extracting Figma Links from Linear Issues
+
+When working on a Linear issue (via ContextA8C Linear provider), check the issue description for Figma URLs. Common patterns:
+- `https://www.figma.com/design/<FILE_KEY>/<NAME>?node-id=<NODE_ID>`
+- `https://www.figma.com/file/<FILE_KEY>/<NAME>?node-id=<NODE_ID>`
+
+If a Figma link is found:
+1. Call `get_design_context` with the full URL to get layout and style details
+2. Call `get_screenshot` to get a visual reference image
+3. Optionally call `get_variable_defs` for design token values
+
+URLs without a `node-id` parameter return data for the entire page (noisy). Prefer links with specific node IDs.
+
+## Mapping Figma to iOS
+
+`get_design_context` returns React + Tailwind code by default. Translate to iOS:
+
+### SwiftUI Mapping
+| Figma | SwiftUI |
+|-------|---------|
+| Auto Layout (horizontal) | `HStack(spacing:)` |
+| Auto Layout (vertical) | `VStack(spacing:)` |
+| Padding | `.padding()` modifiers |
+| Fill container | `.frame(maxWidth: .infinity)` |
+| Fixed size | `.frame(width:height:)` |
+| Border radius | `.clipShape(RoundedRectangle(cornerRadius:))` |
+| Text styles | `.font()` modifier |
+| Opacity | `.opacity()` |
+| Shadow | `.shadow()` |
+
+### POS Views
+Map Figma values to POS design tokens — do NOT use hardcoded values:
+- **Spacing** → `POSSpacing` (`.xSmall` through `.xxLarge`)
+- **Padding** → `POSPadding` (`.xSmall` through `.xxLarge`)
+- **Typography** → `POSFontStyle` (`.posHeadingBold`, `.posBodyLargeRegular()`, etc.)
+- **Colors** → `Color+POSColorPalette` (`.posPrimary`, `.posSurface`, `.posError`, etc.)
+
+### Main App Views
+- Use existing color assets from the project's asset catalog
+- Use system fonts with appropriate text styles
+- Follow spacing patterns in nearby existing code

--- a/.claude/rules/figma-design.md
+++ b/.claude/rules/figma-design.md
@@ -99,9 +99,9 @@ URLs without a `node-id` parameter return data for the entire page (noisy). Pref
 | Auto Layout (vertical) | `VStack(spacing:)` |
 | Padding | `.padding()` modifiers |
 | Fill container | `.frame(maxWidth: .infinity)` |
-| Fixed size | `.frame(width:height:)` |
+| Fixed size | `.frame(width:height:)` — use `@ScaledMetric` to make sizes scalable for accessibility |
 | Border radius | `.clipShape(RoundedRectangle(cornerRadius:))` |
-| Text styles | `.font()` modifier |
+| Text styles | `.font()` modifier — find the closest system font matching the Figma style. Leave a `// TODO:` warning if no exact match exists for the developer to double-check |
 | Opacity | `.opacity()` |
 | Shadow | `.shadow()` |
 
@@ -113,6 +113,6 @@ Map Figma values to POS design tokens — do NOT use hardcoded values:
 - **Colors** → `Color+POSColorPalette` (`.posPrimary`, `.posSurface`, `.posError`, etc.)
 
 ### Main App Views
-- Use existing color assets from the project's asset catalog
-- Use system fonts with appropriate text styles
+- Use existing color assets from the project's asset catalog. Leave a `// TODO:` warning if no matching color asset is found
+- Use system fonts with appropriate text styles. Leave a `// TODO:` warning if no matching system font is found
 - Follow spacing patterns in nearby existing code

--- a/.claude/rules/verification.md
+++ b/.claude/rules/verification.md
@@ -1,12 +1,14 @@
 # Agent Verification Rules
 
+> **Environment note**: `.mcp.json` is auto-loaded by Claude Code CLI. If mobile-mcp tools are unavailable, read `.mcp.json` for the server config and help the user configure their environment — see `agent-environment-awareness.md`.
+
 Agents can verify their changes work from a user's perspective using two complementary loops: **snapshot-driven iteration** (fast inner loop) and **simulator-based E2E verification** (slower outer loop).
 
 ## Prerequisites
 - **Node.js** (see `.nvmrc` for version) — required by mobile-mcp for simulator interaction
 - **Java** — required by WireMock mock server (`brew install openjdk` if missing)
 - **Booted iOS simulator** — `xcrun simctl boot <UDID>`
-- **mobile-mcp** — auto-configured via `.mcp.json` (project-scoped, no manual setup needed)
+- **mobile-mcp** — auto-configured via `.mcp.json` in Claude Code CLI (other environments: see `agent-environment-awareness.md`)
 
 ## `/verify` — E2E Simulator Verification
 
@@ -34,7 +36,7 @@ Uses `swift-snapshot-testing` to render SwiftUI views to PNG images. The agent r
 
 ## mobile-mcp Tools
 
-Configured via `.mcp.json` at the project root. Provides:
+Configured via `.mcp.json` at the project root (auto-loaded in Claude Code CLI; other environments may need manual config). Provides:
 - `screenshot` — capture current simulator screen
 - `list_ui_elements` — get accessibility tree with element positions
 - `tap` / `swipe` / `type_text` — interact with UI elements

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,7 +34,8 @@
       "Bash(bundle exec fastlane *)",
       "Bash(./API-Mocks/scripts/start.sh *)",
       "Bash(./API-Mocks/scripts/stop.sh *)",
-      "mcp__mobile-mcp__*"
+      "mcp__mobile-mcp__*",
+      "mcp__figma__*"
     ],
     "deny": [
       "Bash(git push --force *)",

--- a/.claude/skills/snapshot/SKILL.md
+++ b/.claude/skills/snapshot/SKILL.md
@@ -2,7 +2,7 @@
 name: snapshot
 description: Use swift-snapshot-testing to visually verify SwiftUI views during implementation. Renders views to PNG for comparison against design references. Fast feedback loop (~25s/cycle).
 user-invocable: true
-allowed-tools: "Bash, Read, Write, Edit, Grep, Glob"
+allowed-tools: "Bash, Read, Write, Edit, Grep, Glob, mcp__figma__*"
 argument-hint: "[view-name or test-target]"
 ---
 
@@ -59,6 +59,18 @@ Common test targets in this project:
 
 ## Goal: Collect References
 
+### Option A: Figma MCP (preferred when a Figma link is available)
+
+If you have a Figma URL (from a Linear issue, user message, or PR description):
+
+1. Use the Figma MCP `get_screenshot` tool with the Figma URL to get a visual reference image
+2. Use `get_design_context` to get layout structure, spacing, and style details
+3. Optionally use `get_variable_defs` for design token values (colors, spacing, typography)
+
+See `.claude/rules/figma-design.md` for mapping Figma design values to iOS/SwiftUI code.
+
+### Option B: User-provided images
+
 If the user provides design reference images (Figma exports, screenshots):
 ```bash
 mkdir -p ~/Downloads/snapshot_experiment
@@ -66,7 +78,9 @@ cp ~/path/to/design.png ~/Downloads/snapshot_experiment/design.png
 ```
 Read each reference image to understand the target state before writing code.
 
-If no reference image, the goal is inferred from the user's description of desired UI behavior.
+### Option C: Description-based
+
+If no reference image or Figma link is available, the goal is inferred from the user's description of desired UI behavior.
 
 ## Scaffold: Create Snapshot Test
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
     "mobile-mcp": {
       "command": "npx",
       "args": ["-y", "@mobilenext/mobile-mcp@latest"]
+    },
+    "figma": {
+      "url": "https://mcp.figma.com/mcp",
+      "type": "http"
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 WooCommerce iOS is the official mobile client for WooCommerce stores, developed by Automattic. Large-scale Swift app using MVVM + Coordinators, SwiftUI and UIKit, Combine, and a Flux/Redux-inspired business logic layer (Yosemite).
 
+> **Multi-environment support**: These instructions work across Claude Code (CLI), Claude Desktop, Cursor, VS Code, and other AI agents. MCP setup differs by environment — see `.agents/rules/agent-environment-awareness.md`.
+
 ## Repository Layout
 
 ```
@@ -59,7 +61,13 @@ Use the `bootstrap` skill to set up the environment from a clean checkout. It wi
 ContextA8C is an Automattic MCP server that gives AI tools access to Slack, P2s, Linear, Field Guide, GitHub Enterprise, and other internal resources. It is optional — the agent works without it but provides richer context when available.
 
 - **Setup and usage**: See `.agents/rules/context-a8c.md`
-- **Claude Code setup skill**: `/setup-context-a8c`
+- **Claude Code setup skill**: `/setup-context-a8c` (uses `claude mcp add` internally — requires the `claude` CLI binary; see `.agents/rules/agent-environment-awareness.md` for other environments)
+
+## Design References (Figma MCP)
+
+When working on UI tasks, agents should proactively check for Figma design links — in the Linear issue description, user messages, or PR descriptions. If a Figma link is found, use the Figma MCP to fetch design context before implementing UI. If no link is found but the task involves visible UI changes, ask the user if design references are available.
+
+- **Setup and usage**: See `.agents/rules/figma-design.md`
 
 ## Build Commands
 
@@ -277,6 +285,6 @@ Agents can verify their changes work from a user's perspective using two complem
 - **`/verify`** — E2E simulator verification: builds the app, launches on simulator, navigates UI via mobile-mcp, screenshots and checks elements. Auto-detects scope from `git diff` using `.claude/references/feature-map.json`. Environment-aware — uses existing session during development, sets up WireMock mocked environment only when needed.
 - **`/snapshot`** — Fast UI iteration: uses `swift-snapshot-testing` to render SwiftUI views to PNG (~25s/cycle). Agent reads images, compares against design goals, iterates. Temporary — artifacts are never committed.
 
-**Prerequisites**: Node.js (see `.nvmrc`), Java (for WireMock), booted iOS simulator. mobile-mcp is auto-configured via `.mcp.json`.
+**Prerequisites**: Node.js (see `.nvmrc`), Java (for WireMock), booted iOS simulator. mobile-mcp is auto-configured via `.mcp.json` (Claude Code CLI; other environments may need manual MCP config — see `agent-environment-awareness.md`).
 
 See `.claude/rules/verification.md` for full details on tools, mock server setup, and launch arguments.


### PR DESCRIPTION
## Description

Adds Figma MCP server integration so AI agents can proactively fetch design context from Figma links found in Linear issues during UI development. Also adds agent environment awareness rules for multi-client MCP setup guidance.

**What changes:**

- **Figma MCP server** added to `.mcp.json` with tool permissions in `settings.json`
- **`figma-design.md`** rule file — proactive design awareness guidelines, Figma MCP tools reference, setup instructions for multiple environments, unavailability handling, Figma-to-iOS/SwiftUI mapping, POS design token mapping
- **`agent-environment-awareness.md`** rule file — agents must not assume their runtime environment; ask the user when MCP setup is needed
- **Snapshot skill** updated to use Figma MCP as preferred design reference source
- **AGENTS.md** updated with Design References section and multi-environment support callout
- **Existing rules** (`context-a8c.md`, `verification.md`) updated with environment-awareness cross-references

**Agent workflow improvement:** When an agent works on a Linear issue containing a Figma link, it will automatically fetch design context and screenshots via Figma MCP before implementing UI — no manual export needed. If no Figma link is found but the task involves visible UI changes, the agent asks the user for design references.

## Setup flow / environment selection example

<img width="744" height="436" alt="Screenshot 2026-03-05 at 12 54 16" src="https://github.com/user-attachments/assets/cea0fdb4-1fa0-42e6-8c77-63e11dbf0303" />

## Test Steps

- Start a new Claude Code session in the project
- Test with a Figma URL: ask the agent to fetch design context from a known Figma link
- Verify the agent uses `get_design_context` and `get_screenshot` tools
- Or suggests Figma MCP installation steps if not installed.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.