### PR TITLE
Fix See Receipt button missing after cash payment

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [*] Fix infinite retries in InfiniteScrollIndicator [https://github.com/woocommerce/woocommerce-ios/pull/16778]
 - [*] Fix attendance status filter in Bookings [https://github.com/woocommerce/woocommerce-ios/pull/16779]
 - [*] Fix Custom Fields closing immediately when opened from a product in the Orders tab [https://github.com/woocommerce/woocommerce-ios/pull/16782]
+- [*] Fix See Receipt button missing after collecting payment [https://github.com/woocommerce/woocommerce-ios/pull/16788]
 
 
 24.2

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -58,6 +58,11 @@ final class OrderDetailsViewModel {
         editNoteViewModel.update(order: order)
     }
 
+    @MainActor
+    func refreshReceiptEligibility() async {
+        dataSource.isEligibleForBackendReceipt = await isEligibleForBackendReceipt()
+    }
+
     let productLeftTitle = NSLocalizedString("PRODUCT", comment: "Product section title")
 
     let productRightTitle = NSLocalizedString("QTY", comment: "Quantity abbreviation for section title")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -214,8 +214,16 @@ private extension OrderDetailsViewController {
             guard let self = self else {
                 return
             }
+            let previousStatus = self.viewModel.order.status
             self.viewModel.update(order: order)
             self.reloadTableViewSectionsAndData()
+
+            if order.status != previousStatus {
+                Task { @MainActor [weak self] in
+                    await self?.viewModel.refreshReceiptEligibility()
+                    self?.reloadTableViewSectionsAndData()
+                }
+            }
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -690,6 +690,43 @@ final class OrderDetailsViewModelTests: XCTestCase {
         XCTAssertFalse(isWooShippingSupported)
     }
 
+    // MARK: - `refreshReceiptEligibility`
+
+    func test_refreshReceiptEligibility_when_order_is_eligible_then_updates_dataSource() async {
+        // Given
+        let order = Order.fake().copy(siteID: 123, orderID: 456, status: .completed)
+        let receiptEligibilityUseCase = MockReceiptEligibilityUseCase()
+        receiptEligibilityUseCase.isEligibleForReceipt = true
+        let viewModel = OrderDetailsViewModel(order: order,
+                                              stores: storesManager,
+                                              storageManager: storageManager,
+                                              receiptEligibilityUseCase: receiptEligibilityUseCase)
+        XCTAssertFalse(viewModel.dataSource.isEligibleForBackendReceipt)
+
+        // When
+        await viewModel.refreshReceiptEligibility()
+
+        // Then
+        XCTAssertTrue(viewModel.dataSource.isEligibleForBackendReceipt)
+    }
+
+    func test_refreshReceiptEligibility_when_order_is_not_eligible_then_dataSource_remains_false() async {
+        // Given
+        let order = Order.fake().copy(siteID: 123, orderID: 456, status: .pending)
+        let receiptEligibilityUseCase = MockReceiptEligibilityUseCase()
+        receiptEligibilityUseCase.isEligibleForReceipt = false
+        let viewModel = OrderDetailsViewModel(order: order,
+                                              stores: storesManager,
+                                              storageManager: storageManager,
+                                              receiptEligibilityUseCase: receiptEligibilityUseCase)
+
+        // When
+        await viewModel.refreshReceiptEligibility()
+
+        // Then
+        XCTAssertFalse(viewModel.dataSource.isEligibleForBackendReceipt)
+    }
+
     func test_isWooShippingSupported_returns_false_when_woo_shipping_plugin_is_not_minimum_version() async {
         // Given
         let featureFlagService = MockFeatureFlagService(revampedShippingLabelCreation: true)


### PR DESCRIPTION
Closes: WOOMOB-2386

## Description

Fixes the "See receipt" button not appearing immediately on the Order Details screen after collecting a cash payment. The button only appeared after manually reloading the screen.

### Root cause
After a cash payment, `PaymentMethodsViewModel` updates the order asynchronously, which triggers the `EntityListener` in `OrderDetailsViewController`. The listener updated the order data and reloaded the table view, but never rechecked receipt eligibility (`isEligibleForBackendReceipt`). This property was only computed during `syncEverything()` (initial load / pull-to-refresh), so the receipt button row was never added to the payment section.

### Fix 
When the entity listener detects an order status change (e.g., from pending to completed after cash payment), it now refreshes receipt eligibility via a new `refreshReceiptEligibility()` method on `OrderDetailsViewModel`, then rebuilds the table view sections so the button appears immediately.


## Test Steps

1. Create a new order with items
2. Tap "Collect Payment" and select "Cash"
3. Complete the cash payment flow
4. Observe that the "See receipt" button appears immediately on the Order Details screen without needing to pull-to-refresh

## Screenshots

https://github.com/user-attachments/assets/6712f070-e658-4772-a5ef-6608671a7e07



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.