### PR TITLE
[Woo POS][Refunds] In order, hide already refunded products from product list

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -12,6 +12,7 @@ import struct Yosemite.POSRefundsResult
 import struct Yosemite.POSRefundableItem
 import struct Yosemite.POSRefundAmounts
 import struct Yosemite.POSOrderItem
+import struct Yosemite.POSOrderRefund
 import class Yosemite.Store
 import class Yosemite.AsyncPaginationTracker
 import protocol Experiments.FeatureFlagService
@@ -28,6 +29,7 @@ protocol POSOrderListControllerProtocol {
     var ordersViewState: POSOrderListState { get }
     var selectedOrder: POSOrder? { get }
     var isLoadingOrderRefunds: Bool { get }
+    var displayedLineItems: [POSOrderItem] { get }
     var refundActionAvailability: RefundActionAvailability { get }
     var refundSelectableItems: [POSRefundSelectableItem] { get }
     func loadOrders() async
@@ -108,6 +110,20 @@ enum RefundActionAvailability {
             return .unavailable
         }
         return .available
+    }
+
+    @MainActor
+    var displayedLineItems: [POSOrderItem] {
+        guard let order = selectedOrder else { return [] }
+        guard featureFlags.isFeatureFlagEnabled(.pointOfSaleRefundsi1),
+              !isLoadingOrderRefunds else {
+            return order.lineItems
+        }
+        let refundedQuantities = order.refunds.flatMap(\.items).refundedQuantitiesByItemID()
+        return order.lineItems.filter { item in
+            let refunded = refundedQuantities[item.itemID] ?? 0
+            return refunded < NSDecimalNumber(decimal: item.quantity).intValue
+        }
     }
 
     @MainActor

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -7,6 +7,7 @@ import protocol Yosemite.POSOrderListFetchStrategy
 import protocol Yosemite.POSRefundsServiceProtocol
 import struct Yosemite.POSOrder
 import struct Yosemite.POSRefund
+import struct Yosemite.POSRefundItem
 import struct Yosemite.POSRefundsResult
 import struct Yosemite.POSRefundableItem
 import struct Yosemite.POSRefundAmounts
@@ -283,7 +284,7 @@ enum RefundActionAvailability {
         }
 
         // Calculate already refunded quantities per itemID
