### PR TITLE
Show PN setup intro instead of error when site is connected

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -40,6 +40,15 @@ Organize every test into three blocks with comments:
 - Module tests: `Modules/Tests/<ModuleName>Tests/`
 - Test plan: `WooCommerce/WooCommerceTests/UnitTests.xctestplan`
 
+## Async Tests
+- Mark `async` XCTest methods with `@MainActor` to prevent flaky failures from threading issues
+- This applies to all `async` test methods in XCTest classes (Swift Testing handles this differently)
+
+## Core Data in Tests
+- Use `storageManager.performAndSave({ storage in ... }, completion: {}, on: .main)` for all storage insertions and mutations
+- Do NOT use `storage.insertNewObject(...)` directly — always go through `performAndSave` to ensure thread-safe operations
+- This prevents flaky test failures caused by Core Data threading violations
+
 ## What to Test
 - **ViewModels**: state changes, action dispatching, data transformation, error handling
 - **Stores**: action handling with MockNetwork and MockStorageManager

--- a/Modules/Tests/CLAUDE.md
+++ b/Modules/Tests/CLAUDE.md
@@ -31,6 +31,10 @@ Organize tests into three logical blocks with comments:
 }
 ```
 
+## XCTest Async Rules
+- Mark all `async` XCTest methods with `@MainActor` to prevent flaky failures from threading issues
+- Use `storageManager.performAndSave({ storage in ... }, completion: {}, on: .main)` for all Core Data operations in tests — never use `storage.insertNewObject(...)` directly
+
 ## Async Testing Patterns
 These patterns target modern Swift concurrency when using the Swift Testing framework.
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,6 @@
 -----
 - [*] Update booking badge styling to match design [https://github.com/woocommerce/woocommerce-ios/pull/16802#pullrequestreview-3927676114]
 - [*] Display details of legacy bookable product type in a web view [https://github.com/woocommerce/woocommerce-ios/pull/16798]
-- [Internal] Show push notification setup screen instead of error when store is already connected [PR_URL]
 
 
 24.3

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Update booking badge styling to match design [https://github.com/woocommerce/woocommerce-ios/pull/16802#pullrequestreview-3927676114]
 - [*] Display details of legacy bookable product type in a web view [https://github.com/woocommerce/woocommerce-ios/pull/16798]
+- [Internal] Show push notification setup screen instead of error when store is already connected [PR_URL]
 
 
 24.3

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WPComPushNotificationsSetup.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WPComPushNotificationsSetup.swift
@@ -22,6 +22,7 @@ extension WooAnalyticsEvent {
         enum IntroductionViewState: String {
             case notConnected = "not_connected"
             case updateRequired = "update_required"
+            case connected = "connected"
         }
 
         static func introductionView(state: IntroductionViewState) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsView.swift
@@ -152,7 +152,7 @@ struct WPComPushNotificationsBenefitsView: View {
 
     private var primaryButtonText: String {
         switch viewModel.variant {
-        case .connect:
+        case .connect, .setup:
             return Localization.continueButton
         case .pluginUpdate:
             return Localization.updatePluginButton

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -249,7 +249,7 @@ extension WPComPushNotificationsBenefitsViewModel {
         static let setupTitle = NSLocalizedString(
             "wpcomPushNotificationsBenefitsViewModel.updatePluginTitle",
             value: "Get push notifications for your store",
-            comment: "Title of the Push Notifications Benefits View when the site is already connected"
+            comment: "Title of the Push Notifications Benefits View when WooCommerce plugin is outdated"
         )
 
         static let updatePluginDescription = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -11,6 +11,7 @@ final class WPComPushNotificationsBenefitsViewModel {
     enum Variant: Equatable {
         case connect
         case pluginUpdate(currentVersion: String)
+        case setup
     }
 
     let termsAttributedString: AttributedString
@@ -18,7 +19,7 @@ final class WPComPushNotificationsBenefitsViewModel {
     var title: String {
         switch variant {
         case .connect: Localization.connectWPComTitle
-        case .pluginUpdate: Localization.updatePluginTitle
+        case .pluginUpdate, .setup: Localization.setupTitle
         }
     }
 
@@ -26,6 +27,7 @@ final class WPComPushNotificationsBenefitsViewModel {
         switch variant {
         case .connect: Localization.connectWPComDescription
         case .pluginUpdate: Localization.updatePluginDescription
+        case .setup: Localization.setupDescription
         }
     }
 
@@ -133,6 +135,9 @@ final class WPComPushNotificationsBenefitsViewModel {
                 siteAlreadyConnected: true,
                 pluginOutdatedVersion: currentVersion
             )
+        case .setup:
+            analytics.track(event: .WPComPushNotificationsSetup.introductionButtonTap(.continue))
+            pushNotificationSetupCoordinator?.startSetup(siteAlreadyConnected: true)
         }
     }
 
@@ -165,8 +170,8 @@ private extension WPComPushNotificationsBenefitsViewModel {
                 variant = .pluginUpdate(currentVersion: currentVersion)
                 analytics.track(event: .WPComPushNotificationsSetup.introductionView(state: .updateRequired))
             } else {
-                error = .noMissingRequirements
-                analytics.track(.pushNotificationsSetupIntroductionError, properties: ["error_type": "generic"], error: error)
+                variant = .setup
+                analytics.track(event: .WPComPushNotificationsSetup.introductionView(state: .connected))
             }
         } catch {
             DDLogError("⛔️ Plugin version check failed: \(error)")
@@ -179,14 +184,13 @@ private extension WPComPushNotificationsBenefitsViewModel {
 extension WPComPushNotificationsBenefitsViewModel {
     enum VariantCheckError: Error {
         case noPermission
-        case noMissingRequirements
         case generic(underlyingError: Error)
 
         var message: String {
             switch self {
             case .noPermission:
                 Localization.noPermission
-            case .noMissingRequirements, .generic:
+            case .generic:
                 Localization.generic
             }
         }
@@ -242,10 +246,10 @@ extension WPComPushNotificationsBenefitsViewModel {
             comment: "Main description text of the WordPress.com Push Notifications Benefits View"
         )
 
-        static let updatePluginTitle = NSLocalizedString(
-            "wpcomPushNotificationsBenefitsViewModel.updatePluginTitle",
+        static let setupTitle = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsViewModel.setupTitle",
             value: "Get push notifications for your store",
-            comment: "Title of the Push Notifications Benefits View when WooCommerce plugin is outdated"
+            comment: "Title of the Push Notifications Benefits View when the site is already connected"
         )
 
         static let updatePluginDescription = NSLocalizedString(
@@ -253,6 +257,12 @@ extension WPComPushNotificationsBenefitsViewModel {
             value: "Your store is already connected to a WordPress.com account, but you’ll need to " +
             "update WooCommerce plugin to enable push notifications for new orders, reviews, and more.",
             comment: "Description text on the Push Notifications Benefits View when WooCommerce plugin is outdated"
+        )
+
+        static let setupDescription = NSLocalizedString(
+            "wpcomPushNotificationsBenefitsViewModel.setupDescription",
+            value: "You’re one step away from getting notifications for new orders, reviews and more.",
+            comment: "Description text on the Push Notifications Benefits View when the site is connected and plugin is up to date"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -247,7 +247,7 @@ extension WPComPushNotificationsBenefitsViewModel {
         )
 
         static let setupTitle = NSLocalizedString(
-            "wpcomPushNotificationsBenefitsViewModel.setupTitle",
+            "wpcomPushNotificationsBenefitsViewModel.updatePluginTitle",
             value: "Get push notifications for your store",
             comment: "Title of the Push Notifications Benefits View when the site is already connected"
         )

--- a/WooCommerce/WooCommerceTests/Analytics/WooAnalyticsEvent+WPComPushNotificationsSetupTests.swift
+++ b/WooCommerce/WooCommerceTests/Analytics/WooAnalyticsEvent+WPComPushNotificationsSetupTests.swift
@@ -10,7 +10,8 @@ struct WooAnalyticsEvent_PushNotificationsSetupTests {
         // Given
         let cases: [(WooAnalyticsEvent.WPComPushNotificationsSetup.IntroductionViewState, String)] = [
             (.notConnected, "not_connected"),
-            (.updateRequired, "update_required")
+            (.updateRequired, "update_required"),
+            (.connected, "connected")
         ]
 
         for (state, expected) in cases {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/WPComPushNotificationsBenefitsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/WPComPushNotificationsBenefitsViewModelTests.swift
@@ -85,7 +85,7 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isCheckingPlugin)
     }
 
-    func test_error_is_noMissingRequirements_when_jetpack_connected_and_plugin_compatible() async {
+    func test_variant_is_setup_when_jetpack_connected_and_plugin_compatible() async {
         // Given
         let connectionService = MockJetpackConnectionService()
         connectionService.fetchConnectionDataResult = .success(
@@ -99,9 +99,8 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
         await viewModel.determineSetupVariant()
 
         // Then
-        guard case .noMissingRequirements = viewModel.error else {
-            return XCTFail("Expected noMissingRequirements error, got \(String(describing: viewModel.error))")
-        }
+        XCTAssertEqual(viewModel.variant, .setup)
+        XCTAssertNil(viewModel.error)
         XCTAssertFalse(viewModel.isCheckingPlugin)
     }
 
@@ -211,6 +210,47 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(provider.receivedEvents.contains("push_notifications_setup_introduction_view"))
+    }
+
+    func test_determineSetupVariant_when_jetpack_connected_and_plugin_compatible_then_tracks_introduction_view_with_connected_state() async {
+        // Given
+        let provider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: provider)
+        let connectionService = MockJetpackConnectionService()
+        connectionService.fetchConnectionDataResult = .success(
+            JetpackConnectionData.fake().copy(isRegistered: true)
+        )
+        let checker = MockPluginVersionChecker()
+        checker.result = .success(.compatible)
+        let viewModel = makeViewModel(jetpackConnectionService: connectionService, pluginVersionChecker: checker, analytics: analytics)
+
+        // When
+        await viewModel.determineSetupVariant()
+
+        // Then
+        provider.assertReceived(event: "push_notifications_setup_introduction_view", with: ["state": "connected"])
+    }
+
+    func test_continueTapped_when_setup_variant_then_tracks_continue_button_label() async {
+        // Given
+        let provider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: provider)
+        let connectionService = MockJetpackConnectionService()
+        connectionService.fetchConnectionDataResult = .success(
+            JetpackConnectionData.fake().copy(isRegistered: true)
+        )
+        let checker = MockPluginVersionChecker()
+        checker.result = .success(.compatible)
+        let viewModel = makeViewModel(jetpackConnectionService: connectionService,
+                                      pluginVersionChecker: checker,
+                                      analytics: analytics)
+        await viewModel.determineSetupVariant()
+
+        // When
+        viewModel.continueTapped()
+
+        // Then
+        provider.assertReceived(event: "push_notifications_setup_introduction_button_tap", with: ["button_label": "continue"])
     }
 
     func test_determineSetupVariant_when_plugin_check_fails_then_does_not_track_introduction_view() async {
@@ -369,7 +409,7 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isCheckingPlugin)
     }
 
-    func test_determineSetupVariant_when_site_is_JCP_and_plugin_compatible_then_sets_noMissingRequirements_error() async {
+    func test_determineSetupVariant_when_site_is_JCP_and_plugin_compatible_then_sets_setup_variant() async {
         // Given
         let checker = MockPluginVersionChecker()
         checker.result = .success(.compatible)
@@ -379,9 +419,8 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
         await viewModel.determineSetupVariant()
 
         // Then
-        guard case .noMissingRequirements = viewModel.error else {
-            return XCTFail("Expected noMissingRequirements error, got \(String(describing: viewModel.error))")
-        }
+        XCTAssertEqual(viewModel.variant, .setup)
+        XCTAssertNil(viewModel.error)
         XCTAssertFalse(viewModel.isCheckingPlugin)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/WPComPushNotificationsBenefitsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/WPComPushNotificationsBenefitsViewModelTests.swift
@@ -244,7 +244,7 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
         let viewModel = makeViewModel(jetpackConnectionService: connectionService,
                                       pluginVersionChecker: checker,
                                       analytics: analytics)
-        await viewModel.determineSetupVariant()
+        await viewModel.determineSetupVariant() // Precondition: set variant to .setup
 
         // When
         viewModel.continueTapped()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -1457,6 +1457,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
     }
 
+    @MainActor
     func test_productsSectionViewModels_when_we_have_top_products_and_filters_it_shows_one_section() async throws {
         // Given
         let popularProductId: Int64 = 1
@@ -1725,34 +1726,42 @@ final class ProductSelectorViewModelTests: XCTestCase {
 private extension ProductSelectorViewModelTests {
     @discardableResult
     func insert(_ readOnlyProduct: Yosemite.Product) -> StorageProduct {
-        let product = storage.insertNewObject(ofType: StorageProduct.self)
-        product.update(with: readOnlyProduct)
-        return product
+        storageManager.performAndSave({ storage in
+            let product = storage.insertNewObject(ofType: StorageProduct.self)
+            product.update(with: readOnlyProduct)
+        }, completion: {}, on: .main)
+        return storageManager.viewStorage.loadProduct(siteID: readOnlyProduct.siteID, productID: readOnlyProduct.productID)!
     }
 
     func insert(_ readOnlyProducts: [Yosemite.Product]) {
-        for readOnlyProduct in readOnlyProducts {
-            let product = storage.insertNewObject(ofType: StorageProduct.self)
-            product.update(with: readOnlyProduct)
-        }
+        storageManager.performAndSave({ storage in
+            for readOnlyProduct in readOnlyProducts {
+                let product = storage.insertNewObject(ofType: StorageProduct.self)
+                product.update(with: readOnlyProduct)
+            }
+        }, completion: {}, on: .main)
     }
 
     func insert(_ readOnlyProduct: Yosemite.Product, withSearchTerm keyword: String, filterKey: String = "all") {
         insert(readOnlyProduct)
 
-        let searchResult = storage.insertNewObject(ofType: ProductSearchResults.self)
-        searchResult.keyword = keyword
-        searchResult.filterKey = filterKey
+        storageManager.performAndSave({ storage in
+            let searchResult = storage.insertNewObject(ofType: ProductSearchResults.self)
+            searchResult.keyword = keyword
+            searchResult.filterKey = filterKey
 
-        if let storedProduct = storage.loadProduct(siteID: readOnlyProduct.siteID, productID: readOnlyProduct.productID) {
-            searchResult.addToProducts(storedProduct)
-        }
+            if let storedProduct = storage.loadProduct(siteID: readOnlyProduct.siteID, productID: readOnlyProduct.productID) {
+                searchResult.addToProducts(storedProduct)
+            }
+        }, completion: {}, on: .main)
     }
 
     func insert(_ readOnlyProductBundleItem: Yosemite.ProductBundleItem, for product: StorageProduct) {
-        let bundleItem = storage.insertNewObject(ofType: StorageProductBundleItem.self)
-        bundleItem.update(with: readOnlyProductBundleItem)
-        bundleItem.product = product
+        storageManager.performAndSave({ storage in
+            let bundleItem = storage.insertNewObject(ofType: StorageProductBundleItem.self)
+            bundleItem.update(with: readOnlyProductBundleItem)
+            bundleItem.product = product
+        }, completion: {}, on: .main)
     }
 
     func createAndInsertBundleProduct(bundleItems: [Yosemite.ProductBundleItem]) -> Yosemite.Product {


### PR DESCRIPTION
Closes: WOOMOB-2468

## Description
When the site is already connected to WordPress.com and the WooCommerce plugin is up to date, the push notification intro screen was showing a `noMissingRequirements` error with a "Contact Support" button. This was incorrect — the user should proceed to the setup flow instead.

This PR:
- Adds a new `.setup` variant to the PN intro screen that shows when the site is connected and plugin is compatible
- Updates the intro copy: "Get push notifications for your store" / "You're one step away from getting notifications for new orders, reviews and more." with Continue / Not now CTAs
- Lets the setup flow handle the compatibility check and token registration
- Removes the `noMissingRequirements` error case that was incorrectly modeling a success state as an error
- Adds `.connected` analytics state for tracking.

Also added some fixes for another flaky test that was blocking the PR. AI rules for unit tests have also been updated.

## Test Steps
1. Log in to a store that is already connected to WordPress.com and has WooCommerce plugin >= 10.5.3 or update the plugin version in the debug panel.
2. Navigate to Push Notifications setup from dashboard or Menu > Settings.
3. Verify the intro screen shows "Get push notifications for your store" with "Continue" and "Not now" buttons. Xcode should log `🔵 Tracked push_notifications_setup_introduction_view` with `state: connected`.
4. Tap "Continue" and verify the setup flow starts with compatibility check and push registration steps.

## Screenshots


https://github.com/user-attachments/assets/14486e1a-62ca-41f0-9b78-0ad93e4be4f1



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.