### PR TITLE
[Woo POS][Refunds] Refund reason prompt improvements

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Bookings/BookingNote/POSBookingNoteView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/BookingNote/POSBookingNoteView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import Combine
 import WooFoundation
 import struct Yosemite.POSBooking
 
@@ -9,16 +8,11 @@ struct POSBookingNoteView: View {
     @State private var noteText: String
     @State private var buttonState: POSButtonState = .idle
     @State private var errorMessage: String?
-    @FocusState private var isTextFieldFocused: Bool
 
     @Environment(POSBookingsModel.self) private var bookingsModel
     @Environment(\.posAnalytics) private var analytics
 
     @Binding private(set) var isShowingNoteView: Bool
-
-    @State private var buttonFrame: CGRect = .zero
-    @State private var keyboardFrame: CGRect = .zero
-    @State private var shouldMinimizePadding: Bool = false
 
     private var originalNote: String
     @State private var isEditingExistingNote: Bool
@@ -37,72 +31,20 @@ struct POSBookingNoteView: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .center, spacing: conditionalPadding(POSSpacing.medium)) {
-                POSPageHeaderView(
-                    title: isEditingExistingNote ? Localization.editTitle : Localization.addTitle,
-                    backButtonConfiguration: .init(
-                        state: buttonState != .idle ? .disabled : .enabled,
-                        action: {
-                            withAnimation {
-                                isShowingNoteView = false
-                                isTextFieldFocused = false
-                            }
-                        }
-                    )
-                )
-
-                VStack(alignment: .center, spacing: conditionalPadding(POSSpacing.medium)) {
-                    Spacer()
-
-                    VStack(alignment: .center, spacing: POSSpacing.xSmall) {
-                        TextField("",
-                                  text: $noteText,
-                                  prompt: Text(Localization.placeholder).foregroundColor(.posOnDisabledContainer))
-                        .foregroundStyle(Color.posOnSurface)
-                        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
-                        .textInputAutocapitalization(.sentences)
-                        .multilineTextAlignment(.center)
-                        .font(POSFontStyle.posHeadingRegular)
-                        .focused()
-                        .focused($isTextFieldFocused)
-
-                        if let errorMessage {
-                            Text(errorMessage)
-                                .font(POSFontStyle.posBodySmallRegular())
-                                .foregroundColor(.posError)
-                        }
-                    }
-
-                    Spacer()
-
-                    Button(action: {
-                        saveNote()
-                    }, label: {
-                        Text(hasChanges ? Localization.saveButton : Localization.addButton)
-                    })
-                    .measureFrame {
-                        buttonFrame = $0
-                    }
-                    .buttonStyle(POSFilledButtonStyle(size: .normal, state: buttonState))
-                    .dynamicTypeSize(...DynamicTypeSize.accessibility3)
-                    .frame(maxWidth: .infinity)
-                    .disabled(buttonState != .idle || !hasChanges)
-                }
-                .padding([.horizontal])
-                .padding(.bottom, keyboardFrame.height)
-            }
-            .animation(.easeInOut, value: errorMessage)
-            .onChange(of: noteText) {
-                errorMessage = nil
-            }
-            .onReceive(Publishers.keyboardFrame) {
-                keyboardFrame = $0
-                shouldMinimizePadding = $0.intersects(buttonFrame)
-            }
-            .animation(.default, value: shouldMinimizePadding)
-        }
-        .background(Color.posSurfaceBright)
+        POSSingleFieldInputView(
+            title: isEditingExistingNote ? Localization.editTitle : Localization.addTitle,
+            placeholder: Localization.placeholder,
+            buttonTitle: hasChanges ? Localization.saveButton : Localization.addButton,
+            text: $noteText,
+            buttonState: $buttonState,
+            errorMessage: $errorMessage,
+            isButtonEnabled: hasChanges,
+            onSubmit: { saveNote() },
+            onClose: {
+                isShowingNoteView = false
+            },
+            autocapitalization: .sentences
+        )
     }
 
     private func saveNote() {
@@ -121,7 +63,6 @@ struct POSBookingNoteView: View {
                     buttonState = .success
                 } completion: {
                     isShowingNoteView = false
-                    isTextFieldFocused = false
                 }
             } catch {
                 analytics.track(event: WooAnalyticsEvent.PointOfSale.bookingNoteAddFailed(error: error))
@@ -129,21 +70,6 @@ struct POSBookingNoteView: View {
                 buttonState = .idle
             }
         }
