### PR TITLE
POS: Fix crashes and state loss when switching apps or changing size class on iOS 18

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
@@ -3,6 +3,10 @@ import SwiftUI
 /// An alternative split view implementation that gives more control of the split view design,
 /// including the sidebar and content arrangement and separator colors.
 /// Just as NavigationSplitView, it adapts to a list -> details navigation on smaller screens.
+///
+/// Both sidebar and detail are always in the view tree — layout adapts via frame widths and offset,
+/// never conditional branches on size class. This prevents view destruction (and loss of @State,
+/// presented sheets, @Environment objects) when horizontalSizeClass flickers during background transitions.
 struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: View, SelectionValue: Hashable & Identifiable>: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Binding private var selection: SelectionValue?
@@ -27,52 +31,38 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
         self.setDefaultValue = setDefaultValue
     }
 
-    var body: some View {
-        Group {
-            switch horizontalSizeClass {
-            case .regular:
-                GeometryReader { geometry in
-                    HStack(spacing: 0) {
-                        sidebar($selection)
-                            .frame(width: geometry.size.width * Constants.sidebarWidthFraction)
+    private var isRegular: Bool {
+        horizontalSizeClass == .regular
+    }
 
-                        NavigationStack(path: $detailNavigationPath) {
-                            VStack {
-                                if let selection = selection {
-                                    detail(selection, $detailNavigationPath)
-                                        .frame(maxWidth: .infinity)
-                                        .transition(.opacity)
-                                } else {
-                                    detailPlaceholderView()
-                                        .frame(maxWidth: .infinity)
-                                        .transition(.opacity)
-                                }
-                            }
-                            .animation(.default, value: selection != nil)
-                            .navigationBarHidden(true)
-                        }
-                    }
-                }
-            default:
+    var body: some View {
+        GeometryReader { geometry in
+            HStack(spacing: 0) {
+                sidebar($selection)
+                    .frame(width: sidebarWidth(for: geometry.size.width))
+
                 NavigationStack(path: $detailNavigationPath) {
-                    ZStack {
-                        if let selection {
+                    VStack {
+                        if let selection = selection {
                             detail(selection, $detailNavigationPath)
-                                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                .transition(.move(edge: .trailing))
+                                .frame(maxWidth: .infinity)
+                                .transition(.opacity)
                         } else {
-                            sidebar($selection)
-                                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                .transition(.move(edge: .leading))
+                            detailPlaceholderView()
+                                .frame(maxWidth: .infinity)
+                                .transition(.opacity)
                         }
                     }
                     .animation(.default, value: selection != nil)
                     .navigationBarHidden(true)
                 }
+                .frame(width: detailWidth(for: geometry.size.width))
             }
+            .offset(x: compactOffset(for: geometry.size.width))
         }
+        .animation(.default, value: selection != nil)
         .onAppear {
-            if horizontalSizeClass == .regular, selection == nil {
+            if isRegular, selection == nil {
                 setDefaultValue?()
             }
         }
@@ -85,6 +75,21 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
             guard oldValue?.id != newValue?.id else { return }
             detailNavigationPath = NavigationPath()
         }
+    }
+
+    // MARK: - Layout
+
+    private func sidebarWidth(for totalWidth: CGFloat) -> CGFloat {
+        isRegular ? totalWidth * Constants.sidebarWidthFraction : totalWidth
+    }
+
+    private func detailWidth(for totalWidth: CGFloat) -> CGFloat {
+        isRegular ? totalWidth * (1 - Constants.sidebarWidthFraction) : totalWidth
+    }
+
+    private func compactOffset(for totalWidth: CGFloat) -> CGFloat {
+        guard !isRegular, selection != nil else { return 0 }
+        return -totalWidth
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

On iOS 18, switching apps while using POS (e.g. during a payment) could dismiss presented sheets, lose scroll position, or crash. This happened because `horizontalSizeClass` briefly flickers from `.regular` to `.compact` during background transitions, and `POSNavigationSplitView` used separate view branches for each size class — so the flicker destroyed and recreated the entire view hierarchy.

The previous crash was easy to recreate, by switching apps with the order for a booking open.

> Fatal error: No Observable object of type POSOrderListModel found. A View.environmentObject(_:) for POSOrderListModel may be missing as an ancestor of this view.

### Keep the views alive

This updates `POSNavigationSplitView` so both sidebar and detail are always in the view tree. Instead of switching between two different layouts, a single HStack adapts via frame widths and offset:

  - Regular: sidebar 35%, detail 65%
  - Compact, no selection: both 100% width, detail off-screen
  - Compact, with selection: both 100% width, sidebar off-screen

Since no views are ever removed from the tree, the background size class flicker is harmless — it briefly changes frame widths while the app is invisible, but nothing is destroyed or recreated.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

  - Open POS bookings or orders in regular (landscape iPad) layout
  - Start a card payment for a booking, then switch to another app and back — payment sheet should survive
  - Repeat at different payment steps (tap card, processing, complete)
  - Scroll down in a list, switch apps and back — scroll position preserved
  - In compact layout, selecting an item should slide to detail; back button should slide to list
  - Resize via Stage Manager or Split View — layout should adapt without crashes or stuck states

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/8729c8ef-2bfb-4dc2-b222-71982be70f99


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
