### PR TITLE
Fix bottom sheet opening collapsed in edit flows

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -23,7 +23,7 @@ final class AddEditCouponHostingController: UIHostingController<AddEditCoupon> {
                 self.presentedViewController?.dismiss(animated: true, completion: nil)
             }
             let bottomSheet = BottomSheetListSelectorViewController(viewProperties: viewProperties, command: command, onDismiss: nil)
-            let bottomSheetViewController = BottomSheetViewController(childViewController: bottomSheet)
+            let bottomSheetViewController = BottomSheetViewController(childViewController: bottomSheet, initialPosition: .expanded)
             bottomSheetViewController.show(from: self)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1652,7 +1652,7 @@ private extension ProductFormViewController {
                 self?.viewModel.updateProductType(productType: selectedProductType)
             })
         }
-        let productTypesListPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command)
+        let productTypesListPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command, initialPosition: .expanded)
         productTypesListPresenter.show(from: self, sourceView: cell, arrowDirections: .any)
     }
 }


### PR DESCRIPTION
## Description

Follow-up on #16806.

I've realized that the edit case for the coupon and product type selection needs updating as well.

## Test Steps

1. Log in to any store
2. Open any product.
3. Tap on the row "Product type"
4. Note that the bottom drawer opens with all options shown
5. Navigate the Menu/Coupons
6. Open a coupon
7. Tap "..."/Edit Coupon
8. Tap Discount Type
9.  Note that the bottom drawer opens with all options shown

## Screenshots

|  | Before | After |
| --- | --- | --- |
| Coupon | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-20 at 13 37 52" src="https://github.com/user-attachments/assets/2a3f6af2-101e-44ed-8d98-6d5b565e434d" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-20 at 13 42 47" src="https://github.com/user-attachments/assets/9643ccfe-ac17-46c1-89c4-199698cb0fdc" /> |
| Product | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-20 at 13 38 31" src="https://github.com/user-attachments/assets/9ab1e5f3-b19f-4a94-bf4b-d20546258e60" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-20 at 13 42 35" src="https://github.com/user-attachments/assets/269c9582-35c7-4185-93d5-9fb622a3d2c9" /> |
---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.