### PR TITLE
Exclude checkout-draft orders from order list

### DIFF
--- a/Modules/Sources/NetworkingCore/Model/OrderStatusEnum.swift
+++ b/Modules/Sources/NetworkingCore/Model/OrderStatusEnum.swift
@@ -85,7 +85,7 @@ public extension OrderStatusEnum {
 
     /// Statuses that represent internal/transient states and should not appear
     /// in the main order list (e.g., incomplete checkout sessions, app drafts).
-    static var statusesHiddenFromOrderList: [OrderStatusEnum] {
+    static var statusesHiddenFromOrderListByDefault: [OrderStatusEnum] {
         [.autoDraft, .checkoutDraft]
     }
 }

--- a/Modules/Sources/NetworkingCore/Model/OrderStatusEnum.swift
+++ b/Modules/Sources/NetworkingCore/Model/OrderStatusEnum.swift
@@ -85,9 +85,7 @@ public extension OrderStatusEnum {
 
     /// Statuses that represent internal/transient states and should not appear
     /// in the main order list (e.g., incomplete checkout sessions, app drafts).
-    static var statusesHiddenFromOrderListByDefault: [OrderStatusEnum] {
-        [.autoDraft, .checkoutDraft]
-    }
+    static let statusesHiddenFromOrderListByDefault: [OrderStatusEnum] = [.autoDraft, .checkoutDraft]
 }
 
 /// RawRepresentable Conformance

--- a/Modules/Sources/NetworkingCore/Model/OrderStatusEnum.swift
+++ b/Modules/Sources/NetworkingCore/Model/OrderStatusEnum.swift
@@ -8,6 +8,7 @@ import Codegen
 ///
 public enum OrderStatusEnum: Codable, Hashable, Comparable, Sendable, GeneratedFakeable {
     case autoDraft
+    case checkoutDraft
     case pending
     case processing
     case onHold
@@ -28,6 +29,12 @@ public extension OrderStatusEnum {
                 "orderStatusEnum.localizedName.autoDraft",
                 value: "Draft",
                 comment: "Display label for auto-draft order status."
+            )
+        case .checkoutDraft:
+            return NSLocalizedString(
+                "orderStatusEnum.localizedName.checkoutDraft",
+                value: "Checkout Draft",
+                comment: "Display label for checkout-draft order status."
             )
         case .pending:
             return NSLocalizedString(
@@ -75,6 +82,12 @@ public extension OrderStatusEnum {
             return payload // unable to localize at runtime.
         }
     }
+
+    /// Statuses that represent internal/transient states and should not appear
+    /// in the main order list (e.g., incomplete checkout sessions, app drafts).
+    static var statusesHiddenFromOrderList: [OrderStatusEnum] {
+        [.autoDraft, .checkoutDraft]
+    }
 }
 
 /// RawRepresentable Conformance
@@ -87,6 +100,8 @@ extension OrderStatusEnum: RawRepresentable {
         switch rawValue {
         case Keys.autoDraft:
             self = .autoDraft
+        case Keys.checkoutDraft:
+            self = .checkoutDraft
         case Keys.pending:
             self = .pending
         case Keys.processing:
@@ -111,6 +126,7 @@ extension OrderStatusEnum: RawRepresentable {
     public var rawValue: String {
         switch self {
         case .autoDraft:            return Keys.autoDraft
+        case .checkoutDraft:        return Keys.checkoutDraft
         case .pending:              return Keys.pending
         case .processing:           return Keys.processing
         case .onHold:               return Keys.onHold
@@ -127,7 +143,8 @@ extension OrderStatusEnum: RawRepresentable {
 /// Enum containing the 'Known' OrderStatus Keys
 ///
 private enum Keys {
-    static let autoDraft    = "auto-draft"
+    static let autoDraft      = "auto-draft"
+    static let checkoutDraft  = "checkout-draft"
     static let pending      = "pending"
     static let processing   = "processing"
     static let onHold       = "on-hold"

--- a/Modules/Sources/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
+++ b/Modules/Sources/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
@@ -107,8 +107,7 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
     private let storageManager: StorageManagerType
     /// The conditions to use when fetching the results.
     ///
-    /// In the future, we can allow this to be mutable if necessary.
-    private let query: Query
+    private var query: Query
 
     /// The NotificationCenter to use for observing notifications.
     private let notificationCenter: NotificationCenter
@@ -149,6 +148,24 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
 
         startObservingStorageManagerDidResetNotifications()
         startObservingObjectsDidChangeNotifications()
+    }
+
+    /// Updates the query and restarts fetching with the new conditions.
+    ///
+    /// If the provider was previously started via `start()`, the fetch will be
+    /// restarted immediately with the new query. Otherwise, the new query will
+    /// be used the next time `start()` is called.
+    public func updateQuery(_ newQuery: Query) {
+        let wasActive = fetchedResultsControllerIsActive
+        query = newQuery
+        fetchedResultsController = createFetchedResultsController(query: newQuery)
+
+        guard wasActive else { return }
+        do {
+            try activateFetchedResultsController()
+        } catch {
+            DDLogError("⛔️ FetchResultSnapshotsProvider: Failed to restart with updated query: \(error)")
+        }
     }
 
     /// Retrieve the immutable type pointed to by `objectID`.

--- a/Modules/Sources/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
+++ b/Modules/Sources/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
@@ -161,11 +161,7 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
         fetchedResultsController = createFetchedResultsController(query: newQuery)
 
         guard wasActive else { return }
-        do {
-            try activateFetchedResultsController()
-        } catch {
-            DDLogError("⛔️ FetchResultSnapshotsProvider: Failed to restart with updated query: \(error)")
-        }
+        performFetchLoggingErrors()
     }
 
     /// Retrieve the immutable type pointed to by `objectID`.
@@ -244,7 +240,10 @@ private extension FetchResultSnapshotsProvider {
         guard fetchedResultsControllerIsActive else {
             return
         }
+        performFetchLoggingErrors()
+    }
 
+    func performFetchLoggingErrors() {
         do {
             try activateFetchedResultsController()
         } catch {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 24.4
 -----
+- [*] Hide checkout draft orders from the order list [https://github.com/woocommerce/woocommerce-ios/pull/16803]
 
 
 24.3

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
@@ -10,6 +10,7 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
     enum OrderStatusRow: Identifiable {
         case any
         case autoDraft
+        case checkoutDraft
         case pending
         case processing
         case onHold
@@ -28,6 +29,8 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
             switch status {
             case .autoDraft:
                 self = .autoDraft
+            case .checkoutDraft:
+                self = .checkoutDraft
             case .pending:
                 self = .pending
             case .processing:
@@ -51,6 +54,8 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
             switch self {
             case .autoDraft:
                 return .autoDraft
+            case .checkoutDraft:
+                return .checkoutDraft
             case .any:
                 return nil
             case .pending:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1114,7 +1114,7 @@ extension EditableOrderViewModel {
             title = orderStatus.name ?? orderStatus.slug
             color = {
                 switch orderStatus.status {
-                case .autoDraft, .pending, .cancelled, .refunded, .custom:
+                case .autoDraft, .checkoutDraft, .pending, .cancelled, .refunded, .custom:
                     return .gray(.shade5)
                 case .onHold:
                     return .withColorStudio(.orange, shade: .shade5)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusEnum+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusEnum+UI.swift
@@ -4,7 +4,7 @@ import enum Yosemite.OrderStatusEnum
 extension OrderStatusEnum {
     var backgroundColor: UIColor {
         switch self {
-        case .autoDraft, .pending, .cancelled, .refunded, .custom:
+        case .autoDraft, .checkoutDraft, .pending, .cancelled, .refunded, .custom:
                 .gray(.shade5)
         case .onHold:
                 .withColorStudio(.orange, shade: .shade5)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusFilterViewController.swift
@@ -72,6 +72,10 @@ private extension OrderStatusFilterViewController {
         rows = [.any]
         for status in allowedStatuses {
             switch status.status {
+            case .autoDraft:
+                rows.append(.autoDraft)
+            case .checkoutDraft:
+                rows.append(.checkoutDraft)
             case .pending:
                 rows.append(.pending)
             case .processing:
@@ -88,8 +92,6 @@ private extension OrderStatusFilterViewController {
                 rows.append(.refunded)
             case .custom:
                 rows.append(Row.custom(status))
-            default:
-                break
             }
         }
     }
@@ -153,6 +155,8 @@ private extension OrderStatusFilterViewController {
         // The order of the statuses declaration is according to the Order's lifecycle
         // and it is used to determine the user facing display order using the synthesized allCases
         case any
+        case autoDraft
+        case checkoutDraft
         case pending
         case processing
         case onHold
@@ -166,6 +170,10 @@ private extension OrderStatusFilterViewController {
             switch self {
             case .any:
                 return nil
+            case .autoDraft:
+                return .autoDraft
+            case .checkoutDraft:
+                return .checkoutDraft
             case .pending:
                 return .pending
             case .processing:

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -237,7 +237,7 @@ final class OrderListViewModel {
             // Only exclude hidden statuses (drafts) when no explicit status filter is selected.
             // When the user picks specific statuses, respect their choice.
             let excludeHiddenStatuses: NSPredicate? = {
-                guard filters?.orderStatus == nil else {
+                guard filters?.orderStatus?.isEmpty != false else {
                     return nil
                 }
                 return NSPredicate(

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -59,6 +59,7 @@ final class OrderListViewModel {
     private(set) var filters: FilterOrderListViewModel.Filters? {
         didSet {
             if filters != oldValue {
+                snapshotsProvider.updateQuery(Self.createQuery(siteID: siteID, filters: filters))
                 onShouldResynchronizeIfNewFiltersAreApplied?()
             }
         }
@@ -139,9 +140,13 @@ final class OrderListViewModel {
         self.notificationCenter = notificationCenter
         self.filters = filters
         self.featureFlagService = featureFlagService
-        self.snapshotsProvider = FetchResultSnapshotsProvider<StorageOrder>(storageManager: storageManager,
-                                                                            query: Self.createQuery(siteID: siteID,
-                                                                                                    filters: filters))
+        self.snapshotsProvider = FetchResultSnapshotsProvider<StorageOrder>(
+            storageManager: storageManager,
+            query: Self.createQuery(
+                siteID: siteID,
+                filters: filters
+            )
+        )
     }
 
     deinit {
@@ -229,13 +234,24 @@ final class OrderListViewModel {
     private static func createQuery(siteID: Int64, filters: FilterOrderListViewModel.Filters?) -> FetchResultSnapshotsProvider<StorageOrder>.Query {
         let predicateStatus: NSPredicate = {
             let excludeSearchCache = NSPredicate(format: "exclusiveForSearch = false")
-            let excludeHiddenStatuses = NSPredicate(
-                format: "NOT (statusKey IN %@)",
-                OrderStatusEnum.statusesHiddenFromOrderList.map { $0.rawValue }
-            )
+            // Only exclude hidden statuses (drafts) when no explicit status filter is selected.
+            // When the user picks specific statuses, respect their choice.
+            let excludeHiddenStatuses: NSPredicate? = {
+                guard filters?.orderStatus == nil else {
+                    return nil
+                }
+                return NSPredicate(
+                    format: "NOT (statusKey IN %@)",
+                    OrderStatusEnum.statusesHiddenFromOrderListByDefault.map { $0.rawValue }
+                )
+            }()
             let excludeNonMatchingStatus = filters?.orderStatus.map { NSPredicate(format: "statusKey IN %@", $0.map { $0.rawValue }) }
 
-            let predicates = [excludeSearchCache, excludeHiddenStatuses, excludeNonMatchingStatus].compactMap { $0 }
+            let predicates = [
+                excludeSearchCache,
+                excludeHiddenStatuses,
+                excludeNonMatchingStatus
+            ].compactMap { $0 }
             return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
         }()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -229,9 +229,13 @@ final class OrderListViewModel {
     private static func createQuery(siteID: Int64, filters: FilterOrderListViewModel.Filters?) -> FetchResultSnapshotsProvider<StorageOrder>.Query {
         let predicateStatus: NSPredicate = {
             let excludeSearchCache = NSPredicate(format: "exclusiveForSearch = false")
+            let excludeHiddenStatuses = NSPredicate(
+                format: "NOT (statusKey IN %@)",
+                OrderStatusEnum.statusesHiddenFromOrderList.map { $0.rawValue }
+            )
             let excludeNonMatchingStatus = filters?.orderStatus.map { NSPredicate(format: "statusKey IN %@", $0.map { $0.rawValue }) }
 
-            let predicates = [excludeSearchCache, excludeNonMatchingStatus].compactMap { $0 }
+            let predicates = [excludeSearchCache, excludeHiddenStatuses, excludeNonMatchingStatus].compactMap { $0 }
             return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
         }()
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -209,6 +209,32 @@ final class OrderListViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.orderIDs(from: snapshot), visibleOrders.orderIDs)
     }
 
+    func test_given_explicit_checkout_draft_filter_it_shows_checkout_draft_orders() throws {
+        // Given
+        let filters = FilterOrderListViewModel.Filters(orderStatus: [.checkoutDraft],
+                                                       dateRange: nil,
+                                                       product: nil,
+                                                       customer: nil,
+                                                       salesChannel: nil,
+                                                       numberOfActiveFilters: 1)
+        let viewModel = OrderListViewModel(siteID: siteID,
+                                           storageManager: storageManager,
+                                           filters: filters)
+
+        let draftOrders = [
+            insertOrder(id: 1, status: .checkoutDraft),
+            insertOrder(id: 2, status: .checkoutDraft),
+        ]
+        _ = insertOrder(id: 100, status: .processing)
+
+        // When
+        let snapshot = try activateAndRetrieveSnapshot(of: viewModel)
+
+        // Then
+        XCTAssertEqual(snapshot.numberOfItems, draftOrders.count)
+        XCTAssertEqual(viewModel.orderIDs(from: snapshot), draftOrders.orderIDs)
+    }
+
     // MARK: - App Activation
 
     func test_it_requests_a_resynchronization_when_the_app_is_activated() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -247,6 +247,10 @@ final class OrderListViewModelTests: XCTestCase {
         let initialSnapshot = try activateAndRetrieveSnapshot(of: viewModel)
         XCTAssertEqual(initialSnapshot.numberOfItems, 1, "Only processing order should be visible initially")
 
+        // Cancel the subscription from activateAndRetrieveSnapshot so it
+        // doesn't re-fulfill the old expectation when new snapshots arrive.
+        subscriptions.removeAll()
+
         // When — apply checkout-draft filter
         let filters = FilterOrderListViewModel.Filters(orderStatus: [.checkoutDraft],
                                                        dateRange: nil,
@@ -256,7 +260,7 @@ final class OrderListViewModelTests: XCTestCase {
                                                        numberOfActiveFilters: 1)
 
         let updatedSnapshot: FetchResultSnapshot = waitFor { promise in
-            viewModel.snapshot.dropFirst().first().sink { snapshot in
+            viewModel.snapshot.dropFirst().sink { snapshot in
                 promise(snapshot)
             }.store(in: &self.subscriptions)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -172,6 +172,43 @@ final class OrderListViewModelTests: XCTestCase {
         XCTAssertEqual(snapshot.numberOfItems(inSection: sectionID), expectedOrders.future.count)
     }
 
+    // MARK: - Hidden Statuses
+
+    func test_given_no_filter_it_excludes_checkout_draft_orders_from_the_list() throws {
+        // Given
+        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, filters: nil)
+
+        let visibleOrders = [
+            insertOrder(id: 1, status: .processing),
+            insertOrder(id: 2, status: .completed),
+        ]
+        _ = insertOrder(id: 100, status: .checkoutDraft)
+
+        // When
+        let snapshot = try activateAndRetrieveSnapshot(of: viewModel)
+
+        // Then
+        XCTAssertEqual(snapshot.numberOfItems, visibleOrders.count)
+        XCTAssertEqual(viewModel.orderIDs(from: snapshot), visibleOrders.orderIDs)
+    }
+
+    func test_given_no_filter_it_excludes_auto_draft_orders_from_the_list() throws {
+        // Given
+        let viewModel = OrderListViewModel(siteID: siteID, storageManager: storageManager, filters: nil)
+
+        let visibleOrders = [
+            insertOrder(id: 1, status: .processing),
+        ]
+        _ = insertOrder(id: 100, status: .autoDraft)
+
+        // When
+        let snapshot = try activateAndRetrieveSnapshot(of: viewModel)
+
+        // Then
+        XCTAssertEqual(snapshot.numberOfItems, visibleOrders.count)
+        XCTAssertEqual(viewModel.orderIDs(from: snapshot), visibleOrders.orderIDs)
+    }
+
     // MARK: - App Activation
 
     func test_it_requests_a_resynchronization_when_the_app_is_activated() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -235,6 +235,39 @@ final class OrderListViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.orderIDs(from: snapshot), draftOrders.orderIDs)
     }
 
+    func test_when_filter_changes_to_checkoutDraft_then_query_is_rebuilt_and_drafts_appear() throws {
+        // Given — start with no filter (drafts hidden by default)
+        let viewModel = OrderListViewModel(siteID: siteID,
+                                           storageManager: storageManager,
+                                           filters: nil)
+
+        let draftOrder = insertOrder(id: 1, status: .checkoutDraft)
+        _ = insertOrder(id: 2, status: .processing)
+
+        let initialSnapshot = try activateAndRetrieveSnapshot(of: viewModel)
+        XCTAssertEqual(initialSnapshot.numberOfItems, 1, "Only processing order should be visible initially")
+
+        // When — apply checkout-draft filter
+        let filters = FilterOrderListViewModel.Filters(orderStatus: [.checkoutDraft],
+                                                       dateRange: nil,
+                                                       product: nil,
+                                                       customer: nil,
+                                                       salesChannel: nil,
+                                                       numberOfActiveFilters: 1)
+
+        let updatedSnapshot: FetchResultSnapshot = waitFor { promise in
+            viewModel.snapshot.dropFirst().first().sink { snapshot in
+                promise(snapshot)
+            }.store(in: &self.subscriptions)
+
+            viewModel.updateFilters(filters: filters)
+        }
+
+        // Then
+        XCTAssertEqual(updatedSnapshot.numberOfItems, 1)
+        XCTAssertEqual(viewModel.orderIDs(from: updatedSnapshot), [draftOrder].orderIDs)
+    }
+
     // MARK: - App Activation
 
     func test_it_requests_a_resynchronization_when_the_app_is_activated() {


### PR DESCRIPTION
Fixes WOOMOB-2431

## Description

Checkout drafts (incomplete checkout sessions with status `checkout-draft`) appear in the order list, cluttering it on stores with many abandoned carts.

This is a local (client-side) measure to filter out internal order statuses from the order list. It adds `checkoutDraft` as a first-class case to `OrderStatusEnum` and excludes both `checkout-draft` and `auto-draft` orders from the main order list via a CoreData predicate.

**What changed:**
- Added `checkoutDraft` enum case to `OrderStatusEnum` with raw value `"checkout-draft"`
- Added `statusesHiddenFromOrderListByDefault` static property that centralizes which internal statuses to hide
- Added `NOT (statusKey IN %@)` predicate in `OrderListViewModel.createQuery()` to filter out hidden statuses by default
- When the user explicitly selects a hidden status in filters, the exclusion predicate is skipped so those orders appear
- Handled the new case in all exhaustive switches (background colors, dashboard status row, order status filter)

**Stale predicate fix:**
The CoreData fetch predicate in `OrderListViewModel` was only built once during init and never rebuilt when filters changed. The network resync happened correctly, but the local query kept using the stale predicate — so checkout-draft orders stayed hidden even when explicitly filtered. Fixed by adding `updateQuery(_:)` to `FetchResultSnapshotsProvider` and calling it from the `filters` didSet.

## Test Steps

1. Connect to a store with abandoned checkout orders. (Or create a bunch of "Draft" orders)
2. Open the Orders tab
3. Verify checkout-draft orders no longer appear in the list
4. Open order filters → select "Checkout Draft" status → apply
5. Verify checkout-draft orders now appear in the filtered list
6. Clear the filter — verify checkout-draft orders are hidden again
7. Apply other status filters (e.g., Processing, Completed) — verify filtering works correctly
8. Search for an order — verify search still returns results as expected

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.