### PR TITLE
Add notification checks to troubleshooting tool

### DIFF
--- a/Modules/Sources/NetworkingCore/Model/Site.swift
+++ b/Modules/Sources/NetworkingCore/Model/Site.swift
@@ -273,6 +273,10 @@ public extension Site {
     static func isCIAB(isGarden: Bool, gardenName: String?) -> Bool {
         isGarden && gardenName ==  Constants.commerceGardenName
     }
+
+    var isCIAB: Bool {
+        Site.isCIAB(isGarden: isGarden, gardenName: gardenName)
+    }
 }
 
 /// Defines all of the Site CodingKeys.

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 24.5
 -----
 - [*] Add analytics setting check to troubleshooting tool [https://github.com/woocommerce/woocommerce-ios/pull/16871]
+- [*] Add notification check to troubleshooting tool [https://github.com/woocommerce/woocommerce-ios/pull/16875]
 
 
 24.4

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ConnectivityTool.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ConnectivityTool.swift
@@ -12,6 +12,7 @@ extension WooAnalyticsEvent {
             case orders
             case products
             case analytics
+            case notifications
         }
 
         static func automaticTimeoutRetry() -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -13,6 +13,10 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
     ///
     private var subscriptions: Set<AnyCancellable> = []
 
+    /// Retains the Jetpack setup coordinator while the flow is active.
+    ///
+    private var jetpackSetupCoordinator: JetpackSetupCoordinator?
+
 
     init() {
         viewModel = ConnectivityToolViewModel()
@@ -47,6 +51,16 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
             }
             .store(in: &subscriptions)
 
+        // Start Jetpack setup when requested
+        viewModel.$shouldStartJetpackSetup
+            .filter { $0 }
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.viewModel.shouldStartJetpackSetup = false
+                self?.startJetpackSetup()
+            }
+            .store(in: &subscriptions)
+
         // Listen to the contact support button
         rootView.onContactSupportTapped = { [weak self] in
             self?.showContactSupportForm()
@@ -55,6 +69,13 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    private func startJetpackSetup() {
+        guard let site = viewModel.stores.sessionManager.defaultSite else { return }
+        let coordinator = JetpackSetupCoordinator(site: site, rootViewController: self)
+        jetpackSetupCoordinator = coordinator
+        coordinator.startSetup()
     }
 
     private func showContactSupportForm() {

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -75,6 +75,7 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
         guard let site = viewModel.stores.sessionManager.defaultSite else { return }
         let coordinator = JetpackSetupCoordinator(site: site, rootViewController: self, onCompletion: { [weak self] in
             self?.viewModel.retryTest(.notifications)
+            self?.jetpackSetupCoordinator = nil
         })
         jetpackSetupCoordinator = coordinator
         coordinator.startSetup()

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -196,12 +196,18 @@ struct ConnectivityToolCard: View {
         /// Represents an action to could be performed when presenting an error.
         ///
         struct Action {
+            let id: String?
             let title: String
             let systemImage: String
             let action: () -> ()
             let technicalDetails: String?
 
-            init(title: String, systemImage: String, action: @escaping () -> Void = {}, technicalDetails: String? = nil) {
+            init(id: String? = nil,
+                 title: String,
+                 systemImage: String,
+                 action: @escaping () -> Void = {},
+                 technicalDetails: String? = nil) {
+                self.id = id
                 self.title = title
                 self.systemImage = systemImage
                 self.action = action

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -30,7 +30,8 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
         }
         .store(in: &subscriptions)
 
-        // Open selected URL in-app using Safari
+        // Open selected URL — system URLs (e.g. notification settings) via UIApplication,
+        // web URLs in-app using Safari.
         viewModel.$selectedURL
             .removeDuplicates()
             .compactMap { $0 }
@@ -38,7 +39,11 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
             .sink { [weak self] url in
                 guard let self else { return }
                 self.viewModel.selectedURL = nil
-                WebviewHelper.launch(url, with: self)
+                if url.scheme == "http" || url.scheme == "https" {
+                    WebviewHelper.launch(url, with: self)
+                } else {
+                    UIApplication.shared.open(url)
+                }
             }
             .store(in: &subscriptions)
 

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -30,6 +30,18 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
         }
         .store(in: &subscriptions)
 
+        // Open selected URL in-app using Safari
+        viewModel.$selectedURL
+            .removeDuplicates()
+            .compactMap { $0 }
+            .receive(on: RunLoop.main)
+            .sink { [weak self] url in
+                guard let self else { return }
+                self.viewModel.selectedURL = nil
+                WebviewHelper.launch(url, with: self)
+            }
+            .store(in: &subscriptions)
+
         // Listen to the contact support button
         rootView.onContactSupportTapped = { [weak self] in
             self?.showContactSupportForm()

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -73,7 +73,9 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
 
     private func startJetpackSetup() {
         guard let site = viewModel.stores.sessionManager.defaultSite else { return }
-        let coordinator = JetpackSetupCoordinator(site: site, rootViewController: self)
+        let coordinator = JetpackSetupCoordinator(site: site, rootViewController: self, onCompletion: { [weak self] in
+            self?.viewModel.retryTest(.notifications)
+        })
         jetpackSetupCoordinator = coordinator
         coordinator.startSetup()
     }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
@@ -18,22 +18,14 @@ extension ConnectivityToolViewModel {
             DDLogError("Connectivity Tool: ❌ Jetpack plugin check failed\n\(error)")
             switch error {
             case .pluginNotActive:
-                let setupJetpackAction = ConnectivityToolCard.ConnectivityState.Action(
-                    title: Localization.Action.setupJetpack,
-                    systemImage: SystemImages.setupJetpack.rawValue,
-                    action: { [weak self] in
-                        self?.shouldStartJetpackSetup = true
-                    }
-                )
+                let setupJetpackAction = makeNotificationAction(.setupJetpack) { [weak self] in
+                    self?.shouldStartJetpackSetup = true
+                }
                 return .error(Localization.ErrorMessage.jetpackPluginNotActive,
                               [setupJetpackAction, retryAction(for: .notifications)])
             case .requestFailed(let underlyingError):
                 let technicalDetails = String(describing: underlyingError)
-                let viewDetailsAction = ConnectivityToolCard.ConnectivityState.Action(
-                    title: Localization.Action.viewDetails,
-                    systemImage: SystemImages.viewDetails.rawValue,
-                    technicalDetails: technicalDetails
-                )
+                let viewDetailsAction = makeNotificationAction(.viewDetails, technicalDetails: technicalDetails)
                 return .error(Localization.ErrorMessage.notificationConfigCheckFailed,
                               [viewDetailsAction, retryAction(for: .notifications)])
             }
@@ -43,13 +35,9 @@ extension ConnectivityToolViewModel {
         let permissionResult = await checkNotificationPermission()
         if case .failure = permissionResult {
             DDLogInfo("Connectivity Tool: ⚠️ Notifications not authorized")
-            let openSettingsAction = ConnectivityToolCard.ConnectivityState.Action(
-                title: Localization.Action.openSettings,
-                systemImage: SystemImages.openSettings.rawValue,
-                action: { [weak self] in
+            let openSettingsAction = makeNotificationAction(.openSettings) { [weak self] in
                     self?.selectedURL = URL(string: UIApplication.openNotificationSettingsURLString)
                 }
-            )
             return .error(Localization.ErrorMessage.notificationsNotAuthorized, [openSettingsAction, retryAction(for: .notifications)])
         }
 
@@ -63,31 +51,19 @@ extension ConnectivityToolViewModel {
             DDLogInfo("Connectivity Tool: ⚠️ Notification config issue: \(configError)")
             switch configError {
             case .deviceNotRegistered:
-                let registerAction = ConnectivityToolCard.ConnectivityState.Action(
-                    title: Localization.Action.registerDevice,
-                    systemImage: SystemImages.enableAction.rawValue,
-                    action: { [weak self] in
-                        self?.registerDeviceForNotifications()
-                    }
-                )
+                let registerAction = makeNotificationAction(.registerDevice) { [weak self] in
+                    self?.registerDeviceForNotifications()
+                }
                 return .error(Localization.ErrorMessage.deviceNotRegistered, [registerAction])
             case .orderNotificationsDisabled(let settings):
-                let enableAction = ConnectivityToolCard.ConnectivityState.Action(
-                    title: Localization.Action.enableOrderNotifications,
-                    systemImage: SystemImages.enableAction.rawValue,
-                    action: { [weak self] in
-                        self?.enableOrderNotifications(settings: settings)
-                    }
-                )
+                let enableAction = makeNotificationAction(.enableOrderNotifications) { [weak self] in
+                    self?.enableOrderNotifications(settings: settings)
+                }
                 return .error(Localization.ErrorMessage.orderNotificationsDisabled,
                               [enableAction, retryAction(for: .notifications)])
             case .requestFailed(let error):
                 let technicalDetails = String(describing: error)
-                let viewDetailsAction = ConnectivityToolCard.ConnectivityState.Action(
-                    title: Localization.Action.viewDetails,
-                    systemImage: SystemImages.viewDetails.rawValue,
-                    technicalDetails: technicalDetails
-                )
+                let viewDetailsAction = makeNotificationAction(.viewDetails, technicalDetails: technicalDetails)
                 return .error(Localization.ErrorMessage.notificationConfigCheckFailed,
                               [viewDetailsAction, retryAction(for: .notifications)])
             }
@@ -226,16 +202,70 @@ extension ConnectivityToolViewModel {
     /// Restores the notifications card to its interactive error state after a failed enable attempt.
     ///
     private func restoreNotificationsCardActions(settings: NotificationSettings) {
-        let enableAction = ConnectivityToolCard.ConnectivityState.Action(
-            title: Localization.Action.enableOrderNotifications,
-            systemImage: SystemImages.enableAction.rawValue,
-            action: { [weak self] in
-                self?.enableOrderNotifications(settings: settings)
-            }
-        )
+        let enableAction = makeNotificationAction(.enableOrderNotifications) { [weak self] in
+            self?.enableOrderNotifications(settings: settings)
+        }
         updateCardState(for: .notifications,
                         state: .error(Localization.ErrorMessage.orderNotificationsDisabled,
                                       [enableAction, retryAction(for: .notifications)]))
+    }
+
+    /// Represents the type of action displayed when a notification check fails.
+    ///
+    enum NotificationFailedAction: String {
+        case setupJetpack
+        case openSettings
+        case registerDevice
+        case enableOrderNotifications
+        case viewDetails
+
+        var id: String {
+            rawValue
+        }
+
+        var title: String {
+            switch self {
+            case .setupJetpack:
+                return Localization.Action.setupJetpack
+            case .openSettings:
+                return Localization.Action.openSettings
+            case .registerDevice:
+                return Localization.Action.registerDevice
+            case .enableOrderNotifications:
+                return Localization.Action.enableOrderNotifications
+            case .viewDetails:
+                return Localization.Action.viewDetails
+            }
+        }
+
+        var systemImage: String {
+            switch self {
+            case .setupJetpack:
+                return SystemImages.setupJetpack.rawValue
+            case .openSettings:
+                return SystemImages.openSettings.rawValue
+            case .registerDevice:
+                return SystemImages.enableAction.rawValue
+            case .enableOrderNotifications:
+                return SystemImages.enableAction.rawValue
+            case .viewDetails:
+                return SystemImages.viewDetails.rawValue
+            }
+        }
+    }
+
+    /// Creates a `ConnectivityToolCard.ConnectivityState.Action` from a `NotificationFailedAction` case.
+    ///
+    func makeNotificationAction(_ type: NotificationFailedAction,
+                                action: @escaping () -> Void = {},
+                                technicalDetails: String? = nil) -> ConnectivityToolCard.ConnectivityState.Action {
+        ConnectivityToolCard.ConnectivityState.Action(
+            id: type.id,
+            title: type.title,
+            systemImage: type.systemImage,
+            action: action,
+            technicalDetails: technicalDetails
+        )
     }
 
     /// Error types for the Jetpack plugin check.

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
@@ -53,7 +53,14 @@ extension ConnectivityToolViewModel {
             DDLogInfo("Connectivity Tool: ⚠️ Notification config issue: \(configError)")
             switch configError {
             case .deviceNotRegistered:
-                return .error(Localization.ErrorMessage.deviceNotRegistered, [retryAction(for: .notifications)])
+                let registerAction = ConnectivityToolCard.ConnectivityState.Action(
+                    title: Localization.Action.registerDevice,
+                    systemImage: SystemImages.enableAction.rawValue,
+                    action: { [weak self] in
+                        self?.registerDeviceForNotifications()
+                    }
+                )
+                return .error(Localization.ErrorMessage.deviceNotRegistered, [registerAction])
             case .orderNotificationsDisabled(let settings):
                 let enableAction = ConnectivityToolCard.ConnectivityState.Action(
                     title: Localization.Action.enableOrderNotifications,
@@ -64,8 +71,6 @@ extension ConnectivityToolViewModel {
                 )
                 return .error(Localization.ErrorMessage.orderNotificationsDisabled,
                               [enableAction, retryAction(for: .notifications)])
-            case .siteNotFound:
-                return .error(Localization.ErrorMessage.notificationSiteNotFound, [retryAction(for: .notifications)])
             case .requestFailed(let error):
                 let technicalDetails = String(describing: error)
                 let viewDetailsAction = ConnectivityToolCard.ConnectivityState.Action(
@@ -129,7 +134,8 @@ extension ConnectivityToolViewModel {
     ///
     @MainActor
     func checkNotificationConfig() async -> Result<Void, NotificationConfigError> {
-        guard let deviceID, let numericDeviceID = Int64(deviceID) else {
+        guard let deviceID = pushNotesManager.deviceID,
+              let numericDeviceID = Int64(deviceID) else {
             return .failure(.deviceNotRegistered)
         }
 
@@ -138,19 +144,13 @@ extension ConnectivityToolViewModel {
                 guard let self else { return }
                 switch result {
                 case .success(let settings):
-                    guard let blog = settings.blogs.first(where: { $0.blogID == self.siteID }) else {
-                        continuation.resume(returning: .failure(.siteNotFound))
-                        return
-                    }
-                    guard let device = blog.devices.first(where: { $0.deviceID == numericDeviceID }) else {
-                        continuation.resume(returning: .failure(.deviceNotRegistered))
-                        return
-                    }
-                    if device.storeOrder {
-                        continuation.resume(returning: .success(()))
-                    } else {
+                    guard let blog = settings.blogs.first(where: { $0.blogID == self.siteID }),
+                          let device = blog.devices.first(where: { $0.deviceID == numericDeviceID }),
+                          device.storeOrder else {
                         continuation.resume(returning: .failure(.orderNotificationsDisabled(settings: settings)))
+                        return
                     }
+                    continuation.resume(returning: .success(()))
                 case .failure(let error):
                     continuation.resume(returning: .failure(.requestFailed(error)))
                 }
@@ -162,7 +162,8 @@ extension ConnectivityToolViewModel {
     /// Enables order notifications for the current site and device.
     ///
     func enableOrderNotifications(settings: NotificationSettings) {
-        guard let deviceID, let numericDeviceID = Int64(deviceID) else { return }
+        guard let deviceID = pushNotesManager.deviceID,
+              let numericDeviceID = Int64(deviceID) else { return }
 
         // Show loading indicator while enabling.
         if let cardIndex = cards.lastIndex(where: { $0.testCase == .notifications }) {
@@ -199,6 +200,34 @@ extension ConnectivityToolViewModel {
             }
         }
         stores.dispatch(action)
+    }
+
+    /// Registers the device for push notifications and re-runs the notifications check.
+    ///
+    func registerDeviceForNotifications() {
+        // Show loading indicator while registering.
+        if let cardIndex = cards.lastIndex(where: { $0.testCase == .notifications }) {
+            cards[cardIndex] = ConnectivityTest.notifications.inProgressCard
+        }
+
+        Task { @MainActor in
+            do {
+                _ = try await pushNotesManager.registerDeviceAndWaitForTokenAcceptance()
+                DDLogInfo("Connectivity Tool: ✅ Device registered for push notifications")
+            } catch {
+                DDLogError("Connectivity Tool: ❌ Failed to register device for push notifications\n\(error)")
+            }
+            // Re-run the full notifications check regardless of outcome.
+            let state = await testNotifications()
+            if let index = cards.lastIndex(where: { $0.testCase == .notifications }) {
+                cards[index] = ConnectivityTool.Card(
+                    testCase: .notifications,
+                    title: ConnectivityTest.notifications.title,
+                    icon: ConnectivityTest.notifications.icon,
+                    state: state
+                )
+            }
+        }
     }
 
     /// Restores the notifications card to its interactive error state after a failed enable attempt.
@@ -238,7 +267,6 @@ extension ConnectivityToolViewModel {
     enum NotificationConfigError: Error {
         case deviceNotRegistered
         case orderNotificationsDisabled(settings: NotificationSettings)
-        case siteNotFound
         case requestFailed(Error)
     }
 }
@@ -272,12 +300,6 @@ private extension ConnectivityToolViewModel {
                 "Enable them to receive alerts when new orders come in.",
                 comment: "Message when order notifications are disabled in the connectivity tool"
             )
-            static let notificationSiteNotFound = NSLocalizedString(
-                "connectivityToolViewModel.errorMessage.notificationSiteNotFound",
-                value: "Your store was not found in the notification settings.\n\n" +
-                "Try logging out and back in to re-register.",
-                comment: "Message when the site is not found in notification settings in the connectivity tool"
-            )
             static let notificationConfigCheckFailed = NSLocalizedString(
                 "connectivityToolViewModel.errorMessage.notificationConfigCheckFailed",
                 value: "We couldn't check your notification settings.\n\n" +
@@ -305,6 +327,11 @@ private extension ConnectivityToolViewModel {
                 "connectivityToolViewModel.action.openSettings",
                 value: "Open Settings",
                 comment: "Action button to open device notification settings in the connectivity tool"
+            )
+            static let registerDevice = NSLocalizedString(
+                "connectivityToolViewModel.action.registerDevice",
+                value: "Register Device",
+                comment: "Action button to register the device for push notifications in the connectivity tool"
             )
             static let enableOrderNotifications = NSLocalizedString(
                 "connectivityToolViewModel.action.enableOrderNotifications",

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
@@ -16,14 +16,27 @@ extension ConnectivityToolViewModel {
         let jetpackResult = await checkJetpackPluginActiveIfNeeded()
         if case .failure(let error) = jetpackResult {
             DDLogError("Connectivity Tool: ❌ Jetpack plugin check failed\n\(error)")
-            let setupJetpackAction = ConnectivityToolCard.ConnectivityState.Action(
-                title: Localization.Action.setupJetpack,
-                systemImage: SystemImages.setupJetpack.rawValue,
-                action: { [weak self] in
-                    self?.shouldStartJetpackSetup = true
-                }
-            )
-            return .error(Localization.ErrorMessage.jetpackPluginNotActive, [setupJetpackAction, retryAction(for: .notifications)])
+            switch error {
+            case .pluginNotActive:
+                let setupJetpackAction = ConnectivityToolCard.ConnectivityState.Action(
+                    title: Localization.Action.setupJetpack,
+                    systemImage: SystemImages.setupJetpack.rawValue,
+                    action: { [weak self] in
+                        self?.shouldStartJetpackSetup = true
+                    }
+                )
+                return .error(Localization.ErrorMessage.jetpackPluginNotActive,
+                              [setupJetpackAction, retryAction(for: .notifications)])
+            case .requestFailed(let underlyingError):
+                let technicalDetails = String(describing: underlyingError)
+                let viewDetailsAction = ConnectivityToolCard.ConnectivityState.Action(
+                    title: Localization.Action.viewDetails,
+                    systemImage: SystemImages.viewDetails.rawValue,
+                    technicalDetails: technicalDetails
+                )
+                return .error(Localization.ErrorMessage.notificationConfigCheckFailed,
+                              [viewDetailsAction, retryAction(for: .notifications)])
+            }
         }
 
         // Sub-check 2: iOS notification permission is authorized.

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
@@ -149,12 +149,13 @@ extension ConnectivityToolViewModel {
             return .failure(.deviceNotRegistered)
         }
 
+        let currentSiteID = siteID
+
         return await withCheckedContinuation { continuation in
-            let action = AccountAction.loadNotificationSettings(deviceID: numericDeviceID) { [weak self] result in
-                guard let self else { return }
+            let action = AccountAction.loadNotificationSettings(deviceID: numericDeviceID) { result in
                 switch result {
                 case .success(let settings):
-                    guard let blog = settings.blogs.first(where: { $0.blogID == self.siteID }),
+                    guard let blog = settings.blogs.first(where: { $0.blogID == currentSiteID }),
                           let device = blog.devices.first(where: { $0.deviceID == numericDeviceID }),
                           device.storeOrder else {
                         continuation.resume(returning: .failure(.orderNotificationsDisabled(settings: settings)))

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
@@ -309,4 +309,11 @@ private extension ConnectivityToolViewModel {
             )
         }
     }
+
+    enum SystemImages: String {
+        case readMore = "arrow.up.forward.app"
+        case viewDetails = "info.circle"
+        case enableAction = "checkmark.circle"
+        case openSettings = "gear"
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
@@ -92,7 +92,7 @@ extension ConnectivityToolViewModel {
             return .success(())
         }
 
-        /// Authenticate the JetpackConnectionStore with WPCom credentials.
+        /// Authenticate the JetpackConnectionStore with current network.
         if let siteURL {
             stores.dispatch(JetpackConnectionAction.authenticate(siteURL: siteURL, network: network))
         }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
@@ -17,15 +17,14 @@ extension ConnectivityToolViewModel {
         let jetpackResult = await checkJetpackPluginActiveIfNeeded()
         if case .failure(let error) = jetpackResult {
             DDLogError("Connectivity Tool: ❌ Jetpack plugin check failed\n\(error)")
-            let readMoreAction = ConnectivityToolCard.ConnectivityState.Action(
-                title: Localization.Action.readMore,
-                systemImage: SystemImages.readMore.rawValue,
+            let setupJetpackAction = ConnectivityToolCard.ConnectivityState.Action(
+                title: Localization.Action.setupJetpack,
+                systemImage: SystemImages.setupJetpack.rawValue,
                 action: { [weak self] in
-                    self?.selectedURL = WooConstants.URLs.troubleshootJetpackConnection.asURL()
-                    self?.analytics.track(event: .ConnectivityTool.readMoreTapped())
+                    self?.shouldStartJetpackSetup = true
                 }
             )
-            return .error(Localization.ErrorMessage.jetpackPluginNotActive, [readMoreAction, retryAction(for: .notifications)])
+            return .error(Localization.ErrorMessage.jetpackPluginNotActive, [setupJetpackAction, retryAction(for: .notifications)])
         }
 
         // Sub-check 2: iOS notification permission is authorized.
@@ -297,6 +296,11 @@ private extension ConnectivityToolViewModel {
                 value: "View technical details",
                 comment: "Button to view technical error details in the connectivity tool"
             )
+            static let setupJetpack = NSLocalizedString(
+                "connectivityToolViewModel.action.setupJetpack",
+                value: "Setup Jetpack",
+                comment: "Action button to start the Jetpack setup flow in the connectivity tool"
+            )
             static let openSettings = NSLocalizedString(
                 "connectivityToolViewModel.action.openSettings",
                 value: "Open Settings",
@@ -311,9 +315,9 @@ private extension ConnectivityToolViewModel {
     }
 
     enum SystemImages: String {
-        case readMore = "arrow.up.forward.app"
         case viewDetails = "info.circle"
         case enableAction = "checkmark.circle"
         case openSettings = "gear"
+        case setupJetpack = "bolt.fill"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
@@ -18,14 +18,14 @@ extension ConnectivityToolViewModel {
         if case .failure(let error) = jetpackResult {
             DDLogError("Connectivity Tool: ❌ Jetpack plugin check failed\n\(error)")
             let readMoreAction = ConnectivityToolCard.ConnectivityState.Action(
-                title: NotificationLocalization.Action.readMore,
+                title: Localization.Action.readMore,
                 systemImage: SystemImages.readMore.rawValue,
                 action: { [weak self] in
                     self?.selectedURL = WooConstants.URLs.troubleshootJetpackConnection.asURL()
                     self?.analytics.track(event: .ConnectivityTool.readMoreTapped())
                 }
             )
-            return .error(NotificationLocalization.ErrorMessage.jetpackPluginNotActive, [readMoreAction, retryAction(for: .notifications)])
+            return .error(Localization.ErrorMessage.jetpackPluginNotActive, [readMoreAction, retryAction(for: .notifications)])
         }
 
         // Sub-check 2: iOS notification permission is authorized.
@@ -33,7 +33,7 @@ extension ConnectivityToolViewModel {
         if case .failure = permissionResult {
             DDLogInfo("Connectivity Tool: ⚠️ Notifications not authorized")
             let openSettingsAction = ConnectivityToolCard.ConnectivityState.Action(
-                title: NotificationLocalization.Action.openSettings,
+                title: Localization.Action.openSettings,
                 systemImage: SystemImages.openSettings.rawValue,
                 action: { [weak self] in
                     if let url = URL(string: UIApplication.openNotificationSettingsURLString) {
@@ -41,7 +41,7 @@ extension ConnectivityToolViewModel {
                     }
                 }
             )
-            return .error(NotificationLocalization.ErrorMessage.notificationsNotAuthorized, [openSettingsAction, retryAction(for: .notifications)])
+            return .error(Localization.ErrorMessage.notificationsNotAuthorized, [openSettingsAction, retryAction(for: .notifications)])
         }
 
         // Sub-check 3: Notification config — device registered and order notifications enabled.
@@ -54,27 +54,27 @@ extension ConnectivityToolViewModel {
             DDLogInfo("Connectivity Tool: ⚠️ Notification config issue: \(configError)")
             switch configError {
             case .deviceNotRegistered:
-                return .error(NotificationLocalization.ErrorMessage.deviceNotRegistered, [retryAction(for: .notifications)])
+                return .error(Localization.ErrorMessage.deviceNotRegistered, [retryAction(for: .notifications)])
             case .orderNotificationsDisabled(let settings):
                 let enableAction = ConnectivityToolCard.ConnectivityState.Action(
-                    title: NotificationLocalization.Action.enableOrderNotifications,
+                    title: Localization.Action.enableOrderNotifications,
                     systemImage: SystemImages.enableAction.rawValue,
                     action: { [weak self] in
                         self?.enableOrderNotifications(settings: settings)
                     }
                 )
-                return .error(NotificationLocalization.ErrorMessage.orderNotificationsDisabled,
+                return .error(Localization.ErrorMessage.orderNotificationsDisabled,
                               [enableAction, retryAction(for: .notifications)])
             case .siteNotFound:
-                return .error(NotificationLocalization.ErrorMessage.notificationSiteNotFound, [retryAction(for: .notifications)])
+                return .error(Localization.ErrorMessage.notificationSiteNotFound, [retryAction(for: .notifications)])
             case .requestFailed(let error):
                 let technicalDetails = String(describing: error)
                 let viewDetailsAction = ConnectivityToolCard.ConnectivityState.Action(
-                    title: NotificationLocalization.Action.viewDetails,
+                    title: Localization.Action.viewDetails,
                     systemImage: SystemImages.viewDetails.rawValue,
                     technicalDetails: technicalDetails
                 )
-                return .error(NotificationLocalization.ErrorMessage.notificationConfigCheckFailed,
+                return .error(Localization.ErrorMessage.notificationConfigCheckFailed,
                               [viewDetailsAction, retryAction(for: .notifications)])
             }
         }
@@ -207,7 +207,7 @@ extension ConnectivityToolViewModel {
     private func restoreNotificationsCardActions(settings: NotificationSettings) {
         guard let index = cards.lastIndex(where: { $0.testCase == .notifications }) else { return }
         let enableAction = ConnectivityToolCard.ConnectivityState.Action(
-            title: NotificationLocalization.Action.enableOrderNotifications,
+            title: Localization.Action.enableOrderNotifications,
             systemImage: SystemImages.enableAction.rawValue,
             action: { [weak self] in
                 self?.enableOrderNotifications(settings: settings)
@@ -217,7 +217,7 @@ extension ConnectivityToolViewModel {
             testCase: .notifications,
             title: ConnectivityTest.notifications.title,
             icon: ConnectivityTest.notifications.icon,
-            state: .error(NotificationLocalization.ErrorMessage.orderNotificationsDisabled, [enableAction, retryAction(for: .notifications)])
+            state: .error(Localization.ErrorMessage.orderNotificationsDisabled, [enableAction, retryAction(for: .notifications)])
         )
     }
 
@@ -247,7 +247,7 @@ extension ConnectivityToolViewModel {
 // MARK: - Localization
 
 private extension ConnectivityToolViewModel {
-    enum NotificationLocalization {
+    enum Localization {
         enum ErrorMessage {
             static let jetpackPluginNotActive = NSLocalizedString(
                 "connectivityToolViewModel.errorMessage.jetpackPluginNotActive",

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
@@ -35,9 +35,7 @@ extension ConnectivityToolViewModel {
                 title: Localization.Action.openSettings,
                 systemImage: SystemImages.openSettings.rawValue,
                 action: { [weak self] in
-                    if let url = URL(string: UIApplication.openNotificationSettingsURLString) {
-                        self?.selectedURL = url
-                    }
+                    self?.selectedURL = URL(string: UIApplication.openNotificationSettingsURLString)
                 }
             )
             return .error(Localization.ErrorMessage.notificationsNotAuthorized, [openSettingsAction, retryAction(for: .notifications)])
@@ -166,9 +164,7 @@ extension ConnectivityToolViewModel {
               let numericDeviceID = Int64(deviceID) else { return }
 
         // Show loading indicator while enabling.
-        if let cardIndex = cards.lastIndex(where: { $0.testCase == .notifications }) {
-            cards[cardIndex] = ConnectivityTest.notifications.inProgressCard
-        }
+        updateCardState(for: .notifications, state: .inProgress)
 
         // Build updated settings with storeOrder enabled for this device/blog.
         let updatedBlogs: [NotificationSettings.Blog] = settings.blogs.map { blog in
@@ -186,14 +182,7 @@ extension ConnectivityToolViewModel {
             switch result {
             case .success:
                 DDLogInfo("Connectivity Tool: ✅ Order notifications enabled successfully")
-                if let index = self.cards.lastIndex(where: { $0.testCase == .notifications }) {
-                    self.cards[index] = ConnectivityTool.Card(
-                        testCase: .notifications,
-                        title: ConnectivityTest.notifications.title,
-                        icon: ConnectivityTest.notifications.icon,
-                        state: .success
-                    )
-                }
+                self.updateCardState(for: .notifications, state: .success)
             case .failure(let error):
                 DDLogError("Connectivity Tool: ❌ Failed to enable order notifications\n\(error)")
                 self.restoreNotificationsCardActions(settings: settings)
@@ -206,9 +195,7 @@ extension ConnectivityToolViewModel {
     ///
     func registerDeviceForNotifications() {
         // Show loading indicator while registering.
-        if let cardIndex = cards.lastIndex(where: { $0.testCase == .notifications }) {
-            cards[cardIndex] = ConnectivityTest.notifications.inProgressCard
-        }
+        updateCardState(for: .notifications, state: .inProgress)
 
         Task { @MainActor in
             do {
@@ -219,21 +206,13 @@ extension ConnectivityToolViewModel {
             }
             // Re-run the full notifications check regardless of outcome.
             let state = await testNotifications()
-            if let index = cards.lastIndex(where: { $0.testCase == .notifications }) {
-                cards[index] = ConnectivityTool.Card(
-                    testCase: .notifications,
-                    title: ConnectivityTest.notifications.title,
-                    icon: ConnectivityTest.notifications.icon,
-                    state: state
-                )
-            }
+            updateCardState(for: .notifications, state: state)
         }
     }
 
     /// Restores the notifications card to its interactive error state after a failed enable attempt.
     ///
     private func restoreNotificationsCardActions(settings: NotificationSettings) {
-        guard let index = cards.lastIndex(where: { $0.testCase == .notifications }) else { return }
         let enableAction = ConnectivityToolCard.ConnectivityState.Action(
             title: Localization.Action.enableOrderNotifications,
             systemImage: SystemImages.enableAction.rawValue,
@@ -241,12 +220,9 @@ extension ConnectivityToolViewModel {
                 self?.enableOrderNotifications(settings: settings)
             }
         )
-        cards[index] = ConnectivityTool.Card(
-            testCase: .notifications,
-            title: ConnectivityTest.notifications.title,
-            icon: ConnectivityTest.notifications.icon,
-            state: .error(Localization.ErrorMessage.orderNotificationsDisabled, [enableAction, retryAction(for: .notifications)])
-        )
+        updateCardState(for: .notifications,
+                        state: .error(Localization.ErrorMessage.orderNotificationsDisabled,
+                                      [enableAction, retryAction(for: .notifications)]))
     }
 
     /// Error types for the Jetpack plugin check.

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
@@ -2,7 +2,6 @@ import Foundation
 import UIKit
 import Yosemite
 import enum Networking.SitePluginStatusEnum
-import protocol WooFoundation.Analytics
 import UserNotifications
 
 // MARK: - Notifications Check

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
@@ -1,0 +1,312 @@
+import Foundation
+import UIKit
+import Yosemite
+import enum Networking.SitePluginStatusEnum
+import protocol WooFoundation.Analytics
+import UserNotifications
+
+// MARK: - Notifications Check
+
+extension ConnectivityToolViewModel {
+
+    /// Test notification settings: Jetpack plugin status, iOS permission, and notification config.
+    ///
+    @MainActor
+    func testNotifications() async -> ConnectivityToolCard.ConnectivityState {
+        // Sub-check 1: Jetpack plugin is active.
+        let jetpackResult = await checkJetpackPluginActiveIfNeeded()
+        if case .failure(let error) = jetpackResult {
+            DDLogError("Connectivity Tool: ❌ Jetpack plugin check failed\n\(error)")
+            let readMoreAction = ConnectivityToolCard.ConnectivityState.Action(
+                title: NotificationLocalization.Action.readMore,
+                systemImage: SystemImages.readMore.rawValue,
+                action: { [weak self] in
+                    self?.selectedURL = WooConstants.URLs.troubleshootJetpackConnection.asURL()
+                    self?.analytics.track(event: .ConnectivityTool.readMoreTapped())
+                }
+            )
+            return .error(NotificationLocalization.ErrorMessage.jetpackPluginNotActive, [readMoreAction, retryAction(for: .notifications)])
+        }
+
+        // Sub-check 2: iOS notification permission is authorized.
+        let permissionResult = await checkNotificationPermission()
+        if case .failure = permissionResult {
+            DDLogInfo("Connectivity Tool: ⚠️ Notifications not authorized")
+            let openSettingsAction = ConnectivityToolCard.ConnectivityState.Action(
+                title: NotificationLocalization.Action.openSettings,
+                systemImage: SystemImages.openSettings.rawValue,
+                action: { [weak self] in
+                    if let url = URL(string: UIApplication.openNotificationSettingsURLString) {
+                        self?.selectedURL = url
+                    }
+                }
+            )
+            return .error(NotificationLocalization.ErrorMessage.notificationsNotAuthorized, [openSettingsAction, retryAction(for: .notifications)])
+        }
+
+        // Sub-check 3: Notification config — device registered and order notifications enabled.
+        let configResult = await checkNotificationConfig()
+        switch configResult {
+        case .success:
+            DDLogInfo("Connectivity Tool: ✅ Notification settings configured")
+            return .success
+        case .failure(let configError):
+            DDLogInfo("Connectivity Tool: ⚠️ Notification config issue: \(configError)")
+            switch configError {
+            case .deviceNotRegistered:
+                return .error(NotificationLocalization.ErrorMessage.deviceNotRegistered, [retryAction(for: .notifications)])
+            case .orderNotificationsDisabled(let settings):
+                let enableAction = ConnectivityToolCard.ConnectivityState.Action(
+                    title: NotificationLocalization.Action.enableOrderNotifications,
+                    systemImage: SystemImages.enableAction.rawValue,
+                    action: { [weak self] in
+                        self?.enableOrderNotifications(settings: settings)
+                    }
+                )
+                return .error(NotificationLocalization.ErrorMessage.orderNotificationsDisabled,
+                              [enableAction, retryAction(for: .notifications)])
+            case .siteNotFound:
+                return .error(NotificationLocalization.ErrorMessage.notificationSiteNotFound, [retryAction(for: .notifications)])
+            case .requestFailed(let error):
+                let technicalDetails = String(describing: error)
+                let viewDetailsAction = ConnectivityToolCard.ConnectivityState.Action(
+                    title: NotificationLocalization.Action.viewDetails,
+                    systemImage: SystemImages.viewDetails.rawValue,
+                    technicalDetails: technicalDetails
+                )
+                return .error(NotificationLocalization.ErrorMessage.notificationConfigCheckFailed,
+                              [viewDetailsAction, retryAction(for: .notifications)])
+            }
+        }
+    }
+
+    /// Authenticates and retrieves the Jetpack plugin details to verify it's active.
+    ///
+    @MainActor
+    func checkJetpackPluginActiveIfNeeded() async -> Result<Void, JetpackCheckError> {
+        /// WPCom and CIAB sites have Jetpack by default so skip this check
+        guard stores.sessionManager.defaultSite?.isWordPressComStore == false,
+              stores.sessionManager.defaultSite?.isCIAB == false else {
+            return .success(())
+        }
+
+        /// Authenticate the JetpackConnectionStore with WPCom credentials.
+        if let siteURL {
+            stores.dispatch(JetpackConnectionAction.authenticate(siteURL: siteURL, network: network))
+        }
+
+        return await withCheckedContinuation { continuation in
+            let action = JetpackConnectionAction.retrieveJetpackPluginDetails(siteID: siteID) { result in
+                switch result {
+                case .success(let plugin):
+                    if plugin.status == .active || plugin.status == .networkActive {
+                        continuation.resume(returning: .success(()))
+                    } else {
+                        continuation.resume(returning: .failure(.pluginNotActive(status: plugin.status)))
+                    }
+                case .failure(let error):
+                    continuation.resume(returning: .failure(.requestFailed(error)))
+                }
+            }
+            stores.dispatch(action)
+        }
+    }
+
+    /// Checks the iOS notification authorization status.
+    ///
+    func checkNotificationPermission() async -> Result<Void, NotificationPermissionError> {
+        await withCheckedContinuation { continuation in
+            userNotificationCenter.loadAuthorizationStatus(queue: .main) { status in
+                if status == .authorized {
+                    continuation.resume(returning: .success(()))
+                } else {
+                    continuation.resume(returning: .failure(.notAuthorized(status: status)))
+                }
+            }
+        }
+    }
+
+    /// Checks that the device is registered for notifications and order notifications are enabled.
+    ///
+    @MainActor
+    func checkNotificationConfig() async -> Result<Void, NotificationConfigError> {
+        guard let deviceID, let numericDeviceID = Int64(deviceID) else {
+            return .failure(.deviceNotRegistered)
+        }
+
+        return await withCheckedContinuation { continuation in
+            let action = AccountAction.loadNotificationSettings(deviceID: numericDeviceID) { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case .success(let settings):
+                    guard let blog = settings.blogs.first(where: { $0.blogID == self.siteID }) else {
+                        continuation.resume(returning: .failure(.siteNotFound))
+                        return
+                    }
+                    guard let device = blog.devices.first(where: { $0.deviceID == numericDeviceID }) else {
+                        continuation.resume(returning: .failure(.deviceNotRegistered))
+                        return
+                    }
+                    if device.storeOrder {
+                        continuation.resume(returning: .success(()))
+                    } else {
+                        continuation.resume(returning: .failure(.orderNotificationsDisabled(settings: settings)))
+                    }
+                case .failure(let error):
+                    continuation.resume(returning: .failure(.requestFailed(error)))
+                }
+            }
+            stores.dispatch(action)
+        }
+    }
+
+    /// Enables order notifications for the current site and device.
+    ///
+    func enableOrderNotifications(settings: NotificationSettings) {
+        guard let deviceID, let numericDeviceID = Int64(deviceID) else { return }
+
+        // Show loading indicator while enabling.
+        if let cardIndex = cards.lastIndex(where: { $0.testCase == .notifications }) {
+            cards[cardIndex] = ConnectivityTest.notifications.inProgressCard
+        }
+
+        // Build updated settings with storeOrder enabled for this device/blog.
+        let updatedBlogs: [NotificationSettings.Blog] = settings.blogs.map { blog in
+            guard blog.blogID == siteID else { return blog }
+            let updatedDevices: [NotificationSettings.Device] = blog.devices.map { device in
+                guard device.deviceID == numericDeviceID else { return device }
+                return device.copy(storeOrder: true)
+            }
+            return blog.copy(devices: updatedDevices)
+        }
+        let updatedSettings = settings.copy(blogs: updatedBlogs)
+
+        let action = AccountAction.updateNotificationSettings(notificationSettings: updatedSettings) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success:
+                DDLogInfo("Connectivity Tool: ✅ Order notifications enabled successfully")
+                if let index = self.cards.lastIndex(where: { $0.testCase == .notifications }) {
+                    self.cards[index] = ConnectivityTool.Card(
+                        testCase: .notifications,
+                        title: ConnectivityTest.notifications.title,
+                        icon: ConnectivityTest.notifications.icon,
+                        state: .success
+                    )
+                }
+            case .failure(let error):
+                DDLogError("Connectivity Tool: ❌ Failed to enable order notifications\n\(error)")
+                self.restoreNotificationsCardActions(settings: settings)
+            }
+        }
+        stores.dispatch(action)
+    }
+
+    /// Restores the notifications card to its interactive error state after a failed enable attempt.
+    ///
+    private func restoreNotificationsCardActions(settings: NotificationSettings) {
+        guard let index = cards.lastIndex(where: { $0.testCase == .notifications }) else { return }
+        let enableAction = ConnectivityToolCard.ConnectivityState.Action(
+            title: NotificationLocalization.Action.enableOrderNotifications,
+            systemImage: SystemImages.enableAction.rawValue,
+            action: { [weak self] in
+                self?.enableOrderNotifications(settings: settings)
+            }
+        )
+        cards[index] = ConnectivityTool.Card(
+            testCase: .notifications,
+            title: ConnectivityTest.notifications.title,
+            icon: ConnectivityTest.notifications.icon,
+            state: .error(NotificationLocalization.ErrorMessage.orderNotificationsDisabled, [enableAction, retryAction(for: .notifications)])
+        )
+    }
+
+    /// Error types for the Jetpack plugin check.
+    ///
+    enum JetpackCheckError: Error {
+        case pluginNotActive(status: SitePluginStatusEnum)
+        case requestFailed(Error)
+    }
+
+    /// Error types for the notification permission check.
+    ///
+    enum NotificationPermissionError: Error {
+        case notAuthorized(status: UNAuthorizationStatus)
+    }
+
+    /// Error types for the notification config check.
+    ///
+    enum NotificationConfigError: Error {
+        case deviceNotRegistered
+        case orderNotificationsDisabled(settings: NotificationSettings)
+        case siteNotFound
+        case requestFailed(Error)
+    }
+}
+
+// MARK: - Localization
+
+private extension ConnectivityToolViewModel {
+    enum NotificationLocalization {
+        enum ErrorMessage {
+            static let jetpackPluginNotActive = NSLocalizedString(
+                "connectivityToolViewModel.errorMessage.jetpackPluginNotActive",
+                value: "The Jetpack plugin doesn't appear to be active on your site.\n\n" +
+                "Push notifications require an active Jetpack connection.",
+                comment: "Message when Jetpack plugin is not active in the connectivity tool"
+            )
+            static let notificationsNotAuthorized = NSLocalizedString(
+                "connectivityToolViewModel.errorMessage.notificationsNotAuthorized",
+                value: "Push notifications are not allowed for this app.\n\n" +
+                "Enable them in your device Settings to receive order notifications.",
+                comment: "Message when iOS notification permission is denied in the connectivity tool"
+            )
+            static let deviceNotRegistered = NSLocalizedString(
+                "connectivityToolViewModel.errorMessage.deviceNotRegistered",
+                value: "Your device doesn't appear to be registered for push notifications.\n\n" +
+                "Try logging out and back in to re-register.",
+                comment: "Message when the device is not registered for push notifications in the connectivity tool"
+            )
+            static let orderNotificationsDisabled = NSLocalizedString(
+                "connectivityToolViewModel.errorMessage.orderNotificationsDisabled",
+                value: "Order notifications are not enabled for this store.\n\n" +
+                "Enable them to receive alerts when new orders come in.",
+                comment: "Message when order notifications are disabled in the connectivity tool"
+            )
+            static let notificationSiteNotFound = NSLocalizedString(
+                "connectivityToolViewModel.errorMessage.notificationSiteNotFound",
+                value: "Your store was not found in the notification settings.\n\n" +
+                "Try logging out and back in to re-register.",
+                comment: "Message when the site is not found in notification settings in the connectivity tool"
+            )
+            static let notificationConfigCheckFailed = NSLocalizedString(
+                "connectivityToolViewModel.errorMessage.notificationConfigCheckFailed",
+                value: "We couldn't check your notification settings.\n\n" +
+                "Contact our support team for further assistance.",
+                comment: "Message when the notification config check fails in the connectivity tool"
+            )
+        }
+        enum Action {
+            static let readMore = NSLocalizedString(
+                "connectivityToolViewModel.action.readMore",
+                value: "Read more",
+                comment: "Action button title for an error on the connectivity tool"
+            )
+            static let viewDetails = NSLocalizedString(
+                "connectivityToolViewModel.action.viewTechnicalDetails",
+                value: "View technical details",
+                comment: "Button to view technical error details in the connectivity tool"
+            )
+            static let openSettings = NSLocalizedString(
+                "connectivityToolViewModel.action.openSettings",
+                value: "Open Settings",
+                comment: "Action button to open device notification settings in the connectivity tool"
+            )
+            static let enableOrderNotifications = NSLocalizedString(
+                "connectivityToolViewModel.action.enableOrderNotifications",
+                value: "Enable Order Notifications",
+                comment: "Action button to enable order notifications in the connectivity tool"
+            )
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -21,6 +21,10 @@ final class ConnectivityToolViewModel {
     ///
     @Published var selectedURL: URL?
 
+    /// Set to `true` when the user taps "Setup Jetpack" to signal the view layer to start the Jetpack setup flow.
+    ///
+    @Published var shouldStartJetpackSetup = false
+
     /// Remote used to check the connection to WPCom servers.
     ///
     private let announcementsRemote: AnnouncementsRemote

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -9,9 +9,7 @@ import class Networking.SystemStatusRemote
 import class Networking.OrdersRemote
 import class Networking.ProductsRemote
 import class Networking.UserAgent
-import enum Networking.SitePluginStatusEnum
 import protocol WooFoundation.Analytics
-import UserNotifications
 
 final class ConnectivityToolViewModel {
 
@@ -41,19 +39,19 @@ final class ConnectivityToolViewModel {
 
     /// Stores manager for dispatching Yosemite actions.
     ///
-    private let stores: StoresManager
+    let stores: StoresManager
 
     /// Analytics tracker.
     ///
-    private let analytics: Analytics
+    let analytics: Analytics
 
     /// Adapter for checking notification authorization status.
     ///
-    private let userNotificationCenter: UserNotificationsCenterAdapter
+    let userNotificationCenter: UserNotificationsCenterAdapter
 
     /// WordPress.com device identifier for notification settings.
     ///
-    private let deviceID: String?
+    let deviceID: String?
 
     /// Credentials used for authenticating Jetpack connection requests.
     ///
@@ -61,15 +59,15 @@ final class ConnectivityToolViewModel {
 
     /// The site URL used for authenticating Jetpack connection requests.
     ///
-    private let siteURL: String?
+    let siteURL: String?
 
     /// Site to be tested.
     ///
-    private let siteID: Int64
+    let siteID: Int64
 
     private var latestTestResult: [ConnectivityTestResult] = []
 
-    private let network: AlamofireNetwork
+    let network: AlamofireNetwork
 
     init(session: SessionManagerProtocol = ServiceLocator.stores.sessionManager,
          stores: StoresManager = ServiceLocator.stores,
@@ -380,242 +378,6 @@ final class ConnectivityToolViewModel {
         )
     }
 
-    // MARK: - Notifications Check
-
-    /// Test notification settings: Jetpack plugin status, iOS permission, and notification config.
-    ///
-    @MainActor
-    func testNotifications() async -> ConnectivityToolCard.ConnectivityState {
-        // Sub-check 1: Jetpack plugin is active.
-        let jetpackResult = await checkJetpackPluginActiveIfNeeded()
-        if case .failure(let error) = jetpackResult {
-            DDLogError("Connectivity Tool: ❌ Jetpack plugin check failed\n\(error)")
-            let readMoreAction = ConnectivityToolCard.ConnectivityState.Action(
-                title: Localization.Action.readMore,
-                systemImage: SystemImages.readMore.rawValue,
-                action: { [weak self] in
-                    self?.selectedURL = WooConstants.URLs.troubleshootJetpackConnection.asURL()
-                    self?.analytics.track(event: .ConnectivityTool.readMoreTapped())
-                }
-            )
-            return .error(Localization.ErrorMessage.jetpackPluginNotActive, [readMoreAction, retryAction(for: .notifications)])
-        }
-
-        // Sub-check 2: iOS notification permission is authorized.
-        let permissionResult = await checkNotificationPermission()
-        if case .failure = permissionResult {
-            DDLogInfo("Connectivity Tool: ⚠️ Notifications not authorized")
-            let openSettingsAction = ConnectivityToolCard.ConnectivityState.Action(
-                title: Localization.Action.openSettings,
-                systemImage: SystemImages.openSettings.rawValue,
-                action: { [weak self] in
-                    if let url = URL(string: UIApplication.openNotificationSettingsURLString) {
-                        self?.selectedURL = url
-                    }
-                }
-            )
-            return .error(Localization.ErrorMessage.notificationsNotAuthorized, [openSettingsAction, retryAction(for: .notifications)])
-        }
-
-        // Sub-check 3: Notification config — device registered and order notifications enabled.
-        let configResult = await checkNotificationConfig()
-        switch configResult {
-        case .success:
-            DDLogInfo("Connectivity Tool: ✅ Notification settings configured")
-            return .success
-        case .failure(let configError):
-            DDLogInfo("Connectivity Tool: ⚠️ Notification config issue: \(configError)")
-            switch configError {
-            case .deviceNotRegistered:
-                return .error(Localization.ErrorMessage.deviceNotRegistered, [retryAction(for: .notifications)])
-            case .orderNotificationsDisabled(let settings):
-                let enableAction = ConnectivityToolCard.ConnectivityState.Action(
-                    title: Localization.Action.enableOrderNotifications,
-                    systemImage: SystemImages.enableAction.rawValue,
-                    action: { [weak self] in
-                        self?.enableOrderNotifications(settings: settings)
-                    }
-                )
-                return .error(Localization.ErrorMessage.orderNotificationsDisabled,
-                              [enableAction, retryAction(for: .notifications)])
-            case .siteNotFound:
-                return .error(Localization.ErrorMessage.notificationSiteNotFound, [retryAction(for: .notifications)])
-            case .requestFailed(let error):
-                let technicalDetails = String(describing: error)
-                let viewDetailsAction = ConnectivityToolCard.ConnectivityState.Action(
-                    title: Localization.Action.viewDetails,
-                    systemImage: SystemImages.viewDetails.rawValue,
-                    technicalDetails: technicalDetails
-                )
-                return .error(Localization.ErrorMessage.notificationConfigCheckFailed,
-                              [viewDetailsAction, retryAction(for: .notifications)])
-            }
-        }
-    }
-
-    /// Authenticates and retrieves the Jetpack plugin details to verify it's active.
-    ///
-    @MainActor
-    private func checkJetpackPluginActiveIfNeeded() async -> Result<Void, JetpackCheckError> {
-        /// WPCom and CIAB sites have Jetpack by default so skip this check
-        guard stores.sessionManager.defaultSite?.isWordPressComStore == false,
-              stores.sessionManager.defaultSite?.isCIAB == false else {
-            return .success(())
-        }
-
-        /// Authenticate the JetpackConnectionStore with WPCom credentials.
-        if let siteURL {
-            stores.dispatch(JetpackConnectionAction.authenticate(siteURL: siteURL, network: network))
-        }
-
-        return await withCheckedContinuation { continuation in
-            let action = JetpackConnectionAction.retrieveJetpackPluginDetails(siteID: siteID) { result in
-                switch result {
-                case .success(let plugin):
-                    if plugin.status == .active || plugin.status == .networkActive {
-                        continuation.resume(returning: .success(()))
-                    } else {
-                        continuation.resume(returning: .failure(.pluginNotActive(status: plugin.status)))
-                    }
-                case .failure(let error):
-                    continuation.resume(returning: .failure(.requestFailed(error)))
-                }
-            }
-            stores.dispatch(action)
-        }
-    }
-
-    /// Checks the iOS notification authorization status.
-    ///
-    private func checkNotificationPermission() async -> Result<Void, NotificationPermissionError> {
-        await withCheckedContinuation { continuation in
-            userNotificationCenter.loadAuthorizationStatus(queue: .main) { status in
-                if status == .authorized {
-                    continuation.resume(returning: .success(()))
-                } else {
-                    continuation.resume(returning: .failure(.notAuthorized(status: status)))
-                }
-            }
-        }
-    }
-
-    /// Checks that the device is registered for notifications and order notifications are enabled.
-    ///
-    @MainActor
-    private func checkNotificationConfig() async -> Result<Void, NotificationConfigError> {
-        guard let deviceID, let numericDeviceID = Int64(deviceID) else {
-            return .failure(.deviceNotRegistered)
-        }
-
-        return await withCheckedContinuation { continuation in
-            let action = AccountAction.loadNotificationSettings(deviceID: numericDeviceID) { [weak self] result in
-                guard let self else { return }
-                switch result {
-                case .success(let settings):
-                    guard let blog = settings.blogs.first(where: { $0.blogID == self.siteID }) else {
-                        continuation.resume(returning: .failure(.siteNotFound))
-                        return
-                    }
-                    guard let device = blog.devices.first(where: { $0.deviceID == numericDeviceID }) else {
-                        continuation.resume(returning: .failure(.deviceNotRegistered))
-                        return
-                    }
-                    if device.storeOrder {
-                        continuation.resume(returning: .success(()))
-                    } else {
-                        continuation.resume(returning: .failure(.orderNotificationsDisabled(settings: settings)))
-                    }
-                case .failure(let error):
-                    continuation.resume(returning: .failure(.requestFailed(error)))
-                }
-            }
-            stores.dispatch(action)
-        }
-    }
-
-    /// Enables order notifications for the current site and device.
-    ///
-    private func enableOrderNotifications(settings: NotificationSettings) {
-        guard let deviceID, let numericDeviceID = Int64(deviceID) else { return }
-
-        // Show loading indicator while enabling.
-        if let cardIndex = cards.lastIndex(where: { $0.testCase == .notifications }) {
-            cards[cardIndex] = ConnectivityTest.notifications.inProgressCard
-        }
-
-        // Build updated settings with storeOrder enabled for this device/blog.
-        let updatedBlogs: [NotificationSettings.Blog] = settings.blogs.map { blog in
-            guard blog.blogID == siteID else { return blog }
-            let updatedDevices: [NotificationSettings.Device] = blog.devices.map { device in
-                guard device.deviceID == numericDeviceID else { return device }
-                return device.copy(storeOrder: true)
-            }
-            return blog.copy(devices: updatedDevices)
-        }
-        let updatedSettings = settings.copy(blogs: updatedBlogs)
-
-        let action = AccountAction.updateNotificationSettings(notificationSettings: updatedSettings) { [weak self] result in
-            guard let self else { return }
-            switch result {
-            case .success:
-                DDLogInfo("Connectivity Tool: ✅ Order notifications enabled successfully")
-                if let index = self.cards.lastIndex(where: { $0.testCase == .notifications }) {
-                    self.cards[index] = ConnectivityTool.Card(
-                        testCase: .notifications,
-                        title: ConnectivityTest.notifications.title,
-                        icon: ConnectivityTest.notifications.icon,
-                        state: .success
-                    )
-                }
-            case .failure(let error):
-                DDLogError("Connectivity Tool: ❌ Failed to enable order notifications\n\(error)")
-                self.restoreNotificationsCardActions(settings: settings)
-            }
-        }
-        stores.dispatch(action)
-    }
-
-    /// Restores the notifications card to its interactive error state after a failed enable attempt.
-    ///
-    private func restoreNotificationsCardActions(settings: NotificationSettings) {
-        guard let index = cards.lastIndex(where: { $0.testCase == .notifications }) else { return }
-        let enableAction = ConnectivityToolCard.ConnectivityState.Action(
-            title: Localization.Action.enableOrderNotifications,
-            systemImage: SystemImages.enableAction.rawValue,
-            action: { [weak self] in
-                self?.enableOrderNotifications(settings: settings)
-            }
-        )
-        cards[index] = ConnectivityTool.Card(
-            testCase: .notifications,
-            title: ConnectivityTest.notifications.title,
-            icon: ConnectivityTest.notifications.icon,
-            state: .error(Localization.ErrorMessage.orderNotificationsDisabled, [enableAction, retryAction(for: .notifications)])
-        )
-    }
-
-    /// Error types for the Jetpack plugin check.
-    ///
-    enum JetpackCheckError: Error {
-        case pluginNotActive(status: SitePluginStatusEnum)
-        case requestFailed(Error)
-    }
-
-    /// Error types for the notification permission check.
-    ///
-    enum NotificationPermissionError: Error {
-        case notAuthorized(status: UNAuthorizationStatus)
-    }
-
-    /// Error types for the notification config check.
-    ///
-    enum NotificationConfigError: Error {
-        case deviceNotRegistered
-        case orderNotificationsDisabled(settings: NotificationSettings)
-        case siteNotFound
-        case requestFailed(Error)
-    }
-
     private func stateForSiteResult<T>(_ result: Result<T, Error>, operation: ConnectivityTest) -> ConnectivityToolCard.ConnectivityState {
         guard case let .failure(error) = result else {
             return .success
@@ -671,7 +433,7 @@ final class ConnectivityToolViewModel {
         }
     }
 
-    private func retryAction(for testCase: ConnectivityTest) -> ConnectivityToolCard.ConnectivityState.Action {
+    func retryAction(for testCase: ConnectivityTest) -> ConnectivityToolCard.ConnectivityState.Action {
         let retryText = Localization.Action.retry
         return .init(title: retryText, systemImage: SystemImages.retry.rawValue, action: { [weak self] in
             self?.retryTest(testCase)
@@ -878,42 +640,6 @@ private extension ConnectivityToolViewModel {
                 "Contact our support team for further assistance.",
                 comment: "Message when the analytics setting check fails in the connectivity tool"
             )
-            static let jetpackPluginNotActive = NSLocalizedString(
-                "connectivityToolViewModel.errorMessage.jetpackPluginNotActive",
-                value: "The Jetpack plugin doesn't appear to be active on your site.\n\n" +
-                "Push notifications require an active Jetpack connection.",
-                comment: "Message when Jetpack plugin is not active in the connectivity tool"
-            )
-            static let notificationsNotAuthorized = NSLocalizedString(
-                "connectivityToolViewModel.errorMessage.notificationsNotAuthorized",
-                value: "Push notifications are not allowed for this app.\n\n" +
-                "Enable them in your device Settings to receive order notifications.",
-                comment: "Message when iOS notification permission is denied in the connectivity tool"
-            )
-            static let deviceNotRegistered = NSLocalizedString(
-                "connectivityToolViewModel.errorMessage.deviceNotRegistered",
-                value: "Your device doesn't appear to be registered for push notifications.\n\n" +
-                "Try logging out and back in to re-register.",
-                comment: "Message when the device is not registered for push notifications in the connectivity tool"
-            )
-            static let orderNotificationsDisabled = NSLocalizedString(
-                "connectivityToolViewModel.errorMessage.orderNotificationsDisabled",
-                value: "Order notifications are not enabled for this store.\n\n" +
-                "Enable them to receive alerts when new orders come in.",
-                comment: "Message when order notifications are disabled in the connectivity tool"
-            )
-            static let notificationSiteNotFound = NSLocalizedString(
-                "connectivityToolViewModel.errorMessage.notificationSiteNotFound",
-                value: "Your store was not found in the notification settings.\n\n" +
-                "Try logging out and back in to re-register.",
-                comment: "Message when the site is not found in notification settings in the connectivity tool"
-            )
-            static let notificationConfigCheckFailed = NSLocalizedString(
-                "connectivityToolViewModel.errorMessage.notificationConfigCheckFailed",
-                value: "We couldn't check your notification settings.\n\n" +
-                "Contact our support team for further assistance.",
-                comment: "Message when the notification config check fails in the connectivity tool"
-            )
         }
         enum Action {
             static let readMore = NSLocalizedString(
@@ -936,21 +662,11 @@ private extension ConnectivityToolViewModel {
                 value: "Enable Analytics",
                 comment: "Action button to enable WooCommerce Analytics in the connectivity tool"
             )
-            static let openSettings = NSLocalizedString(
-                "connectivityToolViewModel.action.openSettings",
-                value: "Open Settings",
-                comment: "Action button to open device notification settings in the connectivity tool"
-            )
-            static let enableOrderNotifications = NSLocalizedString(
-                "connectivityToolViewModel.action.enableOrderNotifications",
-                value: "Enable Order Notifications",
-                comment: "Action button to enable order notifications in the connectivity tool"
-            )
         }
     }
 }
 
-private extension ConnectivityToolViewModel {
+extension ConnectivityToolViewModel {
     enum SystemImages: String {
         case retry = "arrow.clockwise"
         case readMore = "arrow.up.forward.app"

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -329,9 +329,7 @@ final class ConnectivityToolViewModel {
     ///
     private func enableAnalytics(retries: Int = 0) {
         // Hide card content and show loading indicator while enabling.
-        if let cardIndex = cards.lastIndex(where: { $0.testCase == .analyticsSetting }) {
-            cards[cardIndex] = ConnectivityTest.analyticsSetting.inProgressCard
-        }
+        updateCardState(for: .analyticsSetting, state: .inProgress)
 
         let action = SettingAction.enableAnalyticsSetting(siteID: siteID) { [weak self] result in
             guard let self else { return }
@@ -339,14 +337,7 @@ final class ConnectivityToolViewModel {
             case .success:
                 DDLogInfo("Connectivity Tool: ✅ Analytics enabled successfully")
                 // Update the analytics setting card to show relaunch message.
-                if let index = self.cards.lastIndex(where: { $0.testCase == .analyticsSetting }) {
-                    self.cards[index] = ConnectivityTool.Card(
-                        testCase: .analyticsSetting,
-                        title: ConnectivityTest.analyticsSetting.title,
-                        icon: ConnectivityTest.analyticsSetting.icon,
-                        state: .empty(Localization.analyticsEnabledRelaunch)
-                    )
-                }
+                self.updateCardState(for: .analyticsSetting, state: .empty(Localization.analyticsEnabledRelaunch))
             case .failure(let error):
                 if retries < 1 {
                     // Retry once due to known API quirk where first request fails.
@@ -364,9 +355,6 @@ final class ConnectivityToolViewModel {
     /// Restores the analytics setting card to its interactive error state after a failed enable attempt.
     ///
     private func restoreAnalyticsCardActions() {
-        guard let index = cards.lastIndex(where: { $0.testCase == .analyticsSetting }) else {
-            return
-        }
         let enableAction = ConnectivityToolCard.ConnectivityState.Action(
             title: Localization.Action.enableAnalytics,
             systemImage: SystemImages.enableAction.rawValue,
@@ -374,12 +362,16 @@ final class ConnectivityToolViewModel {
                 self?.enableAnalytics()
             }
         )
-        cards[index] = ConnectivityTool.Card(
-            testCase: .analyticsSetting,
-            title: ConnectivityTest.analyticsSetting.title,
-            icon: ConnectivityTest.analyticsSetting.icon,
-            state: .error(Localization.ErrorMessage.analyticsDisabled, [enableAction, retryAction(for: .analyticsSetting)])
-        )
+        updateCardState(for: .analyticsSetting,
+                        state: .error(Localization.ErrorMessage.analyticsDisabled,
+                                      [enableAction, retryAction(for: .analyticsSetting)]))
+    }
+
+    /// Updates the state of the card matching the given test case.
+    ///
+    func updateCardState(for testCase: ConnectivityTest, state: ConnectivityToolCard.ConnectivityState) {
+        guard let index = cards.lastIndex(where: { $0.testCase == testCase }) else { return }
+        cards[index] = cards[index].updatingState(state)
     }
 
     private func stateForSiteResult<T>(_ result: Result<T, Error>, operation: ConnectivityTest) -> ConnectivityToolCard.ConnectivityState {

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -9,13 +9,19 @@ import class Networking.SystemStatusRemote
 import class Networking.OrdersRemote
 import class Networking.ProductsRemote
 import class Networking.UserAgent
+import enum Networking.SitePluginStatusEnum
 import protocol WooFoundation.Analytics
+import UserNotifications
 
 final class ConnectivityToolViewModel {
 
     /// Cards to be rendered by the view.
     ///
     @Published var cards: [ConnectivityTool.Card] = []
+
+    /// URL selected by an action button, to be opened in-app by the view layer.
+    ///
+    @Published var selectedURL: URL?
 
     /// Remote used to check the connection to WPCom servers.
     ///
@@ -41,6 +47,22 @@ final class ConnectivityToolViewModel {
     ///
     private let analytics: Analytics
 
+    /// Adapter for checking notification authorization status.
+    ///
+    private let userNotificationCenter: UserNotificationsCenterAdapter
+
+    /// WordPress.com device identifier for notification settings.
+    ///
+    private let deviceID: String?
+
+    /// Credentials used for authenticating Jetpack connection requests.
+    ///
+    private let credentials: Credentials?
+
+    /// The site URL used for authenticating Jetpack connection requests.
+    ///
+    private let siteURL: String?
+
     /// Site to be tested.
     ///
     private let siteID: Int64
@@ -49,7 +71,9 @@ final class ConnectivityToolViewModel {
 
     init(session: SessionManagerProtocol = ServiceLocator.stores.sessionManager,
          stores: StoresManager = ServiceLocator.stores,
-         analytics: Analytics = ServiceLocator.analytics) {
+         analytics: Analytics = ServiceLocator.analytics,
+         userNotificationCenter: UserNotificationsCenterAdapter = UNUserNotificationCenter.current(),
+         deviceID: String? = ServiceLocator.pushNotesManager.deviceID) {
 
         let network = AlamofireNetwork(credentials: session.defaultCredentials, selectedSite: nil, appPasswordSupportState: nil)
         self.announcementsRemote = AnnouncementsRemote(network: network)
@@ -58,6 +82,10 @@ final class ConnectivityToolViewModel {
         self.productsRemote = ProductsRemote(network: network)
         self.stores = stores
         self.analytics = analytics
+        self.userNotificationCenter = userNotificationCenter
+        self.deviceID = deviceID
+        self.credentials = session.defaultCredentials
+        self.siteURL = session.defaultSite?.url
         self.siteID = session.defaultStoreID ?? .zero
 
         Task {
@@ -71,7 +99,7 @@ final class ConnectivityToolViewModel {
     private func startConnectivityTest(sinceTest: ConnectivityTest = .internetConnection) async {
         let supportedTests: [ConnectivityTest] = {
             if stores.isAuthenticatedWithoutWPCom == false {
-                [.internetConnection, .wpComServers, .site, .siteOrders, .loadingProducts, .analyticsSetting]
+                [.internetConnection, .wpComServers, .site, .siteOrders, .loadingProducts, .analyticsSetting, .notifications]
             } else {
                 [.internetConnection, .site, .siteOrders, .loadingProducts, .analyticsSetting]
             }
@@ -140,6 +168,8 @@ final class ConnectivityToolViewModel {
             return await testFetchingProducts()
         case .analyticsSetting:
             return await testAnalyticsSetting()
+        case .notifications:
+            return await testNotifications()
         }
     }
 
@@ -347,6 +377,230 @@ final class ConnectivityToolViewModel {
         )
     }
 
+    // MARK: - Notifications Check
+
+    /// Test notification settings: Jetpack plugin status, iOS permission, and notification config.
+    ///
+    @MainActor
+    func testNotifications() async -> ConnectivityToolCard.ConnectivityState {
+        // Sub-check 1: Jetpack plugin is active.
+        let jetpackResult = await checkJetpackPluginActive()
+        if case .failure(let error) = jetpackResult {
+            DDLogError("Connectivity Tool: ❌ Jetpack plugin check failed\n\(error)")
+            let readMoreAction = ConnectivityToolCard.ConnectivityState.Action(
+                title: Localization.Action.readMore,
+                systemImage: SystemImages.readMore.rawValue,
+                action: { [weak self] in
+                    self?.selectedURL = WooConstants.URLs.troubleshootJetpackConnection.asURL()
+                    self?.analytics.track(event: .ConnectivityTool.readMoreTapped())
+                }
+            )
+            return .error(Localization.ErrorMessage.jetpackPluginNotActive, [readMoreAction, retryAction(for: .notifications)])
+        }
+
+        // Sub-check 2: iOS notification permission is authorized.
+        let permissionResult = await checkNotificationPermission()
+        if case .failure = permissionResult {
+            DDLogInfo("Connectivity Tool: ⚠️ Notifications not authorized")
+            let openSettingsAction = ConnectivityToolCard.ConnectivityState.Action(
+                title: Localization.Action.openSettings,
+                systemImage: SystemImages.openSettings.rawValue,
+                action: {
+                    if let url = URL(string: UIApplication.openNotificationSettingsURLString) {
+                        UIApplication.shared.open(url)
+                    }
+                }
+            )
+            return .error(Localization.ErrorMessage.notificationsNotAuthorized, [openSettingsAction, retryAction(for: .notifications)])
+        }
+
+        // Sub-check 3: Notification config — device registered and order notifications enabled.
+        let configResult = await checkNotificationConfig()
+        switch configResult {
+        case .success:
+            DDLogInfo("Connectivity Tool: ✅ Notification settings configured")
+            return .success
+        case .failure(let configError):
+            DDLogInfo("Connectivity Tool: ⚠️ Notification config issue: \(configError)")
+            switch configError {
+            case .deviceNotRegistered:
+                return .error(Localization.ErrorMessage.deviceNotRegistered, [retryAction(for: .notifications)])
+            case .orderNotificationsDisabled(let settings):
+                let enableAction = ConnectivityToolCard.ConnectivityState.Action(
+                    title: Localization.Action.enableOrderNotifications,
+                    systemImage: SystemImages.enableAction.rawValue,
+                    action: { [weak self] in
+                        self?.enableOrderNotifications(settings: settings)
+                    }
+                )
+                return .error(Localization.ErrorMessage.orderNotificationsDisabled,
+                              [enableAction, retryAction(for: .notifications)])
+            case .siteNotFound:
+                return .error(Localization.ErrorMessage.notificationSiteNotFound, [retryAction(for: .notifications)])
+            case .requestFailed(let error):
+                let technicalDetails = String(describing: error)
+                let viewDetailsAction = ConnectivityToolCard.ConnectivityState.Action(
+                    title: Localization.Action.viewDetails,
+                    systemImage: SystemImages.viewDetails.rawValue,
+                    technicalDetails: technicalDetails
+                )
+                return .error(Localization.ErrorMessage.notificationConfigCheckFailed,
+                              [viewDetailsAction, retryAction(for: .notifications)])
+            }
+        }
+    }
+
+    /// Authenticates and retrieves the Jetpack plugin details to verify it's active.
+    ///
+    @MainActor
+    private func checkJetpackPluginActive() async -> Result<Void, Error> {
+        // Authenticate the JetpackConnectionStore with WPCom credentials.
+        if let siteURL, let credentials {
+            let network = AlamofireNetwork(credentials: credentials, selectedSite: nil, appPasswordSupportState: nil)
+            stores.dispatch(JetpackConnectionAction.authenticate(siteURL: siteURL, network: network))
+        }
+
+        return await withCheckedContinuation { continuation in
+            let action = JetpackConnectionAction.retrieveJetpackPluginDetails(siteID: siteID) { result in
+                switch result {
+                case .success(let plugin):
+                    if plugin.status == .active || plugin.status == .networkActive {
+                        continuation.resume(returning: .success(()))
+                    } else {
+                        let error = NSError(domain: "ConnectivityTool",
+                                            code: 0,
+                                            userInfo: [NSLocalizedDescriptionKey: "Jetpack plugin is installed but not active (status: \(plugin.status))"])
+                        continuation.resume(returning: .failure(error))
+                    }
+                case .failure(let error):
+                    continuation.resume(returning: .failure(error))
+                }
+            }
+            stores.dispatch(action)
+        }
+    }
+
+    /// Checks the iOS notification authorization status.
+    ///
+    private func checkNotificationPermission() async -> Result<Void, Error> {
+        await withCheckedContinuation { continuation in
+            userNotificationCenter.loadAuthorizationStatus(queue: .main) { status in
+                if status == .authorized {
+                    continuation.resume(returning: .success(()))
+                } else {
+                    let error = NSError(domain: "ConnectivityTool",
+                                        code: 0,
+                                        userInfo: [NSLocalizedDescriptionKey: "Notification permission status: \(status.rawValue)"])
+                    continuation.resume(returning: .failure(error))
+                }
+            }
+        }
+    }
+
+    /// Checks that the device is registered for notifications and order notifications are enabled.
+    ///
+    @MainActor
+    private func checkNotificationConfig() async -> Result<Void, NotificationConfigError> {
+        guard let deviceID, let numericDeviceID = Int64(deviceID) else {
+            return .failure(.deviceNotRegistered)
+        }
+
+        return await withCheckedContinuation { continuation in
+            let action = AccountAction.loadNotificationSettings(deviceID: numericDeviceID) { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case .success(let settings):
+                    guard let blog = settings.blogs.first(where: { $0.blogID == self.siteID }) else {
+                        continuation.resume(returning: .failure(.siteNotFound))
+                        return
+                    }
+                    guard let device = blog.devices.first(where: { $0.deviceID == numericDeviceID }) else {
+                        continuation.resume(returning: .failure(.deviceNotRegistered))
+                        return
+                    }
+                    if device.storeOrder {
+                        continuation.resume(returning: .success(()))
+                    } else {
+                        continuation.resume(returning: .failure(.orderNotificationsDisabled(settings: settings)))
+                    }
+                case .failure(let error):
+                    continuation.resume(returning: .failure(.requestFailed(error)))
+                }
+            }
+            stores.dispatch(action)
+        }
+    }
+
+    /// Enables order notifications for the current site and device.
+    ///
+    private func enableOrderNotifications(settings: NotificationSettings) {
+        guard let deviceID, let numericDeviceID = Int64(deviceID) else { return }
+
+        // Show loading indicator while enabling.
+        if let cardIndex = cards.lastIndex(where: { $0.testCase == .notifications }) {
+            cards[cardIndex] = ConnectivityTest.notifications.inProgressCard
+        }
+
+        // Build updated settings with storeOrder enabled for this device/blog.
+        let updatedBlogs: [NotificationSettings.Blog] = settings.blogs.map { blog in
+            guard blog.blogID == siteID else { return blog }
+            let updatedDevices: [NotificationSettings.Device] = blog.devices.map { device in
+                guard device.deviceID == numericDeviceID else { return device }
+                return device.copy(storeOrder: true)
+            }
+            return blog.copy(devices: updatedDevices)
+        }
+        let updatedSettings = settings.copy(blogs: updatedBlogs)
+
+        let action = AccountAction.updateNotificationSettings(notificationSettings: updatedSettings) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success:
+                DDLogInfo("Connectivity Tool: ✅ Order notifications enabled successfully")
+                if let index = self.cards.lastIndex(where: { $0.testCase == .notifications }) {
+                    self.cards[index] = ConnectivityTool.Card(
+                        testCase: .notifications,
+                        title: ConnectivityTest.notifications.title,
+                        icon: ConnectivityTest.notifications.icon,
+                        state: .success
+                    )
+                }
+            case .failure(let error):
+                DDLogError("Connectivity Tool: ❌ Failed to enable order notifications\n\(error)")
+                self.restoreNotificationsCardActions(settings: settings)
+            }
+        }
+        stores.dispatch(action)
+    }
+
+    /// Restores the notifications card to its interactive error state after a failed enable attempt.
+    ///
+    private func restoreNotificationsCardActions(settings: NotificationSettings) {
+        guard let index = cards.lastIndex(where: { $0.testCase == .notifications }) else { return }
+        let enableAction = ConnectivityToolCard.ConnectivityState.Action(
+            title: Localization.Action.enableOrderNotifications,
+            systemImage: SystemImages.enableAction.rawValue,
+            action: { [weak self] in
+                self?.enableOrderNotifications(settings: settings)
+            }
+        )
+        cards[index] = ConnectivityTool.Card(
+            testCase: .notifications,
+            title: ConnectivityTest.notifications.title,
+            icon: ConnectivityTest.notifications.icon,
+            state: .error(Localization.ErrorMessage.orderNotificationsDisabled, [enableAction, retryAction(for: .notifications)])
+        )
+    }
+
+    /// Error types for the notification config check.
+    ///
+    enum NotificationConfigError: Error {
+        case deviceNotRegistered
+        case orderNotificationsDisabled(settings: NotificationSettings)
+        case siteNotFound
+        case requestFailed(Error)
+    }
+
     private func stateForSiteResult<T>(_ result: Result<T, Error>, operation: ConnectivityTest) -> ConnectivityToolCard.ConnectivityState {
         guard case let .failure(error) = result else {
             return .success
@@ -355,14 +609,14 @@ final class ConnectivityToolViewModel {
         let message: String
         let readMore = Localization.Action.readMore
         let generalTroubleshootAction = { [weak self] in
-            UIApplication.shared.open(WooConstants.URLs.troubleshootErrorLoadingData.asURL())
+            self?.selectedURL = WooConstants.URLs.troubleshootErrorLoadingData.asURL()
             self?.analytics.track(event: .ConnectivityTool.readMoreTapped())
         }
         var readMoreAction = ConnectivityToolCard.ConnectivityState.Action(title: readMore,
                                                                            systemImage: SystemImages.readMore.rawValue,
                                                                            action: generalTroubleshootAction)
         let jetpackTroubleshootAction = { [weak self] in
-            UIApplication.shared.open(WooConstants.URLs.troubleshootJetpackConnection.asURL())
+            self?.selectedURL = WooConstants.URLs.troubleshootJetpackConnection.asURL()
             self?.analytics.track(event: .ConnectivityTool.readMoreTapped())
         }
 
@@ -420,6 +674,7 @@ final class ConnectivityToolViewModel {
             case .siteOrders: return .orders
             case .loadingProducts: return .products
             case .analyticsSetting: return .analytics
+            case .notifications: return .notifications
             }
         }()
         analytics.track(event: .ConnectivityTool.requestResponse(test: eventTest, success: success, timeTaken: timeTaken))
@@ -526,6 +781,7 @@ fileprivate struct ConnectivityTestResult {
         case .siteOrders: "Fetching your site orders"
         case .loadingProducts: "Fetching products in your store"
         case .analyticsSetting: "Checking analytics setting"
+        case .notifications: "Checking notification settings"
         }
     }
 
@@ -607,6 +863,42 @@ private extension ConnectivityToolViewModel {
                 "Contact our support team for further assistance.",
                 comment: "Message when the analytics setting check fails in the connectivity tool"
             )
+            static let jetpackPluginNotActive = NSLocalizedString(
+                "connectivityToolViewModel.errorMessage.jetpackPluginNotActive",
+                value: "The Jetpack plugin doesn't appear to be active on your site.\n\n" +
+                "Push notifications require an active Jetpack connection.",
+                comment: "Message when Jetpack plugin is not active in the connectivity tool"
+            )
+            static let notificationsNotAuthorized = NSLocalizedString(
+                "connectivityToolViewModel.errorMessage.notificationsNotAuthorized",
+                value: "Push notifications are not allowed for this app.\n\n" +
+                "Enable them in your device Settings to receive order notifications.",
+                comment: "Message when iOS notification permission is denied in the connectivity tool"
+            )
+            static let deviceNotRegistered = NSLocalizedString(
+                "connectivityToolViewModel.errorMessage.deviceNotRegistered",
+                value: "Your device doesn't appear to be registered for push notifications.\n\n" +
+                "Try logging out and back in to re-register.",
+                comment: "Message when the device is not registered for push notifications in the connectivity tool"
+            )
+            static let orderNotificationsDisabled = NSLocalizedString(
+                "connectivityToolViewModel.errorMessage.orderNotificationsDisabled",
+                value: "Order notifications are not enabled for this store.\n\n" +
+                "Enable them to receive alerts when new orders come in.",
+                comment: "Message when order notifications are disabled in the connectivity tool"
+            )
+            static let notificationSiteNotFound = NSLocalizedString(
+                "connectivityToolViewModel.errorMessage.notificationSiteNotFound",
+                value: "Your store was not found in the notification settings.\n\n" +
+                "Try logging out and back in to re-register.",
+                comment: "Message when the site is not found in notification settings in the connectivity tool"
+            )
+            static let notificationConfigCheckFailed = NSLocalizedString(
+                "connectivityToolViewModel.errorMessage.notificationConfigCheckFailed",
+                value: "We couldn't check your notification settings.\n\n" +
+                "Contact our support team for further assistance.",
+                comment: "Message when the notification config check fails in the connectivity tool"
+            )
         }
         enum Action {
             static let readMore = NSLocalizedString(
@@ -629,6 +921,16 @@ private extension ConnectivityToolViewModel {
                 value: "Enable Analytics",
                 comment: "Action button to enable WooCommerce Analytics in the connectivity tool"
             )
+            static let openSettings = NSLocalizedString(
+                "connectivityToolViewModel.action.openSettings",
+                value: "Open Settings",
+                comment: "Action button to open device notification settings in the connectivity tool"
+            )
+            static let enableOrderNotifications = NSLocalizedString(
+                "connectivityToolViewModel.action.enableOrderNotifications",
+                value: "Enable Order Notifications",
+                comment: "Action button to enable order notifications in the connectivity tool"
+            )
         }
     }
 }
@@ -639,6 +941,7 @@ private extension ConnectivityToolViewModel {
         case readMore = "arrow.up.forward.app"
         case viewDetails = "info.circle"
         case enableAction = "checkmark.circle"
+        case openSettings = "gear"
     }
 }
 
@@ -650,6 +953,7 @@ extension ConnectivityToolViewModel {
         case siteOrders
         case loadingProducts
         case analyticsSetting
+        case notifications
 
         var title: String {
             switch self {
@@ -689,6 +993,12 @@ extension ConnectivityToolViewModel {
                     value: "Checking analytics setting",
                     comment: "Title for the analytics setting check in the connectivity tool"
                 )
+            case .notifications:
+                NSLocalizedString(
+                    "connectivityToolViewModel.connectivityTest.notifications",
+                    value: "Checking notification settings",
+                    comment: "Title for the notification settings check in the connectivity tool"
+                )
             }
         }
 
@@ -706,6 +1016,8 @@ extension ConnectivityToolViewModel {
                     .system("cart")
             case .analyticsSetting:
                     .system("chart.bar.xaxis")
+            case .notifications:
+                    .system("bell.badge")
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -408,9 +408,9 @@ final class ConnectivityToolViewModel {
             let openSettingsAction = ConnectivityToolCard.ConnectivityState.Action(
                 title: Localization.Action.openSettings,
                 systemImage: SystemImages.openSettings.rawValue,
-                action: {
+                action: { [weak self] in
                     if let url = URL(string: UIApplication.openNotificationSettingsURLString) {
-                        UIApplication.shared.open(url)
+                        self?.selectedURL = url
                     }
                 }
             )

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -69,6 +69,8 @@ final class ConnectivityToolViewModel {
 
     private var latestTestResult: [ConnectivityTestResult] = []
 
+    private let network: AlamofireNetwork
+
     init(session: SessionManagerProtocol = ServiceLocator.stores.sessionManager,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
@@ -76,6 +78,7 @@ final class ConnectivityToolViewModel {
          deviceID: String? = ServiceLocator.pushNotesManager.deviceID) {
 
         let network = AlamofireNetwork(credentials: session.defaultCredentials, selectedSite: nil, appPasswordSupportState: nil)
+        self.network = network
         self.announcementsRemote = AnnouncementsRemote(network: network)
         self.systemStatusRemote = SystemStatusRemote(network: network)
         self.orderRemote = OrdersRemote(network: network)
@@ -384,7 +387,7 @@ final class ConnectivityToolViewModel {
     @MainActor
     func testNotifications() async -> ConnectivityToolCard.ConnectivityState {
         // Sub-check 1: Jetpack plugin is active.
-        let jetpackResult = await checkJetpackPluginActive()
+        let jetpackResult = await checkJetpackPluginActiveIfNeeded()
         if case .failure(let error) = jetpackResult {
             DDLogError("Connectivity Tool: ❌ Jetpack plugin check failed\n\(error)")
             let readMoreAction = ConnectivityToolCard.ConnectivityState.Action(
@@ -453,10 +456,15 @@ final class ConnectivityToolViewModel {
     /// Authenticates and retrieves the Jetpack plugin details to verify it's active.
     ///
     @MainActor
-    private func checkJetpackPluginActive() async -> Result<Void, Error> {
-        // Authenticate the JetpackConnectionStore with WPCom credentials.
-        if let siteURL, let credentials {
-            let network = AlamofireNetwork(credentials: credentials, selectedSite: nil, appPasswordSupportState: nil)
+    private func checkJetpackPluginActiveIfNeeded() async -> Result<Void, Error> {
+        /// WPCom and CIAB sites have Jetpack by default so skip this check
+        guard stores.sessionManager.defaultSite?.isWordPressComStore == false,
+              stores.sessionManager.defaultSite?.isCIAB == false else {
+            return .success(())
+        }
+
+        /// Authenticate the JetpackConnectionStore with WPCom credentials.
+        if let siteURL {
             stores.dispatch(JetpackConnectionAction.authenticate(siteURL: siteURL, network: network))
         }
 

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -666,13 +666,12 @@ private extension ConnectivityToolViewModel {
     }
 }
 
-extension ConnectivityToolViewModel {
+private extension ConnectivityToolViewModel {
     enum SystemImages: String {
         case retry = "arrow.clockwise"
         case readMore = "arrow.up.forward.app"
         case viewDetails = "info.circle"
         case enableAction = "checkmark.circle"
-        case openSettings = "gear"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -456,7 +456,7 @@ final class ConnectivityToolViewModel {
     /// Authenticates and retrieves the Jetpack plugin details to verify it's active.
     ///
     @MainActor
-    private func checkJetpackPluginActiveIfNeeded() async -> Result<Void, Error> {
+    private func checkJetpackPluginActiveIfNeeded() async -> Result<Void, JetpackCheckError> {
         /// WPCom and CIAB sites have Jetpack by default so skip this check
         guard stores.sessionManager.defaultSite?.isWordPressComStore == false,
               stores.sessionManager.defaultSite?.isCIAB == false else {
@@ -475,13 +475,10 @@ final class ConnectivityToolViewModel {
                     if plugin.status == .active || plugin.status == .networkActive {
                         continuation.resume(returning: .success(()))
                     } else {
-                        let error = NSError(domain: "ConnectivityTool",
-                                            code: 0,
-                                            userInfo: [NSLocalizedDescriptionKey: "Jetpack plugin is installed but not active (status: \(plugin.status))"])
-                        continuation.resume(returning: .failure(error))
+                        continuation.resume(returning: .failure(.pluginNotActive(status: plugin.status)))
                     }
                 case .failure(let error):
-                    continuation.resume(returning: .failure(error))
+                    continuation.resume(returning: .failure(.requestFailed(error)))
                 }
             }
             stores.dispatch(action)
@@ -490,16 +487,13 @@ final class ConnectivityToolViewModel {
 
     /// Checks the iOS notification authorization status.
     ///
-    private func checkNotificationPermission() async -> Result<Void, Error> {
+    private func checkNotificationPermission() async -> Result<Void, NotificationPermissionError> {
         await withCheckedContinuation { continuation in
             userNotificationCenter.loadAuthorizationStatus(queue: .main) { status in
                 if status == .authorized {
                     continuation.resume(returning: .success(()))
                 } else {
-                    let error = NSError(domain: "ConnectivityTool",
-                                        code: 0,
-                                        userInfo: [NSLocalizedDescriptionKey: "Notification permission status: \(status.rawValue)"])
-                    continuation.resume(returning: .failure(error))
+                    continuation.resume(returning: .failure(.notAuthorized(status: status)))
                 }
             }
         }
@@ -598,6 +592,19 @@ final class ConnectivityToolViewModel {
             icon: ConnectivityTest.notifications.icon,
             state: .error(Localization.ErrorMessage.orderNotificationsDisabled, [enableAction, retryAction(for: .notifications)])
         )
+    }
+
+    /// Error types for the Jetpack plugin check.
+    ///
+    enum JetpackCheckError: Error {
+        case pluginNotActive(status: SitePluginStatusEnum)
+        case requestFailed(Error)
+    }
+
+    /// Error types for the notification permission check.
+    ///
+    enum NotificationPermissionError: Error {
+        case notAuthorized(status: UNAuthorizationStatus)
     }
 
     /// Error types for the notification config check.

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -47,7 +47,7 @@ final class ConnectivityToolViewModel {
 
     /// Analytics tracker.
     ///
-    let analytics: Analytics
+    private let analytics: Analytics
 
     /// Adapter for checking notification authorization status.
     ///

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -180,7 +180,7 @@ final class ConnectivityToolViewModel {
 
     /// Retries the last failed test case and the subsequent ones.
     ///
-    private func retryTest(_ testCase: ConnectivityTest) {
+    func retryTest(_ testCase: ConnectivityTest) {
         // Remove the last test result and card.
         if !latestTestResult.isEmpty {
             latestTestResult.removeLast()

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -57,10 +57,6 @@ final class ConnectivityToolViewModel {
     ///
     let pushNotesManager: PushNotesManager
 
-    /// Credentials used for authenticating Jetpack connection requests.
-    ///
-    private let credentials: Credentials?
-
     /// The site URL used for authenticating Jetpack connection requests.
     ///
     let siteURL: String?
@@ -89,7 +85,6 @@ final class ConnectivityToolViewModel {
         self.analytics = analytics
         self.userNotificationCenter = userNotificationCenter
         self.pushNotesManager = pushNotesManager
-        self.credentials = session.defaultCredentials
         self.siteURL = session.defaultSite?.url
         self.siteID = session.defaultStoreID ?? .zero
 

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -55,7 +55,7 @@ final class ConnectivityToolViewModel {
 
     /// WordPress.com device identifier for notification settings.
     ///
-    let deviceID: String?
+    let pushNotesManager: PushNotesManager
 
     /// Credentials used for authenticating Jetpack connection requests.
     ///
@@ -77,7 +77,7 @@ final class ConnectivityToolViewModel {
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
          userNotificationCenter: UserNotificationsCenterAdapter = UNUserNotificationCenter.current(),
-         deviceID: String? = ServiceLocator.pushNotesManager.deviceID) {
+         pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
 
         let network = AlamofireNetwork(credentials: session.defaultCredentials, selectedSite: nil, appPasswordSupportState: nil)
         self.network = network
@@ -88,7 +88,7 @@ final class ConnectivityToolViewModel {
         self.stores = stores
         self.analytics = analytics
         self.userNotificationCenter = userNotificationCenter
-        self.deviceID = deviceID
+        self.pushNotesManager = pushNotesManager
         self.credentials = session.defaultCredentials
         self.siteURL = session.defaultSite?.url
         self.siteID = session.defaultStoreID ?? .zero

--- a/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
@@ -204,7 +204,7 @@ struct ConnectivityToolViewModelTests {
         let mockNotificationCenter = MockUserNotificationsCenterAdapter()
         mockNotificationCenter.authorizationStatus = .authorized
 
-        let deviceID = "123"
+        let mockPushNotesManager = MockPushNotificationsManager(mockedDeviceID: "123")
         let numericDeviceID = Int64(123)
         let device = NotificationSettings.Device(deviceID: numericDeviceID, newComment: true, storeOrder: true)
         let blog = NotificationSettings.Blog(blogID: site.siteID, devices: [device])
@@ -221,7 +221,7 @@ struct ConnectivityToolViewModelTests {
 
         let sut = ConnectivityToolViewModel(session: session, stores: stores,
                                             userNotificationCenter: mockNotificationCenter,
-                                            deviceID: deviceID)
+                                            pushNotesManager: mockPushNotesManager)
 
         // When
         let result = await sut.testNotifications()
@@ -262,9 +262,10 @@ struct ConnectivityToolViewModelTests {
             }
         }
 
+        let mockPushNotesManager = MockPushNotificationsManager(mockedDeviceID: "123")
         let sut = ConnectivityToolViewModel(session: session, stores: stores,
                                             userNotificationCenter: mockNotificationCenter,
-                                            deviceID: "123")
+                                            pushNotesManager: mockPushNotesManager)
 
         // When
         let result = await sut.testNotifications()
@@ -286,9 +287,10 @@ struct ConnectivityToolViewModelTests {
         let mockNotificationCenter = MockUserNotificationsCenterAdapter()
         mockNotificationCenter.authorizationStatus = .denied
 
+        let mockPushNotesManager = MockPushNotificationsManager(mockedDeviceID: "123")
         let sut = ConnectivityToolViewModel(session: session, stores: stores,
                                             userNotificationCenter: mockNotificationCenter,
-                                            deviceID: "123")
+                                            pushNotesManager: mockPushNotesManager)
 
         // When
         let result = await sut.testNotifications()
@@ -310,9 +312,10 @@ struct ConnectivityToolViewModelTests {
         let mockNotificationCenter = MockUserNotificationsCenterAdapter()
         mockNotificationCenter.authorizationStatus = .authorized
 
+        let mockPushNotesManager = MockPushNotificationsManager(mockedDeviceID: nil)
         let sut = ConnectivityToolViewModel(session: session, stores: stores,
                                             userNotificationCenter: mockNotificationCenter,
-                                            deviceID: nil)
+                                            pushNotesManager: mockPushNotesManager)
 
         // When
         let result = await sut.testNotifications()
@@ -335,7 +338,7 @@ struct ConnectivityToolViewModelTests {
         let mockNotificationCenter = MockUserNotificationsCenterAdapter()
         mockNotificationCenter.authorizationStatus = .authorized
 
-        let deviceID = "456"
+        let mockPushNotesManager = MockPushNotificationsManager(mockedDeviceID: "456")
         let numericDeviceID = Int64(456)
         let device = NotificationSettings.Device(deviceID: numericDeviceID, newComment: true, storeOrder: false)
         let blog = NotificationSettings.Blog(blogID: site.siteID, devices: [device])
@@ -352,7 +355,7 @@ struct ConnectivityToolViewModelTests {
 
         let sut = ConnectivityToolViewModel(session: session, stores: stores,
                                             userNotificationCenter: mockNotificationCenter,
-                                            deviceID: deviceID)
+                                            pushNotesManager: mockPushNotesManager)
 
         // When
         let result = await sut.testNotifications()
@@ -384,9 +387,10 @@ struct ConnectivityToolViewModelTests {
             }
         }
 
+        let mockPushNotesManager = MockPushNotificationsManager(mockedDeviceID: "789")
         let sut = ConnectivityToolViewModel(session: session, stores: stores,
                                             userNotificationCenter: mockNotificationCenter,
-                                            deviceID: "789")
+                                            pushNotesManager: mockPushNotesManager)
 
         // When
         let result = await sut.testNotifications()

--- a/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
@@ -267,7 +267,7 @@ struct ConnectivityToolViewModelTests {
             return
         }
         #expect(message.contains("Jetpack"))
-        #expect(actions.contains(where: { $0.title == "Setup Jetpack" }))
+        #expect(actions.contains(where: { $0.id == ConnectivityToolViewModel.NotificationFailedAction.setupJetpack.id }))
     }
 
     @Test func test_testNotifications_when_permission_denied_then_returns_error_with_open_settings() async {
@@ -292,7 +292,7 @@ struct ConnectivityToolViewModelTests {
             return
         }
         #expect(message.contains("not allowed"))
-        #expect(actions.contains(where: { $0.title == "Open Settings" }))
+        #expect(actions.contains(where: { $0.id == ConnectivityToolViewModel.NotificationFailedAction.openSettings.id }))
     }
 
     @Test func test_testNotifications_when_no_device_id_then_returns_device_not_registered_error() async {
@@ -317,8 +317,7 @@ struct ConnectivityToolViewModelTests {
             return
         }
         #expect(message.contains("doesn't appear to be registered"))
-        #expect(actions.contains(where: { $0.title == "Register Device" }))
-        #expect(!actions.contains(where: { $0.title == "Retry" }))
+        #expect(actions.contains(where: { $0.id == ConnectivityToolViewModel.NotificationFailedAction.registerDevice.id }))
     }
 
     @Test func test_testNotifications_when_order_notifications_disabled_then_returns_error_with_enable_action() async {
@@ -357,7 +356,7 @@ struct ConnectivityToolViewModelTests {
             return
         }
         #expect(message.contains("Order notifications are not enabled"))
-        #expect(actions.contains(where: { $0.title == "Enable Order Notifications" }))
+        #expect(actions.contains(where: { $0.id == ConnectivityToolViewModel.NotificationFailedAction.enableOrderNotifications.id }))
     }
 
     @Test func test_testNotifications_when_config_request_fails_then_returns_error_with_technical_details() async {
@@ -391,7 +390,7 @@ struct ConnectivityToolViewModelTests {
             Issue.record("Expected .error state but got \(result)")
             return
         }
-        #expect(actions.contains(where: { $0.title == "View technical details" }))
+        #expect(actions.contains(where: { $0.id == ConnectivityToolViewModel.NotificationFailedAction.viewDetails.id }))
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
@@ -25,7 +25,7 @@ struct ConnectivityToolViewModelTests {
         let result = await sut.testAnalyticsSetting()
 
         // Then
-        #expect(result == .success)
+        assertState(result, is: .success)
     }
 
     @Test func test_testAnalyticsSetting_when_analytics_disabled_then_returns_error_with_enable_action() async {
@@ -195,11 +195,13 @@ struct ConnectivityToolViewModelTests {
 
 }
 
-// MARK: - ConnectivityToolCard.ConnectivityState: Equatable
+// MARK: - Helpers
 
-extension ConnectivityToolCard.ConnectivityState: @retroactive Equatable {
-    public static func == (lhs: ConnectivityToolCard.ConnectivityState, rhs: ConnectivityToolCard.ConnectivityState) -> Bool {
-        switch (lhs, rhs) {
+private func assertState(_ actual: ConnectivityToolCard.ConnectivityState,
+                          is expected: ConnectivityToolCard.ConnectivityState,
+                          sourceLocation: SourceLocation = #_sourceLocation) {
+    let matches: Bool = {
+        switch (actual, expected) {
         case (.inProgress, .inProgress):
             return true
         case (.success, .success):
@@ -211,5 +213,6 @@ extension ConnectivityToolCard.ConnectivityState: @retroactive Equatable {
         default:
             return false
         }
-    }
+    }()
+    #expect(matches, "Expected \(expected) but got \(actual)", sourceLocation: sourceLocation)
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 import Yosemite
+import enum Networking.SitePluginStatusEnum
 @testable import WooCommerce
 
 @MainActor
@@ -191,6 +192,209 @@ struct ConnectivityToolViewModelTests {
         // Then — verify the analytics test type maps correctly.
         // trackResponseEvent passes WooAnalyticsEvent.ConnectivityTool.Test.analytics as the test param.
         #expect(WooAnalyticsEvent.ConnectivityTool.Test.analytics.rawValue == "analytics")
+    }
+
+    // MARK: - testNotifications
+
+    @Test func test_testNotifications_when_wpcom_site_authorized_and_config_ok_then_returns_success() async {
+        // Given
+        let site = Site.fake().copy(isWordPressComStore: true)
+        let session = SessionManager.makeForTesting(authenticated: true, defaultSite: site)
+        let stores = MockStoresManager(sessionManager: session)
+        let mockNotificationCenter = MockUserNotificationsCenterAdapter()
+        mockNotificationCenter.authorizationStatus = .authorized
+
+        let deviceID = "123"
+        let numericDeviceID = Int64(123)
+        let device = NotificationSettings.Device(deviceID: numericDeviceID, newComment: true, storeOrder: true)
+        let blog = NotificationSettings.Blog(blogID: site.siteID, devices: [device])
+        let settings = NotificationSettings(blogs: [blog])
+
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case let .loadNotificationSettings(_, onCompletion):
+                onCompletion(.success(settings))
+            default:
+                break
+            }
+        }
+
+        let sut = ConnectivityToolViewModel(session: session, stores: stores,
+                                            userNotificationCenter: mockNotificationCenter,
+                                            deviceID: deviceID)
+
+        // When
+        let result = await sut.testNotifications()
+
+        // Then
+        assertState(result, is: .success)
+    }
+
+    @Test func test_testNotifications_when_jetpack_not_active_then_returns_error_with_read_more() async {
+        // Given — self-hosted site (isWordPressComStore: false)
+        let site = Site.fake().copy(isWordPressComStore: false)
+        let session = SessionManager.makeForTesting(authenticated: true, defaultSite: site)
+        let stores = MockStoresManager(sessionManager: session)
+        let mockNotificationCenter = MockUserNotificationsCenterAdapter()
+        mockNotificationCenter.authorizationStatus = .authorized
+
+        let inactivePlugin = SitePlugin(siteID: site.siteID,
+                                        plugin: "jetpack/jetpack",
+                                        status: .inactive,
+                                        name: "Jetpack",
+                                        pluginUri: "",
+                                        author: "",
+                                        authorUri: "",
+                                        descriptionRaw: "",
+                                        descriptionRendered: "",
+                                        version: "1.0",
+                                        networkOnly: false,
+                                        requiresWPVersion: "",
+                                        requiresPHPVersion: "",
+                                        textDomain: "")
+
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case let .retrieveJetpackPluginDetails(_, completion):
+                completion(.success(inactivePlugin))
+            default:
+                break
+            }
+        }
+
+        let sut = ConnectivityToolViewModel(session: session, stores: stores,
+                                            userNotificationCenter: mockNotificationCenter,
+                                            deviceID: "123")
+
+        // When
+        let result = await sut.testNotifications()
+
+        // Then
+        guard case let .error(message, actions) = result else {
+            Issue.record("Expected .error state but got \(result)")
+            return
+        }
+        #expect(message.contains("Jetpack"))
+        #expect(actions.contains(where: { $0.title == "Read more" }))
+    }
+
+    @Test func test_testNotifications_when_permission_denied_then_returns_error_with_open_settings() async {
+        // Given — WPCom site to skip Jetpack check
+        let site = Site.fake().copy(isWordPressComStore: true)
+        let session = SessionManager.makeForTesting(authenticated: true, defaultSite: site)
+        let stores = MockStoresManager(sessionManager: session)
+        let mockNotificationCenter = MockUserNotificationsCenterAdapter()
+        mockNotificationCenter.authorizationStatus = .denied
+
+        let sut = ConnectivityToolViewModel(session: session, stores: stores,
+                                            userNotificationCenter: mockNotificationCenter,
+                                            deviceID: "123")
+
+        // When
+        let result = await sut.testNotifications()
+
+        // Then
+        guard case let .error(message, actions) = result else {
+            Issue.record("Expected .error state but got \(result)")
+            return
+        }
+        #expect(message.contains("not allowed"))
+        #expect(actions.contains(where: { $0.title == "Open Settings" }))
+    }
+
+    @Test func test_testNotifications_when_no_device_id_then_returns_device_not_registered_error() async {
+        // Given
+        let site = Site.fake().copy(isWordPressComStore: true)
+        let session = SessionManager.makeForTesting(authenticated: true, defaultSite: site)
+        let stores = MockStoresManager(sessionManager: session)
+        let mockNotificationCenter = MockUserNotificationsCenterAdapter()
+        mockNotificationCenter.authorizationStatus = .authorized
+
+        let sut = ConnectivityToolViewModel(session: session, stores: stores,
+                                            userNotificationCenter: mockNotificationCenter,
+                                            deviceID: nil)
+
+        // When
+        let result = await sut.testNotifications()
+
+        // Then
+        guard case let .error(message, _) = result else {
+            Issue.record("Expected .error state but got \(result)")
+            return
+        }
+        #expect(message.contains("not appear to be registered"))
+    }
+
+    @Test func test_testNotifications_when_order_notifications_disabled_then_returns_error_with_enable_action() async {
+        // Given
+        let site = Site.fake().copy(isWordPressComStore: true)
+        let session = SessionManager.makeForTesting(authenticated: true, defaultSite: site)
+        let stores = MockStoresManager(sessionManager: session)
+        let mockNotificationCenter = MockUserNotificationsCenterAdapter()
+        mockNotificationCenter.authorizationStatus = .authorized
+
+        let deviceID = "456"
+        let numericDeviceID = Int64(456)
+        let device = NotificationSettings.Device(deviceID: numericDeviceID, newComment: true, storeOrder: false)
+        let blog = NotificationSettings.Blog(blogID: site.siteID, devices: [device])
+        let settings = NotificationSettings(blogs: [blog])
+
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case let .loadNotificationSettings(_, onCompletion):
+                onCompletion(.success(settings))
+            default:
+                break
+            }
+        }
+
+        let sut = ConnectivityToolViewModel(session: session, stores: stores,
+                                            userNotificationCenter: mockNotificationCenter,
+                                            deviceID: deviceID)
+
+        // When
+        let result = await sut.testNotifications()
+
+        // Then
+        guard case let .error(message, actions) = result else {
+            Issue.record("Expected .error state but got \(result)")
+            return
+        }
+        #expect(message.contains("Order notifications are not enabled"))
+        #expect(actions.contains(where: { $0.title == "Enable Order Notifications" }))
+    }
+
+    @Test func test_testNotifications_when_config_request_fails_then_returns_error_with_technical_details() async {
+        // Given
+        let site = Site.fake().copy(isWordPressComStore: true)
+        let session = SessionManager.makeForTesting(authenticated: true, defaultSite: site)
+        let stores = MockStoresManager(sessionManager: session)
+        let mockNotificationCenter = MockUserNotificationsCenterAdapter()
+        mockNotificationCenter.authorizationStatus = .authorized
+
+        let testError = NSError(domain: "TestDomain", code: 500, userInfo: nil)
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case let .loadNotificationSettings(_, onCompletion):
+                onCompletion(.failure(testError))
+            default:
+                break
+            }
+        }
+
+        let sut = ConnectivityToolViewModel(session: session, stores: stores,
+                                            userNotificationCenter: mockNotificationCenter,
+                                            deviceID: "789")
+
+        // When
+        let result = await sut.testNotifications()
+
+        // Then
+        guard case let .error(_, actions) = result else {
+            Issue.record("Expected .error state but got \(result)")
+            return
+        }
+        #expect(actions.contains(where: { $0.title == "View technical details" }))
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
@@ -230,7 +230,7 @@ struct ConnectivityToolViewModelTests {
         assertState(result, is: .success)
     }
 
-    @Test func test_testNotifications_when_jetpack_not_active_then_returns_error_with_read_more() async {
+    @Test func test_testNotifications_when_jetpack_not_active_then_returns_error_with_setup_jetpack_action() async {
         // Given — self-hosted site (isWordPressComStore: false)
         let site = Site.fake().copy(isWordPressComStore: false)
         let session = SessionManager.makeForTesting(authenticated: true, defaultSite: site)

--- a/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
@@ -262,11 +262,10 @@ struct ConnectivityToolViewModelTests {
         let result = await sut.testNotifications()
 
         // Then
-        guard case let .error(message, actions) = result else {
+        guard case let .error(_, actions) = result else {
             Issue.record("Expected .error state but got \(result)")
             return
         }
-        #expect(message.contains("Jetpack"))
         #expect(actions.contains(where: { $0.id == ConnectivityToolViewModel.NotificationFailedAction.setupJetpack.id }))
     }
 
@@ -287,11 +286,10 @@ struct ConnectivityToolViewModelTests {
         let result = await sut.testNotifications()
 
         // Then
-        guard case let .error(message, actions) = result else {
+        guard case let .error(_, actions) = result else {
             Issue.record("Expected .error state but got \(result)")
             return
         }
-        #expect(message.contains("not allowed"))
         #expect(actions.contains(where: { $0.id == ConnectivityToolViewModel.NotificationFailedAction.openSettings.id }))
     }
 
@@ -312,11 +310,10 @@ struct ConnectivityToolViewModelTests {
         let result = await sut.testNotifications()
 
         // Then
-        guard case let .error(message, actions) = result else {
+        guard case let .error(_, actions) = result else {
             Issue.record("Expected .error state but got \(result)")
             return
         }
-        #expect(message.contains("doesn't appear to be registered"))
         #expect(actions.contains(where: { $0.id == ConnectivityToolViewModel.NotificationFailedAction.registerDevice.id }))
     }
 
@@ -351,11 +348,10 @@ struct ConnectivityToolViewModelTests {
         let result = await sut.testNotifications()
 
         // Then
-        guard case let .error(message, actions) = result else {
+        guard case let .error(_, actions) = result else {
             Issue.record("Expected .error state but got \(result)")
             return
         }
-        #expect(message.contains("Order notifications are not enabled"))
         #expect(actions.contains(where: { $0.id == ConnectivityToolViewModel.NotificationFailedAction.enableOrderNotifications.id }))
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
@@ -318,11 +318,13 @@ struct ConnectivityToolViewModelTests {
         let result = await sut.testNotifications()
 
         // Then
-        guard case let .error(message, _) = result else {
+        guard case let .error(message, actions) = result else {
             Issue.record("Expected .error state but got \(result)")
             return
         }
-        #expect(message.contains("not appear to be registered"))
+        #expect(message.contains("doesn't appear to be registered"))
+        #expect(actions.contains(where: { $0.title == "Register Device" }))
+        #expect(!actions.contains(where: { $0.title == "Retry" }))
     }
 
     @Test func test_testNotifications_when_order_notifications_disabled_then_returns_error_with_enable_action() async {

--- a/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
@@ -275,7 +275,7 @@ struct ConnectivityToolViewModelTests {
             return
         }
         #expect(message.contains("Jetpack"))
-        #expect(actions.contains(where: { $0.title == "Read more" }))
+        #expect(actions.contains(where: { $0.title == "Setup Jetpack" }))
     }
 
     @Test func test_testNotifications_when_permission_denied_then_returns_error_with_open_settings() async {


### PR DESCRIPTION
Closes WOOMOB-1856

## Description
Adds notification diagnostics to the Connectivity Tool (troubleshooting screen), running four sub-checks:

1. **Jetpack plugin is active** (self-hosted sites only) — with a "Setup Jetpack" action to start the Jetpack setup flow
2. **iOS notification permission is authorized** — with an "Open Settings" action to navigate to device notification settings
3. **Device is registered for push notifications** — with a "Register Device" action that triggers `PushNotesManager.registerDeviceAndWaitForTokenAcceptance` to re-register the device
4. **Order notifications are enabled** — with an "Enable Order Notifications" action to update the notification setting directly

Each check provides actionable error states with contextual buttons. The notification check logic is extracted into a dedicated `ConnectivityToolViewModel+Notifications.swift` extension.

Additional improvements:
- Retry now targets the specific failed test instead of relying on position
- URLs are routed through the `selectedURL` publisher instead of calling `UIApplication.shared.open` directly from the ViewModel

## Test Steps
0. Log in to a test store with WPCom credentials on a physical device.
1. Open the app → Settings → Troubleshoot Connection
2. Verify the notification settings check appears.
3. On a self-hosted site without Jetpack plugin (JCP site), verify that Jetpack is detected to be unavailable. Tapping "Setup Jetpack" should start the Jetpack setup flow.
4. Disable notifications in device Settings, re-run → verify "Open Settings" action appears. Tapping it should navigate to Settings.
5. Disable order notifications for the store, re-run → verify "Enable Order Notifications" action appears. Tapping it should update the notification setting for new orders.
6. Verify retry buttons re-run the correct test.

## Screenshots

Notification disabled | Jetpack not installed | Order notification disabled
--- | --- | ---
<img width="320" alt="image" src="https://github.com/user-attachments/assets/28d3d08a-7bab-424b-85e7-6c9c8eb6af84" /> | <img width="320" alt="image" src="https://github.com/user-attachments/assets/dcf9593e-e551-49fc-9f89-72dd0c91ab23" /> | <img width="320" alt="image" src="https://github.com/user-attachments/assets/5cb7864e-dde5-47df-890e-94fc479c93e1" />




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.