### PR TITLE
[POS] Migrate Settings to use POSNavigationSplitView

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHardwareDetailView.swift
@@ -8,7 +8,7 @@ struct POSSettingsHardwareDetailView: View {
 
     let settingsController: POSSettingsControllerProtocol
 
-    @State private var navigationPath: [NavigationDestination] = []
+    @Binding var navigationPath: NavigationPath
     @State private var showBarcodeScanningSetupModal: Bool = false
     @State private var showBarcodeScanningDocumentationModal: Bool = false
     @State private var showCardReaderDocumentationModal: Bool = false
@@ -48,68 +48,68 @@ struct POSSettingsHardwareDetailView: View {
 
     var body: some View {
         @Bindable var posModel = posModel
-        NavigationStack(path: $navigationPath) {
-            VStack(spacing: POSSpacing.none) {
-                POSPageHeaderView(title: Localization.hardwareTitle)
-                    .foregroundColor(.posSurface)
-                    .accessibilityAddTraits(.isHeader)
+        VStack(spacing: POSSpacing.none) {
+            POSPageHeaderView(title: Localization.hardwareTitle)
+                .foregroundColor(.posSurface)
+                .accessibilityAddTraits(.isHeader)
 
-                VStack(spacing: POSSpacing.small) {
-                    ForEach(HardwareDestination.allCases) { destination in
-                        NavigationLink(value: NavigationDestination.hardware(destination)) {
-                            VStack(alignment: .leading, spacing: POSPadding.xSmall) {
-                                Text(destination.title)
-                                    .font(.posBodyLargeBold)
-                                    .foregroundStyle(Color.posOnSurface)
-                                    .dynamicTypeSize(...DynamicTypeSize.accessibility2)
-                                Text(destination.subtitle)
-                                    .font(.posBodyMediumRegular())
-                                    .foregroundStyle(.secondary)
-                                    .dynamicTypeSize(...DynamicTypeSize.accessibility2)
-                            }
-                            .padding()
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(Color.posSurfaceContainerLowest)
-                            .posItemCardBorderStyles()
+            VStack(spacing: POSSpacing.small) {
+                ForEach(HardwareDestination.allCases) { destination in
+                    NavigationLink(value: NavigationDestination.hardware(destination)) {
+                        VStack(alignment: .leading, spacing: POSPadding.xSmall) {
+                            Text(destination.title)
+                                .font(.posBodyLargeBold)
+                                .foregroundStyle(Color.posOnSurface)
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                            Text(destination.subtitle)
+                                .font(.posBodyMediumRegular())
+                                .foregroundStyle(.secondary)
+                                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                         }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("\(destination.title), \(destination.subtitle)")
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color.posSurfaceContainerLowest)
+                        .posItemCardBorderStyles()
                     }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(destination.title), \(destination.subtitle)")
                 }
-                .padding(.horizontal, POSPadding.medium)
+            }
+            .padding(.horizontal, POSPadding.medium)
 
-                Spacer()
+            Spacer()
+        }
+        .background(backgroundColor)
+        .navigationDestination(for: NavigationDestination.self) { destination in
+            switch destination {
+            case .hardware(.cardReaders):
+                cardReadersView
+                    .environment(\.posHeaderBackButtonConfiguration, nil)
+            case .hardware(.scanners):
+                scannersView
+                    .environment(\.posHeaderBackButtonConfiguration, nil)
             }
-            .background(backgroundColor)
-            .navigationDestination(for: NavigationDestination.self) { destination in
-                switch destination {
-                case .hardware(.cardReaders):
-                    cardReadersView
-                case .hardware(.scanners):
-                    scannersView
-                }
-            }
-            .posModal(item: $posModel.cardPresentPaymentAlertViewModel, onDismiss: {
-                posModel.cardPresentPaymentAlertViewModel?.onDismiss?()
-            }, content: { alertType in
-                PointOfSaleCardPresentPaymentAlert(alertType: alertType)
-                    .posInteractiveDismissDisabled(alertType.isDismissDisabled)
-            })
-            .posModal(item: $posModel.cardPresentPaymentOnboardingViewContainer, onDismiss: {
-                posModel.cancelCardPaymentsOnboarding()
-            }, content: { viewContainer in
-                paymentsOnboardingView(from: viewContainer)
-            })
-            .posSheet(isPresented: $showSupport) {
-                supportForm
-                    .interactiveDismissDisabled(true)
-            }
-            .posModal(isPresented: $showBarcodeScanningSetupModal) {
-                POSBarcodeScannerSetup(isPresented: $showBarcodeScanningSetupModal, analytics: analytics)
-            }
-            .posFullScreenCover(isPresented: $showBarcodeScanningDocumentationModal) {
-                SafariView(url: POSConstants.URLs.pointOfSaleBarcodeScannerDocumentation.asURL())
-            }
+        }
+        .posModal(item: $posModel.cardPresentPaymentAlertViewModel, onDismiss: {
+            posModel.cardPresentPaymentAlertViewModel?.onDismiss?()
+        }, content: { alertType in
+            PointOfSaleCardPresentPaymentAlert(alertType: alertType)
+                .posInteractiveDismissDisabled(alertType.isDismissDisabled)
+        })
+        .posModal(item: $posModel.cardPresentPaymentOnboardingViewContainer, onDismiss: {
+            posModel.cancelCardPaymentsOnboarding()
+        }, content: { viewContainer in
+            paymentsOnboardingView(from: viewContainer)
+        })
+        .posSheet(isPresented: $showSupport) {
+            supportForm
+                .interactiveDismissDisabled(true)
+        }
+        .posModal(isPresented: $showBarcodeScanningSetupModal) {
+            POSBarcodeScannerSetup(isPresented: $showBarcodeScanningSetupModal, analytics: analytics)
+        }
+        .posFullScreenCover(isPresented: $showBarcodeScanningDocumentationModal) {
+            SafariView(url: POSConstants.URLs.pointOfSaleBarcodeScannerDocumentation.asURL())
         }
     }
 }
@@ -512,6 +512,9 @@ private extension POSSettingsHardwareDetailView {
 
 #if DEBUG
 #Preview {
-    POSSettingsHardwareDetailView(settingsController: POSSettingsPreviewController())
+    @Previewable @State var navigationPath = NavigationPath()
+    NavigationStack(path: $navigationPath) {
+        POSSettingsHardwareDetailView(settingsController: POSSettingsPreviewController(), navigationPath: $navigationPath)
+    }
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHelpDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsHelpDetailView.swift
@@ -13,43 +13,41 @@ struct POSSettingsHelpDetailView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            VStack(spacing: POSSpacing.none) {
-                POSPageHeaderView(title: Localization.helpTitle)
-                    .foregroundColor(.posSurface)
-                    .accessibilityAddTraits(.isHeader)
+        VStack(spacing: POSSpacing.none) {
+            POSPageHeaderView(title: Localization.helpTitle)
+                .foregroundColor(.posSurface)
+                .accessibilityAddTraits(.isHeader)
 
-                ScrollView {
-                    VStack(spacing: POSSpacing.small) {
-                        POSSettingsCard(
-                            title: Localization.productRestrictionsInfo,
-                            subtitle: Localization.productRestrictionsInfoSubtitle,
-                            action: {
-                                showProductRestrictions = true
-                            }
-                        )
+            ScrollView {
+                VStack(spacing: POSSpacing.small) {
+                    POSSettingsCard(
+                        title: Localization.productRestrictionsInfo,
+                        subtitle: Localization.productRestrictionsInfoSubtitle,
+                        action: {
+                            showProductRestrictions = true
+                        }
+                    )
 
-                        POSSettingsCard(
-                            title: Localization.documentationTitle,
-                            subtitle: Localization.documentationSubtitle,
-                            action: {
-                                showDocumentation = true
-                            }
-                        )
+                    POSSettingsCard(
+                        title: Localization.documentationTitle,
+                        subtitle: Localization.documentationSubtitle,
+                        action: {
+                            showDocumentation = true
+                        }
+                    )
 
-                        POSSettingsCard(
-                            title: Localization.getSupportTitle,
-                            subtitle: Localization.getSupportSubtitle,
-                            action: {
-                                showSupport = true
-                            }
-                        )
-                    }
-                    .padding(.horizontal, POSPadding.medium)
+                    POSSettingsCard(
+                        title: Localization.getSupportTitle,
+                        subtitle: Localization.getSupportSubtitle,
+                        action: {
+                            showSupport = true
+                        }
+                    )
                 }
+                .padding(.horizontal, POSPadding.medium)
             }
-            .background(backgroundColor)
         }
+        .background(backgroundColor)
         .posModal(isPresented: $showProductRestrictions) {
             // TODO: Remove copy on POSFloatingControlView.documentationView
             // WOOMOB-1168

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogDetailView.swift
@@ -9,25 +9,23 @@ struct POSSettingsLocalCatalogDetailView: View {
 
     var body: some View {
         @Bindable var viewModel = viewModel
-        NavigationStack {
-            VStack(spacing: POSSpacing.none) {
-                POSPageHeaderView(title: Localization.localCatalogTitle)
-                    .foregroundColor(.posSurface)
-                    .accessibilityAddTraits(.isHeader)
+        VStack(spacing: POSSpacing.none) {
+            POSPageHeaderView(title: Localization.localCatalogTitle)
+                .foregroundColor(.posSurface)
+                .accessibilityAddTraits(.isHeader)
 
-                ScrollView {
-                    VStack(spacing: POSSpacing.medium) {
-                        catalogStatus
-                        if viewModel.deviceHasCellularCapability {
-                            managingDataUsage
-                        }
-                        manualCatalogUpdate
+            ScrollView {
+                VStack(spacing: POSSpacing.medium) {
+                    catalogStatus
+                    if viewModel.deviceHasCellularCapability {
+                        managingDataUsage
                     }
-                    .padding(.horizontal, POSPadding.medium)
+                    manualCatalogUpdate
                 }
+                .padding(.horizontal, POSPadding.medium)
             }
-            .background(Style.backgroundColor)
         }
+        .background(Style.backgroundColor)
         .task {
             await viewModel.loadCatalogData()
         }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsStoreDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsStoreDetailView.swift
@@ -18,28 +18,26 @@ struct POSSettingsStoreDetailView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            VStack(spacing: POSSpacing.none) {
-                POSPageHeaderView(title: Localization.storeTitle)
-                    .foregroundColor(.posSurface)
-                    .accessibilityAddTraits(.isHeader)
+        VStack(spacing: POSSpacing.none) {
+            POSPageHeaderView(title: Localization.storeTitle)
+                .foregroundColor(.posSurface)
+                .accessibilityAddTraits(.isHeader)
 
-                ScrollView {
-                    VStack(spacing: POSSpacing.medium) {
-                        storeInformationView
+            ScrollView {
+                VStack(spacing: POSSpacing.medium) {
+                    storeInformationView
 
-                        receiptInformationView
-                            .renderedIf(viewModel.shouldShowReceiptInformation)
-                    }
-                    .padding(.horizontal, POSPadding.medium)
+                    receiptInformationView
+                        .renderedIf(viewModel.shouldShowReceiptInformation)
                 }
+                .padding(.horizontal, POSPadding.medium)
             }
-            .background(backgroundColor)
-            .task {
-                isLoading = true
-                await viewModel.retrievePOSReceiptSettings()
-                isLoading = false
-            }
+        }
+        .background(backgroundColor)
+        .task {
+            isLoading = true
+            await viewModel.retrievePOSReceiptSettings()
+            isLoading = false
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
@@ -3,18 +3,24 @@ import SwiftUI
 struct POSSettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.posAnalytics) private var analytics
-    @State private var selection: SidebarNavigation? = .store
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @State private var selection: SidebarNavigation?
 
     let settingsController: POSSettingsControllerProtocol
 
     var body: some View {
-        GeometryReader { geometry in
-            HStack(spacing: POSSpacing.none) {
-                listView
-                .frame(width: geometry.size.width * Constants.sidebarWidthFraction)
-
-                detailView
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+        POSNavigationSplitView(selection: $selection) { _ in
+            listView
+        } detail: { selection, navigationPath in
+            detailView(for: selection, navigationPath: navigationPath)
+                .environment(\.posHeaderBackButtonConfiguration,
+                             horizontalSizeClass == .compact ?
+                                .init(state: .enabled, action: { self.selection = nil }) : nil)
+        } detailPlaceholderView: {
+            POSSettingsStoreDetailView(viewModel: settingsController.storeViewModel)
+        } setDefaultValue: {
+            if selection == nil {
+                selection = .store
             }
         }
     }
@@ -68,12 +74,12 @@ extension POSSettingsView {
     }
 
     @ViewBuilder
-    private var detailView: some View {
+    private func detailView(for selection: SidebarNavigation, navigationPath: Binding<NavigationPath>) -> some View {
         switch selection {
         case .store:
             POSSettingsStoreDetailView(viewModel: settingsController.storeViewModel)
         case .hardware:
-            POSSettingsHardwareDetailView(settingsController: settingsController)
+            POSSettingsHardwareDetailView(settingsController: settingsController, navigationPath: navigationPath)
         case .localCatalog:
             if let viewModel = settingsController.localCatalogViewModel {
                 POSSettingsLocalCatalogDetailView(viewModel: viewModel)
@@ -82,8 +88,6 @@ extension POSSettingsView {
             }
         case .help:
             POSSettingsHelpDetailView()
-        default:
-            EmptyView()
         }
     }
 
@@ -111,12 +115,6 @@ extension POSSettingsView {
         .buttonStyle(.plain)
         .accessibilityAddTraits(.isButton)
         .accessibilityLabel(SidebarNavigation.help.title)
-    }
-}
-
-extension POSSettingsView {
-    enum Constants {
-        static let sidebarWidthFraction: CGFloat = 0.35
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
@@ -36,8 +36,8 @@ extension POSSettingsView {
                                                action: {
                                                    analytics.track(.pointOfSaleSettingsCloseButtonTapped)
                                                    dismiss()
-                                               },
-                                               buttonIcon: "chevron.left"))
+                                               }))
+            .posHeaderBackButtonIcon(systemName: "xmark")
             .foregroundColor(.posSurface)
             .accessibilityAddTraits(.isHeader)
 


### PR DESCRIPTION
## Description
Replaces the manual `GeometryReader` + `HStack` split layout in POS Settings with `POSNavigationSplitView`, the same navigation component used by Orders and Bookings.

This brings Settings in line with the shared navigation pattern, gaining:
- Automatic compact/regular size class adaptation (sidebar + detail on iPad, push navigation on phone)
- Back button support in compact mode
- Consistent split view layout and animation behavior
- Navigation path management for hardware detail's internal navigation

### Changes
- **POSSettingsView**: Replaced manual split with `POSNavigationSplitView`, added `setDefaultValue` and compact back button via environment
- **POSSettingsStoreDetailView / HelpDetailView / LocalCatalogDetailView**: Removed `NavigationStack` wrappers (now provided by `POSNavigationSplitView`)
- **POSSettingsHardwareDetailView**: Changed navigation path from `@State` to `@Binding` (received from split view), removed `NavigationStack` wrapper, reset `posHeaderBackButtonConfiguration` environment on pushed views so their explicit back buttons take precedence

## Test Steps
1. Open POS and tap Settings
2. On iPad, verify the sidebar/detail split layout looks the same as before
3. Tap each settings section (Store, Hardware, Product catalog, Help) and verify the detail pane updates
4. In Hardware, navigate to Card readers and Barcode scanners - verify back navigation works
5. If testing on iPhone or compact width, verify tapping a section pushes the detail view, and the back button returns to the sidebar

### Video

#### iPad

https://github.com/user-attachments/assets/7884626c-a359-4611-b420-fca9e2e2b948

#### iPhone

https://github.com/user-attachments/assets/070632a8-65d5-48b2-93ea-58b9b3cde7e7

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.