### PR TITLE
Show push notification setup entry points for JCP users

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -971,7 +971,7 @@ private extension DashboardViewModel {
         dismissedWPComConnectionSuggestion = userDefaults.hideWPComConnectionOnDashboard
         shouldSuggestWPComConnection = pushNotesManager.hasStoredSiteIDsRegisteredForWooPNs &&
             registeredSiteIDs.contains(siteID) == false &&
-            stores.isAuthenticatedWithoutWPCom &&
+            (stores.isAuthenticatedWithoutWPCom || stores.sessionManager.defaultSite?.isJetpackCPConnected == true) &&
             !dismissedWPComConnectionSuggestion &&
             featureFlagService.isFeatureFlagEnabled(.selfDrivenPushTokenAppPasswords)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -384,7 +384,7 @@ private extension SettingsViewModel {
     }
 
     func shouldShowEnablePushNotificationsRow(siteID: Int64) -> Bool {
-        guard stores.isAuthenticatedWithoutWPCom else {
+        guard stores.isAuthenticatedWithoutWPCom || stores.sessionManager.defaultSite?.isJetpackCPConnected == true else {
             return false
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -105,21 +105,23 @@ struct WPComPushNotificationsBenefitsView: View {
     }
 
     private var title: some View {
-        Text(Localization.title)
+        Text(viewModel.title)
             .font(.largeTitle)
             .fontWeight(.bold)
     }
 
     private var detail: some View {
         VStack(alignment: .leading, spacing: Layout.contentSpacing) {
-            Text(Localization.description)
+            Text(viewModel.description)
                 .font(.body)
                 .frame(maxWidth: .infinity, alignment: .leading)
-            Text(Localization.subdescription)
-                .font(.body)
-            Link(Localization.whatIsWPCom, destination: WooConstants.URLs.whatIsWPCom.asURL())
-                .font(.body)
-                .foregroundColor(Color(UIColor.accent))
+            if case .connect = viewModel.variant {
+                Text(Localization.subdescription)
+                    .font(.body)
+                Link(Localization.whatIsWPCom, destination: WooConstants.URLs.whatIsWPCom.asURL())
+                    .font(.body)
+                    .foregroundColor(Color(UIColor.accent))
+            }
         }
     }
 
@@ -198,16 +200,6 @@ fileprivate extension WPComPushNotificationsBenefitsView {
     }
 
     enum Localization {
-        static let title = NSLocalizedString("wpcomPushNotificationsBenefitsView.title",
-                                             value: "Unlock push notifications with WordPress.com",
-                                             comment: "Title of the WordPress.com Push Notifications Benefits View")
-
-        static let description = NSLocalizedString(
-            "wpcomPushNotificationsBenefitsView.mainDescription",
-            value: "Connect your store to WordPress.com to get access to push notifications for new orders, reviews and more.",
-            comment: "Main description text of the WordPress.com Push Notifications Benefits View"
-        )
-
         static let subdescription = NSLocalizedString(
             "wpcomPushNotificationsBenefitsView.subdescription",
             value: "It only takes a minute.",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -244,13 +244,14 @@ extension WPComPushNotificationsBenefitsViewModel {
 
         static let updatePluginTitle = NSLocalizedString(
             "wpcomPushNotificationsBenefitsViewModel.updatePluginTitle",
-            value: "Get push notifications for your store.",
+            value: "Get push notifications for your store",
             comment: "Title of the Push Notifications Benefits View when WooCommerce plugin is outdated"
         )
 
         static let updatePluginDescription = NSLocalizedString(
             "wpcomPushNotificationsBenefitsViewModel.updatePluginDescription",
-            value: "Your store is already connected to a WordPress.com account, but you’ll need to update WooCommerce plugin to enable push notifications for new orders, reviews, and more.",
+            value: "Your store is already connected to a WordPress.com account, but you’ll need to " +
+            "update WooCommerce plugin to enable push notifications for new orders, reviews, and more.",
             comment: "Description text on the Push Notifications Benefits View when WooCommerce plugin is outdated"
         )
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -19,6 +19,7 @@ final class WPComPushNotificationsBenefitsViewModel {
     private(set) var isCheckingPlugin: Bool = false
     private(set) var error: VariantCheckError?
 
+    private let stores: StoresManager
     private let analytics: Analytics
     private let onDismiss: () -> Void
     private let jetpackConnectionService: JetpackConnectionServiceProtocol
@@ -28,10 +29,12 @@ final class WPComPushNotificationsBenefitsViewModel {
 
     init(siteID: Int64,
          siteURL: String,
+         stores: StoresManager = ServiceLocator.stores,
          jetpackConnectionService: JetpackConnectionServiceProtocol = JetpackConnectionService(),
          pluginVersionChecker: PluginVersionCheckerProtocol? = nil,
          analytics: Analytics = ServiceLocator.analytics,
          onDismiss: @escaping () -> Void) {
+        self.stores = stores
         self.jetpackConnectionService = jetpackConnectionService
         self.analytics = analytics
         self.onDismiss = onDismiss
@@ -74,6 +77,15 @@ final class WPComPushNotificationsBenefitsViewModel {
     /// then checks the WooCommerce plugin version if Jetpack is connected.
     func determineSetupVariant() async {
         isCheckingPlugin = true
+        defer {
+            isCheckingPlugin = false
+        }
+
+        /// Skip Jetpack connection check if site is JCP
+        guard stores.sessionManager.defaultSite?.isJetpackCPConnected == false else {
+            return await checkWooPluginVersion()
+        }
+
         do {
             let connectionData = try await jetpackConnectionService.fetchConnectionData()
             /// only site-connection is required for Woo PN
@@ -94,7 +106,6 @@ final class WPComPushNotificationsBenefitsViewModel {
                 analytics.track(.pushNotificationsSetupIntroductionError, properties: ["error_type": "generic"], error: error)
             }
         }
-        isCheckingPlugin = false
     }
 
     func continueTapped() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -15,6 +15,20 @@ final class WPComPushNotificationsBenefitsViewModel {
 
     let termsAttributedString: AttributedString
 
+    var title: String {
+        switch variant {
+        case .connect: Localization.connectWPComTitle
+        case .pluginUpdate: Localization.updatePluginTitle
+        }
+    }
+
+    var description: String {
+        switch variant {
+        case .connect: Localization.connectWPComDescription
+        case .pluginUpdate: Localization.updatePluginDescription
+        }
+    }
+
     private(set) var variant: Variant = .connect
     private(set) var isCheckingPlugin: Bool = false
     private(set) var error: VariantCheckError?
@@ -214,6 +228,30 @@ extension WPComPushNotificationsBenefitsViewModel {
             "wpcomPushNotificationsBenefitsViewModel.shareDetails",
             value: "share details",
             comment: "The action to be agreed upon when tapping the Continue button on the Push Notifications Benefits View."
+        )
+
+        static let connectWPComTitle = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsViewModel.title",
+            value: "Unlock push notifications with WordPress.com",
+            comment: "Title of the WordPress.com Push Notifications Benefits View"
+        )
+
+        static let connectWPComDescription = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsViewModel.mainDescription",
+            value: "Connect your store to WordPress.com to get access to push notifications for new orders, reviews and more.",
+            comment: "Main description text of the WordPress.com Push Notifications Benefits View"
+        )
+
+        static let updatePluginTitle = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsViewModel.updatePluginTitle",
+            value: "Get push notifications for your store.",
+            comment: "Title of the Push Notifications Benefits View when WooCommerce plugin is outdated"
+        )
+
+        static let updatePluginDescription = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsViewModel.updatePluginDescription",
+            value: "Your store is already connected to a WordPress.com account, but you’ll need to update WooCommerce plugin to enable push notifications for new orders, reviews, and more.",
+            comment: "Description text on the Push Notifications Benefits View when WooCommerce plugin is outdated"
         )
     }
 }

--- a/WooCommerce/WooCommerceTests/Extensions/DateWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/DateWooTests.swift
@@ -1,12 +1,17 @@
 import XCTest
+import YosemiteTestHelpers
 @testable import WooCommerce
+@testable import Yosemite
 
 
 /// Date+Woo: Unit Tests
 ///
 final class DateWooTests: XCTestCase {
 
+    private let originalStores: StoresManager = ServiceLocator.stores
+
     override func tearDown() {
+        ServiceLocator.setStores(originalStores)
         ServiceLocator.stores.removeDefaultStore()
         super.tearDown()
     }
@@ -114,8 +119,9 @@ final class DateWooTests: XCTestCase {
         // Given
         // GMT: Monday, December 25, 2023 3:23:31 AM
         let date = Date(timeIntervalSince1970: 1703474611)
-        ServiceLocator.stores.updateDefaultStore(storeID: 1)
-        ServiceLocator.stores.updateDefaultStore(.fake().copy(siteID: 1, gmtOffset: -12))
+        let site = Site.fake().copy(siteID: 1, gmtOffset: -12)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: site))
+        ServiceLocator.setStores(stores)
         let locale = Locale(identifier: "en_US")
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeLocalNotificationSchedulerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeLocalNotificationSchedulerTests.swift
@@ -212,18 +212,13 @@ final class BlazeLocalNotificationSchedulerTests: XCTestCase {
                                                          blazeEligibilityChecker: blazeEligibilityChecker)
         await sut.scheduleNoCampaignReminder()
 
-        waitForExpectation(timeout: 0.5) { exp in
-            exp.isInverted = true
+        // When
+        insertCampaigns([fakeBlazeCampaign])
 
-            // When
-            insertCampaigns([fakeBlazeCampaign])
-
-            // Then
-            // No local notifications should be requested
-            if self.pushNotesManager.requestedLocalNotifications.isNotEmpty {
-                exp.fulfill()
-            }
-        }
+        // Then
+        // No local notifications should be requested
+        try await Task.sleep(nanoseconds: 500_000_000)
+        XCTAssertTrue(pushNotesManager.requestedLocalNotifications.isEmpty)
     }
 
     func test_no_campaign_notification_is_not_scheduled_when_notification_already_has_been_interacted_with() async throws {
@@ -483,6 +478,5 @@ private extension BlazeLocalNotificationSchedulerTests {
             let newCampaign = storage.insertNewObject(ofType: StorageBlazeCampaignListItem.self)
             newCampaign.update(with: campaign)
         }
-        storage.saveIfNeeded()
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -1127,6 +1127,33 @@ final class DashboardViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_shouldSuggestWPComConnection_returns_true_when_site_is_JCP_and_not_registered_and_feature_flag_enabled() async {
+        // Given
+        let jcpSite = Site.fake().copy(siteID: sampleSiteID, isJetpackThePluginInstalled: false, isJetpackConnected: true)
+        stores.updateDefaultStore(jcpSite)
+        mockReloadingData()
+        stores.authenticate(credentials: SessionSettings.wpcomCredentials)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenAppPasswords: true)
+        let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [],
+                                                            hasStoredSiteIDsRegisteredForWooPNs: true)
+
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           featureFlags: featureFlagService,
+                                           userDefaults: userDefaults,
+                                           pushNotesManager: pushNotesManager,
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
+
+        // When
+        await viewModel.reloadAllData()
+
+        // Then
+        XCTAssertTrue(viewModel.shouldSuggestWPComConnection)
+    }
+
+    @MainActor
     func test_hideWPComConnectionSuggestion_updates_relevant_properties() async {
         // Given
         mockReloadingData()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/WPComPushNotificationsBenefitsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/WPComPushNotificationsBenefitsViewModelTests.swift
@@ -353,18 +353,54 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isCheckingPlugin)
     }
 
+    // MARK: - determineSetupVariant for JCP site
+
+    func test_determineSetupVariant_when_site_is_JCP_skips_jetpack_connection_check_and_sets_pluginUpdate_variant() async {
+        // Given
+        let checker = MockPluginVersionChecker()
+        checker.result = .success(.incompatible(currentVersion: "10.0.0", requiredVersion: "10.5.3"))
+        let viewModel = makeViewModel(isJCPSite: true, pluginVersionChecker: checker)
+
+        // When
+        await viewModel.determineSetupVariant()
+
+        // Then
+        XCTAssertEqual(viewModel.variant, .pluginUpdate(currentVersion: "10.0.0"))
+        XCTAssertFalse(viewModel.isCheckingPlugin)
+    }
+
+    func test_determineSetupVariant_when_site_is_JCP_and_plugin_compatible_then_sets_noMissingRequirements_error() async {
+        // Given
+        let checker = MockPluginVersionChecker()
+        checker.result = .success(.compatible)
+        let viewModel = makeViewModel(isJCPSite: true, pluginVersionChecker: checker)
+
+        // When
+        await viewModel.determineSetupVariant()
+
+        // Then
+        guard case .noMissingRequirements = viewModel.error else {
+            return XCTFail("Expected noMissingRequirements error, got \(String(describing: viewModel.error))")
+        }
+        XCTAssertFalse(viewModel.isCheckingPlugin)
+    }
+
     // MARK: - Helpers
 
     private let sampleSiteID: Int64 = 123
 
     private func makeViewModel(
+        isJCPSite: Bool = false,
         jetpackConnectionService: JetpackConnectionServiceProtocol = MockJetpackConnectionService(),
         pluginVersionChecker: PluginVersionCheckerProtocol? = nil,
         analytics: Analytics = ServiceLocator.analytics
     ) -> WPComPushNotificationsBenefitsViewModel {
-        WPComPushNotificationsBenefitsViewModel(
+        let site = Site.fake().copy(isJetpackThePluginInstalled: !isJCPSite, isJetpackConnected: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: site))
+        return WPComPushNotificationsBenefitsViewModel(
             siteID: sampleSiteID,
             siteURL: "https://example.com",
+            stores: stores,
             jetpackConnectionService: jetpackConnectionService,
             pluginVersionChecker: pluginVersionChecker,
             analytics: analytics,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -343,6 +343,23 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.enablePushNotifications) })
     }
 
+    func test_sections_contains_enablePushNotifications_row_when_site_is_JCP_and_feature_flag_enabled_and_not_registered() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenAppPasswords: true)
+        let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: false, isJetpackConnected: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
+        let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
+        let viewModel = SettingsViewModel(stores: stores,
+                                          featureFlagService: featureFlagService,
+                                          defaults: defaults,
+                                          pushNotesManager: pushNotesManager)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.enablePushNotifications) })
+    }
 
     func test_sections_does_not_contain_connectivity_row_for_wpcom_site() {
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true, isWordPressComStore: true)


