### PR TITLE
Remove hardcoded date_type from revenue stats API call

### DIFF
--- a/Modules/Sources/NetworkingCore/Remote/OrderStatsRemoteV4.swift
+++ b/Modules/Sources/NetworkingCore/Remote/OrderStatsRemoteV4.swift
@@ -33,11 +33,6 @@ public final class OrderStatsRemoteV4: Remote {
             ParameterKeys.after: dateFormatter.string(from: earliestDateToInclude),
             ParameterKeys.before: dateFormatter.string(from: latestDateToInclude),
             ParameterKeys.quantity: String(quantity),
-            // Product stats in `ProductsReportsRemote.loadTopProductsReport` are based on the order creation date, while the order/revenue
-            // stats are based on a store option in the analytics settings with the order paid date as the default.
-            // In WC version 8.6+, a new parameter `date_type` is available to override the date type so that we can
-            // show the order/revenue and product stats based on the same date column, order creation date.
-            ParameterKeys.dateType: ParameterValues.dateType,
             ParameterKeys.fields: ParameterValues.fieldValues
         ]
 
@@ -71,12 +66,10 @@ private extension OrderStatsRemoteV4 {
         static let before = "before"
         static let quantity = "per_page"
         static let forceRefresh = "force_cache_refresh"
-        static let dateType = "date_type"
         static let fields = "fields"
     }
 
     enum ParameterValues {
-        static let dateType = "date_created"
         static let fieldValues = ["orders_count", "num_items_sold", "total_sales", "net_revenue", "avg_order_value"]
     }
 }

--- a/Modules/Tests/NetworkingTests/Remote/OrderStatsRemoteV4Tests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/OrderStatsRemoteV4Tests.swift
@@ -97,7 +97,7 @@ final class OrderStatsRemoteV4Tests: XCTestCase {
         XCTAssertTrue(result.isFailure)
     }
 
-    func test_loadOrderStats_sets_date_type_parameter_to_date_created() throws {
+    func test_loadOrderStats_does_not_send_date_type_parameter() throws {
         // Given
         let remote = OrderStatsRemoteV4(network: network)
 
@@ -111,6 +111,6 @@ final class OrderStatsRemoteV4Tests: XCTestCase {
                               forceRefresh: false) { _ in }
 
         // Then
-        XCTAssertEqual(network.queryParametersDictionary?["date_type"] as? String, "date_created")
+        XCTAssertNil(network.queryParametersDictionary?["date_type"])
     }
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 24.4
 -----
+- [*] Fix My Store dashboard showing different revenue numbers than wp-admin by respecting the store's date type setting [https://github.com/woocommerce/woocommerce-ios/pull/16812]
 - [Internal] Skip Jetpack benefits screen during setup when self driven push notifications feature is enabled [https://github.com/woocommerce/woocommerce-ios/pull/16791]
 - [*] Update booking badge styling to match design [https://github.com/woocommerce/woocommerce-ios/pull/16802#pullrequestreview-3927676114]
 - [*] Display details of legacy bookable product type in a web view [https://github.com/woocommerce/woocommerce-ios/pull/16798]


### PR DESCRIPTION
Closes: WOOMOB-2484

## Description

The app was hardcoding `date_type=date_created` in revenue stats requests, overriding the store's `woocommerce_date_type` setting (defaults to `date_paid`). This caused My Store to show different numbers than wp-admin for the same date range. Removing the parameter lets the server use the store's own setting.

Mirrors the Android fix in woocommerce/woocommerce-android#15493.

## Test Steps

1. Open My Store dashboard
2. Compare revenue numbers with wp-admin Analytics for the same store and date range - Numbers should now match
3. Verify that no `date_type` parameter is sent in the API request (check network logs)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.