### PR TITLE
Fix product detail webview routing for booking products

### DIFF
--- a/WooCommerce/Classes/Routing/ProductDetail/ProductAdminURLProvider.swift
+++ b/WooCommerce/Classes/Routing/ProductDetail/ProductAdminURLProvider.swift
@@ -6,8 +6,9 @@ enum ProductAdminURLProvider {
 
     static func editURL(for product: Product, site: Site?) -> URL? {
         guard let base = site?.adminURLWithFallback() else { return nil }
+        let adminBase = base.appending(path: "admin.php", directoryHint: .notDirectory)
 
-        var components = URLComponents(url: base, resolvingAgainstBaseURL: false)!
+        var components = URLComponents(url: adminBase, resolvingAgainstBaseURL: false)!
         components.queryItems = [
             URLQueryItem(name: "page", value: "next-admin"),
             URLQueryItem(name: "p", value: "/woocommerce/services/edit/\(product.productID)")

--- a/WooCommerce/Classes/Routing/ProductDetail/ProductAdminURLProvider.swift
+++ b/WooCommerce/Classes/Routing/ProductDetail/ProductAdminURLProvider.swift
@@ -10,7 +10,7 @@ enum ProductAdminURLProvider {
         var components = URLComponents(url: base, resolvingAgainstBaseURL: false)!
         components.queryItems = [
             URLQueryItem(name: "page", value: "next-admin"),
-            URLQueryItem(name: "p", value: "/woocommerce/products/edit/\(product.productID)")
+            URLQueryItem(name: "p", value: "/woocommerce/services/edit/\(product.productID)")
         ]
 
         return components.url

--- a/WooCommerce/WooCommerceTests/Routing/ProductDetail/ProductAdminURLProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/Routing/ProductDetail/ProductAdminURLProviderTests.swift
@@ -16,6 +16,6 @@ final class ProductAdminURLProviderTests {
 
         // Then
         #expect(url.absoluteString ==
-                "\(storeURL)/wp-admin?page=next-admin&p=/woocommerce/services/edit/\(productID)")
+                "\(storeURL)/wp-admin/admin.php?page=next-admin&p=/woocommerce/services/edit/\(productID)")
     }
 }

--- a/WooCommerce/WooCommerceTests/Routing/ProductDetail/ProductAdminURLProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/Routing/ProductDetail/ProductAdminURLProviderTests.swift
@@ -10,9 +10,12 @@ final class ProductAdminURLProviderTests {
     private lazy var aSite = Site.fake().copy(url: storeURL)
 
     @Test
-    private func validateEditAdminURL() async throws {
+    func test_editURL_uses_services_path() throws {
+        // Given / When
         let url = try #require(ProductAdminURLProvider.editURL(for: aProduct, site: aSite))
+
+        // Then
         #expect(url.absoluteString ==
-                "\(storeURL)/wp-admin?page=next-admin&p=/woocommerce/products/edit/\(productID)")
+                "\(storeURL)/wp-admin?page=next-admin&p=/woocommerce/services/edit/\(productID)")
     }
 }


### PR DESCRIPTION
Closes [WOOMOB-2420](https://linear.app/a8c/issue/WOOMOB-2420)

## Description

Updates the path used to open bookable services in the admin view.

## Test Steps
1. Have a CIAB store with a bookable product ready.
2. Open the app
3. Navigate the products
4. Tap a bookable product
5. Note that the breadcrumb has "Services" instead of "Products"

## Screenshots
| Before | After |
| --- | --- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-06 at 12 48 09" src="https://github.com/user-attachments/assets/f27f3094-3798-417e-bd3a-b80e4a053597" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-06 at 12 46 52" src="https://github.com/user-attachments/assets/2b58e592-0268-4c20-9b31-cfe6c22a57b3" /> |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
