### PR TITLE
Update booking badge styling to match Figma design

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 24.4
 -----
+- [*] Update booking badge styling to match design [https://github.com/woocommerce/woocommerce-ios/pull/16802#pullrequestreview-3927676114]
 
 
 24.3

--- a/WooCommerce/Classes/Bookings/BookingBadgeView.swift
+++ b/WooCommerce/Classes/Bookings/BookingBadgeView.swift
@@ -103,7 +103,7 @@ extension BookingPaymentStatus: BookingBadgeable {
         }
     }
 
-    private var text: String {
+    var text: String {
         switch self {
         case .paid:
             return Localization.paid

--- a/WooCommerce/Classes/Bookings/BookingBadgeView.swift
+++ b/WooCommerce/Classes/Bookings/BookingBadgeView.swift
@@ -24,28 +24,28 @@ struct BookingBadgeView: View {
 // MARK: - Badge Styles
 
 extension BookingBadgeView {
-static func `default`(text: String) -> BookingBadgeView {
+    static func `default`(text: String) -> BookingBadgeView {
         BookingBadgeView(text: text,
                          textColor: BadgeStyle.lightText,
                          backgroundColor: BadgeStyle.defaultBackground,
                          borderColor: BadgeStyle.border)
     }
 
-static func info(text: String) -> BookingBadgeView {
+    static func info(text: String) -> BookingBadgeView {
         BookingBadgeView(text: text,
                          textColor: BadgeStyle.cancelledText,
                          backgroundColor: BadgeStyle.cancelled,
                          borderColor: nil)
     }
 
-static func warning(text: String) -> BookingBadgeView {
+    static func warning(text: String) -> BookingBadgeView {
         BookingBadgeView(text: text,
                          textColor: BadgeStyle.lightText,
                          backgroundColor: BadgeStyle.warning,
                          borderColor: nil)
     }
 
-static func muted(text: String) -> BookingBadgeView {
+    static func muted(text: String) -> BookingBadgeView {
         BookingBadgeView(text: text,
                          textColor: BadgeStyle.lightText,
                          backgroundColor: BadgeStyle.muted,
@@ -158,7 +158,7 @@ private extension BookingBadgeView {
 private enum BadgeStyle {
     static let lightGray6 = UIColor.systemGray6.resolvedColor(with: .init(userInterfaceStyle: .light))
 
-static let defaultBackground = Color(uiColor: UIColor { traits in
+    static let defaultBackground = Color(uiColor: UIColor { traits in
         traits.userInterfaceStyle == .dark ? lightGray6 : .clear
     })
     static let muted = Color(uiColor: lightGray6)

--- a/WooCommerce/Classes/Bookings/BookingBadgeView.swift
+++ b/WooCommerce/Classes/Bookings/BookingBadgeView.swift
@@ -6,81 +6,101 @@ import enum Yosemite.BookingStatus
 struct BookingBadgeView: View {
     let text: String
     let textColor: Color
-    let color: Color
+    let backgroundColor: Color
+    let borderColor: Color?
 
     var body: some View {
         BadgeView(text: text,
                   customizations: .init(
                     textColor: textColor,
-                    backgroundColor: color,
-                    bordered: false,
+                    backgroundColor: backgroundColor,
+                    borderColor: borderColor,
                     bold: false
                   ),
                   backgroundShape: .roundedRectangle(cornerRadius: Layout.cornerRadius))
     }
 }
 
-private extension BookingBadgeView {
-    enum Layout {
-        static let cornerRadius: CGFloat = 4
+// MARK: - Badge Styles
+
+extension BookingBadgeView {
+    static func `default`(text: String) -> BookingBadgeView {
+        BookingBadgeView(text: text,
+                         textColor: BadgeStyle.lightText,
+                         backgroundColor: BadgeStyle.defaultBackground,
+                         borderColor: BadgeStyle.border)
+    }
+
+    static func info(text: String) -> BookingBadgeView {
+        BookingBadgeView(text: text,
+                         textColor: BadgeStyle.cancelledText,
+                         backgroundColor: BadgeStyle.cancelled,
+                         borderColor: nil)
+    }
+
+    static func warning(text: String) -> BookingBadgeView {
+        BookingBadgeView(text: text,
+                         textColor: BadgeStyle.lightText,
+                         backgroundColor: BadgeStyle.warning,
+                         borderColor: nil)
+    }
+
+    static func muted(text: String) -> BookingBadgeView {
+        BookingBadgeView(text: text,
+                         textColor: BadgeStyle.lightText,
+                         backgroundColor: BadgeStyle.muted,
+                         borderColor: nil)
     }
 }
 
+// MARK: - BookingBadgeable
+
 protocol BookingBadgeable {
-    var text: String { get }
-    var textColor: Color { get }
-    var badgeColor: Color { get }
+    var bookingBadge: BookingBadgeView { get }
 }
 
 extension BookingBadgeView {
     init(_ badgeable: BookingBadgeable) {
-        self.init(text: badgeable.text, textColor: badgeable.textColor, color: badgeable.badgeColor)
+        self = badgeable.bookingBadge
     }
 }
+
+// MARK: - BookingAttendanceStatus
 
 extension BookingAttendanceStatus: BookingBadgeable {
-    var badgeColor: Color {
-        BadgeColor.default
-    }
-
-    var text: String {
-        self.localizedTitle
-    }
-
-    var textColor: Color {
-        BadgeColor.defaultText
+    var bookingBadge: BookingBadgeView {
+        switch self {
+        case .attended:
+            return .default(text: localizedTitle)
+        case .unattended, .unknown:
+            return .muted(text: localizedTitle)
+        }
     }
 }
+
+// MARK: - BookingStatus
 
 extension BookingStatus: BookingBadgeable {
-    var badgeColor: Color {
+    var bookingBadge: BookingBadgeView {
         switch self {
         case .cancelled:
-            return BadgeColor.cancelledBackground
-        case .unpaid:
-            return BadgeColor.info
+            return .info(text: localizedTitle)
         default:
-            return BadgeColor.default
-        }
-    }
-
-    var text: String {
-        self.localizedTitle
-    }
-
-    var textColor: Color {
-        switch self {
-        case .cancelled:
-            return BadgeColor.cancelledText
-        default:
-            return BadgeColor.defaultText
+            return .default(text: localizedTitle)
         }
     }
 }
 
+// MARK: - BookingPaymentStatus
+
 extension BookingPaymentStatus: BookingBadgeable {
-    var badgeColor: Color {
-        BadgeColor.default
+    var bookingBadge: BookingBadgeView {
+        switch self {
+        case .paid, .refunded, .partiallyRefunded:
+            return .default(text: text)
+        case .unpaid, .failed:
+            return .warning(text: text)
+        }
     }
 
     var text: String {
@@ -96,10 +116,6 @@ extension BookingPaymentStatus: BookingBadgeable {
         case .partiallyRefunded:
             return Localization.partiallyRefunded
         }
-    }
-
-    var textColor: Color {
-        BadgeColor.defaultText
     }
 
     private enum Localization {
@@ -131,10 +147,24 @@ extension BookingPaymentStatus: BookingBadgeable {
     }
 }
 
-fileprivate enum BadgeColor {
-    static let `default` = Color(uiColor: .systemGray6.resolvedColor(with: .init(userInterfaceStyle: .light)))
-    static let info = try! Color(rgbString: "rgba(255, 227, 101, 1)")
-    static let cancelledBackground = try! Color(rgbString: "rgba(225, 236, 248, 1)")
-    static let cancelledText = try! Color(rgbString: "rgba(0, 23, 88, 1)")
-    static let defaultText = Color(UIColor.label.resolvedColor(with: .init(userInterfaceStyle: .light)))
+// MARK: - Layout & Colors
+
+private extension BookingBadgeView {
+    enum Layout {
+        static let cornerRadius: CGFloat = 4
+    }
+}
+
+private enum BadgeStyle {
+    static let lightGray6 = UIColor.systemGray6.resolvedColor(with: .init(userInterfaceStyle: .light))
+
+    static let defaultBackground = Color(uiColor: UIColor { traits in
+        traits.userInterfaceStyle == .dark ? lightGray6 : .clear
+    })
+    static let muted = Color(uiColor: lightGray6)
+    static let cancelled = Color(UIColor(red: 225/255, green: 236/255, blue: 248/255, alpha: 1))
+    static let cancelledText = Color(UIColor(red: 0/255, green: 23/255, blue: 88/255, alpha: 1))
+    static let warning = try! Color(rgbString: "rgba(255, 227, 101, 1)")
+    static let lightText = Color(UIColor.label.resolvedColor(with: .init(userInterfaceStyle: .light)))
+    static let border = Color(uiColor: .systemGray5)
 }

--- a/WooCommerce/Classes/Bookings/BookingBadgeView.swift
+++ b/WooCommerce/Classes/Bookings/BookingBadgeView.swift
@@ -51,9 +51,9 @@ extension BookingAttendanceStatus: BookingBadgeable {
     var badgeColor: Color {
         switch self {
         case .attended:
-            return .clear
+            return BadgeColor.defaultBackground
         case .unattended, .unknown:
-            return BadgeColor.default
+            return BadgeColor.muted
         }
     }
 
@@ -62,7 +62,12 @@ extension BookingAttendanceStatus: BookingBadgeable {
     }
 
     var textColor: Color {
-        BadgeColor.defaultText
+        switch self {
+        case .attended:
+            return BadgeColor.lightText
+        case .unattended, .unknown:
+            return BadgeColor.lightText
+        }
     }
 
     var isBordered: Bool {
@@ -73,10 +78,10 @@ extension BookingAttendanceStatus: BookingBadgeable {
 extension BookingStatus: BookingBadgeable {
     var badgeColor: Color {
         switch self {
-        case .unpaid:
-            return BadgeColor.info
+        case .cancelled:
+            return BadgeColor.cancelled
         default:
-            return BadgeColor.default
+            return BadgeColor.defaultBackground
         }
     }
 
@@ -85,15 +90,25 @@ extension BookingStatus: BookingBadgeable {
     }
 
     var textColor: Color {
-        BadgeColor.defaultText
+        switch self {
+        case .cancelled:
+            return BadgeColor.cancelledText
+        default:
+            return BadgeColor.lightText
+        }
+    }
+
+    var isBordered: Bool {
+        self != .cancelled
     }
 }
+
 
 extension BookingPaymentStatus: BookingBadgeable {
     var badgeColor: Color {
         switch self {
         case .paid, .refunded, .partiallyRefunded:
-            return .clear
+            return BadgeColor.defaultBackground
         case .unpaid, .failed:
             return BadgeColor.info
         }
@@ -115,7 +130,12 @@ extension BookingPaymentStatus: BookingBadgeable {
     }
 
     var textColor: Color {
-        BadgeColor.defaultText
+        switch self {
+        case .paid, .refunded, .partiallyRefunded:
+            return BadgeColor.lightText
+        case .unpaid, .failed:
+            return BadgeColor.lightText
+        }
     }
 
     var isBordered: Bool {
@@ -157,8 +177,16 @@ extension BookingPaymentStatus: BookingBadgeable {
 }
 
 fileprivate enum BadgeColor {
-    static let `default` = Color(uiColor: .systemGray6)
+    static let lightGray6 = UIColor.systemGray6.resolvedColor(with: .init(userInterfaceStyle: .light))
+
+    /// Clear in light mode, light-mode systemGray6 in dark mode.
+    static let defaultBackground = Color(uiColor: UIColor { traits in
+        traits.userInterfaceStyle == .dark ? lightGray6 : .clear
+    })
+    static let muted = Color(uiColor: lightGray6)
+    static let cancelled = Color(UIColor(red: 225/255, green: 236/255, blue: 248/255, alpha: 1))
+    static let cancelledText = Color(UIColor(red: 0/255, green: 23/255, blue: 88/255, alpha: 1))
     static let info = try! Color(rgbString: "rgba(255, 227, 101, 1)")
-    static let defaultText = Color(uiColor: .label)
+    static let lightText = Color(UIColor.label.resolvedColor(with: .init(userInterfaceStyle: .light)))
     static let border = Color(uiColor: .systemGray5)
 }

--- a/WooCommerce/Classes/Bookings/BookingBadgeView.swift
+++ b/WooCommerce/Classes/Bookings/BookingBadgeView.swift
@@ -7,114 +7,103 @@ struct BookingBadgeView: View {
     let text: String
     let textColor: Color
     let backgroundColor: Color
-    let isBordered: Bool
+    let borderColor: Color?
 
     var body: some View {
         BadgeView(text: text,
                   customizations: .init(
                     textColor: textColor,
                     backgroundColor: backgroundColor,
-                    borderColor: isBordered ? BadgeColor.border : nil,
+                    borderColor: borderColor,
                     bold: false
                   ),
                   backgroundShape: .roundedRectangle(cornerRadius: Layout.cornerRadius))
     }
 }
 
-private extension BookingBadgeView {
-    enum Layout {
-        static let cornerRadius: CGFloat = 4
+// MARK: - Badge Styles
+
+extension BookingBadgeView {
+static func `default`(text: String) -> BookingBadgeView {
+        BookingBadgeView(text: text,
+                         textColor: BadgeStyle.lightText,
+                         backgroundColor: BadgeStyle.defaultBackground,
+                         borderColor: BadgeStyle.border)
+    }
+
+static func info(text: String) -> BookingBadgeView {
+        BookingBadgeView(text: text,
+                         textColor: BadgeStyle.cancelledText,
+                         backgroundColor: BadgeStyle.cancelled,
+                         borderColor: nil)
+    }
+
+static func warning(text: String) -> BookingBadgeView {
+        BookingBadgeView(text: text,
+                         textColor: BadgeStyle.lightText,
+                         backgroundColor: BadgeStyle.warning,
+                         borderColor: nil)
+    }
+
+static func muted(text: String) -> BookingBadgeView {
+        BookingBadgeView(text: text,
+                         textColor: BadgeStyle.lightText,
+                         backgroundColor: BadgeStyle.muted,
+                         borderColor: nil)
     }
 }
 
-protocol BookingBadgeable {
-    var text: String { get }
-    var textColor: Color { get }
-    var badgeColor: Color { get }
-    var isBordered: Bool { get }
-}
+// MARK: - BookingBadgeable
 
-extension BookingBadgeable {
-    var isBordered: Bool { false }
+protocol BookingBadgeable {
+    var bookingBadge: BookingBadgeView { get }
 }
 
 extension BookingBadgeView {
     init(_ badgeable: BookingBadgeable) {
-        self.init(text: badgeable.text,
-                  textColor: badgeable.textColor,
-                  backgroundColor: badgeable.badgeColor,
-                  isBordered: badgeable.isBordered)
+        self = badgeable.bookingBadge
     }
 }
+
+// MARK: - BookingAttendanceStatus
 
 extension BookingAttendanceStatus: BookingBadgeable {
-    var badgeColor: Color {
+    var bookingBadge: BookingBadgeView {
         switch self {
         case .attended:
-            return BadgeColor.defaultBackground
+            return .default(text: localizedTitle)
         case .unattended, .unknown:
-            return BadgeColor.muted
+            return .muted(text: localizedTitle)
         }
-    }
-
-    var text: String {
-        self.localizedTitle
-    }
-
-    var textColor: Color {
-        switch self {
-        case .attended:
-            return BadgeColor.lightText
-        case .unattended, .unknown:
-            return BadgeColor.lightText
-        }
-    }
-
-    var isBordered: Bool {
-        self == .attended
     }
 }
+
+// MARK: - BookingStatus
 
 extension BookingStatus: BookingBadgeable {
-    var badgeColor: Color {
+    var bookingBadge: BookingBadgeView {
         switch self {
         case .cancelled:
-            return BadgeColor.cancelled
+            return .info(text: localizedTitle)
         default:
-            return BadgeColor.defaultBackground
+            return .default(text: localizedTitle)
         }
-    }
-
-    var text: String {
-        self.localizedTitle
-    }
-
-    var textColor: Color {
-        switch self {
-        case .cancelled:
-            return BadgeColor.cancelledText
-        default:
-            return BadgeColor.lightText
-        }
-    }
-
-    var isBordered: Bool {
-        self != .cancelled
     }
 }
 
+// MARK: - BookingPaymentStatus
 
 extension BookingPaymentStatus: BookingBadgeable {
-    var badgeColor: Color {
+    var bookingBadge: BookingBadgeView {
         switch self {
         case .paid, .refunded, .partiallyRefunded:
-            return BadgeColor.defaultBackground
+            return .default(text: text)
         case .unpaid, .failed:
-            return BadgeColor.info
+            return .warning(text: text)
         }
     }
 
-    var text: String {
+    private var text: String {
         switch self {
         case .paid:
             return Localization.paid
@@ -126,24 +115,6 @@ extension BookingPaymentStatus: BookingBadgeable {
             return Localization.refunded
         case .partiallyRefunded:
             return Localization.partiallyRefunded
-        }
-    }
-
-    var textColor: Color {
-        switch self {
-        case .paid, .refunded, .partiallyRefunded:
-            return BadgeColor.lightText
-        case .unpaid, .failed:
-            return BadgeColor.lightText
-        }
-    }
-
-    var isBordered: Bool {
-        switch self {
-        case .paid, .refunded, .partiallyRefunded:
-            return true
-        case .unpaid, .failed:
-            return false
         }
     }
 
@@ -176,17 +147,24 @@ extension BookingPaymentStatus: BookingBadgeable {
     }
 }
 
-fileprivate enum BadgeColor {
+// MARK: - Layout & Colors
+
+private extension BookingBadgeView {
+    enum Layout {
+        static let cornerRadius: CGFloat = 4
+    }
+}
+
+private enum BadgeStyle {
     static let lightGray6 = UIColor.systemGray6.resolvedColor(with: .init(userInterfaceStyle: .light))
 
-    /// Clear in light mode, light-mode systemGray6 in dark mode.
-    static let defaultBackground = Color(uiColor: UIColor { traits in
+static let defaultBackground = Color(uiColor: UIColor { traits in
         traits.userInterfaceStyle == .dark ? lightGray6 : .clear
     })
     static let muted = Color(uiColor: lightGray6)
     static let cancelled = Color(UIColor(red: 225/255, green: 236/255, blue: 248/255, alpha: 1))
     static let cancelledText = Color(UIColor(red: 0/255, green: 23/255, blue: 88/255, alpha: 1))
-    static let info = try! Color(rgbString: "rgba(255, 227, 101, 1)")
+    static let warning = try! Color(rgbString: "rgba(255, 227, 101, 1)")
     static let lightText = Color(UIColor.label.resolvedColor(with: .init(userInterfaceStyle: .light)))
     static let border = Color(uiColor: .systemGray5)
 }

--- a/WooCommerce/Classes/Bookings/BookingBadgeView.swift
+++ b/WooCommerce/Classes/Bookings/BookingBadgeView.swift
@@ -6,14 +6,15 @@ import enum Yosemite.BookingStatus
 struct BookingBadgeView: View {
     let text: String
     let textColor: Color
-    let color: Color
+    let backgroundColor: Color
+    let isBordered: Bool
 
     var body: some View {
         BadgeView(text: text,
                   customizations: .init(
                     textColor: textColor,
-                    backgroundColor: color,
-                    bordered: false,
+                    backgroundColor: backgroundColor,
+                    borderColor: isBordered ? BadgeColor.border : nil,
                     bold: false
                   ),
                   backgroundShape: .roundedRectangle(cornerRadius: Layout.cornerRadius))
@@ -30,17 +31,30 @@ protocol BookingBadgeable {
     var text: String { get }
     var textColor: Color { get }
     var badgeColor: Color { get }
+    var isBordered: Bool { get }
+}
+
+extension BookingBadgeable {
+    var isBordered: Bool { false }
 }
 
 extension BookingBadgeView {
     init(_ badgeable: BookingBadgeable) {
-        self.init(text: badgeable.text, textColor: badgeable.textColor, color: badgeable.badgeColor)
+        self.init(text: badgeable.text,
+                  textColor: badgeable.textColor,
+                  backgroundColor: badgeable.badgeColor,
+                  isBordered: badgeable.isBordered)
     }
 }
 
 extension BookingAttendanceStatus: BookingBadgeable {
     var badgeColor: Color {
-        BadgeColor.default
+        switch self {
+        case .attended:
+            return .clear
+        case .unattended, .unknown:
+            return BadgeColor.default
+        }
     }
 
     var text: String {
@@ -50,13 +64,15 @@ extension BookingAttendanceStatus: BookingBadgeable {
     var textColor: Color {
         BadgeColor.defaultText
     }
+
+    var isBordered: Bool {
+        self == .attended
+    }
 }
 
 extension BookingStatus: BookingBadgeable {
     var badgeColor: Color {
         switch self {
-        case .cancelled:
-            return BadgeColor.cancelledBackground
         case .unpaid:
             return BadgeColor.info
         default:
@@ -69,18 +85,18 @@ extension BookingStatus: BookingBadgeable {
     }
 
     var textColor: Color {
-        switch self {
-        case .cancelled:
-            return BadgeColor.cancelledText
-        default:
-            return BadgeColor.defaultText
-        }
+        BadgeColor.defaultText
     }
 }
 
 extension BookingPaymentStatus: BookingBadgeable {
     var badgeColor: Color {
-        BadgeColor.default
+        switch self {
+        case .paid, .refunded, .partiallyRefunded:
+            return .clear
+        case .unpaid, .failed:
+            return BadgeColor.info
+        }
     }
 
     var text: String {
@@ -100,6 +116,15 @@ extension BookingPaymentStatus: BookingBadgeable {
 
     var textColor: Color {
         BadgeColor.defaultText
+    }
+
+    var isBordered: Bool {
+        switch self {
+        case .paid, .refunded, .partiallyRefunded:
+            return true
+        case .unpaid, .failed:
+            return false
+        }
     }
 
     private enum Localization {
@@ -132,9 +157,8 @@ extension BookingPaymentStatus: BookingBadgeable {
 }
 
 fileprivate enum BadgeColor {
-    static let `default` = Color(uiColor: .systemGray6.resolvedColor(with: .init(userInterfaceStyle: .light)))
+    static let `default` = Color(uiColor: .systemGray6)
     static let info = try! Color(rgbString: "rgba(255, 227, 101, 1)")
-    static let cancelledBackground = try! Color(rgbString: "rgba(225, 236, 248, 1)")
-    static let cancelledText = try! Color(rgbString: "rgba(0, 23, 88, 1)")
-    static let defaultText = Color(UIColor.label.resolvedColor(with: .init(userInterfaceStyle: .light)))
+    static let defaultText = Color(uiColor: .label)
+    static let border = Color(uiColor: .systemGray5)
 }

--- a/WooCommerce/Classes/Bookings/BookingBadgeView.swift
+++ b/WooCommerce/Classes/Bookings/BookingBadgeView.swift
@@ -6,101 +6,81 @@ import enum Yosemite.BookingStatus
 struct BookingBadgeView: View {
     let text: String
     let textColor: Color
-    let backgroundColor: Color
-    let borderColor: Color?
+    let color: Color
 
     var body: some View {
         BadgeView(text: text,
                   customizations: .init(
                     textColor: textColor,
-                    backgroundColor: backgroundColor,
-                    borderColor: borderColor,
+                    backgroundColor: color,
+                    bordered: false,
                     bold: false
                   ),
                   backgroundShape: .roundedRectangle(cornerRadius: Layout.cornerRadius))
     }
 }
 
-// MARK: - Badge Styles
-
-extension BookingBadgeView {
-    static func `default`(text: String) -> BookingBadgeView {
-        BookingBadgeView(text: text,
-                         textColor: BadgeStyle.lightText,
-                         backgroundColor: BadgeStyle.defaultBackground,
-                         borderColor: BadgeStyle.border)
-    }
-
-    static func info(text: String) -> BookingBadgeView {
-        BookingBadgeView(text: text,
-                         textColor: BadgeStyle.cancelledText,
-                         backgroundColor: BadgeStyle.cancelled,
-                         borderColor: nil)
-    }
-
-    static func warning(text: String) -> BookingBadgeView {
-        BookingBadgeView(text: text,
-                         textColor: BadgeStyle.lightText,
-                         backgroundColor: BadgeStyle.warning,
-                         borderColor: nil)
-    }
-
-    static func muted(text: String) -> BookingBadgeView {
-        BookingBadgeView(text: text,
-                         textColor: BadgeStyle.lightText,
-                         backgroundColor: BadgeStyle.muted,
-                         borderColor: nil)
+private extension BookingBadgeView {
+    enum Layout {
+        static let cornerRadius: CGFloat = 4
     }
 }
 
-// MARK: - BookingBadgeable
-
 protocol BookingBadgeable {
-    var bookingBadge: BookingBadgeView { get }
+    var text: String { get }
+    var textColor: Color { get }
+    var badgeColor: Color { get }
 }
 
 extension BookingBadgeView {
     init(_ badgeable: BookingBadgeable) {
-        self = badgeable.bookingBadge
+        self.init(text: badgeable.text, textColor: badgeable.textColor, color: badgeable.badgeColor)
     }
 }
-
-// MARK: - BookingAttendanceStatus
 
 extension BookingAttendanceStatus: BookingBadgeable {
-    var bookingBadge: BookingBadgeView {
-        switch self {
-        case .attended:
-            return .default(text: localizedTitle)
-        case .unattended, .unknown:
-            return .muted(text: localizedTitle)
-        }
+    var badgeColor: Color {
+        BadgeColor.default
+    }
+
+    var text: String {
+        self.localizedTitle
+    }
+
+    var textColor: Color {
+        BadgeColor.defaultText
     }
 }
-
-// MARK: - BookingStatus
 
 extension BookingStatus: BookingBadgeable {
-    var bookingBadge: BookingBadgeView {
+    var badgeColor: Color {
         switch self {
         case .cancelled:
-            return .info(text: localizedTitle)
+            return BadgeColor.cancelledBackground
+        case .unpaid:
+            return BadgeColor.info
         default:
-            return .default(text: localizedTitle)
+            return BadgeColor.default
+        }
+    }
+
+    var text: String {
+        self.localizedTitle
+    }
+
+    var textColor: Color {
+        switch self {
+        case .cancelled:
+            return BadgeColor.cancelledText
+        default:
+            return BadgeColor.defaultText
         }
     }
 }
 
-// MARK: - BookingPaymentStatus
-
 extension BookingPaymentStatus: BookingBadgeable {
-    var bookingBadge: BookingBadgeView {
-        switch self {
-        case .paid, .refunded, .partiallyRefunded:
-            return .default(text: text)
-        case .unpaid, .failed:
-            return .warning(text: text)
-        }
+    var badgeColor: Color {
+        BadgeColor.default
     }
 
     var text: String {
@@ -116,6 +96,10 @@ extension BookingPaymentStatus: BookingBadgeable {
         case .partiallyRefunded:
             return Localization.partiallyRefunded
         }
+    }
+
+    var textColor: Color {
+        BadgeColor.defaultText
     }
 
     private enum Localization {
@@ -147,24 +131,10 @@ extension BookingPaymentStatus: BookingBadgeable {
     }
 }
 
-// MARK: - Layout & Colors
-
-private extension BookingBadgeView {
-    enum Layout {
-        static let cornerRadius: CGFloat = 4
-    }
-}
-
-private enum BadgeStyle {
-    static let lightGray6 = UIColor.systemGray6.resolvedColor(with: .init(userInterfaceStyle: .light))
-
-    static let defaultBackground = Color(uiColor: UIColor { traits in
-        traits.userInterfaceStyle == .dark ? lightGray6 : .clear
-    })
-    static let muted = Color(uiColor: lightGray6)
-    static let cancelled = Color(UIColor(red: 225/255, green: 236/255, blue: 248/255, alpha: 1))
-    static let cancelledText = Color(UIColor(red: 0/255, green: 23/255, blue: 88/255, alpha: 1))
-    static let warning = try! Color(rgbString: "rgba(255, 227, 101, 1)")
-    static let lightText = Color(UIColor.label.resolvedColor(with: .init(userInterfaceStyle: .light)))
-    static let border = Color(uiColor: .systemGray5)
+fileprivate enum BadgeColor {
+    static let `default` = Color(uiColor: .systemGray6.resolvedColor(with: .init(userInterfaceStyle: .light)))
+    static let info = try! Color(rgbString: "rgba(255, 227, 101, 1)")
+    static let cancelledBackground = try! Color(rgbString: "rgba(225, 236, 248, 1)")
+    static let cancelledText = try! Color(rgbString: "rgba(0, 23, 88, 1)")
+    static let defaultText = Color(UIColor.label.resolvedColor(with: .init(userInterfaceStyle: .light)))
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
@@ -35,16 +35,17 @@ struct BadgeView: View {
     struct Customizations {
         let textColor: Color
         let backgroundColor: Color
-        let bordered: Bool
+        /// Border color for the badge. When `nil`, no border is drawn.
+        let borderColor: Color?
         let bold: Bool
 
         init(textColor: Color = Color(.textBrand),
              backgroundColor: Color = Color(.wooCommercePurple(.shade0)),
-             bordered: Bool = true,
+             borderColor: Color? = .white,
              bold: Bool = true) {
             self.textColor = textColor
             self.backgroundColor = backgroundColor
-            self.bordered = bordered
+            self.borderColor = borderColor
             self.bold = bold
         }
     }
@@ -106,18 +107,18 @@ private extension BadgeView {
         case .circle:
             Circle()
                 .fill(customizations.backgroundColor)
-                .if(customizations.bordered) { view in
-                    view.overlay {
-                        Circle().stroke(Color.white, lineWidth: Layout.borderLineWidth)
+                .overlay {
+                    if let borderColor = customizations.borderColor {
+                        Circle().stroke(borderColor, lineWidth: Layout.borderLineWidth)
                     }
                 }
         case .roundedRectangle(let cornerRadius):
             RoundedRectangle(cornerRadius: cornerRadius)
                 .fill(customizations.backgroundColor)
-                .if(customizations.bordered) { view in
-                    view.overlay {
+                .overlay {
+                    if let borderColor = customizations.borderColor {
                         RoundedRectangle(cornerRadius: cornerRadius)
-                            .stroke(Color.white, lineWidth: Layout.borderLineWidth)
+                            .stroke(borderColor, lineWidth: Layout.borderLineWidth)
                     }
                 }
         }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
@@ -107,18 +107,18 @@ private extension BadgeView {
         case .circle:
             Circle()
                 .fill(customizations.backgroundColor)
-                .overlay {
-                    if let borderColor = customizations.borderColor {
-                        Circle().stroke(borderColor, lineWidth: Layout.borderLineWidth)
+                .if(customizations.borderColor != nil) { view in
+                    view.overlay {
+                        Circle().stroke(customizations.borderColor ?? .clear, lineWidth: Layout.borderLineWidth)
                     }
                 }
         case .roundedRectangle(let cornerRadius):
             RoundedRectangle(cornerRadius: cornerRadius)
                 .fill(customizations.backgroundColor)
-                .overlay {
-                    if let borderColor = customizations.borderColor {
+                .if(customizations.borderColor != nil) { view in
+                    view.overlay {
                         RoundedRectangle(cornerRadius: cornerRadius)
-                            .stroke(borderColor, lineWidth: Layout.borderLineWidth)
+                            .stroke(customizations.borderColor ?? .clear, lineWidth: Layout.borderLineWidth)
                     }
                 }
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
@@ -357,7 +357,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
             XCTFail("Header section not found")
             return
         }
-        XCTAssertEqual(headerContent.statusBadge.text, "Attended")
+        XCTAssertEqual(headerContent.statusBadge.bookingBadge.text, "Attended")
     }
 
     func test_shouldShowAttendanceButton_returns_false_when_booking_is_cancelled() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingPaymentStatusTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingPaymentStatusTests.swift
@@ -54,8 +54,8 @@ struct BookingPaymentStatusTests {
         #expect(status == .partiallyRefunded)
     }
 
-    @Test("BookingPaymentStatus text values")
-    func test_text_values() {
+    @Test("BookingPaymentStatus conforms to BookingBadgeable")
+    func test_bookingBadgeable_conformance() {
         #expect(BookingPaymentStatus.paid.text == "Paid")
         #expect(BookingPaymentStatus.unpaid.text == "Unpaid")
         #expect(BookingPaymentStatus.failed.text == "Failed")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingPaymentStatusTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingPaymentStatusTests.swift
@@ -54,10 +54,9 @@ struct BookingPaymentStatusTests {
         #expect(status == .partiallyRefunded)
     }
 
-    @Test("BookingPaymentStatus conforms to BookingBadgeable")
-    func test_bookingBadgeable_conformance() {
-        let status: BookingBadgeable = BookingPaymentStatus.paid
-        #expect(status.text == "Paid")
+    @Test("BookingPaymentStatus text values")
+    func test_text_values() {
+        #expect(BookingPaymentStatus.paid.text == "Paid")
         #expect(BookingPaymentStatus.unpaid.text == "Unpaid")
         #expect(BookingPaymentStatus.failed.text == "Failed")
         #expect(BookingPaymentStatus.refunded.text == "Refunded")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingPaymentStatusTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingPaymentStatusTests.swift
@@ -56,8 +56,7 @@ struct BookingPaymentStatusTests {
 
     @Test("BookingPaymentStatus conforms to BookingBadgeable")
     func test_bookingBadgeable_conformance() {
-        let status: BookingBadgeable = BookingPaymentStatus.paid
-        #expect(status.text == "Paid")
+        #expect(BookingPaymentStatus.paid.text == "Paid")
         #expect(BookingPaymentStatus.unpaid.text == "Unpaid")
         #expect(BookingPaymentStatus.failed.text == "Failed")
         #expect(BookingPaymentStatus.refunded.text == "Refunded")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingPaymentStatusTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingPaymentStatusTests.swift
@@ -56,7 +56,8 @@ struct BookingPaymentStatusTests {
 
     @Test("BookingPaymentStatus conforms to BookingBadgeable")
     func test_bookingBadgeable_conformance() {
-        #expect(BookingPaymentStatus.paid.text == "Paid")
+        let status: BookingBadgeable = BookingPaymentStatus.paid
+        #expect(status.text == "Paid")
         #expect(BookingPaymentStatus.unpaid.text == "Unpaid")
         #expect(BookingPaymentStatus.failed.text == "Failed")
         #expect(BookingPaymentStatus.refunded.text == "Refunded")


### PR DESCRIPTION
Closes [WOOMOB-2414](https://linear.app/a8c/issue/WOOMOB-2414)

## Description
Updates the attendance status and payment status badges to match lxixW6aBBNkCd9ooBK70Z1-fi-3297_12974.

Added helper static functions to BookingBadgeView to create the `default`, `info`, `warning` and `muted` styled badges required for the states.

## Test Steps
1. Login to a CIAB store with various attendance and payment states.
2. Navigate the Bookings/All
3. Validate that badges match the design

## Screenshots
<img height="600" alt="image" src="https://github.com/user-attachments/assets/c6b33c4a-e5f8-4077-919d-151302bf6868" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.