### PR TITLE
Make trunk prototype builds on-demand and add nightly build pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,6 +34,7 @@ steps:
         # Buildkite considers this implicitly satisfied if the `depends_on` step is skipped due to `if:` condition. So this will run unconditionally on PRs
         # https://buildkite.com/docs/pipelines/configure/dependencies#how-skipped-steps-affect-dependencies
         depends_on: prototype_build_triggered
+        if: build.pull_request.id != null || build.branch == "trunk"
         command: .buildkite/commands/prototype-build.sh
         plugins: [$CI_TOOLKIT]
         notify:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,27 +23,22 @@ steps:
   #################
   # Create Prototype Build
   #################
-  - label: ":hammer_and_wrench: Prototype Build"
-    command: .buildkite/commands/prototype-build.sh
-    plugins: [$CI_TOOLKIT]
-    if: build.pull_request.id != null
-    notify:
-      - github_commit_status:
-          context: Prototype Build
-
   - group: ":rocket: Prototype Build"
-    if: build.branch == "trunk"
+    # Prototype Builds are on-demand on `trunk`, but always built on PRs
     steps:
-      - input: Deploy Prototype Build?
+      - input: Create Prototype Build?
         prompt: Share a Prototype Build via Firebase App Distribution?
-        key: prototype_triggered
-      - label: Prototype Build
-        depends_on: prototype_triggered
+        key: prototype_build_triggered
+        if: build.branch == "trunk"
+      - label: ":firebase: Prototype Build"
+        # Buildkite considers this implicitly satisfied if the `depends_on` step is skipped due to `if:` condition. So this will run unconditionally on PRs
+        # https://buildkite.com/docs/pipelines/configure/dependencies#how-skipped-steps-affect-dependencies
+        depends_on: prototype_build_triggered
         command: .buildkite/commands/prototype-build.sh
         plugins: [$CI_TOOLKIT]
         notify:
           - github_commit_status:
-              context: Prototype Build From Trunk
+              context: Prototype Build
 
   #################
   # Run Unit Tests

--- a/.buildkite/schedules/nightly-prototype-build.yml
+++ b/.buildkite/schedules/nightly-prototype-build.yml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+agents:
+  queue: mac
+
+env:
+  IMAGE_ID: $IMAGE_ID
+
+steps:
+  - label: ":rocket: Nightly Prototype Build"
+    command: .buildkite/commands/prototype-build.sh
+    plugins: [$CI_TOOLKIT]


### PR DESCRIPTION
Closes [AINFRA-2170](https://linear.app/a8c/issue/AINFRA-2170/set-up-nightly-trunk-prototype-builds-for-woo-mobile)
Android counterpart: https://github.com/woocommerce/woocommerce-android/pull/15537

## Description

 - Added a scheduled pipeline for nightly prototype builds, triggered on `trunk` by a Buildkite schedule to run every day at midnight (see https://github.com/Automattic/buildkite-ci/pull/827)
 - Simplify the pipeline to DRY the steps for building Prototype Builds, and add the `if: build.branch == "trunk"` condition only on the `input` step, instead of duplicating the case for PR vs `trunk`
    - Buildkite considers `depends_on` conditions implicitly satisfied for steps that have been skipped due to `if:` condition ([Source](https://buildkite.com/docs/pipelines/configure/dependencies#how-skipped-steps-affect-dependencies)). So this technique allows to `depend_on` the `input` step on `trunk` but run unconditionally on PRs, without having to duplicate the step building the Prototype Build in the YAML pipeline.

This was discussed in p1773397624341559/1773394983.779039-slack-CC7L49W13 and provides a balance between having builds from `trunk` all while not overwhelming CI usage too much for building unnecessary.

### Before

| Use case | Prototype Build |
|---|---|
| PRs | ✅ Always |
| `trunk` commits | 🙋 On Demand |
| Nightly Builds | ❌ N/A |

### After

| Use case | Prototype Build |
|---|---|
| PRs | ✅ Always |
| `trunk` commits | 🙋 On Demand |
| Nightly Builds | 🕐 [Every day at midnight](https://github.com/Automattic/buildkite-ci/pull/827/changes#diff-a4c0ccc7211dd4a61a44a27ca84029456fd5b52fa9c733322dac329e1fdb4a29) |

## Testing

 - [x] Verify a Prototype Build is created on this PR and you get the PR comment for it

> [!NOTE]
> Unfortunately, it's not going to be possible to test the cases of `trunk` builds nor scheduled nightly builds until after this PR and https://github.com/Automattic/buildkite-ci/pull/827 land.