### PR TITLE
Crash on missing URL auth schemes

### DIFF
--- a/WooCommerce/Classes/Extensions/Bundle+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Bundle+Woo.swift
@@ -28,8 +28,11 @@ extension Bundle {
     /// Use this for values that must be wired up at build time via xcconfig.
     /// A crash on first launch makes misconfiguration obvious immediately.
     private func requiredNonEmptyInfoPlistString(for key: String) -> String {
-        guard let value = object(forInfoDictionaryKey: key) as? String, !value.isEmpty else {
-            fatalError("\(key) is missing or empty in Info.plist. Check the xcconfig setup.")
+        guard let value = object(forInfoDictionaryKey: key) as? String else {
+            fatalError("\(key) not found in Info.plist. Check the xcconfig setup.")
+        }
+        guard !value.isEmpty else {
+            fatalError("\(key) is empty in Info.plist. Check the xcconfig setup.")
         }
         return value
     }

--- a/WooCommerce/Classes/Extensions/Bundle+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Bundle+Woo.swift
@@ -31,9 +31,11 @@ extension Bundle {
         guard let value = object(forInfoDictionaryKey: key) as? String else {
             fatalError("\(key) not found in Info.plist. Check the xcconfig setup.")
         }
+
         guard !value.isEmpty else {
             fatalError("\(key) is empty in Info.plist. Check the xcconfig setup.")
         }
+
         return value
     }
 }

--- a/WooCommerce/Classes/Extensions/Bundle+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Bundle+Woo.swift
@@ -15,18 +15,22 @@ extension Bundle {
 
     /// WordPress.com Magic Link URL scheme, read from Info.plist (`WCDotcomAuthScheme`).
     ///
+    /// - Important: Crashes if the value is missing or empty — this is a developer error
+    ///   indicating the xcconfig is misconfigured.
     var dotcomAuthScheme: String {
         guard let scheme = object(forInfoDictionaryKey: "WCDotcomAuthScheme") as? String, !scheme.isEmpty else {
-            return ""
+            fatalError("WCDotcomAuthScheme is missing or empty in Info.plist. Check the xcconfig setup.")
         }
         return scheme
     }
 
     /// Google Sign-In URL scheme, read from Info.plist (`WCGoogleAuthScheme`).
     ///
+    /// - Important: Crashes if the value is missing or empty — this is a developer error
+    ///   indicating the xcconfig is misconfigured.
     var googleAuthScheme: String {
         guard let scheme = object(forInfoDictionaryKey: "WCGoogleAuthScheme") as? String, !scheme.isEmpty else {
-            return ""
+            fatalError("WCGoogleAuthScheme is missing or empty in Info.plist. Check the xcconfig setup.")
         }
         return scheme
     }

--- a/WooCommerce/Classes/Extensions/Bundle+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Bundle+Woo.swift
@@ -14,24 +14,23 @@ extension Bundle {
     }
 
     /// WordPress.com Magic Link URL scheme, read from Info.plist (`WCDotcomAuthScheme`).
-    ///
-    /// - Important: Crashes if the value is missing or empty — this is a developer error
-    ///   indicating the xcconfig is misconfigured.
     var dotcomAuthScheme: String {
-        guard let scheme = object(forInfoDictionaryKey: "WCDotcomAuthScheme") as? String, !scheme.isEmpty else {
-            fatalError("WCDotcomAuthScheme is missing or empty in Info.plist. Check the xcconfig setup.")
-        }
-        return scheme
+        requiredNonEmptyInfoPlistString(for: "WCDotcomAuthScheme")
     }
 
     /// Google Sign-In URL scheme, read from Info.plist (`WCGoogleAuthScheme`).
-    ///
-    /// - Important: Crashes if the value is missing or empty — this is a developer error
-    ///   indicating the xcconfig is misconfigured.
     var googleAuthScheme: String {
-        guard let scheme = object(forInfoDictionaryKey: "WCGoogleAuthScheme") as? String, !scheme.isEmpty else {
-            fatalError("WCGoogleAuthScheme is missing or empty in Info.plist. Check the xcconfig setup.")
+        requiredNonEmptyInfoPlistString(for: "WCGoogleAuthScheme")
+    }
+
+    /// Reads a `String` value from Info.plist and crashes if it is missing or empty.
+    ///
+    /// Use this for values that must be wired up at build time via xcconfig.
+    /// A crash on first launch makes misconfiguration obvious immediately.
+    private func requiredNonEmptyInfoPlistString(for key: String) -> String {
+        guard let value = object(forInfoDictionaryKey: key) as? String, !value.isEmpty else {
+            fatalError("\(key) is missing or empty in Info.plist. Check the xcconfig setup.")
         }
-        return scheme
+        return value
     }
 }


### PR DESCRIPTION
Closes AINFRA-2229

## Description

Follow-up to #16850.
`Bundle.dotcomAuthScheme` and `Bundle.googleAuthScheme` now `fatalError` when the Info.plist value is missing or empty, instead of silently returning `""`.

A misconfigured xcconfig is a developer error — crashing on first launch surfaces it immediately rather than letting empty strings propagate through auth flows.

Discussion: https://github.com/woocommerce/woocommerce-ios/pull/16850#discussion_r2985832436

## Test Steps

1. Build and run — app should launch normally (xcconfig values are present).
2. To verify the crash path: temporarily remove `WCDotcomAuthScheme` from the xcconfig and confirm the app crashes with a clear message.

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

---

*PR created by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*