### PR TITLE
Hide manual order status edit button for CIAB sites

### DIFF
--- a/Modules/Sources/Yosemite/Tools/CIAB/CIABAffectedFeature.swift
+++ b/Modules/Sources/Yosemite/Tools/CIAB/CIABAffectedFeature.swift
@@ -14,6 +14,7 @@ public enum CIABAffectedFeature: CaseIterable {
     case pointOfSale
     case cardReader
     case storeSetupDashboardCard
+    case manualOrderStatusUpdate
 }
 
 extension CIABAffectedFeature {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 - [*] Fix hiding coupon and product options when opending drawer [https://github.com/woocommerce/woocommerce-ios/pull/16806]
 - [*] Add FedEx as a supported carrier in the shipping label creation flow [https://github.com/woocommerce/woocommerce-ios/pull/16815]
 - [*] Fix sheet/popover presentation showing trimmed content on iPad [https://github.com/woocommerce/woocommerce-ios/pull/16817]
+- [*] Hide edit status button in order details and order edit form for CIAB sites [https://github.com/woocommerce/woocommerce-ios/pull/16827]
 
 
 24.3

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -240,6 +240,8 @@ final class OrderDetailsDataSource: NSObject {
 
     private let featureFlags: FeatureFlagService
 
+    private let ciabEligibilityChecker: CIABEligibilityCheckerProtocol
+
     init(order: Order,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration,
@@ -248,7 +250,8 @@ final class OrderDetailsDataSource: NSObject {
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          siteSettings: [SiteSetting] = ServiceLocator.selectedSiteSettings.siteSettings,
          userIsAdmin: Bool = ServiceLocator.stores.sessionManager.defaultRoles.contains(.administrator),
-         featureFlags: FeatureFlagService = ServiceLocator.featureFlagService) {
+         featureFlags: FeatureFlagService = ServiceLocator.featureFlagService,
+         ciabEligibilityChecker: CIABEligibilityCheckerProtocol = ServiceLocator.ciabEligibilityChecker) {
         self.storageManager = storageManager
         self.order = order
         self.cardPresentPaymentsConfiguration = cardPresentPaymentsConfiguration
@@ -259,6 +262,7 @@ final class OrderDetailsDataSource: NSObject {
         self.siteSettings = siteSettings
         self.userIsAdmin = userIsAdmin
         self.featureFlags = featureFlags
+        self.ciabEligibilityChecker = ciabEligibilityChecker
 
         super.init()
     }
@@ -1041,9 +1045,11 @@ private extension OrderDetailsDataSource {
     }
 
     private func configureSummary(cell: SummaryTableViewCell) {
+        let isStatusEditingSupported = ciabEligibilityChecker.isFeatureSupportedForCurrentSite(.manualOrderStatusUpdate)
         let cellViewModel = SummaryTableViewCellViewModel(
             order: order,
-            status: lookUpOrderStatus(for: order)
+            status: lookUpOrderStatus(for: order),
+            isEditButtonVisible: isStatusEditingSupported
         )
 
         cell.configure(cellViewModel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -18,6 +18,7 @@ final class EditableOrderViewModel: ObservableObject {
     private let storageManager: StorageManagerType
     private let currencyFormatter: CurrencyFormatter
     private let featureFlagService: FeatureFlagService
+    private let ciabEligibilityChecker: CIABEligibilityCheckerProtocol
     private let permissionChecker: CaptureDevicePermissionChecker
     private let posNotificationScheduler: POSNotificationScheduling
 
@@ -165,6 +166,12 @@ final class EditableOrderViewModel: ObservableObject {
     /// Indicates if the order status list (selector) should be shown or not.
     ///
     @Published var shouldShowOrderStatusListSheet: Bool = false
+
+    /// Whether manual order status editing is supported for the current site.
+    ///
+    var isOrderStatusEditingEnabled: Bool {
+        ciabEligibilityChecker.isFeatureSupportedForCurrentSite(.manualOrderStatusUpdate)
+    }
 
     /// Defines if the view should be disabled.
     @Published private(set) var disabled: Bool = false
@@ -459,6 +466,7 @@ final class EditableOrderViewModel: ObservableObject {
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          analytics: Analytics = ServiceLocator.analytics,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         ciabEligibilityChecker: CIABEligibilityCheckerProtocol = ServiceLocator.ciabEligibilityChecker,
          orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared,
          permissionChecker: CaptureDevicePermissionChecker = AVCaptureDevicePermissionChecker(),
          posNotificationScheduler: POSNotificationScheduling = POSNotificationScheduler(),
@@ -473,6 +481,7 @@ final class EditableOrderViewModel: ObservableObject {
         self.analytics = analytics
         self.orderSynchronizer = RemoteOrderSynchronizer(siteID: siteID, flow: flow, stores: stores, currencySettings: currencySettings)
         self.featureFlagService = featureFlagService
+        self.ciabEligibilityChecker = ciabEligibilityChecker
         self.orderDurationRecorder = orderDurationRecorder
         self.permissionChecker = permissionChecker
         self.posNotificationScheduler = posNotificationScheduler

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -273,7 +273,9 @@ struct OrderForm: View {
                         }
 
                         Group {
-                            OrderStatusSection(viewModel: viewModel, topDivider: !viewModel.shouldShowNonEditableIndicators)
+                            OrderStatusSection(viewModel: viewModel,
+                                               topDivider: !viewModel.shouldShowNonEditableIndicators,
+                                               isEditButtonVisible: viewModel.isOrderStatusEditingEnabled)
                             Spacer(minLength: Layout.sectionSpacing)
                         }
                         .renderedIf(flow == .editing)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
@@ -14,6 +14,10 @@ struct OrderStatusSection: View {
     ///
     private(set) var topDivider: Bool = true
 
+    /// Whether the edit status button should be displayed.
+    ///
+    private(set) var isEditButtonVisible: Bool = true
+
     var body: some View {
         Divider()
             .renderedIf(topDivider)
@@ -45,6 +49,7 @@ struct OrderStatusSection: View {
                         viewModel.updateOrderStatus(newStatus: newStatus)
                     }.ignoresSafeArea()
                 }
+                .renderedIf(isEditButtonVisible)
             }
         }
         .padding(.horizontal, insets: safeAreaInsets)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
@@ -33,6 +33,7 @@ final class SummaryTableViewCell: UITableViewCell {
         subtitleLabel.text = viewModel.subtitle
         salesChannelLabel.text = viewModel.salesChannel
         salesChannelLabel.isHidden = (salesChannelLabel.text == nil)
+        updateStatusButton.isHidden = !viewModel.isEditButtonVisible
         display(presentation: viewModel.presentation)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCellViewModel.swift
@@ -13,10 +13,14 @@ struct SummaryTableViewCellViewModel {
 
     let presentation: OrderStatusPresentation
 
+    /// Whether the edit status button should be displayed.
+    let isEditButtonVisible: Bool
+
     private let calendar: Calendar
 
     init(order: Order,
          status: OrderStatus?,
+         isEditButtonVisible: Bool = true,
          calendar: Calendar = .current) {
 
         billingAddress = order.billingAddress
@@ -28,6 +32,7 @@ struct SummaryTableViewCellViewModel {
             title: status?.name ?? order.status.rawValue
         )
 
+        self.isEditButtonVisible = isEditButtonVisible
         self.calendar = calendar
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -3563,6 +3563,32 @@ private extension EditableOrderViewModelTests {
     }
 }
 
+// MARK: - CIAB Order Status Editing
+
+    func test_isOrderStatusEditingEnabled_when_non_CIAB_site_then_returns_true() {
+        // Given
+        let checker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: false)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               stores: stores,
+                                               storageManager: storageManager,
+                                               ciabEligibilityChecker: checker)
+
+        // Then
+        XCTAssertTrue(viewModel.isOrderStatusEditingEnabled)
+    }
+
+    func test_isOrderStatusEditingEnabled_when_CIAB_site_then_returns_false() {
+        // Given
+        let checker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: true)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               stores: stores,
+                                               storageManager: storageManager,
+                                               ciabEligibilityChecker: checker)
+
+        // Then
+        XCTAssertFalse(viewModel.isOrderStatusEditingEnabled)
+    }
+
 // MARK: - POS Notification Tests & MockPOSNotificationScheduler
 private extension EditableOrderViewModelTests {
     final class MockPOSNotificationScheduler: POSNotificationScheduling {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -258,7 +258,7 @@ final class EditableOrderViewModelTests: XCTestCase {
 
     func test_view_model_loads_synced_pending_order_status() {
         // Given
-        storageManager.insertOrderStatus(.init(name: "Pending payment", siteID: sampleSiteID, slug: "pending", total: 0))
+        insertOrderStatus(.init(name: "Pending payment", siteID: sampleSiteID, slug: "pending", total: 0))
 
         // When
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
@@ -269,8 +269,8 @@ final class EditableOrderViewModelTests: XCTestCase {
 
     func test_view_model_is_updated_when_order_status_updated() {
         // Given
-        storageManager.insertOrderStatus(.init(name: "Pending payment", siteID: sampleSiteID, slug: "pending", total: 0))
-        storageManager.insertOrderStatus(.init(name: "Processing", siteID: sampleSiteID, slug: "processing", total: 0))
+        insertOrderStatus(.init(name: "Pending payment", siteID: sampleSiteID, slug: "pending", total: 0))
+        insertOrderStatus(.init(name: "Processing", siteID: sampleSiteID, slug: "processing", total: 0))
 
         // When
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
@@ -462,9 +462,9 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Inserts necessary objects to storage.
         storageManager.insertSampleProduct(readOnlyProduct: bundledProduct)
         storageManager.insertSampleProduct(readOnlyProduct: bundledVariableProduct)
-        let storageBundleProduct = storageManager.insertSampleProduct(readOnlyProduct: bundleProduct)
-        storageManager.insert(bundleItem, for: storageBundleProduct)
-        storageManager.insert(variableBundleItem, for: storageBundleProduct)
+        storageManager.insertSampleProduct(readOnlyProduct: bundleProduct)
+        insertBundleItem(bundleItem, forProductWithSiteID: sampleSiteID, productID: bundleProduct.productID)
+        insertBundleItem(variableBundleItem, forProductWithSiteID: sampleSiteID, productID: bundleProduct.productID)
 
         let order = Order.fake().copy(siteID: sampleSiteID, orderID: sampleOrderID, items: [
             // Bundle order item
@@ -528,7 +528,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Given
         let product0 = Product.fake().copy(siteID: sampleSiteID, productID: 0, purchasable: true)
         let product1 = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
-        storageManager.insertProducts([product0, product1])
+        insertProducts([product0, product1])
         viewModel.toggleProductSelectorVisibility()
         let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
@@ -552,7 +552,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Given
         let product0 = Product.fake().copy(siteID: sampleSiteID, productID: 0, purchasable: true)
         let product1 = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
-        storageManager.insertProducts([product0, product1])
+        insertProducts([product0, product1])
         viewModel.toggleProductSelectorVisibility()
         let productSelectorViewModel = try XCTUnwrap(viewModel.productSelectorViewModel)
 
@@ -1238,7 +1238,7 @@ final class EditableOrderViewModelTests: XCTestCase {
     func test_product_is_tracked_when_removed_from_order() throws {
         // Given
         let product0 = Product.fake().copy(siteID: sampleSiteID, productID: 0, purchasable: true)
-        storageManager.insertProducts([product0])
+        insertProducts([product0])
         let analytics = MockAnalyticsProvider()
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                storageManager: storageManager,
@@ -2393,7 +2393,7 @@ final class EditableOrderViewModelTests: XCTestCase {
 
     func test_when_initialItem_is_bundle_product_it_sets_configurableScannedProductViewModel_without_order_items() throws {
         // Given
-        let bundleProduct = storageManager.createAndInsertBundleProduct(siteID: sampleSiteID, productID: 1, bundleItems: [.fake()])
+        let bundleProduct = createAndInsertBundleProduct(siteID: sampleSiteID, productID: 1, bundleItems: [.fake()])
 
         // When
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialItem: .product(bundleProduct))
@@ -2861,8 +2861,8 @@ final class EditableOrderViewModelTests: XCTestCase {
 
     func test_bundle_child_order_items_excluded_from_productRows_and_added_to_parent_childProductRows() throws {
         let bundleItem = ProductBundleItem.fake().copy(productID: 5)
-        let bundleProduct = storageManager.createAndInsertBundleProduct(siteID: sampleSiteID, productID: 606, bundleItems: [bundleItem])
-        storageManager.insertProducts([.fake().copy(siteID: sampleSiteID, productID: bundleItem.productID, purchasable: true)])
+        let bundleProduct = createAndInsertBundleProduct(siteID: sampleSiteID, productID: 606, bundleItems: [bundleItem])
+        insertProducts([.fake().copy(siteID: sampleSiteID, productID: bundleItem.productID, purchasable: true)])
         let order = Order.fake().copy(siteID: sampleSiteID, orderID: 1, items: [
             // Bundle product order item.
             .fake().copy(itemID: 6, productID: bundleProduct.productID, quantity: 2),
@@ -2891,9 +2891,9 @@ final class EditableOrderViewModelTests: XCTestCase {
     func test_when_existing_items_contain_bundle_and_non_bundle_then_selecting_same_bundle_results_in_two_bundles() throws {
         // Given
         let bundleItem = ProductBundleItem.fake().copy(productID: 5)
-        let bundleProduct = storageManager.createAndInsertBundleProduct(siteID: sampleSiteID, productID: 606, bundleItems: [bundleItem])
+        let bundleProduct = createAndInsertBundleProduct(siteID: sampleSiteID, productID: 606, bundleItems: [bundleItem])
         let nonBundleProduct = Product.fake().copy(siteID: sampleSiteID, productID: 777, purchasable: true)
-        storageManager.insertProducts([nonBundleProduct,
+        insertProducts([nonBundleProduct,
                                        // Product of the bundled item.
                                        .fake().copy(siteID: sampleSiteID, productID: bundleItem.productID, purchasable: true)])
         let order = Order.fake().copy(siteID: sampleSiteID, orderID: 1, items: [
@@ -2958,10 +2958,10 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Given
         let itemProductID: Int64 = 777
         let bundleItem = ProductBundleItem.fake().copy(productID: itemProductID)
-        let bundleProduct = storageManager.createAndInsertBundleProduct(siteID: sampleSiteID, productID: 606, bundleItems: [bundleItem])
+        let bundleProduct = createAndInsertBundleProduct(siteID: sampleSiteID, productID: 606, bundleItems: [bundleItem])
         // Non-bundle product is in storage but not part of the order.
         let nonBundleProduct = Product.fake().copy(siteID: sampleSiteID, productID: itemProductID, purchasable: true)
-        storageManager.insertProducts([nonBundleProduct,
+        insertProducts([nonBundleProduct,
                                        // Product of the bundled item.
                                        .fake().copy(siteID: sampleSiteID, productID: bundleItem.productID, purchasable: true)])
 
@@ -3023,9 +3023,9 @@ final class EditableOrderViewModelTests: XCTestCase {
     func test_when_no_existing_items_then_selecting_bundle_twice_results_in_two_bundle_items() throws {
         // Given
         let bundleItem = ProductBundleItem.fake().copy(productID: 5)
-        let bundleProduct = storageManager.createAndInsertBundleProduct(siteID: sampleSiteID, productID: 606, bundleItems: [bundleItem])
+        let bundleProduct = createAndInsertBundleProduct(siteID: sampleSiteID, productID: 606, bundleItems: [bundleItem])
         // Product of the bundled item.
-        storageManager.insertProducts([.fake().copy(siteID: sampleSiteID, productID: bundleItem.productID, purchasable: true)])
+        insertProducts([.fake().copy(siteID: sampleSiteID, productID: bundleItem.productID, purchasable: true)])
 
         let order = Order.fake().copy(siteID: sampleSiteID, orderID: 1, items: [])
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order), stores: stores, storageManager: storageManager)
@@ -3089,9 +3089,9 @@ final class EditableOrderViewModelTests: XCTestCase {
     func test_selecting_bundle_then_canceling_then_selecting_bundle_again_results_in_one_bundle_item_with_the_latest_configuration() throws {
         // Given
         let bundleItem = ProductBundleItem.fake().copy(productID: 5)
-        let bundleProduct = storageManager.createAndInsertBundleProduct(siteID: sampleSiteID, productID: 606, bundleItems: [bundleItem])
+        let bundleProduct = createAndInsertBundleProduct(siteID: sampleSiteID, productID: 606, bundleItems: [bundleItem])
         // Product of the bundled item.
-        storageManager.insertProducts([.fake().copy(siteID: sampleSiteID, productID: bundleItem.productID, purchasable: true)])
+        insertProducts([.fake().copy(siteID: sampleSiteID, productID: bundleItem.productID, purchasable: true)])
 
         let order = Order.fake().copy(siteID: sampleSiteID, orderID: 1, items: [])
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order), stores: stores, storageManager: storageManager)
@@ -3149,8 +3149,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Given
         let bundledItems = [ProductBundleItem.fake().copy(productID: 2, pricedIndividually: false),
                             ProductBundleItem.fake().copy(productID: 3, pricedIndividually: true)]
-        let product = storageManager.createAndInsertBundleProduct(siteID: sampleSiteID, productID: sampleProductID, bundleItems: bundledItems)
-        storageManager.insertProducts([Product.fake().copy(siteID: sampleSiteID, productID: 2),
+        let product = createAndInsertBundleProduct(siteID: sampleSiteID, productID: sampleProductID, bundleItems: bundledItems)
+        insertProducts([Product.fake().copy(siteID: sampleSiteID, productID: 2),
                                        Product.fake().copy(siteID: sampleSiteID, productID: 3)])
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
 
@@ -3170,8 +3170,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Given
         let bundledItems = [ProductBundleItem.fake().copy(productID: 2, pricedIndividually: false),
                             ProductBundleItem.fake().copy(productID: 3, pricedIndividually: true)]
-        let product = storageManager.createAndInsertBundleProduct(siteID: sampleSiteID, productID: sampleProductID, bundleItems: bundledItems)
-        storageManager.insertProducts([Product.fake().copy(siteID: sampleSiteID, productID: 2),
+        let product = createAndInsertBundleProduct(siteID: sampleSiteID, productID: sampleProductID, bundleItems: bundledItems)
+        insertProducts([Product.fake().copy(siteID: sampleSiteID, productID: 2),
                                        Product.fake().copy(siteID: sampleSiteID, productID: 3)])
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
 
@@ -3189,7 +3189,7 @@ final class EditableOrderViewModelTests: XCTestCase {
 
     func test_createProductRowViewModel_sets_isReadOnly_to_false_for_non_bundle_parent_and_child_items() throws {
         // Given
-        storageManager.insertProducts([Product.fake().copy(siteID: sampleSiteID, productID: 1),
+        insertProducts([Product.fake().copy(siteID: sampleSiteID, productID: 1),
                                        Product.fake().copy(siteID: sampleSiteID, productID: 2),
                                        Product.fake().copy(siteID: sampleSiteID, productID: 3)])
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager)
@@ -3466,6 +3466,32 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(mockScheduler.scheduleCallCount, 0)
         XCTAssertNil(mockScheduler.lastMerchantType)
     }
+
+    // MARK: - CIAB Order Status Editing
+
+    func test_isOrderStatusEditingEnabled_when_non_CIAB_site_then_returns_true() {
+        // Given
+        let checker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: false)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               stores: stores,
+                                               storageManager: storageManager,
+                                               ciabEligibilityChecker: checker)
+
+        // Then
+        XCTAssertTrue(viewModel.isOrderStatusEditingEnabled)
+    }
+
+    func test_isOrderStatusEditingEnabled_when_CIAB_site_then_returns_false() {
+        // Given
+        let checker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: true)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               stores: stores,
+                                               storageManager: storageManager,
+                                               ciabEligibilityChecker: checker)
+
+        // Then
+        XCTAssertFalse(viewModel.isOrderStatusEditingEnabled)
+    }
 }
 
 private extension EditableOrderViewModelTests {
@@ -3488,33 +3514,40 @@ private extension EditableOrderViewModelTests {
     }
 }
 
-private extension MockStorageManager {
+// MARK: - Storage Helpers
+private extension EditableOrderViewModelTests {
 
     func insertOrderStatus(_ readOnlyOrderStatus: OrderStatus) {
-        let orderStatus = viewStorage.insertNewObject(ofType: StorageOrderStatus.self)
-        orderStatus.update(with: readOnlyOrderStatus)
-        viewStorage.saveIfNeeded()
+        storageManager.performAndSave({ storage in
+            let orderStatus = storage.insertNewObject(ofType: StorageOrderStatus.self)
+            orderStatus.update(with: readOnlyOrderStatus)
+        }, completion: {}, on: .main)
     }
 
     func insertProducts(_ readOnlyProducts: [Product]) {
-        for readOnlyProduct in readOnlyProducts {
-            let product = viewStorage.insertNewObject(ofType: StorageProduct.self)
+        storageManager.performAndSave({ storage in
+            for readOnlyProduct in readOnlyProducts {
+                let product = storage.insertNewObject(ofType: StorageProduct.self)
+                product.update(with: readOnlyProduct)
+            }
+        }, completion: {}, on: .main)
+    }
+
+    func insertProduct(_ readOnlyProduct: Product) {
+        storageManager.performAndSave({ storage in
+            let product = storage.insertNewObject(ofType: StorageProduct.self)
             product.update(with: readOnlyProduct)
-            viewStorage.saveIfNeeded()
-        }
+        }, completion: {}, on: .main)
     }
 
-    @discardableResult
-    func insert(_ readOnlyProduct: Product) -> StorageProduct {
-        let product = viewStorage.insertNewObject(ofType: StorageProduct.self)
-        product.update(with: readOnlyProduct)
-        return product
-    }
-
-    func insert(_ readOnlyProductBundleItem: ProductBundleItem, for product: StorageProduct) {
-        let bundleItem = viewStorage.insertNewObject(ofType: StorageProductBundleItem.self)
-        bundleItem.update(with: readOnlyProductBundleItem)
-        bundleItem.product = product
+    func insertBundleItem(_ readOnlyProductBundleItem: ProductBundleItem, forProductWithSiteID siteID: Int64 = 123, productID: Int64) {
+        storageManager.performAndSave({ storage in
+            let bundleItem = storage.insertNewObject(ofType: StorageProductBundleItem.self)
+            bundleItem.update(with: readOnlyProductBundleItem)
+            if let storageProduct = storage.loadProduct(siteID: siteID, productID: productID) {
+                bundleItem.product = storageProduct
+            }
+        }, completion: {}, on: .main)
     }
 
     func createAndInsertBundleProduct(siteID: Int64, productID: Int64, bundleItems: [Yosemite.ProductBundleItem]) -> Yosemite.Product {
@@ -3523,11 +3556,16 @@ private extension MockStorageManager {
                                                 productTypeKey: ProductType.bundle.rawValue,
                                                 purchasable: true,
                                                 bundledItems: bundleItems)
-        let storageProduct = insert(bundleProduct)
+        storageManager.performAndSave({ storage in
+            let storageProduct = storage.insertNewObject(ofType: StorageProduct.self)
+            storageProduct.update(with: bundleProduct)
 
-        bundleItems.forEach { bundleItem in
-            insert(bundleItem, for: storageProduct)
-        }
+            bundleItems.forEach { item in
+                let storageBundleItem = storage.insertNewObject(ofType: StorageProductBundleItem.self)
+                storageBundleItem.update(with: item)
+                storageBundleItem.product = storageProduct
+            }
+        }, completion: {}, on: .main)
 
         return bundleProduct
     }
@@ -3562,32 +3600,6 @@ private extension EditableOrderViewModelTests {
                        email: "")
     }
 }
-
-// MARK: - CIAB Order Status Editing
-
-    func test_isOrderStatusEditingEnabled_when_non_CIAB_site_then_returns_true() {
-        // Given
-        let checker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: false)
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
-                                               stores: stores,
-                                               storageManager: storageManager,
-                                               ciabEligibilityChecker: checker)
-
-        // Then
-        XCTAssertTrue(viewModel.isOrderStatusEditingEnabled)
-    }
-
-    func test_isOrderStatusEditingEnabled_when_CIAB_site_then_returns_false() {
-        // Given
-        let checker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: true)
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
-                                               stores: stores,
-                                               storageManager: storageManager,
-                                               ciabEligibilityChecker: checker)
-
-        // Then
-        XCTAssertFalse(viewModel.isOrderStatusEditingEnabled)
-    }
 
 // MARK: - POS Notification Tests & MockPOSNotificationScheduler
 private extension EditableOrderViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell/SummaryTableViewCellTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell/SummaryTableViewCellTests.swift
@@ -48,6 +48,30 @@ final class SummaryTableViewCellTests: XCTestCase {
         XCTAssertEqual(mirror.paymentStatusLabel.text, orderStatus.name)
     }
 
+    func test_edit_button_is_visible_when_viewModel_isEditButtonVisible_is_true() throws {
+        // Given
+        let mirror = try self.mirror(of: cell)
+        let viewModel = SummaryTableViewCellViewModel(order: sampleOrder(), status: nil, isEditButtonVisible: true)
+
+        // When
+        cell.configure(viewModel)
+
+        // Then
+        XCTAssertFalse(mirror.updateStatusButton.isHidden)
+    }
+
+    func test_edit_button_is_hidden_when_viewModel_isEditButtonVisible_is_false() throws {
+        // Given
+        let mirror = try self.mirror(of: cell)
+        let viewModel = SummaryTableViewCellViewModel(order: sampleOrder(), status: nil, isEditButtonVisible: false)
+
+        // When
+        cell.configure(viewModel)
+
+        // Then
+        XCTAssertTrue(mirror.updateStatusButton.isHidden)
+    }
+
     func test_tapping_button_executes_callback() throws {
         // Given
         let mirror = try self.mirror(of: cell)


### PR DESCRIPTION
Closes: WOOMOB-2505

## Description
CIAB sites should not allow manual order status updates. This PR hides the edit status button in two places:

1. **Order Details screen** (`SummaryTableViewCell`) — the pencil button is hidden when the current site is CIAB
2. **Order Edit Form** (`OrderStatusSection`) — the pencil edit button is hidden via `.renderedIf`

A new `manualOrderStatusUpdate` case is added to `CIABAffectedFeature`, which is automatically included in the unsupported features list for CIAB sites. The CIAB eligibility check is injected through view models (`SummaryTableViewCellViewModel` and `EditableOrderViewModel`) for testability.

## Test Steps
1. Log into a CIAB site (garden site with `gardenName == "commerce"`)
2. Navigate to an order's detail screen → the pencil icon next to the status badge should **not** appear
3. Tap Edit on an order → the status section should show the badge but **no** edit button
4. Log into a regular (non-CIAB) site → both edit buttons should appear as before

## Screenshots
Screen | CIAB Site | Non-CIAB
--- |  ---- | ---
Order details | <img width="320" alt="Simulator Screenshot - iPhone 17 - 2026-03-17 at 11 58 18" src="https://github.com/user-attachments/assets/ee87bada-b567-491f-840a-ff346d9531ed" /> | <img width="320" alt="Simulator Screenshot - iPhone 17 - 2026-03-17 at 11 58 59" src="https://github.com/user-attachments/assets/559bae21-18bd-419c-8947-02b9e0530611" />
Edit order | <img width="320" alt="Simulator Screenshot - iPhone 17 - 2026-03-17 at 11 58 27" src="https://github.com/user-attachments/assets/54f1dfcc-9478-4e62-bc77-0a12329ab0b8" /> | <img width="320"  alt="Simulator Screenshot - iPhone 17 - 2026-03-17 at 11 59 04" src="https://github.com/user-attachments/assets/c4c5036e-2880-4290-90fd-d07b6b0282bc" />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.