### PR TITLE
Update activesupport to fix security vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.8)
     abbrev (0.1.2)
-    activesupport (8.1.2)
+    activesupport (8.1.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -258,7 +258,7 @@ GEM
       concurrent-ruby (~> 1.0)
     java-properties (0.3.0)
     jmespath (1.6.2)
-    json (2.18.0)
+    json (2.19.3)
     jwt (2.10.2)
       base64
     kramdown (2.5.1)
@@ -272,7 +272,8 @@ GEM
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (6.0.1)
+    minitest (6.0.2)
+      drb (~> 2.0)
       prism (~> 1.5)
     multi_json (1.19.1)
     multipart-post (2.4.1)
@@ -300,7 +301,7 @@ GEM
     prime (0.1.4)
       forwardable
       singleton
-    prism (1.8.0)
+    prism (1.9.0)
     progress_bar (1.3.4)
       highline (>= 1.6)
       options (~> 2.3.0)


### PR DESCRIPTION
## Summary
- Updates `activesupport` gem to fix three security vulnerabilities published on 2026-03-23
- **GHSA-cg4j-q9v8-6v38**: ReDoS vulnerability in `number_to_delimited` (`NumberToDelimitedConverter` used a regex with `gsub!` causing quadratic time complexity)
- **GHSA-89vf-4333-qx8v**: XSS vulnerability in `SafeBuffer#%`
- **GHSA-2j26-frm8-cmj9**: DoS vulnerability in number helpers

## Test plan
- [ ] Verify CI passes
- [ ] Confirm `activesupport` version in `Gemfile.lock` is patched (>= 8.1.2.1 for 8.1.x, >= 8.0.4.1 for 8.0.x, >= 7.2.3.1 for 7.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)