### PR TITLE
Fix race condition in OrderDetailsViewModel FRC reload callback

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -421,12 +421,7 @@ extension OrderDetailsViewModel {
 //
 extension OrderDetailsViewModel {
     func configureResultsControllers(onReload: @escaping () -> Void) {
-        dataSource.configureResultsControllers(onReload: { [weak self] in
-            guard let self = self else { return }
-
-            self.updateMissingInfoInOrderAfterReload()
-            onReload()
-        })
+        dataSource.configureResultsControllers(onReload: onReload)
     }
 }
 
@@ -959,12 +954,6 @@ extension OrderDetailsViewModel {
     ///
     private func insertNote(_ orderNote: OrderNote) {
         orderNotes.insert(orderNote, at: 0)
-    }
-
-    private func updateMissingInfoInOrderAfterReload() {
-        // Listening for changes in the order listener do not include changes in their relationships' properties.
-        // Update them here.
-        update(order: order.copy(fees: self.dataSource.customAmounts))
     }
 }
 


### PR DESCRIPTION
## Description

Fixes a race condition in `OrderDetailsViewModel` that caused `fulfillmentStatus` to flicker between valid values and `.unknown` on the order details screen.

### Root cause

`updateMissingInfoInOrderAfterReload()` was a **vestigial method** left behind after two separate PRs evolved the code:

1. **PR #11112** (Nov 2023) — Added a dedicated `feeLinesResultsController` (FRC for `StorageOrderFeeLine`) to detect custom amount changes in CoreData. Also added `updateMissingInfoInOrderAfterReload()` to patch `self.order.fees` from this FRC on every reload callback.

2. **PR #14999** (Jan 2025) — Removed `feeLinesResultsController` for I/O performance, replacing `feeLines` with `order.fees` (a snapshot property). However, `updateMissingInfoInOrderAfterReload()` was **not removed** — it became a no-op that still called the full `update(order:)` cascade.

### The race condition

The `update(order:)` cascade re-creates product/variation FRCs and triggers additional `onReload` callbacks. When an FRC fires between a network sync's CoreData save and the sync completion handler:

1. Network sync saves fresh order data to CoreData
2. FRC detects change → fires `onReload`
3. `updateMissingInfoInOrderAfterReload()` calls `update(order: order.copy(fees: ...))` — but `self.order` still holds the **stale** pre-sync snapshot
4. This stale order (with `fulfillmentStatus = .unknown`) overwrites the freshly synced data
5. Sync completion handler eventually fires with the correct order, but the UI has already flickered

### Why removing it is safe

- The method was already a **no-op** since PR #14999 — it copies `self.order` with fees from the same snapshot source (`order.fees`), effectively doing nothing
- Fees are correctly included in `Order+ReadOnlyConvertible.toReadOnly()`, so they propagate through normal sync paths
- `viewWillAppear` calls `syncEverything`, which refreshes the full order (including fee name changes) when returning from edit flows
- The original use case (custom amount name updates after editing) is covered by the `viewWillAppear` → `syncEverything` path

## Test Steps

- Edit the code in `OrderDetailsViewModel.update(order newOrder: Order)` to print the new order status. Or just put a breakpoints.
- Build and run in Xcode
- Open an order that has a fulfillment status (CIAB site). Use Proxyman and find an order that actually has `_fulfillment_status` in metadata.
- In the app navigate to that order details.
- Make sure the logged/printed `newOrder.fulfillmentStatus` is not unknown and matches the one returned in `orders` response.
- Edit the order (e.g., change a custom amount name), save, return to details
- Verify the change is reflected after returning

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.