### PR TITLE
Display net_revenue instead of total_sales on dashboard

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -26,6 +26,7 @@ git diff trunk...HEAD --stat -- . ':!*Tests*' ':!*Test*' ':!*.generated.*'
 ```
 
 4. Review the changes to write an accurate description. Read modified files if needed.
+   - **Never include actual Linear issue links** (e.g., `https://linear.app/...`) in PR descriptions — Linear is an internal resource. Only reference the issue ID (e.g., `WOOMOB-2485`).
 
 5. Determine if RELEASE-NOTES.txt needs updating. If the change is user-facing, remind about adding a release note entry.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,7 @@ WooCommerce/Classes/POS/         # App-target POS integration (POSTabCoordinator
   - `Fix product type filters issue`
   - `Update Stripe SDK to 5.1.1`
   - `Remove redundant MainActor annotation`
+- **PR creation**: Always use the `/pr` skill when creating pull requests
 - **PR merge policy**: Merge commits (not squash). 1 reviewer required. PR author merges own PR.
 - **PR size**: Keep non-test diff under 300 lines (enforced by Danger)
 - **Labels and milestones**: Required on non-draft PRs

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Fix My Store dashboard showing different revenue numbers than wp-admin by respecting the store's date type setting [https://github.com/woocommerce/woocommerce-ios/pull/16812]
 - [Internal] Skip Jetpack benefits screen during setup when self driven push notifications feature is enabled [https://github.com/woocommerce/woocommerce-ios/pull/16791]
 - [*] Update booking badge styling to match design [https://github.com/woocommerce/woocommerce-ios/pull/16802#pullrequestreview-3927676114]
+- [*] Fix dashboard showing inflated revenue by displaying net sales instead of total sales, matching wp-admin [https://github.com/woocommerce/woocommerce-ios/pull/16814]
 - [*] Display details of legacy bookable product type in a web view [https://github.com/woocommerce/woocommerce-ios/pull/16798]
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -21,13 +21,26 @@ struct StatsDataTextFormatter {
                             numberOfFractionDigits: numberOfFractionDigits)
     }
 
-    /// Creates the text to display for the net revenue.
+    /// Creates the text to display for the net revenue (totals only, no interval support).
     ///
     static func createNetRevenueText(orderStats: OrderStatsV4?,
                                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
                                      currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue,
                                      numberOfFractionDigits: Int = ServiceLocator.currencySettings.fractionDigits) -> String {
         return formatAmount(orderStats?.totals.netRevenue,
+                            currencyFormatter: currencyFormatter,
+                            currencyCode: currencyCode,
+                            numberOfFractionDigits: numberOfFractionDigits)
+    }
+
+    /// Creates the text to display for the net sales on the dashboard, with interval support.
+    ///
+    static func createNetSalesText(orderStats: OrderStatsV4?,
+                                   selectedIntervalIndex: Int?,
+                                   currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+                                   currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue,
+                                   numberOfFractionDigits: Int = ServiceLocator.currencySettings.fractionDigits) -> String {
+        return formatAmount(netRevenue(at: selectedIntervalIndex, orderStats: orderStats),
                             currencyFormatter: currencyFormatter,
                             currencyCode: currencyCode,
                             numberOfFractionDigits: numberOfFractionDigits)
@@ -319,7 +332,7 @@ private extension StatsDataTextFormatter {
         }
     }
 
-    /// Retrieves the total revenue from the provided order stats and, optionally, a specific interval.
+    /// Retrieves the total revenue (gross) from the provided order stats and, optionally, a specific interval.
     ///
     static func totalRevenue(at selectedIndex: Int?, orderStats: OrderStatsV4?) -> Decimal? {
         let orderStatsIntervals = StatsIntervalDataParser.sortStatsIntervals(from: orderStats)
@@ -328,6 +341,20 @@ private extension StatsDataTextFormatter {
             return orderStats.subtotals.grossRevenue
         } else if let orderStats {
             return orderStats.totals.grossRevenue
+        } else {
+            return nil
+        }
+    }
+
+    /// Retrieves the net revenue from the provided order stats and, optionally, a specific interval.
+    ///
+    static func netRevenue(at selectedIndex: Int?, orderStats: OrderStatsV4?) -> Decimal? {
+        let orderStatsIntervals = StatsIntervalDataParser.sortStatsIntervals(from: orderStats)
+        if let selectedIndex, selectedIndex < orderStatsIntervals.count {
+            let orderStats = orderStatsIntervals[selectedIndex]
+            return orderStats.subtotals.netRevenue
+        } else if let orderStats {
+            return orderStats.totals.netRevenue
         } else {
             return nil
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/OrderStatsV4Interval+Chart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/OrderStatsV4Interval+Chart.swift
@@ -2,8 +2,8 @@ import Foundation
 import Yosemite
 
 extension OrderStatsV4Interval {
-    /// Value of the revenue during a stats interval.
+    /// Value of the net revenue during a stats interval.
     var revenueValue: Decimal {
-        return subtotals.grossRevenue
+        return subtotals.netRevenue
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -348,9 +348,9 @@ private extension StorePerformanceView {
             comment: "Title of the custom time range on the store performance card on the Dashboard screen"
         )
         static let revenue = NSLocalizedString(
-            "storePerformanceView.revenue",
-            value: "Revenue",
-            comment: "Revenue stat label on dashboard."
+            "storePerformanceView.netSales",
+            value: "Net sales",
+            comment: "Net sales stat label on dashboard — shows revenue excluding taxes, shipping, and fees."
         )
         static let noRevenueText = NSLocalizedString(
             "storePerformanceView.noRevenueText",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
@@ -139,8 +139,8 @@ private extension StoreStatsChart {
             comment: "Value for the x-Axis of the store stats chart on the Dashboard screen"
         )
         static let yValue = NSLocalizedString(
-            "storeStatsChart.yValue",
-            value: "Revenue",
+            "storeStatsChart.yValueNetSales",
+            value: "Net sales",
             comment: "Value for the y-Axis of the store stats chart on the Dashboard screen"
         )
         static let zeroRevenue = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsPeriodViewModel.swift
@@ -28,10 +28,10 @@ final class StoreStatsPeriodViewModel {
     private(set) lazy var revenueStatsText: AnyPublisher<String, Never> = $orderStatsData.combineLatest($selectedIntervalIndex, currencySettings.$currencyCode)
         .compactMap { [weak self] orderStatsData, selectedIntervalIndex, currencyCode in
             guard let self else { return "-" }
-            return StatsDataTextFormatter.createTotalRevenueText(orderStats: orderStatsData.stats,
-                                                                 selectedIntervalIndex: selectedIntervalIndex,
-                                                                 currencyFormatter: self.currencyFormatter,
-                                                                 currencyCode: currencyCode.rawValue)
+            return StatsDataTextFormatter.createNetSalesText(orderStats: orderStatsData.stats,
+                                                              selectedIntervalIndex: selectedIntervalIndex,
+                                                              currencyFormatter: self.currencyFormatter,
+                                                              currencyCode: currencyCode.rawValue)
         }
         .removeDuplicates()
         .eraseToAnyPublisher()

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
@@ -187,9 +187,9 @@ private struct UnableToFetchView: View {
 private extension StoreInfoView {
     enum Localization {
         static let revenue = AppLocalizedString(
-            "storeWidgets.infoView.revenue",
-            value: "Revenue",
-            comment: "Revenue title label for the store info widget"
+            "storeWidgets.infoView.netSales",
+            value: "Net sales",
+            comment: "Net sales title label for the store info widget — shows revenue excluding taxes, shipping, and fees."
         )
         static let visitors = AppLocalizedString(
             "storeWidgets.infoView.visitors",

--- a/WooCommerce/StoreWidgets/Lockscreen/StoreInfoRectangularWidget.swift
+++ b/WooCommerce/StoreWidgets/Lockscreen/StoreInfoRectangularWidget.swift
@@ -55,9 +55,9 @@ private struct UnableToFetchView: View {
 private extension StoreInfoRectangularView {
     enum Localization {
         static let revenue = AppLocalizedString(
-            "storeWidgets.storeInfoRectangularWidget.revenue",
-            value: "Revenue",
-            comment: "Revenue title label for the store info widget"
+            "storeWidgets.storeInfoRectangularWidget.netSales",
+            value: "Net sales",
+            comment: "Net sales title label for the store info widget — shows revenue excluding taxes, shipping, and fees."
         )
     }
 }

--- a/WooCommerce/StoreWidgets/StoreInfoDataService.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoDataService.swift
@@ -67,7 +67,7 @@ final class StoreInfoDataService {
 
             // Assemble stats data
             let conversion = siteStats.visitors > 0 ? Double(revenueAndOrders.totals.totalOrders) / Double(siteStats.visitors) : 0
-            return Stats(revenue: revenueAndOrders.totals.grossRevenue,
+            return Stats(revenue: revenueAndOrders.totals.netRevenue,
                          totalOrders: revenueAndOrders.totals.totalOrders,
                          totalVisitors: siteStats.visitors,
                          conversion: min(conversion, 1))
@@ -85,7 +85,7 @@ final class StoreInfoDataService {
     ///
     private func todayStatsWithoutVisitors(for storeID: Int64) async throws -> Stats {
         let revenueAndOrders = try await fetchTodaysRevenueAndOrders(for: storeID)
-        return Stats(revenue: revenueAndOrders.totals.grossRevenue,
+        return Stats(revenue: revenueAndOrders.totals.netRevenue,
                      totalOrders: revenueAndOrders.totals.totalOrders,
                      totalVisitors: nil,
                      conversion: nil)

--- a/WooCommerce/Woo Watch App/MyStore/MyStoreView.swift
+++ b/WooCommerce/Woo Watch App/MyStore/MyStoreView.swift
@@ -188,9 +188,9 @@ fileprivate extension MyStoreView {
 
     enum Localization {
         static let revenue = AppLocalizedString(
-            "watch.mystore.revenue.title",
-            value: "Revenue",
-            comment: "Revenue title on the watch store stats screen."
+            "watch.mystore.netSales.title",
+            value: "Net sales",
+            comment: "Net sales title on the watch store stats screen."
         )
         static let today = AppLocalizedString(
             "watch.mystore.today.title",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
@@ -95,6 +95,44 @@ final class StatsDataTextFormatterTests: XCTestCase {
         XCTAssertEqual(totalRevenue, "$25")
     }
 
+    // MARK: Net Sales (Dashboard)
+
+    func test_createNetSalesText_returns_net_revenue_from_totals() {
+        // Given
+        let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 100, netRevenue: 62))
+
+        // When
+        let netSales = StatsDataTextFormatter.createNetSalesText(orderStats: orderStats,
+                                                                 selectedIntervalIndex: nil,
+                                                                 currencyFormatter: currencyFormatter,
+                                                                 currencyCode: currencyCode.rawValue)
+
+        // Then
+        XCTAssertEqual(netSales, "$62")
+    }
+
+    func test_createNetSalesText_returns_net_revenue_from_selected_interval() {
+        // Given
+        let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(netRevenue: 62.7),
+                                                  intervals: [.fake().copy(dateStart: "2019-07-09 01:00:00",
+                                                                           dateEnd: "2019-07-09 01:59:59",
+                                                                           subtotals: .fake().copy(netRevenue: 25)),
+                                                              .fake().copy(dateStart: "2019-07-09 00:00:00",
+                                                                           dateEnd: "2019-07-09 00:59:59",
+                                                                           subtotals: .fake().copy(netRevenue: 31))
+                                                  ])
+        let selectedIntervalIndex = 1 // Corresponds to the second earliest interval, which is the first interval in `OrderStatsV4`.
+
+        // When
+        let netSales = StatsDataTextFormatter.createNetSalesText(orderStats: orderStats,
+                                                                 selectedIntervalIndex: selectedIntervalIndex,
+                                                                 currencyFormatter: currencyFormatter,
+                                                                 currencyCode: currencyCode.rawValue)
+
+        // Then
+        XCTAssertEqual(netSales, "$25")
+    }
+
     func test_createDelta_for_grossRevenue_returns_expected_delta() {
         // Given
         let previousOrderStats = OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 10))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -57,7 +57,7 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         // When
         let orderStats = OrderStatsV4(siteID: siteID,
                                       granularity: timeRange.intervalGranularity,
-                                      totals: .fake().copy(totalOrders: 3, grossRevenue: 6220.7),
+                                      totals: .fake().copy(totalOrders: 3, netRevenue: 6220.7),
                                       intervals: [.fake()])
         insertOrderStats(orderStats, timeRange: timeRange)
 


### PR DESCRIPTION
Closes: WOOMOB-2485

## Description

The app was showing `total_sales` (mapped to `grossRevenue` in Swift), which includes taxes, shipping, and fees. wp-admin's Analytics dashboard shows `net_revenue` ("Net sales") instead — pure product revenue excluding those components.

This PR switches all revenue displays to read `netRevenue` and renames labels from "Revenue" to "Net sales" to match wp-admin. Affected surfaces:

- **My Store dashboard** — stat card + chart
- **Watch app** — My Store screen
- **Home screen widget**
- **Lock screen widget**

The Analytics Hub is not affected — it already reads the correct field via a separate code path (`WCAnalyticsStatsTotals+UI.swift`).

Ref: pe5sF9-58j-p2, [Android fix PR](https://github.com/woocommerce/woocommerce-android/pull/15493)

## Test Steps

1. Open the app and go to My Store (first tab)
2. Look at the top stats card row — verify the first metric is labeled **"Net sales"** (not "Revenue")
3. Ensure the store has at least one order with shipping or tax so the value differs from the old total_sales
4. Compare the displayed value against wp-admin → Analytics → Revenue report → "Net sales" for the same period — they should match
5. Tap into different time ranges (today, this week, this month, this year) and verify values align
6. Tap a chart interval — the selected interval value should also use net revenue
7. Check the **home screen widget** — verify it shows "Net sales" with the correct value
8. Check the **lock screen widget** — verify it shows "Net sales"
9. If you have an Apple Watch paired, verify the Watch app My Store screen shows the updated value

## Web admin Reference 

<img width="1176" height="598" alt="Screenshot 2026-03-13 at 13 26 18" src="https://github.com/user-attachments/assets/3f0ee40b-40b3-4d5a-a72d-72c28974d686" />

## App Screenshots

Before | After
--- | ---
<img width="532" height="789" alt="Screenshot 2026-03-13 at 13 20 43" src="https://github.com/user-attachments/assets/37b5b91c-125b-4d30-b5cf-4c5334e78d68" /> | <img width="534" height="789" alt="Screenshot 2026-03-13 at 13 23 26" src="https://github.com/user-attachments/assets/63164f8c-c4a7-48b3-b21e-fcf352460fa3" />

## Widget Screenshots

Before | After
--- | ---
<img width="512" height="247" alt="Screenshot 2026-03-13 at 14 13 59" src="https://github.com/user-attachments/assets/9cdd5bec-5bca-47ab-ad5e-8c3e4c68a788" /> | <img width="508" height="246" alt="Screenshot 2026-03-13 at 14 10 14" src="https://github.com/user-attachments/assets/e695e11d-a424-438a-a580-55d4d1c20ef2" />

## Watch App Screenshots

Before | After
--- | ---
<img width="374" height="446" alt="Simulator Screenshot - Apple Watch Series 10 (42mm) - 2026-03-13 at 14 38 09" src="https://github.com/user-attachments/assets/74d2fb52-047b-40ca-9026-aafba52ffeb5" /> | <img width="374" height="446" alt="Simulator Screenshot - Apple Watch Series 10 (42mm) - 2026-03-13 at 14 37 33" src="https://github.com/user-attachments/assets/c19750cd-942b-4cf3-bbb4-dc1aae19864e" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.