### PR TITLE
Animate order details loading bar dismissal

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -98,7 +98,10 @@ final class OrderDetailsViewController: UIViewController {
         syncEverything { [weak self] in
             ServiceLocator.analytics.track(event: waitingTracker.end())
 
-            self?.topLoaderView.isHidden = true
+            UIView.animate(withDuration: 0.3) {
+                self?.topLoaderView.alpha = 0
+                self?.topLoaderView.isHidden = true
+            }
 
             /// We add the refresh control to the tableview just after the `topLoaderView` disappear for the first time.
             if self?.tableView.refreshControl == nil {


### PR DESCRIPTION
## Description
The "Loading content" top bar in Order Details disappears instantly when loading completes, which feels snappy. This wraps the hiding in a `UIView.animate` block so the bar fades out and collapses smoothly via the stack view.

## Test Steps
1. Open an order from the Orders list
2. Observe the "Loading content" bar at the top
3. When loading finishes, the bar should fade out and collapse smoothly instead of disappearing instantly

### Demo

Before | After
--- | ---
![tab_unanimated1](https://github.com/user-attachments/assets/a329e9c1-2437-4f67-a147-ddcbaff39dd7) | ![bar_animated1](https://github.com/user-attachments/assets/04b5a99a-aa05-4311-aa67-cb51d0267f27)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.