### PR TITLE
Add CIAB badge for dev builds

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -110,7 +110,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .ageRangeRequirementsCompliance:
             return false
         case .ciabSiteBadge:
-            return buildConfig == .localDeveloper
+            return buildConfig == .localDeveloper && !isUITesting
         default:
             return true
         }

--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -109,6 +109,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .ageRangeRequirementsCompliance:
             return false
+        case .ciabSiteBadge:
+            return buildConfig == .localDeveloper
         default:
             return true
         }

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -229,4 +229,8 @@ public enum FeatureFlag: Int, CaseIterable {
     /// https://developer.apple.com/news/?id=2ezb6jhj
     ///
     case ageRangeRequirementsCompliance
+
+    /// Displays a "CIAB" badge next to site names for CIAB sites (local dev only)
+    ///
+    case ciabSiteBadge
 }

--- a/Modules/Sources/NetworkingCore/Model/Site.swift
+++ b/Modules/Sources/NetworkingCore/Model/Site.swift
@@ -270,6 +270,12 @@ public extension Site {
         plan == WooConstants.freePlanSlug
     }
 
+    /// Whether this site is a CIAB (Commerce in a Box) site.
+    ///
+    public var isCIAB: Bool {
+        Site.isCIAB(isGarden: isGarden, gardenName: gardenName)
+    }
+
     static func isCIAB(isGarden: Bool, gardenName: String?) -> Bool {
         isGarden && gardenName ==  Constants.commerceGardenName
     }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -704,6 +704,7 @@ extension StorePickerViewController: UITableViewDataSource {
 
         cell.name = site.name
         cell.url = site.url
+        cell.displaysCIABBadge = site.isCIAB && ServiceLocator.featureFlagService.isFeatureFlagEnabled(.ciabSiteBadge)
         cell.allowsCheckmark = viewModel.multipleStoresAvailable && site.isWooCommerceActive
         cell.displaysCheckmark = currentlySelectedSite?.siteID == site.siteID && site.isWooCommerceActive
         cell.displaysNotice = site.isWooCommerceActive == false

--- a/WooCommerce/Classes/Authentication/Epilogue/StoreTableViewCell.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StoreTableViewCell.swift
@@ -32,6 +32,34 @@ class StoreTableViewCell: UITableViewCell {
     ///
     @IBOutlet private var urlLabel: UILabel!
 
+    /// Badge label displayed next to the store name for CIAB sites.
+    ///
+    private lazy var ciabBadgeLabel: PaddedLabel = {
+        let label = PaddedLabel()
+        label.text = "CIAB"
+        label.textInsets = Constants.badgeInsets
+        label.font = .preferredFont(forTextStyle: .caption2)
+        label.textColor = .white
+        label.backgroundColor = .systemOrange
+        label.layer.cornerRadius = Constants.badgeCornerRadius
+        label.layer.masksToBounds = true
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+        return label
+    }()
+
+    /// Stack view wrapping nameLabel and the CIAB badge.
+    ///
+    private lazy var nameStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.spacing = Constants.badgeSpacing
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
     /// Store's Name
     ///
     var name: String? {
@@ -83,12 +111,21 @@ class StoreTableViewCell: UITableViewCell {
         }
     }
 
+    /// Whether to display the CIAB badge next to the store name.
+    ///
+    var displaysCIABBadge: Bool = false {
+        didSet {
+            ciabBadgeLabel.isHidden = !displaysCIABBadge
+        }
+    }
+
     // MARK: - Overridden Methods
 
     override func awakeFromNib() {
         super.awakeFromNib()
         configureBackground()
         configureNameLabel()
+        configureCIABBadge()
         configureUrlLabel()
         configureNoticeImageView()
     }
@@ -128,6 +165,40 @@ private extension StoreTableViewCell {
         nameLabel.accessibilityIdentifier = "name-label"
     }
 
+    /// Wraps `nameLabel` in a horizontal stack view and adds the CIAB badge label.
+    /// The stack view takes over the nameLabel's position in the layout.
+    ///
+    func configureCIABBadge() {
+        guard let container = nameLabel.superview else { return }
+
+        // Collect nameLabel's constraints from the superview that reference it
+        let relatedConstraints = container.constraints.filter { constraint in
+            constraint.firstItem === nameLabel || constraint.secondItem === nameLabel
+        }
+
+        // Deactivate those constraints — we'll re-pin via the stack view
+        NSLayoutConstraint.deactivate(relatedConstraints)
+
+        nameLabel.removeFromSuperview()
+        nameLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        nameStackView.addArrangedSubview(nameLabel)
+        nameStackView.addArrangedSubview(ciabBadgeLabel)
+        container.addSubview(nameStackView)
+
+        // Re-apply equivalent constraints: the stack view takes nameLabel's original position
+        NSLayoutConstraint.activate([
+            nameStackView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            nameStackView.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor),
+            nameStackView.topAnchor.constraint(equalTo: container.topAnchor, constant: Constants.nameTopPadding)
+        ])
+
+        // Re-pin urlLabel top to stack view bottom (was pinned to nameLabel bottom)
+        urlLabel.topAnchor.constraint(equalTo: nameStackView.bottomAnchor).isActive = true
+
+        ciabBadgeLabel.isHidden = true
+    }
+
     func configureUrlLabel() {
         urlLabel.textColor = .textSubtle
         urlLabel.accessibilityIdentifier = "url-label"
@@ -136,5 +207,12 @@ private extension StoreTableViewCell {
     func configureNoticeImageView() {
         noticeImageView.image = .noticeImage
         noticeImageView.tintColor = .warning
+    }
+
+    enum Constants {
+        static let badgeCornerRadius: CGFloat = 4
+        static let badgeSpacing: CGFloat = 6
+        static let badgeInsets = UIEdgeInsets(top: 2, left: 6, bottom: 2, right: 6)
+        static let nameTopPadding: CGFloat = 10
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/StoreTableViewCell.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StoreTableViewCell.swift
@@ -39,8 +39,8 @@ class StoreTableViewCell: UITableViewCell {
         label.text = "CIAB"
         label.textInsets = Constants.badgeInsets
         label.font = .preferredFont(forTextStyle: .caption2)
-        label.textColor = .white
-        label.backgroundColor = .systemOrange
+        label.textColor = .textBrand
+        label.backgroundColor = .wooCommercePurple(.shade0)
         label.layer.cornerRadius = Constants.badgeCornerRadius
         label.layer.masksToBounds = true
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -73,6 +73,11 @@ struct DashboardView: View {
 
     private let storePlanSynchronizer = ServiceLocator.storePlanSynchronizer
     private let connectivityObserver = ServiceLocator.connectivityObserver
+    private let featureFlagService = ServiceLocator.featureFlagService
+
+    private var shouldShowCIABBadge: Bool {
+        currentSite?.isCIAB == true && featureFlagService.isFeatureFlagEnabled(.ciabSiteBadge)
+    }
 
     private var shouldShowJetpackBenefitsBanner: Bool {
         let isJetpackCPSite = currentSite?.isJetpackCPConnected == true
@@ -94,11 +99,19 @@ struct DashboardView: View {
         ScrollView {
             VStack(spacing: Layout.padding) {
                 // Store title
-                Text(currentSite?.name ?? Localization.title)
-                    .subheadlineStyle()
-                    .padding(Layout.sectionHeadingPadding)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .renderedIf(verticalSizeClass == .regular)
+                HStack(spacing: Layout.ciabBadgeSpacing) {
+                    Text(currentSite?.name ?? Localization.title)
+                        .subheadlineStyle()
+                    if shouldShowCIABBadge {
+                        BadgeView(text: Localization.ciabBadge,
+                                  customizations: .init(textColor: .white,
+                                                        backgroundColor: .orange,
+                                                        borderColor: nil))
+                    }
+                }
+                .padding(Layout.sectionHeadingPadding)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .renderedIf(verticalSizeClass == .regular)
 
                 // Feature announcement if any.
                 featureAnnouncementCard
@@ -439,6 +452,7 @@ private extension DashboardView {
         static let dotBadgePadding = EdgeInsets(top: 6, leading: 0, bottom: 0, trailing: 2)
         static let dotBadgeSize: CGFloat = 6
         static let dotBadgeOffset = CGSize(width: 7, height: -7)
+        static let ciabBadgeSpacing: CGFloat = 6
     }
     enum Localization {
         static let title = NSLocalizedString(
@@ -446,6 +460,7 @@ private extension DashboardView {
             value: "My store",
             comment: "Title of the bottom tab item that presents the user's store dashboard, and default title for the store dashboard"
         )
+        static let ciabBadge = "CIAB"
         static let done = NSLocalizedString(
             "dashboardView.supportForm.done",
             value: "Done",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -103,10 +103,7 @@ struct DashboardView: View {
                     Text(currentSite?.name ?? Localization.title)
                         .subheadlineStyle()
                     if shouldShowCIABBadge {
-                        BadgeView(text: Localization.ciabBadge,
-                                  customizations: .init(textColor: .white,
-                                                        backgroundColor: .orange,
-                                                        borderColor: nil))
+                        BadgeView(text: Localization.ciabBadge)
                     }
                 }
                 .padding(Layout.sectionHeadingPadding)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -84,6 +84,19 @@ private extension DashboardViewHostingController {
         tabBarItem.image = .statsAltImage
         tabBarItem.title = Localization.title
         tabBarItem.accessibilityIdentifier = "tab-bar-my-store-item"
+
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.ciabSiteBadge) {
+            ServiceLocator.stores.site
+                .sink { [weak self] site in
+                    guard let self else { return }
+                    if site?.isCIAB == true {
+                        tabBarItem.title = Localization.title + " [CIAB]"
+                    } else {
+                        tabBarItem.title = Localization.title
+                    }
+                }
+                .store(in: &subscriptions)
+        }
     }
 
     /// Presents the privacy banner if needed.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -84,19 +84,6 @@ private extension DashboardViewHostingController {
         tabBarItem.image = .statsAltImage
         tabBarItem.title = Localization.title
         tabBarItem.accessibilityIdentifier = "tab-bar-my-store-item"
-
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.ciabSiteBadge) {
-            ServiceLocator.stores.site
-                .sink { [weak self] site in
-                    guard let self else { return }
-                    if site?.isCIAB == true {
-                        tabBarItem.title = Localization.title + " [CIAB]"
-                    } else {
-                        tabBarItem.title = Localization.title
-                    }
-                }
-                .store(in: &subscriptions)
-        }
     }
 
     /// Presents the privacy banner if needed.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -84,6 +84,20 @@ private extension DashboardViewHostingController {
         tabBarItem.image = .statsAltImage
         tabBarItem.title = Localization.title
         tabBarItem.accessibilityIdentifier = "tab-bar-my-store-item"
+
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.ciabSiteBadge) {
+            ServiceLocator.stores.site
+                .sink { [weak self] site in
+                    guard let self else { return }
+                    if site?.isCIAB == true {
+                        tabBarItem.badgeValue = "CIAB"
+                        tabBarItem.badgeColor = .wooCommercePurple(.shade60)
+                    } else {
+                        tabBarItem.badgeValue = nil
+                    }
+                }
+                .store(in: &subscriptions)
+        }
     }
 
     /// Presents the privacy banner if needed.

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -67,6 +67,7 @@ private extension HubMenu {
                 } label: {
                     Row(title: viewModel.storeTitle,
                         titleBadge: viewModel.planName,
+                        secondaryTitleBadge: viewModel.isCIABSite ? "CIAB" : nil,
                         iconBadge: nil,
                         description: viewModel.storeURL.host ?? viewModel.storeURL.absoluteString,
                         icon: .remote(viewModel.avatarURL),
@@ -239,6 +240,10 @@ private extension HubMenu {
         ///
         let titleBadge: String?
 
+        /// Secondary text badge displayed after the primary title badge (e.g. "CIAB" indicator)
+        ///
+        var secondaryTitleBadge: String?
+
         /// Badge displayed on the icon.
         ///
         let iconBadge: HubMenuBadgeType?
@@ -315,6 +320,13 @@ private extension HubMenu {
 
                         if let titleBadge, titleBadge.isNotEmpty {
                             BadgeView(text: titleBadge)
+                        }
+
+                        if let secondaryTitleBadge, secondaryTitleBadge.isNotEmpty {
+                            BadgeView(text: secondaryTitleBadge,
+                                      customizations: .init(textColor: .white,
+                                                            backgroundColor: .orange,
+                                                            borderColor: nil))
                         }
                     }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -323,10 +323,7 @@ private extension HubMenu {
                         }
 
                         if let secondaryTitleBadge, secondaryTitleBadge.isNotEmpty {
-                            BadgeView(text: secondaryTitleBadge,
-                                      customizations: .init(textColor: .white,
-                                                            backgroundColor: .orange,
-                                                            borderColor: nil))
+                            BadgeView(text: secondaryTitleBadge)
                         }
                     }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -52,6 +52,8 @@ final class HubMenuViewModel: ObservableObject {
 
     @Published private(set) var planName = ""
 
+    @Published private(set) var isCIABSite = false
+
     @Published private(set) var storeURL = WooConstants.URLs.blog.asURL()
 
     @Published private(set) var woocommerceAdminURL = WooConstants.URLs.blog.asURL()
@@ -345,6 +347,13 @@ private extension HubMenuViewModel {
         $currentSite
             .compactMap { $0?.name }
             .assign(to: &$storeTitle)
+
+        $currentSite
+            .map { [weak self] site in
+                site?.isCIAB == true
+                && self?.featureFlagService.isFeatureFlagEnabled(.ciabSiteBadge) == true
+            }
+            .assign(to: &$isCIABSite)
 
         $currentSite
             .compactMap { site -> URL? in


### PR DESCRIPTION
## Description

Adds a "CIAB" badge next to site names for CIAB (Commerce in a Box) sites, helping developers quickly identify CIAB vs regular WooCommerce sites. The badge appears in 4 locations:

- **Dashboard** — orange `BadgeView` badge next to the site title
- **Hub Menu** — secondary orange badge next to the plan badge in the store row
- **Tab bar** — `[CIAB]` suffix on the "My store" tab title
- **Store Picker** — `[CIAB]` suffix on site names in the store list

Gated behind a new `ciabSiteBadge` feature flag, enabled only in local developer builds. Overridable at runtime via Settings → Feature Flag Overrides.

Also adds a convenience `isCIAB` computed property on `Site` to simplify CIAB checks throughout the codebase.

## Test Steps

1. Build in debug (local developer) configuration
2. Log into a CIAB site (isGarden=true, gardenName="commerce")
3. Verify "CIAB" badge appears on Dashboard, Hub Menu, tab bar, and Store Picker
4. Log into a non-CIAB site — no badge should appear
5. Toggle the flag off in Settings → Feature Flag Overrides — badges should disappear

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.