### PR TITLE
POS Vertically centre payment amounts between cash button and card reader view

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersFailedView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersFailedView.swift
@@ -28,6 +28,7 @@ struct PointOfSaleCardPresentPaymentScanningForReadersFailedView: View {
                     .matchedGeometryEffect(id: animation.contentTransitionId, in: animation.namespace, properties: .position)
             }
         }
+        .scrollVerticallyIfNeeded()
         .posModalCloseButton(action: viewModel.buttonViewModel.actionHandler,
                              accessibilityLabel: viewModel.buttonViewModel.title)
         .multilineTextAlignment(.center)

--- a/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
@@ -26,6 +26,7 @@ struct POSPaymentContentView: View {
             paymentContentView
 
             if shouldShowTotalsFields {
+                Spacer()
                 totalsFieldsView
             }
 

--- a/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
@@ -26,7 +26,6 @@ struct POSPaymentContentView: View {
             paymentContentView
 
             if shouldShowTotalsFields {
-                Spacer()
                 totalsFieldsView
             }
 

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -26,7 +26,6 @@ struct TotalsView: View {
             case .idle, .syncing, .loaded:
                 VStack(alignment: .center) {
                     Spacer()
-                        .renderedIf(cardReaderViewLayout.topPadding == nil)
 
                     if isShowingPaymentView {
                         PaymentViewContent(

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -40,7 +40,7 @@ struct TotalsView: View {
                         )
                     }
 
-                    if isShowingPaymentView && isShowingTotalsFields && cardReaderViewLayout.topPadding == nil {
+                    if isShowingPaymentView && isShowingTotalsFields {
                         Spacer()
                     }
 
@@ -185,7 +185,7 @@ private extension TotalsView {
                     .processingPayment:
                 if POSPaymentViewHelper().shouldShowDisconnectedMessage(readerConnectionStatus: paymentModel.cardReaderConnectionStatus,
                                                                     paymentState: paymentModel.paymentState) {
-                    return .outlined
+                    return .primary
                 }
             }
         }

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -40,7 +40,7 @@ struct TotalsView: View {
                         )
                     }
 
-                    if isShowingPaymentView && isShowingTotalsFields {
+                    if isShowingPaymentView && isShowingTotalsFields && cardReaderViewLayout.topPadding == nil {
                         Spacer()
                     }
 

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -40,6 +40,10 @@ struct TotalsView: View {
                         )
                     }
 
+                    if isShowingPaymentView && isShowingTotalsFields {
+                        Spacer()
+                    }
+
                     if isShowingTotalsFields {
                         TotalsFieldsContent(
                             orderState: posModel.orderState,
@@ -51,7 +55,6 @@ struct TotalsView: View {
                     }
 
                     Spacer()
-                        .renderedIf(viewHelper.shouldApplyPadding(paymentState: paymentModel.paymentState))
 
                     CashPaymentButton(
                         orderState: posModel.orderState,

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -42,6 +42,10 @@ struct TotalsView: View {
                             )
                         }
 
+                        if isShowingPaymentView && isShowingTotalsFields {
+                            Spacer()
+                        }
+
                         if isShowingTotalsFields {
                             TotalsFieldsContent(
                                 orderState: posModel.orderState,

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -28,33 +28,31 @@ struct TotalsView: View {
                     Spacer()
                         .renderedIf(cardReaderViewLayout.topPadding == nil)
 
-                    VStack(alignment: .center, spacing: 0) {
-                        if isShowingPaymentView {
-                            PaymentViewContent(
-                                paymentState: paymentModel.paymentState,
-                                cardReaderViewLayout: cardReaderViewLayout,
-                                isShowingTotalsFields: isShowingTotalsFields,
-                                backgroundColor: backgroundColor,
-                                orderState: posModel.orderState,
-                                cardReaderConnectionStatus: paymentModel.cardReaderConnectionStatus,
-                                cardPresentPaymentInlineMessage: paymentModel.cardPresentPaymentInlineMessage,
-                                connectCardReaderAction: paymentModel.connectCardReader
-                            )
-                        }
+                    if isShowingPaymentView {
+                        PaymentViewContent(
+                            paymentState: paymentModel.paymentState,
+                            cardReaderViewLayout: cardReaderViewLayout,
+                            isShowingTotalsFields: isShowingTotalsFields,
+                            backgroundColor: backgroundColor,
+                            orderState: posModel.orderState,
+                            cardReaderConnectionStatus: paymentModel.cardReaderConnectionStatus,
+                            cardPresentPaymentInlineMessage: paymentModel.cardPresentPaymentInlineMessage,
+                            connectCardReaderAction: paymentModel.connectCardReader
+                        )
+                    }
 
-                        if isShowingPaymentView && isShowingTotalsFields {
-                            Spacer()
-                        }
+                    if isShowingPaymentView && isShowingTotalsFields {
+                        Spacer()
+                    }
 
-                        if isShowingTotalsFields {
-                            TotalsFieldsContent(
-                                orderState: posModel.orderState,
-                                paymentState: paymentModel.paymentState,
-                                cart: posModel.cart,
-                                totalsFieldAnimation: totalsFieldAnimation
-                            )
-                            .opacity(shouldShowTotalsFields ? 1 : 0)
-                        }
+                    if isShowingTotalsFields {
+                        TotalsFieldsContent(
+                            orderState: posModel.orderState,
+                            paymentState: paymentModel.paymentState,
+                            cart: posModel.cart,
+                            totalsFieldAnimation: totalsFieldAnimation
+                        )
+                        .opacity(shouldShowTotalsFields ? 1 : 0)
                     }
 
                     Spacer()

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -40,10 +40,6 @@ struct TotalsView: View {
                         )
                     }
 
-                    if isShowingPaymentView && isShowingTotalsFields {
-                        Spacer()
-                    }
-
                     if isShowingTotalsFields {
                         TotalsFieldsContent(
                             orderState: posModel.orderState,

--- a/Modules/Sources/WooFoundation/ViewModifiers/View+ScrollModifiers.swift
+++ b/Modules/Sources/WooFoundation/ViewModifiers/View+ScrollModifiers.swift
@@ -1,52 +1,17 @@
 import SwiftUI
 
-/// Preference key for communicating sizes
-public struct SizePreferenceKey: PreferenceKey {
-    public static var defaultValue: CGSize? = nil
-
-    public static func reduce(value: inout CGSize?, nextValue: () -> CGSize?) {
-        // Take the response of the first child which updates the key. Disallow further updates from its children.
-        value = value ?? nextValue()
-    }
-}
-
-/// View modifier that conditionally wraps the `content` in a `ScrollView` if the `content` height exceeds the view height.
+/// View modifier that wraps content in a vertical `ScrollView` that only scrolls when content exceeds the available height.
+/// Content that fits within the viewport fills the space normally (Spacers expand, no bounce).
 ///
 public struct ConditionalVerticalScrollModifier: ViewModifier {
-    /// Defines if the content should scroll or not.
-    @State private var shouldScroll: Bool = false
-
     public func body(content: Content) -> some View {
         GeometryReader { parentGeometry in
-            Group {
-                if shouldScroll {
-                    ScrollView(.vertical, showsIndicators: false) {
-                        contentGeometryListener(content: content)
-                    }
-                } else {
-                    contentGeometryListener(content: content)
-                }
+            ScrollView(.vertical, showsIndicators: false) {
+                content
+                    .frame(minHeight: parentGeometry.size.height)
             }
-            .onPreferenceChange(SizePreferenceKey.self) { contentSize in
-                /// Using `onPreferenceChange` avoid changing state (`shouldScroll`) during a layout pass.
-                /// Changing state that's used to layout the view during layout can cause an infinite loop and make the screen unresponsive.
-                if let contentSize = contentSize {
-                    shouldScroll = contentSize.height > parentGeometry.size.height
-                }
-            }
+            .scrollBounceBehavior(.basedOnSize)
         }
-    }
-
-    /// Updates the `SizePreferenceKey` by adding a clear background to the `content` that has a `GeometryReader` attached to it.
-    /// This is used in the parent to update the `shouldScroll` property when the content vertical geometry is greater than the parent vertical geometry.
-    ///
-    private func contentGeometryListener(content: Content) -> some View {
-        content
-            .background(
-                GeometryReader { geometry in
-                    Color.clear
-                        .preference(key: SizePreferenceKey.self, value: geometry.size)
-                })
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the design of the payment screen to match latest designs.

Specifically, we centre the totals between the cash button and the card payment prompts.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Check both payment flows:

- Purchasing products
- Paying for bookings

Check that the amounts are vertically centred for various pre-payment scenarios:

- No reader attached
- Reader attached
- $0 orders

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/a3b9bc8c-ed2d-4fad-8799-b8e7c6270cc8


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
