### PR TITLE
Enable SwiftLint rule: empty_count

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -29,6 +29,9 @@ only_rules:
 
   - duplicate_imports
 
+  # Prefer checking `isEmpty` over comparing `count` to zero.
+  - empty_count
+
   # Arguments can be omitted when matching enums with associated types if they
   # are not used.
   - empty_enum_arguments

--- a/Modules/Sources/Networking/Internal/Queue.swift
+++ b/Modules/Sources/Networking/Internal/Queue.swift
@@ -11,7 +11,7 @@ struct Queue<T> {
     fileprivate var head = 0
 
     public var isEmpty: Bool {
-        return count == 0
+        return isEmpty
     }
 
     public var count: Int {

--- a/Modules/Sources/Networking/Model/ShippingLabel/Shipments/WooShippingShipmentItem.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Shipments/WooShippingShipmentItem.swift
@@ -53,6 +53,6 @@ public typealias WooShippingShipments = [String: [WooShippingShipmentItem]]
 public extension WooShippingShipmentItem {
     var quantity: Decimal {
         guard let subItems else { return 0 }
-        return subItems.count > 0 ? Decimal(subItems.count) : 1
+        return !subItems.isEmpty ? Decimal(subItems.count) : 1
     }
 }

--- a/Modules/Sources/WordPressShared/Utility/RichContentFormatter.swift
+++ b/Modules/Sources/WordPressShared/Utility/RichContentFormatter.swift
@@ -51,7 +51,7 @@ import WordPressSharedObjC
     /// - Returns: The formatted string.
     ///
     @objc public class func formatContentString(_ string: String, isPrivateSite isPrivate: Bool) -> String {
-        guard string.count > 0 else {
+        guard !string.isEmpty else {
             return string
         }
 
@@ -75,7 +75,7 @@ import WordPressSharedObjC
     /// - Returns: The formatted string.
     ///
     @objc public class func removeForbiddenTags(_ string: String) -> String {
-        guard string.count > 0 else {
+        guard !string.isEmpty else {
             return string
         }
         var content = string
@@ -107,7 +107,7 @@ import WordPressSharedObjC
     /// - Returns: The formatted string.
     ///
     @objc public class func normalizeParagraphs(_ string: String) -> String {
-        guard string.count > 0 else {
+        guard !string.isEmpty else {
             return string
         }
         var content = string
@@ -149,7 +149,7 @@ import WordPressSharedObjC
         // We don't want to remove new lines from preformatted tag blocks,
         // so get the ranges of such blocks.
         let matches = RegEx.preTags.matches(in: content, options: .reportCompletion, range: NSRange(location: 0, length: content.count))
-        if matches.count == 0 {
+        if matches.isEmpty {
 
             // No blocks found, so we'll parse the whole string.
             ranges.append(NSRange(location: 0, length: content.count))
@@ -193,7 +193,7 @@ import WordPressSharedObjC
     /// - Returns: The formatted string.
     ///
     @objc public class func removeInlineStyles(_ string: String) -> String {
-        guard string.count > 0 else {
+        guard !string.isEmpty else {
             return string
         }
         var content = string
@@ -216,7 +216,7 @@ import WordPressSharedObjC
     /// - Returns: The formatted string.
     ///
     @objc public class func resizeGalleryImageURL(_ string: String, isPrivateSite isPrivate: Bool) -> String {
-        guard string.count > 0 else {
+        guard !string.isEmpty else {
             return string
         }
 
@@ -294,7 +294,7 @@ import WordPressSharedObjC
     /// - Returns: The formatted string.
     ///
     @objc public class func removeTrailingBreakTags(_ string: String) -> String {
-        guard string.count > 0 else {
+        guard !string.isEmpty else {
             return string
         }
 

--- a/Modules/Sources/Yosemite/Internal/Queue.swift
+++ b/Modules/Sources/Yosemite/Internal/Queue.swift
@@ -10,7 +10,7 @@ public struct Queue<T> {
     fileprivate var head = 0
 
     public var isEmpty: Bool {
-        return count == 0
+        return isEmpty
     }
 
     public var count: Int {

--- a/Modules/Sources/Yosemite/Internal/String+Extensions.swift
+++ b/Modules/Sources/Yosemite/Internal/String+Extensions.swift
@@ -12,7 +12,7 @@ extension String {
         let urlComponents = latin.components(separatedBy: String.slugSafeCharacters.inverted)
         let result = urlComponents.filter { $0 != "" }.joined(separator: "-")
 
-        guard result.count > 0 else {
+        guard !result.isEmpty else {
             return nil
         }
 

--- a/Modules/Sources/Yosemite/Model/Orders/StoredOrderSettings.swift
+++ b/Modules/Sources/Yosemite/Model/Orders/StoredOrderSettings.swift
@@ -30,7 +30,7 @@ public struct StoredOrderSettings: Codable, Equatable {
 
         public func numberOfActiveFilters() -> Int {
             var total = 0
-            if let orderStatusesFilter = orderStatusesFilter, orderStatusesFilter.count > 0 {
+            if let orderStatusesFilter = orderStatusesFilter, !orderStatusesFilter.isEmpty {
                 total += 1
             }
             if let dateRangeFilter = dateRangeFilter, dateRangeFilter.filter != .any {

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemService.swift
@@ -38,7 +38,7 @@ public final class PointOfSaleItemService: PointOfSaleItemServiceProtocol {
             let pagedProducts = try await fetchStrategy.fetchProducts(pageNumber: pageNumber)
             let products = pagedProducts.items
 
-            if pageNumber != 1 && products.count == 0 {
+            if pageNumber != 1 && products.isEmpty {
                 return .init(items: [], hasMorePages: false, totalItems: 0)
             }
 

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderListService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderListService.swift
@@ -28,7 +28,7 @@ public final class POSOrderListService: POSOrderListServiceProtocol {
                 pageSize: 25
             )
 
-            if pageNumber != 1 && pagedOrders.items.count == 0 {
+            if pageNumber != 1 && pagedOrders.items.isEmpty {
                 return .init(items: [], hasMorePages: false, totalItems: 0)
             }
 
@@ -54,7 +54,7 @@ public final class POSOrderListService: POSOrderListServiceProtocol {
                 pageSize: 25
             )
 
-            if pageNumber != 1 && pagedOrders.items.count == 0 {
+            if pageNumber != 1 && pagedOrders.items.isEmpty {
                 return .init(items: [], hasMorePages: false, totalItems: 0)
             }
 

--- a/Modules/Sources/Yosemite/Stores/AppSettingsStore.swift
+++ b/Modules/Sources/Yosemite/Stores/AppSettingsStore.swift
@@ -1156,7 +1156,7 @@ extension AppSettingsStore {
 
     func loadSiteHasAtLeastOneIPPTransactionFinished(siteID: Int64, onCompletion: (Bool) -> Void) {
         let storeSettings = getStoreSettings(for: siteID)
-        let hasStoredTransactionsByReader = storeSettings.firstInPersonPaymentsTransactionsByReaderType.count > 0
+        let hasStoredTransactionsByReader = !storeSettings.firstInPersonPaymentsTransactionsByReaderType.isEmpty
         let hasLegacyIPPTransactionStored = generalAppSettings.value(for: \.sitesWithAtLeastOneIPPTransactionFinished).contains(siteID)
         onCompletion(hasStoredTransactionsByReader || hasLegacyIPPTransactionStored)
     }

--- a/Modules/Sources/Yosemite/Stores/ReceiptStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ReceiptStore.swift
@@ -147,7 +147,7 @@ private extension ReceiptStore {
 
     func discountLineDescription(order: Order) -> String {
         var couponCodes = ""
-        if order.coupons.count > 0 {
+        if !order.coupons.isEmpty {
             couponCodes = order.coupons.map {
                 $0.code
             }

--- a/Modules/Tests/HardwareTests/CardBrandTests.swift
+++ b/Modules/Tests/HardwareTests/CardBrandTests.swift
@@ -83,7 +83,7 @@ final class CardBrandTests: XCTestCase {
 
     func test_card_brand_has_icon_data_for_all_brands() throws {
         for cardBrand in Hardware.CardBrand.allCases {
-            XCTAssert(cardBrand.iconData.count > 0)
+            XCTAssert(!cardBrand.iconData.isEmpty)
         }
     }
 

--- a/Modules/Tests/NetworkingTests/Mapper/CouponListMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/CouponListMapperTests.swift
@@ -26,7 +26,7 @@ class CouponListMapperTests: XCTestCase {
     ///
     func test_CouponsList_map_includes_siteID_in_parsed_results() throws {
         let coupons = try mapLoadAllCouponsResponseWithDataEnvelope()
-        XCTAssertTrue(coupons.count > 0)
+        XCTAssertTrue(!coupons.isEmpty)
 
         for coupon in coupons {
             XCTAssertEqual(coupon.siteID, dummySiteID)

--- a/Modules/Tests/NetworkingTests/Mapper/InboxNoteListMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/InboxNoteListMapperTests.swift
@@ -26,7 +26,7 @@ final class InboxNoteListMapperTests: XCTestCase {
     ///
     func test_InboxNoteListMapper_includes_siteID_in_parsed_results() throws {
         let inboxNotes = try mapLoadInboxNoteListResponse()
-        XCTAssertTrue(inboxNotes.count > 0)
+        XCTAssertTrue(!inboxNotes.isEmpty)
 
         for inboxNote in inboxNotes {
             XCTAssertEqual(inboxNote.siteID, dummySiteID)

--- a/Modules/Tests/NetworkingTests/Mapper/SubscriptionListMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/SubscriptionListMapperTests.swift
@@ -27,7 +27,7 @@ final class SubscriptionListMapperTests: XCTestCase {
         let subscriptions = try mapLoadSubscriptionListResponseWithDataEnvelope()
 
         // Then
-        XCTAssertTrue(subscriptions.count > 0)
+        XCTAssertTrue(!subscriptions.isEmpty)
         for subscription in subscriptions {
             XCTAssertEqual(subscription.siteID, sampleSiteID)
         }

--- a/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
@@ -214,7 +214,7 @@ struct POSCatalogSyncRemoteTests {
         let pagedVariations = try await remote.loadProductVariations(modifiedAfter: modifiedAfter, siteID: sampleSiteID, pageNumber: 1)
 
         // Then
-        #expect(pagedVariations.items.count > 0)
+        #expect(!pagedVariations.items.isEmpty)
 
         let firstVariation = try #require(pagedVariations.items.first)
         #expect(firstVariation.siteID == sampleSiteID)
@@ -761,8 +761,8 @@ struct POSCatalogSyncRemoteTests {
         let catalog = try await remote.downloadCatalog(for: sampleSiteID, downloadURL: downloadURL, allowCellular: true)
 
         // Then
-        #expect(catalog.products.count == 0)
-        #expect(catalog.variations.count == 0)
+        #expect(catalog.products.isEmpty)
+        #expect(catalog.variations.isEmpty)
     }
 
     @Test func downloadCatalog_throws_error_for_empty_url() async throws {

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -592,7 +592,7 @@ final class POSOrderListControllerTests {
         sut.clearRefundSelection()
 
         // Then
-        #expect(sut.refundSelectableItems.count == 0)
+        #expect(sut.refundSelectableItems.isEmpty)
     }
 
     @MainActor
@@ -993,7 +993,7 @@ final class POSOrderListControllerTests {
         try await sut.processRefund(reason: .none)
 
         // Then
-        #expect(sut.refundSelectableItems.count == 0)
+        #expect(sut.refundSelectableItems.isEmpty)
     }
 
     @MainActor

--- a/Modules/Tests/PointOfSaleTests/Models/POSOrderListStateTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/POSOrderListStateTests.swift
@@ -112,10 +112,10 @@ struct POSOrderListStateTests {
         #expect(inlineErrorState.orders.count == 2)
 
         let emptyState = POSOrderListState.empty
-        #expect(emptyState.orders.count == 0)
+        #expect(emptyState.orders.isEmpty)
 
         let fullErrorState = POSOrderListState.error(errorState)
-        #expect(fullErrorState.orders.count == 0)
+        #expect(fullErrorState.orders.isEmpty)
     }
 }
 

--- a/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
@@ -192,7 +192,7 @@ struct PointOfSaleAggregateModelTests {
 
             // Then
             #expect(sut.cart.purchasableItems.count == 2)
-            #expect(sut.cart.coupons.count == 0)
+            #expect(sut.cart.coupons.isEmpty)
         }
 
         enum CartTestError: Error {

--- a/Modules/Tests/StorageTests/Extensions/NSManagedObjectContextStorageTests.swift
+++ b/Modules/Tests/StorageTests/Extensions/NSManagedObjectContextStorageTests.swift
@@ -98,7 +98,7 @@ class NSManagedObjectContextStorageTests: XCTestCase {
         context.deleteAllObjects(ofType: DummyEntity.self)
 
         XCTAssert(context.countObjects(ofType: DummyEntity.self) == 0)
-        XCTAssert(context.allObjects(ofType: DummyEntity.self).count == 0)
+        XCTAssert(context.allObjects(ofType: DummyEntity.self).isEmpty)
     }
 
     /// Verifies that firstObject effectively retrieves a single instance, when applicable

--- a/Modules/Tests/StorageTests/GRDB/POSSearchIndexBuilderTests.swift
+++ b/Modules/Tests/StorageTests/GRDB/POSSearchIndexBuilderTests.swift
@@ -571,7 +571,7 @@ struct POSSearchIndexBuilderTests {
         let shirtVariationsAfter = try await grdbManager.databaseConnection.read { db in
             try POSSearchIndexBuilder.search(siteID: siteID, term: "VSHIRT", in: db)
         }
-        #expect(shirtVariationsAfter.count == 0)
+        #expect(shirtVariationsAfter.isEmpty)
 
         let pantsVariationsAfter = try await grdbManager.databaseConnection.read { db in
             try POSSearchIndexBuilder.search(siteID: siteID, term: "VPANTS", in: db)

--- a/Modules/Tests/WordPressSharedTests/LanguagesTests.swift
+++ b/Modules/Tests/WordPressSharedTests/LanguagesTests.swift
@@ -7,8 +7,8 @@ class LanguagesTests: XCTestCase {
     func testLanguagesEffectivelyLoadJsonFile() {
         let languages = WordPressComLanguageDatabase()
 
-        XCTAssert(languages.all.count != 0)
-        XCTAssert(languages.popular.count != 0)
+        XCTAssert(!languages.all.isEmpty)
+        XCTAssert(!languages.popular.isEmpty)
     }
 
     func testAllLanguagesHaveValidFields() {
@@ -16,8 +16,8 @@ class LanguagesTests: XCTestCase {
         let sum = languages.all + languages.popular
 
         for language in sum {
-            XCTAssert(language.slug.count > 0)
-            XCTAssert(language.name.count > 0)
+            XCTAssert(!language.slug.isEmpty)
+            XCTAssert(!language.name.isEmpty)
         }
     }
 

--- a/Modules/Tests/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -159,7 +159,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
             discoveryMethod: .bluetoothScan,
             onReaderDiscovered: { discoveredReaders in
                 XCTAssertTrue(self.mockCardReaderService.didReceiveAConfigurationProvider)
-                if discoveredReaders.count == 0 {
+                if discoveredReaders.isEmpty {
                     expectation.fulfill()
                 }
             },

--- a/Modules/Tests/YosemiteTests/Stores/SystemPlugin/SystemPluginsUpsertUseCaseTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SystemPlugin/SystemPluginsUpsertUseCaseTests.swift
@@ -135,7 +135,7 @@ struct SystemPluginsUpsertUseCaseTests {
 
         // Then - all plugins should be removed
         let storedPlugins = viewStorage.loadSystemPlugins(siteID: siteID)
-        #expect(storedPlugins.count == 0)
+        #expect(storedPlugins.isEmpty)
     }
 
     @Test func upsert_handles_site_isolation() async throws {

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPCom2FALoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPCom2FALoginViewModel.swift
@@ -154,7 +154,7 @@ extension WPCom2FALoginViewModel: ASAuthorizationControllerDelegate, ASAuthoriza
     @available(iOS 16, *)
     func extractClientData(from credential: ASAuthorizationPlatformPublicKeyCredentialAssertion, challengeInfo: WebauthnChallengeInfo) -> Data? {
 
-        if credential.rawClientDataJSON.count > 0 {
+        if !credential.rawClientDataJSON.isEmpty {
             return credential.rawClientDataJSON
         }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1251,7 +1251,7 @@ extension OrderDetailsDataSource {
                 break
             }
 
-            if rows.count == 0 {
+            if rows.isEmpty {
                 return nil
             }
 
@@ -1338,7 +1338,7 @@ extension OrderDetailsDataSource {
         }()
 
         let shippingLinesSection: Section? = {
-            guard shippingLines.count > 0 else {
+            guard !shippingLines.isEmpty else {
                 return nil
             }
 
@@ -1370,7 +1370,7 @@ extension OrderDetailsDataSource {
                 return nil
             }
 
-            guard orderTracking.count > 0 else {
+            guard !orderTracking.isEmpty else {
                 return nil
             }
 
@@ -1391,7 +1391,7 @@ extension OrderDetailsDataSource {
             }
 
             let title: String?
-            if orderTracking.count == 0 {
+            if orderTracking.isEmpty {
                 title = NSLocalizedString(
                     "orderDetails.addTrackingRow.title",
                     value: "Optional Tracking Information",

--- a/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
@@ -102,11 +102,11 @@ final class ShippingProvidersViewModel {
     /// Convenience property to check if the data collection is empty
     ///
     var isListEmpty: Bool {
-        return providersExcludingStoreCountry.fetchedObjects.count == 0
+        return providersExcludingStoreCountry.fetchedObjects.isEmpty
     }
 
     private var storeCountryHasProviders: Bool {
-        return providersForStoreCountry.fetchedObjects.count != 0
+        return !providersForStoreCountry.fetchedObjects.isEmpty
     }
 
     /// Designated initializer

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsPeriodViewModel.swift
@@ -257,7 +257,7 @@ private extension StoreStatsPeriodViewModel {
         /// with x being the number of intervals available from order stats.
         ///
         if let orderStats = orderStatsResultsController.fetchedObjects.first,
-           orderStats.intervals.count > 0,
+           !orderStats.intervals.isEmpty,
            let items = siteStats?.items,
            items.count > orderStats.intervals.count {
             let sortedItems = items.sorted(by: { (lhs, rhs) -> Bool in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
@@ -555,7 +555,7 @@ private extension BillingInformationViewController {
             }
 
             let title = NSLocalizedString("Contact Details", comment: "Section header title for contact details in billing information")
-            guard rows.count != 0 else {
+            guard !rows.isEmpty else {
                 return nil
             }
             return Section(title: title, secondaryTitle: nil, rows: rows)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/OrderRefundsOptionsDeterminer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/OrderRefundsOptionsDeterminer.swift
@@ -47,7 +47,7 @@ final class OrderRefundsOptionsDeterminer: OrderRefundsOptionsDeterminerProtocol
         let orderTotal = (currencyFormatter.convertToDecimal(order.total) ?? 0) as Decimal
 
         let thereIsSomeAmountToRefund = orderTotal - alreadyRefundedTotal > 0
-        let thereAreItemsToRefund = determineRefundableOrderItems(from: order, with: refunds).count > 0
+        let thereAreItemsToRefund = !determineRefundableOrderItems(from: order, with: refunds).isEmpty
 
         return thereIsSomeAmountToRefund || thereAreItemsToRefund
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -271,7 +271,7 @@ private extension ReviewOrderViewModel {
         }()
 
         let shippingMethodRow: Row? = {
-            guard order.shippingLines.count > 0 else { return nil }
+            guard !order.shippingLines.isEmpty else { return nil }
             return Row.shippingMethod(method: shippingMethod)
         }()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageListViewModel.swift
@@ -25,7 +25,7 @@ final class ShippingLabelPackageListViewModel: ObservableObject {
     /// Returns if the custom packages header should be shown in Package List
     ///
     var showCustomPackagesHeader: Bool {
-        return customPackages.count > 0
+        return !customPackages.isEmpty
     }
 
     /// Whether there are saved custom or predefined packages to select from.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
@@ -42,7 +42,7 @@ final class FilterOrderListViewModel: FilterListViewModel {
 
         var readableString: String {
             var readable: [String] = []
-            if let orderStatus = orderStatus, orderStatus.count > 0 {
+            if let orderStatus = orderStatus, !orderStatus.isEmpty {
                 readable = orderStatus.map { $0.rawValue.capitalized }
             }
             if let dateRange = dateRange {
@@ -295,7 +295,7 @@ extension Array: FilterType where Element == OrderStatusEnum {
     /// Returns the localized text version of the array
     ///
     var description: String {
-        if self.count == 0 {
+        if self.isEmpty {
             return NSLocalizedString("Any", comment: "Display label for all order statuses selected in Order Filters")
         }
         else if self.count == 1 {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -447,7 +447,7 @@ private extension ProductFormActionsFactory {
         case .tags:
             return product.product.tags.isNotEmpty
         case .linkedProducts:
-            return (product.upsellIDs.count > 0 || product.crossSellIDs.count > 0)
+            return (!product.upsellIDs.isEmpty || !product.crossSellIDs.isEmpty)
         // Downloadable files. Only core product types for downloadable files are able to handle downloadable files.
         case .downloadableFiles:
             return product.downloadable

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -163,7 +163,7 @@ private extension ProductFormTableViewDataSource {
                            productUIImageLoader: productUIImageLoader)
             return
         }
-        if productImageStatuses.count > 0 {
+        if !productImageStatuses.isEmpty {
             if allowsMultipleImages {
                 cell.configure(with: productImageStatuses,
                                config: .addImages,

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesGalleryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesGalleryViewController.swift
@@ -141,7 +141,7 @@ private extension ProductImagesGalleryViewController {
                 self.collectionView.reloadData()
             }
 
-            if self.productImages.count == 0 {
+            if self.productImages.isEmpty {
                 self.navigationController?.popViewController(animated: true)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewModel.swift
@@ -95,7 +95,7 @@ private extension AddAttributeViewModel {
         for _ in 0..<localAndGlobalAttributes.count {
             attributesRows.append(.existingAttribute)
         }
-        let attributesSection = attributesRows.count > 0 ? Section(header: Localization.headerAttributes, footer: nil, rows: attributesRows) : nil
+        let attributesSection = !attributesRows.isEmpty ? Section(header: Localization.headerAttributes, footer: nil, rows: attributesRows) : nil
 
         sections = [Section(header: nil, footer: Localization.footerTextField, rows: [.attributeTextField]), attributesSection].compactMap { $0 }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateAllVariationsUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateAllVariationsUseCase.swift
@@ -42,7 +42,7 @@ final class GenerateAllVariationsUseCase {
                 }
 
                 // Guard for no variations to generate
-                guard variationsToGenerate.count > 0 else {
+                guard !variationsToGenerate.isEmpty else {
                     return onStateChanged(.finished(false, product))
                 }
 

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
@@ -61,7 +61,7 @@ final class ReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHan
     }
 
     var hasUnreadNotifications: Bool {
-        return unreadNotifications.count != 0
+        return !unreadNotifications.isEmpty
     }
 
     private var unreadNotifications: [Note] {

--- a/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
+++ b/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
@@ -26,7 +26,7 @@ final class StripeCardReaderIntegrationTests: XCTestCase {
             readerService.cancelDiscovery()
                 .fulfillOnCompletion(expectation: receivedReaders)
         } receiveValue: { readers in
-            if readers.count > 0 {
+            if !readers.isEmpty {
                 readerService.cancelDiscovery()
                     .fulfillOnCompletion(expectation: receivedReaders)
             }
@@ -100,7 +100,7 @@ final class StripeCardReaderIntegrationTests: XCTestCase {
 
         // Test also that connectedReaders is updated
         readerService.connectedReaders.sink { connectedReader in
-            if connectedReader.count > 0 {
+            if !connectedReader.isEmpty {
                 connectedreaderIsPublished.fulfill()
             }
         }.store(in: &self.cancellables)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -1289,7 +1289,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // Then
         waitUntil {
-            viewModel.productRows.count == 0 // no product matches the filter and search term
+            viewModel.productRows.isEmpty // no product matches the filter and search term
         }
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
@@ -776,7 +776,7 @@ final class ProductImageUploaderTests: XCTestCase {
         // Wait for the upload to be processed
         let _ = waitFor { promise in
             actionHandler.addUpdateObserver(self) { statuses in
-                if statuses.count > 0 {
+                if !statuses.isEmpty {
                     promise(statuses)
                 }
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -55,7 +55,7 @@ final class SettingsViewModelTests: XCTestCase {
         viewModel.onViewDidLoad()
 
         // Then
-        XCTAssertTrue(viewModel.sections.count > 0)
+        XCTAssertTrue(!viewModel.sections.isEmpty)
     }
 
     func test_sections_contain_install_jetpack_row_when_default_site_is_jcp() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Reprint Shipping Label/PrintShippingLabelCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Reprint Shipping Label/PrintShippingLabelCoordinatorTests.swift
@@ -76,7 +76,7 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         waitUntil {
             // Since `UIPrintInteractionController` does not conform to `UIViewController`, its presentation is hard to test.
             // Here we wait for the in-progress UI to be presented then dismissed.
-            viewController.presentedViewControllers.count == 0
+            viewController.presentedViewControllers.isEmpty
         }
     }
 

--- a/WooCommerce/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
+++ b/WooCommerce/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
@@ -100,7 +100,7 @@ extension FancyAlertViewController {
             message = NSLocalizedString("Incorrect username or password. Please try entering your login details again.", comment: "An error message shown when a user signed in with incorrect credentials.")
         }
 
-        if message.trim().count == 0 {
+        if message.trim().isEmpty {
             message = NSLocalizedString("Log in failed. Please try again.", comment: "A generic error message for a failed log in.")
         }
 

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -101,7 +101,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
     ///     You will want to set this to `true` if the error was caused after pressing a button
     ///     (e.g. Next button).
     func displayError(message: String, moveVoiceOverFocus: Bool = false) {
-        guard message.count > 0 else {
+        guard !message.isEmpty else {
             errorLabel?.isHidden = true
             return
         }

--- a/WooCommerce/WordPressAuthenticator/UI/SearchTableViewCell.swift
+++ b/WooCommerce/WordPressAuthenticator/UI/SearchTableViewCell.swift
@@ -98,7 +98,7 @@ extension SearchTableViewCell: UITextFieldDelegate {
             sanitizedString = string.trimmingCharacters(in: .whitespacesAndNewlines)
         }
 
-        let hasValidEdits = sanitizedString.count > 0 || range.length > 0
+        let hasValidEdits = !sanitizedString.isEmpty || range.length > 0
 
         if hasValidEdits {
             guard let start = textField.position(from: textField.beginningOfDocument, offset: range.location),
@@ -129,7 +129,7 @@ extension SearchTableViewCell: UITextFieldDelegate {
             return
         }
 
-        if text.count == 0 {
+        if text.isEmpty {
             delegate.startSearch(for: "")
         } else {
             delegate.startSearch(for: text)

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -319,7 +319,7 @@ extension TwoFAViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
     @available(iOS 16, *)
     func extractClientData(from credential: ASAuthorizationPlatformPublicKeyCredentialAssertion, challengeInfo: WebauthnChallengeInfo) -> Data? {
 
-        if credential.rawClientDataJSON.count > 0 {
+        if !credential.rawClientDataJSON.isEmpty {
             return credential.rawClientDataJSON
         }
 

--- a/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/WordPressComRestApi.swift
+++ b/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/WordPressComRestApi.swift
@@ -507,7 +507,7 @@ extension WordPressComRestApi {
         }
 
         var errorDictionary: AnyObject? = responseDictionary as AnyObject?
-        if let errorArray = responseDictionary["errors"] as? [AnyObject], errorArray.count > 0 {
+        if let errorArray = responseDictionary["errors"] as? [AnyObject], !errorArray.isEmpty {
             errorDictionary = errorArray.first
         }
         guard let errorEntry = errorDictionary as? [String: AnyObject],

--- a/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/WordPressOrgXMLRPCValidator.swift
+++ b/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/WordPressOrgXMLRPCValidator.swift
@@ -318,7 +318,7 @@ open class WordPressOrgXMLRPCValidator: NSObject {
         let matches = rsdURLRegExp.matches(in: html,
                                                    options: NSRegularExpression.MatchingOptions(),
                                                    range: NSRange(location: 0, length: html.count))
-        if matches.count <= 0 {
+        if matches.isEmpty {
             return nil
         }
 


### PR DESCRIPTION
## Summary

- Adds the `empty_count` rule to the SwiftLint `only_rules` list.
  This rule flags comparisons of `.count` against zero, preferring `.isEmpty` instead for clarity and performance.
- **50 auto-fixed violations** across the codebase (all resolved by `swiftlint --fix`).
- **0 agentic fixes** needed.
- **0 violations** remaining for human review.

This is part of the Orchard SwiftLint rollout campaign, which progressively enables lint rules across Automattic repos.

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*