### PR TITLE
Woomob 2426 ios coupon drawer doesnt open fully on mobile

### DIFF
--- a/Modules/Sources/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/Modules/Sources/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -87,13 +87,13 @@ public class BottomSheetViewController: UIViewController {
         } else {
             transitioningDelegate = self
             modalPresentationStyle = .custom
-        }
-        // When opening in a non-collapsed position, force the child view to lay out
-        // so content-based heights (e.g. table view contentSize) are accurate
-        // before the presentation controller computes the drawer frame.
-        if initialPosition != .collapsed {
-            childViewController?.loadViewIfNeeded()
-            childViewController?.view.layoutIfNeeded()
+            // When opening in a non-collapsed position, force the child view to lay out
+            // so content-based heights (e.g. table view contentSize) are accurate
+            // before the presentation controller computes the drawer frame.
+            if initialPosition != .collapsed {
+                childViewController?.loadViewIfNeeded()
+                childViewController?.view.layoutIfNeeded()
+            }
         }
 
         presenting.present(self, animated: true)

--- a/Modules/Sources/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/Modules/Sources/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -125,7 +125,7 @@ public class BottomSheetViewController: UIViewController {
         super.viewDidAppear(animated)
 
         if initialPosition != .collapsed {
-            presentedVC?.transition(to: initialPosition)
+            presentedVC?.transition(to: initialPosition, animated: false)
         }
     }
 

--- a/Modules/Sources/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/Modules/Sources/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -31,6 +31,9 @@ public class BottomSheetViewController: UIViewController {
 
     private var customHeaderSpacing: CGFloat?
 
+    /// The position the drawer should open to after presentation.
+    private let initialPosition: DrawerPosition
+
     public override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return childViewController?.supportedInterfaceOrientations ?? super.supportedInterfaceOrientations
     }
@@ -41,9 +44,11 @@ public class BottomSheetViewController: UIViewController {
     private weak var childViewController: DrawerPresentableViewController?
 
     public init(childViewController: DrawerPresentableViewController,
-         customHeaderSpacing: CGFloat? = nil) {
+         customHeaderSpacing: CGFloat? = nil,
+         initialPosition: DrawerPosition = .collapsed) {
         self.childViewController = childViewController
         self.customHeaderSpacing = customHeaderSpacing
+        self.initialPosition = initialPosition
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -114,6 +119,14 @@ public class BottomSheetViewController: UIViewController {
 
     @objc func buttonPressed() {
         dismiss(animated: true, completion: nil)
+    }
+
+    override public func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if initialPosition != .collapsed {
+            presentedVC?.transition(to: initialPosition)
+        }
     }
 
     override public func viewDidLoad() {
@@ -214,7 +227,7 @@ public class BottomSheetViewController: UIViewController {
             return
         }
 
-        self.presentedVC?.transition(to: .collapsed)
+        self.presentedVC?.transition(to: initialPosition)
     }
 }
 

--- a/Modules/Sources/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/Modules/Sources/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -88,6 +88,14 @@ public class BottomSheetViewController: UIViewController {
             transitioningDelegate = self
             modalPresentationStyle = .custom
         }
+        // When opening in a non-collapsed position, force the child view to lay out
+        // so content-based heights (e.g. table view contentSize) are accurate
+        // before the presentation controller computes the drawer frame.
+        if initialPosition != .collapsed {
+            childViewController?.loadViewIfNeeded()
+            childViewController?.view.layoutIfNeeded()
+        }
+
         presenting.present(self, animated: true)
     }
 

--- a/Modules/Sources/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/Modules/Sources/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -31,7 +31,6 @@ public class BottomSheetViewController: UIViewController {
 
     private var customHeaderSpacing: CGFloat?
 
-    /// The position the drawer should open to after presentation.
     private let initialPosition: DrawerPosition
 
     public override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
@@ -119,14 +118,6 @@ public class BottomSheetViewController: UIViewController {
 
     @objc func buttonPressed() {
         dismiss(animated: true, completion: nil)
-    }
-
-    override public func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        if initialPosition != .collapsed {
-            presentedVC?.transition(to: initialPosition, animated: false)
-        }
     }
 
     override public func viewDidLoad() {
@@ -244,7 +235,9 @@ extension BottomSheetViewController: UIViewControllerTransitioningDelegate {
     }
 
     public func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
-        return DrawerPresentationController(presentedViewController: presented, presenting: presenting)
+        let controller = DrawerPresentationController(presentedViewController: presented, presenting: presenting)
+        controller.currentPosition = initialPosition
+        return controller
     }
 }
 

--- a/Modules/Sources/WordPressUI/BottomSheet/DrawerPresentationController.swift
+++ b/Modules/Sources/WordPressUI/BottomSheet/DrawerPresentationController.swift
@@ -224,13 +224,7 @@ public class DrawerPresentationController: FancyAlertPresentationController {
         configureScrollViewInsets()
     }
 
