### PR TITLE
Add iPhone support to POS with Tap to Pay

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -44,6 +44,7 @@ final class POSPaymentModel {
     private let analytics: POSAnalyticsProviding
     private let collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking
     private let celebration: PaymentCaptureCelebrationProtocol
+    let preferredConnectionMethod: CardReaderConnectionMethod
 
     // MARK: - Internal
     private var startPaymentOnCardReaderConnection: AnyCancellable?
@@ -67,6 +68,7 @@ final class POSPaymentModel {
          analytics: POSAnalyticsProviding,
          collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking,
          celebration: PaymentCaptureCelebrationProtocol = PaymentCaptureCelebration(),
+         preferredConnectionMethod: CardReaderConnectionMethod = .bluetooth,
          paymentState: PointOfSalePaymentState = .idle) {
         self.cardPresentPaymentService = cardPresentPaymentService
         self.orderProvider = orderProvider
@@ -77,6 +79,7 @@ final class POSPaymentModel {
         self.analytics = analytics
         self.collectOrderPaymentAnalyticsTracker = collectOrderPaymentAnalyticsTracker
         self.celebration = celebration
+        self.preferredConnectionMethod = preferredConnectionMethod
         self.paymentState = paymentState
 
         publishCardReaderConnectionStatus()
@@ -94,6 +97,19 @@ extension POSPaymentModel {
 
         subscribeToPaymentSessionEvents()
 
+        // For Tap to Pay, pre-connect the reader but don't auto-collect.
+        // The user selects a payment method from the buttons.
+        if preferredConnectionMethod == .tapToPay {
+            connectTapToPayReader()
+            return
+        }
+
+        await startPaymentFlow()
+    }
+
+    /// Starts the full payment flow: waits for reader connection, then collects.
+    /// Used by bluetooth (auto) and by explicit payment method button taps.
+    private func startPaymentFlow() async {
         // Invalidate stale `startPaymentOnCardReaderConnection` callbacks
         // so only the latest subscription can reach `collectCardPayment`.
         startPaymentGeneration += 1
@@ -105,7 +121,7 @@ extension POSPaymentModel {
         guard case .connected = cardReaderConnectionStatus else {
             DDLogInfo("🃏 [CardPayment] reader not connected, waiting for connection")
             startPaymentOnCardReaderConnection?.cancel()
-            return startPaymentOnCardReaderConnection = cardPresentPaymentService.readerConnectionStatusPublisher
+            startPaymentOnCardReaderConnection = cardPresentPaymentService.readerConnectionStatusPublisher
                 .filter { status in
                     switch status {
                     case .connected:
@@ -121,6 +137,8 @@ extension POSPaymentModel {
                         await self?.cancelThenCollectCardPayment(generation: generation)
                     }
                 }
+
+            return
         }
 
         // Reader is connected — cancel any stale payment, then collect.
@@ -159,7 +177,7 @@ extension POSPaymentModel {
     }
 
     private func collectPayment(for order: Order) async throws {
-        _ = try await cardPresentPaymentService.collectPayment(for: order, using: .bluetooth, channel: .pos)
+        _ = try await cardPresentPaymentService.collectPayment(for: order, using: preferredConnectionMethod, channel: .pos)
     }
 
     func cancelThenCollectPayment() {
@@ -177,8 +195,36 @@ extension POSPaymentModel {
     func connectCardReader() {
         analytics.track(.pointOfSaleCardReaderConnectionTapped)
         Task { @MainActor [weak self] in
-            _ = try await self?.cardPresentPaymentService.connectReader(using: .bluetooth)
+            guard let self else { return }
+            _ = try await self.cardPresentPaymentService.connectReader(using: self.preferredConnectionMethod)
         }
+    }
+
+    /// Pre-connects the Tap to Pay reader without starting payment collection.
+    func connectTapToPayReader() {
+        Task { @MainActor [weak self] in
+            _ = try await self?.cardPresentPaymentService.connectReader(using: .tapToPay)
+        }
+    }
+
+    /// Starts payment using a specific connection method. Used when the user
+    /// explicitly chooses Tap to Pay or Card Reader from the payment buttons.
+    func startPaymentWithMethod(_ method: CardReaderConnectionMethod) async {
+        subscribeToPaymentSessionEvents()
+
+        // If switching from Tap to Pay to bluetooth, disconnect TTP first
+        if method == .bluetooth, case .connected = cardReaderConnectionStatus {
+            await cardPresentPaymentService.disconnectReader()
+        }
+
+        // Connect with the chosen method, then run the standard payment flow
+        if case .disconnected = cardReaderConnectionStatus {
+            Task { @MainActor [weak self] in
+                _ = try await self?.cardPresentPaymentService.connectReader(using: method)
+            }
+        }
+
+        await startPaymentFlow()
     }
 
     func disconnectCardReader() {

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -118,6 +118,7 @@ protocol PointOfSaleAggregateModelProtocol {
          receiptSender: POSReceiptSending,
          soundPlayer: PointOfSaleSoundPlayerProtocol = PointOfSaleSoundPlayer(),
          paymentState: PointOfSalePaymentState = .idle,
+         preferredConnectionMethod: CardReaderConnectionMethod = .bluetooth,
          siteID: Int64,
          catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol? = nil,
          isLocalCatalogEligible: Bool = false) {
@@ -156,6 +157,7 @@ protocol PointOfSaleAggregateModelProtocol {
                 }),
             analytics: analytics,
             collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker,
+            preferredConnectionMethod: preferredConnectionMethod,
             paymentState: paymentState)
         weakSelf = self
 
@@ -453,6 +455,7 @@ extension PointOfSaleAggregateModel {
         })
         trackOrderSyncState(syncOrderResult)
         await removeMissingProductsFromCatalogAfterSync()
+
         await paymentModel.startPayment()
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
@@ -4,6 +4,7 @@ struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageView: View {
     private let viewModel = PointOfSaleCardPresentPaymentReaderDisconnectedMessageViewModel()
     private let connectCardReader: () -> Void
     @ScaledMetric private var scale: CGFloat = 1.0
+    @Environment(\.posLayoutScale) private var layoutScale
 
     @State private var width: CGFloat = 0
 
@@ -39,7 +40,8 @@ struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageView: View {
                 Text(viewModel.connectReaderButtonTitle)
             }
             .buttonStyle(POSFilledButtonStyle(size: .normal))
-            .frame(width: width * 0.5)
+            .if(layoutScale == .tablet) { $0.frame(width: width * 0.5) }
+            .if(layoutScale == .phone) { $0.frame(maxWidth: .infinity).padding(.horizontal, POSPadding.medium) }
         }
         .frame(maxWidth: .infinity)
         .measureWidth({ containerWidth in

--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView.swift
@@ -6,6 +6,7 @@ struct PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView: View {
     let animation: POSCardPresentPaymentInLineMessageAnimation
 
     @State private var width: CGFloat = 0
+    @Environment(\.posLayoutScale) private var layoutScale
 
     var body: some View {
         VStack(alignment: .center, spacing: POSSpacing.none) {
@@ -35,7 +36,8 @@ struct PointOfSaleCardPresentPaymentValidatingOrderErrorMessageView: View {
             if let tryAgainButtonViewModel = viewModel.tryAgainButtonViewModel {
                 Button(tryAgainButtonViewModel.title, action: tryAgainButtonViewModel.actionHandler)
                     .buttonStyle(POSFilledButtonStyle(size: .normal))
-                    .frame(width: width * 0.5)
+                    .if(layoutScale == .tablet) { $0.frame(width: width * 0.5) }
+                    .if(layoutScale == .phone) { $0.frame(maxWidth: .infinity).padding(.horizontal, POSPadding.medium) }
             }
         }
         .multilineTextAlignment(.center)

--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
@@ -7,6 +7,7 @@ struct PointOfSalePaymentSuccessView: View {
     let successAction: PaymentFlowAction
     let onSuccessScreenBarcodeScanned: ((Result<String, HIDBarcodeParserError>) -> Void)?
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
+    @Environment(\.posLayoutScale) private var layoutScale
 
     @State private var isShowingSendReceiptView: Bool = false
     @State private var isViewLoaded: Bool = false
@@ -85,8 +86,14 @@ struct PointOfSalePaymentSuccessView: View {
 
                 PaymentsActionButtons(successAction: successAction,
                                       isShowingSendReceiptView: $isShowingSendReceiptView)
-                    .containerRelativeFrame(.horizontal, count: 2, span: 1, spacing: POSSpacing.none)
-                    .frame(maxWidth: .infinity, alignment: .center)
+                    .if(layoutScale == .tablet) {
+                        $0.containerRelativeFrame(.horizontal, count: 2, span: 1, spacing: POSSpacing.none)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    }
+                    .if(layoutScale == .phone) {
+                        $0.frame(maxWidth: .infinity)
+                            .padding(.horizontal, POSPadding.medium)
+                    }
                     .offset(y: isViewLoaded ? 0 : -Constants.animationOffset)
                     .opacity(isViewLoaded ? 1 : 0)
 

--- a/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
@@ -11,6 +11,7 @@ struct ItemListView: View {
     @EnvironmentObject var modalManager: POSModalManager
     @EnvironmentObject var sheetManager: POSSheetManager
     @EnvironmentObject var coverManager: POSFullScreenCoverManager
+    @Environment(\.posHeaderLeadingContent) private var headerLeadingContent
 
     @Binding var selectedItemListType: ItemListType
     @Binding var searchTerm: String
@@ -275,7 +276,11 @@ private extension ItemListView {
     @ViewBuilder
     var headerView: some View {
         VStack {
-            POSPageHeaderView(items: headerViewItems, trailingContent: {
+            POSPageHeaderView(items: headerViewItems, leadingContent: {
+                if !isSearching, let headerLeadingContent {
+                    headerLeadingContent
+                }
+            }, trailingContent: {
                 HStack {
                     if isSearching {
                         POSSearchField(

--- a/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
@@ -6,31 +6,18 @@ struct POSFloatingControlView: View {
     @Environment(\.posFeatureFlags) private var featureFlags
     @Environment(\.posAnalytics) private var analytics
     @Environment(PointOfSaleAggregateModel.self) private var posModel
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @Binding private var showExitPOSModal: Bool
-    @Binding private var showSupport: Bool
-    @Binding private var showDocumentation: Bool
-    @Binding private var showSettings: Bool
-    @State private var showProductRestrictionsModal: Bool = false
-    @State private var showBarcodeScanningModal: Bool = false
-    @State private var showOrders: Bool = false
-    @State private var showBookings: Bool = false
     @Environment(\.posBookingsEligible) private var isBookingsEligible
 
-    init(showExitPOSModal: Binding<Bool>,
-         showSupport: Binding<Bool>,
-         showDocumentation: Binding<Bool>,
-         showSettings: Binding<Bool>) {
-        self._showExitPOSModal = showExitPOSModal
-        self._showSupport = showSupport
-        self._showDocumentation = showDocumentation
-        self._showSettings = showSettings
-    }
+    let menuPresenter: POSMenuPresenter
 
     var body: some View {
         HStack {
             Menu {
-                menuOptions()
+                menuPresenter.menuOptions(
+                    featureFlags: featureFlags,
+                    isBookingsEligible: isBookingsEligible,
+                    analytics: analytics
+                )
             } label: {
                 VStack {
                     Spacer()
@@ -52,84 +39,11 @@ struct POSFloatingControlView: View {
                 .background(backgroundColor)
                 .cornerRadius(Constants.cornerRadius)
                 .disabled(posModel.paymentState.shownFullScreen)
-                .disabled(horizontalSizeClass != .regular)
-        }
-        .posModal(isPresented: $showProductRestrictionsModal) {
-            SimpleProductsOnlyInformation(isPresented: $showProductRestrictionsModal)
-        }
-        .posModal(isPresented: $showBarcodeScanningModal) {
-            POSBarcodeScannerSetup(isPresented: $showBarcodeScanningModal, analytics: analytics)
-        }
-        .posFullScreenCover(isPresented: $showOrders) {
-            POSOrdersView(isPresented: $showOrders)
-        }
-        .posFullScreenCover(isPresented: $showBookings) {
-            POSBookingsContainerView(isPresented: $showBookings)
-                .environment(\.floatingControlAreaSize, .zero)
-        }
-        .onChange(of: showBookings) { _, isShowing in
-            if isShowing {
-                posModel.paymentModel.deactivate()
-            } else if posModel.orderStage == .finalizing {
-                Task { @MainActor in
-                    await posModel.paymentModel.activate()
-                }
-            }
         }
         .frame(height: Constants.size)
         .background(Color.clear)
         .animation(.default, value: backgroundAppearance)
         .posShadow(.large, cornerRadius: Constants.cornerRadius)
-    }
-}
-
-private extension POSFloatingControlView {
-    @ViewBuilder private func menuOptions() -> some View {
-        Button {
-            analytics.track(.pointOfSaleExitMenuItemTapped)
-            showExitPOSModal = true
-        } label: {
-            Label(
-                title: { Text(Localization.exitPointOfSale) },
-                icon: { Image(systemName: "rectangle.portrait.and.arrow.forward") }
-            )
-        }
-        .accessibilityIdentifier("pos-exit-menu-item")
-        if horizontalSizeClass == .regular {
-            Button {
-                analytics.track(.pointOfSaleSettingsMenuItemTapped)
-                showSettings = true
-            } label: {
-                Label(
-                    title: { Text(Localization.settings) },
-                    icon: { Image(systemName: "gearshape") }
-                )
-            }
-
-            if featureFlags.isFeatureFlagEnabled(.pointOfSaleHistoricalOrdersi1) {
-                Button {
-                    analytics.track(event: WooAnalyticsEvent.PointOfSale.ordersMenuItemTapped())
-                    showOrders = true
-                } label: {
-                    Label(
-                        title: { Text(Localization.orders) },
-                        icon: { Image(systemName: "text.document") }
-                    )
-                }
-            }
-
-            if featureFlags.isFeatureFlagEnabled(.pointOfSaleBookings) && isBookingsEligible {
-                Button {
-                    analytics.track(event: WooAnalyticsEvent.PointOfSale.bookingsMenuItemTapped())
-                    showBookings = true
-                } label: {
-                    Label(
-                        title: { Text(Localization.bookings) },
-                        icon: { Image(systemName: "calendar") }
-                    )
-                }
-            }
-        }
     }
 }
 
@@ -164,42 +78,12 @@ private extension POSFloatingControlView {
         static let size: CGFloat = 80
         static let cornerRadius: CGFloat = POSCornerRadiusStyle.medium.value
     }
-
-    enum Localization {
-        static let orders = NSLocalizedString(
-            "pointOfSale.floatingButtons.orders.button.title",
-            value: "Orders",
-            comment: "The title of the menu button to access Point of Sale historical orders, shown in a fullscreen view."
-        )
-
-        static let exitPointOfSale = NSLocalizedString(
-            "pointOfSale.floatingButtons.exit.button.title",
-            value: "Exit POS",
-            comment: "The title of the menu button to exit Point of Sale, shown in a popover menu." +
-            "The action is confirmed in a modal."
-        )
-
-        static let bookings = NSLocalizedString(
-            "pointOfSale.floatingButtons.bookings.button.title",
-            value: "Bookings",
-            comment: "The title of the menu button to access Point of Sale bookings, shown in a fullscreen view."
-        )
-
-        static let settings = NSLocalizedString(
-            "pointOfSale.floatingButtons.settings.button.title",
-            value: "Settings",
-            comment: "The title of the menu button to access Point of Sale settings."
-        )
-    }
 }
 
 #if DEBUG
 
 #Preview("Reader Disconnected") {
-    POSFloatingControlView(showExitPOSModal: .constant(false),
-                           showSupport: .constant(false),
-                           showDocumentation: .constant(false),
-                           showSettings: .constant(false))
+    POSFloatingControlView(menuPresenter: POSMenuPresenter())
         .environment(\.posBackgroundAppearance, .primary)
         .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }
@@ -210,19 +94,13 @@ private extension POSFloatingControlView {
     let posModel = POSPreviewHelpers.makePreviewAggregateModel(
         cardPresentPaymentService: paymentService
     )
-    return POSFloatingControlView(showExitPOSModal: .constant(false),
-                                  showSupport: .constant(false),
-                                  showDocumentation: .constant(false),
-                                  showSettings: .constant(false))
+    return POSFloatingControlView(menuPresenter: POSMenuPresenter())
         .environment(\.posBackgroundAppearance, .primary)
         .environment(posModel)
 }
 
 #Preview("Secondary/disabled Background") {
-    POSFloatingControlView(showExitPOSModal: .constant(false),
-                           showSupport: .constant(false),
-                           showDocumentation: .constant(false),
-                           showSettings: .constant(false))
+    POSFloatingControlView(menuPresenter: POSMenuPresenter())
         .environment(\.posBackgroundAppearance, .secondary)
         .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }

--- a/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
@@ -15,6 +15,7 @@ struct POSPaymentContentView: View {
     let onDismiss: (() -> Void)?
 
     @Environment(POSPaymentModel.self) private var paymentModel
+    @Environment(\.posLayoutScale) private var layoutScale
     private let viewHelper = POSPaymentViewHelper()
 
     var body: some View {
@@ -33,7 +34,7 @@ struct POSPaymentContentView: View {
             Spacer()
                 .renderedIf(viewHelper.shouldApplyPadding(paymentState: paymentModel.paymentState))
 
-            cashPaymentButtonView
+            paymentMethodButtonsView
         }
         .background(viewHelper.paymentBackgroundColor(for: paymentModel.paymentState))
         .animation(.default, value: paymentModel.paymentState)
@@ -142,8 +143,11 @@ struct POSPaymentContentView: View {
                 leading: POSPadding.large,
                 bottom: POSPadding.medium,
                 trailing: POSPadding.large))
-            .frame(minWidth: 382)
-            .fixedSize(horizontal: true, vertical: false)
+            .if(layoutScale == .tablet) { view in
+                view
+                    .frame(minWidth: 382)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
             Spacer()
         }
         .transition(.opacity)
@@ -164,24 +168,62 @@ struct POSPaymentContentView: View {
         .foregroundColor(Color.posOnSurface)
     }
 
-    // MARK: - Cash Payment Button
+    // MARK: - Payment Method Buttons
 
-    @ViewBuilder
-    private var cashPaymentButtonView: some View {
-        if viewHelper.shouldShowCashPaymentButton(
+    private var shouldShowTapToPayButtons: Bool {
+        paymentModel.preferredConnectionMethod == .tapToPay
+        && paymentModel.paymentState.card == .idle
+        && !paymentModel.isZeroTotal
+    }
+
+    private var shouldShowCashButton: Bool {
+        viewHelper.shouldShowCashPaymentButton(
             paymentState: paymentModel.paymentState,
             cardReaderConnectionStatus: paymentModel.cardReaderConnectionStatus,
-            isZeroTotal: paymentModel.isZeroTotal) {
-            Button(action: {
-                Task { @MainActor in
-                    await paymentModel.startCashPayment()
+            isZeroTotal: paymentModel.isZeroTotal)
+    }
+
+    @ViewBuilder
+    private var paymentMethodButtonsView: some View {
+        if shouldShowTapToPayButtons || shouldShowCashButton {
+            VStack(spacing: POSSpacing.small) {
+                if shouldShowTapToPayButtons {
+                    Button(action: {
+                        Task { @MainActor in
+                            await paymentModel.startPaymentWithMethod(.tapToPay)
+                        }
+                    }) {
+                        Label(Localization.tapToPayButton, systemImage: "wave.3.right")
+                            .font(POSFontStyle.posBodyLargeBold)
+                    }
+                    .buttonStyle(POSFilledButtonStyle(size: .normal))
+                    .padding(.horizontal, POSPadding.medium)
+
+                    Button(action: {
+                        Task { @MainActor in
+                            await paymentModel.startPaymentWithMethod(.bluetooth)
+                        }
+                    }) {
+                        Label(Localization.cardReaderButton, systemImage: "creditcard.and.123")
+                            .font(POSFontStyle.posBodyLargeBold)
+                    }
+                    .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+                    .padding(.horizontal, POSPadding.medium)
                 }
-            }) {
-                Text(Localization.cashPaymentButton)
-                    .font(POSFontStyle.posBodyLargeBold)
+
+                if shouldShowCashButton {
+                    Button(action: {
+                        Task { @MainActor in
+                            await paymentModel.startCashPayment()
+                        }
+                    }) {
+                        Text(Localization.cashPaymentButton)
+                            .font(POSFontStyle.posBodyLargeBold)
+                    }
+                    .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+                    .padding(.horizontal, POSPadding.medium)
+                }
             }
-            .buttonStyle(POSOutlinedButtonStyle(size: .normal))
-            .padding(.horizontal, POSPadding.medium)
             .safeAreaPadding(.bottom, POSPadding.medium)
         }
     }
@@ -214,6 +256,18 @@ private extension POSPaymentContentView {
             value: "Cash payment",
             comment: "Button to start a cash payment in the payment flow"
         )
+
+        static let tapToPayButton = NSLocalizedString(
+            "pointOfSale.paymentContent.tapToPayButton",
+            value: "Tap to Pay",
+            comment: "Button to start a Tap to Pay payment on iPhone in the POS payment flow"
+        )
+
+        static let cardReaderButton = NSLocalizedString(
+            "pointOfSale.paymentContent.cardReaderButton",
+            value: "Card reader",
+            comment: "Button to start a payment with an external card reader in the POS payment flow"
+        )
     }
 }
 
@@ -228,14 +282,21 @@ struct POSCardPaymentContentView: View {
     let connectCardReaderAction: () -> Void
     var showLoadingWhenIdle: Bool = false
 
+    @Environment(POSPaymentModel.self) private var paymentModel
+
     private let viewHelper = POSPaymentViewHelper()
 
     @ViewBuilder
     var body: some View {
         if viewHelper.shouldShowDisconnectedMessage(readerConnectionStatus: cardReaderConnectionStatus,
                                                     paymentState: paymentState) {
-            PointOfSaleCardPresentPaymentReaderDisconnectedMessageView {
-                connectCardReaderAction()
+            if paymentModel.preferredConnectionMethod == .tapToPay {
+                // Tap to Pay auto-connects - show loading instead of "Reader not connected"
+                POSPaymentLoadingView()
+            } else {
+                PointOfSaleCardPresentPaymentReaderDisconnectedMessageView {
+                    connectCardReaderAction()
+                }
             }
         } else if let inlineMessage = cardPresentPaymentInlineMessage {
             switch inlineMessage {

--- a/Modules/Sources/PointOfSale/Presentation/Phone/POSCartButton.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Phone/POSCartButton.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+struct POSCartButton: View {
+    let itemCount: Int
+    let action: () -> Void
+
+    private var isEmpty: Bool { itemCount == 0 }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: POSSpacing.small) {
+                Image(systemName: "cart.fill")
+                    .font(.posBodyMediumBold)
+
+                if isEmpty {
+                    Text(Localization.emptyCart)
+                        .font(.posBodyMediumBold)
+                } else {
+                    Text(cartLabel)
+                        .font(.posBodyMediumBold)
+                }
+            }
+            .padding(.horizontal, POSPadding.medium)
+            .padding(.vertical, POSPadding.medium)
+            .frame(maxWidth: .infinity)
+            .background(isEmpty ? Color.posDisabledContainer : Color.posPrimaryContainer)
+            .foregroundStyle(isEmpty ? Color.posOnDisabledContainer : Color.posOnPrimaryContainer)
+            .cornerRadius(POSCornerRadiusStyle.medium.value)
+        }
+        .disabled(isEmpty)
+        .padding(.horizontal, POSPadding.medium)
+        .padding(.bottom, POSPadding.small)
+        .animation(.spring(duration: 0.3), value: itemCount)
+    }
+
+    private var cartLabel: String {
+        itemCount == 1
+            ? String(format: Localization.singleItem, itemCount)
+            : String(format: Localization.multipleItems, itemCount)
+    }
+
+    private enum Localization {
+        static let emptyCart = NSLocalizedString(
+            "pointOfSale.phone.cartButton.empty",
+            value: "Cart",
+            comment: "Title shown on the cart button when no items have been added to the POS cart."
+        )
+        static let singleItem = NSLocalizedString(
+            "pointOfSale.phone.cartButton.singleItem",
+            value: "%1$d item",
+            comment: "Cart button label showing singular item count. %1$d is the number of items."
+        )
+        static let multipleItems = NSLocalizedString(
+            "pointOfSale.phone.cartButton.multipleItems",
+            value: "%1$d items",
+            comment: "Cart button label showing plural item count. %1$d is the number of items."
+        )
+    }
+}
+
+#if DEBUG
+#Preview("Empty") {
+    POSCartButton(itemCount: 0, action: {})
+        .environment(\.posLayoutScale, .phone)
+}
+
+#Preview("With items") {
+    POSCartButton(itemCount: 3, action: {})
+        .environment(\.posLayoutScale, .phone)
+}
+#endif

--- a/Modules/Sources/PointOfSale/Presentation/Phone/POSCartButton.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Phone/POSCartButton.swift
@@ -34,9 +34,7 @@ struct POSCartButton: View {
     }
 
     private var cartLabel: String {
-        itemCount == 1
-            ? String(format: Localization.singleItem, itemCount)
-            : String(format: Localization.multipleItems, itemCount)
+        CartViewHelper().itemsInCartLabel(for: itemCount) ?? Localization.emptyCart
     }
 
     private enum Localization {
@@ -44,16 +42,6 @@ struct POSCartButton: View {
             "pointOfSale.phone.cartButton.empty",
             value: "Cart",
             comment: "Title shown on the cart button when no items have been added to the POS cart."
-        )
-        static let singleItem = NSLocalizedString(
-            "pointOfSale.phone.cartButton.singleItem",
-            value: "%1$d item",
-            comment: "Cart button label showing singular item count. %1$d is the number of items."
-        )
-        static let multipleItems = NSLocalizedString(
-            "pointOfSale.phone.cartButton.multipleItems",
-            value: "%1$d items",
-            comment: "Cart button label showing plural item count. %1$d is the number of items."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Phone/PointOfSaleDashboardPhoneView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Phone/PointOfSaleDashboardPhoneView.swift
@@ -1,0 +1,178 @@
+import SwiftUI
+
+struct PointOfSaleDashboardPhoneView: View {
+    @Environment(PointOfSaleAggregateModel.self) private var posModel
+    @Environment(POSPaymentModel.self) private var paymentModel
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.posAnalytics) private var analytics
+    @Environment(\.posFeatureFlags) private var featureFlags
+    @Environment(\.posBookingsEligible) private var isBookingsEligible
+
+    let viewState: PointOfSaleDashboardView.ViewState
+    let menuPresenter: POSMenuPresenter
+
+    @State private var isCartPresented: Bool
+    @State private var isShowingCheckout = false
+
+    init(viewState: PointOfSaleDashboardView.ViewState,
+         menuPresenter: POSMenuPresenter = POSMenuPresenter(),
+         isCartPresented: Bool = false) {
+        self.viewState = viewState
+        self.menuPresenter = menuPresenter
+        self._isCartPresented = State(initialValue: isCartPresented)
+    }
+
+    var body: some View {
+        switch viewState {
+        case .loading(let isCatalogSyncing):
+            PointOfSaleLoadingView(
+                isCatalogSyncing: isCatalogSyncing,
+                onExit: { dismiss() }
+            )
+            .transition(.opacity)
+            .ignoresSafeArea()
+        case .ineligible(let reason):
+            POSIneligibleView(reason: reason, onRefresh: {
+                try await posModel.entryPointController.refreshEligibility(reason: reason)
+            })
+            .frame(maxWidth: .infinity)
+        case .error(let error):
+            PointOfSaleItemListFullscreenErrorView(error: error, onAction: {
+                Task {
+                    await posModel.purchasableItemsController.loadItems(base: .root)
+                }
+            }, onExit: error.errorType == .initialCatalogSyncError ? {
+                dismiss()
+            } : nil)
+        case .content:
+            phoneContentView
+        case .unsupportedWidth:
+            EmptyView()
+        }
+    }
+
+    private var phoneContentView: some View {
+        ZStack {
+            if !isCartPresented {
+                productsScreen
+            }
+
+            if isCartPresented {
+                cartSheetContent
+                    .transition(.move(edge: .bottom))
+                    .zIndex(1)
+            }
+        }
+        .animation(.spring(response: 0.35, dampingFraction: 0.86), value: isCartPresented)
+        .onAppear {
+            if posModel.orderStage == .finalizing {
+                var transaction = Transaction()
+                transaction.disablesAnimations = true
+                withTransaction(transaction) {
+                    isCartPresented = true
+                    isShowingCheckout = true
+                }
+            }
+        }
+        .onChange(of: posModel.orderStage) { oldStage, newStage in
+            switch newStage {
+            case .finalizing:
+                isShowingCheckout = true
+            case .building:
+                if oldStage == .finalizing {
+                    isShowingCheckout = false
+                    isCartPresented = false
+                }
+            }
+        }
+    }
+
+    // MARK: - Products Screen
+
+    private var productsScreen: some View {
+        @Bindable var viewStateCoordinator = posModel.viewStateCoordinatorForView
+        return ZStack(alignment: .bottom) {
+            VStack(spacing: POSSpacing.none) {
+                ItemListView(
+                    selectedItemListType: $viewStateCoordinator.selectedItemListType,
+                    searchTerm: $viewStateCoordinator.searchTerm
+                )
+                .environment(\.posHeaderLeadingContent, AnyView(phoneMenuButton))
+            }
+
+            POSCartButton(
+                itemCount: posModel.cart.purchasableItems.count + posModel.cart.coupons.count,
+                action: { isCartPresented = true }
+            )
+        }
+        .background(Color.posSurface)
+    }
+
+    private var phoneMenuButton: some View {
+        Menu {
+            menuPresenter.menuOptions(
+                featureFlags: featureFlags,
+                isBookingsEligible: isBookingsEligible,
+                analytics: analytics
+            )
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.posBodyMediumBold)
+                .foregroundStyle(Color.posOnSurface)
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
+        }
+        .accessibilityIdentifier("pos-phone-menu-button")
+    }
+
+    // MARK: - Cart Sheet Content
+
+    private var cartSheetContent: some View {
+        ZStack {
+            Color.posSurface
+                .ignoresSafeArea()
+
+            if isShowingCheckout {
+                totalsContent
+                    .transition(.move(edge: .trailing))
+            } else {
+                cartListView
+                    .transition(.move(edge: .leading))
+            }
+        }
+        .animation(.default, value: isShowingCheckout)
+    }
+
+    private var totalsContent: some View {
+        VStack(spacing: POSSpacing.none) {
+            if !paymentModel.paymentState.shownFullScreen {
+                POSPageHeaderView(
+                    title: "",
+                    backButtonConfiguration: .init(
+                        state: .enabled,
+                        action: {
+                            isShowingCheckout = false
+                            posModel.addMoreToCart()
+                        }
+                    )
+                )
+            }
+            TotalsView()
+        }
+    }
+
+    private var cartListView: some View {
+        CartView()
+            .posHeaderBackButtonIcon(systemName: "xmark")
+            .environment(\.posHeaderBackButtonConfiguration,
+                          POSPageHeaderBackButtonConfiguration(
+                            state: .enabled,
+                            action: { isCartPresented = false }
+                          ))
+            .onChange(of: posModel.orderStage) { _, newValue in
+                if newValue == .finalizing {
+                    isShowingCheckout = true
+                }
+            }
+    }
+}

--- a/Modules/Sources/PointOfSale/Presentation/Phone/PointOfSaleDashboardPhoneView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Phone/PointOfSaleDashboardPhoneView.swift
@@ -169,10 +169,5 @@ struct PointOfSaleDashboardPhoneView: View {
                             state: .enabled,
                             action: { isCartPresented = false }
                           ))
-            .onChange(of: posModel.orderStage) { _, newValue in
-                if newValue == .finalizing {
-                    isShowingCheckout = true
-                }
-            }
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -8,10 +8,7 @@ struct PointOfSaleDashboardView: View {
     @Environment(\.posExternalViews) private var externalViews
     @Environment(\.dismiss) private var dismiss
 
-    @State private var showExitPOSModal: Bool = false
-    @State private var showSupport: Bool = false
-    @State private var showDocumentation: Bool = false
-    @State private var showSettings: Bool = false
+    @State private var menuPresenter = POSMenuPresenter()
     @State private var waitingTimeTracker: WaitingTimeTracker?
 
     @State private var floatingSize: CGSize = .zero
@@ -57,6 +54,89 @@ struct PointOfSaleDashboardView: View {
 
     var body: some View {
         @Bindable var posModel = posModel
+        Group {
+            if horizontalSizeClass == .compact {
+                PointOfSaleDashboardPhoneView(viewState: viewState, menuPresenter: menuPresenter)
+            } else {
+                tabletView
+            }
+        }
+        .environment(\.posBackgroundAppearance, backgroundAppearance)
+        .animation(.easeInOut, value: viewState == .loading())
+        .background(Color.posSurface)
+        .navigationBarBackButtonHidden(true)
+        .posModal(item: $posModel.cardPresentPaymentOnboardingViewContainer, onDismiss: {
+            posModel.cancelCardPaymentsOnboarding()
+        }) { factory in
+            paymentsOnboardingView(from: factory)
+        }
+        .posModal(item: $posModel.cardPresentPaymentAlertViewModel,
+                  onDismiss: {
+            posModel.cardPresentPaymentAlertViewModel?.onDismiss?()
+        }) { alertType in
+            PointOfSaleCardPresentPaymentAlert(alertType: alertType)
+                .posInteractiveDismissDisabled(alertType.isDismissDisabled)
+        }
+        .posModal(isPresented: $menuPresenter.showExitPOSModal) {
+            PointOfSaleExitPosAlertView(isPresented: $menuPresenter.showExitPOSModal)
+            .frame(maxWidth: Constants.exitPOSSheetMaxWidth)
+        }
+        .posRootModal()
+        .posSheet(isPresented: $menuPresenter.showSupport) {
+            supportForm
+                .interactiveDismissDisabled(true)
+        }
+        .posSheet(isPresented: $menuPresenter.showDocumentation) {
+            documentationView
+        }
+        .posFullScreenCover(isPresented: $menuPresenter.showSettings) {
+            POSSettingsView(settingsController: posModel.settingsController)
+        }
+        .onChange(of: menuPresenter.showSettings) { oldValue, newValue in
+            guard !newValue, oldValue else { return }
+            Task {
+                await posModel.checkStaleSyncStatus()
+            }
+        }
+        .posModal(isPresented: $menuPresenter.showProductRestrictionsModal) {
+            SimpleProductsOnlyInformation(isPresented: $menuPresenter.showProductRestrictionsModal)
+        }
+        .posModal(isPresented: $menuPresenter.showBarcodeScanningModal) {
+            POSBarcodeScannerSetup(isPresented: $menuPresenter.showBarcodeScanningModal, analytics: analytics)
+        }
+        .posFullScreenCover(isPresented: $menuPresenter.showOrders) {
+            POSOrdersView(isPresented: $menuPresenter.showOrders)
+        }
+        .posFullScreenCover(isPresented: $menuPresenter.showBookings) {
+            POSBookingsContainerView(isPresented: $menuPresenter.showBookings)
+                .environment(\.floatingControlAreaSize, .zero)
+        }
+        .onChange(of: menuPresenter.showBookings) { _, isShowing in
+            if isShowing {
+                posModel.paymentModel.deactivate()
+            } else if posModel.orderStage == .finalizing {
+                Task { @MainActor in
+                    await posModel.paymentModel.activate()
+                }
+            }
+        }
+        .onChange(of: posModel.entryPointController.eligibilityState) { oldValue, newValue in
+            guard case .eligible = newValue, oldValue != newValue else { return }
+            loadItemsWhenEligible()
+        }
+        .ignoresSafeArea(.keyboard)
+        .onAppear {
+            trackTimeForInitialLoadingState()
+            loadItemsWhenEligible()
+        }
+        .onChange(of: viewState) { oldValue, newValue in
+            if newValue == .content && oldValue != newValue {
+                trackElapsedTimeForInitialLoadingState()
+            }
+        }
+    }
+
+    private var tabletView: some View {
         ZStack(alignment: .bottomLeading) {
             switch viewState {
             case .loading(let isCatalogSyncing):
@@ -89,7 +169,7 @@ struct PointOfSaleDashboardView: View {
                             await posModel.couponsSearchController.loadItems(base: .root)
                         }
                     }
-                }, onExit: error.errorType == .initialCatalogSyncError ? { // TODO: WOOMOB-1692 remove specialisation of errors if possible
+                }, onExit: error.errorType == .initialCatalogSyncError ? {
                     dismiss()
                 } : nil)
             case .content:
@@ -101,10 +181,7 @@ struct PointOfSaleDashboardView: View {
                     .ignoresSafeArea()
             }
 
-            POSFloatingControlView(showExitPOSModal: $showExitPOSModal,
-                                   showSupport: $showSupport,
-                                   showDocumentation: $showDocumentation,
-                                   showSettings: $showSettings)
+            POSFloatingControlView(menuPresenter: menuPresenter)
             .offset(x: Constants.floatingControlHorizontalOffset, y: -Constants.floatingControlVerticalOffset)
             .padding(.bottom, Constants.floatingControlBottomPadding)
             .trackSize(size: $floatingSize)
@@ -116,57 +193,6 @@ struct PointOfSaleDashboardView: View {
         .environment(\.floatingControlAreaSize,
                       CGSizeMake(floatingSize.width + Constants.floatingControlHorizontalOffset,
                                  floatingSize.height + Constants.floatingControlVerticalOffset))
-        .environment(\.posBackgroundAppearance, backgroundAppearance)
-        .animation(.easeInOut, value: viewState == .loading())
-        .background(Color.posSurface)
-        .navigationBarBackButtonHidden(true)
-        .posModal(item: $posModel.cardPresentPaymentOnboardingViewContainer, onDismiss: {
-            posModel.cancelCardPaymentsOnboarding()
-        }) { factory in
-            paymentsOnboardingView(from: factory)
-        }
-        .posModal(item: $posModel.cardPresentPaymentAlertViewModel,
-                  onDismiss: {
-            posModel.cardPresentPaymentAlertViewModel?.onDismiss?()
-        }) { alertType in
-            PointOfSaleCardPresentPaymentAlert(alertType: alertType)
-                .posInteractiveDismissDisabled(alertType.isDismissDisabled)
-        }
-        .posModal(isPresented: $showExitPOSModal) {
-            PointOfSaleExitPosAlertView(isPresented: $showExitPOSModal)
-            .frame(maxWidth: Constants.exitPOSSheetMaxWidth)
-        }
-        .posRootModal()
-        .posSheet(isPresented: $showSupport) {
-            supportForm
-                .interactiveDismissDisabled(true)
-        }
-        .posSheet(isPresented: $showDocumentation) {
-            documentationView
-        }
-        .posFullScreenCover(isPresented: $showSettings) {
-            POSSettingsView(settingsController: posModel.settingsController)
-        }
-        .onChange(of: showSettings) { oldValue, newValue in
-            guard !newValue, oldValue else { return }
-            Task {
-                await posModel.checkStaleSyncStatus()
-            }
-        }
-        .onChange(of: posModel.entryPointController.eligibilityState) { oldValue, newValue in
-            guard case .eligible = newValue, oldValue != newValue else { return }
-            loadItemsWhenEligible()
-        }
-        .ignoresSafeArea(.keyboard)
-        .onAppear {
-            trackTimeForInitialLoadingState()
-            loadItemsWhenEligible()
-        }
-        .onChange(of: viewState) { oldValue, newValue in
-            if newValue == .content && oldValue != newValue {
-                trackElapsedTimeForInitialLoadingState()
-            }
-        }
     }
 
     private var contentView: some View {
@@ -205,11 +231,11 @@ struct PointOfSaleDashboardView: View {
 private extension PointOfSaleDashboardView {
     var supportForm: some View {
         NavigationView {
-            externalViews.createSupportFormView(isPresented: $showSupport, sourceTag: Constants.supportTag)
+            externalViews.createSupportFormView(isPresented: $menuPresenter.showSupport, sourceTag: Constants.supportTag)
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button(Localization.supportCancel) {
-                            showSupport = false
+                            menuPresenter.showSupport = false
                         }
                     }
                 }
@@ -224,7 +250,7 @@ private extension PointOfSaleDashboardView {
     func paymentsOnboardingView(from factory: CardPresentPaymentOnboardingViewContainer) -> some View {
         factory.configuration.showSupport = { [weak posModel] in
             posModel?.cancelCardPaymentsOnboarding()
-            showSupport = true
+            menuPresenter.showSupport = true
         }
 
         return PointOfSaleCardPresentPaymentOnboardingView(viewModel: .init(onboardingViewContainer: factory,

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -50,6 +50,7 @@ public struct PointOfSaleEntryPointView: View {
     private let catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol?
     private let isLocalCatalogEligible: Bool
     private let isBookingsEligible: Bool
+    private let preferredConnectionMethod: CardReaderConnectionMethod
 
     /// periphery: ignore - public in preparation of move to POS module
     public init(siteID: Int64,
@@ -77,6 +78,7 @@ public struct PointOfSaleEntryPointView: View {
          grdbManager: GRDBManagerProtocol?,
          catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol?,
          isLocalCatalogEligible: Bool,
+         preferredConnectionMethod: CardReaderConnectionMethod = .bluetooth,
          services: POSDependencyProviding,
          itemProvider: PointOfSaleItemServiceProtocol? = nil) {
         self.onPointOfSaleModeActiveStateChange = onPointOfSaleModeActiveStateChange
@@ -164,6 +166,7 @@ public struct PointOfSaleEntryPointView: View {
         self.catalogSyncCoordinator = catalogSyncCoordinator
         self.isLocalCatalogEligible = isLocalCatalogEligible
         self.isBookingsEligible = isBookingsEligible
+        self.preferredConnectionMethod = preferredConnectionMethod
     }
 
     public var body: some View {
@@ -195,6 +198,7 @@ public struct PointOfSaleEntryPointView: View {
                 popularPurchasableItemsController: popularPurchasableItemsController,
                 barcodeScanService: barcodeScanService,
                 receiptSender: receiptSender,
+                preferredConnectionMethod: preferredConnectionMethod,
                 siteID: siteID,
                 catalogSyncCoordinator: catalogSyncCoordinator,
                 isLocalCatalogEligible: isLocalCatalogEligible)
@@ -214,6 +218,7 @@ public struct PointOfSaleEntryPointView: View {
             view.environment(bookingsModel!)
         }
         .environment(\.siteTimezone, siteTimezone)
+        .environment(\.posLayoutScale, horizontalSizeClass == .compact ? .phone : .tablet)
         .injectKeyboardObserver()
         .onAppear {
             onPointOfSaleModeActiveStateChange(true)

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/DynamicFrameScaler.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/DynamicFrameScaler.swift
@@ -3,14 +3,21 @@ import SwiftUI
 /// A view modifier that adjusts the width multiplier based on dynamic type size.
 struct DynamicWidthScaler: ViewModifier {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.posLayoutScale) private var layoutScale
     let containerWidth: CGFloat
     let threshold: DynamicTypeSize
     let smallSizeScale: CGFloat
     let largeSizeScale: CGFloat
 
     func body(content: Content) -> some View {
-        content
-            .frame(width: containerWidth * widthMultiplier)
+        if layoutScale == .phone {
+            content
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, POSPadding.medium)
+        } else {
+            content
+                .frame(width: containerWidth * widthMultiplier)
+        }
     }
 
     /// Returns a width multiplier based on the current dynamic type size

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSPageHeaderView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSPageHeaderView.swift
@@ -88,59 +88,17 @@ struct POSPageHeaderView<LeadingContent: View, TrailingContent: View, BottomCont
         self.bottomContent = bottomContent()
     }
 
+    @Environment(\.posLayoutScale) private var layoutScale
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(alignment: hStackAlignment, spacing: Constants.horizontalSpacing) {
                 leadingContent
 
-                VStack(alignment: .leading, spacing: Constants.titleSubtitleSpacing) {
-                    HStack(alignment: hStackAlignment, spacing: Constants.horizontalSpacing) {
-                        if showsBackButton {
-                            backButton
-                        }
-                        ForEach(0..<items.count, id: \.self) { index in
-                            VStack(alignment: .leading, spacing: Constants.titleSubtitleSpacing) {
-                                HStack(spacing: POSSpacing.small) {
-                                    if items[index].title.isNotEmpty {
-                                        Button(action: {
-                                            items[index].action?()
-                                        }) {
-                                            Text(items[index].title)
-                                                .font(.posHeadingBold)
-                                                .lineLimit(1)
-                                                .minimumScaleFactor(0.5)
-                                                .dynamicTypeSize(...POSHeaderLayoutConstants.maximumDynamicTypeSize)
-                                                .foregroundColor(items[index].isSelected ? .posOnSurface : .posOnSurfaceVariantLowest)
-                                        }
-                                        .disabled(items[index].isSelected)
-                                        .accessibilityElement()
-                                        .accessibilityAddTraits(items.count == 1 ? .isHeader : [.isHeader, .isButton])
-                                        .accessibilityLabel(items[index].title)
-                                    }
-
-                                    if items[index].isLoading {
-                                        ProgressView()
-                                            .progressViewStyle(.circular)
-                                            .scaleEffect(0.7)
-                                            .transition(.opacity.combined(with: .scale))
-                                    }
-                                }
-
-                                if let subtitle = items[index].subtitle {
-                                    Text(subtitle)
-                                        .font(.posBodyLargeRegular())
-                                        .lineLimit(1)
-                                        .minimumScaleFactor(0.5)
-                                        .dynamicTypeSize(...POSHeaderLayoutConstants.maximumDynamicTypeSize)
-                                        .foregroundColor(.posOnSurface)
-                                }
-                            }
-                        }
-                    }
-                }
+                itemsContent
 
                 if items.isNotEmpty {
-                    Spacer()
+                    Spacer(minLength: 0)
                 }
 
                 trailingContent
@@ -152,6 +110,63 @@ struct POSPageHeaderView<LeadingContent: View, TrailingContent: View, BottomCont
         .padding(.leading, shouldHaveLeadingPaddingForItems ? POSHeaderLayoutConstants.sectionHorizontalPadding : POSPadding.none)
         .padding(.trailing, POSHeaderLayoutConstants.sectionHorizontalPadding)
         .padding(.vertical, POSHeaderLayoutConstants.sectionVerticalPadding)
+    }
+
+    @ViewBuilder
+    private var itemsContent: some View {
+        let itemsRow = VStack(alignment: .leading, spacing: Constants.titleSubtitleSpacing) {
+            HStack(alignment: hStackAlignment, spacing: Constants.horizontalSpacing) {
+                if showsBackButton {
+                    backButton
+                }
+                ForEach(0..<items.count, id: \.self) { index in
+                    VStack(alignment: .leading, spacing: Constants.titleSubtitleSpacing) {
+                        HStack(spacing: POSSpacing.small) {
+                            if items[index].title.isNotEmpty {
+                                Button(action: {
+                                    items[index].action?()
+                                }) {
+                                    Text(items[index].title)
+                                        .font(.posHeadingBold)
+                                        .lineLimit(1)
+                                        .fixedSize(horizontal: true, vertical: false)
+                                        .dynamicTypeSize(...POSHeaderLayoutConstants.maximumDynamicTypeSize)
+                                        .foregroundColor(items[index].isSelected ? .posOnSurface : .posOnSurfaceVariantLowest)
+                                }
+                                .disabled(items[index].isSelected)
+                                .accessibilityElement()
+                                .accessibilityAddTraits(items.count == 1 ? .isHeader : [.isHeader, .isButton])
+                                .accessibilityLabel(items[index].title)
+                            }
+
+                            if items[index].isLoading {
+                                ProgressView()
+                                    .progressViewStyle(.circular)
+                                    .scaleEffect(0.7)
+                                    .transition(.opacity.combined(with: .scale))
+                            }
+                        }
+
+                        if let subtitle = items[index].subtitle {
+                            Text(subtitle)
+                                .font(.posBodyLargeRegular())
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.5)
+                                .dynamicTypeSize(...POSHeaderLayoutConstants.maximumDynamicTypeSize)
+                                .foregroundColor(.posOnSurface)
+                        }
+                    }
+                }
+            }
+        }
+
+        if layoutScale == .phone {
+            ScrollView(.horizontal, showsIndicators: false) {
+                itemsRow
+            }
+        } else {
+            itemsRow
+        }
     }
 
     private var shouldHaveLeadingPaddingForItems: Bool {

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSSuccessIcon.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSSuccessIcon.swift
@@ -1,24 +1,26 @@
 import SwiftUI
 
 struct POSSuccessIcon: View {
+    @Environment(\.posLayoutScale) private var layoutScale
+
     var body: some View {
         ZStack {
             Circle()
-                .frame(width: Constants.iconSize, height: Constants.iconSize)
+                .frame(width: iconSize, height: iconSize)
                 .foregroundColor(.posSuccess)
-            PointOfSaleAssets.successCheck.image
-                .renderingMode(.template)
+            Image(systemName: "checkmark")
+                .font(.system(size: checkmarkSize, weight: .bold))
                 .foregroundColor(.posOnSuccess)
-                .frame(width: Constants.checkmarkSize)
                 .accessibilityHidden(true)
         }
     }
-}
 
-private extension POSSuccessIcon {
-    enum Constants {
-        static let iconSize: CGFloat = 165
-        static let checkmarkSize: CGFloat = 52
+    private var iconSize: CGFloat {
+        layoutScale == .phone ? 72 : 165
+    }
+
+    private var checkmarkSize: CGFloat {
+        layoutScale == .phone ? 28 : 64
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
@@ -3,18 +3,20 @@ import SwiftUI
 struct POSSettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.posAnalytics) private var analytics
-    @State private var selection: SidebarNavigation? = .store
+    @State private var selection: SidebarNavigation?
 
     let settingsController: POSSettingsControllerProtocol
 
     var body: some View {
-        GeometryReader { geometry in
-            HStack(spacing: POSSpacing.none) {
-                listView
-                .frame(width: geometry.size.width * Constants.sidebarWidthFraction)
-
-                detailView
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+        POSNavigationSplitView(selection: $selection) { _ in
+            listView
+        } detail: { selectedItem, _ in
+            detailContent(for: selectedItem)
+        } detailPlaceholderView: {
+            EmptyView()
+        } setDefaultValue: {
+            if selection == nil {
+                selection = .store
             }
         }
     }
@@ -68,22 +70,33 @@ extension POSSettingsView {
     }
 
     @ViewBuilder
-    private var detailView: some View {
-        switch selection {
-        case .store:
-            POSSettingsStoreDetailView(viewModel: settingsController.storeViewModel)
-        case .hardware:
-            POSSettingsHardwareDetailView(settingsController: settingsController)
-        case .localCatalog:
-            if let viewModel = settingsController.localCatalogViewModel {
-                POSSettingsLocalCatalogDetailView(viewModel: viewModel)
-            } else {
-                EmptyView()
+    private func detailContent(for item: SidebarNavigation) -> some View {
+        VStack(spacing: POSSpacing.none) {
+            POSPageHeaderView(
+                title: item.title,
+                backButtonConfiguration: .init(
+                    state: .enabled,
+                    action: { selection = nil }
+                )
+            )
+
+            Group {
+                switch item {
+                case .store:
+                    POSSettingsStoreDetailView(viewModel: settingsController.storeViewModel)
+                case .hardware:
+                    POSSettingsHardwareDetailView(settingsController: settingsController)
+                case .localCatalog:
+                    if let viewModel = settingsController.localCatalogViewModel {
+                        POSSettingsLocalCatalogDetailView(viewModel: viewModel)
+                    } else {
+                        EmptyView()
+                    }
+                case .help:
+                    POSSettingsHelpDetailView()
+                }
             }
-        case .help:
-            POSSettingsHelpDetailView()
-        default:
-            EmptyView()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 
@@ -111,12 +124,6 @@ extension POSSettingsView {
         .buttonStyle(.plain)
         .accessibilityAddTraits(.isButton)
         .accessibilityLabel(SidebarNavigation.help.title)
-    }
-}
-
-extension POSSettingsView {
-    enum Constants {
-        static let sidebarWidthFraction: CGFloat = 0.35
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -270,6 +270,7 @@ private extension TotalsView {
 }
 
 private struct TotalsFieldsContent: View {
+    @Environment(\.posLayoutScale) private var layoutScale
     let orderState: PointOfSaleOrderState
     let paymentState: PointOfSalePaymentState
     let cart: Cart
@@ -333,8 +334,13 @@ private struct TotalsFieldsContent: View {
             )
         }
         .padding(TotalsView.Constants.totalsLineViewPadding)
-        .frame(minWidth: TotalsView.Constants.pricesIdealWidth)
-        .fixedSize(horizontal: true, vertical: false)
+        .if(layoutScale == .tablet) {
+            $0.frame(minWidth: TotalsView.Constants.pricesIdealWidth)
+                .fixedSize(horizontal: true, vertical: false)
+        }
+        .if(layoutScale == .phone) {
+            $0.frame(maxWidth: .infinity)
+        }
         .matchedGeometryEffect(id: Self.matchedGeometryId, in: totalsFieldAnimation)
     }
 }
@@ -406,13 +412,17 @@ private struct TotalFieldView: View {
 }
 
 private struct ShimmeringLineView: View {
+    @Environment(\.posLayoutScale) private var layoutScale
     let width: CGFloat
     let height: CGFloat
 
     var body: some View {
         Color.posOnSurfaceVariantLowest
-            .frame(width: width, height: height)
-            .fixedSize(horizontal: true, vertical: true)
+            .frame(maxWidth: layoutScale == .phone ? .infinity : width,
+                   minHeight: layoutScale == .phone ? max(height, 48) : height,
+                   maxHeight: layoutScale == .phone ? max(height, 48) : height)
+            .fixedSize(horizontal: layoutScale != .phone, vertical: true)
+            .padding(.horizontal, layoutScale == .phone ? POSPadding.medium : 0)
             .shimmering(active: true)
             .cornerRadius(TotalsView.Constants.shimmeringCornerRadius)
     }

--- a/Modules/Sources/PointOfSale/Utils/POSFontStyle.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSFontStyle.swift
@@ -85,20 +85,119 @@ private extension POSFontStyle {
         static let bodySmall: CGFloat = 16
         static let caption: CGFloat = 14
     }
+
+    enum PhoneFontSize {
+        static let heading: CGFloat = 24
+        static let bodyXLarge: CGFloat = 22
+        static let bodyLarge: CGFloat = 18
+        static let bodyMedium: CGFloat = 16
+        static let bodySmall: CGFloat = 14
+        static let caption: CGFloat = 12
+    }
+
+    enum MinimumFloor {
+        static let heading: CGFloat = 16
+        static let bodyXLarge: CGFloat = 14
+        static let bodyLarge: CGFloat = 13
+        static let bodyMedium: CGFloat = 12
+        static let bodySmall: CGFloat = 11
+        static let caption: CGFloat = 11
+        static let buttonSymbol: CGFloat = 11
+    }
+}
+
+// MARK: - Scale-aware sizing
+
+extension POSFontStyle {
+    func baseSize(for scale: POSLayoutScale) -> CGFloat {
+        switch scale {
+        case .tablet:
+            return tabletBaseSize
+        case .phone:
+            return phoneBaseSize
+        }
+    }
+
+    func font(baseSize: CGFloat, maximumContentSizeCategory: UIContentSizeCategory?) -> Font {
+        let scaledSize = scaledValue(baseSize, maximumContentSizeCategory: maximumContentSizeCategory)
+        let flooredSize = max(scaledSize, minimumFloor)
+        return Font.system(size: flooredSize, weight: fontWeight)
+    }
+
+    private var tabletBaseSize: CGFloat {
+        switch self {
+        case .posHeadingBold, .posHeadingRegular: return FontSize.heading
+        case .posBodyXLargeRegular, .posBodyXLargeBold: return FontSize.bodyXLarge
+        case .posBodyLargeBold, .posBodyLargeRegular: return FontSize.bodyLarge
+        case .posBodyMediumBold, .posBodyMediumRegular: return FontSize.bodyMedium
+        case .posBodySmallBold, .posBodySmallRegular: return FontSize.bodySmall
+        case .posCaptionBold, .posCaptionRegular: return FontSize.caption
+        case .posButtonSymbolXSmall: return 16
+        case .posButtonSymbolSmall: return 20
+        case .posButtonSymbolMedium: return 24
+        case .posButtonSymbolLarge: return 30
+        }
+    }
+
+    private var phoneBaseSize: CGFloat {
+        switch self {
+        case .posHeadingBold, .posHeadingRegular: return PhoneFontSize.heading
+        case .posBodyXLargeRegular, .posBodyXLargeBold: return PhoneFontSize.bodyXLarge
+        case .posBodyLargeBold, .posBodyLargeRegular: return PhoneFontSize.bodyLarge
+        case .posBodyMediumBold, .posBodyMediumRegular: return PhoneFontSize.bodyMedium
+        case .posBodySmallBold, .posBodySmallRegular: return PhoneFontSize.bodySmall
+        case .posCaptionBold, .posCaptionRegular: return PhoneFontSize.caption
+        case .posButtonSymbolXSmall: return 14
+        case .posButtonSymbolSmall: return 16
+        case .posButtonSymbolMedium: return 20
+        case .posButtonSymbolLarge: return 24
+        }
+    }
+
+    private var minimumFloor: CGFloat {
+        switch self {
+        case .posHeadingBold, .posHeadingRegular: return MinimumFloor.heading
+        case .posBodyXLargeRegular, .posBodyXLargeBold: return MinimumFloor.bodyXLarge
+        case .posBodyLargeBold, .posBodyLargeRegular: return MinimumFloor.bodyLarge
+        case .posBodyMediumBold, .posBodyMediumRegular: return MinimumFloor.bodyMedium
+        case .posBodySmallBold, .posBodySmallRegular: return MinimumFloor.bodySmall
+        case .posCaptionBold, .posCaptionRegular: return MinimumFloor.caption
+        case .posButtonSymbolXSmall, .posButtonSymbolSmall,
+             .posButtonSymbolMedium, .posButtonSymbolLarge: return MinimumFloor.buttonSymbol
+        }
+    }
+
+    var fontWeight: Font.Weight {
+        switch self {
+        case .posHeadingBold, .posBodyXLargeBold, .posBodyLargeBold,
+             .posBodyMediumBold, .posBodySmallBold, .posCaptionBold:
+            return .bold
+        case .posBodyXLargeRegular:
+            return .semibold
+        case .posButtonSymbolXSmall, .posButtonSymbolSmall,
+             .posButtonSymbolMedium, .posButtonSymbolLarge:
+            return .semibold
+        case .posHeadingRegular, .posBodyLargeRegular, .posBodyMediumRegular,
+             .posBodySmallRegular, .posCaptionRegular:
+            return .regular
+        }
+    }
 }
 
 // MARK: - Helpers
 
 private struct POSScaledFont: ViewModifier {
-    // Declaring dynamicTypeSize ensures it's automatically observed
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
+    @Environment(\.posLayoutScale) var layoutScale
     var style: POSFontStyle
 
     func body(content: Content) -> some View {
         let category = UIContentSizeCategory(dynamicTypeSize)
+        let base = style.baseSize(for: layoutScale)
+        let font = style.font(baseSize: base, maximumContentSizeCategory: category)
 
         return content
-            .font(style.font(maximumContentSizeCategory: category))
+            .font(font)
             .if(shouldUnderline()) { view in
                 view.underline()
             }

--- a/Modules/Sources/PointOfSale/Utils/POSHeaderLeadingContentKey.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSHeaderLeadingContentKey.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct POSHeaderLeadingContentKey: EnvironmentKey {
+    static let defaultValue: AnyView? = nil
+}
+
+extension EnvironmentValues {
+    var posHeaderLeadingContent: AnyView? {
+        get { self[POSHeaderLeadingContentKey.self] }
+        set { self[POSHeaderLeadingContentKey.self] = newValue }
+    }
+}

--- a/Modules/Sources/PointOfSale/Utils/POSLayoutScale.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSLayoutScale.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+enum POSLayoutScale {
+    case tablet
+    case phone
+}
+
+struct POSLayoutScaleKey: EnvironmentKey {
+    static let defaultValue: POSLayoutScale = .tablet
+}
+
+extension EnvironmentValues {
+    var posLayoutScale: POSLayoutScale {
+        get { self[POSLayoutScaleKey.self] }
+        set { self[POSLayoutScaleKey.self] = newValue }
+    }
+}

--- a/Modules/Sources/PointOfSale/Utils/POSMenuPresenter.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSMenuPresenter.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+import struct WooFoundation.WooAnalyticsEvent
+
+@Observable
+final class POSMenuPresenter {
+    var showExitPOSModal = false
+    var showSupport = false
+    var showDocumentation = false
+    var showSettings = false
+    var showOrders = false
+    var showBookings = false
+    var showProductRestrictionsModal = false
+    var showBarcodeScanningModal = false
+
+    @ViewBuilder
+    func menuOptions(featureFlags: POSFeatureFlagProviding,
+                     isBookingsEligible: Bool,
+                     analytics: POSAnalyticsProviding) -> some View {
+        Button {
+            analytics.track(.pointOfSaleExitMenuItemTapped)
+            self.showExitPOSModal = true
+        } label: {
+            Label(
+                title: { Text(Localization.exitPointOfSale) },
+                icon: { Image(systemName: "rectangle.portrait.and.arrow.forward") }
+            )
+        }
+        .accessibilityIdentifier("pos-exit-menu-item")
+
+        Button {
+            analytics.track(.pointOfSaleSettingsMenuItemTapped)
+            self.showSettings = true
+        } label: {
+            Label(
+                title: { Text(Localization.settings) },
+                icon: { Image(systemName: "gearshape") }
+            )
+        }
+
+        if featureFlags.isFeatureFlagEnabled(.pointOfSaleHistoricalOrdersi1) {
+            Button {
+                analytics.track(event: WooAnalyticsEvent.PointOfSale.ordersMenuItemTapped())
+                self.showOrders = true
+            } label: {
+                Label(
+                    title: { Text(Localization.orders) },
+                    icon: { Image(systemName: "text.document") }
+                )
+            }
+        }
+
+        if featureFlags.isFeatureFlagEnabled(.pointOfSaleBookings) && isBookingsEligible {
+            Button {
+                analytics.track(event: WooAnalyticsEvent.PointOfSale.bookingsMenuItemTapped())
+                self.showBookings = true
+            } label: {
+                Label(
+                    title: { Text(Localization.bookings) },
+                    icon: { Image(systemName: "calendar") }
+                )
+            }
+        }
+    }
+
+    private enum Localization {
+        static let exitPointOfSale = NSLocalizedString(
+            "pointOfSale.menu.exit.button.title",
+            value: "Exit POS",
+            comment: "The title of the menu button to exit Point of Sale."
+        )
+        static let settings = NSLocalizedString(
+            "pointOfSale.menu.settings.button.title",
+            value: "Settings",
+            comment: "The title of the menu button to access Point of Sale settings."
+        )
+        static let orders = NSLocalizedString(
+            "pointOfSale.menu.orders.button.title",
+            value: "Orders",
+            comment: "The title of the menu button to access Point of Sale orders."
+        )
+        static let bookings = NSLocalizedString(
+            "pointOfSale.menu.bookings.button.title",
+            value: "Bookings",
+            comment: "The title of the menu button to access Point of Sale bookings."
+        )
+    }
+}

--- a/Modules/Sources/PointOfSale/ViewHelpers/PointOfSaleDashboardViewHelper.swift
+++ b/Modules/Sources/PointOfSale/ViewHelpers/PointOfSaleDashboardViewHelper.swift
@@ -8,10 +8,6 @@ struct PointOfSaleDashboardViewHelper {
         horizontalSizeClass: UserInterfaceSizeClass?
     ) -> PointOfSaleDashboardView.ViewState {
 
-        guard case .regular = horizontalSizeClass else {
-            return .unsupportedWidth
-        }
-
         guard let eligibilityState else {
             return .loading(isCatalogSyncing: itemsContainerState.isCatalogSyncing)
         }

--- a/WooCommerce/Classes/POS/TabBar/POSHostingController.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSHostingController.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+import UIKit
+
+/// A hosting controller for POS that locks orientation based on device type.
+/// Phone: portrait only. iPad: landscape only.
+final class POSHostingController<Content: View>: UIHostingController<Content> {
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        UIDevice.current.userInterfaceIdiom == .phone ? .portrait : .landscape
+    }
+}

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -280,6 +280,11 @@ private extension POSTabCoordinator {
                 let isBookingsEligible = storesManager.sessionManager.defaultSite
                     .map { CIABEligibilityChecker().isSiteCIAB($0) } ?? false
 
+                let supportDeterminer = CardReaderSupportDeterminer(siteID: siteID, stores: storesManager)
+                let siteSupports = supportDeterminer.siteSupportsTapToPayReader()
+                let deviceSupports = siteSupports ? await supportDeterminer.deviceSupportsTapToPayReader() : false
+                let preferredConnectionMethod: CardReaderConnectionMethod = (siteSupports && deviceSupports) ? .tapToPay : .bluetooth
+
                 let posView = PointOfSaleEntryPointView(
                     siteID: siteID,
                     itemFetchStrategyFactory: createItemFetchStrategyFactory(isLocalCatalogEnabled: isLocalCatalogEligible),
@@ -315,11 +320,12 @@ private extension POSTabCoordinator {
                     grdbManager: grdbManager,
                     catalogSyncCoordinator: catalogSyncCoordinator,
                     isLocalCatalogEligible: isLocalCatalogEligible,
+                    preferredConnectionMethod: preferredConnectionMethod,
                     services: serviceAdaptor,
                     itemProvider: itemProvider
                 )
 
-                let hostingController = UIHostingController(rootView: posView)
+                let hostingController = POSHostingController(rootView: posView)
                 hostingController.modalPresentationStyle = .fullScreen
                 viewControllerToPresent.present(hostingController, animated: true)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
@@ -60,7 +60,7 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
             return false
         }
 
-        guard userInterfaceIdiom == .pad else {
+        guard userInterfaceIdiom == .pad || userInterfaceIdiom == .phone else {
             return false
         }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -950,7 +950,7 @@ private extension MainTabBarController {
         guard bookingsFeatureAvailable else {
             return false
         }
-        return isPad ? !isPOSTabVisible : true
+        return !isPOSTabVisible
     }
 }
 


### PR DESCRIPTION
## Description

Adds iPhone portrait support to WooCommerce POS while keeping the tablet layout untouched. On devices that support Tap to Pay, it becomes the default payment method with explicit payment method selection buttons.

### Key changes:

**Phone Layout**
- New `PointOfSaleDashboardPhoneView` with products screen, cart sheet (slide-up), and checkout flow
- `POSCartButton` at bottom of products screen shows item count
- `POSMenuPresenter` extracted from `POSFloatingControlView` for shared menu between tablet (floating) and phone (hamburger)
- Products/Coupons header scrolls horizontally on phone to prevent clipping

**Responsive Design**
- `POSLayoutScale` environment value (.phone/.tablet) drives sizing decisions
- Phone-specific font sizes in `POSFontStyle` with minimum floor
- `DynamicFrameScaler` uses full-width on phone instead of 50% container width
- Payment views (success, error, disconnected) adapt button widths for phone

**Tap to Pay**
- Check device + site Tap to Pay support at POS launch
- Pre-connect Tap to Pay reader on checkout without auto-collecting
- Show "Tap to Pay" (primary), "Card Reader", and "Cash" payment buttons
- `startPaymentWithMethod()` for explicit payment method selection

**App Target**
- POS tab enabled on iPhone (was iPad-only)
- `POSHostingController` locks orientation per device (portrait on phone, landscape on iPad)
- Settings refactored to use `POSNavigationSplitView` (same as Orders/Bookings)
- Bookings tab hidden when POS visible to prevent tab index crash

## Test Steps

1. Open app on iPhone simulator
2. Tap POS tab
3. Verify products screen shows with hamburger menu, Products/Coupons tabs, search
4. Add items to cart, verify cart button shows count
5. Tap cart button, verify cart sheet slides up
6. Tap "Check out", verify checkout screen shows totals
7. If Tap to Pay supported: verify "Tap to Pay", "Card Reader", "Cash" buttons appear
8. Open Settings from hamburger menu, verify list -> detail navigation works on phone
9. Open same flow on iPad, verify tablet layout is unchanged

## Screenshots

(Screenshots to be added)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.