### PR TITLE
Fix product duplication to copy custom fields

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -17,6 +17,7 @@
 - [*] Fix sheet/popover presentation showing trimmed content on iPad [https://github.com/woocommerce/woocommerce-ios/pull/16817]
 - [*] Hide edit status button in order details and order edit form for CIAB sites [https://github.com/woocommerce/woocommerce-ios/pull/16827]
 - [*] Display booking location from product data in booking details [https://github.com/woocommerce/woocommerce-ios/pull/16826]
+- [*] Fix product duplication missing custom fields [https://github.com/woocommerce/woocommerce-ios/pull/16831]
 
 
 24.3

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
@@ -80,6 +80,15 @@ final class ProductFormRemoteActionUseCase {
             guard let self else { return }
             switch result {
             case .success(let data):
+                // Copy custom fields from the original product to the duplicated product.
+                if originalProduct.product.customFields.isNotEmpty {
+                    Task { [weak self] in
+                        await self?.copyCustomFields(originalProduct.product.customFields,
+                                                     toProductID: data.product.productID,
+                                                     siteID: data.product.siteID)
+                    }
+                }
+
                 let variableTypes: [ProductType] = [.variable, .variableSubscription]
                 guard variableTypes.contains(data.product.productType) else {
                     return onCompletion(.success(data))
@@ -344,6 +353,26 @@ private extension ProductFormRemoteActionUseCase {
                 self?.stores.dispatch(action)
             }
         } as ProductVariation?
+    }
+
+    func copyCustomFields(_ customFields: [MetaData],
+                           toProductID newProductID: Int64,
+                           siteID: Int64) async {
+        guard customFields.isNotEmpty else { return }
+        let metadata: [[String: Any?]] = customFields.map { ["key": $0.key, "value": $0.value.stringValue] }
+        await withCheckedContinuation { [weak self] continuation in
+            let action = MetaDataAction.updateMetaData(
+                siteID: siteID,
+                parentItemID: newProductID,
+                metaDataType: .product,
+                metadata: metadata
+            ) { _ in
+                continuation.resume()
+            }
+            DispatchQueue.main.async { [weak self] in
+                self?.stores.dispatch(action)
+            }
+        } as Void
     }
 
     func duplicateProductVariation(_ newVariation: CreateProductVariation, parent: EditableProductModel) async {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
@@ -80,14 +80,24 @@ final class ProductFormRemoteActionUseCase {
             guard let self else { return }
             switch result {
             case .success(let data):
+                let originalCustomFields = originalProduct.product.customFields
+
                 // Copy custom fields from the original product to the duplicated product.
-                self.copyCustomFields(originalProduct.product.customFields,
+                self.copyCustomFields(originalCustomFields,
                                       toProductID: data.product.productID,
                                       siteID: data.product.siteID)
 
+                // Wrap completion to optimistically inject custom fields so the UI shows them immediately.
+                let onCompletionWithCustomFields: DuplicateProductCompletion = { result in
+                    onCompletion(result.map { data in
+                        ResultData(product: EditableProductModel(product: data.product.product.copy(customFields: originalCustomFields)),
+                                   password: data.password)
+                    })
+                }
+
                 let variableTypes: [ProductType] = [.variable, .variableSubscription]
                 guard variableTypes.contains(data.product.productType) else {
-                    return onCompletion(.success(data))
+                    return onCompletionWithCustomFields(.success(data))
                 }
                 self.duplicateVariations(originalProduct.product.variations,
                                          from: originalProduct.productID,
@@ -96,10 +106,10 @@ final class ProductFormRemoteActionUseCase {
                     switch result {
                     case .success(let product):
                         ServiceLocator.analytics.track(successEventName)
-                        onCompletion(.success(ResultData(product: product, password: data.password)))
+                        onCompletionWithCustomFields(.success(ResultData(product: product, password: data.password)))
                     case .failure(let error):
                         ServiceLocator.analytics.track(failureEventName, withError: error)
-                        onCompletion(.failure(error))
+                        onCompletionWithCustomFields(.failure(error))
                     }
                 })
             case .failure(let error):

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
@@ -81,13 +81,9 @@ final class ProductFormRemoteActionUseCase {
             switch result {
             case .success(let data):
                 // Copy custom fields from the original product to the duplicated product.
-                if originalProduct.product.customFields.isNotEmpty {
-                    Task { [weak self] in
-                        await self?.copyCustomFields(originalProduct.product.customFields,
-                                                     toProductID: data.product.productID,
-                                                     siteID: data.product.siteID)
-                    }
-                }
+                self.copyCustomFields(originalProduct.product.customFields,
+                                      toProductID: data.product.productID,
+                                      siteID: data.product.siteID)
 
                 let variableTypes: [ProductType] = [.variable, .variableSubscription]
                 guard variableTypes.contains(data.product.productType) else {
@@ -357,22 +353,16 @@ private extension ProductFormRemoteActionUseCase {
 
     func copyCustomFields(_ customFields: [MetaData],
                            toProductID newProductID: Int64,
-                           siteID: Int64) async {
+                           siteID: Int64) {
         guard customFields.isNotEmpty else { return }
         let metadata: [[String: Any?]] = customFields.map { ["key": $0.key, "value": $0.value.stringValue] }
-        await withCheckedContinuation { [weak self] continuation in
-            let action = MetaDataAction.updateMetaData(
-                siteID: siteID,
-                parentItemID: newProductID,
-                metaDataType: .product,
-                metadata: metadata
-            ) { _ in
-                continuation.resume()
-            }
-            DispatchQueue.main.async { [weak self] in
-                self?.stores.dispatch(action)
-            }
-        } as Void
+        let action = MetaDataAction.updateMetaData(
+            siteID: siteID,
+            parentItemID: newProductID,
+            metaDataType: .product,
+            metadata: metadata
+        ) { _ in }
+        stores.dispatch(action)
     }
 
     func duplicateProductVariation(_ newVariation: CreateProductVariation, parent: EditableProductModel) async {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
@@ -364,14 +364,18 @@ private extension ProductFormRemoteActionUseCase {
     func copyCustomFields(_ customFields: [MetaData],
                            toProductID newProductID: Int64,
                            siteID: Int64) {
-        guard customFields.isNotEmpty else { return }
+        if customFields.isEmpty { return }
         let metadata: [[String: Any?]] = customFields.map { ["key": $0.key, "value": $0.value.stringValue] }
         let action = MetaDataAction.updateMetaData(
             siteID: siteID,
             parentItemID: newProductID,
             metaDataType: .product,
             metadata: metadata
-        ) { _ in }
+        ) { result in
+            if case .failure(let error) = result {
+                DDLogError("⚠️ Failed to copy custom fields to duplicated product: \(error)")
+            }
+        }
         stores.dispatch(action)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCaseTests.swift
@@ -474,6 +474,44 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         XCTAssertEqual(result, .failure(.invalidSKU))
     }
 
+    func test_duplicating_product_with_custom_fields_dispatches_metadata_update_action() {
+        // Given
+        let customFields = [
+            MetaData(metadataID: 1, key: "color", value: "red"),
+            MetaData(metadataID: 2, key: "size", value: "large")
+        ]
+        let product = Product.fake().copy(productID: 5, siteID: siteID, customFields: customFields)
+        let model = EditableProductModel(product: product)
+        let duplicatedProduct = Product.fake().copy(productID: 99, siteID: siteID)
+        mockAddProduct(result: .success(duplicatedProduct))
+
+        var receivedParentItemID: Int64?
+        var receivedMetadata: [[String: Any?]]?
+        storesManager.whenReceivingAction(ofType: MetaDataAction.self) { action in
+            if case let MetaDataAction.updateMetaData(_, parentItemID, _, metadata, onCompletion) = action {
+                receivedParentItemID = parentItemID
+                receivedMetadata = metadata
+                onCompletion(.success([]))
+            }
+        }
+
+        let useCase = ProductFormRemoteActionUseCase(stores: storesManager)
+
+        // When
+        useCase.duplicateProduct(originalProduct: model, password: nil) { _ in }
+        waitUntil {
+            receivedMetadata != nil
+        }
+
+        // Then
+        XCTAssertEqual(receivedParentItemID, 99)
+        XCTAssertEqual(receivedMetadata?.count, 2)
+        XCTAssertEqual(receivedMetadata?[0]["key"] as? String, "color")
+        XCTAssertEqual(receivedMetadata?[0]["value"] as? String, "red")
+        XCTAssertEqual(receivedMetadata?[1]["key"] as? String, "size")
+        XCTAssertEqual(receivedMetadata?[1]["value"] as? String, "large")
+    }
+
     func test_duplicating_variable_product_triggers_retrieving_original_product_variations_and_creating_new_variations_for_duplicated_product() {
         // Given
         let testVariationIDs: [Int64] = [11, 20, 35]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCaseTests.swift
@@ -480,9 +480,9 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
             MetaData(metadataID: 1, key: "color", value: "red"),
             MetaData(metadataID: 2, key: "size", value: "large")
         ]
-        let product = Product.fake().copy(productID: 5, siteID: siteID, customFields: customFields)
+        let product = Product.fake().copy(siteID: siteID, productID: 5, customFields: customFields)
         let model = EditableProductModel(product: product)
-        let duplicatedProduct = Product.fake().copy(productID: 99, siteID: siteID)
+        let duplicatedProduct = Product.fake().copy(siteID: siteID, productID: 99)
         mockAddProduct(result: .success(duplicatedProduct))
 
         var receivedParentItemID: Int64?

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCaseTests.swift
@@ -474,7 +474,7 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         XCTAssertEqual(result, .failure(.invalidSKU))
     }
 
-    func test_duplicating_product_with_custom_fields_dispatches_metadata_update_action() {
+    func test_duplicating_product_with_custom_fields_dispatches_metadata_update_action() throws {
         // Given
         let customFields = [
             MetaData(metadataID: 1, key: "color", value: "red"),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCaseTests.swift
@@ -498,7 +498,8 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         let useCase = ProductFormRemoteActionUseCase(stores: storesManager)
 
         // When
-        useCase.duplicateProduct(originalProduct: model, password: nil) { _ in }
+        var result: Result<ResultData, ProductUpdateError>?
+        useCase.duplicateProduct(originalProduct: model, password: nil) { result = $0 }
 
         // Then
         XCTAssertEqual(receivedParentItemID, 99)
@@ -507,6 +508,10 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         XCTAssertEqual(receivedMetadata?[0]["value"] as? String, "red")
         XCTAssertEqual(receivedMetadata?[1]["key"] as? String, "size")
         XCTAssertEqual(receivedMetadata?[1]["value"] as? String, "large")
+
+        // Verify the returned product optimistically includes custom fields
+        let returnedProduct = try XCTUnwrap(result?.get().product)
+        XCTAssertEqual(returnedProduct.product.customFields, customFields)
     }
 
     func test_duplicating_variable_product_triggers_retrieving_original_product_variations_and_creating_new_variations_for_duplicated_product() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCaseTests.swift
@@ -499,9 +499,6 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
 
         // When
         useCase.duplicateProduct(originalProduct: model, password: nil) { _ in }
-        waitUntil {
-            receivedMetadata != nil
-        }
 
         // Then
         XCTAssertEqual(receivedParentItemID, 99)


### PR DESCRIPTION
Closes [WOOMOB-1871](https://linear.app/a8c/issue/WOOMOB-1871)

## Description

When duplicating a product from the iOS app, custom fields (metadata) are not copied to the duplicated product. This PR fixes that as well as optimistically updating the local store for the "Custom Fields" row to appear on the new product.

## Test Steps

1. Create a product with custom fields
2. Duplicate the product
3. Verify the duplicated product has the same custom fields as the original
4. Note that the new product's custom field row is presented

## Screenshots

| Before | After |
| --- | --- |
| ![Simulator Screen Recording - iPhone 17 Pro - 2026-03-19 at 09 42 55](https://github.com/user-attachments/assets/bdef9255-36a6-4f1a-b222-b37db9747e7e) | ![Simulator Screen Recording - iPhone 17 Pro - 2026-03-19 at 09 20 28](https://github.com/user-attachments/assets/f9c02edd-fb9c-4825-86e4-60febce3f5e8) |

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.