-    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        guard hasCompletedPresentation else {
-            return
-        }
-        transition(to: currentPosition)
-    }
+    private var traitChangeRegistration: UITraitChangeRegistration?
 
     public override func presentationTransitionDidEnd(_ completed: Bool) {
         super.presentationTransitionDidEnd(completed)
@@ -313,9 +307,18 @@ public class DrawerPresentationController: FancyAlertPresentationController {
 
         addGestures()
         observe(scrollView: presentableViewController?.scrollableView)
+        registerTraitChanges()
     }
 
     private var hasCompletedPresentation = false
+
+    private func registerTraitChanges() {
+        guard traitChangeRegistration == nil else { return }
+        traitChangeRegistration = registerForTraitChanges([UITraitVerticalSizeClass.self, UITraitHorizontalSizeClass.self]) { [weak self] (_: DrawerPresentationController, _: UITraitCollection) in
+            guard let self, self.hasCompletedPresentation else { return }
+            self.transition(to: self.currentPosition)
+        }
+    }
 
     /// Represents whether the view is animating to a new position
     private var isPresentedViewAnimating = false

--- a/Modules/Sources/WordPressUI/BottomSheet/DrawerPresentationController.swift
+++ b/Modules/Sources/WordPressUI/BottomSheet/DrawerPresentationController.swift
@@ -182,7 +182,7 @@ public class DrawerPresentationController: FancyAlertPresentationController {
 
     /// Animates between the drawer positions
     /// - Parameter position: The position to animate to
-    public func transition(to position: DrawerPosition) {
+    public func transition(to position: DrawerPosition, animated: Bool = true) {
         currentPosition = position
 
         if position == .closed {
@@ -206,7 +206,7 @@ public class DrawerPresentationController: FancyAlertPresentationController {
             margin = 0
         }
 
-        setTopMargin(margin)
+        setTopMargin(margin, animated: animated)
     }
 
     @objc func dismiss() {

--- a/Modules/Sources/WordPressUI/BottomSheet/DrawerPresentationController.swift
+++ b/Modules/Sources/WordPressUI/BottomSheet/DrawerPresentationController.swift
@@ -138,7 +138,12 @@ public class DrawerPresentationController: FancyAlertPresentationController {
         }
 
         var frame = containerView.frame
-        let y = collapsedYPosition
+        let y: CGFloat
+        if currentPosition == .expanded {
+            y = max(collapsedYPosition - containerView.safeAreaInsets.bottom, containerView.safeAreaInsets.top)
+        } else {
+            y = collapsedYPosition
+        }
         var width: CGFloat = containerView.bounds.width - (containerView.safeAreaInsets.left + containerView.safeAreaInsets.right)
 
         frame.origin.y = y

--- a/Modules/Sources/WordPressUI/BottomSheet/DrawerPresentationController.swift
+++ b/Modules/Sources/WordPressUI/BottomSheet/DrawerPresentationController.swift
@@ -226,11 +226,15 @@ public class DrawerPresentationController: FancyAlertPresentationController {
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
+        guard hasCompletedPresentation else {
+            return
+        }
         transition(to: currentPosition)
     }
 
     public override func presentationTransitionDidEnd(_ completed: Bool) {
         super.presentationTransitionDidEnd(completed)
+        hasCompletedPresentation = completed
 
         configureScrollViewInsets()
     }
@@ -310,6 +314,8 @@ public class DrawerPresentationController: FancyAlertPresentationController {
         addGestures()
         observe(scrollView: presentableViewController?.scrollableView)
     }
+
+    private var hasCompletedPresentation = false
 
     /// Represents whether the view is animating to a new position
     private var isPresentedViewAnimating = false

--- a/Modules/Sources/WordPressUI/BottomSheet/DrawerPresentationController.swift
+++ b/Modules/Sources/WordPressUI/BottomSheet/DrawerPresentationController.swift
@@ -138,7 +138,12 @@ public class DrawerPresentationController: FancyAlertPresentationController {
         }
 
         var frame = containerView.frame
-        let y = collapsedYPosition
+        let y: CGFloat
+        if currentPosition != .collapsed {
+            y = max(collapsedYPosition - containerView.safeAreaInsets.bottom, containerView.safeAreaInsets.top)
+        } else {
+            y = collapsedYPosition
+        }
         var width: CGFloat = containerView.bounds.width - (containerView.safeAreaInsets.left + containerView.safeAreaInsets.right)
 
         frame.origin.y = y
@@ -221,11 +226,15 @@ public class DrawerPresentationController: FancyAlertPresentationController {
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
+        guard hasCompletedPresentation else {
+            return
+        }
         transition(to: currentPosition)
     }
 
     public override func presentationTransitionDidEnd(_ completed: Bool) {
         super.presentationTransitionDidEnd(completed)
+        hasCompletedPresentation = completed
 
         configureScrollViewInsets()
     }
@@ -305,6 +314,8 @@ public class DrawerPresentationController: FancyAlertPresentationController {
         addGestures()
         observe(scrollView: presentableViewController?.scrollableView)
     }
+
+    private var hasCompletedPresentation = false
 
     /// Represents whether the view is animating to a new position
     private var isPresentedViewAnimating = false

--- a/Modules/Sources/WordPressUI/BottomSheet/DrawerPresentationController.swift
+++ b/Modules/Sources/WordPressUI/BottomSheet/DrawerPresentationController.swift
@@ -139,7 +139,7 @@ public class DrawerPresentationController: FancyAlertPresentationController {
 
         var frame = containerView.frame
         let y: CGFloat
-        if currentPosition == .expanded {
+        if currentPosition != .collapsed {
             y = max(collapsedYPosition - containerView.safeAreaInsets.bottom, containerView.safeAreaInsets.top)
         } else {
             y = collapsedYPosition
@@ -187,7 +187,7 @@ public class DrawerPresentationController: FancyAlertPresentationController {
 
     /// Animates between the drawer positions
     /// - Parameter position: The position to animate to
-    public func transition(to position: DrawerPosition, animated: Bool = true) {
+    public func transition(to position: DrawerPosition) {
         currentPosition = position
 
         if position == .closed {
@@ -211,7 +211,7 @@ public class DrawerPresentationController: FancyAlertPresentationController {
             margin = 0
         }
 
-        setTopMargin(margin, animated: animated)
+        setTopMargin(margin)
     }
 
     @objc func dismiss() {

--- a/Modules/Sources/WordPressUI/BottomSheet/DrawerPresentationController.swift
+++ b/Modules/Sources/WordPressUI/BottomSheet/DrawerPresentationController.swift
@@ -138,12 +138,7 @@ public class DrawerPresentationController: FancyAlertPresentationController {
         }
 
         var frame = containerView.frame
-        let y: CGFloat
-        if currentPosition != .collapsed {
-            y = max(collapsedYPosition - containerView.safeAreaInsets.bottom, containerView.safeAreaInsets.top)
-        } else {
-            y = collapsedYPosition
-        }
+        let y = collapsedYPosition
         var width: CGFloat = containerView.bounds.width - (containerView.safeAreaInsets.left + containerView.safeAreaInsets.right)
 
         frame.origin.y = y
@@ -226,15 +221,11 @@ public class DrawerPresentationController: FancyAlertPresentationController {
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        guard hasCompletedPresentation else {
-            return
-        }
         transition(to: currentPosition)
     }
 
     public override func presentationTransitionDidEnd(_ completed: Bool) {
         super.presentationTransitionDidEnd(completed)
-        hasCompletedPresentation = completed
 
         configureScrollViewInsets()
     }
@@ -314,8 +305,6 @@ public class DrawerPresentationController: FancyAlertPresentationController {
         addGestures()
         observe(scrollView: presentableViewController?.scrollableView)
     }
-
-    private var hasCompletedPresentation = false
 
     /// Represents whether the view is animating to a new position
     private var isPresentedViewAnimating = false

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [Internal] Skip Jetpack benefits screen during setup when self driven push notifications feature is enabled [https://github.com/woocommerce/woocommerce-ios/pull/16791]
 - [*] Update booking badge styling to match design [https://github.com/woocommerce/woocommerce-ios/pull/16802#pullrequestreview-3927676114]
 - [*] Display details of legacy bookable product type in a web view [https://github.com/woocommerce/woocommerce-ios/pull/16798]
+- [*] Fix hiding coupon and product options when opending drawer [https://github.com/woocommerce/woocommerce-ios/pull/16806]
 
 
 24.3

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorPresenter.swift
@@ -5,22 +5,26 @@ import WordPressUI
 ///
 final class BottomSheetListSelectorPresenter<Command: BottomSheetListSelectorCommand> {
     private let bottomSheetChildViewController: DrawerPresentableViewController
+    private let initialPosition: DrawerPosition
 
     /// - Notable Parameters:
     ///   - onDismiss: Called when the bottom sheet is dismissed. Useful when tapping on each bottom sheet row does not trigger navigation changes.
+    ///   - initialPosition: The position the drawer should open to. Defaults to `.collapsed`.
     init(viewProperties: BottomSheetListSelectorViewProperties,
          command: Command,
-         onDismiss: ((_ selected: Command.Model?) -> Void)? = nil) {
+         onDismiss: ((_ selected: Command.Model?) -> Void)? = nil,
+         initialPosition: DrawerPosition = .collapsed) {
         bottomSheetChildViewController = BottomSheetListSelectorViewController(viewProperties: viewProperties,
                                                                                command: command,
                                                                                onDismiss: onDismiss)
+        self.initialPosition = initialPosition
     }
 
     func show(from presenting: UIViewController,
               sourceView: UIView? = nil,
               sourceBarButtonItem: UIBarButtonItem? = nil,
               arrowDirections: UIPopoverArrowDirection = .any) {
-        let bottomSheet = BottomSheetViewController(childViewController: bottomSheetChildViewController)
+        let bottomSheet = BottomSheetViewController(childViewController: bottomSheetChildViewController, initialPosition: initialPosition)
         bottomSheet.show(from: presenting, sourceView: sourceView, sourceBarButtonItem: sourceBarButtonItem, arrowDirections: arrowDirections)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
@@ -41,11 +41,6 @@ UIViewController, UITableViewDataSource, UITableViewDelegate where Command.Model
 
         configureMainView()
         configureTableView()
-
-        // Force table view to compute accurate multiline cell heights
-        // so contentSize is correct for drawer height calculation.
-        tableView.reloadData()
-        tableView.layoutIfNeeded()
     }
 
     override func viewDidLayoutSubviews() {

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
@@ -41,6 +41,11 @@ UIViewController, UITableViewDataSource, UITableViewDelegate where Command.Model
 
         configureMainView()
         configureTableView()
+
+        // Force table view to compute accurate multiline cell heights
+        // so contentSize is correct for drawer height calculation.
+        tableView.reloadData()
+        tableView.layoutIfNeeded()
     }
 
     override func viewDidLayoutSubviews() {

--- a/WooCommerce/Classes/ViewRelated/Coupons/EnhancedCouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/EnhancedCouponListViewController.swift
@@ -131,7 +131,7 @@ private extension EnhancedCouponListViewController {
         }
 
         let bottomSheet = BottomSheetListSelectorViewController(viewProperties: viewProperties, command: command, onDismiss: nil)
-        let bottomSheetViewController = BottomSheetViewController(childViewController: bottomSheet)
+        let bottomSheetViewController = BottomSheetViewController(childViewController: bottomSheet, initialPosition: .expanded)
         bottomSheetViewController.show(from: self)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -176,7 +176,7 @@ private extension AddProductCoordinator {
             }
         }
 
-        let productTypesListPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command)
+        let productTypesListPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command, initialPosition: .expanded)
 
         // `topmostPresentedViewController` is used because another bottom sheet could have been presented before.
         productTypesListPresenter.show(from: navigationController.topmostPresentedViewController,


### PR DESCRIPTION
Closes [WOOMOB-2426](https://linear.app/a8c/issue/WOOMOB-2426)

## Description

The PR addresses two things. Opens the product create and coupon create bottom drawer in the extended mode to show all cases. Also, it removes the "bouncy" animation visible when the drawer slides in, it is more prominent if you enable slow animations on the simulator.

### Changes
- BottomSheetViewController has an initialPosition init property to override the default `compact` position.
- Suppress traitCollectionDidChange while the appearance transition is not completed to address the "bouncy" animation issue.


## Test Steps
1. Log in to any store
2. Navigate to the Products tab
3. Tap +
4. Note that the bottom drawer opens with all options shown
5. Navigate the Menu/Coupons
6. Tap +
7.  Note that the bottom drawer opens with all options shown
8. Note that in both cases, the bottom drawer opens without the bouncing animation.

## Screenshots

| Case | Before | After |
| --- | --- | --- |
| Coupon | <img width="1206" height="2622" alt="before_coupon" src="https://github.com/user-attachments/assets/ebb2457b-11ac-4d48-b249-66438f3242b3" /> | <img width="1206" height="2622" alt="after_coupon" src="https://github.com/user-attachments/assets/dbb2895f-75d9-481d-9eda-62e78bef409c" /> |
| Coupon open | ![before_coupon_slow](https://github.com/user-attachments/assets/22f8bece-de53-44d5-bf49-fa5f3391004b) | ![after_coupon_slow](https://github.com/user-attachments/assets/322e8c55-e8a9-4bd4-8918-51a2d83cd22d) |
| Product | <img width="1206" height="2622" alt="before_product" src="https://github.com/user-attachments/assets/b6e00637-7e9a-481d-8d83-75c2af4d4faa" /> | <img width="1206" height="2622" alt="after_product" src="https://github.com/user-attachments/assets/e0c39a8b-94db-440b-9933-47aec0300e74" /> |
| Product open | ![before_product_slow](https://github.com/user-attachments/assets/1796a606-bece-4496-9907-7ebf2c49ef6b) | ![after_product_slow](https://github.com/user-attachments/assets/af2ba00b-90ba-4671-8eba-7c856e6e9664) |
---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
