### PR TITLE
Add Clear CoreData Storage debug option

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/DebugPanelView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/DebugPanelView.swift
@@ -16,6 +16,14 @@ struct DebugPanelView: View {
             }
 
             Button {
+                ServiceLocator.storageManager.reset {
+                    ServiceLocator.noticePresenter.enqueue(notice: Notice(title: "CoreData storage cleared"))
+                }
+            } label: {
+                Text("Clear CoreData Storage")
+            }
+
+            Button {
                 ServiceLocator.crashLogging.crash()
             } label: {
                 Text("Crash Immediately")


### PR DESCRIPTION
## Description

This just adds a convenient way to clear local storage without logging out and back in, by adding an extra item to the Debug Panel to clear the CoreData storage.

## Test Steps

I guess there are multiple ways to test this, but here is just one.

1. Log in to a CIAB store
2. Navigate the Bookings/All
3. Note that bookings are loaded
4. Navigate to Menu/Settings/Debug Panel
5. Tap "Clear CoreData Storage"
6. Navigate back to bookings
7. Note that the list is empty

## Screenshots
![Simulator Screen Recording - iPhone 17 Pro - 2026-03-17 at 13 12 37](https://github.com/user-attachments/assets/f80c8948-17d3-41d7-bd40-3f3c31b9ced2)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.