### PR TITLE
Fix auto-start refund re-triggering when resizing windows

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -46,7 +46,8 @@ struct POSBookingDetailView: View {
                     POSOrderDetailsView(
                         order: booking.order,
                         onBack: { navigationPath.removeLast() },
-                        autoStartRefund: true,
+                        flow: .bookings,
+                        autoStartNextRefundFlow: true,
                         onRefundSuccess: {
                             Task {
                                 isDetailsUpdating = true

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -8,7 +8,8 @@ import typealias Yosemite.OrderItemAttribute
 struct POSOrderDetailsView: View {
     let order: POSOrder
     let onBack: () -> Void
-    var autoStartRefund: Bool = false
+    var flow: Flow = .orders
+    @State var autoStartNextRefundFlow: Bool = false
     var onRefundSuccess: (() -> Void)? = nil
     var onRefundFailure: ((Error) -> Void)? = nil
 
@@ -81,14 +82,14 @@ struct POSOrderDetailsView: View {
                 order: order,
                 onRetryLoading: { initiateRefundFlow() },
                 onRetryPreparation: {
-                    if autoStartRefund {
+                    if flow == .bookings {
                         initiateRefundFlow()
                     } else {
                         refundModalState = .itemSelection
                     }
                 },
-                onEditRefund: autoStartRefund ? nil : { refundModalState = .itemSelection },
-                showsItemSelection: !autoStartRefund,
+                onEditRefund: flow == .bookings ? nil : { refundModalState = .itemSelection },
+                showsItemSelection: flow != .bookings,
                 onRefundSuccess: onRefundSuccess,
                 onRefundFailure: onRefundFailure,
                 errorStrings: .init(
@@ -108,7 +109,8 @@ struct POSOrderDetailsView: View {
             .posHeaderBackButtonIcon(systemName: "xmark")
         }
         .onAppear {
-            if autoStartRefund {
+            if autoStartNextRefundFlow {
+                autoStartNextRefundFlow = false
                 initiateRefundFlow()
             }
             analytics.track(event: WooAnalyticsEvent.PointOfSale.orderDetailsLoaded(
@@ -321,7 +323,7 @@ private extension POSOrderDetailsView {
         case .refunded:
             return .init(primary: email, secondary: [])
         case .completed:
-            if autoStartRefund {
+            if flow == .bookings {
                 return .init(primary: .issueRefund, secondary: [email])
             }
             guard featureFlags.isFeatureFlagEnabled(.pointOfSaleRefundsi1) else {
@@ -390,14 +392,14 @@ private extension POSOrderDetailsView {
             let result = await orderListModel.ordersController.startRefundFlow()
             switch result {
             case .hasItemsToRefund:
-                if autoStartRefund {
+                if flow == .bookings {
                     navigateToRefundReview()
                 } else {
                     refundModalState = .itemSelection
                 }
             case .nothingToRefund:
-                if autoStartRefund {
-                    // Temporary log to track "nothing to refund" case for bookings (autoStartRefund == true)
+                if flow == .bookings {
+                    // Temporary log to track "nothing to refund" case for bookings (flow == .bookings == true)
                     // This can be removed once we're sure it works as expected.
                     // Context: p1772005017449939-slack-C070SJRA8DP
                     analytics.track(event: WooAnalyticsEvent.PointOfSale.bookingRefundFailed(
@@ -552,6 +554,13 @@ private enum Localization {
         value: "Please try again.",
         comment: "Subtitle shown when refund data preparation fails"
     )
+}
+
+extension POSOrderDetailsView {
+    enum Flow {
+        case orders
+        case bookings
+    }
 }
 
 #if DEBUG


### PR DESCRIPTION
## Description

On iPadOS 26, window resizing can recreate SwiftUI views inside `.navigationDestination`, causing `.onAppear` to fire again and re-triggering the auto-start refund flow.

This PR splits the old `autoStartRefund: Bool` into two separate concerns:

- **`Flow` enum** (`.orders` / `.bookings`) - controls stable behavior differences (skip item selection, show edit button, etc.). Not affected by view recreation.
- **`@State autoStartNextRefundFlow`** - one-shot trigger that is consumed (set to `false`) on first `.onAppear`. Even if the view is recreated and `@State` reinitializes, the `Flow` enum still correctly controls modal behavior.

## Test Steps

1. Open POS
2. Go to Bookings, select a paid booking
3. Tap overflow menu -> Issue Refund
4. Verify the refund modal appears
5. Dismiss the modal (proceed with refund or just close)
6. Resize the window - verify the refund flow does not restart
7. Complete or dismiss the refund - verify normal behavior

### Before

https://github.com/user-attachments/assets/f684431b-4941-4f80-9340-ed1c307e6bcc

### After


https://github.com/user-attachments/assets/f8557a62-202a-403d-af03-9d6f14f22643


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.