### PR TITLE
Update bookings filter for new v2 customer IDs

### DIFF
--- a/.claude/rules/data-model.md
+++ b/.claude/rules/data-model.md
@@ -1,0 +1,23 @@
+# CoreData Model Changes
+
+When making changes to the CoreData data model (adding/removing/modifying entities or attributes in the `.xcdatamodeld`):
+
+1. **Create a new model version**: Copy the current model to a new version (increment the number), make changes there, and update `_XCCurrentVersionName` in `.xccurrentversion` to point to the new model file. This step is critical — forgetting to select the new version in `.xccurrentversion` means the app will still use the old model at runtime.
+
+2. **Update the changelog**: Add an entry at the top of `Modules/Sources/Storage/Model/MIGRATIONS.md` documenting what changed, following the existing format:
+   ```
+   ## Model NNN (Release X.X.X.X)
+   - @username YYYY-MM-DD
+     - Added `attributeName` attribute to `EntityName` entity.
+   ```
+
+3. **Add a migration test**: Add a test in `Modules/Tests/StorageTests/CoreData/MigrationTests.swift` that verifies the migration from the previous model version to the new one. Follow existing test patterns:
+   - Insert data in the source model version
+   - Verify the new attribute/entity does NOT exist in the source
+   - Migrate to the new model version
+   - Verify the new attribute/entity exists with correct defaults
+   - Verify new values can be set and saved
+
+4. **Update Storage properties**: Add/modify `@NSManaged` properties in the corresponding `+CoreDataProperties.swift` file.
+
+5. **Run codegen**: Run Sourcery to regenerate Copiable/Fakeable conformances if the affected model conforms to `GeneratedCopiable` or `GeneratedFakeable`.

