### PR TITLE
Refactor and simplify `OrderItemRefund` creation requirements

### DIFF
--- a/Modules/Sources/NetworkingCore/Model/Refund/OrderItemRefund.swift
+++ b/Modules/Sources/NetworkingCore/Model/Refund/OrderItemRefund.swift
@@ -28,19 +28,19 @@ public struct OrderItemRefund: Codable, Equatable, GeneratedFakeable, GeneratedC
     /// OrderItemRefund struct initializer.
     ///
     public init(itemID: Int64,
-                name: String,
-                productID: Int64,
-                variationID: Int64,
-                refundedItemID: String?,
+                name: String = "",
+                productID: Int64 = 0,
+                variationID: Int64 = 0,
+                refundedItemID: String? = nil,
                 quantity: Decimal,
-                price: NSDecimalNumber,
-                sku: String?,
-                subtotal: String,
-                subtotalTax: String,
-                taxClass: String,
+                price: NSDecimalNumber = .zero,
+                sku: String? = nil,
+                subtotal: String = "",
+                subtotalTax: String = "",
+                taxClass: String = "",
                 taxes: [OrderItemTaxRefund],
                 total: String,
-                totalTax: String) {
+                totalTax: String = "") {
         self.itemID = itemID
         self.name = name
         self.productID = productID

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundsService.swift
@@ -153,19 +153,9 @@ public final class POSRefundsService: POSRefundsServiceProtocol {
 
             return OrderItemRefund(
                 itemID: item.itemID,
-                name: "",
-                productID: 0,
-                variationID: 0,
-                refundedItemID: nil,
                 quantity: refundQuantity,
-                price: NSDecimalNumber.zero,
-                sku: nil,
-                subtotal: "",
-                subtotalTax: "",
-                taxClass: "",
                 taxes: refundTaxes,
-                total: refundTotal,
-                totalTax: ""
+                total: refundTotal
             )
         }
 

--- a/Modules/Tests/NetworkingTests/Encoder/OrderItemRefundEncoderTests.swift
+++ b/Modules/Tests/NetworkingTests/Encoder/OrderItemRefundEncoderTests.swift
@@ -1,0 +1,127 @@
+import Testing
+import Foundation
+@testable import Networking
+@testable import NetworkingCore
+
+struct OrderItemRefundEncoderTests {
+
+    // MARK: - Default Values
+
+    @Test func init_with_only_required_fields_then_defaults_are_set_correctly() {
+        // When
+        let item = OrderItemRefund(
+            itemID: 42,
+            quantity: 2,
+            taxes: [],
+            total: "10.00"
+        )
+
+        // Then
+        #expect(item.itemID == 42)
+        #expect(item.quantity == 2)
+        #expect(item.total == "10.00")
+        #expect(item.taxes == [])
+
+        // Defaulted fields
+        #expect(item.name == "")
+        #expect(item.productID == 0)
+        #expect(item.variationID == 0)
+        #expect(item.refundedItemID == nil)
+        #expect(item.price == .zero)
+        #expect(item.sku == nil)
+        #expect(item.subtotal == "")
+        #expect(item.subtotalTax == "")
+        #expect(item.taxClass == "")
+        #expect(item.totalTax == "")
+    }
+
+    @Test func init_with_explicit_values_then_overrides_defaults() {
+        // When
+        let item = OrderItemRefund(
+            itemID: 1,
+            name: "Widget",
+            productID: 99,
+            variationID: 5,
+            refundedItemID: "42",
+            quantity: 3,
+            price: NSDecimalNumber(string: "15.50"),
+            sku: "WDG-001",
+            subtotal: "46.50",
+            subtotalTax: "4.65",
+            taxClass: "standard",
+            taxes: [],
+            total: "46.50",
+            totalTax: "4.65"
+        )
+
+        // Then
+        #expect(item.name == "Widget")
+        #expect(item.productID == 99)
+        #expect(item.variationID == 5)
+        #expect(item.refundedItemID == "42")
+        #expect(item.price == NSDecimalNumber(string: "15.50"))
+        #expect(item.sku == "WDG-001")
+        #expect(item.subtotal == "46.50")
+        #expect(item.subtotalTax == "4.65")
+        #expect(item.taxClass == "standard")
+        #expect(item.totalTax == "4.65")
+    }
+
+    // MARK: - Encoding
+
+    @Test func encode_then_only_encodes_quantity_total_and_taxes() throws {
+        // Given
+        let item = OrderItemRefund(
+            itemID: 42,
+            name: "Should not be encoded",
+            productID: 99,
+            quantity: 2,
+            taxes: [OrderItemTaxRefund(taxID: 5, subtotal: "", total: "1.50")],
+            total: "20.00"
+        )
+
+        // When
+        let data = try JSONEncoder().encode(item)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        // Then — only the 3 encoded fields should be present
+        #expect(json.keys.count == 3)
+        #expect(json["qty"] as? Int == 2)
+        #expect(json["refund_total"] as? String == "20.00")
+        #expect(json["refund_tax"] != nil)
+
+        // Verify non-encoded fields are absent
+        #expect(json["id"] == nil)
+        #expect(json["name"] == nil)
+        #expect(json["product_id"] == nil)
+        #expect(json["variation_id"] == nil)
+        #expect(json["price"] == nil)
+        #expect(json["sku"] == nil)
+        #expect(json["subtotal"] == nil)
+        #expect(json["subtotal_tax"] == nil)
+        #expect(json["tax_class"] == nil)
+        #expect(json["total_tax"] == nil)
+    }
+
+    @Test func encode_taxes_then_formats_as_dictionary() throws {
+        // Given
+        let item = OrderItemRefund(
+            itemID: 1,
+            quantity: 1,
+            taxes: [
+                OrderItemTaxRefund(taxID: 10, subtotal: "", total: "1.99"),
+                OrderItemTaxRefund(taxID: 20, subtotal: "", total: "0.50")
+            ],
+            total: "15.00"
+        )
+
+        // When
+        let data = try JSONEncoder().encode(item)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let taxDict = try #require(json["refund_tax"] as? [String: String])
+
+        // Then — taxes encoded as { "tax_id": "total" } dictionary
+        #expect(taxDict["10"] == "1.99")
+        #expect(taxDict["20"] == "0.50")
+    }
+}

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSRefundMapperTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSRefundMapperTests.swift
@@ -155,15 +155,11 @@ private extension POSRefundMapperTests {
                         total: String = "-10.00") -> OrderItemRefund {
         OrderItemRefund(itemID: 0,
                         name: name,
-                        productID: 0,
-                        variationID: 0,
                         refundedItemID: refundedItemID,
                         quantity: quantity,
                         price: price,
-                        sku: nil,
                         subtotal: total,
                         subtotalTax: "0.00",
-                        taxClass: "",
                         taxes: [],
                         total: total,
                         totalTax: "0.00")
@@ -177,15 +173,11 @@ private extension POSRefundMapperTests {
                                totalTax: String = "-2.00") -> OrderItemRefund {
         OrderItemRefund(itemID: 0,
                         name: name,
-                        productID: 0,
-                        variationID: 0,
                         refundedItemID: refundedItemID,
                         quantity: quantity,
                         price: price,
-                        sku: nil,
                         subtotal: total,
                         subtotalTax: "0.00",
-                        taxClass: "",
                         taxes: [],
                         total: total,
                         totalTax: totalTax)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundCreationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundCreationUseCase.swift
@@ -55,19 +55,9 @@ struct RefundCreationUseCase {
     private func createRefundItems() -> [OrderItemRefund] {
         var refundItems = items.map { refundable -> OrderItemRefund in
             OrderItemRefund(itemID: refundable.item.itemID,
-                            name: "",
-                            productID: .min,
-                            variationID: .min,
-                            refundedItemID: nil,
                             quantity: Decimal(refundable.quantity),
-                            price: .zero,
-                            sku: nil,
-                            subtotal: "",
-                            subtotalTax: "",
-                            taxClass: "",
                             taxes: createTaxes(from: refundable),
-                            total: calculateTotal(of: refundable),
-                            totalTax: "")
+                            total: calculateTotal(of: refundable))
         }
 
         if let shippingLine = shippingLine {
@@ -85,19 +75,9 @@ struct RefundCreationUseCase {
     ///
     private func createShippingItem(from shippingLine: ShippingLine) -> OrderItemRefund {
         OrderItemRefund(itemID: shippingLine.shippingID,
-                        name: "",
-                        productID: .min,
-                        variationID: .min,
-                        refundedItemID: nil,
                         quantity: .zero,
-                        price: .zero,
-                        sku: nil,
-                        subtotal: "",
-                        subtotalTax: "",
-                        taxClass: "",
                         taxes: createTaxes(from: shippingLine),
-                        total: shippingLine.total,
-                        totalTax: "")
+                        total: shippingLine.total)
     }
 
     /// Returns an `[OrderItemRefund]` based on the provided `[OrderFeeLine]`
@@ -105,19 +85,9 @@ struct RefundCreationUseCase {
     private func createFeeItems(from feeLines: [OrderFeeLine]) -> [OrderItemRefund] {
         feeLines.map { feeLine -> OrderItemRefund in
             OrderItemRefund(itemID: feeLine.feeID,
-                            name: "",
-                            productID: .min,
-                            variationID: .min,
-                            refundedItemID: nil,
                             quantity: .zero,
-                            price: .zero,
-                            sku: nil,
-                            subtotal: "",
-                            subtotalTax: "",
-                            taxClass: "",
                             taxes: createTaxes(from: feeLine),
-                            total: feeLine.total,
-                            totalTax: "")
+                            total: feeLine.total)
         }
 
     }


### PR DESCRIPTION
Closes WOOMOB-2092

## Description

When creating `OrderItemRefund`, we populate a bunch of properties as zero/empty that are currently required by the business/app layer, but not needed by the API for creating it, this only sends itemID, quantity, total, and taxes.

A cleaner separation could be to have 2 entities, `OrderItemRefund` and `OrderItemRefundRequest`, but touches a bigger picture (refunds model, storage, etc, ... ) without a clear benefit. In order to keep things simpler and a cleaner interface in the model and services, this PR just makes these fields not required and sets defaults in the networking layer.

We also add tests.

## Test Steps
- Process a refund through POS and IPP. It should work normally

## Screenshots
N/A
---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