### PR DESCRIPTION
Closes WOOMOB-2406

## Description
Shows push notification (PN) setup entry points for sites connected via Jetpack Connection Package (JCP):

- **Dashboard**: `shouldSuggestWPComConnection` now returns `true` for JCP sites with the feature flag enabled, so the WPCom connection card appears when PN registration hasn't been done.
- **Settings**: `shouldShowEnablePushNotificationsRow` now returns `true` for JCP sites, showing the "Enable Push Notifications" row in Settings.
- **PN Benefits screen**: `determineSetupVariant` skips the Jetpack connection API call for JCP sites (they are already connected) and goes directly to the WooCommerce plugin version check. The view conditionally hides the "What is WordPress.com" link and subdescription for the plugin-update variant.

Also adds unit tests covering all three new JCP code paths. And attempted fixing some unrelated flaky tests (again).

## Test Steps
1. Log in to a JCP site (Jetpack Connection Package — Jetpack connected but plugin not installed) with WPCom credentials.
2. Ensure the `selfDrivenPushTokenAppPasswords` feature flag is enabled.
3. Verify the "Enable Push Notifications" row appears in Settings.
4. Navigate to the Dashboard and verify the WPCom push notifications connection card appears if the site is not yet registered.
5. Tap the card and verify the PN benefits screen loads without errors (should skip Jetpack connection check and proceed to plugin version check).

## Screenshots


https://github.com/user-attachments/assets/d4aca7da-07ec-4842-8a24-7af44dd1b7fe



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.