### PR TITLE
Fix site discovery showing errors for already connected stores

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 24.4
 -----
+- [*] Fix site discovery showing errors for stores already connected to the account [https://github.com/woocommerce/woocommerce-ios/pull/16835]
 - [*] Remove the flashing empty state in booking list when updating filters [https://github.com/woocommerce/woocommerce-ios/pull/16824]
 - [*] Fix My Store dashboard showing different revenue numbers than wp-admin by respecting the store's date type setting [https://github.com/woocommerce/woocommerce-ios/pull/16812]
 - [Internal] Skip Jetpack benefits screen during setup when self driven push notifications feature is enabled [https://github.com/woocommerce/woocommerce-ios/pull/16791]

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -335,8 +335,37 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             return
         }
 
+        // Check if the site already belongs to the current account before showing
+        // an error. The user may have typed a URL for a site they already have.
+        let matcher = ULAccountMatcher(storageManager: storageManager)
+        matcher.refreshStoredSites()
+        if let matchedSite = matcher.matchedSite(originalURL: site.url) {
+            if matchedSite.isWooCommerceActive {
+                switchToAlreadyConnectedSite(matchedSite, in: navigationController)
+                return
+            } else {
+                let noWoo = noWooUI(for: matchedSite,
+                                    with: matcher,
+                                    navigationController: navigationController,
+                                    onStorePickerDismiss: {})
+                navigationController.show(noWoo, sender: nil)
+                return
+            }
+        }
+
         let errorUI = errorUI(for: site, in: navigationController)
         navigationController.show(errorUI, sender: nil)
+    }
+
+    /// Navigates back to the store picker and selects the site that the user
+    /// entered via site discovery, as if they had tapped it in the list.
+    private func switchToAlreadyConnectedSite(_ site: Site, in navigationController: UINavigationController) {
+        navigationController.popToRootViewController(animated: true)
+        if let storePicker = navigationController.viewControllers
+            .compactMap({ $0 as? StorePickerViewController })
+            .first {
+            storePicker.selectSite(site)
+        }
     }
 
     /// Handles site credential login

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/UserDefaults+EditStoreList.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/UserDefaults+EditStoreList.swift
@@ -12,4 +12,12 @@ extension UserDefaults {
     func saveHiddenStoreIDs(_ ids: [Int64]) {
         self[.hiddenStoreIDs] = ids
     }
+
+    /// Removes a single store from the hidden list, making it visible in the picker again.
+    func unhideStoreID(_ storeID: Int64) {
+        var ids = hiddenStoreIDs
+        guard ids.contains(storeID) else { return }
+        ids.removeAll { $0 == storeID }
+        saveHiddenStoreIDs(ids)
+    }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -377,6 +377,19 @@ private extension StorePickerViewController {
 }
 
 
+// MARK: - Site Discovery Support
+//
+extension StorePickerViewController {
+    /// Selects a site programmatically, updating the UI as if the user tapped it.
+    /// Also unhides the site if it was hidden, so it remains visible in the picker.
+    func selectSite(_ site: Site) {
+        viewModel.unhideStoreIfNeeded(site.siteID)
+        currentlySelectedSite = site
+        tableView.reloadData()
+    }
+}
+
+
 // MARK: - Notifications
 //
 extension StorePickerViewController {

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
@@ -98,6 +98,12 @@ final class StorePickerViewModel {
         let hiddenStoreIDs = userDefaults.hiddenStoreIDs
         displayedStores = allFetchedSites.filter { hiddenStoreIDs.contains($0.siteID) == false }
     }
+
+    /// Ensures the given store is not hidden, so it appears in the picker.
+    func unhideStoreIfNeeded(_ siteID: Int64) {
+        userDefaults.unhideStoreID(siteID)
+        updateDisplayedStores()
+    }
 }
 
 // MARK: - Private helpers

--- a/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
@@ -8,6 +8,30 @@ struct EditStoreListViewModelTests {
     private let site1 = Site.fake().copy(siteID: 123)
     private let site2 = Site.fake().copy(siteID: 135)
 
+    @Test func unhideStoreID_removes_store_from_hidden_list() {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        userDefaults.saveHiddenStoreIDs([site1.siteID, site2.siteID])
+
+        // When
+        userDefaults.unhideStoreID(site1.siteID)
+
+        // Then
+        #expect(userDefaults.hiddenStoreIDs == [site2.siteID])
+    }
+
+    @Test func unhideStoreID_does_nothing_when_store_is_not_hidden() {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        userDefaults.saveHiddenStoreIDs([site2.siteID])
+
+        // When
+        userDefaults.unhideStoreID(site1.siteID)
+
+        // Then
+        #expect(userDefaults.hiddenStoreIDs == [site2.siteID])
+    }
+
     @Test func hasChanges_returns_correct_values() {
         // Given
         let availableSites = [site1, site2]

--- a/WooCommerce/WooCommerceTests/Authentication/StorePickerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/StorePickerViewModelTests.swift
@@ -328,6 +328,42 @@ final class StorePickerViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.displayedStores, [testSite2])
     }
+
+    @MainActor
+    func test_unhideStoreIfNeeded_removes_store_from_hidden_list_and_updates_displayedStores() async throws {
+        // Given
+        let testSite1 = Site.fake().copy(siteID: 123, name: "abc", isWooCommerceActive: true)
+        let testSite2 = Site.fake().copy(siteID: 124, name: "def", isWooCommerceActive: true)
+        storageManager.insertSampleSite(readOnlySite: testSite1)
+        storageManager.insertSampleSite(readOnlySite: testSite2)
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case let .synchronizeSites(_, onCompletion):
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
+
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: UUID().uuidString))
+        userDefaults.saveHiddenStoreIDs([testSite1.siteID])
+
+        let viewModel = StorePickerViewModel(configuration: .switchingStores,
+                                             stores: stores,
+                                             storageManager: storageManager,
+                                             userDefaults: userDefaults)
+        await viewModel.refreshSites(currentlySelectedSiteID: nil)
+        XCTAssertEqual(viewModel.displayedStores, [testSite2])
+
+        // When
+        viewModel.unhideStoreIfNeeded(testSite1.siteID)
+
+        // Then
+        XCTAssertTrue(userDefaults.hiddenStoreIDs.isEmpty)
+        XCTAssertEqual(viewModel.displayedStores, [testSite1, testSite2])
+    }
 }
 
 private extension StorePickerViewModelTests {


### PR DESCRIPTION
WOOMOB-2519

## Description

When a user enters a store URL during site discovery for a store that is already in their site picker, the app incorrectly shows an error screen (account mismatch for WPCom sites or Jetpack connection prompt for self-hosted sites) instead of recognizing the store.

This PR fixes site discovery to check whether the entered URL matches an already-connected store before showing error UI. If matched, the app navigates back to the store picker and selects that store. Hidden stores are also automatically unhidden when selected this way.

**Changes:**
- `AuthenticationManager.troubleshootSite` now checks `ULAccountMatcher` for all site types before falling through to error UI
- `StorePickerViewController.selectSite(_:)` allows programmatic site selection from the discovery flow
- `StorePickerViewModel.unhideStoreIfNeeded(_:)` unhides a store via the injected `UserDefaults`
- `UserDefaults.unhideStoreID(_:)` reusable helper for removing a single store from the hidden list

### Known issue (out of scope)

Entering a site URL for a store that is **not** in the account's site list also leads to the "Connect Jetpack" error screen, even when the site already has Jetpack connected. This is a separate issue — likely related to the site info / API discovery fallback logic — and is not addressed in this PR. Video below.

https://github.com/user-attachments/assets/0f51d773-1c1e-43d2-84a3-e06db9fe3b63

## Test Steps

1. Log in with WP.com into an account that has multiple stores
2. From the store picker, enter a URL of a store that is already in the list
3. Verify the app selects the store instead of showing an error
4. Hide a store from the list, then enter its URL in site discovery
5. Verify the store is unhidden and selected

## Before

https://github.com/user-attachments/assets/1f8c222a-783b-4a41-b642-2b566626ac59

## After

https://github.com/user-attachments/assets/f5573ba7-6e2d-4b98-b51f-b0cc0b97cd80

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.