### PR TITLE
Hide plugins section for CIAB sites

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -104,6 +104,7 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     private let defaults: UserDefaults
     private let pushNotesManager: PushNotesManager
     private let analytics: Analytics
+    private let ciabEligibilityChecker: CIABEligibilityCheckerProtocol
 
     private var subscriptions: Set<AnyCancellable> = []
 
@@ -116,13 +117,15 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          defaults: UserDefaults = .standard,
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
-         analytics: Analytics = ServiceLocator.analytics) {
+         analytics: Analytics = ServiceLocator.analytics,
+         ciabEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker()) {
         self.stores = stores
         self.storageManager = storageManager
         self.featureFlagService = featureFlagService
         self.defaults = defaults
         self.pushNotesManager = pushNotesManager
         self.analytics = analytics
+        self.ciabEligibilityChecker = ciabEligibilityChecker
 
         /// Initialize Sites Results Controller
         ///
@@ -231,6 +234,11 @@ private extension SettingsViewModel {
             // Show the plugins section only if the user has an `admin` role for the default store site.
             //
             guard stores.sessionManager.defaultRoles.contains(.administrator) else {
+                return nil
+            }
+
+            // Hide plugins section for CIAB sites
+            guard !ciabEligibilityChecker.isCurrentSiteCIAB else {
                 return nil
             }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -376,6 +376,53 @@ final class SettingsViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.connectivity) })
     }
+
+    func test_sections_do_not_contain_plugins_when_site_is_CIAB() {
+        // Given
+        let viewModel = SettingsViewModel(
+            stores: stores,
+            storageManager: storageManager,
+            ciabEligibilityChecker: MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: true))
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.plugins) })
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.woocommerceDetails) })
+    }
+
+    func test_sections_contain_plugins_when_site_is_not_CIAB_and_user_is_admin() {
+        // Given
+        let viewModel = SettingsViewModel(
+            stores: stores,
+            storageManager: storageManager,
+            ciabEligibilityChecker: MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: false))
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.plugins) })
+        XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.woocommerceDetails) })
+    }
+
+    func test_sections_do_not_contain_plugins_when_user_is_not_admin() {
+        // Given
+        let sessionManager = SessionManager.makeForTesting(authenticated: true, defaultRoles: [.shopManager])
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let viewModel = SettingsViewModel(
+            stores: stores,
+            storageManager: storageManager,
+            ciabEligibilityChecker: MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: false))
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.plugins) })
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.woocommerceDetails) })
+    }
 }
 
 private final class MockSettingsPresenter: SettingsViewPresenter {


### PR DESCRIPTION
Closes WOOMOB-2513

## Description
CIAB sites enforce `DISALLOW_FILE_MODS` at the server level, making plugin updates impossible. Currently, CIAB users with admin roles can see the Plugins section in settings and encounter errors when attempting updates. It also shows the internals of CIAB and dev versions. We hide the entire plugin section for all CIAB sites regardless of plan tier.

<img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - CIAB general - 2026-03-31 at 10 34 17" src="https://github.com/user-attachments/assets/f4cefbdf-344b-4003-85be-cef13ff00978" />

## Test Steps
- In CIAB site, navigate to Menu > Settings > Confirm no Plugins section
- In non-CIAB site, navigate to Menu > Settings > Confirm Plugins section

## Screenshots
| CIAB | non-CIAB |
|--------|--------|
| <img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - CIAB general - 2026-03-31 at 10 47 17" src="https://github.com/user-attachments/assets/8f244e58-bc0e-4995-9e69-4d7c6bb73c58" /> | <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2026-03-31 at 10 52 56" src="https://github.com/user-attachments/assets/891e68c4-1c62-45ac-bab2-188b74ae785a" /> | 

