### PR TITLE
Fix Jetpack setup during login

### DIFF
--- a/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -113,7 +113,7 @@ final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
                                                                password: password,
                                                                loginURL: loginURL,
                                                                adminURL: adminURL)
-            self.network = WordPressOrgNetwork(configuration: config)
+            self.network = WordPressOrgNetwork(configuration: config, siteAddress: siteAddress)
             self.discoveryTask = Task {
                 guard rootCache.root(for: siteAddress) == nil else { return }
                 _ = await WordPressAPIDiscovery().discoverRESTAPIRootURL(for: siteAddress)

--- a/Modules/Sources/NetworkingCore/Network/WordPressOrgNetwork.swift
+++ b/Modules/Sources/NetworkingCore/Network/WordPressOrgNetwork.swift
@@ -24,6 +24,7 @@ public final class WordPressOrgNetwork: Network {
 
     private let authenticator: CookieNonceAuthenticator
     private let userAgent: String?
+    private let requestConverter: RequestConverter
 
     private lazy var alamofireSession: Alamofire.Session = {
         makeSession(configuration: .default)
@@ -31,12 +32,16 @@ public final class WordPressOrgNetwork: Network {
 
     public var session: URLSession { alamofireSession.session }
 
-    public init(configuration: CookieNonceAuthenticatorConfiguration, userAgent: String = UserAgent.defaultUserAgent) {
+    public init(configuration: CookieNonceAuthenticatorConfiguration,
+                siteAddress: String,
+                userAgent: String = UserAgent.defaultUserAgent) {
         self.authenticator = CookieNonceAuthenticator(configuration: configuration)
         self.userAgent = userAgent
+        self.requestConverter = RequestConverter(siteAddress: siteAddress)
     }
 
     public func responseData(for request: URLRequestConvertible) async throws -> Data? {
+        let request = requestConverter.convert(request)
         return try await withCheckedThrowingContinuation { [weak self] continuation in
             guard let self = self else { return }
 
@@ -70,6 +75,7 @@ public final class WordPressOrgNetwork: Network {
     ///     - completion: Closure to be executed upon completion.
     ///
     public func responseData(for request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void) {
+        let request = requestConverter.convert(request)
         alamofireSession.request(request)
             .validate()
             .responseData { response in
@@ -92,6 +98,7 @@ public final class WordPressOrgNetwork: Network {
     ///     - completion: Closure to be executed upon completion.
     ///
     public func responseData(for request: URLRequestConvertible, completion: @escaping (Swift.Result<Data, Error>) -> Void) {
+        let request = requestConverter.convert(request)
         alamofireSession.request(request)
             .validate()
             .responseData { response in
@@ -105,6 +112,7 @@ public final class WordPressOrgNetwork: Network {
     }
 
     public func responseDataAndHeaders(for request: URLRequestConvertible) async throws -> (Data, ResponseHeaders?) {
+        let request = requestConverter.convert(request)
         let sessionRequest = alamofireSession.request(request).validate()
         let response = await sessionRequest.serializingData().response
         do {
@@ -129,6 +137,7 @@ public final class WordPressOrgNetwork: Network {
     /// - Parameter request: Request that should be performed.
     /// - Returns: A publisher that emits the result of the given request.
     public func responseDataPublisher(for request: URLRequestConvertible) -> AnyPublisher<Swift.Result<Data, Error>, Never> {
+        let request = requestConverter.convert(request)
         return Future() { [weak self] promise in
             guard let self = self else { return }
             self.alamofireSession.request(request).validate().responseData { response in
@@ -146,6 +155,7 @@ public final class WordPressOrgNetwork: Network {
     public func uploadMultipartFormData(multipartFormData: @escaping (MultipartFormData) -> Void,
                                         to request: URLRequestConvertible,
                                         completion: @escaping (Data?, Error?) -> Void) {
+        let request = requestConverter.convert(request)
         alamofireSession
             .upload(multipartFormData: multipartFormData, with: request)
             .responseData() { response in

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
@@ -82,7 +82,7 @@ private extension SiteCredentialLoginViewModel {
         }
 
         // Clear old cookies to avoid reusing a previous session's nonce with new credentials.
-        clearAllCookies()
+        clearCookies(for: siteURL)
 
         // Prepares the authenticator with username and password
         let config = CookieNonceAuthenticatorConfiguration(username: username,
@@ -133,12 +133,9 @@ private extension SiteCredentialLoginViewModel {
         successHandler()
     }
 
-    func clearAllCookies() {
-        if let cookies = cookieJar.cookies {
-            for cookie in cookies {
-                cookieJar.deleteCookie(cookie)
-            }
-        }
+    func clearCookies(for siteURL: String) {
+        guard let url = URL(string: siteURL) else { return }
+        cookieJar.cookies(for: url)?.forEach { cookieJar.deleteCookie($0) }
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
@@ -21,6 +21,7 @@ final class SiteCredentialLoginViewModel: NSObject, ObservableObject {
     private let stores: StoresManager
     private let successHandler: () -> Void
     private let analytics: Analytics
+    private let cookieJar: HTTPCookieStorage
 
     private var loginFields: LoginFields {
         let loginFields = LoginFields()
@@ -34,11 +35,13 @@ final class SiteCredentialLoginViewModel: NSObject, ObservableObject {
     init(siteURL: String,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
+         cookieJar: HTTPCookieStorage = HTTPCookieStorage.shared,
          onLoginSuccess: @escaping () -> Void = {}) {
         self.siteURL = siteURL
         self.stores = stores
         self.analytics = analytics
         self.successHandler = onLoginSuccess
+        self.cookieJar = cookieJar
         super.init()
         configurePrimaryButton()
     }
@@ -77,6 +80,10 @@ private extension SiteCredentialLoginViewModel {
             isLoggingIn = false
             return
         }
+
+        // Clear old cookies to avoid reusing a previous session's nonce with new credentials.
+        clearAllCookies()
+
         // Prepares the authenticator with username and password
         let config = CookieNonceAuthenticatorConfiguration(username: username,
                                                            password: password,
@@ -124,6 +131,14 @@ private extension SiteCredentialLoginViewModel {
     func handleCompletion() {
         analytics.track(.loginJetpackSiteCredentialDidFinishLogin)
         successHandler()
+    }
+
+    func clearAllCookies() {
+        if let cookies = cookieJar.cookies {
+            for cookie in cookies {
+                cookieJar.deleteCookie(cookie)
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
@@ -82,7 +82,7 @@ private extension SiteCredentialLoginViewModel {
                                                            password: password,
                                                            loginURL: loginURL,
                                                            adminURL: adminURL)
-        let network = WordPressOrgNetwork(configuration: config)
+        let network = WordPressOrgNetwork(configuration: config, siteAddress: siteURL)
         let authenticationAction = JetpackConnectionAction.authenticate(siteURL: siteURL, network: network)
         stores.dispatch(authenticationAction)
     }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -221,7 +221,7 @@ private extension WrongAccountErrorViewModel {
 
             switch result {
             case .success(let siteInfo):
-                self.isSelfHostedSite = !siteInfo.isWPCom
+                self.isSelfHostedSite = !siteInfo.isWPCom && !siteInfo.isCommerceGarden
             case .failure(let error):
                 DDLogWarn("⚠️ Error fetching site info: \(error)")
             }


### PR DESCRIPTION
Closes: WOOMOB-2531

## Description

Context: Jetpack connection during login requires site credential login as the user's WPCom account is not connected to the remote site yet.

PR #16816 changed `JetpackConnectionRemote` from `RESTRequest` to `JetpackRequest` for several methods. This works for the non-login flow (`JetpackSetupCoordinator`) which uses `AlamofireNetwork` — it has a `RequestConverter` that converts `JetpackRequest` to `RESTRequest` when needed.

However, the login flow (`SiteCredentialLoginViewModel`) uses `WordPressOrgNetwork` (cookie auth), which had no `RequestConverter`. This meant `JetpackRequest` would generate a WPCom tunnel URL authenticated with WPCom credentials. This causes the setup to fail during login.

This fix adds a `RequestConverter` to `WordPressOrgNetwork`, matching the pattern already used by `AlamofireNetwork`. The converter automatically converts `JetpackRequest(availableAsRESTRequest: true)` into `RESTRequest` before making network calls. The `siteAddress` parameter is now required in the `WordPressOrgNetwork` initializer to ensure the converter always has the site URL.

Notes:
- Jetpack connection is now blocked for CIAB sites as site credentials are not obvious to find for these sites.
- There are existing issues with sites that block site credential login (e.g. with captcha). This should be addressed in a separate issue targeting trunk, as the fix would not be trivial.


## Test Steps

1. Log in to a Jetpack store with a WPCom account that's not connected to that store.
2. On the wrong account modal, select Connect Jetpack.
3. Enter incorrect site credentials for the store.
4. Verify that an error is displayed for incorrect credentials.
5. Enter correct site credentials.
6. Verify the Jetpack connection data is fetched correctly.

## Screenshots

Self-hosted sites:

https://github.com/user-attachments/assets/1a93778e-e608-417b-8157-26b1b28adc17


WPCom/CIAB sites:

<img width="320" alt="Simulator Screenshot - iPhone 17 - 2026-03-28 at 22 28 04" src="https://github.com/user-attachments/assets/7f288daa-a6aa-450c-807a-a043fd9276f3" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.