### PR TITLE
Disable FedEx support

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -109,6 +109,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .ageRangeRequirementsCompliance:
             return false
+        case .wooShippingFedEx:
+            return false
         default:
             return true
         }

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -229,4 +229,8 @@ public enum FeatureFlag: Int, CaseIterable {
     /// https://developer.apple.com/news/?id=2ezb6jhj
     ///
     case ageRangeRequirementsCompliance
+
+    /// Enables FedEx as a carrier option in WooShipping label creation
+    ///
+    case wooShippingFedEx
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,7 +16,6 @@
 - [*] Update logic for payment status of bookings [https://github.com/woocommerce/woocommerce-ios/pull/16805]
 - [Internal] Unify Jetpack setup flow for JCP sites [https://github.com/woocommerce/woocommerce-ios/pull/16816]
 - [*] Fix hiding coupon and product options when opending drawer [https://github.com/woocommerce/woocommerce-ios/pull/16806]
-- [*] Add FedEx as a supported carrier in the shipping label creation flow [https://github.com/woocommerce/woocommerce-ios/pull/16815]
 - [Internal] Treat ecommerce garden sites as having WooCommerce by default [https://github.com/woocommerce/woocommerce-ios/pull/16820]
 - [*] Remove the redundant Price row from booking details [https://github.com/woocommerce/woocommerce-ios/pull/16821]
 - [*] Fix sheet/popover presentation showing trimmed content on iPad [https://github.com/woocommerce/woocommerce-ios/pull/16817]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -1,6 +1,7 @@
+import Combine
+import Experiments
 import Foundation
 import SwiftUI
-import Combine
 import Yosemite
 import protocol Storage.StorageManagerType
 import protocol WooFoundation.Analytics
@@ -10,6 +11,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
     private let stores: StoresManager
     private let storage: StorageManagerType
     private let analytics: Analytics
+    private let featureFlagService: FeatureFlagService
 
     private let starAnimation: Animation = .spring(duration: 0.2)
 
@@ -20,11 +22,13 @@ final class WooShippingAddPackageViewModel: ObservableObject {
          siteID: Int64 = ServiceLocator.stores.sessionManager.defaultStoreID ?? 0,
          stores: StoresManager = ServiceLocator.stores,
          storage: StorageManagerType = ServiceLocator.storageManager,
-         analytics: Analytics = ServiceLocator.analytics) {
+         analytics: Analytics = ServiceLocator.analytics,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.siteID = siteID
         self.stores = stores
         self.storage = storage
         self.analytics = analytics
+        self.featureFlagService = featureFlagService
 
         selectedPackageType = .custom
         previousSelectedPackage = selectedPackage
@@ -172,9 +176,13 @@ final class WooShippingAddPackageViewModel: ObservableObject {
         }.sorted { $0.id < $1.id }
         let predefinedSavedPackages = packages.savedPredefinedPackages.map {
             return $0.toPackageData()
+        }.filter {
+            $0.source.sourceID != WooShippingCarrier.fedex.rawValue || featureFlagService.isFeatureFlagEnabled(.wooShippingFedEx)
         }.sorted { $0.id < $1.id }
         var carrierPackages: [WooShippingCarrierPackages] = packages.allPredefinedOptions.compactMap {
             return $0.toCarrierPackages()
+        }.filter {
+            $0.carrier != .fedex || featureFlagService.isFeatureFlagEnabled(.wooShippingFedEx)
         }
         if self.carrierPackages.isNotEmpty {
             // sort new packages so they stay in similar order

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -1,4 +1,5 @@
 import Combine
+import Experiments
 import Foundation
 import Yosemite
 import protocol WooFoundation.Analytics
@@ -12,6 +13,7 @@ final class WooShippingServiceViewModel: ObservableObject {
     private let destinationAddress: WooShippingAddress?
     private let stores: StoresManager
     private let analytics: Analytics
+    private let featureFlagService: FeatureFlagService
 
     /// List of tabs to display for the shipping services.
     /// Contains the data about available shipping rates, grouped by carrier.
@@ -58,6 +60,7 @@ final class WooShippingServiceViewModel: ObservableObject {
          destinationAddress: WooShippingAddress?,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          onSelectRate: ((_ selectedRate: WooShippingSelectedRate) -> Void)? = nil) {
         self.siteID = order.siteID
         self.orderID = order.orderID
@@ -65,6 +68,7 @@ final class WooShippingServiceViewModel: ObservableObject {
         self.destinationAddress = destinationAddress
         self.stores = stores
         self.analytics = analytics
+        self.featureFlagService = featureFlagService
         self.onSelectRate = onSelectRate
         observeSelectedTab()
     }
@@ -239,6 +243,9 @@ private extension WooShippingServiceViewModel {
         serviceTabs = standardRates.grouped(by: { $0.carrierID })
             .compactMap { (carrierID, rates) -> WooShippingServiceTab? in
                 guard let carrier = WooShippingCarrier(rawValue: carrierID) else {
+                    return nil
+                }
+                if carrier == .fedex && !featureFlagService.isFeatureFlagEnabled(.wooShippingFedEx) {
                     return nil
                 }
                 let cards = rates


### PR DESCRIPTION
## Description
WOOMOB-2573

Temporarily disables FedEx in the Woo Shipping label creation flow behind a local feature flag.

Slack discussion: p1774885649652989/1774550237.060069-slack-C05VBLKHHV1

## Test Steps
1. Open an order that can be used to create a shipping label (The site should be connected to staging server).
2. Start the shipping label flow.
3. Go to the package selection screen.
4. Open the `Carrier` tab.
5. Confirm FedEx is not shown in the carrier list.
6. Continue to the shipping rates step.
7. Confirm FedEx rates are not shown.

## Screenshots
|Before|After|
|-|-|
|<img width="300" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-03-31 at 01 01 16" src="https://github.com/user-attachments/assets/036d2c72-1426-4476-935c-e2b9f61cff61" />|<img width="300"  alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-03-31 at 00 59 27" src="https://github.com/user-attachments/assets/270baa5d-1024-43b1-a5b1-5b321f2a36c2" />|

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.