### PR TITLE
Update release notes for 24.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <!--
 Contains editorialized release notes. Raw release notes should go into `RELEASE-NOTES.txt`.
 -->
+## 24.3
+Managing your store just got better. We improved scrolling in order and product lists, made receipts more reliable across payment methods and order statuses, and improved Tap to Pay reliability for multi-store setups. We also improved login, booking filters, and Scan to Pay tracking.
+
 ## 24.2
 This update shows store setup tasks more reliably, ensures barcode scanning works seamlessly in Point of Sale, and enhances media library reliability. Update now for a smoother store management experience!
 

--- a/WooCommerce/Resources/release_notes.txt
+++ b/WooCommerce/Resources/release_notes.txt
@@ -1,9 +1,1 @@
-- [*] Fix issue displaying onboarding tasks when logging in to sites with pretty permalinks using site credentials [https://github.com/woocommerce/woocommerce-ios/pull/16731]
-- [*] Fix scrolling glitch on Orders and Products lists [https://github.com/woocommerce/woocommerce-ios/pull/16714]
-- [*] POS: Fix bookings/orders/settings dismissal when switching apps [https://github.com/woocommerce/woocommerce-ios/pull/16757]
-- [*] Fix "See Receipt" button not appearing for orders with custom statuses [https://github.com/woocommerce/woocommerce-ios/pull/16673]
-- [*] Payments: A note is added to the order when Scan to Pay is used [https://github.com/woocommerce/woocommerce-ios/pull/16549]
-- [*] Fix infinite retries in InfiniteScrollIndicator [https://github.com/woocommerce/woocommerce-ios/pull/16778]
-- [*] Fix attendance status filter in Bookings [https://github.com/woocommerce/woocommerce-ios/pull/16779]
-- [*] Fix Custom Fields closing immediately when opened from a product in the Orders tab [https://github.com/woocommerce/woocommerce-ios/pull/16782]
-- [*] Fix See Receipt button missing after collecting payment [https://github.com/woocommerce/woocommerce-ios/pull/16788]
+Managing your store just got better. We improved scrolling in order and product lists, made receipts more reliable across payment methods and order statuses, and improved Tap to Pay reliability for multi-store setups. We also improved login, booking filters, and Scan to Pay tracking.


### PR DESCRIPTION
## Description
Replace raw bullet-point release notes with a user-friendly marketing paragraph for the App Store, and add the same copy to CHANGELOG.md.

## Test Steps
- Verify `release_notes.txt` contains only the marketing paragraph (no bullet points)
- Verify `CHANGELOG.md` has `## 24.3` as the first version entry with the same text

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.