### PR TITLE
[POS][Refunds] Add `Refunded Products` section to order details

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -421,6 +421,7 @@ enum RefundActionAvailability {
         }
         do {
             let refunds = try await refundsService.loadOrderRefunds(for: order)
+            guard selectedOrder?.id == order.id else { return }
             selectedOrder = order.copy(refunds: .some(refunds))
         } catch {
             DDLogError("⛔️ Failed to load refund details: \(error)")

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -415,6 +415,7 @@ enum RefundActionAvailability {
 
         clearRefundSelection()
         try? await updateOrder(orderID: order.id)
+        await loadRefundedProducts()
     }
 
     func loadRefundedProducts() async {

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -16,6 +16,7 @@ import class Yosemite.Store
 import class Yosemite.AsyncPaginationTracker
 import protocol Experiments.FeatureFlagService
 import class WooFoundation.CurrencyFormatter
+import CocoaLumberjackSwift
 
 enum StartRefundFlowResult {
     case hasItemsToRefund
@@ -426,7 +427,7 @@ enum RefundActionAvailability {
         do {
             refundedProducts = try await refundsService.loadRefundedProducts(for: order)
         } catch {
-            debugPrint("⛔️ Failed to load refunded products: \(error)")
+            DDLogError("⛔️ Failed to load refunded products: \(error)")
             refundedProducts = []
         }
     }

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -7,6 +7,7 @@ import protocol Yosemite.POSOrderListFetchStrategy
 import protocol Yosemite.POSRefundsServiceProtocol
 import struct Yosemite.POSOrder
 import struct Yosemite.POSRefund
+import struct Yosemite.POSRefundItem
 import struct Yosemite.POSRefundsResult
 import struct Yosemite.POSRefundableItem
 import struct Yosemite.POSRefundAmounts
@@ -27,6 +28,7 @@ protocol POSOrderListControllerProtocol {
     var selectedOrder: POSOrder? { get }
     var refundActionAvailability: RefundActionAvailability { get }
     var refundSelectableItems: [POSRefundSelectableItem] { get }
+    var refundedProducts: [POSRefundItem] { get }
     func loadOrders() async
     func refreshOrders() async
     func loadNextOrders() async
@@ -38,6 +40,7 @@ protocol POSOrderListControllerProtocol {
     func toggleAllRefundItemsSelection()
     func preparePOSRefundReviewData() -> POSRefundReviewData?
     func processRefund(reason: String?) async throws
+    func loadRefundedProducts() async
 }
 
 protocol POSSearchingOrderListControllerProtocol: POSOrderListControllerProtocol {
@@ -66,6 +69,7 @@ enum RefundActionAvailability {
     private(set) var selectedOrder: POSOrder?
     private(set) var selectedOrderRefundsState: POSOrderListSelectedOrderRefundsState = .idle
     private(set) var refundSelectableItems: [POSRefundSelectableItem] = []
+    private(set) var refundedProducts: [POSRefundItem] = []
     private let orderListFetchStrategyFactory: POSOrderListFetchStrategyFactoryProtocol
     private let refundsService: POSRefundsServiceProtocol
     private let featureFlags: POSFeatureFlagProviding
@@ -222,6 +226,7 @@ enum RefundActionAvailability {
     func selectOrder(_ order: POSOrder?) {
         selectedOrder = order
         selectedOrderRefundsState = .idle
+        refundedProducts = []
     }
 
     @MainActor
@@ -410,6 +415,19 @@ enum RefundActionAvailability {
 
         clearRefundSelection()
         try? await updateOrder(orderID: order.id)
+    }
+
+    func loadRefundedProducts() async {
+        guard let order = selectedOrder, order.refunds.isNotEmpty else {
+            refundedProducts = []
+            return
+        }
+        do {
+            refundedProducts = try await refundsService.loadRefundedProducts(for: order)
+        } catch {
+            debugPrint("⛔️ Failed to load refunded products: \(error)")
+            refundedProducts = []
+        }
     }
 }
 

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -7,7 +7,6 @@ import protocol Yosemite.POSOrderListFetchStrategy
 import protocol Yosemite.POSRefundsServiceProtocol
 import struct Yosemite.POSOrder
 import struct Yosemite.POSRefund
-import struct Yosemite.POSRefundItem
 import struct Yosemite.POSRefundsResult
 import struct Yosemite.POSRefundableItem
 import struct Yosemite.POSRefundAmounts

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -29,7 +29,6 @@ protocol POSOrderListControllerProtocol {
     var selectedOrder: POSOrder? { get }
     var refundActionAvailability: RefundActionAvailability { get }
     var refundSelectableItems: [POSRefundSelectableItem] { get }
-    var refundedProducts: [POSRefundItem] { get }
     func loadOrders() async
     func refreshOrders() async
     func loadNextOrders() async
@@ -41,7 +40,7 @@ protocol POSOrderListControllerProtocol {
     func toggleAllRefundItemsSelection()
     func preparePOSRefundReviewData() -> POSRefundReviewData?
     func processRefund(reason: String?) async throws
-    func loadRefundedProducts() async
+    func loadOrderRefunds() async
 }
 
 protocol POSSearchingOrderListControllerProtocol: POSOrderListControllerProtocol {
@@ -70,7 +69,6 @@ enum RefundActionAvailability {
     private(set) var selectedOrder: POSOrder?
     private(set) var selectedOrderRefundsState: POSOrderListSelectedOrderRefundsState = .idle
     private(set) var refundSelectableItems: [POSRefundSelectableItem] = []
-    private(set) var refundedProducts: [POSRefundItem] = []
     private let orderListFetchStrategyFactory: POSOrderListFetchStrategyFactoryProtocol
     private let refundsService: POSRefundsServiceProtocol
     private let featureFlags: POSFeatureFlagProviding
@@ -227,7 +225,6 @@ enum RefundActionAvailability {
     func selectOrder(_ order: POSOrder?) {
         selectedOrder = order
         selectedOrderRefundsState = .idle
-        refundedProducts = []
     }
 
     @MainActor
@@ -416,19 +413,18 @@ enum RefundActionAvailability {
 
         clearRefundSelection()
         try? await updateOrder(orderID: order.id)
-        await loadRefundedProducts()
+        await loadOrderRefunds()
     }
 
-    func loadRefundedProducts() async {
+    func loadOrderRefunds() async {
         guard let order = selectedOrder, order.refunds.isNotEmpty else {
-            refundedProducts = []
             return
         }
         do {
-            refundedProducts = try await refundsService.loadRefundedProducts(for: order)
+            let refunds = try await refundsService.loadOrderRefunds(for: order)
+            selectedOrder = order.copy(refunds: .some(refunds))
         } catch {
-            DDLogError("⛔️ Failed to load refunded products: \(error)")
-            refundedProducts = []
+            DDLogError("⛔️ Failed to load refund details: \(error)")
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -416,6 +416,7 @@ enum RefundActionAvailability {
     }
 
     func loadOrderRefunds() async {
+        guard featureFlags.isFeatureFlagEnabled(.pointOfSaleRefundsi1) else { return }
         guard let order = selectedOrder, order.refunds.isNotEmpty else {
             return
         }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -58,8 +58,9 @@ struct POSOrderDetailsView: View {
                     if !order.lineItems.isEmpty {
                         productsSection(order)
                     }
-                    if shouldShowDedicatedRefundsSection && !orderListModel.ordersController.refundedProducts.isEmpty {
-                        refundedProductsSection(orderListModel.ordersController.refundedProducts)
+                    let refundedItems = order.refunds.flatMap { $0.items }
+                    if shouldShowDedicatedRefundsSection && !refundedItems.isEmpty {
+                        refundedProductsSection(refundedItems)
                     }
                     POSTotalsSectionView(
                         sectionTitle: Localization.totalsTitle,
@@ -118,7 +119,7 @@ struct POSOrderDetailsView: View {
         }
         .task {
             guard shouldShowDedicatedRefundsSection else { return }
-            await orderListModel.ordersController.loadRefundedProducts()
+            await orderListModel.ordersController.loadOrderRefunds()
         }
         .onAppear {
             if autoStartNextRefundFlow {

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -265,8 +265,8 @@ private extension POSOrderDetailsView {
     @ViewBuilder
 
     func productImageView(item: POSOrderItem) -> some View {
-        POSItemImageView(imageSource: item.imageSrc, imageSize: 56, scale: 1)
-            .frame(width: 56, height: 56)
+        POSItemImageView(imageSource: item.imageSrc, imageSize: Constants.productImageSize, scale: 1)
+            .frame(width: Constants.productImageSize, height: Constants.productImageSize)
             .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value))
     }
 
@@ -311,8 +311,8 @@ private extension POSOrderDetailsView {
     @ViewBuilder
     func refundedProductRow(item: POSRefundItem) -> some View {
         HStack(alignment: .center, spacing: POSSpacing.medium) {
-            POSItemImageView(imageSource: item.imageSrc, imageSize: 56, scale: 1)
-                .frame(width: 56, height: 56)
+            POSItemImageView(imageSource: item.imageSrc, imageSize: Constants.productImageSize, scale: 1)
+                .frame(width: Constants.productImageSize, height: Constants.productImageSize)
                 .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value))
 
             VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
@@ -505,6 +505,12 @@ private extension POSOrderDetailsView {
     }
 }
 
+
+// MARK: - Constants
+
+private enum Constants {
+    static let productImageSize: CGFloat = 56
+}
 
 // MARK: - Localization
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -27,6 +27,10 @@ struct POSOrderDetailsView: View {
         horizontalSizeClass == .compact
     }
 
+    private var shouldShowDedicatedRefundsSection: Bool {
+        featureFlags.isFeatureFlagEnabled(.pointOfSaleRefundsi1)
+    }
+
     private var dateFormatter: DateFormatter {
         let formatter = DateFormatter.dateAndTimeFormatter
         formatter.timeZone = siteTimezone
@@ -54,7 +58,7 @@ struct POSOrderDetailsView: View {
                     if !order.lineItems.isEmpty {
                         productsSection(order)
                     }
-                    if !orderListModel.ordersController.refundedProducts.isEmpty {
+                    if shouldShowDedicatedRefundsSection && !orderListModel.ordersController.refundedProducts.isEmpty {
                         refundedProductsSection(orderListModel.ordersController.refundedProducts)
                     }
                     POSTotalsSectionView(
@@ -113,6 +117,7 @@ struct POSOrderDetailsView: View {
             .posHeaderBackButtonIcon(systemName: "xmark")
         }
         .task {
+            guard shouldShowDedicatedRefundsSection else { return }
             await orderListModel.ordersController.loadRefundedProducts()
         }
         .onAppear {

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -178,10 +178,10 @@ private extension POSOrderDetailsView {
                 .accessibilityAddTraits(.isHeader)
 
             VStack(spacing: POSSpacing.small) {
-                ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+                ForEach(items) { item in
                     refundedProductRow(item: item)
 
-                    if index < items.count - 1 {
+                    if item.id != items.last?.id {
                         divider
                     }
                 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import struct WooFoundation.WooAnalyticsEvent
 import struct Yosemite.POSOrder
 import struct Yosemite.POSOrderItem
+import struct Yosemite.POSRefundItem
 import enum Yosemite.OrderStatusEnum
 import typealias Yosemite.OrderItemAttribute
 
@@ -52,6 +53,9 @@ struct POSOrderDetailsView: View {
                 VStack(alignment: .leading, spacing: POSSpacing.medium) {
                     if !order.lineItems.isEmpty {
                         productsSection(order)
+                    }
+                    if !orderListModel.ordersController.refundedProducts.isEmpty {
+                        refundedProductsSection(orderListModel.ordersController.refundedProducts)
                     }
                     POSTotalsSectionView(
                         sectionTitle: Localization.totalsTitle,
@@ -108,6 +112,9 @@ struct POSOrderDetailsView: View {
             }
             .posHeaderBackButtonIcon(systemName: "xmark")
         }
+        .task {
+            await orderListModel.ordersController.loadRefundedProducts()
+        }
         .onAppear {
             if autoStartNextRefundFlow {
                 autoStartNextRefundFlow = false
@@ -146,6 +153,29 @@ private extension POSOrderDetailsView {
                     productRow(item: item)
 
                     if index < order.lineItems.count - 1 {
+                        divider
+                    }
+                }
+            }
+        }
+        .padding(POSPadding.medium)
+        .background(Color.posSurfaceContainerLowest)
+        .posItemCardBorderStyles()
+    }
+
+    @ViewBuilder
+    func refundedProductsSection(_ items: [POSRefundItem]) -> some View {
+        VStack(alignment: .leading, spacing: POSSpacing.medium) {
+            Text(Localization.refundedProductsTitle)
+                .font(.posBodyXLargeRegular)
+                .foregroundStyle(Color.posOnSurface)
+                .accessibilityAddTraits(.isHeader)
+
+            VStack(spacing: POSSpacing.small) {
+                ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+                    refundedProductRow(item: item)
+
+                    if index < items.count - 1 {
                         divider
                     }
                 }
@@ -266,6 +296,53 @@ private extension POSOrderDetailsView {
         Text(item.formattedTotal)
             .font(.posBodyMediumRegular())
             .foregroundStyle(Color.posOnSurface)
+    }
+}
+
+// MARK: - Refunded Product Components
+
+private extension POSOrderDetailsView {
+    @ViewBuilder
+    func refundedProductRow(item: POSRefundItem) -> some View {
+        HStack(alignment: .center, spacing: POSSpacing.medium) {
+            POSItemImageView(imageSource: item.imageSrc, imageSize: 56, scale: 1)
+                .frame(width: 56, height: 56)
+                .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value))
+
+            VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
+                Text(item.name)
+                    .font(.posBodyLargeBold)
+                    .foregroundStyle(Color.posOnSurface)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(Localization.quantityLabel(item.quantity.intValue,
+                                                item.formattedPrice))
+                    .font(.posBodyMediumRegular())
+                    .foregroundStyle(Color.posOnSurfaceVariantHighest)
+            }
+
+            Spacer()
+
+            Text(item.formattedTotal)
+                .font(.posBodyMediumRegular())
+                .foregroundStyle(Color.posOnSurface)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(refundedProductRowAccessibilityLabel(for: item))
+    }
+
+    private func refundedProductRowAccessibilityLabel(for item: POSRefundItem) -> String {
+        let format = NSLocalizedString(
+            "pos.orderDetailsView.refundedProductRow.accessibilityLabel",
+            value: "%1$@, Quantity: %2$@ at %3$@ each, Refunded %4$@",
+            comment: "Accessibility label for refunded product row. " +
+            "%1$@ is product name, %2$@ is quantity, %3$@ is unit price, %4$@ is refund total."
+        )
+        return String(format: format,
+                      item.name,
+                      String(item.quantity.intValue),
+                      item.formattedPrice,
+                      item.formattedTotal)
     }
 }
 
@@ -430,6 +507,12 @@ private enum Localization {
         "pos.orderDetailsView.productsTitle",
         value: "Products",
         comment: "Section title for the products list"
+    )
+
+    static let refundedProductsTitle = NSLocalizedString(
+        "pos.orderDetailsView.refundedProductsTitle",
+        value: "Refunded products",
+        comment: "Section title for the refunded products list in order details"
     )
 
     static func quantityLabel(_ quantity: Int, _ unitPrice: String) -> String {

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -27,7 +27,6 @@ import struct Yosemite.POSOrder
 import struct Yosemite.POSOrderItem
 import struct Yosemite.POSOrderRefund
 import struct Yosemite.POSRefund
-import struct Yosemite.POSRefundItem
 import struct Yosemite.POSRefundsResult
 import typealias Yosemite.OrderItemAttribute
 import class Yosemite.POSOrderListService

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -27,6 +27,7 @@ import struct Yosemite.POSOrder
 import struct Yosemite.POSOrderItem
 import struct Yosemite.POSOrderRefund
 import struct Yosemite.POSRefund
+import struct Yosemite.POSRefundItem
 import struct Yosemite.POSRefundsResult
 import typealias Yosemite.OrderItemAttribute
 import class Yosemite.POSOrderListService
@@ -828,6 +829,7 @@ final class POSConfigurablePreviewBookingListController: POSSearchingBookingList
 // MARK: - Preview Orders Controller
 final class POSConfigurablePreviewOrderListController: POSSearchingOrderListControllerProtocol {
     var refundSelectableItems: [POSRefundSelectableItem]
+    var refundedProducts: [POSRefundItem] = []
     let ordersViewState: POSOrderListState
 
     init(state: POSOrderListState) {
@@ -854,6 +856,7 @@ final class POSConfigurablePreviewOrderListController: POSSearchingOrderListCont
     func toggleAllRefundItemsSelection() {}
     func preparePOSRefundReviewData() -> POSRefundReviewData? { nil }
     func processRefund(reason: String?) async throws {}
+    func loadRefundedProducts() async {}
 }
 
 // MARK: - Barcode Scan Service
@@ -912,6 +915,8 @@ final class POSRefundsServicePreview: POSRefundsServiceProtocol {
     }
 
     func createRefund(orderID: Int64, items: [Yosemite.POSRefundableItem], reason: String?, isAutomaticRefund: Bool) async throws {}
+
+    func loadRefundedProducts(for order: Yosemite.POSOrder) async throws -> [Yosemite.POSRefundItem] { [] }
 }
 
 final class POSReceiptServicePreview: POSReceiptServiceProtocol {

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -829,7 +829,6 @@ final class POSConfigurablePreviewBookingListController: POSSearchingBookingList
 // MARK: - Preview Orders Controller
 final class POSConfigurablePreviewOrderListController: POSSearchingOrderListControllerProtocol {
     var refundSelectableItems: [POSRefundSelectableItem]
-    var refundedProducts: [POSRefundItem] = []
     let ordersViewState: POSOrderListState
 
     init(state: POSOrderListState) {
@@ -856,7 +855,7 @@ final class POSConfigurablePreviewOrderListController: POSSearchingOrderListCont
     func toggleAllRefundItemsSelection() {}
     func preparePOSRefundReviewData() -> POSRefundReviewData? { nil }
     func processRefund(reason: String?) async throws {}
-    func loadRefundedProducts() async {}
+    func loadOrderRefunds() async {}
 }
 
 // MARK: - Barcode Scan Service
@@ -916,7 +915,7 @@ final class POSRefundsServicePreview: POSRefundsServiceProtocol {
 
     func createRefund(orderID: Int64, items: [Yosemite.POSRefundableItem], reason: String?, isAutomaticRefund: Bool) async throws {}
 
-    func loadRefundedProducts(for order: Yosemite.POSOrder) async throws -> [Yosemite.POSRefundItem] { [] }
+    func loadOrderRefunds(for order: Yosemite.POSOrder) async throws -> [Yosemite.POSOrderRefund] { [] }
 }
 
 final class POSReceiptServicePreview: POSReceiptServiceProtocol {

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderRefund.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderRefund.swift
@@ -6,12 +6,15 @@ public struct POSOrderRefund: Equatable, Hashable {
     public let refundID: Int64
     public let formattedTotal: String
     public let reason: String?
+    public let items: [POSRefundItem]
 
     public init(refundID: Int64,
                 formattedTotal: String,
-                reason: String? = nil) {
+                reason: String? = nil,
+                items: [POSRefundItem] = []) {
         self.refundID = refundID
         self.formattedTotal = formattedTotal
         self.reason = reason
+        self.items = items
     }
 }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundItem.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundItem.swift
@@ -5,9 +5,22 @@ public struct POSRefundItem: Equatable, Hashable {
     /// This matches the `itemID` on `POSOrderItem`.
     public let refundedItemID: Int64?
     public let quantity: Decimal
+    public let name: String
+    public let formattedPrice: String
+    public let formattedTotal: String
+    public let imageSrc: String?
 
-    public init(refundedItemID: Int64?, quantity: Decimal) {
+    public init(refundedItemID: Int64?,
+                quantity: Decimal,
+                name: String = "",
+                formattedPrice: String = "",
+                formattedTotal: String = "",
+                imageSrc: String? = nil) {
         self.refundedItemID = refundedItemID
         self.quantity = quantity
+        self.name = name
+        self.formattedPrice = formattedPrice
+        self.formattedTotal = formattedTotal
+        self.imageSrc = imageSrc
     }
 }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundItem.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundItem.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-public struct POSRefundItem: Equatable, Hashable {
+public struct POSRefundItem: Identifiable, Equatable, Hashable {
+    public let id: UUID
+
     /// The original order line item ID that was refunded.
     /// This matches the `itemID` on `POSOrderItem`.
     public let refundedItemID: Int64?
@@ -15,12 +17,32 @@ public struct POSRefundItem: Equatable, Hashable {
                 name: String = "",
                 formattedPrice: String = "",
                 formattedTotal: String = "",
-                imageSrc: String? = nil) {
+                imageSrc: String? = nil,
+                id: UUID = UUID()) {
+        self.id = id
         self.refundedItemID = refundedItemID
         self.quantity = quantity
         self.name = name
         self.formattedPrice = formattedPrice
         self.formattedTotal = formattedTotal
         self.imageSrc = imageSrc
+    }
+
+    public static func == (lhs: POSRefundItem, rhs: POSRefundItem) -> Bool {
+        lhs.refundedItemID == rhs.refundedItemID &&
+        lhs.quantity == rhs.quantity &&
+        lhs.name == rhs.name &&
+        lhs.formattedPrice == rhs.formattedPrice &&
+        lhs.formattedTotal == rhs.formattedTotal &&
+        lhs.imageSrc == rhs.imageSrc
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(refundedItemID)
+        hasher.combine(quantity)
+        hasher.combine(name)
+        hasher.combine(formattedPrice)
+        hasher.combine(formattedTotal)
+        hasher.combine(imageSrc)
     }
 }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundItem.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundItem.swift
@@ -14,10 +14,10 @@ public struct POSRefundItem: Identifiable, Equatable, Hashable {
 
     public init(refundedItemID: Int64?,
                 quantity: Decimal,
-                name: String = "",
-                formattedPrice: String = "",
-                formattedTotal: String = "",
-                imageSrc: String? = nil,
+                name: String,
+                formattedPrice: String,
+                formattedTotal: String,
+                imageSrc: String?,
                 id: UUID = UUID()) {
         self.id = id
         self.refundedItemID = refundedItemID

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundMapper.swift
@@ -1,5 +1,6 @@
 import Foundation
 import struct NetworkingCore.Refund
+import class WooFoundationCore.CurrencyFormatter
 
 struct POSRefundMapper {
     func map(refund: NetworkingCore.Refund) -> POSRefund {
@@ -8,5 +9,29 @@ struct POSRefundMapper {
             return POSRefundItem(refundedItemID: refundedItemID, quantity: item.quantity)
         }
         return POSRefund(items: refundItems)
+    }
+
+    func mapWithDisplayData(refund: NetworkingCore.Refund,
+                            orderItems: [POSOrderItem],
+                            currencyFormatter: CurrencyFormatter,
+                            currency: String) -> [POSRefundItem] {
+        let orderItemsByID = Dictionary(uniqueKeysWithValues: orderItems.map { ($0.itemID, $0) })
+
+        return refund.items.map { item in
+            let refundedItemID = item.refundedItemID.flatMap { Int64($0) }
+            let matchedOrderItem = refundedItemID.flatMap { orderItemsByID[$0] }
+
+            let formattedPrice = currencyFormatter.formatAmount(item.price.abs(), with: currency) ?? ""
+            let formattedTotal = currencyFormatter.formatAmount(item.total, with: currency) ?? ""
+
+            return POSRefundItem(
+                refundedItemID: refundedItemID,
+                quantity: abs(item.quantity),
+                name: item.name,
+                formattedPrice: formattedPrice,
+                formattedTotal: formattedTotal,
+                imageSrc: matchedOrderItem?.imageSrc
+            )
+        }
     }
 }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundMapper.swift
@@ -6,7 +6,12 @@ struct POSRefundMapper {
     func map(refund: NetworkingCore.Refund) -> POSRefund {
         let refundItems = refund.items.map { item in
             let refundedItemID = item.refundedItemID.flatMap { Int64($0) }
-            return POSRefundItem(refundedItemID: refundedItemID, quantity: item.quantity)
+            return POSRefundItem(refundedItemID: refundedItemID,
+                                 quantity: item.quantity,
+                                 name: item.name,
+                                 formattedPrice: "",
+                                 formattedTotal: "",
+                                 imageSrc: nil)
         }
         return POSRefund(items: refundItems)
     }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundMapper.swift
@@ -3,20 +3,7 @@ import struct NetworkingCore.Refund
 import class WooFoundationCore.CurrencyFormatter
 
 struct POSRefundMapper {
-    func map(refund: NetworkingCore.Refund) -> POSRefund {
-        let refundItems = refund.items.map { item in
-            let refundedItemID = item.refundedItemID.flatMap { Int64($0) }
-            return POSRefundItem(refundedItemID: refundedItemID,
-                                 quantity: item.quantity,
-                                 name: item.name,
-                                 formattedPrice: "",
-                                 formattedTotal: "",
-                                 imageSrc: nil)
-        }
-        return POSRefund(items: refundItems)
-    }
-
-    func mapWithDisplayData(refund: NetworkingCore.Refund,
+    func map(refund: NetworkingCore.Refund,
                             orderItems: [POSOrderItem],
                             currencyFormatter: CurrencyFormatter,
                             currency: String) -> [POSRefundItem] {

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
@@ -6,6 +6,7 @@ import struct NetworkingCore.Refund
 import struct NetworkingCore.OrderItemRefund
 import struct NetworkingCore.OrderItemTaxRefund
 import class WooFoundation.CurrencySettings
+import class WooFoundationCore.CurrencyFormatter
 
 public final class POSRefundsService: POSRefundsServiceProtocol {
     private let refundsRemote: POSRefundsRemoteProtocol
@@ -43,6 +44,21 @@ public final class POSRefundsService: POSRefundsServiceProtocol {
         self.paymentGatewayRemote = paymentGatewayRemote
         self.refundCalculator = refundCalculator
         self.mapper = POSRefundMapper()
+    }
+
+    public func loadRefundedProducts(for order: POSOrder) async throws -> [POSRefundItem] {
+        let refunds = try await refundsRemote.loadRefunds(for: siteID, by: order.id, with: order.refunds.map { $0.refundID })
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        let currency = currencySettings.currencyCode.rawValue
+
+        return refunds.flatMap { refund in
+            mapper.mapWithDisplayData(
+                refund: refund,
+                orderItems: order.lineItems,
+                currencyFormatter: currencyFormatter,
+                currency: currency
+            )
+        }
     }
 
     public func providePointOfSaleRefunds(for order: POSOrder) async throws -> POSRefundsResult {

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
@@ -52,7 +52,7 @@ public final class POSRefundsService: POSRefundsServiceProtocol {
         let currency = currencySettings.currencyCode.rawValue
 
         return refunds.map { refund in
-            let items = mapper.mapWithDisplayData(
+            let items = mapper.map(
                 refund: refund,
                 orderItems: order.lineItems,
                 currencyFormatter: currencyFormatter,
@@ -75,7 +75,16 @@ public final class POSRefundsService: POSRefundsServiceProtocol {
         let refunds = try await refundsTask
         let gateways = await gatewaysTask
 
-        let mappedRefunds = refunds.map { mapper.map(refund: $0) }
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        let currency = currencySettings.currencyCode.rawValue
+        let mappedRefunds = refunds.map { refund in
+            POSRefund(items: mapper.map(
+                refund: refund,
+                orderItems: order.lineItems,
+                currencyFormatter: currencyFormatter,
+                currency: currency
+            ))
+        }
         let isFullyRefunded = areAllProductsFullyRefunded(
             orderedQuantities: order.lineItemQuantitiesByProductOrVariationID,
             refunds: refunds

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
@@ -46,17 +46,24 @@ public final class POSRefundsService: POSRefundsServiceProtocol {
         self.mapper = POSRefundMapper()
     }
 
-    public func loadRefundedProducts(for order: POSOrder) async throws -> [POSRefundItem] {
+    public func loadOrderRefunds(for order: POSOrder) async throws -> [POSOrderRefund] {
         let refunds = try await refundsRemote.loadRefunds(for: siteID, by: order.id, with: order.refunds.map { $0.refundID })
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         let currency = currencySettings.currencyCode.rawValue
 
-        return refunds.flatMap { refund in
-            mapper.mapWithDisplayData(
+        return refunds.map { refund in
+            let items = mapper.mapWithDisplayData(
                 refund: refund,
                 orderItems: order.lineItems,
                 currencyFormatter: currencyFormatter,
                 currency: currency
+            )
+            let formattedTotal = currencyFormatter.formatAmount(refund.amount, with: currency) ?? ""
+            return POSOrderRefund(
+                refundID: refund.refundID,
+                formattedTotal: formattedTotal,
+                reason: refund.reason.isEmpty ? nil : refund.reason,
+                items: items
             )
         }
     }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsServiceProtocol.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsServiceProtocol.swift
@@ -44,4 +44,5 @@ public protocol POSRefundsServiceProtocol {
     func providePointOfSaleRefunds(for order: POSOrder) async throws -> POSRefundsResult
     func calculateRefundAmounts(for items: [POSRefundableItem]) -> POSRefundAmounts
     func createRefund(orderID: Int64, items: [POSRefundableItem], reason: String?, isAutomaticRefund: Bool) async throws
+    func loadRefundedProducts(for order: POSOrder) async throws -> [POSRefundItem]
 }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsServiceProtocol.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsServiceProtocol.swift
@@ -44,5 +44,5 @@ public protocol POSRefundsServiceProtocol {
     func providePointOfSaleRefunds(for order: POSOrder) async throws -> POSRefundsResult
     func calculateRefundAmounts(for items: [POSRefundableItem]) -> POSRefundAmounts
     func createRefund(orderID: Int64, items: [POSRefundableItem], reason: String?, isAutomaticRefund: Bool) async throws
-    func loadRefundedProducts(for order: POSOrder) async throws -> [POSRefundItem]
+    func loadOrderRefunds(for order: POSOrder) async throws -> [POSOrderRefund]
 }

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -1138,6 +1138,7 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func test_loadOrderRefunds_when_order_has_refunds_then_enriches_refunds_with_items() async throws {
         // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
         let order = makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
         refundsService.loadOrderRefundsResultToReturn = [
@@ -1206,6 +1207,7 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func test_selectOrder_then_new_order_has_no_refunded_items() async throws {
         // Given: Load some refunded products first
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
         let order = makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
         refundsService.loadOrderRefundsResultToReturn = [
@@ -1231,6 +1233,7 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func test_loadOrderRefunds_when_selected_order_changes_during_fetch_then_discards_stale_result() async throws {
         // Given: Select Order A and start loading its refunds
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
         let orderA = makeOrder(id: 1, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(orderA)
         refundsService.shouldSuspendLoadOrderRefunds = true

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -11,6 +11,7 @@ import enum Yosemite.OrderStatusEnum
 import typealias Yosemite.OrderItemAttribute
 @testable import struct Yosemite.POSRefund
 @testable import struct Yosemite.POSRefundItem
+import struct Yosemite.POSOrderRefund
 @testable import struct Yosemite.POSRefundsResult
 @testable import struct Yosemite.POSRefundableItem
 import class WooFoundation.CurrencySettings
@@ -1133,6 +1134,79 @@ final class POSOrderListControllerTests {
         #expect(orderListService.loadOrderWasCalled == true)
         #expect(orderListService.lastLoadOrderID == order.id)
     }
+
+    @MainActor
+    @Test func test_loadRefundedProducts_when_order_has_refunds_then_populates_refundedProducts() async throws {
+        // Given
+        let order = makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        sut.selectOrder(order)
+        refundsService.loadRefundedProductsResultToReturn = [
+            POSRefundItem(refundedItemID: 1, quantity: 1, name: "Item A", formattedPrice: "$10.00", formattedTotal: "-$10.00"),
+            POSRefundItem(refundedItemID: 2, quantity: 1, name: "Item B", formattedPrice: "$5.00", formattedTotal: "-$5.00")
+        ]
+
+        // When
+        await sut.loadRefundedProducts()
+
+        // Then
+        #expect(sut.refundedProducts.count == 2)
+    }
+
+    @MainActor
+    @Test func test_loadRefundedProducts_when_no_selected_order_then_refundedProducts_is_empty() async throws {
+        // Given — no order selected
+
+        // When
+        await sut.loadRefundedProducts()
+
+        // Then
+        #expect(sut.refundedProducts.isEmpty)
+    }
+
+    @MainActor
+    @Test func test_loadRefundedProducts_when_order_has_no_refunds_then_refundedProducts_is_empty() async throws {
+        // Given
+        let order = makeOrder(refunds: [])
+        sut.selectOrder(order)
+
+        // When
+        await sut.loadRefundedProducts()
+
+        // Then
+        #expect(sut.refundedProducts.isEmpty)
+    }
+
+    @MainActor
+    @Test func test_loadRefundedProducts_when_service_throws_then_refundedProducts_is_empty() async throws {
+        // Given
+        let order = makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        sut.selectOrder(order)
+        refundsService.loadRefundedProductsErrorToThrow = NSError(domain: "test", code: 1)
+
+        // When
+        await sut.loadRefundedProducts()
+
+        // Then
+        #expect(sut.refundedProducts.isEmpty)
+    }
+
+    @MainActor
+    @Test func test_selectOrder_then_clears_refundedProducts() async throws {
+        // Given: Load some refunded products first
+        let order = makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        sut.selectOrder(order)
+        refundsService.loadRefundedProductsResultToReturn = [
+            POSRefundItem(refundedItemID: 1, quantity: 1, name: "Item A", formattedPrice: "$10.00", formattedTotal: "-$10.00")
+        ]
+        await sut.loadRefundedProducts()
+        try #require(sut.refundedProducts.count == 1)
+
+        // When
+        sut.selectOrder(makeOrder(id: 2))
+
+        // Then
+        #expect(sut.refundedProducts.isEmpty)
+    }
 }
 
 private extension POSOrderListControllerTests {
@@ -1152,7 +1226,8 @@ private extension POSOrderListControllerTests {
                    status: OrderStatusEnum = .completed,
                    paymentMethodID: String = "woocommerce_payments",
                    paymentMethodTitle: String = "cod",
-                   lineItems: [POSOrderItem] = []) -> POSOrder {
+                   lineItems: [POSOrderItem] = [],
+                   refunds: [POSOrderRefund] = []) -> POSOrder {
         POSOrder(
             id: id,
             number: "\(id)",
@@ -1164,7 +1239,7 @@ private extension POSOrderListControllerTests {
             paymentMethodID: paymentMethodID,
             paymentMethodTitle: paymentMethodTitle,
             lineItems: lineItems,
-            refunds: [],
+            refunds: refunds,
             formattedDiscountTotal: nil,
             formattedTotalTax: "$0.00",
             formattedPaymentTotal: "$25.99",

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -482,7 +482,7 @@ final class POSOrderListControllerTests {
         // Given: Order has 3 units of item, 1 was previously refunded
         featureFlags.isPointOfSaleRefundsi1Enabled = true
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
-            refunds: [POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -1)])],
+            refunds: [POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -1, name: "", formattedPrice: "", formattedTotal: "", imageSrc: nil)])],
             isFullyRefunded: false,
             supportsAutomaticRefund: true
         )
@@ -504,7 +504,7 @@ final class POSOrderListControllerTests {
         // Given: Order has 2 units of item, both were previously refunded
         featureFlags.isPointOfSaleRefundsi1Enabled = true
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
-            refunds: [POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -2)])],
+            refunds: [POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -2, name: "", formattedPrice: "", formattedTotal: "", imageSrc: nil)])],
             isFullyRefunded: false,
             supportsAutomaticRefund: true
         )
@@ -529,8 +529,8 @@ final class POSOrderListControllerTests {
         featureFlags.isPointOfSaleRefundsi1Enabled = true
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
             refunds: [
-                POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -2)]),
-                POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -2)])
+                POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -2, name: "", formattedPrice: "", formattedTotal: "", imageSrc: nil)]),
+                POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -2, name: "", formattedPrice: "", formattedTotal: "", imageSrc: nil)])
             ],
             isFullyRefunded: false,
             supportsAutomaticRefund: true

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -1142,8 +1142,18 @@ final class POSOrderListControllerTests {
         sut.selectOrder(order)
         refundsService.loadOrderRefundsResultToReturn = [
             POSOrderRefund(refundID: 1, formattedTotal: "-$15.00", items: [
-                POSRefundItem(refundedItemID: 1, quantity: 1, name: "Item A", formattedPrice: "$10.00", formattedTotal: "-$10.00"),
-                POSRefundItem(refundedItemID: 2, quantity: 1, name: "Item B", formattedPrice: "$5.00", formattedTotal: "-$5.00")
+                POSRefundItem(refundedItemID: 1,
+                              quantity: 1,
+                              name: "Item A",
+                              formattedPrice: "$10.00",
+                              formattedTotal: "-$10.00",
+                              imageSrc: "some image source"),
+                POSRefundItem(refundedItemID: 2,
+                              quantity: 1,
+                              name: "Item B",
+                              formattedPrice: "$5.00",
+                              formattedTotal: "-$5.00",
+                              imageSrc: "some image source")
             ])
         ]
 
@@ -1200,7 +1210,12 @@ final class POSOrderListControllerTests {
         sut.selectOrder(order)
         refundsService.loadOrderRefundsResultToReturn = [
             POSOrderRefund(refundID: 1, formattedTotal: "-$10.00", items: [
-                POSRefundItem(refundedItemID: 1, quantity: 1, name: "Item A", formattedPrice: "$10.00", formattedTotal: "-$10.00")
+                POSRefundItem(refundedItemID: 1,
+                              quantity: 1,
+                              name: "Item A",
+                              formattedPrice: "$10.00",
+                              formattedTotal: "-$10.00",
+                              imageSrc: "some image source")
             ])
         ]
         await sut.loadOrderRefunds()

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -1136,76 +1136,81 @@ final class POSOrderListControllerTests {
     }
 
     @MainActor
-    @Test func test_loadRefundedProducts_when_order_has_refunds_then_populates_refundedProducts() async throws {
+    @Test func test_loadOrderRefunds_when_order_has_refunds_then_enriches_refunds_with_items() async throws {
         // Given
         let order = makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
-        refundsService.loadRefundedProductsResultToReturn = [
-            POSRefundItem(refundedItemID: 1, quantity: 1, name: "Item A", formattedPrice: "$10.00", formattedTotal: "-$10.00"),
-            POSRefundItem(refundedItemID: 2, quantity: 1, name: "Item B", formattedPrice: "$5.00", formattedTotal: "-$5.00")
+        refundsService.loadOrderRefundsResultToReturn = [
+            POSOrderRefund(refundID: 1, formattedTotal: "-$15.00", items: [
+                POSRefundItem(refundedItemID: 1, quantity: 1, name: "Item A", formattedPrice: "$10.00", formattedTotal: "-$10.00"),
+                POSRefundItem(refundedItemID: 2, quantity: 1, name: "Item B", formattedPrice: "$5.00", formattedTotal: "-$5.00")
+            ])
         ]
 
         // When
-        await sut.loadRefundedProducts()
+        await sut.loadOrderRefunds()
 
         // Then
-        #expect(sut.refundedProducts.count == 2)
+        let refundedItems = sut.selectedOrder?.refunds.flatMap { $0.items }
+        #expect(refundedItems?.count == 2)
     }
 
     @MainActor
-    @Test func test_loadRefundedProducts_when_no_selected_order_then_refundedProducts_is_empty() async throws {
+    @Test func test_loadOrderRefunds_when_no_selected_order_then_selectedOrder_is_nil() async throws {
         // Given — no order selected
 
         // When
-        await sut.loadRefundedProducts()
+        await sut.loadOrderRefunds()
 
         // Then
-        #expect(sut.refundedProducts.isEmpty)
+        #expect(sut.selectedOrder == nil)
     }
 
     @MainActor
-    @Test func test_loadRefundedProducts_when_order_has_no_refunds_then_refundedProducts_is_empty() async throws {
+    @Test func test_loadOrderRefunds_when_order_has_no_refunds_then_refunds_unchanged() async throws {
         // Given
         let order = makeOrder(refunds: [])
         sut.selectOrder(order)
 
         // When
-        await sut.loadRefundedProducts()
+        await sut.loadOrderRefunds()
 
         // Then
-        #expect(sut.refundedProducts.isEmpty)
+        #expect(sut.selectedOrder?.refunds.flatMap { $0.items }.isEmpty == true)
     }
 
     @MainActor
-    @Test func test_loadRefundedProducts_when_service_throws_then_refundedProducts_is_empty() async throws {
+    @Test func test_loadOrderRefunds_when_service_throws_then_refunds_unchanged() async throws {
         // Given
         let order = makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
-        refundsService.loadRefundedProductsErrorToThrow = NSError(domain: "test", code: 1)
+        refundsService.loadOrderRefundsErrorToThrow = NSError(domain: "test", code: 1)
 
         // When
-        await sut.loadRefundedProducts()
+        await sut.loadOrderRefunds()
 
         // Then
-        #expect(sut.refundedProducts.isEmpty)
+        #expect(sut.selectedOrder?.refunds.first?.items.isEmpty == true)
     }
 
     @MainActor
-    @Test func test_selectOrder_then_clears_refundedProducts() async throws {
+    @Test func test_selectOrder_then_new_order_has_no_refunded_items() async throws {
         // Given: Load some refunded products first
         let order = makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
-        refundsService.loadRefundedProductsResultToReturn = [
-            POSRefundItem(refundedItemID: 1, quantity: 1, name: "Item A", formattedPrice: "$10.00", formattedTotal: "-$10.00")
+        refundsService.loadOrderRefundsResultToReturn = [
+            POSOrderRefund(refundID: 1, formattedTotal: "-$10.00", items: [
+                POSRefundItem(refundedItemID: 1, quantity: 1, name: "Item A", formattedPrice: "$10.00", formattedTotal: "-$10.00")
+            ])
         ]
-        await sut.loadRefundedProducts()
-        try #require(sut.refundedProducts.count == 1)
+        await sut.loadOrderRefunds()
+        try #require(sut.selectedOrder?.refunds.flatMap { $0.items }.count == 1)
 
         // When
         sut.selectOrder(makeOrder(id: 2))
 
         // Then
-        #expect(sut.refundedProducts.isEmpty)
+        #expect(sut.selectedOrder?.refunds.flatMap { $0.items }.isEmpty == true)
     }
 }
 

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -1227,6 +1227,42 @@ final class POSOrderListControllerTests {
         // Then
         #expect(sut.selectedOrder?.refunds.flatMap { $0.items }.isEmpty == true)
     }
+
+    @MainActor
+    @Test func test_loadOrderRefunds_when_selected_order_changes_during_fetch_then_discards_stale_result() async throws {
+        // Given: Select Order A and start loading its refunds
+        let orderA = makeOrder(id: 1, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        sut.selectOrder(orderA)
+        refundsService.shouldSuspendLoadOrderRefunds = true
+        refundsService.loadOrderRefundsResultToReturn = [
+            POSOrderRefund(refundID: 1, formattedTotal: "-$10.00", items: [
+                POSRefundItem(refundedItemID: 1,
+                              quantity: 1,
+                              name: "Item A",
+                              formattedPrice: "$10.00",
+                              formattedTotal: "-$10.00",
+                              imageSrc: nil)
+            ])
+        ]
+
+        // Start the fetch. Await until mock confirms it's been called and is suspended
+        let loadTask = Task { @MainActor in
+            await sut.loadOrderRefunds()
+        }
+        await refundsService.awaitLoadOrderRefundsCall()
+
+        // When: Switch to Order B while fetch is genuinely in-flight
+        let orderB = makeOrder(id: 2, refunds: [POSOrderRefund(refundID: 2, formattedTotal: "-$5.00")])
+        sut.selectOrder(orderB)
+
+        // Resume Order A's fetch — it should complete but discard the result
+        refundsService.resumeLoadOrderRefunds()
+        await loadTask.value
+
+        // Then: selectedOrder should still be Order B, not overwritten by Order A's result
+        #expect(sut.selectedOrder?.id == 2)
+        #expect(sut.selectedOrder?.refunds.flatMap { $0.items }.isEmpty == true)
+    }
 }
 
 private extension POSOrderListControllerTests {

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
@@ -1,7 +1,6 @@
 import Foundation
 @testable import PointOfSale
 import struct Yosemite.POSOrder
-import struct Yosemite.POSRefundItem
 
 final class MockPOSOrderListController: POSSearchingOrderListControllerProtocol {
     var ordersViewState: POSOrderListState = .empty

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
@@ -1,12 +1,14 @@
 import Foundation
 @testable import PointOfSale
 import struct Yosemite.POSOrder
+import struct Yosemite.POSRefundItem
 
 final class MockPOSOrderListController: POSSearchingOrderListControllerProtocol {
     var ordersViewState: POSOrderListState = .empty
     var selectedOrder: POSOrder?
     var refundActionAvailability: RefundActionAvailability = .available
     var refundSelectableItems: [POSRefundSelectableItem] = []
+    var refundedProducts: [POSRefundItem] = []
     var updateOrderCalled = false
     var spyUpdateOrderID: Int64?
     var shouldThrowError = false
@@ -81,6 +83,8 @@ final class MockPOSOrderListController: POSSearchingOrderListControllerProtocol 
             refundReason: nil
         )
     }
+
+    func loadRefundedProducts() async {}
 
     // MARK: - Refund Processing
 

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
@@ -8,7 +8,6 @@ final class MockPOSOrderListController: POSSearchingOrderListControllerProtocol 
     var selectedOrder: POSOrder?
     var refundActionAvailability: RefundActionAvailability = .available
     var refundSelectableItems: [POSRefundSelectableItem] = []
-    var refundedProducts: [POSRefundItem] = []
     var updateOrderCalled = false
     var spyUpdateOrderID: Int64?
     var shouldThrowError = false
@@ -84,7 +83,7 @@ final class MockPOSOrderListController: POSSearchingOrderListControllerProtocol 
         )
     }
 
-    func loadRefundedProducts() async {}
+    func loadOrderRefunds() async {}
 
     // MARK: - Refund Processing
 

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSRefundsService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSRefundsService.swift
@@ -48,6 +48,16 @@ final class MockPOSRefundsService: POSRefundsServiceProtocol {
         return calculator.calculateRefundAmounts(for: items, numberOfDecimals: 2)
     }
 
+    var loadRefundedProductsResultToReturn: [POSRefundItem] = []
+    var loadRefundedProductsErrorToThrow: Error?
+
+    func loadRefundedProducts(for order: Yosemite.POSOrder) async throws -> [POSRefundItem] {
+        if let error = loadRefundedProductsErrorToThrow {
+            throw error
+        }
+        return loadRefundedProductsResultToReturn
+    }
+
     // MARK: - createRefund
 
     var createRefundCalled = false

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSRefundsService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSRefundsService.swift
@@ -48,14 +48,14 @@ final class MockPOSRefundsService: POSRefundsServiceProtocol {
         return calculator.calculateRefundAmounts(for: items, numberOfDecimals: 2)
     }
 
-    var loadRefundedProductsResultToReturn: [POSRefundItem] = []
-    var loadRefundedProductsErrorToThrow: Error?
+    var loadOrderRefundsResultToReturn: [POSOrderRefund] = []
+    var loadOrderRefundsErrorToThrow: Error?
 
-    func loadRefundedProducts(for order: Yosemite.POSOrder) async throws -> [POSRefundItem] {
-        if let error = loadRefundedProductsErrorToThrow {
+    func loadOrderRefunds(for order: Yosemite.POSOrder) async throws -> [POSOrderRefund] {
+        if let error = loadOrderRefundsErrorToThrow {
             throw error
         }
-        return loadRefundedProductsResultToReturn
+        return loadOrderRefundsResultToReturn
     }
 
     // MARK: - createRefund

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSRefundsService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSRefundsService.swift
@@ -50,8 +50,30 @@ final class MockPOSRefundsService: POSRefundsServiceProtocol {
 
     var loadOrderRefundsResultToReturn: [POSOrderRefund] = []
     var loadOrderRefundsErrorToThrow: Error?
+    var shouldSuspendLoadOrderRefunds = false
+    private var loadOrderRefundsContinuation: CheckedContinuation<Void, Never>?
+    private var loadOrderRefundsCallContinuation: CheckedContinuation<Void, Never>?
+
+    func awaitLoadOrderRefundsCall() async {
+        await withCheckedContinuation { continuation in
+            loadOrderRefundsCallContinuation = continuation
+        }
+    }
+
+    func resumeLoadOrderRefunds() {
+        loadOrderRefundsContinuation?.resume()
+        loadOrderRefundsContinuation = nil
+    }
 
     func loadOrderRefunds(for order: Yosemite.POSOrder) async throws -> [POSOrderRefund] {
+        loadOrderRefundsCallContinuation?.resume()
+        loadOrderRefundsCallContinuation = nil
+
+        if shouldSuspendLoadOrderRefunds {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                loadOrderRefundsContinuation = continuation
+            }
+        }
         if let error = loadOrderRefundsErrorToThrow {
             throw error
         }

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSRefundMapperTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSRefundMapperTests.swift
@@ -1,0 +1,184 @@
+import Testing
+import Foundation
+@testable import Yosemite
+@testable import NetworkingCore
+import class WooFoundation.CurrencySettings
+import class WooFoundation.CurrencyFormatter
+
+struct POSRefundMapperTests {
+    private let sut = POSRefundMapper()
+    private let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+    private let currency = CurrencySettings().currencyCode.rawValue
+
+    @Test func test_mapWithDisplayData_then_maps_name_from_refund_item() {
+        // Given
+        let refund = makeRefund(items: [makeRefundItem(name: "Coffee Mug")])
+
+        // When
+        let result = sut.mapWithDisplayData(refund: refund,
+                                            orderItems: [],
+                                            currencyFormatter: currencyFormatter,
+                                            currency: currency)
+
+        // Then
+        #expect(result.first?.name == "Coffee Mug")
+    }
+
+    @Test func test_mapWithDisplayData_then_converts_quantity_to_absolute_value() {
+        // Given
+        let refund = makeRefund(items: [makeRefundItem(quantity: -2)])
+
+        // When
+        let result = sut.mapWithDisplayData(refund: refund,
+                                            orderItems: [],
+                                            currencyFormatter: currencyFormatter,
+                                            currency: currency)
+
+        // Then
+        #expect(result.first?.quantity == 2)
+    }
+
+    @Test func test_mapWithDisplayData_then_formats_price_as_positive() {
+        // Given
+        let refund = makeRefund(items: [makeRefundItem(price: NSDecimalNumber(value: -14.99))])
+
+        // When
+        let result = sut.mapWithDisplayData(refund: refund,
+                                            orderItems: [],
+                                            currencyFormatter: currencyFormatter,
+                                            currency: currency)
+
+        // Then
+        #expect(result.first?.formattedPrice.contains("-") == false)
+        #expect(result.first?.formattedPrice.contains("14.99") == true)
+    }
+
+    @Test func test_mapWithDisplayData_then_formats_total_as_negative() {
+        // Given
+        let refund = makeRefund(items: [makeRefundItem(total: "-14.99")])
+
+        // When
+        let result = sut.mapWithDisplayData(refund: refund,
+                                            orderItems: [],
+                                            currencyFormatter: currencyFormatter,
+                                            currency: currency)
+
+        // Then
+        #expect(result.first?.formattedTotal.contains("-") == true)
+        #expect(result.first?.formattedTotal.contains("14.99") == true)
+    }
+
+    @Test func test_mapWithDisplayData_when_order_item_matches_then_resolves_image() {
+        // Given
+        let refund = makeRefund(items: [makeRefundItem(refundedItemID: "42")])
+        let orderItem = makeOrderItem(itemID: 42, imageSrc: "https://example.com/img.jpg")
+
+        // When
+        let result = sut.mapWithDisplayData(refund: refund,
+                                            orderItems: [orderItem],
+                                            currencyFormatter: currencyFormatter,
+                                            currency: currency)
+
+        // Then
+        #expect(result.first?.imageSrc == "https://example.com/img.jpg")
+    }
+
+    @Test func test_mapWithDisplayData_when_no_matching_order_item_then_image_is_nil() {
+        // Given
+        let refund = makeRefund(items: [makeRefundItem(refundedItemID: "42")])
+        let orderItem = makeOrderItem(itemID: 99, imageSrc: "https://example.com/img.jpg")
+
+        // When
+        let result = sut.mapWithDisplayData(refund: refund,
+                                            orderItems: [orderItem],
+                                            currencyFormatter: currencyFormatter,
+                                            currency: currency)
+
+        // Then
+        #expect(result.first?.imageSrc == nil)
+    }
+
+    @Test func test_mapWithDisplayData_when_refundedItemID_is_nil_then_image_is_nil() {
+        // Given
+        let refund = makeRefund(items: [makeRefundItem(name: "Deleted Product", refundedItemID: nil)])
+
+        // When
+        let result = sut.mapWithDisplayData(refund: refund,
+                                            orderItems: [],
+                                            currencyFormatter: currencyFormatter,
+                                            currency: currency)
+
+        // Then
+        #expect(result.first?.imageSrc == nil)
+        #expect(result.first?.name == "Deleted Product")
+    }
+
+    @Test func test_mapWithDisplayData_with_multiple_items_then_returns_all() {
+        // Given
+        let refund = makeRefund(items: [
+            makeRefundItem(name: "Item A"),
+            makeRefundItem(name: "Item B"),
+            makeRefundItem(name: "Item C")
+        ])
+
+        // When
+        let result = sut.mapWithDisplayData(refund: refund,
+                                            orderItems: [],
+                                            currencyFormatter: currencyFormatter,
+                                            currency: currency)
+
+        // Then
+        #expect(result.count == 3)
+        #expect(result.map(\.name) == ["Item A", "Item B", "Item C"])
+    }
+}
+
+private extension POSRefundMapperTests {
+    func makeRefund(items: [OrderItemRefund]) -> Refund {
+        Refund(refundID: 1,
+               orderID: 100,
+               siteID: 123,
+               dateCreated: Date(),
+               amount: "14.99",
+               reason: "Test",
+               refundedByUserID: 0,
+               isAutomated: nil,
+               createAutomated: nil,
+               items: items,
+               shippingLines: nil)
+    }
+
+    func makeRefundItem(name: String = "Test Item",
+                        refundedItemID: String? = "1",
+                        quantity: Decimal = -1,
+                        price: NSDecimalNumber = NSDecimalNumber(value: -10.00),
+                        total: String = "-10.00") -> OrderItemRefund {
+        OrderItemRefund(itemID: 0,
+                        name: name,
+                        productID: 0,
+                        variationID: 0,
+                        refundedItemID: refundedItemID,
+                        quantity: quantity,
+                        price: price,
+                        sku: nil,
+                        subtotal: total,
+                        subtotalTax: "0.00",
+                        taxClass: "",
+                        taxes: [],
+                        total: total,
+                        totalTax: "0.00")
+    }
+
+    func makeOrderItem(itemID: Int64, imageSrc: String?) -> POSOrderItem {
+        POSOrderItem(itemID: itemID,
+                     name: "Order Item",
+                     quantity: 1,
+                     price: 10.00,
+                     total: 10.00,
+                     totalTax: 0,
+                     formattedPrice: "$10.00",
+                     formattedTotal: "$10.00",
+                     imageSrc: imageSrc,
+                     attributes: [])
+    }
+}

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSRefundMapperTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSRefundMapperTests.swift
@@ -10,12 +10,12 @@ struct POSRefundMapperTests {
     private let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
     private let currency = CurrencySettings().currencyCode.rawValue
 
-    @Test func test_mapWithDisplayData_then_maps_name_from_refund_item() {
+    @Test func test_map_then_maps_name_from_refund_item() {
         // Given
         let refund = makeRefund(items: [makeRefundItem(name: "Coffee Mug")])
 
         // When
-        let result = sut.mapWithDisplayData(refund: refund,
+        let result = sut.map(refund: refund,
                                             orderItems: [],
                                             currencyFormatter: currencyFormatter,
                                             currency: currency)
@@ -24,96 +24,96 @@ struct POSRefundMapperTests {
         #expect(result.first?.name == "Coffee Mug")
     }
 
-    @Test func test_mapWithDisplayData_then_converts_quantity_to_absolute_value() {
+    @Test func test_map_then_converts_quantity_to_absolute_value() {
         // Given
         let refund = makeRefund(items: [makeRefundItem(quantity: -2)])
 
         // When
-        let result = sut.mapWithDisplayData(refund: refund,
-                                            orderItems: [],
-                                            currencyFormatter: currencyFormatter,
-                                            currency: currency)
+        let result = sut.map(refund: refund,
+                             orderItems: [],
+                             currencyFormatter: currencyFormatter,
+                             currency: currency)
 
         // Then
         #expect(result.first?.quantity == 2)
     }
 
-    @Test func test_mapWithDisplayData_then_formats_price_as_positive() {
+    @Test func test_map_then_formats_price_as_positive() {
         // Given
         let refund = makeRefund(items: [makeRefundItem(price: NSDecimalNumber(value: -14.99))])
 
         // When
-        let result = sut.mapWithDisplayData(refund: refund,
-                                            orderItems: [],
-                                            currencyFormatter: currencyFormatter,
-                                            currency: currency)
+        let result = sut.map(refund: refund,
+                             orderItems: [],
+                             currencyFormatter: currencyFormatter,
+                             currency: currency)
 
         // Then
         #expect(result.first?.formattedPrice.contains("-") == false)
         #expect(result.first?.formattedPrice.contains("14.99") == true)
     }
 
-    @Test func test_mapWithDisplayData_then_formats_total_as_negative() {
+    @Test func test_map_then_formats_total_as_negative() {
         // Given
         let refund = makeRefund(items: [makeRefundItem(total: "-14.99")])
 
         // When
-        let result = sut.mapWithDisplayData(refund: refund,
-                                            orderItems: [],
-                                            currencyFormatter: currencyFormatter,
-                                            currency: currency)
+        let result = sut.map(refund: refund,
+                             orderItems: [],
+                             currencyFormatter: currencyFormatter,
+                             currency: currency)
 
         // Then
         #expect(result.first?.formattedTotal.contains("-") == true)
         #expect(result.first?.formattedTotal.contains("14.99") == true)
     }
 
-    @Test func test_mapWithDisplayData_when_order_item_matches_then_resolves_image() {
+    @Test func test_map_when_order_item_matches_then_resolves_image() {
         // Given
         let refund = makeRefund(items: [makeRefundItem(refundedItemID: "42")])
         let orderItem = makeOrderItem(itemID: 42, imageSrc: "https://example.com/img.jpg")
 
         // When
-        let result = sut.mapWithDisplayData(refund: refund,
-                                            orderItems: [orderItem],
-                                            currencyFormatter: currencyFormatter,
-                                            currency: currency)
+        let result = sut.map(refund: refund,
+                             orderItems: [orderItem],
+                             currencyFormatter: currencyFormatter,
+                             currency: currency)
 
         // Then
         #expect(result.first?.imageSrc == "https://example.com/img.jpg")
     }
 
-    @Test func test_mapWithDisplayData_when_no_matching_order_item_then_image_is_nil() {
+    @Test func test_map_when_no_matching_order_item_then_image_is_nil() {
         // Given
         let refund = makeRefund(items: [makeRefundItem(refundedItemID: "42")])
         let orderItem = makeOrderItem(itemID: 99, imageSrc: "https://example.com/img.jpg")
 
         // When
-        let result = sut.mapWithDisplayData(refund: refund,
-                                            orderItems: [orderItem],
-                                            currencyFormatter: currencyFormatter,
-                                            currency: currency)
+        let result = sut.map(refund: refund,
+                             orderItems: [orderItem],
+                             currencyFormatter: currencyFormatter,
+                             currency: currency)
 
         // Then
         #expect(result.first?.imageSrc == nil)
     }
 
-    @Test func test_mapWithDisplayData_when_refundedItemID_is_nil_then_image_is_nil() {
+    @Test func test_map_when_refundedItemID_is_nil_then_image_is_nil() {
         // Given
         let refund = makeRefund(items: [makeRefundItem(name: "Deleted Product", refundedItemID: nil)])
 
         // When
-        let result = sut.mapWithDisplayData(refund: refund,
-                                            orderItems: [],
-                                            currencyFormatter: currencyFormatter,
-                                            currency: currency)
+        let result = sut.map(refund: refund,
+                             orderItems: [],
+                             currencyFormatter: currencyFormatter,
+                             currency: currency)
 
         // Then
         #expect(result.first?.imageSrc == nil)
         #expect(result.first?.name == "Deleted Product")
     }
 
-    @Test func test_mapWithDisplayData_with_multiple_items_then_returns_all() {
+    @Test func test_map_with_multiple_items_then_returns_all() {
         // Given
         let refund = makeRefund(items: [
             makeRefundItem(name: "Item A"),
@@ -122,7 +122,7 @@ struct POSRefundMapperTests {
         ])
 
         // When
-        let result = sut.mapWithDisplayData(refund: refund,
+        let result = sut.map(refund: refund,
                                             orderItems: [],
                                             currencyFormatter: currencyFormatter,
                                             currency: currency)


### PR DESCRIPTION
Closes WOOMOB-1781

## Description

This PR adds a `Refunded Products` section to the order details, between `Products` and `Totals` which adds an extra row per product refunded. Figma: POS-Refunds?node-id=52-73&p=f&focus-id=360-19866&m=dev-fi-DK955L5K0bTfkjrHTBLmqo

We hide it behind `pointOfSaleRefundsi1` as we'll launch POS refunds M1-M2-M3 together.

<img width="494" height="585" alt="Screenshot 2026-03-07 at 13 37 49" src="https://github.com/user-attachments/assets/784cb54c-9548-4151-a9b3-75b25e18ce25" />

## Test Steps
1. In a POS order with existing refunds (total or partial), observe that the new card is rendered with refund details:
  - 1 row per refunded product
  - If n products of the same type are refunded, they show together:

<img width="772" height="211" alt="Screenshot 2026-03-07 at 13 58 44" src="https://github.com/user-attachments/assets/1e942beb-2a87-44e3-b31b-211146d22b16" />

2. Process a new refund on an order that does not have them. Upon completing the refund flow, observe how the order details view is updated with the refund.

## Screenshots
| Dark | Light |
|--------|--------|
| <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2026-03-07 at 13 35 09" src="https://github.com/user-attachments/assets/552f0b5b-1a8d-4480-92b0-44dd4aaef1b5" /> | <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2026-03-07 at 13 35 22" src="https://github.com/user-attachments/assets/f1fda2e5-4a5f-45c1-a7f8-bff9acc03b07" /> | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
