### PR TITLE
Fix empty state flash when updating booking list filters

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 24.4
 -----
+- [*] Remove the flashing empty state in booking list when updating filters [https://github.com/woocommerce/woocommerce-ios/pull/16824]
 - [*] Fix My Store dashboard showing different revenue numbers than wp-admin by respecting the store's date type setting [https://github.com/woocommerce/woocommerce-ios/pull/16812]
 - [Internal] Skip Jetpack benefits screen during setup when self driven push notifications feature is enabled [https://github.com/woocommerce/woocommerce-ios/pull/16791]
 - [*] Update booking badge styling to match design [https://github.com/woocommerce/woocommerce-ios/pull/16802#pullrequestreview-3927676114]

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListViewModel.swift
@@ -124,6 +124,7 @@ final class BookingListViewModel: ObservableObject {
     func updateFilters(_ filters: BookingFiltersViewModel.Filters) {
         hasFilters = filters.numberOfActiveFilters > 0
         self.filters = tabDateFilters.mergingDates(with: filters.bookingFilters)
+        syncState = .syncingFirstPage
         resultsController.predicate = currentPredicate
         paginationTracker.resync(reason: Self.refreshCacheReason) {}
     }
@@ -162,9 +163,13 @@ private extension BookingListViewModel {
     }
 
     /// Updates row view models and sync state.
-    func updateResults() {
+    /// - Parameter afterSync: Whether this is called after a sync completes.
+    ///   When `false` (e.g. from a results controller callback), the state
+    ///   will not transition to `.empty` to avoid flashing the empty state
+    ///   while a sync is still in progress.
+    func updateResults(afterSync: Bool = false) {
         bookings = resultsController.fetchedObjects
-        transitionToResultsUpdatedState()
+        transitionToResultsUpdatedState(afterSync: afterSync)
     }
 }
 
@@ -196,7 +201,7 @@ extension BookingListViewModel: PaginationTrackerDelegate {
                 onCompletion?(.failure(error))
             }
 
-            self?.updateResults()
+            self?.updateResults(afterSync: true)
         }
         stores.dispatch(action)
     }
@@ -220,10 +225,17 @@ extension BookingListViewModel {
         }
     }
 
-    /// Update states after sync is complete.
-    func transitionToResultsUpdatedState() {
+    /// Update states after results change.
+    /// - Parameter afterSync: When `true`, allows transitioning to `.empty`
+    ///   state. When `false` (results controller callback), only transitions
+    ///   to `.results` to avoid flashing the empty state during a sync.
+    func transitionToResultsUpdatedState(afterSync: Bool = false) {
         shouldShowBottomActivityIndicator = false
-        syncState = bookings.isNotEmpty ? .results : .empty
+        if bookings.isNotEmpty {
+            syncState = .results
+        } else if afterSync {
+            syncState = .empty
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
@@ -632,6 +632,73 @@ class BookingListViewModelTests {
         #expect(bookingIDs.contains(cancelledBooking.bookingID), "Cancelled bookings should be included in All tab")
     }
 
+    @Test func state_is_syncingFirstPage_when_updating_filters_with_no_matching_bookings_in_storage() {
+        // Given
+        let testDate = Date(timeIntervalSince1970: 1609459200) // 2021-01-01 00:00:00 UTC
+        let booking = createBooking(id: 1, startDate: testDate, status: .confirmed)
+        insertBookings([booking])
+
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            // Don't complete the sync — keep it in progress
+        }
+
+        let viewModel = BookingListViewModel(siteID: sampleSiteID,
+                                             type: .all,
+                                             stores: stores,
+                                             storage: storageManager,
+                                             currentDate: testDate)
+        #expect(viewModel.syncState == .results, "Should have results from storage")
+
+        // When — apply a filter that doesn't match any bookings in storage
+        let userFilters = BookingFiltersViewModel.Filters(
+            teamMembers: [BookingTeamMemberFilter(resourceID: 99, name: "Unknown")],
+            products: [],
+            attendanceStatus: nil,
+            customers: [],
+            dateRange: nil,
+            numberOfActiveFilters: 1
+        )
+        viewModel.updateFilters(userFilters)
+
+        // Then — should show loading state, not empty state
+        #expect(viewModel.syncState == .syncingFirstPage,
+                "Should show loading state instead of empty state while syncing after filter change")
+    }
+
+    @Test func state_is_empty_after_updating_filters_when_sync_completes_with_no_results() {
+        // Given
+        let testDate = Date(timeIntervalSince1970: 1609459200) // 2021-01-01 00:00:00 UTC
+        let booking = createBooking(id: 1, startDate: testDate, status: .confirmed)
+        insertBookings([booking])
+
+        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+            guard let onCompletion = action.synchronizeBookingsCompletion else { return }
+            onCompletion(.success(false))
+        }
+
+        let viewModel = BookingListViewModel(siteID: sampleSiteID,
+                                             type: .all,
+                                             stores: stores,
+                                             storage: storageManager,
+                                             currentDate: testDate)
+        #expect(viewModel.syncState == .results, "Should have results from storage")
+
+        // When — apply a filter and let sync complete with no results
+        let userFilters = BookingFiltersViewModel.Filters(
+            teamMembers: [BookingTeamMemberFilter(resourceID: 99, name: "Unknown")],
+            products: [],
+            attendanceStatus: nil,
+            customers: [],
+            dateRange: nil,
+            numberOfActiveFilters: 1
+        )
+        viewModel.updateFilters(userFilters)
+
+        // Then — sync completed with no matching results, should show empty state
+        #expect(viewModel.syncState == .empty,
+                "Should show empty state after sync completes with no matching results")
+    }
+
     @Test func today_tab_excludes_cancelled_bookings_after_applying_filters() {
         // Given
         let testDate = Date(timeIntervalSince1970: 1609459200) // 2021-01-01 00:00:00 UTC


### PR DESCRIPTION
## Description

Fixes WOOMOB-2499

When changing or clearing filters on the booking list, the results controller predicate update triggers a callback that sets `syncState` to `.empty` before the resync completes. This causes a brief flash of the empty state view before the loading spinner appears.

**Fix:** Add an `afterSync` parameter to `updateResults`/`transitionToResultsUpdatedState` so that only the sync completion handler can transition to `.empty`. Results controller callbacks (predicate changes, cache clears) can only transition to `.results`, preventing the flash. Additionally, `updateFilters` now sets `syncState = .syncingFirstPage` immediately to show the loading state right away.

## Test Steps

1. Open the Bookings tab
2. Apply a filter (e.g., by team member or product)
3. Clear the filter
4. Observe that the list shows a loading spinner instead of briefly flashing the empty state

## Screenshots

https://github.com/user-attachments/assets/404c6911-23f7-478d-908f-c8c3135a285b



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.