### PR TITLE
Fix interactive dismiss not blocked for ProductSelector on iOS 18+

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -18,6 +18,7 @@
 - [*] Hide edit status button in order details and order edit form for CIAB sites [https://github.com/woocommerce/woocommerce-ios/pull/16827]
 - [*] Offer site credentials login when the site info check fails but the site has a WordPress REST API [https://github.com/woocommerce/woocommerce-ios/pull/16832]
 - [*] Display booking location from product data in booking details [https://github.com/woocommerce/woocommerce-ios/pull/16826]
+- [*] Fix sheets with discard-changes prompts being dismissable [https://github.com/woocommerce/woocommerce-ios/pull/16836]
 
 
 24.3

--- a/WooCommerce/Classes/View Modifiers/View+DiscardChanges.swift
+++ b/WooCommerce/Classes/View Modifiers/View+DiscardChanges.swift
@@ -108,7 +108,6 @@ struct CloseButtonWithDiscardPrompt<Label>: ViewModifier where Label: View {
                     }, label: closeButtonLabel)
                 }
             })
-            .interactiveDismissDisabled()
             .confirmationDialog(title, isPresented: $isShowingPrompt) {
                 Button(discardButtonTitle, role: .destructive, action: {
                     didDismiss?()

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -278,6 +278,7 @@ private extension CustomFieldsListView {
                 } : nil
             ))
         }
+        .interactiveDismissDisabled()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -163,6 +163,7 @@ struct AnalyticsHubView: View {
             NavigationView {
                 AnalyticsHubCustomizeView(viewModel: customizeViewModel)
             }
+            .interactiveDismissDisabled()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCustomizationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCustomizationView.swift
@@ -38,6 +38,7 @@ struct DashboardCustomizationView: View {
             .background(Color(uiColor: .listBackground))
             .closeButtonWithDiscardChangesPrompt(hasChanges: viewModel.hasChanges)
         }
+        .interactiveDismissDisabled()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -167,7 +167,8 @@ struct OrderFormPresentationWrapper: View {
                 }
                 .accessibilityIdentifier(OrderForm.Accessibility.cancelButtonIdentifier)
             },
-            isShowingSecondaryView: $viewModel.isProductSelectorPresented)
+            isShowingSecondaryView: $viewModel.isProductSelectorPresented,
+            isSecondaryViewInteractiveDismissable: false)
         // When we're side-by-side, show the notices over the combined screen
         .if(horizontalSizeClass == .regular, transform: {
             $0

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -191,7 +191,6 @@ struct ProductSelectorView: View {
                 // no-op
             }
         }
-        .interactiveDismissDisabled()
     }
 
     private func updateSyncApproach(for horizontalSizeClass: UserInterfaceSizeClass?) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorView.swift
@@ -105,7 +105,6 @@ struct ProductVariationSelectorView: View {
             viewModel.onLoadTrigger.send()
         }
         .notice($viewModel.notice, autoDismiss: false)
-        .interactiveDismissDisabled()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
@@ -19,13 +19,15 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View, DismissBut
     @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
     @ViewBuilder let dismissBarButton: () -> DismissButton
     @Binding var isShowingSecondaryView: Bool
+    var isSecondaryViewInteractiveDismissable: Bool = true
 
     var body: some View {
         if horizontalSizeClass == .compact {
             ModalOnModalView(primaryView: primaryView,
                              secondaryView: secondaryView,
                              dismissBarButton: dismissBarButton,
-                             isShowingSecondaryView: $isShowingSecondaryView)
+                             isShowingSecondaryView: $isShowingSecondaryView,
+                             isInteractiveDismissable: isSecondaryViewInteractiveDismissable)
                 .environment(\.adaptiveModalContainerPresentationStyle, .modalOnModal)
         } else {
             SideBySideView(primaryView: primaryView,
@@ -41,6 +43,7 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View, DismissBut
         @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
         @ViewBuilder let dismissBarButton: () -> DismissButton
         @Binding var isShowingSecondaryView: Bool
+        let isInteractiveDismissable: Bool
 
         var body: some View {
             NavigationView {
@@ -56,6 +59,7 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View, DismissBut
                     NavigationView {
                         secondaryView($isShowingSecondaryView)
                     }
+                    .interactiveDismissDisabled(!isInteractiveDismissable)
                 }
             }
             .navigationViewStyle(.stack)


### PR DESCRIPTION
Closes WOOMOB-65

## Description
On iOS 18+, .interactiveDismissDisabled() only works when applied on the direct content of the .sheet() closure — not when placed deeper in the view hierarchy. This caused several modal screens with discard-changes prompts to be dismissable via swipe, bypassing the confirmation dialog.

This PR moves .interactiveDismissDisabled() to the sheet content level for the affected screens:

- ProductSelector — via a new isSecondaryViewInteractiveDismissable parameter on AdaptiveModalContainer
- CustomFieldEditor — on the NavigationView returned by buildCustomFieldEditorView
- AnalyticsHub Customize — on the NavigationView wrapping AnalyticsHubCustomizeView
- Dashboard Customize — on the NavigationStack in DashboardCustomizationView

The redundant .interactiveDismissDisabled() calls inside ProductSelectorView, ProductVariationSelectorView, and CloseButtonWithDiscardPrompt have been removed.

## Test Steps
1. On iOS 18+ simulator, create a new order
2. Tap "Add Products" to open the product selector
3. Attempt to swipe down to dismiss — the sheet should not dismiss
4. Try swiping on the sheet content, edges, and navigation bar — none should dismiss the sheet

## Screenshots
| Case | Recording |
| --- | --- |
| Product selector | ![Simulator Screen Recording - iPhone 16 - 2026-03-19 at 12 41 57](https://github.com/user-attachments/assets/5c303de6-cc22-4dc4-89e9-97047c9758ee) |
| Custom property | ![Simulator Screen Recording - iPhone 16 - 2026-03-19 at 13 37 14](https://github.com/user-attachments/assets/517cce13-3e72-42a6-a43f-02fbd037c532) |
| Dashboard customization | ![Simulator Screen Recording - iPhone 16 - 2026-03-19 at 13 59 52](https://github.com/user-attachments/assets/6b5547d3-beef-4d63-8621-d9db487079ce) |
| Analytics customization | ![Simulator Screen Recording - iPhone 16 - 2026-03-19 at 14 00 38](https://github.com/user-attachments/assets/21cf922c-4b7d-4d52-80ce-3d70ff738553) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.