-    }
-}
-
-// MARK: - Helpers
-
-private extension POSBookingNoteView {
-    enum Constants {
-        static let minimumPadding: CGFloat = POSSpacing.xSmall
-    }
-
-    func conditionalPadding(_ padding: CGFloat) -> CGFloat {
-        if shouldMinimizePadding {
-            return Constants.minimumPadding
-        }
-        return padding
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundLoadingView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundLoadingView.swift
@@ -14,7 +14,9 @@ struct POSRefundLoadingView: View {
                 .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity)
-        .padding(POSPadding.xLarge)
+        .padding(.horizontal, POSPadding.xLarge)
+        .padding(.bottom, POSPadding.xLarge)
+        .padding(.top, POSPadding.xxLarge)
         .background(Color.posSurfaceBright)
         .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
         .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding * 2))

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -83,6 +83,7 @@ struct POSRefundModalContentView: View {
     let errorStrings: POSRefundErrorStrings
 
     @State private var isShowingEmailReceiptView = false
+    @State private var currentRefundReason: String?
 
     var body: some View {
         content
@@ -149,6 +150,7 @@ struct POSRefundModalContentView: View {
                 onSave: { reason in
                     var updated = reviewData
                     updated.refundReason = reason
+                    currentRefundReason = reason
                     modalState = .review(updated)
                 },
                 onBack: { modalState = .review(reviewData) },
@@ -205,10 +207,11 @@ struct POSRefundModalContentView: View {
     }
 
     private func navigateToRefundReview() {
-        guard let reviewData = orderListModel.ordersController.preparePOSRefundReviewData() else {
+        guard var reviewData = orderListModel.ordersController.preparePOSRefundReviewData() else {
             modalState = .preparationError
             return
         }
+        reviewData.refundReason = currentRefundReason
         modalState = .review(reviewData)
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -153,10 +153,7 @@ struct POSRefundModalContentView: View {
                     currentRefundReason = reason
                     modalState = .review(updated)
                 },
-                onBack: { modalState = .review(reviewData) },
-                onClose: {
-                    dismissModal?()
-                }
+                onBack: { modalState = .review(reviewData) }
             )
         case .confirmation(let reviewData):
             POSRefundConfirmationView(

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -12,7 +12,6 @@ enum RefundModalState: Identifiable, Equatable {
     case nothingToRefund
     case itemSelection
     case review(POSRefundReviewData)
-    case reasonInput(POSRefundReviewData)
     case confirmation(POSRefundReviewData)
     case processing(POSRefundReviewData)
     case success(POSRefundReviewData)
@@ -26,7 +25,6 @@ enum RefundModalState: Identifiable, Equatable {
         case .nothingToRefund: return "nothingToRefund"
         case .itemSelection: return "itemSelection"
         case .review: return "review"
-        case .reasonInput: return "reasonInput"
         case .confirmation: return "confirmation"
         case .processing: return "processing"
         case .success: return "success"
@@ -39,7 +37,7 @@ enum RefundModalState: Identifiable, Equatable {
         switch self {
         case .itemSelection:
             return .selectItems
-        case .review, .reasonInput:
+        case .review:
             return .reviewRefund
         case .confirmation:
             return .confirmRefund
@@ -83,7 +81,9 @@ struct POSRefundModalContentView: View {
     let errorStrings: POSRefundErrorStrings
 
     @State private var isShowingEmailReceiptView = false
+    @State private var isShowingReasonInput = false
     @State private var currentRefundReason: String?
+    @State private var reasonInputReviewData: POSRefundReviewData?
 
     var body: some View {
         content
@@ -91,6 +91,21 @@ struct POSRefundModalContentView: View {
                 POSSendReceiptView(isShowingSendReceiptView: $isShowingEmailReceiptView) { email in
                     try await orderListModel.sendReceipt(order: order, email: email)
                 }
+                .posHeaderBackButtonIcon(systemName: "xmark")
+            }
+            .posFullScreenCover(isPresented: $isShowingReasonInput) {
+                POSRefundReasonView(
+                    initialReason: reasonInputReviewData?.refundReason,
+                    onSave: { reason in
+                        if var reviewData = reasonInputReviewData {
+                            reviewData.refundReason = reason
+                            currentRefundReason = reason
+                            modalState = .review(reviewData)
+                        }
+                        isShowingReasonInput = false
+                    },
+                    onClose: { isShowingReasonInput = false }
+                )
                 .posHeaderBackButtonIcon(systemName: "xmark")
             }
     }
@@ -140,20 +155,12 @@ struct POSRefundModalContentView: View {
                 formattedRefundTotal: reviewData.formattedRefundTotal,
                 paymentMethodDescription: reviewData.paymentMethodDescription,
                 refundReason: reviewData.refundReason,
-                onAddReason: { modalState = .reasonInput(reviewData) },
+                onAddReason: {
+                    reasonInputReviewData = reviewData
+                    isShowingReasonInput = true
+                },
                 onContinue: { modalState = .confirmation(reviewData) },
                 onEditRefund: onEditRefund
-            )
-        case .reasonInput(let reviewData):
-            POSRefundReasonView(
-                initialReason: reviewData.refundReason,
-                onSave: { reason in
-                    var updated = reviewData
-                    updated.refundReason = reason
-                    currentRefundReason = reason
-                    modalState = .review(updated)
-                },
-                onBack: { modalState = .review(reviewData) }
             )
         case .confirmation(let reviewData):
             POSRefundConfirmationView(

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReasonView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReasonView.swift
@@ -1,21 +1,21 @@
 import SwiftUI
 
 struct POSRefundReasonView: View {
-    @Environment(\.posModalParentSize) private var parentSize
     @State private var reasonText: String
-    @FocusState private var isTextFieldFocused: Bool
+    @State private var buttonState: POSButtonState = .idle
+    @State private var errorMessage: String?
 
     private let initialReason: String?
     private let onSave: (String) -> Void
-    private let onBack: () -> Void
+    private let onClose: () -> Void
 
     init(initialReason: String?,
          onSave: @escaping (String) -> Void,
-         onBack: @escaping () -> Void) {
+         onClose: @escaping () -> Void) {
         self._reasonText = State(initialValue: initialReason ?? "")
         self.initialReason = initialReason
         self.onSave = onSave
-        self.onBack = onBack
+        self.onClose = onClose
     }
 
     private var isAddButtonEnabled: Bool {
@@ -23,63 +23,17 @@ struct POSRefundReasonView: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .center, spacing: POSSpacing.medium) {
-                POSPageHeaderView(
-                    title: Localization.title,
-                    backButtonConfiguration: .init(
-                        state: .enabled,
-                        action: onBack
-                    )
-                )
-
-                VStack(alignment: .center, spacing: POSSpacing.medium) {
-                    Spacer()
-
-                    textFieldView
-
-                    Spacer()
-
-                    buttonSection
-                }
-                .padding([.horizontal])
-            }
-        }
-        .background(Color.posSurfaceBright)
-        .posModalFullScreen()
-        .onAppear {
-            isTextFieldFocused = true
-        }
-    }
-}
-
-// MARK: - Subviews
-
-private extension POSRefundReasonView {
-    var textFieldView: some View {
-        TextField("",
-                  text: $reasonText,
-                  prompt: Text(Localization.placeholder).foregroundColor(.posOnSurfaceVariantLowest))
-            .foregroundStyle(Color.posOnSurface)
-            .dynamicTypeSize(...DynamicTypeSize.accessibility1)
-            .multilineTextAlignment(.center)
-            .font(POSFontStyle.posHeadingRegular)
-            .focused($isTextFieldFocused)
-            .onSubmit {
-                saveReasonIfValid()
-            }
-            .padding(.horizontal, POSPadding.xLarge)
-    }
-
-    var buttonSection: some View {
-        Button(action: {
-            saveReasonIfValid()
-        }, label: {
-            Text(Localization.addButton)
-        })
-        .buttonStyle(POSFilledButtonStyle(size: .normal))
-        .disabled(!isAddButtonEnabled)
-        .padding(.horizontal, POSPadding.xLarge)
+        POSSingleFieldInputView(
+            title: Localization.title,
+            placeholder: Localization.placeholder,
+            buttonTitle: Localization.addButton,
+            text: $reasonText,
+            buttonState: $buttonState,
+            errorMessage: $errorMessage,
+            isButtonEnabled: isAddButtonEnabled,
+            onSubmit: { saveReasonIfValid() },
+            onClose: onClose
+        )
     }
 }
 
@@ -122,17 +76,15 @@ private extension POSRefundReasonView {
     POSRefundReasonView(
         initialReason: nil,
         onSave: { _ in },
-        onBack: {}
+        onClose: {}
     )
-    .environmentObject(POSModalManager())
 }
 
 #Preview("POSRefundReasonView - With Existing Reason") {
     POSRefundReasonView(
         initialReason: "Customer not happy with the order.",
         onSave: { _ in },
-        onBack: {}
+        onClose: {}
     )
-    .environmentObject(POSModalManager())
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReasonView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReasonView.swift
@@ -8,17 +8,14 @@ struct POSRefundReasonView: View {
     private let initialReason: String?
     private let onSave: (String) -> Void
     private let onBack: () -> Void
-    private let onClose: () -> Void
 
     init(initialReason: String?,
          onSave: @escaping (String) -> Void,
-         onBack: @escaping () -> Void,
-         onClose: @escaping () -> Void) {
+         onBack: @escaping () -> Void) {
         self._reasonText = State(initialValue: initialReason ?? "")
         self.initialReason = initialReason
         self.onSave = onSave
         self.onBack = onBack
-        self.onClose = onClose
     }
 
     private var isAddButtonEnabled: Bool {
@@ -68,14 +65,6 @@ private extension POSRefundReasonView {
                 .lineLimit(1)
 
             Spacer()
-
-            Button {
-                onClose()
-            } label: {
-                Text(Image(systemName: "xmark"))
-                    .font(.posButtonSymbolLarge)
-            }
-            .accessibilityLabel(Localization.closeButtonAccessibilityLabel)
         }
         .foregroundColor(Color.posOnSurface)
         .padding(POSPadding.xLarge)
@@ -134,12 +123,6 @@ private extension POSRefundReasonView {
             comment: "Accessibility label for back button on refund reason screen"
         )
 
-        static let closeButtonAccessibilityLabel = NSLocalizedString(
-            "pos.refundReasonView.closeButton.accessibilityLabel",
-            value: "Close",
-            comment: "Accessibility label for close button on refund reason screen"
-        )
-
         static let placeholder = NSLocalizedString(
             "pos.refundReasonView.placeholder",
             value: "Reason for refunding order",
@@ -159,8 +142,7 @@ private extension POSRefundReasonView {
     POSRefundReasonView(
         initialReason: nil,
         onSave: { _ in },
-        onBack: {},
-        onClose: {}
+        onBack: {}
     )
     .environmentObject(POSModalManager())
 }
@@ -169,8 +151,7 @@ private extension POSRefundReasonView {
     POSRefundReasonView(
         initialReason: "Customer not happy with the order.",
         onSave: { _ in },
-        onBack: {},
-        onClose: {}
+        onBack: {}
     )
     .environmentObject(POSModalManager())
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReasonView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReasonView.swift
@@ -23,21 +23,28 @@ struct POSRefundReasonView: View {
     }
 
     var body: some View {
-        VStack(spacing: POSSpacing.none) {
-            headerView
+        ScrollView {
+            VStack(alignment: .center, spacing: POSSpacing.medium) {
+                POSPageHeaderView(
+                    title: Localization.title,
+                    backButtonConfiguration: .init(
+                        state: .enabled,
+                        action: onBack
+                    )
+                )
 
-            Spacer()
+                VStack(alignment: .center, spacing: POSSpacing.medium) {
+                    Spacer()
 
-            textFieldView
+                    textFieldView
 
-            Spacer()
+                    Spacer()
+
+                    buttonSection
+                }
+                .padding([.horizontal])
+            }
         }
-        .safeAreaInset(edge: .bottom) {
-            buttonSection
-                .padding(.bottom, POSPadding.xLarge)
-                .background(Color.posSurfaceBright)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.posSurfaceBright)
         .posModalFullScreen()
         .onAppear {
@@ -49,27 +56,6 @@ struct POSRefundReasonView: View {
 // MARK: - Subviews
 
 private extension POSRefundReasonView {
-    var headerView: some View {
-        HStack(spacing: POSSpacing.medium) {
-            Button {
-                onBack()
-            } label: {
-                Text(Image(systemName: "chevron.backward"))
-                    .font(.posButtonSymbolLarge)
-            }
-            .accessibilityLabel(Localization.backButtonAccessibilityLabel)
-
-            Text(Localization.title)
-                .font(.posHeadingBold)
-                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
-                .lineLimit(1)
-
-            Spacer()
-        }
-        .foregroundColor(Color.posOnSurface)
-        .padding(POSPadding.xLarge)
-    }
-
     var textFieldView: some View {
         TextField("",
                   text: $reasonText,
@@ -115,12 +101,6 @@ private extension POSRefundReasonView {
             "pos.refundReasonView.title",
             value: "Refund reason",
             comment: "Title for the refund reason input screen"
-        )
-
-        static let backButtonAccessibilityLabel = NSLocalizedString(
-            "pos.refundReasonView.backButton.accessibilityLabel",
-            value: "Back",
-            comment: "Accessibility label for back button on refund reason screen"
         )
 
         static let placeholder = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
@@ -111,7 +111,7 @@ private extension POSRefundReviewView {
             }
             Text(refundReason ?? Localization.reasonPlaceholder)
                 .font(.posBodyMediumRegular())
-                .foregroundColor(.posOnSurfaceVariantHighest)
+                .foregroundColor(refundReason != nil ? .posOnSurfaceVariantHighest : .posOnSurfaceVariantLowest)
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import Combine
 import WooFoundation
 import class WordPressShared.EmailFormatValidator
 
@@ -7,15 +6,10 @@ struct POSSendReceiptView: View {
     @State private var textFieldInput: String = ""
     @State private var buttonState: POSButtonState = .idle
     @State private var errorMessage: String?
-    @FocusState private var isTextFieldFocused: Bool
     @Environment(\.posAnalytics) private var analytics
 
     @Binding private(set) var isShowingSendReceiptView: Bool
     private let onSendReceipt: (String) async throws -> Void
-
-    @State private var buttonFrame: CGRect = .zero
-    @State private var keyboardFrame: CGRect = .zero
-    @State private var shouldMinimizePadding: Bool = false
 
     init(isShowingSendReceiptView: Binding<Bool>, onSendReceipt: @escaping (String) async throws -> Void) {
         self._isShowingSendReceiptView = isShowingSendReceiptView
@@ -27,73 +21,22 @@ struct POSSendReceiptView: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .center, spacing: conditionalPadding(POSSpacing.medium)) {
-                POSPageHeaderView(title: Localization.emailReceiptNavigationText,
-                                  backButtonConfiguration: .init(state: buttonState != .idle ? .disabled: .enabled,
-                                                                 action: {
-                    withAnimation {
-                        isShowingSendReceiptView = false
-                        isTextFieldFocused = false
-                    }
-                }))
-
-                VStack(alignment: .center, spacing: conditionalPadding(POSSpacing.medium)) {
-                    Spacer()
-
-                    VStack(alignment: .center, spacing: POSSpacing.xSmall) {
-                        TextField("",
-                                  text: $textFieldInput,
-                                  prompt: Text(Localization.textfieldPlaceholder).foregroundColor(.posOnDisabledContainer))
-                        .foregroundStyle(Color.posOnSurface)
-                        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
-                        .keyboardType(.emailAddress)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
-                        .multilineTextAlignment(.center)
-                        .font(POSFontStyle.posHeadingRegular)
-                        .focused()
-                        .focused($isTextFieldFocused)
-                        .onSubmit {
-                            sendReceipt()
-                        }
-
-                        if let errorMessage {
-                            Text(errorMessage)
-                                .font(POSFontStyle.posBodySmallRegular())
-                                .foregroundColor(.posError)
-                        }
-                    }
-
-                    Spacer()
-
-                    Button(action: {
-                        sendReceipt()
-                    }, label: {
-                        Text(Localization.buttonTitle)
-                    })
-                    .measureFrame {
-                        buttonFrame = $0
-                    }
-                    .buttonStyle(POSFilledButtonStyle(size: .normal, state: buttonState))
-                    .dynamicTypeSize(...DynamicTypeSize.accessibility3)
-                    .frame(maxWidth: .infinity)
-                    .disabled(buttonState != .idle)
-                }
-                .padding([.horizontal])
-                .padding(.bottom, keyboardFrame.height)
-            }
-            .animation(.easeInOut, value: errorMessage)
-            .onChange(of: textFieldInput) {
-                errorMessage = nil
-            }
-            .onReceive(Publishers.keyboardFrame) {
-                keyboardFrame = $0
-                shouldMinimizePadding = $0.intersects(buttonFrame)
-            }
-            .animation(.default, value: shouldMinimizePadding)
-        }
-        .background(Color.posSurfaceBright)
+        POSSingleFieldInputView(
+            title: Localization.emailReceiptNavigationText,
+            placeholder: Localization.textfieldPlaceholder,
+            buttonTitle: Localization.buttonTitle,
+            text: $textFieldInput,
+            buttonState: $buttonState,
+            errorMessage: $errorMessage,
+            isButtonEnabled: true,
+            onSubmit: { sendReceipt() },
+            onClose: {
+                isShowingSendReceiptView = false
+            },
+            keyboardType: .emailAddress,
+            autocapitalization: .never,
+            disableAutocorrection: true
+        )
     }
 
     private func sendReceipt() {
@@ -112,26 +55,12 @@ struct POSSendReceiptView: View {
                     buttonState = .success
                 } completion: {
                     isShowingSendReceiptView = false
-                    isTextFieldFocused = false
                 }
             } catch {
                 errorMessage = Localization.sendReceiptErrorText
                 buttonState = .idle
             }
         }
-    }
-}
-
-private extension POSSendReceiptView {
-    enum Constants {
-        static let minimumPadding: CGFloat = POSSpacing.xSmall
-    }
-
-    private func conditionalPadding(_ padding: CGFloat) -> CGFloat {
-        if shouldMinimizePadding {
-            return Constants.minimumPadding
-        }
-        return padding
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSSingleFieldInputView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSSingleFieldInputView.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+import Combine
+import WooFoundation
+
+/// A reusable single-field input view with a header, centered text field, and action button.
+///
+/// Used by views that follow the pattern: navigation header + centered text input + primary button.
+/// Handles keyboard tracking, conditional padding, error display, and button state management.
+///
+/// Consumers provide domain-specific logic for validation, async actions, and analytics
+struct POSSingleFieldInputView: View {
+    let title: String
+    let placeholder: String
+    let buttonTitle: String
+    @Binding var text: String
+    @Binding var buttonState: POSButtonState
+    @Binding var errorMessage: String?
+    let isButtonEnabled: Bool
+    let onSubmit: () -> Void
+    let onClose: () -> Void
+
+    var keyboardType: UIKeyboardType = .default
+    var autocapitalization: TextInputAutocapitalization = .sentences
+    var disableAutocorrection: Bool = false
+
+    @FocusState private var isTextFieldFocused: Bool
+
+    @State private var buttonFrame: CGRect = .zero
+    @State private var keyboardFrame: CGRect = .zero
+    @State private var shouldMinimizePadding: Bool = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .center, spacing: conditionalPadding(POSSpacing.medium)) {
+                POSPageHeaderView(
+                    title: title,
+                    backButtonConfiguration: .init(
+                        state: buttonState != .idle ? .disabled : .enabled,
+                        action: {
+                            withAnimation {
+                                onClose()
+                                isTextFieldFocused = false
+                            }
+                        }
+                    )
+                )
+
+                VStack(alignment: .center, spacing: conditionalPadding(POSSpacing.medium)) {
+                    Spacer()
+
+                    VStack(alignment: .center, spacing: POSSpacing.xSmall) {
+                        TextField("",
+                                  text: $text,
+                                  prompt: Text(placeholder).foregroundColor(.posOnDisabledContainer))
+                        .foregroundStyle(Color.posOnSurface)
+                        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+                        .keyboardType(keyboardType)
+                        .textInputAutocapitalization(autocapitalization)
+                        .autocorrectionDisabled(disableAutocorrection)
+                        .multilineTextAlignment(.center)
+                        .font(POSFontStyle.posHeadingRegular)
+                        .focused()
+                        .focused($isTextFieldFocused)
+                        .onSubmit {
+                            onSubmit()
+                        }
+
+                        if let errorMessage {
+                            Text(errorMessage)
+                                .font(POSFontStyle.posBodySmallRegular())
+                                .foregroundColor(.posError)
+                        }
+                    }
+
+                    Spacer()
+
+                    Button(action: {
+                        onSubmit()
+                    }, label: {
+                        Text(buttonTitle)
+                    })
+                    .measureFrame {
+                        buttonFrame = $0
+                    }
+                    .buttonStyle(POSFilledButtonStyle(size: .normal, state: buttonState))
+                    .dynamicTypeSize(...DynamicTypeSize.accessibility3)
+                    .frame(maxWidth: .infinity)
+                    .disabled(buttonState != .idle || !isButtonEnabled)
+                }
+                .padding(.horizontal, POSPadding.medium)
+                .padding(.bottom, keyboardFrame.height)
+            }
+            .animation(.easeInOut, value: errorMessage)
+            .onChange(of: text) {
+                errorMessage = nil
+            }
+            .onReceive(Publishers.keyboardFrame) {
+                keyboardFrame = $0
+                shouldMinimizePadding = $0.intersects(buttonFrame)
+            }
+            .animation(.default, value: shouldMinimizePadding)
+        }
+        .background(Color.posSurfaceBright)
+    }
+}
+
+// MARK: - Helpers
+
+private extension POSSingleFieldInputView {
+    enum Constants {
+        static let minimumPadding: CGFloat = POSSpacing.xSmall
+    }
+
+    func conditionalPadding(_ padding: CGFloat) -> CGFloat {
+        if shouldMinimizePadding {
+            return Constants.minimumPadding
+        }
+        return padding
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+#Preview("Default") {
+    POSSingleFieldInputView(
+        title: "Email receipt",
+        placeholder: "Type email",
+        buttonTitle: "Send",
+        text: .constant(""),
+        buttonState: .constant(.idle),
+        errorMessage: .constant(nil),
+        isButtonEnabled: false,
+        onSubmit: {},
+        onClose: {},
+        keyboardType: .emailAddress,
+        autocapitalization: .never,
+        disableAutocorrection: true
+    )
+}
+
+#Preview("With Error") {
+    POSSingleFieldInputView(
+        title: "Add note",
+        placeholder: "Type note",
+        buttonTitle: "Add",
+        text: .constant("Some text"),
+        buttonState: .constant(.idle),
+        errorMessage: .constant("Failed to save. Try again."),
+        isButtonEnabled: true,
+        onSubmit: {},
+        onClose: {}
+    )
+}
+
+#Preview("Loading") {
+    POSSingleFieldInputView(
+        title: "Refund reason",
+        placeholder: "Reason for refunding order",
+        buttonTitle: "Add",
+        text: .constant("Customer request"),
+        buttonState: .constant(.loading),
+        errorMessage: .constant(nil),
+        isButtonEnabled: true,
+        onSubmit: {},
+        onClose: {}
+    )
+}
+#endif


### PR DESCRIPTION
Closes WOOMOB-2494

## Description
Addresses 4 items from CfT: 
- _The navigation bar appears higher compared to add note_
- _The close button in the reason screen closes the whole refund flow_
- _refund reason disappears after going back to “Select items to refund” step._ 
- _“Reason for refunding order”_ looks like the reason itself. Placeholder text has the same style as the reason text

https://github.com/user-attachments/assets/ebd66473-7d09-4520-aaa2-96b7fa10301b

## Test Steps
- In POS > Orders, on an order with refundable items: 
  - Enter a reason for refunding > Press on `<` at the top to go back to previous step, there is no longer a `x` button that closes the flow for consistency with the rest of navigation (this differs from designs on purpose).
  - Enter a reason for refunding > Continue > Tap "Back" on the confirmation screen > Note that the reason still persists
  - Note "Reason for refunding order" using a lighter text than once reason is entered 
