### PR TITLE
Fix Pay in Person refund shown as manual refund

### DIFF
--- a/WooCommerce/Classes/Extensions/Order+PaymentMethod.swift
+++ b/WooCommerce/Classes/Extensions/Order+PaymentMethod.swift
@@ -1,0 +1,13 @@
+import Yosemite
+
+extension Order {
+    /// Whether the refund should display the order's payment method title rather than "manual refund".
+    ///
+    /// This is true when either:
+    /// - The refund was processed automatically by the payment gateway (`isAutomated`), or
+    /// - The order was paid via Cash on Delivery (Pay in Person), where the API always returns
+    ///   `refunded_payment: false` because no electronic refund occurs.
+    func refundShowsPaymentMethod(_ refund: Refund) -> Bool {
+        (refund.isAutomated ?? false) || paymentMethodID == PaymentGateway.Constants.cashOnDeliveryGatewayID
+    }
+}

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
@@ -141,10 +141,7 @@ final class OrderPaymentDetailsViewModel {
             return dateFormatter.string(from: refund.dateCreated)
         }()
 
-        let hasRefundGateway = refund.isAutomated ?? false
-
-        // Yes, we're making the assumption that the payment method is the same as the refund method.
-        let refundType = hasRefundGateway ? order.paymentMethodTitle : NSLocalizedString(
+        let refundType = order.refundShowsPaymentMethod(refund) ? order.paymentMethodTitle : NSLocalizedString(
             "manual refund",
             comment: "A manual refund is one where the store owner has given the purchaser alternative funds" +
                 " (cash, check, ACH) instead of using the payment gateway to create a refund " +

--- a/WooCommerce/Classes/ViewModels/Order Details/Refund Details/RefundDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Refund Details/RefundDetailsDataSource.swift
@@ -65,7 +65,7 @@ final class RefundDetailsDataSource: NSObject {
     /// Refund Method
     ///
     private var refundMethod: String {
-        guard refund.isAutomated == true else {
+        guard order.refundShowsPaymentMethod(refund) else {
             return NSLocalizedString("Refunded manually", comment: "Title of the refund detail cell when the refund was done manually.")
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
@@ -210,4 +210,42 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
     func test_giftCards_is_hidden_for_orders_without_giftCard() {
         XCTAssertTrue(viewModel.shouldHideGiftCards)
     }
+
+    func test_refundSummary_when_isAutomated_true_then_shows_payment_method_title() {
+        // Given
+        let refund = MockRefunds.sampleRefund(isAutomated: true)
+        let viewModel = OrderPaymentDetailsViewModel(order: order, refund: refund, currencySettings: CurrencySettings())
+
+        // When
+        let summary = viewModel.refundSummary
+
+        // Then
+        XCTAssertTrue(summary?.contains(order.paymentMethodTitle) == true)
+    }
+
+    func test_refundSummary_when_isAutomated_false_and_not_cod_then_shows_manual_refund() {
+        // Given
+        let refund = MockRefunds.sampleRefund(isAutomated: false)
+        let viewModel = OrderPaymentDetailsViewModel(order: order, refund: refund, currencySettings: CurrencySettings())
+
+        // When
+        let summary = viewModel.refundSummary
+
+        // Then
+        XCTAssertTrue(summary?.contains("manual refund") == true)
+    }
+
+    func test_refundSummary_when_isAutomated_false_and_cod_then_shows_payment_method_title() {
+        // Given
+        let codOrder = order.copy(paymentMethodID: "cod", paymentMethodTitle: "Pay in Person")
+        let refund = MockRefunds.sampleRefund(isAutomated: false)
+        let viewModel = OrderPaymentDetailsViewModel(order: codOrder, refund: refund, currencySettings: CurrencySettings())
+
+        // When
+        let summary = viewModel.refundSummary
+
+        // Then
+        XCTAssertTrue(summary?.contains("Pay in Person") == true)
+        XCTAssertFalse(summary?.contains("manual refund") == true)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
@@ -253,10 +253,10 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
         // Given
         let refund = MockRefunds.sampleRefund(isAutomated: nil)
         let viewModel = OrderPaymentDetailsViewModel(order: order, refund: refund, currencySettings: CurrencySettings())
-        
+
         // When
         let summary = viewModel.refundSummary
-        
+
         // Then
         XCTAssertTrue(summary?.contains("manual refund") == true)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
@@ -248,15 +248,15 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
         XCTAssertTrue(summary?.contains("Pay in Person") == true)
         XCTAssertFalse(summary?.contains("manual refund") == true)
     }
-        
-        func test_refundSummary_when_isAutomated_nil_and_not_cod_then_shows_manual_refund() {
+
+    func test_refundSummary_when_isAutomated_nil_and_not_cod_then_shows_manual_refund() {
         // Given
         let refund = MockRefunds.sampleRefund(isAutomated: nil)
         let viewModel = OrderPaymentDetailsViewModel(order: order, refund: refund, currencySettings: CurrencySettings())
-
+        
         // When
         let summary = viewModel.refundSummary
-
+        
         // Then
         XCTAssertTrue(summary?.contains("manual refund") == true)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
@@ -248,4 +248,16 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
         XCTAssertTrue(summary?.contains("Pay in Person") == true)
         XCTAssertFalse(summary?.contains("manual refund") == true)
     }
+        
+        func test_refundSummary_when_isAutomated_nil_and_not_cod_then_shows_manual_refund() {
+        // Given
+        let refund = MockRefunds.sampleRefund(isAutomated: nil)
+        let viewModel = OrderPaymentDetailsViewModel(order: order, refund: refund, currencySettings: CurrencySettings())
+
+        // When
+        let summary = viewModel.refundSummary
+
+        // Then
+        XCTAssertTrue(summary?.contains("manual refund") == true)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR ensures that cash refunds are marked the same way as cash refunds - with `via Pay in Person`.

For Cash on Delivery (Pay in Person) orders, the API always returns refunded_payment: false because no electronic refund occurs. The display logic was using this flag to decide whether to show the payment method title or "manual refund", so COD refunds always showed as manual.

Added `Order.refundShowsPaymentMethod(_:)` that also checks for the COD gateway, so refunds on Pay in Person orders display the correct payment method title.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/1f44a8d6-e70c-4d58-832f-c9b5dc748611


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
