### PR TITLE
[CIAB] Add order status mapping for display and filters

### DIFF
--- a/WooCommerce/Classes/CIAB/CIABOrderStatusMapper.swift
+++ b/WooCommerce/Classes/CIAB/CIABOrderStatusMapper.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Yosemite
+
+/// Maps WooCommerce Core order statuses to CIAB simplified statuses for display and filtering.
+///
+/// CIAB sites use a simplified set of order statuses:
+/// - **Open**: groups `pending`, `processing`, `on-hold`, and `failed`
+/// - **Completed**, **Cancelled**, **Refunded**: 1:1 mapping with Core statuses
+///
+/// This mapper centralizes the conversion so display, filtering, and API queries stay consistent.
+struct CIABOrderStatusMapper {
+
+    /// The core statuses that map to the CIAB "Open" group.
+    static let openStatuses: Set<OrderStatusEnum> = [.pending, .processing, .onHold, .failed]
+
+    /// The slug used for the synthetic "open" status in CIAB.
+    static let openSlug = "open"
+
+    // MARK: - Display Mapping
+
+    /// Returns the display name for an order status on a CIAB site.
+    ///
+    /// Statuses in the "Open" group return a localized "Open" label.
+    /// All other statuses return their standard localized name.
+    static func displayName(for status: OrderStatusEnum) -> String {
+        if openStatuses.contains(status) {
+            return Localization.open
+        }
+        return status.localizedName
+    }
+
+    /// Returns the `OrderStatusEnum` to use for styling on a CIAB site.
+    ///
+    /// Statuses in the "Open" group return `.custom("open")` so that UI components
+    /// can apply a single badge style. All other statuses pass through unchanged.
+    static func displayStatus(for status: OrderStatusEnum) -> OrderStatusEnum {
+        if openStatuses.contains(status) {
+            return .custom(openSlug)
+        }
+        return status
+    }
+
+    // MARK: - Filter Mapping
+
+    /// Maps an array of `OrderStatus` options from the API into CIAB-friendly filter options.
+    ///
+    /// Replaces individual "Open" group statuses with a single synthetic "Open" entry.
+    /// Only adds the "Open" option once and preserves non-open statuses in their original order.
+    static func mapFilterOptions(_ statuses: [OrderStatus]) -> [OrderStatus] {
+        var result: [OrderStatus] = []
+        var openAdded = false
+
+        for status in statuses {
+            if openStatuses.contains(status.status) {
+                if !openAdded {
+                    // Insert a synthetic "Open" entry using the first open status's siteID and a total of 0.
+                    let openStatus = OrderStatus(name: Localization.open,
+                                                 siteID: status.siteID,
+                                                 slug: openSlug,
+                                                 total: 0)
+                    result.append(openStatus)
+                    openAdded = true
+                }
+                // Skip individual open statuses.
+            } else {
+                result.append(status)
+            }
+        }
+        return result
+    }
+
+    /// Expands CIAB filter selections back to core statuses for API requests.
+    ///
+    /// When the user selects "Open" in the filter UI, this resolves it to the 4 underlying
+    /// core statuses so the API returns the correct results.
+    static func resolveFilterStatuses(_ statuses: [OrderStatusEnum]) -> [OrderStatusEnum] {
+        var resolved: [OrderStatusEnum] = []
+        for status in statuses {
+            if status == .custom(openSlug) {
+                resolved.append(contentsOf: openStatuses)
+            } else {
+                resolved.append(status)
+            }
+        }
+        return resolved
+    }
+}
+
+// MARK: - Localization
+
+private extension CIABOrderStatusMapper {
+    enum Localization {
+        static let open = NSLocalizedString(
+            "ciabOrderStatusMapper.open",
+            value: "Open",
+            comment: "Display label for the CIAB 'Open' order status, which groups pending, processing, on-hold, and failed orders."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1049,7 +1049,8 @@ private extension OrderDetailsDataSource {
         let cellViewModel = SummaryTableViewCellViewModel(
             order: order,
             status: lookUpOrderStatus(for: order),
-            isEditButtonVisible: isStatusEditingSupported
+            isEditButtonVisible: isStatusEditingSupported,
+            isCIAB: ciabEligibilityChecker.isCurrentSiteCIAB
         )
 
         cell.configure(cellViewModel)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrderDashboardRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrderDashboardRow.swift
@@ -85,6 +85,12 @@ private extension LastOrderDashboardRow {
 struct LastOrderDashboardRowViewModel {
     private let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
     let order: Order
+    private let isCIAB: Bool
+
+    init(order: Order, isCIAB: Bool = false) {
+        self.order = order
+        self.isCIAB = isCIAB
+    }
 
     var isPOSOrder: Bool {
         order.salesChannel == .pointOfSale
@@ -106,7 +112,7 @@ struct LastOrderDashboardRowViewModel {
     }
 
     var statusDescription: String {
-        order.status.description
+        isCIAB ? CIABOrderStatusMapper.displayName(for: order.status) : order.status.description
     }
 
     /// The value will only include the year if the `createdDate` is not from the current year.
@@ -127,7 +133,8 @@ struct LastOrderDashboardRowViewModel {
     }
 
     var statusBackgroundColor: Color {
-        Color(uiColor: order.status.backgroundColor)
+        let displayStatus = isCIAB ? CIABOrderStatusMapper.displayStatus(for: order.status) : order.status
+        return Color(uiColor: displayStatus.backgroundColor)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
@@ -77,7 +77,13 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
         }
 
         var description: String {
-            status?.description ?? Localization.anyStatusCase
+            guard let status else {
+                return Localization.anyStatusCase
+            }
+            if status == .custom(CIABOrderStatusMapper.openSlug) {
+                return CIABOrderStatusMapper.displayName(for: status)
+            }
+            return status.description
         }
     }
     // Set externally to trigger callback upon hiding the Inbox card.
@@ -90,13 +96,20 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
     @Published private(set) var allStatuses: [OrderStatusRow] = []
 
     var status: String {
-        selectedOrderStatus?.description ?? Localization.anyStatusCase
+        guard let selectedOrderStatus else {
+            return Localization.anyStatusCase
+        }
+        if selectedOrderStatus == .custom(CIABOrderStatusMapper.openSlug) {
+            return CIABOrderStatusMapper.displayName(for: selectedOrderStatus)
+        }
+        return selectedOrderStatus.description
     }
 
     private let siteID: Int64
     private let stores: StoresManager
     private let storageManager: StorageManagerType
     private let analytics: Analytics
+    private let ciabEligibilityChecker: CIABEligibilityCheckerProtocol
 
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
@@ -108,11 +121,13 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
-         analytics: Analytics = ServiceLocator.analytics) {
+         analytics: Analytics = ServiceLocator.analytics,
+         ciabEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker()) {
         self.siteID = siteID
         self.analytics = analytics
         self.stores = stores
         self.storageManager = storageManager
+        self.ciabEligibilityChecker = ciabEligibilityChecker
 
         Task { @MainActor in
             selectedOrderStatus = await loadLastSelectedOrderStatus()
@@ -131,8 +146,9 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
         do {
             async let orders = loadLast3Orders(for: selectedOrderStatus)
             try? await loadOrderStatuses()
+            let isCIAB = ciabEligibilityChecker.isCurrentSiteCIAB
             rows = try await orders
-                .map { LastOrderDashboardRowViewModel(order: $0) }
+                .map { LastOrderDashboardRowViewModel(order: $0, isCIAB: isCIAB) }
             analytics.track(event: .DynamicDashboard.cardLoadingCompleted(type: .lastOrders))
         } catch {
             syncingError = error
@@ -175,9 +191,13 @@ private extension LastOrdersDashboardCardViewModel {
     @MainActor
     func loadLast3Orders(for status: OrderStatusEnum?) async throws -> [Order] {
         return try await withCheckedThrowingContinuation { continuation in
+            let resolvedStatuses: [String] = {
+                guard let status else { return [] }
+                return CIABOrderStatusMapper.resolveFilterStatuses([status]).map { $0.rawValue }
+            }()
             stores.dispatch(OrderAction.fetchFilteredOrders(
                 siteID: siteID,
-                statuses: [status?.rawValue].compactMap { $0 },
+                statuses: resolvedStatuses,
                 writeStrategy: .doNotSave,
                 pageSize: Constants.numberOfOrdersToShow,
                 onCompletion: { _, result in
@@ -222,10 +242,19 @@ private extension LastOrdersDashboardCardViewModel {
     }
 
     func updateStatuses() {
-        let remoteStatuses = statusResultsController.fetchedObjects
-            .map { OrderStatusEnum(rawValue: $0.slug) }
-            .map { OrderStatusRow($0) }
-        allStatuses = [.any] + remoteStatuses
+        if ciabEligibilityChecker.isCurrentSiteCIAB {
+            let fetchedStatuses = statusResultsController.fetchedObjects.map {
+                OrderStatus(name: $0.name, siteID: $0.siteID, slug: $0.slug, total: Int($0.total))
+            }
+            let mappedStatuses = CIABOrderStatusMapper.mapFilterOptions(fetchedStatuses)
+                .map { OrderStatusRow($0.status) }
+            allStatuses = [.any] + mappedStatuses
+        } else {
+            let remoteStatuses = statusResultsController.fetchedObjects
+                .map { OrderStatusEnum(rawValue: $0.slug) }
+                .map { OrderStatusRow($0) }
+            allStatuses = [.any] + remoteStatuses
+        }
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
@@ -193,7 +193,10 @@ private extension LastOrdersDashboardCardViewModel {
         return try await withCheckedThrowingContinuation { continuation in
             let resolvedStatuses: [String] = {
                 guard let status else { return [] }
-                return CIABOrderStatusMapper.resolveFilterStatuses([status]).map { $0.rawValue }
+                if ciabEligibilityChecker.isCurrentSiteCIAB {
+                    return CIABOrderStatusMapper.resolveFilterStatuses([status]).map { $0.rawValue }
+                }
+                return [status.rawValue]
             }()
             stores.dispatch(OrderAction.fetchFilteredOrders(
                 siteID: siteID,

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
@@ -8,10 +8,12 @@ import WooFoundationCore
 struct OrderListCellViewModel {
     private let order: Order
     private let currencyFormatter: CurrencyFormatter
+    private let isCIAB: Bool
 
-    init(order: Order, currencySettings: CurrencySettings) {
+    init(order: Order, currencySettings: CurrencySettings, isCIAB: Bool = false) {
         self.order = order
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        self.isCIAB = isCIAB
     }
 
     /// For example, #560 Pamela Nguyen
@@ -54,16 +56,16 @@ struct OrderListCellViewModel {
         return formatter.string(from: order.dateCreated)
     }
 
-    /// Status of the order
+    /// Status of the order (mapped for CIAB sites)
     ///
     var status: OrderStatusEnum {
-        return order.status
+        isCIAB ? CIABOrderStatusMapper.displayStatus(for: order.status) : order.status
     }
 
-    /// Textual representation of the status
+    /// Textual representation of the status (mapped for CIAB sites)
     ///
     var statusString: String {
-        return order.status.localizedName
+        isCIAB ? CIABOrderStatusMapper.displayName(for: order.status) : order.status.localizedName
     }
 
     /// Sales channel

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCellViewModel.swift
@@ -21,16 +21,26 @@ struct SummaryTableViewCellViewModel {
     init(order: Order,
          status: OrderStatus?,
          isEditButtonVisible: Bool = true,
+         isCIAB: Bool = false,
          calendar: Calendar = .current) {
 
         billingAddress = order.billingAddress
         dateCreated = order.dateCreated
         salesChannel = order.salesChannel?.description
 
-        presentation = OrderStatusPresentation(
-            style: status?.status ?? order.status,
-            title: status?.name ?? order.status.rawValue
-        )
+        let orderStatus = status?.status ?? order.status
+        let statusTitle = status?.name ?? order.status.rawValue
+        if isCIAB {
+            presentation = OrderStatusPresentation(
+                style: CIABOrderStatusMapper.displayStatus(for: orderStatus),
+                title: CIABOrderStatusMapper.displayName(for: orderStatus)
+            )
+        } else {
+            presentation = OrderStatusPresentation(
+                style: orderStatus,
+                title: statusTitle
+            )
+        }
 
         self.isEditButtonVisible = isEditButtonVisible
         self.calendar = calendar

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusEnum+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Order Status Filter/OrderStatusEnum+UI.swift
@@ -4,7 +4,7 @@ import enum Yosemite.OrderStatusEnum
 extension OrderStatusEnum {
     var backgroundColor: UIColor {
         switch self {
-        case .autoDraft, .pending, .cancelled, .refunded, .custom:
+        case .autoDraft, .pending, .cancelled, .refunded:
                 .gray(.shade5)
         case .onHold:
                 .withColorStudio(.orange, shade: .shade5)
@@ -14,6 +14,10 @@ extension OrderStatusEnum {
                 .withColorStudio(.red, shade: .shade5)
         case .completed:
                 .withColorStudio(.blue, shade: .shade5)
+        case .custom(let slug):
+            slug == CIABOrderStatusMapper.openSlug
+                ? .withColorStudio(.orange, shade: .shade5)
+                : .gray(.shade5)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
@@ -2,6 +2,8 @@ import Foundation
 
 import enum Yosemite.OrderAction
 import struct Yosemite.OrderStatus
+import class Yosemite.CIABEligibilityChecker
+import protocol Yosemite.CIABEligibilityCheckerProtocol
 
 /// Returns what `OrderAction` should be used when synchronizing a list of orders.
 ///
@@ -51,6 +53,15 @@ struct OrderListSyncActionUseCase {
     let siteID: Int64
     /// The current filters applied to the Order List
     let filters: FilterOrderListViewModel.Filters?
+    private let ciabEligibilityChecker: CIABEligibilityCheckerProtocol
+
+    init(siteID: Int64,
+         filters: FilterOrderListViewModel.Filters?,
+         ciabEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker()) {
+        self.siteID = siteID
+        self.filters = filters
+        self.ciabEligibilityChecker = ciabEligibilityChecker
+    }
 
     /// Returns the action to use when synchronizing.
     func actionFor(pageNumber: Int,
@@ -58,7 +69,10 @@ struct OrderListSyncActionUseCase {
                    reason: SyncReason?,
                    lastFullSyncTimestamp: Date?,
                    completionHandler: @escaping (TimeInterval, Error?) -> Void) -> OrderAction {
-        let statuses = CIABOrderStatusMapper.resolveFilterStatuses(filters?.orderStatus ?? []).map { $0.rawValue }
+        let filterStatuses = filters?.orderStatus ?? []
+        let statuses = ciabEligibilityChecker.isCurrentSiteCIAB
+            ? CIABOrderStatusMapper.resolveFilterStatuses(filterStatuses).map { $0.rawValue }
+            : filterStatuses.map { $0.rawValue }
         let startDate = filters?.dateRange?.computedStartDate
         let endDate = filters?.dateRange?.computedEndDate
         let productID = filters?.product?.id

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
@@ -58,7 +58,7 @@ struct OrderListSyncActionUseCase {
                    reason: SyncReason?,
                    lastFullSyncTimestamp: Date?,
                    completionHandler: @escaping (TimeInterval, Error?) -> Void) -> OrderAction {
-        let statuses = (filters?.orderStatus ?? []).map { $0.rawValue }
+        let statuses = CIABOrderStatusMapper.resolveFilterStatuses(filters?.orderStatus ?? []).map { $0.rawValue }
         let startDate = filters?.dateRange?.computedStartDate
         let endDate = filters?.dateRange?.computedEndDate
         let productID = filters?.product?.id

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -65,6 +65,7 @@ final class OrderListViewModel {
     }
 
     private let siteID: Int64
+    private let ciabEligibilityChecker: CIABEligibilityCheckerProtocol
 
     /// Used for tracking whether the app was _previously_ in the background.
     ///
@@ -129,7 +130,8 @@ final class OrderListViewModel {
          pushNotificationsManager: PushNotesManager = ServiceLocator.pushNotesManager,
          notificationCenter: NotificationCenter = .default,
          filters: FilterOrderListViewModel.Filters?,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         ciabEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker()) {
         self.siteID = siteID
         self.cardPresentPaymentsConfiguration = cardPresentPaymentsConfiguration
         self.stores = stores
@@ -139,6 +141,7 @@ final class OrderListViewModel {
         self.notificationCenter = notificationCenter
         self.filters = filters
         self.featureFlagService = featureFlagService
+        self.ciabEligibilityChecker = ciabEligibilityChecker
         self.snapshotsProvider = FetchResultSnapshotsProvider<StorageOrder>(storageManager: storageManager,
                                                                             query: Self.createQuery(siteID: siteID,
                                                                                                     filters: filters))
@@ -229,7 +232,10 @@ final class OrderListViewModel {
     private static func createQuery(siteID: Int64, filters: FilterOrderListViewModel.Filters?) -> FetchResultSnapshotsProvider<StorageOrder>.Query {
         let predicateStatus: NSPredicate = {
             let excludeSearchCache = NSPredicate(format: "exclusiveForSearch = false")
-            let excludeNonMatchingStatus = filters?.orderStatus.map { NSPredicate(format: "statusKey IN %@", $0.map { $0.rawValue }) }
+            let excludeNonMatchingStatus = filters?.orderStatus.map { statuses in
+                let resolved = CIABOrderStatusMapper.resolveFilterStatuses(statuses)
+                return NSPredicate(format: "statusKey IN %@", resolved.map { $0.rawValue })
+            }
 
             let predicates = [excludeSearchCache, excludeNonMatchingStatus].compactMap { $0 }
             return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
@@ -348,7 +354,9 @@ extension OrderListViewModel {
             return nil
         }
 
-        return OrderListCellViewModel(order: order, currencySettings: ServiceLocator.currencySettings)
+        return OrderListCellViewModel(order: order,
+                                      currencySettings: ServiceLocator.currencySettings,
+                                      isCIAB: ciabEligibilityChecker.isCurrentSiteCIAB)
     }
 
     /// Creates an `OrderDetailsViewModel` for the `Order` pointed to by `objectID`.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -144,7 +144,8 @@ final class OrderListViewModel {
         self.ciabEligibilityChecker = ciabEligibilityChecker
         self.snapshotsProvider = FetchResultSnapshotsProvider<StorageOrder>(storageManager: storageManager,
                                                                             query: Self.createQuery(siteID: siteID,
-                                                                                                    filters: filters))
+                                                                                                    filters: filters,
+                                                                                                    isCIAB: ciabEligibilityChecker.isCurrentSiteCIAB))
     }
 
     deinit {
@@ -219,7 +220,8 @@ final class OrderListViewModel {
                                lastFullSyncTimestamp: Date?,
                                completionHandler: @escaping (TimeInterval, Error?) -> Void) -> OrderAction {
         let useCase = OrderListSyncActionUseCase(siteID: siteID,
-                                                 filters: filters)
+                                                 filters: filters,
+                                                 ciabEligibilityChecker: ciabEligibilityChecker)
         return useCase.actionFor(pageNumber: pageNumber,
                                  pageSize: pageSize,
                                  reason: reason,
@@ -229,11 +231,13 @@ final class OrderListViewModel {
         })
     }
 
-    private static func createQuery(siteID: Int64, filters: FilterOrderListViewModel.Filters?) -> FetchResultSnapshotsProvider<StorageOrder>.Query {
+    private static func createQuery(siteID: Int64,
+                                     filters: FilterOrderListViewModel.Filters?,
+                                     isCIAB: Bool) -> FetchResultSnapshotsProvider<StorageOrder>.Query {
         let predicateStatus: NSPredicate = {
             let excludeSearchCache = NSPredicate(format: "exclusiveForSearch = false")
             let excludeNonMatchingStatus = filters?.orderStatus.map { statuses in
-                let resolved = CIABOrderStatusMapper.resolveFilterStatuses(statuses)
+                let resolved = isCIAB ? CIABOrderStatusMapper.resolveFilterStatuses(statuses) : statuses
                 return NSPredicate(format: "statusKey IN %@", resolved.map { $0.rawValue })
             }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -405,8 +405,14 @@ private extension OrdersRootViewController {
     ///
     func resetFiltersIfAnyStatusFilterIsNoMoreExisting(orderStatuses: [OrderStatus]) {
         guard let storedOrderFilters = filters.orderStatus else { return }
-        for storedOrderFilter in storedOrderFilters {
-            if !orderStatuses.map({$0.status}).contains(storedOrderFilter) {
+        let availableStatuses = Set(orderStatuses.map { $0.status })
+        // On CIAB sites, resolve synthetic statuses (e.g. "open") to their underlying core statuses
+        // before checking validity, since the API only returns core statuses.
+        let resolvedFilters = ciabEligibilityChecker.isCurrentSiteCIAB
+            ? CIABOrderStatusMapper.resolveFilterStatuses(storedOrderFilters)
+            : storedOrderFilters
+        for resolvedFilter in resolvedFilters {
+            if !availableStatuses.contains(resolvedFilter) {
                 clearFilters()
                 break
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -65,6 +65,7 @@ final class OrdersRootViewController: UIViewController {
     }()
 
     private let featureFlagService: FeatureFlagService
+    private let ciabEligibilityChecker: CIABEligibilityCheckerProtocol
 
     private let orderDurationRecorder: OrderDurationRecorderProtocol
 
@@ -83,6 +84,7 @@ final class OrdersRootViewController: UIViewController {
         self.siteID = siteID
         self.storageManager = storageManager
         self.featureFlagService = ServiceLocator.featureFlagService
+        self.ciabEligibilityChecker = CIABEligibilityChecker()
         self.orderDurationRecorder = orderDurationRecorder
         self.barcodeScannerItemFinder = barcodeScannerItemFinder
         self.switchDetailsHandler = switchDetailsHandler
@@ -310,7 +312,10 @@ final class OrdersRootViewController: UIViewController {
             DDLogError("⛔️ Unable to fetch stored statuses for Site \(siteID): \(error)")
         }
 
-        let allowedStatuses = statusResultsController.fetchedObjects.map { $0 }
+        let fetchedStatuses: [OrderStatus] = statusResultsController.fetchedObjects.map { $0 }
+        let allowedStatuses = ciabEligibilityChecker.isCurrentSiteCIAB
+            ? CIABOrderStatusMapper.mapFilterOptions(fetchedStatuses)
+            : fetchedStatuses
 
         let viewModel = FilterOrderListViewModel(filters: filters, allowedStatuses: allowedStatuses, siteID: siteID)
         let filterOrderListViewController = FilterListViewController(viewModel: viewModel, onFilterAction: { [weak self] filters in

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -80,11 +80,12 @@ final class OrdersRootViewController: UIViewController {
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared,
          barcodeScannerItemFinder: BarcodeScannerItemFinder = BarcodeScannerItemFinder(),
+         ciabEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker(),
          switchDetailsHandler: @escaping OrderListViewController.SelectOrderDetails) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.featureFlagService = ServiceLocator.featureFlagService
-        self.ciabEligibilityChecker = CIABEligibilityChecker()
+        self.ciabEligibilityChecker = ciabEligibilityChecker
         self.orderDurationRecorder = orderDurationRecorder
         self.barcodeScannerItemFinder = barcodeScannerItemFinder
         self.switchDetailsHandler = switchDetailsHandler

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -27,6 +27,7 @@ final class OrderSearchUICommand: SearchUICommand {
     private let storageManager: StorageManagerType
     private let analytics: Analytics
     private let stores: StoresManager
+    private let ciabEligibilityChecker: CIABEligibilityCheckerProtocol
 
     private let onSelectSearchResult: ((Order, UIViewController) -> Void)
 
@@ -34,12 +35,14 @@ final class OrderSearchUICommand: SearchUICommand {
          onSelectSearchResult: @escaping ((Order, UIViewController) -> Void),
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          analytics: Analytics = ServiceLocator.analytics,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         ciabEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker()) {
         self.siteID = siteID
         self.onSelectSearchResult = onSelectSearchResult
         self.storageManager = storageManager
         self.analytics = analytics
         self.stores = stores
+        self.ciabEligibilityChecker = ciabEligibilityChecker
     }
 
     func createResultsController() -> ResultsController<ResultsControllerModel> {
@@ -66,7 +69,9 @@ final class OrderSearchUICommand: SearchUICommand {
     }
 
     func createCellViewModel(model: Order) -> OrderListCellViewModel {
-        return OrderListCellViewModel(order: model, currencySettings: ServiceLocator.currencySettings)
+        return OrderListCellViewModel(order: model,
+                                      currencySettings: ServiceLocator.currencySettings,
+                                      isCIAB: ciabEligibilityChecker.isCurrentSiteCIAB)
     }
 
     /// Synchronizes the Orders matching a given Keyword

--- a/WooCommerce/WooCommerceTests/CIAB/CIABOrderStatusMapperTests.swift
+++ b/WooCommerce/WooCommerceTests/CIAB/CIABOrderStatusMapperTests.swift
@@ -156,4 +156,30 @@ struct CIABOrderStatusMapperTests {
     func test_resolveFilterStatuses_when_empty_then_returns_empty() {
         #expect(CIABOrderStatusMapper.resolveFilterStatuses([]).isEmpty)
     }
+
+    // MARK: - Filter persistence validation (resolveFilterStatuses used to validate stored filters)
+
+    @Test("Resolved open filter statuses all exist in API-returned statuses")
+    func test_resolveFilterStatuses_when_open_then_all_resolved_statuses_exist_in_api_statuses() {
+        // Given — API returns core statuses; stored filter is synthetic "open"
+        let apiStatuses: Set<OrderStatusEnum> = [.pending, .processing, .onHold, .failed, .completed, .cancelled, .refunded]
+        let storedFilter: [OrderStatusEnum] = [.custom(CIABOrderStatusMapper.openSlug)]
+
+        // When — resolve synthetic status to core statuses for validation
+        let resolved = CIABOrderStatusMapper.resolveFilterStatuses(storedFilter)
+
+        // Then — every resolved status exists in the API set
+        for status in resolved {
+            #expect(apiStatuses.contains(status), "Resolved status \(status) should exist in API statuses")
+        }
+    }
+
+    @Test("Unresolved open filter does not exist in API-returned statuses")
+    func test_custom_open_status_does_not_exist_in_api_statuses() {
+        // Given — API returns core statuses only
+        let apiStatuses: Set<OrderStatusEnum> = [.pending, .processing, .onHold, .failed, .completed, .cancelled, .refunded]
+
+        // Then — the synthetic "open" status is NOT in the API set (the bug scenario)
+        #expect(!apiStatuses.contains(.custom(CIABOrderStatusMapper.openSlug)))
+    }
 }

--- a/WooCommerce/WooCommerceTests/CIAB/CIABOrderStatusMapperTests.swift
+++ b/WooCommerce/WooCommerceTests/CIAB/CIABOrderStatusMapperTests.swift
@@ -1,0 +1,159 @@
+import Testing
+@testable import WooCommerce
+import Yosemite
+
+struct CIABOrderStatusMapperTests {
+
+    // MARK: - displayName
+
+    @Test("displayName maps pending to Open")
+    func test_displayName_when_pending_then_returns_open() {
+        #expect(CIABOrderStatusMapper.displayName(for: .pending) == "Open")
+    }
+
+    @Test("displayName maps processing to Open")
+    func test_displayName_when_processing_then_returns_open() {
+        #expect(CIABOrderStatusMapper.displayName(for: .processing) == "Open")
+    }
+
+    @Test("displayName maps onHold to Open")
+    func test_displayName_when_onHold_then_returns_open() {
+        #expect(CIABOrderStatusMapper.displayName(for: .onHold) == "Open")
+    }
+
+    @Test("displayName maps failed to Open")
+    func test_displayName_when_failed_then_returns_open() {
+        #expect(CIABOrderStatusMapper.displayName(for: .failed) == "Open")
+    }
+
+    @Test("displayName preserves completed")
+    func test_displayName_when_completed_then_returns_localized_name() {
+        #expect(CIABOrderStatusMapper.displayName(for: .completed) == OrderStatusEnum.completed.localizedName)
+    }
+
+    @Test("displayName preserves cancelled")
+    func test_displayName_when_cancelled_then_returns_localized_name() {
+        #expect(CIABOrderStatusMapper.displayName(for: .cancelled) == OrderStatusEnum.cancelled.localizedName)
+    }
+
+    @Test("displayName preserves refunded")
+    func test_displayName_when_refunded_then_returns_localized_name() {
+        #expect(CIABOrderStatusMapper.displayName(for: .refunded) == OrderStatusEnum.refunded.localizedName)
+    }
+
+    // MARK: - displayStatus
+
+    @Test("displayStatus maps open statuses to custom open")
+    func test_displayStatus_when_open_status_then_returns_custom_open() {
+        let openStatuses: [OrderStatusEnum] = [.pending, .processing, .onHold, .failed]
+        for status in openStatuses {
+            #expect(CIABOrderStatusMapper.displayStatus(for: status) == .custom(CIABOrderStatusMapper.openSlug))
+        }
+    }
+
+    @Test("displayStatus preserves non-open statuses")
+    func test_displayStatus_when_non_open_status_then_returns_unchanged() {
+        let nonOpenStatuses: [OrderStatusEnum] = [.completed, .cancelled, .refunded]
+        for status in nonOpenStatuses {
+            #expect(CIABOrderStatusMapper.displayStatus(for: status) == status)
+        }
+    }
+
+    // MARK: - mapFilterOptions
+
+    @Test("mapFilterOptions groups open statuses into single Open entry")
+    func test_mapFilterOptions_when_all_statuses_then_groups_open() {
+        // Given
+        let statuses: [OrderStatus] = [
+            OrderStatus(name: "Pending Payment", siteID: 1, slug: "pending", total: 3),
+            OrderStatus(name: "Processing", siteID: 1, slug: "processing", total: 5),
+            OrderStatus(name: "On hold", siteID: 1, slug: "on-hold", total: 2),
+            OrderStatus(name: "Completed", siteID: 1, slug: "completed", total: 10),
+            OrderStatus(name: "Cancelled", siteID: 1, slug: "cancelled", total: 1),
+            OrderStatus(name: "Refunded", siteID: 1, slug: "refunded", total: 0),
+            OrderStatus(name: "Failed", siteID: 1, slug: "failed", total: 1)
+        ]
+
+        // When
+        let mapped = CIABOrderStatusMapper.mapFilterOptions(statuses)
+
+        // Then
+        #expect(mapped.count == 4) // Open, Completed, Cancelled, Refunded
+        #expect(mapped[0].slug == CIABOrderStatusMapper.openSlug)
+        #expect(mapped[0].name == "Open")
+        #expect(mapped[1].slug == "completed")
+        #expect(mapped[2].slug == "cancelled")
+        #expect(mapped[3].slug == "refunded")
+    }
+
+    @Test("mapFilterOptions preserves non-open statuses unchanged")
+    func test_mapFilterOptions_when_only_non_open_statuses_then_preserves_all() {
+        // Given
+        let statuses: [OrderStatus] = [
+            OrderStatus(name: "Completed", siteID: 1, slug: "completed", total: 10),
+            OrderStatus(name: "Refunded", siteID: 1, slug: "refunded", total: 0)
+        ]
+
+        // When
+        let mapped = CIABOrderStatusMapper.mapFilterOptions(statuses)
+
+        // Then
+        #expect(mapped.count == 2)
+        #expect(mapped[0].slug == "completed")
+        #expect(mapped[1].slug == "refunded")
+    }
+
+    @Test("mapFilterOptions handles empty input")
+    func test_mapFilterOptions_when_empty_then_returns_empty() {
+        #expect(CIABOrderStatusMapper.mapFilterOptions([]).isEmpty)
+    }
+
+    // MARK: - resolveFilterStatuses
+
+    @Test("resolveFilterStatuses expands open to core statuses")
+    func test_resolveFilterStatuses_when_open_then_expands_to_four_statuses() {
+        // Given
+        let statuses: [OrderStatusEnum] = [.custom(CIABOrderStatusMapper.openSlug)]
+
+        // When
+        let resolved = CIABOrderStatusMapper.resolveFilterStatuses(statuses)
+
+        // Then
+        #expect(resolved.count == 4)
+        #expect(Set(resolved) == CIABOrderStatusMapper.openStatuses)
+    }
+
+    @Test("resolveFilterStatuses preserves non-open statuses")
+    func test_resolveFilterStatuses_when_non_open_then_returns_unchanged() {
+        // Given
+        let statuses: [OrderStatusEnum] = [.completed, .cancelled]
+
+        // When
+        let resolved = CIABOrderStatusMapper.resolveFilterStatuses(statuses)
+
+        // Then
+        #expect(resolved == [.completed, .cancelled])
+    }
+
+    @Test("resolveFilterStatuses handles mix of open and non-open")
+    func test_resolveFilterStatuses_when_mixed_then_expands_open_preserves_rest() {
+        // Given
+        let statuses: [OrderStatusEnum] = [.custom(CIABOrderStatusMapper.openSlug), .completed]
+
+        // When
+        let resolved = CIABOrderStatusMapper.resolveFilterStatuses(statuses)
+
+        // Then
+        #expect(resolved.count == 5) // 4 open + completed
+        #expect(resolved.contains(.pending))
+        #expect(resolved.contains(.processing))
+        #expect(resolved.contains(.onHold))
+        #expect(resolved.contains(.failed))
+        #expect(resolved.contains(.completed))
+    }
+
+    @Test("resolveFilterStatuses handles empty input")
+    func test_resolveFilterStatuses_when_empty_then_returns_empty() {
+        #expect(CIABOrderStatusMapper.resolveFilterStatuses([]).isEmpty)
+    }
+}


### PR DESCRIPTION
Closes WOOMOB-2516

> [!NOTE]
> This PR handles the mapping only for store management screens (order list, order detail, filters, dashboard). POS is not touched.
> iOS counterpart of the Android PR: https://github.com/woocommerce/woocommerce-android/pull/15552

## Description
CIAB sites use a simplified set of order statuses instead of the full WooCommerce Core set. This PR maps between them for display and filtering:

| CIAB Status | Core Statuses |
|-------------|--------------|
| Open | pending, processing, on-hold, failed |
| Completed | completed (1:1, no mapping needed) |
| Cancelled | cancelled (1:1, no mapping needed) |
| Refunded | refunded (1:1, no mapping needed) |

Since only "Open" requires actual mapping (the rest are 1:1), the implementation focuses on that single group.

A new `CIABOrderStatusMapper` centralizes all mapping logic with four methods:
- `displayName(for:)` — returns mapped display label for a status
- `displayStatus(for:)` — returns mapped `OrderStatusEnum` for badge styling
- `mapFilterOptions(_:)` — groups 4 open statuses into one "Open" filter option
- `resolveFilterStatuses(_:)` — expands "open" back to 4 core statuses for API requests

Integration points:
- **Order list cells** — status label and badge show "Open" for grouped statuses
- **Order detail summary** — status label and badge show "Open"
- **Order status filters** — "Open" appears as a single filter option instead of 4 separate ones
- **Dashboard orders card** — status label, badge, and filter dropdown reflect CIAB mapping
- **API sync** — "open" filter selection is resolved to 4 core status slugs before API requests

## Demo

Before | After
--- | ---
<img width="576" height="473" alt="Screenshot 2026-04-01 at 13 02 30" src="https://github.com/user-attachments/assets/e79bd2cb-c55e-4d10-9b87-3046d04f0863" /> | <img width="582" height="475" alt="Screenshot 2026-04-01 at 13 02 36" src="https://github.com/user-attachments/assets/c7768b40-7b5c-47d4-9836-27d762e58b1a" />
<img width="581" height="766" alt="Screenshot 2026-04-01 at 13 09 58" src="https://github.com/user-attachments/assets/f7e5e148-ad7f-48cd-a48b-53bccb47190c" /> | <img width="581" height="620" alt="Screenshot 2026-04-01 at 13 09 54" src="https://github.com/user-attachments/assets/cc0433f8-91eb-4815-8cb6-e232246812aa" />

## Test Steps
1. On a CIAB site, open the order list and verify pending/processing/on-hold/failed orders show "Open" status tag with orange badge
2. Tap an order with one of those statuses and verify the detail screen also shows "Open"
3. Open the order filter screen and verify "Open" appears as a single filter option (not 4 separate ones)
4. Select the "Open" filter and verify orders with all 4 core statuses are returned
5. Close and reopen the filter screen — verify "Open" is still selected
6. On a non-CIAB site, verify all order status behavior is unchanged
7. On the Dashboard, verify the last orders card shows "Open" status for grouped statuses and the filter dropdown includes "Open"

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.