-        let refundedQuantitiesByItemID = calculateRefundedQuantitiesByItemID(from: refundsResult.refunds)
+        let refundedQuantitiesByItemID = refundsResult.refunds.flatMap(\.items).refundedQuantitiesByItemID()
 
         // Build selectable items excluding already refunded quantities
         refundSelectableItems = order.lineItems.flatMap { item -> [POSRefundSelectableItem] in
@@ -300,19 +301,6 @@ enum RefundActionAvailability {
         return refundSelectableItems.isEmpty ? .nothingToRefund : .hasItemsToRefund
     }
 
-    /// Calculates the total refunded quantity for each itemID from previous refunds.
-    /// Note: API returns negative quantities for refunds, so we use abs().
-    private func calculateRefundedQuantitiesByItemID(from refunds: [POSRefund]) -> [Int64: Int] {
-        var refundedQuantities: [Int64: Int] = [:]
-        for refund in refunds {
-            for item in refund.items {
-                guard let refundedItemID = item.refundedItemID else { continue }
-                let quantity = NSDecimalNumber(decimal: abs(item.quantity)).intValue
-                refundedQuantities[refundedItemID, default: 0] += quantity
-            }
-        }
-        return refundedQuantities
-    }
 
     @MainActor
     func toggleRefundItemSelection(at index: Int) {

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -183,6 +183,7 @@ private extension POSOrderDetailsView {
         var quantities: [Int64: Int] = [:]
         for refund in order.refunds {
             for item in refund.items {
+                // Accumulate the total refunded quantity for each item ID in the dictionary
                 guard let itemID = item.refundedItemID else { continue }
                 quantities[itemID, default: 0] += abs(NSDecimalNumber(decimal: item.quantity).intValue)
             }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -167,7 +167,7 @@ private struct POSRefundNothingToRefundError: LocalizedError {
 // MARK: - Main Sections
 
 private extension POSOrderDetailsView {
-    private var displayedLineItems: [POSOrderItem] {
+    var displayedLineItems: [POSOrderItem] {
         guard shouldShowDedicatedRefundsSection,
               !orderListModel.ordersController.isLoadingOrderRefunds else {
             return order.lineItems
@@ -223,7 +223,7 @@ private extension POSOrderDetailsView {
     }
 
     @ViewBuilder
-    private var ghostRefundedProductRow: some View {
+    var ghostRefundedProductRow: some View {
         HStack(alignment: .center, spacing: POSSpacing.medium) {
             ghostLine(width: Constants.productImageSize, height: Constants.productImageSize)
 
@@ -238,7 +238,7 @@ private extension POSOrderDetailsView {
         }
     }
 
-    private func ghostLine(width: CGFloat, height: CGFloat) -> some View {
+    func ghostLine(width: CGFloat, height: CGFloat) -> some View {
         Rectangle()
             .fill(Color.posOnSurfaceVariantLowest)
             .frame(width: width, height: height)
@@ -299,7 +299,7 @@ private extension POSOrderDetailsView {
         .accessibilityLabel(headerBottomContentAccessibilityLabel(for: order))
     }
 
-    private func headerBottomContentAccessibilityLabel(for order: POSOrder) -> String {
+    func headerBottomContentAccessibilityLabel(for order: POSOrder) -> String {
         let date = dateFormatter.string(from: order.dateCreated)
         let email = order.customerEmail
         let status = order.status.localizedName
@@ -328,7 +328,7 @@ private extension POSOrderDetailsView {
         .accessibilityLabel(productRowAccessibilityLabel(for: item))
     }
 
-    private func productRowAccessibilityLabel(for item: POSOrderItem) -> String {
+    func productRowAccessibilityLabel(for item: POSOrderItem) -> String {
         let attributesText = item.attributes.isEmpty ? nil : item.attributes.map { "\($0.name): \($0.value)" }.joined(separator: ", ")
         return Localization.productRowAccessibilityLabel(
             name: item.name,

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -179,16 +179,8 @@ private extension POSOrderDetailsView {
         }
     }
 
-    private var refundedQuantitiesByItemID: [Int64: Int] {
-        var quantities: [Int64: Int] = [:]
-        for refund in order.refunds {
-            for item in refund.items {
-                // Accumulate the total refunded quantity for each item ID in the dictionary
-                guard let itemID = item.refundedItemID else { continue }
-                quantities[itemID, default: 0] += abs(NSDecimalNumber(decimal: item.quantity).intValue)
-            }
-        }
-        return quantities
+    var refundedQuantitiesByItemID: [Int64: Int] {
+        order.refunds.flatMap(\.items).refundedQuantitiesByItemID()
     }
 
     @ViewBuilder

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -55,8 +55,8 @@ struct POSOrderDetailsView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: POSSpacing.medium) {
-                    if !order.lineItems.isEmpty {
-                        productsSection(order)
+                    if !displayedLineItems.isEmpty {
+                        productsSection(displayedLineItems)
                     }
                     if shouldShowDedicatedRefundsSection && orderListModel.ordersController.isLoadingOrderRefunds {
                         ghostRefundedProductsSection
@@ -167,8 +167,31 @@ private struct POSRefundNothingToRefundError: LocalizedError {
 // MARK: - Main Sections
 
 private extension POSOrderDetailsView {
+    private var displayedLineItems: [POSOrderItem] {
+        guard shouldShowDedicatedRefundsSection,
+              !orderListModel.ordersController.isLoadingOrderRefunds else {
+            return order.lineItems
+        }
+        let refundedQuantities = refundedQuantitiesByItemID
+        return order.lineItems.filter { item in
+            let refunded = refundedQuantities[item.itemID] ?? 0
+            return refunded < NSDecimalNumber(decimal: item.quantity).intValue
+        }
+    }
+
+    private var refundedQuantitiesByItemID: [Int64: Int] {
+        var quantities: [Int64: Int] = [:]
+        for refund in order.refunds {
+            for item in refund.items {
+                guard let itemID = item.refundedItemID else { continue }
+                quantities[itemID, default: 0] += abs(NSDecimalNumber(decimal: item.quantity).intValue)
+            }
+        }
+        return quantities
+    }
+
     @ViewBuilder
-    func productsSection(_ order: POSOrder) -> some View {
+    func productsSection(_ items: [POSOrderItem]) -> some View {
         VStack(alignment: .leading, spacing: POSSpacing.medium) {
             Text(Localization.productsTitle)
                 .font(.posBodyXLargeRegular)
@@ -176,10 +199,10 @@ private extension POSOrderDetailsView {
                 .accessibilityAddTraits(.isHeader)
 
             VStack(spacing: POSSpacing.small) {
-                ForEach(Array(order.lineItems.enumerated()), id: \.element.itemID) { index, item in
+                ForEach(Array(items.enumerated()), id: \.element.itemID) { index, item in
                     productRow(item: item)
 
-                    if index < order.lineItems.count - 1 {
+                    if index < items.count - 1 {
                         divider
                     }
                 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -55,8 +55,8 @@ struct POSOrderDetailsView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: POSSpacing.medium) {
-                    if !displayedLineItems.isEmpty {
-                        productsSection(displayedLineItems)
+                    if !orderListModel.ordersController.displayedLineItems.isEmpty {
+                        productsSection(orderListModel.ordersController.displayedLineItems)
                     }
                     if shouldShowDedicatedRefundsSection && orderListModel.ordersController.isLoadingOrderRefunds {
                         ghostRefundedProductsSection
@@ -167,22 +167,6 @@ private struct POSRefundNothingToRefundError: LocalizedError {
 // MARK: - Main Sections
 
 private extension POSOrderDetailsView {
-    var displayedLineItems: [POSOrderItem] {
-        guard shouldShowDedicatedRefundsSection,
-              !orderListModel.ordersController.isLoadingOrderRefunds else {
-            return order.lineItems
-        }
-        let refundedQuantities = refundedQuantitiesByItemID
-        return order.lineItems.filter { item in
-            let refunded = refundedQuantities[item.itemID] ?? 0
-            return refunded < NSDecimalNumber(decimal: item.quantity).intValue
-        }
-    }
-
-    var refundedQuantitiesByItemID: [Int64: Int] {
-        order.refunds.flatMap(\.items).refundedQuantitiesByItemID()
-    }
-
     @ViewBuilder
     func productsSection(_ items: [POSOrderItem]) -> some View {
         VStack(alignment: .leading, spacing: POSSpacing.medium) {

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -840,6 +840,7 @@ final class POSConfigurablePreviewOrderListController: POSSearchingOrderListCont
     }
 
     var isLoadingOrderRefunds = false
+    var displayedLineItems: [POSOrderItem] { selectedOrder?.lineItems ?? [] }
     var refundActionAvailability: RefundActionAvailability { .available }
 
     func loadOrders() async {}

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundItem+RefundedQuantities.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundItem+RefundedQuantities.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public extension Array where Element == POSRefundItem {
+    /// Calculates the total refunded quantity for each original order item ID.
+    /// Note: API returns negative quantities for refunds, so we use abs().
+    func refundedQuantitiesByItemID() -> [Int64: Int] {
+        var quantities: [Int64: Int] = [:]
+        for item in self {
+            guard let itemID = item.refundedItemID else { continue }
+            let quantity = NSDecimalNumber(decimal: abs(item.quantity)).intValue
+            quantities[itemID, default: 0] += quantity
+        }
+        return quantities
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -1266,6 +1266,92 @@ final class POSOrderListControllerTests {
         #expect(sut.selectedOrder?.id == 2)
         #expect(sut.selectedOrder?.refunds.flatMap { $0.items }.isEmpty == true)
     }
+
+    @MainActor
+    @Test func test_displayedLineItems_when_loading_refunds_then_returns_all_items() async throws {
+        // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        let items = [makePOSOrderItem(itemID: 1), makePOSOrderItem(itemID: 2)]
+        let order = makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        sut.selectOrder(order)
+
+        // When — refunds are still loading
+        refundsService.shouldSuspendLoadOrderRefunds = true
+        let loadTask = Task { @MainActor in
+            await sut.loadOrderRefunds()
+        }
+        await refundsService.awaitLoadOrderRefundsCall()
+
+        // Then
+        #expect(sut.displayedLineItems.count == 2)
+
+        refundsService.resumeLoadOrderRefunds()
+        await loadTask.value
+    }
+
+    @MainActor
+    @Test func test_displayedLineItems_when_refunds_loaded_then_filters_fully_refunded_items() async throws {
+        // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        let items = [makePOSOrderItem(itemID: 1, quantity: 2), makePOSOrderItem(itemID: 2, quantity: 1)]
+        let order = makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        sut.selectOrder(order)
+        refundsService.loadOrderRefundsResultToReturn = [
+            POSOrderRefund(refundID: 1, formattedTotal: "-$10.00", items: [
+                POSRefundItem(refundedItemID: 2,
+                              quantity: -1,
+                              name: "Item B",
+                              formattedPrice: "$10.00",
+                              formattedTotal: "-$10.00",
+                              imageSrc: nil)
+            ])
+        ]
+
+        // When
+        await sut.loadOrderRefunds()
+
+        // Then — item 2 is fully refunded, only item 1 remains
+        #expect(sut.displayedLineItems.count == 1)
+        #expect(sut.displayedLineItems.first?.itemID == 1)
+    }
+
+    @MainActor
+    @Test func test_displayedLineItems_when_partially_refunded_then_includes_item() async throws {
+        // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        let items = [makePOSOrderItem(itemID: 1, quantity: 3)]
+        let order = makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        sut.selectOrder(order)
+        refundsService.loadOrderRefundsResultToReturn = [
+            POSOrderRefund(refundID: 1, formattedTotal: "-$10.00", items: [
+                POSRefundItem(refundedItemID: 1,
+                              quantity: -1,
+                              name: "Item A",
+                              formattedPrice: "$10.00",
+                              formattedTotal: "-$10.00",
+                              imageSrc: nil)
+            ])
+        ]
+
+        // When
+        await sut.loadOrderRefunds()
+
+        // Then — item 1 is only partially refunded, still displayed
+        #expect(sut.displayedLineItems.count == 1)
+        #expect(sut.displayedLineItems.first?.itemID == 1)
+    }
+
+    @MainActor
+    @Test func test_displayedLineItems_when_feature_flag_disabled_then_returns_all_items() async throws {
+        // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = false
+        let items = [makePOSOrderItem(itemID: 1), makePOSOrderItem(itemID: 2)]
+        let order = makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        sut.selectOrder(order)
+
+        // When/Then — all items returned regardless of refunds
+        #expect(sut.displayedLineItems.count == 2)
+    }
 }
 
 private extension POSOrderListControllerTests {

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
@@ -1,11 +1,13 @@
 import Foundation
 @testable import PointOfSale
 import struct Yosemite.POSOrder
+import struct Yosemite.POSOrderItem
 
 final class MockPOSOrderListController: POSSearchingOrderListControllerProtocol {
     var ordersViewState: POSOrderListState = .empty
     var selectedOrder: POSOrder?
     var isLoadingOrderRefunds = false
+    var displayedLineItems: [POSOrderItem] = []
     var refundActionAvailability: RefundActionAvailability = .available
     var refundSelectableItems: [POSRefundSelectableItem] = []
     var updateOrderCalled = false


### PR DESCRIPTION
Closes WOOMOB-2492

## Description

From CfT:
> One improvement I suggest is removing refunded items from the  and keeping them only in the 

At the moment refunded products appear in both “Products” section in Order Details, as well as “Refunded Products” section. This duplication is not necessary, so we remove them from "Products" if these have been refunded. For partially refunded products of the same type, these will still appear in both sections with the appropriate quantities.

The section rendering previously relied in the whole `POSOrder`. Now we rely on `[POSOrderItem]` instead for more granularity.

## Test Steps
0. In POS > Orders
1. Full refund. Shows no Products section, only Refunded Products

<img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2026-03-20 at 15 50 22" src="https://github.com/user-attachments/assets/39bf3df1-0c01-45ba-8f20-b4060d3c4f30" />

2. Partial refund. Shows both sections.

<img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2026-03-20 at 15 50 34" src="https://github.com/user-attachments/assets/7b2c65d2-c011-459e-ac0d-ccc2a3db0d8b" />

3. Partial refund: Refund some products of the same type, while keeping others. Shows both sections with appropriate quantities.

<img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2026-03-20 at 15 50 46" src="https://github.com/user-attachments/assets/fbf2e349-7ff5-4c2e-84b8-d69cdf915a8a" />
