### PR TITLE
Fix POS refund double negation causing wrong stored quantities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,10 +82,17 @@ xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
   -destination 'platform=iOS Simulator,name=iPhone 16' -sdk iphonesimulator \
   test -only-testing:"WooCommerceTests/SomeTestClass/test_method_name"
 
-# Run module tests (e.g. Yosemite)
+# Run module tests - use the module's own scheme for faster builds
+# When changes only affect a specific module (e.g. Yosemite, PointOfSale),
+# use that module's scheme instead of WooCommerce. Available schemes: Yosemite, PointOfSale, etc.
+xcodebuild -workspace WooCommerce.xcworkspace -scheme Yosemite \
+  -destination 'platform=iOS Simulator,name=iPhone 16' -sdk iphonesimulator \
+  test -only-testing:"YosemiteTests/SomeTestClass"
+
+# Only use the WooCommerce scheme when changes span the main app target
 xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
   -destination 'platform=iOS Simulator,name=iPhone 16' -sdk iphonesimulator \
-  test -only-testing:"YosemiteTests"
+  test -only-testing:"WooCommerceTests"
 
 # Lint (SwiftLint via BuildTools plugin)
 pushd BuildTools && export SDKROOT=$(xcrun --sdk macosx --show-sdk-path) && \

--- a/Modules/Sources/NetworkingCore/Remote/POSRefundsRemoteProtocol.swift
+++ b/Modules/Sources/NetworkingCore/Remote/POSRefundsRemoteProtocol.swift
@@ -4,8 +4,6 @@ public protocol POSRefundsRemoteProtocol {
     func loadRefunds(for siteID: Int64, by orderID: Int64, with refundIDs: [Int64]) async throws -> [Refund]
 
     /// Creates a refund for the specified order.
-    /// - Note: The API expects negative values for refund items:
-    ///   - negative quantity = items being returned
-    ///   - negative total = money being refunded
+    /// - Note: Values should be sent as positive. The WooCommerce API (wc_create_refund) negates them internally.
     func createRefund(for siteID: Int64, by orderID: Int64, refund: Refund) async throws -> Refund
 }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
