### PR TITLE
Open WC Admin in Safari sheet for CIAB sites

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Kingfisher
+import WooFoundation
 import Yosemite
 
 /// This view will be embedded inside the `HubMenuViewController`
@@ -15,6 +16,8 @@ struct HubMenu: View {
     @ObservedObject private var iO = Inject.observer
 
     @ObservedObject private var viewModel: HubMenuViewModel
+
+    @State private var safariSheetURL: URL?
 
     init(viewModel: HubMenuViewModel) {
         self.viewModel = viewModel
@@ -42,6 +45,14 @@ struct HubMenu: View {
         switch menu.id {
         case HubMenuViewModel.GoogleAds.id:
             googleAdsCampaignHandler()
+        case HubMenuViewModel.WoocommerceAdmin.id:
+            // On CIAB sites, open WC Admin in a Safari sheet instead of the in-app webview.
+            // The in-app webview hides the Admin navigation sidebar, which breaks WC Admin
+            // navigation on CIAB sites where the full admin experience is expected.
+            if viewModel.isCIABSite() {
+                safariSheetURL = viewModel.woocommerceAdminURL
+                return
+            }
         case HubMenuViewModel.Settings.id:
             ServiceLocator.analytics.track(.hubMenuSettingsTapped)
         case HubMenuViewModel.Blaze.id:
@@ -96,6 +107,7 @@ private extension HubMenu {
         .listStyle(.insetGrouped)
         .background(Color(.listBackground))
         .accentColor(Color(.listSelectedBackground))
+        .safariSheet(url: $safariSheetURL)
     }
 
     @ViewBuilder
@@ -126,6 +138,8 @@ private extension HubMenu {
             case .blaze:
                 BlazeCampaignListHostingControllerRepresentable(siteID: viewModel.siteID)
             case .wooCommerceAdmin:
+                // Note: On CIAB sites, WC Admin is opened in a Safari sheet instead (see handleTap).
+                // This in-app webview path is only used for non-CIAB sites.
                 webView(url: viewModel.woocommerceAdminURL,
                         title: HubMenuViewModel.Localization.woocommerceAdmin,
                         shouldAuthenticate: viewModel.shouldAuthenticateAdminPage)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -230,6 +230,14 @@ final class HubMenuViewModel: ObservableObject {
         analytics.track(.hubMenuOptionTapped, withProperties: [AnalyticsKeys.trackingOption: menu.trackingOption])
     }
 
+    /// Whether the current site is a CIAB (Commerce in a Box) site.
+    /// On CIAB sites, WC Admin opens in an SFSafariViewController (Safari sheet) instead of the
+    /// in-app webview, because the in-app webview hides the Admin navigation sidebar which is
+    /// needed for full WC Admin navigation.
+    func isCIABSite() -> Bool {
+        siteCIABEligibilityChecker.isCurrentSiteCIAB
+    }
+
     func createGoogleAdsCampaignCoordinator(with navigationController: UINavigationController) -> GoogleAdsCampaignCoordinator {
         GoogleAdsCampaignCoordinator(
             siteID: siteID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -814,6 +814,38 @@ final class HubMenuViewModelTests: XCTestCase {
         // Then
         XCTAssertNotNil(viewModel.generalElements.firstIndex(where: { $0.id == HubMenuViewModel.Payments.id }))
     }
+
+    // MARK: - CIAB WC Admin Safari Sheet
+
+    @MainActor
+    func test_isCIABSite_when_site_is_CIAB_then_returns_true() {
+        // Given
+        let ciabChecker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: true)
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
+                                         siteCIABEligibilityChecker: ciabChecker)
+
+        // When
+        let result = viewModel.isCIABSite()
+
+        // Then
+        XCTAssertTrue(result)
+    }
+
+    @MainActor
+    func test_isCIABSite_when_site_is_not_CIAB_then_returns_false() {
+        // Given
+        let ciabChecker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: false)
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
+                                         siteCIABEligibilityChecker: ciabChecker)
+
+        // When
+        let result = viewModel.isCIABSite()
+
+        // Then
+        XCTAssertFalse(result)
+    }
 }
 
 private extension HubMenuViewModelTests {


### PR DESCRIPTION
## Description

Closes WOOMOB-2589.

On CIAB (Commerce in a Box) sites, the in-app webview hides the Admin navigation sidebar, which breaks the WC Admin experience since users need the sidebar to navigate between screens.

This changes the "WooCommerce Admin" button in the Hub Menu to open in an `SFSafariViewController` (Safari sheet) instead of the in-app webview — **only for CIAB sites**. Non-CIAB sites continue using the existing in-app authenticated webview.

### Changes
- **`HubMenuViewModel`**: Added `isCIABSite()` function that checks the existing `CIABEligibilityChecker`
- **`HubMenu`**: Intercepts the WC Admin tap on CIAB sites and presents a Safari sheet using the existing `.safariSheet(url:)` modifier from `WooFoundation`
- **Tests**: Added unit tests for `isCIABSite()` returning true/false

### Trade-off
`SFSafariViewController` cannot inject app authentication cookies, so CIAB users may need to log in manually in Safari. This is acceptable since the goal is to provide the full WC Admin browsing experience with sidebar navigation.

## Test Steps

1. Log into a **CIAB** site
2. Go to **Menu** tab → tap **WooCommerce Admin**
3. Verify a Safari sheet appears (not the in-app webview) with the admin sidebar visible
4. Dismiss the Safari sheet
5. Log into a **non-CIAB** site
6. Go to **Menu** tab → tap **WooCommerce Admin**
7. Verify the in-app webview opens as before

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.