--- a/Modules/Sources/Fakes/Networking.generated.swift
+++ b/Modules/Sources/Fakes/Networking.generated.swift
@@ -329,6 +329,7 @@ extension Networking.Booking {
             allDay: .fake(),
             cost: .fake(),
             customerID: .fake(),
+            userID: .fake(),
             dateCreated: .fake(),
             dateModified: .fake(),
             endDate: .fake(),

--- a/Modules/Sources/Networking/Model/Bookings/Booking.swift
+++ b/Modules/Sources/Networking/Model/Bookings/Booking.swift
@@ -9,6 +9,7 @@ public struct Booking: Codable, GeneratedCopiable, Hashable, GeneratedFakeable {
     public let allDay: Bool
     public let cost: String
     public let customerID: Int64
+    public let userID: Int64
     public let dateCreated: Date?
     public let dateModified: Date?
     public let endDate: Date
@@ -41,6 +42,7 @@ public struct Booking: Codable, GeneratedCopiable, Hashable, GeneratedFakeable {
                 allDay: Bool,
                 cost: String,
                 customerID: Int64,
+                userID: Int64,
                 dateCreated: Date?,
                 dateModified: Date?,
                 endDate: Date,
@@ -62,6 +64,7 @@ public struct Booking: Codable, GeneratedCopiable, Hashable, GeneratedFakeable {
         self.allDay = allDay
         self.cost = cost
         self.customerID = customerID
+        self.userID = userID
         self.dateCreated = dateCreated
         self.dateModified = dateModified
         self.endDate = endDate
@@ -98,6 +101,7 @@ public struct Booking: Codable, GeneratedCopiable, Hashable, GeneratedFakeable {
                                                      alternativeTypes: [.decimal(transform: { NSDecimalNumber(decimal: $0).stringValue })]) ?? ""
 
         let customerID = try container.decode(Int64.self, forKey: .customerID)
+        let userID = try container.decodeIfPresent(Int64.self, forKey: .userID) ?? 0
 
         let dateCreated: Date?
         if let dateCreatedValue = try container.decodeIfPresent(
@@ -139,6 +143,7 @@ public struct Booking: Codable, GeneratedCopiable, Hashable, GeneratedFakeable {
                   allDay: allDay,
                   cost: cost,
                   customerID: customerID,
+                  userID: userID,
                   dateCreated: dateCreated,
                   dateModified: dateModified,
                   endDate: endDate,
@@ -164,6 +169,7 @@ public struct Booking: Codable, GeneratedCopiable, Hashable, GeneratedFakeable {
         try container.encode(allDay, forKey: .allDay)
         try container.encode(cost, forKey: .cost)
         try container.encode(customerID, forKey: .customerID)
+        try container.encode(userID, forKey: .userID)
         try container.encode(dateCreated, forKey: .dateCreated)
         try container.encode(dateModified, forKey: .dateModified)
         try container.encode(endDate, forKey: .endDate)
@@ -193,6 +199,7 @@ private extension Booking {
         case allDay = "all_day"
         case cost
         case customerID = "customer_id"
+        case userID = "user_id"
         case dateCreated = "date_created"
         case dateModified = "date_modified"
         case endDate = "end"

--- a/Modules/Sources/Networking/Model/Bookings/Booking.swift
+++ b/Modules/Sources/Networking/Model/Bookings/Booking.swift
@@ -8,8 +8,15 @@ public struct Booking: Codable, GeneratedCopiable, Hashable, GeneratedFakeable {
     public let bookingID: Int64
     public let allDay: Bool
     public let cost: String
+
+    /// WooCommerce Customer ID.
+    /// Not the same as WordPress User ID — use `userID` for guest detection.
     public let customerID: Int64
+
+    /// WordPress User ID.
+    /// 0 means the booking was made by a guest (no WP account).
     public let userID: Int64
+
     public let dateCreated: Date?
     public let dateModified: Date?
     public let endDate: Date

--- a/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -435,6 +435,7 @@ extension Networking.Booking {
         allDay: CopiableProp<Bool> = .copy,
         cost: CopiableProp<String> = .copy,
         customerID: CopiableProp<Int64> = .copy,
+        userID: CopiableProp<Int64> = .copy,
         dateCreated: NullableCopiableProp<Date> = .copy,
         dateModified: NullableCopiableProp<Date> = .copy,
         endDate: CopiableProp<Date> = .copy,
@@ -457,6 +458,7 @@ extension Networking.Booking {
         let allDay = allDay ?? self.allDay
         let cost = cost ?? self.cost
         let customerID = customerID ?? self.customerID
+        let userID = userID ?? self.userID
         let dateCreated = dateCreated ?? self.dateCreated
         let dateModified = dateModified ?? self.dateModified
         let endDate = endDate ?? self.endDate
@@ -480,6 +482,7 @@ extension Networking.Booking {
             allDay: allDay,
             cost: cost,
             customerID: customerID,
+            userID: userID,
             dateCreated: dateCreated,
             dateModified: dateModified,
             endDate: endDate,

--- a/Modules/Sources/Networking/Remote/BookingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/BookingsRemote.swift
@@ -138,7 +138,7 @@ public final class BookingsRemote: Remote, BookingsRemoteProtocol {
             }
 
             if filters.customerIDs.isNotEmpty {
-                parameters[ParameterKey.customer] = filters.customerIDs.map(String.init)
+                parameters[ParameterKey.user] = filters.customerIDs.map(String.init)
             }
 
             if filters.resourceIDs.isNotEmpty {
@@ -341,7 +341,7 @@ public extension BookingsRemote {
         static let order: String           = "order"
         static let orderBy: String         = "orderby"
         static let product: String         = "product"
-        static let customer: String        = "customer"
+        static let user: String             = "user"
         static let resource: String        = "resource"
         static let attendanceStatus        = "attendance_status"
         static let paymentStatus           = "booking_status" // to be updated later when payment filtering is supported

--- a/Modules/Sources/Networking/Remote/BookingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/BookingsRemote.swift
@@ -341,7 +341,7 @@ public extension BookingsRemote {
         static let order: String           = "order"
         static let orderBy: String         = "orderby"
         static let product: String         = "product"
-        static let user: String             = "user"
+        static let user: String            = "user"
         static let resource: String        = "resource"
         static let attendanceStatus        = "attendance_status"
         static let paymentStatus           = "booking_status" // to be updated later when payment filtering is supported

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingDetailView.swift
@@ -416,7 +416,7 @@ struct POSBookingDetailView: View {
 
 private extension POSBooking {
     var isGuest: Bool {
-        customerID == 0
+        userID == 0
     }
 }
 

--- a/Modules/Sources/Storage/Model/Booking/Booking+CoreDataProperties.swift
+++ b/Modules/Sources/Storage/Model/Booking/Booking+CoreDataProperties.swift
@@ -12,6 +12,7 @@ extension Booking {
     @NSManaged public var allDay: Bool
     @NSManaged public var cost: String?
     @NSManaged public var customerID: Int64
+    @NSManaged public var userID: Int64
     @NSManaged public var dateCreated: Date?
     @NSManaged public var dateModified: Date?
     @NSManaged public var endDate: Date?

--- a/Modules/Sources/Storage/Model/MIGRATIONS.md
+++ b/Modules/Sources/Storage/Model/MIGRATIONS.md
@@ -5,6 +5,8 @@ This file documents changes in the WCiOS Storage data model. Please explain any 
 ## Model 134 (Release 24.4.0.0)
 - @adborbas 2026-03-16
   - Added `location` attribute to `Booking` entity.
+- @rafaelkayumov 2026-03-16
+  - Added `userID` attribute to `Booking` entity.
 
 ## Model 133 (Release 24.4.0.0)
 - @itsmeichigo 2026-03-11

--- a/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 134.xcdatamodel/contents
+++ b/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 134.xcdatamodel/contents
@@ -84,6 +84,7 @@
         <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="startDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="statusKey" attributeType="String" defaultValueString=""/>
+        <attribute name="userID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="orderInfo" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BookingOrderInfo" inverseName="booking" inverseEntity="BookingOrderInfo"/>
     </entity>
     <entity name="BookingCustomerInfo" representedClassName="BookingCustomerInfo" syncable="YES">

--- a/Modules/Sources/Yosemite/Model/Booking/Booking+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Booking/Booking+ReadOnlyConvertible.swift
@@ -13,6 +13,7 @@ extension Storage.Booking: ReadOnlyConvertible {
         allDay = booking.allDay
         cost = booking.cost
         customerID = booking.customerID
+        userID = booking.userID
 
         /// Falling to back to existing values in case if new values are absent
         /// Booking returned when sending a `PUT` request to `bookings/{booking_id}`
@@ -43,6 +44,7 @@ extension Storage.Booking: ReadOnlyConvertible {
                 allDay: allDay,
                 cost: cost ?? "",
                 customerID: customerID,
+                userID: userID,
                 dateCreated: dateCreated ?? Date(),
                 dateModified: dateModified ?? Date(),
                 endDate: endDate ?? Date(),

--- a/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -62,6 +62,7 @@ extension Yosemite.POSBooking {
     public func copy(
         id: CopiableProp<Int64> = .copy,
         customerID: CopiableProp<Int64> = .copy,
+        userID: CopiableProp<Int64> = .copy,
         customerName: NullableCopiableProp<String> = .copy,
         serviceName: CopiableProp<String> = .copy,
         startDate: CopiableProp<Date> = .copy,
@@ -85,6 +86,7 @@ extension Yosemite.POSBooking {
     ) -> Yosemite.POSBooking {
         let id = id ?? self.id
         let customerID = customerID ?? self.customerID
+        let userID = userID ?? self.userID
         let customerName = customerName ?? self.customerName
         let serviceName = serviceName ?? self.serviceName
         let startDate = startDate ?? self.startDate
@@ -109,6 +111,7 @@ extension Yosemite.POSBooking {
         return Yosemite.POSBooking(
             id: id,
             customerID: customerID,
+            userID: userID,
             customerName: customerName,
             serviceName: serviceName,
             startDate: startDate,

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBooking.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBooking.swift
@@ -13,8 +13,15 @@ public struct POSBooking: Equatable, Hashable, Identifiable, GeneratedCopiable {
     }
 
     public let id: Int64
+
+    /// WooCommerce Customer ID.
+    /// Not the same as WordPress User ID — use `userID` for guest detection.
     public let customerID: Int64
+
+    /// WordPress User ID.
+    /// 0 means the booking was made by a guest (no WP account).
     public let userID: Int64
+
     public let customerName: String?
     public let serviceName: String
     public let startDate: Date

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBooking.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBooking.swift
@@ -14,6 +14,7 @@ public struct POSBooking: Equatable, Hashable, Identifiable, GeneratedCopiable {
 
     public let id: Int64
     public let customerID: Int64
+    public let userID: Int64
     public let customerName: String?
     public let serviceName: String
     public let startDate: Date
@@ -37,6 +38,7 @@ public struct POSBooking: Equatable, Hashable, Identifiable, GeneratedCopiable {
 
     public init(id: Int64,
                 customerID: Int64 = 0,
+                userID: Int64 = 0,
                 customerName: String?,
                 serviceName: String,
                 startDate: Date,
@@ -59,6 +61,7 @@ public struct POSBooking: Equatable, Hashable, Identifiable, GeneratedCopiable {
                 order: POSOrder) {
         self.id = id
         self.customerID = customerID
+        self.userID = userID
         self.customerName = customerName
         self.serviceName = serviceName
         self.startDate = startDate

--- a/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/BookingList/POSBookingMapper.swift
@@ -61,6 +61,7 @@ struct POSBookingMapper {
         return POSBooking(
             id: booking.bookingID,
             customerID: booking.customerID,
+            userID: booking.userID,
             customerName: customerName,
             serviceName: serviceName,
             startDate: booking.startDate,

--- a/Modules/Sources/Yosemite/Tools/Bookings/ResultsController+FilterBookings.swift
+++ b/Modules/Sources/Yosemite/Tools/Bookings/ResultsController+FilterBookings.swift
@@ -6,7 +6,7 @@ extension NSPredicate {
 
         let productIDsPredicate = filters.productIDs.isNotEmpty ? NSPredicate(format: "productID IN %@", filters.productIDs) : nil
 
-        let customerIDsPredicate = filters.customerIDs.isNotEmpty ? NSPredicate(format: "customerID IN %@", filters.customerIDs) : nil
+        let customerIDsPredicate = filters.customerIDs.isNotEmpty ? NSPredicate(format: "userID IN %@", filters.customerIDs) : nil
 
         let resourceIDsPredicate = filters.resourceIDs.isNotEmpty ? NSPredicate(format: "resourceID IN %@", filters.resourceIDs) : nil
 

--- a/Modules/Sources/Yosemite/Tools/Bookings/ResultsController+FilterBookings.swift
+++ b/Modules/Sources/Yosemite/Tools/Bookings/ResultsController+FilterBookings.swift
@@ -6,6 +6,7 @@ extension NSPredicate {
 
         let productIDsPredicate = filters.productIDs.isNotEmpty ? NSPredicate(format: "productID IN %@", filters.productIDs) : nil
 
+        // Note: `customerIDs` filter matches against `userID` (WordPress User ID), not `customerID` (WooCommerce Customer ID).
         let customerIDsPredicate = filters.customerIDs.isNotEmpty ? NSPredicate(format: "userID IN %@", filters.customerIDs) : nil
 
         let resourceIDsPredicate = filters.resourceIDs.isNotEmpty ? NSPredicate(format: "resourceID IN %@", filters.resourceIDs) : nil

--- a/Modules/Tests/StorageTests/CoreData/MigrationTests.swift
+++ b/Modules/Tests/StorageTests/CoreData/MigrationTests.swift
@@ -2490,6 +2490,37 @@ final class MigrationTests: XCTestCase {
 
         XCTAssertEqual(migratedBooking.value(forKey: "location") as? String, updatedValue)
     }
+
+    func test_migrating_from_133_to_134_adds_userID_attribute_to_Booking() throws {
+        // Given
+        let sourceContainer = try startPersistentContainer("Model 133")
+        let sourceContext = sourceContainer.viewContext
+
+        let booking = insertBooking(to: sourceContext)
+        try sourceContext.save()
+
+        XCTAssertNil(booking.entity.attributesByName["userID"], "Precondition. Attribute does not exist.")
+
+        // When
+        let targetContainer = try migrate(sourceContainer, to: "Model 134")
+
+        // Then
+        let targetContext = targetContainer.viewContext
+        let migratedBooking = try XCTUnwrap(targetContext.first(entityName: "Booking"))
+
+        XCTAssertNotNil(migratedBooking.entity.attributesByName["userID"])
+
+        // Default value should be 0
+        let defaultValue = migratedBooking.value(forKey: "userID") as? Int64
+        XCTAssertEqual(defaultValue, 0)
+
+        // Verify new attribute can be set and saved
+        let newUserID: Int64 = 42
+        migratedBooking.setValue(newUserID, forKey: "userID")
+        try targetContext.save()
+
+        XCTAssertEqual(migratedBooking.value(forKey: "userID") as? Int64, newUserID)
+    }
 }
 
 // MARK: - Persistent Store Setup and Migrations

--- a/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Bookings/Booking Details/BookingDetailsView.swift
@@ -319,6 +319,7 @@ struct BookingDetailsView_Previews: PreviewProvider {
             allDay: false,
             cost: "$70.00",
             customerID: 456,
+            userID: 456,
             dateCreated: now,
             dateModified: now,
             endDate: hourFromNow,


### PR DESCRIPTION
Closes: WOOMOB-2462
Replaces https://github.com/woocommerce/woocommerce-ios/pull/16825 and targets release

## Description
Updates bookings filter to support the v2 API's new customer/user ID semantics.
More context here: p1772803935049449-slack-C09FHQNQERG

The Bookings v2 API changes `customer_id` to represent a Woo Customer ID (from `wp_wc_customer_lookup`) and introduces a new `user_id` field for the WP User ID. Since the app filters by WP user IDs, this PR:
- Adds `userID` field to the Booking model across all layers (Networking, Storage/CoreData Model 134, Yosemite)
- Changes the API query parameter from `customer` to `user`
- Updates the local CoreData predicate from `customerID` to `userID`

## POS changes
- Updates the POS guest check to use `userID == 0` instead of `customerID == 0`

## Test Steps
- Log into the app with a CIAB test store that has bookable products and existing bookings
- Test the filter: navigate to bookings list, filter by customer — verify the correct bookings appear
- With the customer filters in place - verify how `/wc-bookings/v2/bookings` request is made in Proxyman
    - Make sure `user` is passed in query params instead of `customer`.
    - Make sure response contains both `customer_id` and `user_id` where `user_id` contains the ID value.
- Test POS guest check: open POS → Bookings, check that guest vs non-guest indicators are correct
- Test data integrity: verify booking details show correct customer info, duration, amounts

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.