@@ -147,8 +147,8 @@ public final class POSRefundsService: POSRefundsServiceProtocol {
 
     private func buildRefund(from request: POSRefundRequest, createAutomated: Bool, numberOfDecimals: Int) -> Refund {
         let items = request.items.map { item in
-            let refundQuantity = Decimal(-item.quantity)
-            let refundTotal = formatDecimalForAPI(-item.refundTotal, numberOfDecimals: numberOfDecimals)
+            let refundQuantity = Decimal(item.quantity)
+            let refundTotal = formatDecimalForAPI(item.refundTotal, numberOfDecimals: numberOfDecimals)
             let refundTaxes = buildRefundTaxes(for: item.refundTax, numberOfDecimals: numberOfDecimals)
 
             return OrderItemRefund(

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSRefundsServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSRefundsServiceTests.swift
@@ -505,8 +505,12 @@ struct POSRefundsServiceTests {
             amount: try #require(Decimal(string: "50.00")),
             reason: nil,
             items: [
-                POSRefundRequestItem(itemID: 10, quantity: 2, refundTotal: try #require(Decimal(string: "32.00")), refundTax: try #require(Decimal(string: "3.20"))),
-                POSRefundRequestItem(itemID: 20, quantity: 1, refundTotal: try #require(Decimal(string: "18.00")), refundTax: try #require(Decimal(string: "1.80")))
+                POSRefundRequestItem(itemID: 10, quantity: 2,
+                                     refundTotal: try #require(Decimal(string: "32.00")),
+                                     refundTax: try #require(Decimal(string: "3.20"))),
+                POSRefundRequestItem(itemID: 20, quantity: 1,
+                                     refundTotal: try #require(Decimal(string: "18.00")),
+                                     refundTax: try #require(Decimal(string: "1.80")))
             ]
         )
         let sut = makeSUT(remote: remote, calculator: calculator)

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSRefundsServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSRefundsServiceTests.swift
@@ -496,6 +496,37 @@ struct POSRefundsServiceTests {
         #expect(remote.spyCreateRefund?.createAutomated == false)
     }
 
+    @Test func createRefund_then_sends_positive_quantities_and_totals_to_remote() async throws {
+        // Given
+        let remote = MockPOSRefundsRemote()
+        let calculator = MockPOSRefundCalculator()
+        calculator.stubRefundRequest = POSRefundRequest(
+            orderID: 456,
+            amount: Decimal(string: "50.00")!,
+            reason: nil,
+            items: [
+                POSRefundRequestItem(itemID: 10, quantity: 2, refundTotal: Decimal(string: "32.00")!, refundTax: Decimal(string: "3.20")!),
+                POSRefundRequestItem(itemID: 20, quantity: 1, refundTotal: Decimal(string: "18.00")!, refundTax: Decimal(string: "1.80")!)
+            ]
+        )
+        let sut = makeSUT(remote: remote, calculator: calculator)
+
+        // When
+        try await sut.createRefund(orderID: 456, items: [], reason: nil, isAutomaticRefund: true)
+
+        // Then - quantities and totals must be positive (the WooCommerce API negates them)
+        let refund = try #require(remote.spyCreateRefund)
+        #expect(refund.items.count == 2)
+
+        let firstItem = refund.items[0]
+        #expect(firstItem.quantity == Decimal(2))
+        #expect(firstItem.total == "32.00")
+
+        let secondItem = refund.items[1]
+        #expect(secondItem.quantity == Decimal(1))
+        #expect(secondItem.total == "18.00")
+    }
+
     @Test func createRefund_when_remote_fails_then_propagates_error() async throws {
         // Given
         let remote = MockPOSRefundsRemote()

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSRefundsServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSRefundsServiceTests.swift
@@ -502,11 +502,11 @@ struct POSRefundsServiceTests {
         let calculator = MockPOSRefundCalculator()
         calculator.stubRefundRequest = POSRefundRequest(
             orderID: 456,
-            amount: Decimal(string: "50.00")!,
+            amount: try #require(Decimal(string: "50.00")),
             reason: nil,
             items: [
-                POSRefundRequestItem(itemID: 10, quantity: 2, refundTotal: Decimal(string: "32.00")!, refundTax: Decimal(string: "3.20")!),
-                POSRefundRequestItem(itemID: 20, quantity: 1, refundTotal: Decimal(string: "18.00")!, refundTax: Decimal(string: "1.80")!)
+                POSRefundRequestItem(itemID: 10, quantity: 2, refundTotal: try #require(Decimal(string: "32.00")), refundTax: try #require(Decimal(string: "3.20"))),
+                POSRefundRequestItem(itemID: 20, quantity: 1, refundTotal: try #require(Decimal(string: "18.00")), refundTax: try #require(Decimal(string: "1.80")))
             ]
         )
         let sut = makeSUT(remote: remote, calculator: calculator)
@@ -521,10 +521,12 @@ struct POSRefundsServiceTests {
         let firstItem = refund.items[0]
         #expect(firstItem.quantity == Decimal(2))
         #expect(firstItem.total == "32.00")
+        #expect(firstItem.taxes.first?.total == "3.20")
 
         let secondItem = refund.items[1]
         #expect(secondItem.quantity == Decimal(1))
         #expect(secondItem.total == "18.00")
+        #expect(secondItem.taxes.first?.total == "1.80")
     }
 
     @Test func createRefund_when_remote_fails_then_propagates_error() async throws {


### PR DESCRIPTION
## Description

Noticed an issue while testing https://github.com/woocommerce/woocommerce/pull/63683

Fixes a bug where POS refund line item quantities and totals were stored with the wrong sign (positive instead of negative) due to double negation. It caused partial refunds in emails displayed with **increased quantity** rather than **decreased quantity**. 

### Root cause

`POSRefundsService.buildRefund()` was pre-negating quantities and totals before sending to the API:
```swift
let refundQuantity = Decimal(-item.quantity)      // sends -2
let refundTotal = formatDecimalForAPI(-item.refundTotal, ...) // sends -32
```

But `wc_create_refund()` in WooCommerce (`wc-order-functions.php:642`) also negates: `$qty * -1`

Result: `-2 * -1 = +2` stored in database (wrong sign).

### Fix

Remove the pre-negation to match the non-POS iOS flow (`RefundCreationUseCase`) and Android (`WooPosGroupRefundItems`), which both correctly send positive values and let the API handle sign conversion.

### Impact

| Flow | Before | After |
|------|--------|-------|
| iOS POS | sends -2, stored as +2 (bug) | sends +2, stored as -2 (correct) |
| iOS non-POS | sends +2, stored as -2 (OK) | unchanged |
| Android | sends +2, stored as -2 (OK) | unchanged |

## How to test

1. Create a POS order with multiple quantities of an item
2. Send email to attach a customer
3. Issue a partial refund from the iOS app
4. Check an automated partial refund email- quantity should show decreased (not increased)

Closes WOOMOB-2541

## Screenshots

### Before
<img width="653" height="853" alt="partial refunds bug order details" src="https://github.com/user-attachments/assets/4cf1b58b-a5db-4c5f-a572-cbc90312a181" />

### After

<img width="626" height="693" alt="image" src="https://github.com/user-attachments/assets/b792cc86-8d1a-477a-997e-4aef1a747d8a" />
